### PR TITLE
Improve UT coverage of calico.datamodel_v1

### DIFF
--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -140,7 +140,7 @@ class EndpointId(object):
                 other.orchestrator == self.orchestrator)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not (self == other)
 
     def __hash__(self):
         return hash(self.endpoint) + hash(self.workload)

--- a/calico/test/test_datamodel_v1.py
+++ b/calico/test/test_datamodel_v1.py
@@ -86,3 +86,31 @@ class TestDatamodel(unittest.TestCase):
             get_profile_id_for_profile_dir("/calico/foo"), None)
         self.assertEquals(
             get_profile_id_for_profile_dir("/calico/v1/policy/profile/prof1/rules"), None)
+
+
+class TestEndpointId(unittest.TestCase):
+
+    def test_equality(self):
+        ep_id = EndpointId("localhost", "orchestrator", "workload", "endpoint")
+        self.assertTrue(ep_id == ep_id)
+        self.assertFalse(ep_id != ep_id)
+
+        self.assertFalse(ep_id == "not an endpoint id")
+        self.assertFalse(ep_id == 42)
+
+        bad_host_ep_id = EndpointId("notlocalhost", "orchestrator",
+                                    "workload", "endpoint")
+        self.assertFalse(ep_id == bad_host_ep_id)
+
+        bad_orchestrator_ep_id = EndpointId("hostname", "notanorchestrator",
+                                            "workload", "endpoint")
+        self.assertFalse(ep_id == bad_orchestrator_ep_id)
+
+        bad_workload_ep_id = EndpointId("hostname", "orchestrator",
+                                        "notworkload", "endpoint")
+        self.assertFalse(ep_id == bad_workload_ep_id)
+
+        bad_endpoint_ep_id = EndpointId("hostname", "orchestrator",
+                                        "workload", "notanendpoint")
+        self.assertFalse(ep_id == bad_endpoint_ep_id)
+        self.assertTrue(ep_id != bad_endpoint_ep_id)


### PR DESCRIPTION
Picking off some (very) low-hanging fruit in our UT coverage.

Old and new coverage statements, for comparison:

```
Name                            Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------
calico/datamodel_v1.py             58      3     10      2    93%   134, 136, 143, 133->134, 136
calico/datamodel_v1.py             58      0     10      0   100%
```