### PR TITLE
Add configuration of IP-in-IP MTU.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.29-dev
+
+- Add support for setting MTU on IP-in-IP device.
+
 ## 0.28
 
 - Felix now restarts if its etcd configuration changes.

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -193,6 +193,9 @@ class Config(object):
         self.add_parameter("IpInIpEnabled",
                            "IP-in-IP device support enabled", False,
                            value_is_bool=True)
+        self.add_parameter("IpInIpMtu",
+                           "MTU to set on the IP-in-IP device", 1440,
+                           value_is_int=True)
 
         # Read the environment variables, then the configuration file.
         self._read_env_vars()
@@ -242,6 +245,7 @@ class Config(object):
         self.LOGLEVSYS = self.parameters["LogSeveritySys"].value
         self.LOGLEVSCR = self.parameters["LogSeverityScreen"].value
         self.IP_IN_IP_ENABLED = self.parameters["IpInIpEnabled"].value
+        self.IP_IN_IP_MTU = self.parameters["IpInIpMtu"].value
 
         self._validate_cfg(final=final)
 

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -90,6 +90,8 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
             _log.info("Tunnel device didn't exist; creating.")
             futils.check_call(["ip", "tunnel", "add", IP_IN_IP_DEV_NAME,
                                "mode", "ipip"])
+        futils.check_call(["ip", "link", "set", IP_IN_IP_DEV_NAME, "mtu",
+                           str(config.IP_IN_IP_MTU)])
         if not devices.interface_up(IP_IN_IP_DEV_NAME):
             _log.info("Tunnel device wasn't up; enabling.")
             futils.check_call(["ip", "link", "set", IP_IN_IP_DEV_NAME, "up"])

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -73,6 +73,7 @@ class TestBasic(BaseTestCase):
         m_config.METADATA_IP = "10.0.0.1"
         m_config.METADATA_PORT = 1234
         m_config.IP_IN_IP_ENABLED = True
+        m_config.IP_IN_IP_MTU = 1480
         m_config.DEFAULT_INPUT_CHAIN_ACTION = "RETURN"
         with gevent.Timeout(5):
             self.assertRaises(TestException,

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -208,6 +208,7 @@ class TestRules(BaseTestCase):
 
         m_config = Mock(spec=Config)
         m_config.IP_IN_IP_ENABLED = True
+        m_config.IP_IN_IP_MTU = 1480
         m_config.METADATA_IP = "123.0.0.1"
         m_config.METADATA_PORT = 1234
         m_config.DEFAULT_INPUT_CHAIN_ACTION = "RETURN"
@@ -224,6 +225,7 @@ class TestRules(BaseTestCase):
             m_check_call.mock_calls,
             [
                 call(["ip", "tunnel", "add", "tunl0", "mode", "ipip"]),
+                call(["ip", "link", "set", "tunl0", "mtu", "1480"]),
                 call(["ip", "link", "set", "tunl0", "up"]),
             ]
         )


### PR DESCRIPTION
Fixes #754.

Helps address https://github.com/Metaswitch/calico-docker/issues/415.