### PR TITLE
Update OpenStack page for 6.1 Fuel integration

### DIFF
--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -33,8 +33,7 @@ following methods:
 
 - our integration with Canonical's Juju Charms - see :doc:`juju-opens-install`
 
-- our experimental integration of Calico with Mirantis Fuel 5.1 - see
-  :doc:`fuel-integration`.
+- our integration of Calico with Mirantis Fuel 6.1 - see :doc:`fuel-integration`
 
 In all cases, you just need at least two servers to get going (one OpenStack
 controller and one OpenStack compute node).


### PR DESCRIPTION
Just noticed that I missed this page when updating the Fuel docs yesterday. Have searched the rest of the docs for 'Fuel 5.1' and not found anything further, so I'm confident that this should be the only missing update.