### PR TITLE
Check config on resync and restart if changed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## 0.28-dev
 
-- Felix now preiodically refreshes iptables to be robust to other processes
+- Felix now restarts if its etcd configuration changes.
+- Felix now periodically refreshes iptables to be robust to other processes
   corrupting its chains.
 - More thorough resynchronization of etcd from the Neutron mechanism driver.
 - Added process-specific information to the diagnostics dumps from Felix.

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -386,8 +386,8 @@ class _EtcdWatcher(gevent.Greenlet):
                     _log.info("Checking configuration for changes...")
                     if (host_dict != self.last_host_config or
                             global_dict != self.last_global_config):
-                        _log.critical("Felix configuration has changed, "
-                                      "felix must restart.")
+                        _log.warning("Felix configuration has changed, "
+                                     "felix must restart.")
                         die_and_restart()
                 else:
                     # First time loading the config.  Report it to the config

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -110,12 +110,62 @@ class TestExcdWatcher(BaseTestCase):
     def setUp(self):
         super(TestExcdWatcher, self).setUp()
         self.m_config = Mock()
+        self.m_config.HOSTNAME = "hostname"
         self.m_config.IFACE_PREFIX = "tap"
         self.m_hosts_ipset = Mock(spec=IpsetActor)
         self.watcher = _EtcdWatcher(self.m_config, self.m_hosts_ipset)
         self.m_splitter = Mock(spec=UpdateSplitter)
         self.watcher.splitter = self.m_splitter
-        self.watcher.client = Mock(spec=etcd.Client)
+        self.client = Mock(spec=etcd.Client)
+        self.watcher.client = self.client
+
+    @patch("gevent.sleep", autospec=True)
+    @patch("calico.felix.fetcd._build_config_dict", autospec=True)
+    @patch("calico.felix.fetcd.die_and_restart", autospec=True)
+    def test_load_config(self, m_die, m_build_dict, m_sleep):
+        # First call, loads the config.
+        m_build_dict.side_effect = iter([
+            # First call, global-only.
+            {"foo": "bar"},
+            # Second call, no change.
+            {"foo": "bar"},
+            # Third call, change of config.
+            {"foo": "baz"}, {"biff": "bop"}])
+        self.client.read.side_effect = iter([
+            # First time round the loop, fail to read global config, should
+            # retry.
+            etcd.EtcdKeyNotFound,
+            # Then get the global config but there's not host-only config.
+            None, etcd.EtcdKeyNotFound,
+            # Twice...
+            None, etcd.EtcdKeyNotFound,
+            # Then some host-only config shows up.
+            None, None])
+
+        # First call.
+        self.watcher._load_config()
+
+        m_sleep.assert_called_once_with(5)
+        self.assertFalse(m_die.called)
+        self.m_config.report_etcd_config.assert_called_once_with(
+            {},
+            {"foo": "bar"}
+        )
+        self.assertEqual(self.watcher.last_host_config, {})
+        self.assertEqual(self.watcher.last_global_config, {"foo": "bar"})
+        self.watcher.configured.set()  # Normally done by the caller.
+        self.client.read.assert_has_calls([
+            call("/calico/v1/config", recursive=True),
+            call("/calico/v1/host/hostname/config", recursive=True),
+        ])
+
+        # Second call, no change.
+        self.watcher._load_config()
+        self.assertFalse(m_die.called)
+
+        # Third call, should detect the config change and die.
+        self.watcher._load_config()
+        m_die.assert_called_once_with()
 
     def test_resync_flag(self):
         self.watcher.resync_after_current_poll = True


### PR DESCRIPTION
The simple brute-force fix for #725:

* [x] Resync if tour watch detects a config change.
* [x] Each time we resync with etcd, check if the config has changed.
* [x] If config has changed, die (and allow init daemon to restart us).
* [x] UTs
* [x] CHANGELOG