### PR TITLE
Use the kernel's RPF check instead of iptables rules.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1
+
+- Explicitly use and enable the kernel's reverse path filtering function,
+  remove our iptables anti-spoofing rules, which were not as robust.
+
 ## 1.0.0
 
 - Add support for setting MTU on IP-in-IP device.

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -33,6 +33,28 @@ from calico.felix.futils import FailedSystemCall
 _log = logging.getLogger(__name__)
 
 
+def check_kernel_config():
+    """
+    Checks the kernel configuration for problems that would break our
+    security guarantees, for example.
+
+    :raises BadKernelConfig if a problem is detected.
+    """
+
+    # To prevent workloads from spoofing their IP addresses, we need to set the
+    # per-interface rp_filter setting to 1, which enables strict RPF checking.
+    # Verify that the kernel's global setting won't override our per-interface
+    # setting with an insecure value.
+    ps_name = "/proc/sys/net/ipv4/conf/all/rp_filter"
+    rp_filter = int(_read_proc_sys(ps_name))
+    if rp_filter > 1:
+        _log.critical("Kernel's RPF check is set to 'loose'.  This would "
+                      "allow endpoints to spoof their IP address.  Calico "
+                      "requires net.ipv4.conf.all.rp_filter to be set to "
+                      "0 or 1.")
+        raise BadKernelConfig("net.ipv4.conf.all.rp_filter set to 'loose'")
+
+
 def interface_exists(interface):
     """
     Checks if an interface exists.
@@ -97,21 +119,20 @@ def configure_interface_ipv4(if_name):
     Configure the various proc file system parameters for the interface for
     IPv4.
 
-    Specifically, allow packets from controlled interfaces to be directed to
-    localhost, and enable proxy ARP.
+    Specifically,
+      - Allow packets from controlled interfaces to be directed to localhost
+      - Enable proxy ARP
+      - Enable the kernel's RPF check.
 
     :param if_name: The name of the interface to configure.
     :returns: None
     """
-    with open('/proc/sys/net/ipv4/conf/%s/route_localnet' % if_name,
-              'wb') as f:
-        f.write('1')
-
-    with open("/proc/sys/net/ipv4/conf/%s/proxy_arp" % if_name, 'wb') as f:
-        f.write('1')
-
-    with open("/proc/sys/net/ipv4/neigh/%s/proxy_delay" % if_name, 'wb') as f:
-        f.write('0')
+    # Enable the kernel's RPF check, which ensures that a VM cannot spoof
+    # its IP address.
+    _write_proc_sys('/proc/sys/net/ipv4/conf/%s/rp_filter' % if_name, 1)
+    _write_proc_sys('/proc/sys/net/ipv4/conf/%s/route_localnet' % if_name, 1)
+    _write_proc_sys("/proc/sys/net/ipv4/conf/%s/proxy_arp" % if_name, 1)
+    _write_proc_sys("/proc/sys/net/ipv4/neigh/%s/proxy_delay" % if_name, 0)
 
 
 def configure_interface_ipv6(if_name, proxy_target):
@@ -126,13 +147,22 @@ def configure_interface_ipv6(if_name, proxy_target):
     :returns: None
     :raises: FailedSystemCall
     """
-    with open("/proc/sys/net/ipv6/conf/%s/proxy_ndp" % if_name, 'wb') as f:
-        f.write('1')
+    _write_proc_sys("/proc/sys/net/ipv6/conf/%s/proxy_ndp" % if_name, 1)
 
     # Allows None if no IPv6 proxy target is required.
     if proxy_target:
         futils.check_call(["ip", "-6", "neigh", "add",
                            "proxy", str(proxy_target), "dev", if_name])
+
+
+def _read_proc_sys(name):
+    with open(name, "rb") as f:
+        return f.read().strip()
+
+
+def _write_proc_sys(name, value):
+    with open(name, "wb") as f:
+        f.write(str(value))
 
 
 def add_route(ip_type, ip, interface, mac):
@@ -358,3 +388,7 @@ class InterfaceWatcher(Actor):
                     else:
                         _log.debug("Network interface has gone away : %s",
                                    rta_data)
+
+
+class BadKernelConfig(Exception):
+    pass

--- a/calico/felix/test/test_profilerules.py
+++ b/calico/felix/test/test_profilerules.py
@@ -44,15 +44,23 @@ RULES_1 = {
 
 RULES_1_CHAINS = {
     'felix-p-prof1-i': [
+        '--append felix-p-prof1-i --jump MARK --set-mark 1',
         '--append felix-p-prof1-i --match set '
             '--match-set src-tag-name src --jump RETURN',
-        '--append felix-p-prof1-i --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1'],
+        '--append felix-p-prof1-i '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ],
     'felix-p-prof1-o': [
+        '--append felix-p-prof1-o --jump MARK --set-mark 1',
         '--append felix-p-prof1-o --match set '
             '--match-set dst-tag-name dst --jump RETURN',
-        '--append felix-p-prof1-o --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1']
+        '--append felix-p-prof1-o '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ]
 }
 
 
@@ -68,15 +76,23 @@ RULES_2 = {
 
 RULES_2_CHAINS = {
     'felix-p-prof1-i': [
+        '--append felix-p-prof1-i --jump MARK --set-mark 1',
         '--append felix-p-prof1-i --match set '
             '--match-set src-tag-added-name src --jump RETURN',
-        '--append felix-p-prof1-i --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1'],
+        '--append felix-p-prof1-i '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ],
     'felix-p-prof1-o': [
+        '--append felix-p-prof1-o --jump MARK --set-mark 1',
         '--append felix-p-prof1-o --match set '
             '--match-set dst-tag-name dst --jump RETURN',
-        '--append felix-p-prof1-o --match comment '
-            '--comment "Mark as not matched" --jump MARK --set-mark 1']
+        '--append felix-p-prof1-o '
+            '--match comment '
+            '--comment "No match, fall through to next profile" '
+            '--jump MARK --set-mark 0',
+    ]
 }
 
 

--- a/docs/source/securing-calico.rst
+++ b/docs/source/securing-calico.rst
@@ -64,6 +64,10 @@ that is heading to or from a local endpoint is processed through the relevant
 security policy.  Then, if the policy accepts the traffic, it is accepted.
 If the policy rejects the traffic it is immediately dropped.
 
+To prevent IPv6-enabled endpoints from spoofing their IP addresses, Felix
+inserts a reverse path filtering rule in the iptables "raw" PREROUTING chain.
+(For IPv4, it enables the rp_filter sysctl on each interface that it controls.)
+
 Securing iptables
 -----------------
 
@@ -80,4 +84,3 @@ access to its REST interface.  We plan to use the RBAC feature of an upcoming
 etcd release to improve this dramatically.  However, until that work is done,
 we recommend blocking access to etcd from all but the IP range(s) used by the
 compute nodes and plugin.
-


### PR DESCRIPTION
Our iptables rules were incorrect, so we required the kernel's
RPF check to be configured or packets could be spoofed.

This change

* explicitly enables the kernel's RPF check on each
  Calico-controlled interface
* explicitly checks that the global RPF value is compatible with
  a per-interface check
* removes our iptables rules that duplicate the RPF check
* adds unit tests for the per-endpoint rule generation code.

It also reverses the sense of the MARK value on a packet so that a
packet has MARK==1 iff a profile chain matches it.  This makes
the logic much simpler to understand and removes the original bug,
which was caused by conflating "packet was not marked as not
matched" and "packet was matched".

Fixes #790.