### PR TITLE
Rework packet marking logic to use the MARK to indicate a match

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## 1.0.1
 
-- Fix that packets that failed to match anti-spoofing rules were incorrectly
-  accepted.
+- Explicitly use and enable the kernel's reverse path filtering function,
+  remove our iptables anti-spoofing rules, which were not as robust.
 
 ## 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1
+
+- Fix that packets that failed to match anti-spoofing rules were incorrectly
+  accepted.
+
 ## 1.0.0
 
 - Add support for setting MTU on IP-in-IP device.

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -97,12 +97,19 @@ def configure_interface_ipv4(if_name):
     Configure the various proc file system parameters for the interface for
     IPv4.
 
-    Specifically, allow packets from controlled interfaces to be directed to
-    localhost, and enable proxy ARP.
+    Specifically,
+      - Allow packets from controlled interfaces to be directed to localhost
+      - Enable proxy ARP
+      - Enable the kernel's RPF check.
 
     :param if_name: The name of the interface to configure.
     :returns: None
     """
+    # Enable the kernel's RPF check, which ensures that a VM cannot spoof
+    # its IP address.
+    with open('/proc/sys/net/ipv4/conf/%s/rp_filter' % if_name, 'wb') as f:
+        f.write('1')
+
     with open('/proc/sys/net/ipv4/conf/%s/route_localnet' % if_name,
               'wb') as f:
         f.write('1')
@@ -119,6 +126,7 @@ def configure_interface_ipv6(if_name, proxy_target):
     Configure an interface to support IPv6 traffic from an endpoint.
       - Enable proxy NDP on the interface.
       - Program the given proxy target (gateway the endpoint will use).
+      - Enable the kernel's RPF check.
 
     :param if_name: The name of the interface to configure.
     :param proxy_target: IPv6 address which is proxied on this interface for
@@ -126,6 +134,11 @@ def configure_interface_ipv6(if_name, proxy_target):
     :returns: None
     :raises: FailedSystemCall
     """
+    # Enable the kernel's RPF check, which ensures that a VM cannot spoof
+    # its IP address.
+    with open('/proc/sys/net/ipv6/conf/%s/rp_filter' % if_name, 'wb') as f:
+        f.write('1')
+
     with open("/proc/sys/net/ipv6/conf/%s/proxy_ndp" % if_name, 'wb') as f:
         f.write('1')
 

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -16,7 +16,95 @@
 felix.frules
 ~~~~~~~~~~~~
 
-Felix rule management, including iptables and ipsets.
+Functions for generating iptables rules.  This covers our top-level
+chains as well as low-level conversion from our datamodel rules to
+iptables format.
+
+iptables background
+~~~~~~~~~~~~~~~~~~~
+
+iptables configuration is split into multiple tables, which each support
+different types of rules.  Each table contains multiple chains, which
+are sequences of rules.  At certain points in packet processing the
+packet is handed to one of the always-present kernel chains in a
+particular table.  The kernel chains have default behaviours but they
+can be modified to add or remove rules, including inserting a jump to
+another chain.
+
+Felix is mainly concerned with the "filter" table, which is used for
+imposing policy rules.  There are multiple kernel chains in the filter
+table.  After the routing decision has been made, packets enter
+
+* the INPUT chain if they are destined for the host itself
+* the OUTPUT chain if they are being sent by the host itself
+* the FORWARD chain if they are to be forwarded between two interfaces.
+
+Note: packets that are being forwarded do not traverse the INPUT or
+OUTPUT chains at all.  INPUT and OUTPUT are only used for packets that
+the host itself is to receive/send.
+
+Packet paths
+~~~~~~~~~~~~
+
+There are a number of possible paths through the filter chains that we
+care about:
+
+* Packets from a local workload to another local workload traverse the
+  FORWARD chain only.  Felix must ensure that those packets have *both*
+  the outbound policy of the sending workload and the inbound policy
+  of the receiving workload applied.  In addition, it must prevent the
+  sender from spoofing its source address.
+
+* Packets from a local workload to a remote address traverse the FORWARD
+  chain only.  Felix must ensure that those packets have the outbound
+  policy of the local workload applied.  In addition, it must prevent the
+  sender from spoofing its source address.
+
+* Packets from a remote address to a local workload traverse the FORWARD
+  chain only.  Felix must apply the inbound policy of the local workload.
+
+* Packets from a local workload to the host itself traverse the INPUT
+  chain.  Felix must apply the outbound policy of the workload.
+
+Chain structure
+~~~~~~~~~~~~~~~
+
+Rather than adding many rules to the kernel chains, which are a shared
+resource (and hence difficult to unpick), Felix creates its own delegate
+chain for each kernel chain and inserts a single jump rule into the
+kernel chain:
+
+* INPUT -> felix-INPUT
+* FORWARD -> felix-FORWARD
+
+The top-level felix-XXX chains are static and configured at start-of-day.
+
+The felix-FORWARD chain sends packet that arrive from a local workload to
+the felix-FROM-ENDPOINT chain, which applies inbound policy.  Packets that
+are denied by policy are dropped immediately.  However, accepted packets
+are returned to the felix-FORWARD chain in case they need to be processed
+further.  felix-FORWARD then directs packets that are going to local
+endpoints to the felix-TO-ENDPOINT chain, which applies inbound policy.
+Similarly, felix-TO-ENDPOINT either drops or returns the packet.  Finally,
+if both the FROM-ENDPOINT and TO-ENDPOINT chains allow the packet,
+felix-FORWARD accepts the packet and allows it through.
+
+The felix-INPUT sends packets from local workloads to the (shared)
+felix-FROM-ENDPOINT chain, which applies outbound policy.  Then it
+(optionally) accepts packets that are returned.
+
+Since workloads come and go, the TO/FROM-ENDPOINT chains are dynamic and
+consist of dispatch tables based on device name.  Those chains are managed
+by dispatch.py.
+
+The dispatch chains direct packets to per-endpoint ("felix-to/from")
+chains, which are responsible for policing IP addresses.  Those chains are
+managed by endpoint.py.  Since the actual policy rules can be shared by
+multiple endpoints, we put each set of policy rules in its own chain and
+the per-endpoint chains send packets to the relevant policy
+(felix-p-xxx-i/o) chains in turn.  Policy profile chains are managed by
+profilerules.py.
+
 """
 import logging
 import itertools
@@ -170,7 +258,8 @@ def rules_to_chain_rewrite_lines(chain_name, rules, ip_version, tag_to_ipset,
                                  on_allow="ACCEPT", on_deny="DROP",
                                  comment_tag=None):
     """
-    Convert our JSON representation of rules into iptables fragments.
+    Convert our JSON representation of a list of rules into iptables
+    fragments.
 
     :returns list[str] a list of fragments.
     """
@@ -203,6 +292,9 @@ def rules_to_chain_rewrite_lines(chain_name, rules, ip_version, tag_to_ipset,
 
 
 def commented_drop_fragment(chain_name, comment):
+    """
+    :return str: a DROP rule fragment with a comment attached.
+    """
     comment = comment[:255]  # Limit imposed by iptables.
     assert re.match(r'[\w: ]{,255}', comment), "Invalid comment %r" % comment
     return ('--append %s --jump DROP -m comment --comment "%s"' %

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -52,13 +52,11 @@ care about:
 * Packets from a local workload to another local workload traverse the
   FORWARD chain only.  Felix must ensure that those packets have *both*
   the outbound policy of the sending workload and the inbound policy
-  of the receiving workload applied.  In addition, it must prevent the
-  sender from spoofing its source address.
+  of the receiving workload applied.
 
 * Packets from a local workload to a remote address traverse the FORWARD
   chain only.  Felix must ensure that those packets have the outbound
-  policy of the local workload applied.  In addition, it must prevent the
-  sender from spoofing its source address.
+  policy of the local workload applied.
 
 * Packets from a remote address to a local workload traverse the FORWARD
   chain only.  Felix must apply the inbound policy of the local workload.

--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -282,7 +282,9 @@ class TestDevices(unittest.TestCase):
         tap = "tap" + str(uuid.uuid4())[:11]
         with mock.patch('__builtin__.open', m_open, create=True):
             devices.configure_interface_ipv4(tap)
-        calls = [mock.call('/proc/sys/net/ipv4/conf/%s/route_localnet' % tap, 'wb'),
+        calls = [mock.call('/proc/sys/net/ipv4/conf/%s/rp_filter' % tap, 'wb'),
+                 M_ENTER, mock.call().write('1'), M_CLEAN_EXIT,
+                 mock.call('/proc/sys/net/ipv4/conf/%s/route_localnet' % tap, 'wb'),
                  M_ENTER, mock.call().write('1'), M_CLEAN_EXIT,
                  mock.call('/proc/sys/net/ipv4/conf/%s/proxy_arp' % tap, 'wb'),
                  M_ENTER, mock.call().write('1'), M_CLEAN_EXIT,
@@ -310,7 +312,10 @@ class TestDevices(unittest.TestCase):
 
         with nested(open_patch, m_check_call) as (_, m_check_call):
             devices.configure_interface_ipv6(if_name, proxy_target)
-            calls = [mock.call('/proc/sys/net/ipv6/conf/%s/proxy_ndp' %
+            calls = [mock.call('/proc/sys/net/ipv6/conf/%s/rp_filter' %
+                               if_name, 'wb'),
+                     M_ENTER, mock.call().write('1'), M_CLEAN_EXIT,
+                     mock.call('/proc/sys/net/ipv6/conf/%s/proxy_ndp' %
                                if_name,
                                'wb'),
                      M_ENTER,

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -273,3 +273,84 @@ class TestLocalEndpoint(BaseTestCase):
                                                            iface,
                                                            data['mac'],
                                                            reset_arp=False)
+
+
+class TestEndpoint(BaseTestCase):
+    def test_get_endpoint_rules(self):
+        to_pfx = '--append felix-to-abcd'
+        from_pfx = '--append felix-from-abcd'
+        expected_result = (
+            {
+                'felix-from-abcd': 
+                [
+                    # Always start with a 0 MARK.
+                    from_pfx + ' --jump MARK --set-mark 0',
+
+                    # Jump to the first profile iff the IP and MAC matches
+                    # the whitelist.
+                    from_pfx + ' --src 10.0.0.1/32 --match mac '
+                               '--mac-source AA:22:33:44:55:66 '
+                               '--jump felix-p-prof-1-o',
+                    from_pfx + ' --src 11.1.2.0/24 --match mac '
+                               '--mac-source AA:22:33:44:55:66 '
+                               '--jump felix-p-prof-1-o',
+                    # Short-circuit: return if the first profile matched.
+                    from_pfx + ' --match mark --mark 1/1 --match comment '
+                               '--comment "Profile matched packet" '
+                               '--jump RETURN',
+
+                    # Jump to second profile iff the IP and MAC matches
+                    # the whitelist.
+                    from_pfx + ' --src 10.0.0.1/32 --match mac '
+                               '--mac-source AA:22:33:44:55:66 '
+                               '--jump felix-p-prof-2-o',
+                    from_pfx + ' --src 11.1.2.0/24 --match mac '
+                               '--mac-source AA:22:33:44:55:66 '
+                               '--jump felix-p-prof-2-o',
+                    # Return if the second profile matched.
+                    from_pfx + ' --match mark --mark 1/1 --match comment '
+                               '--comment "Profile matched packet" '
+                               '--jump RETURN',
+
+                    # Drop the packet if nothing matched.
+                    from_pfx + ' --jump DROP -m comment --comment '
+                               '"Default DROP if no match (endpoint e1):"'
+                ],
+                'felix-to-abcd': 
+                [
+                    # Always start with a 0 MARK.
+                    to_pfx + ' --jump MARK --set-mark 0',
+
+                    # Jump to first profile and return iff it matched.
+                    to_pfx + ' --jump felix-p-prof-1-i',
+                    to_pfx + ' --match mark --mark 1/1 --match comment '
+                             '--comment "Profile accepted packet" '
+                             '--jump RETURN',
+
+                    # Jump to second profile and return iff it matched.
+                    to_pfx + ' --jump felix-p-prof-2-i',
+                    to_pfx + ' --match mark --mark 1/1 --match comment '
+                             '--comment "Profile accepted packet" '
+                             '--jump RETURN',
+
+                    # Drop anything that doesn't match.
+                    to_pfx + ' --jump DROP -m comment --comment "Endpoint e1:"'
+                ]
+            },
+            {
+                # From chain depends on the outbound profiles.
+                'felix-from-abcd': set(['felix-p-prof-1-o',
+                                        'felix-p-prof-2-o']),
+                # To chain depends on the inbound profiles.
+                'felix-to-abcd': set(['felix-p-prof-1-i',
+                                      'felix-p-prof-2-i'])
+            }
+        )
+        result = endpoint._get_endpoint_rules("e1", "abcd", 4,
+                                              ["10.0.0.1", "11.1.2.0/24"],
+                                              "aa:22:33:44:55:66",
+                                              ["prof-1", "prof-2"])
+
+        # Log the whole diff if the comparison fails.
+        self.maxDiff = None
+        self.assertEqual(result, expected_result)

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -285,31 +285,23 @@ class TestEndpoint(BaseTestCase):
                 [
                     # Always start with a 0 MARK.
                     from_pfx + ' --jump MARK --set-mark 0',
+                    # From chain polices the MAC address.
+                    from_pfx + ' --match mac ! --mac-source aa:22:33:44:55:66 '
+                               '--jump DROP --match comment --comment '
+                               '"Incorrect source MAC"',
 
-                    # Jump to the first profile iff the IP and MAC matches
-                    # the whitelist.
-                    from_pfx + ' --src 10.0.0.1/32 --match mac '
-                               '--mac-source AA:22:33:44:55:66 '
-                               '--jump felix-p-prof-1-o',
-                    from_pfx + ' --src 11.1.2.0/24 --match mac '
-                               '--mac-source AA:22:33:44:55:66 '
-                               '--jump felix-p-prof-1-o',
+                    # Jump to the first profile.
+                    from_pfx + ' --jump felix-p-prof-1-o',
                     # Short-circuit: return if the first profile matched.
                     from_pfx + ' --match mark --mark 1/1 --match comment '
-                               '--comment "Profile matched packet" '
+                               '--comment "Profile accepted packet" '
                                '--jump RETURN',
 
-                    # Jump to second profile iff the IP and MAC matches
-                    # the whitelist.
-                    from_pfx + ' --src 10.0.0.1/32 --match mac '
-                               '--mac-source AA:22:33:44:55:66 '
-                               '--jump felix-p-prof-2-o',
-                    from_pfx + ' --src 11.1.2.0/24 --match mac '
-                               '--mac-source AA:22:33:44:55:66 '
-                               '--jump felix-p-prof-2-o',
+                    # Jump to second profile.
+                    from_pfx + ' --jump felix-p-prof-2-o',
                     # Return if the second profile matched.
                     from_pfx + ' --match mark --mark 1/1 --match comment '
-                               '--comment "Profile matched packet" '
+                               '--comment "Profile accepted packet" '
                                '--jump RETURN',
 
                     # Drop the packet if nothing matched.
@@ -334,7 +326,8 @@ class TestEndpoint(BaseTestCase):
                              '--jump RETURN',
 
                     # Drop anything that doesn't match.
-                    to_pfx + ' --jump DROP -m comment --comment "Endpoint e1:"'
+                    to_pfx + ' --jump DROP -m comment --comment '
+                             '"Default DROP if no match (endpoint e1):"'
                 ]
             },
             {
@@ -346,8 +339,7 @@ class TestEndpoint(BaseTestCase):
                                       'felix-p-prof-2-i'])
             }
         )
-        result = endpoint._get_endpoint_rules("e1", "abcd", 4,
-                                              ["10.0.0.1", "11.1.2.0/24"],
+        result = endpoint._get_endpoint_rules("e1", "abcd",
                                               "aa:22:33:44:55:66",
                                               ["prof-1", "prof-2"])
 

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -228,9 +228,15 @@ class TestRules(BaseTestCase):
 
         m_v4_upd = Mock(spec=IptablesUpdater)
         m_v6_upd = Mock(spec=IptablesUpdater)
+        m_v6_raw_upd = Mock(spec=IptablesUpdater)
         m_v4_nat_upd = Mock(spec=IptablesUpdater)
 
-        frules.install_global_rules(m_config, m_v4_upd, m_v6_upd, m_v4_nat_upd)
+        frules.install_global_rules(m_config, m_v4_upd, m_v6_upd, m_v4_nat_upd,
+                                    m_v6_raw_upd)
+
+        m_v6_raw_upd.ensure_rule_inserted.assert_called_once_with(
+            'PREROUTING --in-interface tap+ --match rpfilter --invert -j DROP'
+        )
 
         m_ipset.ensure_exists.assert_called_once_with()
         self.assertEqual(

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -31,55 +31,67 @@ from calico.felix.test.base import BaseTestCase
 
 _log = logging.getLogger(__name__)
 
-DEFAULT_MARK = ('--append chain-foo --match comment '
-                '--comment "Mark as not matched" --jump MARK --set-mark 1')
+DEFAULT_MARK = '--append chain-foo --jump MARK --set-mark 1'
+
+DEFAULT_UNMARK = (
+    '--append chain-foo '
+    '--match comment --comment "No match, fall through to next profile" '
+    '--jump MARK --set-mark 0'
+)
+
 RULES_TESTS = [
     ([{"src_net": "10.0.0.0/8"},], 4,
-     ["--append chain-foo --source 10.0.0.0/8 --jump RETURN",
-      DEFAULT_MARK]),
+     [DEFAULT_MARK,
+      "--append chain-foo --source 10.0.0.0/8 --jump RETURN",
+      DEFAULT_UNMARK]),
 
     ([{"protocol": "icmp",
        "src_net": "10.0.0.0/8",
        "icmp_type": 7,
        "icmp_code": 123},], 4,
-     ["--append chain-foo --protocol icmp --source 10.0.0.0/8 "
+     [DEFAULT_MARK,
+      "--append chain-foo --protocol icmp --source 10.0.0.0/8 "
       "--match icmp --icmp-type 7/123 "
       "--jump RETURN",
-      DEFAULT_MARK]),
+      DEFAULT_UNMARK]),
 
     ([{"protocol": "icmp",
        "src_net": "10.0.0.0/8",
        "icmp_type": 7},], 4,
-     ["--append chain-foo --protocol icmp --source 10.0.0.0/8 "
+     [DEFAULT_MARK,
+      "--append chain-foo --protocol icmp --source 10.0.0.0/8 "
       "--match icmp --icmp-type 7 "
       "--jump RETURN",
-      DEFAULT_MARK]),
+      DEFAULT_UNMARK]),
 
     ([{"protocol": "icmpv6",
        "src_net": "1234::beef",
        "icmp_type": 7},], 6,
-     ["--append chain-foo --protocol icmpv6 --source 1234::beef "
+     [DEFAULT_MARK,
+      "--append chain-foo --protocol icmpv6 --source 1234::beef "
       "--match icmp6 --icmpv6-type 7 "
       "--jump RETURN",
-      DEFAULT_MARK]),
+      DEFAULT_UNMARK]),
 
     ([{"protocol": "tcp",
        "src_tag": "tag-foo",
        "src_ports": ["0:12", 13]}], 4,
-     ["--append chain-foo --protocol tcp "
+     [DEFAULT_MARK,
+      "--append chain-foo --protocol tcp "
       "--match set --match-set ipset-foo src "
       "--match multiport --source-ports 0:12,13 --jump RETURN",
-      DEFAULT_MARK]),
+      DEFAULT_UNMARK]),
 
     ([{"protocol": "tcp",
        "src_ports": [0, "2:3", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]}], 4,
-     ["--append chain-foo --protocol tcp "
+     [DEFAULT_MARK,
+      "--append chain-foo --protocol tcp "
       "--match multiport --source-ports 0,2:3,4,5,6,7,8,9,10,11,12,13,14,15 "
       "--jump RETURN",
       "--append chain-foo --protocol tcp "
       "--match multiport --source-ports 16,17 "
       "--jump RETURN",
-      DEFAULT_MARK]),
+      DEFAULT_UNMARK]),
 ]
 
 IP_SET_MAPPING = {

--- a/calico/felix/test/test_profilerules.py
+++ b/calico/felix/test/test_profilerules.py
@@ -44,15 +44,23 @@ RULES_1 = {
 
 RULES_1_CHAINS = {
     'felix-p-prof1-i': [
+        '--append felix-p-prof1-i --jump MARK --set-mark 1',
         '--append felix-p-prof1-i --match set '
             '--match-set src-tag-name src --jump RETURN',
-        '--append felix-p-prof1-i --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1'],
+        '--append felix-p-prof1-i '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ],
     'felix-p-prof1-o': [
+        '--append felix-p-prof1-o --jump MARK --set-mark 1',
         '--append felix-p-prof1-o --match set '
             '--match-set dst-tag-name dst --jump RETURN',
-        '--append felix-p-prof1-o --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1']
+        '--append felix-p-prof1-o '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ]
 }
 
 
@@ -68,15 +76,23 @@ RULES_2 = {
 
 RULES_2_CHAINS = {
     'felix-p-prof1-i': [
+        '--append felix-p-prof1-i --jump MARK --set-mark 1',
         '--append felix-p-prof1-i --match set '
             '--match-set src-tag-added-name src --jump RETURN',
-        '--append felix-p-prof1-i --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1'],
+        '--append felix-p-prof1-i '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ],
     'felix-p-prof1-o': [
+        '--append felix-p-prof1-o --jump MARK --set-mark 1',
         '--append felix-p-prof1-o --match set '
             '--match-set dst-tag-name dst --jump RETURN',
-        '--append felix-p-prof1-o --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1']
+        '--append felix-p-prof1-o '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ]
 }
 
 

--- a/docs/source/securing-calico.rst
+++ b/docs/source/securing-calico.rst
@@ -84,9 +84,9 @@ compute nodes and plugin.
 Other security options
 ----------------------
 
-Calico uses iptables rules to prevent workloads form spoofing IP addresses
+Calico uses iptables rules to prevent workloads from spoofing IP addresses
 However, the kernel also has a stronger reverse path filtering check that
 drops spoofed packets sooner in the pipeline.  We recommend turning that on
-in all producting deployments.  The kernel's RPF check is controlled by the
+in all production deployments.  The kernel's RPF check is controlled by the
 global and per-interface rp_filter sysctls.
 

--- a/docs/source/securing-calico.rst
+++ b/docs/source/securing-calico.rst
@@ -81,3 +81,12 @@ etcd release to improve this dramatically.  However, until that work is done,
 we recommend blocking access to etcd from all but the IP range(s) used by the
 compute nodes and plugin.
 
+Other security options
+----------------------
+
+Calico uses iptables rules to prevent workloads form spoofing IP addresses
+However, the kernel also has a stronger reverse path filtering check that
+drops spoofed packets sooner in the pipeline.  We recommend turning that on
+in all producting deployments.  The kernel's RPF check is controlled by the
+global and per-interface rp_filter sysctls.
+

--- a/docs/source/securing-calico.rst
+++ b/docs/source/securing-calico.rst
@@ -64,6 +64,10 @@ that is heading to or from a local endpoint is processed through the relevant
 security policy.  Then, if the policy accepts the traffic, it is accepted.
 If the policy rejects the traffic it is immediately dropped.
 
+To prevent IPv6-enabled endpoints from spoofing their IP addresses, Felix
+inserts a reverse path filtering rule in the iptables "raw" PREROUTING chain.
+(For IPv4, it enables the rp_filter sysctl on each interface that it controls.)
+
 Securing iptables
 -----------------
 
@@ -80,13 +84,3 @@ access to its REST interface.  We plan to use the RBAC feature of an upcoming
 etcd release to improve this dramatically.  However, until that work is done,
 we recommend blocking access to etcd from all but the IP range(s) used by the
 compute nodes and plugin.
-
-Other security options
-----------------------
-
-Calico uses iptables rules to prevent workloads from spoofing IP addresses
-However, the kernel also has a stronger reverse path filtering check that
-drops spoofed packets sooner in the pipeline.  We recommend turning that on
-in all production deployments.  The kernel's RPF check is controlled by the
-global and per-interface rp_filter sysctls.
-


### PR DESCRIPTION
* Enables the kernel's RPF checks explicitly for our interfaces.
* Simplifies the iptables profile dispatch rules and uses MARK==1 to indicate acceptance, which avoids the class of bug that was present before.
* Adds UT for _get_endpoint_rules().