### PR TITLE
Update links to reflect the organisation/repo change

### DIFF
--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -337,7 +337,7 @@ def _rule_to_iptables_fragment(chain_name, rule, ip_version, tag_to_ipset,
         icmp_type = rule["icmp_type"]
         if icmp_type == 255:
             # Temporary work-around for this issue:
-            # https://github.com/Metaswitch/calico/issues/451
+            # https://github.com/projectcalico/calico/issues/451
             # This exception will be caught by the caller, which will replace
             # this rule with a DROP rule.  That's arguably better than
             # forbidding this case in the validation routine, which would

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: http://dep.debian.net/deps/dep5
 Upstream-Name: calico
-Source: http://github.com/Metaswitch/calico
+Source: http://github.com/projectcalico/calico
 
 Files: *
 Copyright: 2014, 2015 Metaswitch Networks

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ Calico is an open source solution for virtual networking in
 cloud data centers, developed by `Metaswitch
 Networks <http://www.metaswitch.com/>`__ and released under the `Apache
 2.0
-License <https://github.com/Metaswitch/calico/blob/master/LICENSE>`__.
+License <https://github.com/projectcalico/calico/blob/master/LICENSE>`__.
 You can find high level information about it on `our
 website <http://www.projectcalico.org/>`__, and more detailed documentation
 here.

--- a/docs/source/involved.rst
+++ b/docs/source/involved.rst
@@ -47,7 +47,7 @@ Read the Source, Luke!
 All Calico's code is on `GitHub <https://github.com/Metaswitch>`__, in the
 following repositories, separated by function.
 
-- `calico <https://github.com/Metaswitch/calico>`__ - All of the core Calico
+- `calico <https://github.com/projectcalico/calico>`__ - All of the core Calico
   code except for that specific to Docker/container environments: the Felix
   agent, the OpenStack plugin; testing for all of those; and
   the source for Calico's documentation.
@@ -58,16 +58,16 @@ following repositories, separated by function.
   instructions for demonstrating Calico networking in various container
   environments.
 
-- `calico-neutron <https://github.com/Metaswitch/calico-neutron>`__ -
+- `calico-neutron <https://github.com/projectcalico/calico-neutron>`__ -
   Calico-specific patched version of OpenStack Neutron.
 
-- `calico-nova <https://github.com/Metaswitch/calico-nova>`__ - Calico-specific
+- `calico-nova <https://github.com/projectcalico/calico-nova>`__ - Calico-specific
   patched version of OpenStack Nova.
 
-- `calico-dnsmasq <https://github.com/Metaswitch/calico-dnsmasq>`__ -
+- `calico-dnsmasq <https://github.com/projectcalico/calico-dnsmasq>`__ -
   Calico-specific patched version of Dnsmasq.
 
-- `calico-chef <https://github.com/Metaswitch/calico-chef>`__ - Chef cookbooks
+- `calico-chef <https://github.com/projectcalico/calico-chef>`__ - Chef cookbooks
   for installing test versions of OpenStack-using-Calico.
 
 Contributing

--- a/docs/source/ipv6.rst
+++ b/docs/source/ipv6.rst
@@ -77,7 +77,7 @@ changes will suffice to meet the requirements just listed.
        net.ipv6.conf.eth0.router_solicitation_delay = 10
 
 .. _this known issue: https://kb.isc.org/article/AA-01141/31/How-to-workaround-IPv6-prefix-length-issues-with-ISC-DHCP-clients.html
-.. _a bug: https://github.com/Metaswitch/calico/issues/12
+.. _a bug: https://github.com/projectcalico/calico/issues/12
 
 Implementation details
 ----------------------

--- a/docs/source/juju-opens-install.rst
+++ b/docs/source/juju-opens-install.rst
@@ -25,6 +25,6 @@ out by adding more instances of the ``nova-compute`` charm.
 For more detailed information, please see `this blog post`_ on the Calico blog.
 
 .. _Juju Charms: https://jujucharms.com/
-.. _this bundle file: https://raw.githubusercontent.com/Metaswitch/calico/master/docs/source/_static/juju/bundle.yaml
+.. _this bundle file: https://raw.githubusercontent.com/projectcalico/calico/master/docs/source/_static/juju/bundle.yaml
 .. _any of the standard methods: https://jujucharms.com/docs/1.20/charms-bundles
 .. _this blog post: http://www.projectcalico.org/exploring-juju/

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -16,7 +16,7 @@ License and Acknowledgements
 ============================
 
 Calico's license is documented in
-`our license <https://github.com/Metaswitch/calico/blob/master/LICENSE>`__.
+`our license <https://github.com/projectcalico/calico/blob/master/LICENSE>`__.
 
 It also makes use of other open source components as acknowledged in
 :doc:`licenses`.

--- a/docs/source/opens-chef-install.rst
+++ b/docs/source/opens-chef-install.rst
@@ -100,7 +100,7 @@ Prepare Chef
 
    ::
 
-       git clone https://github.com/Metaswitch/calico-chef.git
+       git clone https://github.com/projectcalico/calico-chef.git
 
 -  Create a directory for the chef installation configuration. The
    following instructions assume you created a ``.chef`` directory under
@@ -154,7 +154,7 @@ How To Use It: For Experienced Chef Users
 -----------------------------------------
 
 We provide a single ``calico`` cookbook in `this
-repository <https://github.com/Metaswitch/calico-chef>`__. This cookbook
+repository <https://github.com/projectcalico/calico-chef>`__. This cookbook
 can be cloned in git and then added to the Chef server in the usual way.
 
 The cookbook defines two roles: ``controller`` and ``compute``. To set


### PR DESCRIPTION
All these links redirect correctly, but this saves people a redirect and means we'll be consistent with new links going forward.

@Lukasa Assigning to you because you've been taking the lead on the repository migration.