### PR TITLE
Rev Calico version to sort out pre-release build dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+calico (1.0.1~rc1) trusty; urgency=medium
+
+  * Replace fork() with posix_spawn() for significant performance improvement
+    in felix.
+
+ -- Shaun Crampton <shaun@projectcalico.org>  Tue, 25 Aug 2015 15:59:00 +0100
+
 calico (1.0.0-1) trusty; urgency=medium
 
   * Calico version 1.0.0 release


### PR DESCRIPTION
This should make the calico-jenkins'hosted package strictly preferred to the other.