### PR TITLE
Minor ordering changes in OpenStack installation landing page

### DIFF
--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -36,7 +36,7 @@ following methods:
 - our integration with Canonical's Juju Charms - see :doc:`juju-opens-install`
 
 In all cases, you just need at least two to three servers to get going (one OpenStack
-controller, one OpenStack compute node, and for Mirantis Fuel, only, a third node to
+controller, one OpenStack compute node and, for Mirantis Fuel, a third node to
 serve as the Fuel master).
 
 .. toctree::b

--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -35,10 +35,11 @@ following methods:
 
 - our integration with Canonical's Juju Charms - see :doc:`juju-opens-install`
 
-In all cases, you just need at least two servers to get going (one OpenStack
-controller and one OpenStack compute node).
+In all cases, you just need at least two to three servers to get going (one OpenStack
+controller, one OpenStack compute node, and for Mirantis Fuel only a third node to
+serve as the Fuel master).
 
-.. toctree::
+.. toctree::b
    :maxdepth: 1
 
    ubuntu-opens-install

--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -31,9 +31,9 @@ following methods:
 - an RPM install for Red Hat Enterprise Linux 7 (RHEL 7) - see
   :doc:`redhat-opens-install`
 
-- our integration with Canonical's Juju Charms - see :doc:`juju-opens-install`
-
 - our integration of Calico with Mirantis Fuel 6.1 - see :doc:`fuel-integration`
+
+- our integration with Canonical's Juju Charms - see :doc:`juju-opens-install`
 
 In all cases, you just need at least two servers to get going (one OpenStack
 controller and one OpenStack compute node).
@@ -41,11 +41,11 @@ controller and one OpenStack compute node).
 .. toctree::
    :maxdepth: 1
 
-   opens-chef-install
-   redhat-opens-install
    ubuntu-opens-install
+   redhat-opens-install
+   fuel-integration
    juju-opens-install
+   opens-chef-install
    opens-upgrade
    bird-rr-config
-   fuel-integration
    worked-examples-openstack

--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -36,7 +36,7 @@ following methods:
 - our integration with Canonical's Juju Charms - see :doc:`juju-opens-install`
 
 In all cases, you just need at least two to three servers to get going (one OpenStack
-controller, one OpenStack compute node, and for Mirantis Fuel only a third node to
+controller, one OpenStack compute node, and for Mirantis Fuel, only, a third node to
 serve as the Fuel master).
 
 .. toctree::b


### PR DESCRIPTION
A few minor updates to the main OpenStack landing page to change the ordering of installation options (based on our expectations of popularity).