### PR TITLE
Don't use gevent 1.1b2, which doesn't work with PyPy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ deps =
     coverage==4.0a5
     unittest2
     git+https://github.com/Metaswitch/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
-    gevent>=1.1a2, !=1.1b1
+    gevent>=1.1a2, !=1.1b1, !=1.1b2


### PR DESCRIPTION
UT build #605 failed - I've reported the problem upstream (in https://github.com/gevent/gevent/issues/619), but for now I'm going to extend the previous workaround (blacklisting the broken gevent release).