### PR TITLE
Add monotonic_time() function

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -188,6 +188,7 @@ class GreenletFilter(logging.Filter):
         record.tid = greenlet_id()
         return True
 
+
 def default_logging():
     """
     Sets up the Calico default logging, with default severities.

--- a/calico/monotonic.py
+++ b/calico/monotonic.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+calico.monotonic
+~~~~~~~~~~~~~~~~
+
+Monotonic clock functions.
+
+monotonic_time() should be used for timing and calculating timer pops
+in preference to time.time() which can be non-monotonic or jump
+wildly, especially in a VM.
+"""
+import logging
+
+_log = logging.getLogger(__name__)
+
+__all__ = ["monotonic_time"]
+
+import ctypes
+import os
+
+
+CLOCK_MONOTONIC_RAW = 4 # see <linux/time.h>
+
+
+class timespec(ctypes.Structure):
+    _fields_ = [
+        ('tv_sec', ctypes.c_long),
+        ('tv_nsec', ctypes.c_long)
+    ]
+
+
+librt = ctypes.CDLL('librt.so.1', use_errno=True)
+clock_gettime = librt.clock_gettime
+clock_gettime.argtypes = [ctypes.c_int, ctypes.POINTER(timespec)]
+
+
+def monotonic_time():
+    """
+    :returns: a time in seconds from an unspecified epoch (which may vary
+        between processes).  Guaranteed to be monotonic within the life of
+        a process.
+    """
+    t = timespec()
+    if clock_gettime(CLOCK_MONOTONIC_RAW , ctypes.pointer(t)) != 0:
+        errno_ = ctypes.get_errno()
+        raise OSError(errno_, os.strerror(errno_))
+    return t.tv_sec + t.tv_nsec * 1e-9

--- a/calico/test/test_monotonic.py
+++ b/calico/test/test_monotonic.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+calico.test.test_monotonic
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Test for monotonic clock functions.
+"""
+import logging
+import time
+from unittest import TestCase
+from calico.monotonic import monotonic_time
+
+_log = logging.getLogger(__name__)
+
+
+class TestMonotonic(TestCase):
+
+    def test_mainline(self):
+        a = monotonic_time()
+        time.sleep(0.01)
+        b = monotonic_time()
+        self.assertTrue(b >= a+0.01, msg="Monotonic time did not increase as "
+                                         "expected: %s, %s" % (a, b))


### PR DESCRIPTION
This is the monotonic-time branch rebased against master and with tweaked tox settings.

It's required for #732. I'm trying to get a clean UT pass, so that we might be able to merge it.

UT failures from the original monotonic-time branch [are in a Gist](https://gist.github.com/alexwlchan/c99921d9b8af21d416a0). Seems to be passing now, but I want to get Jenkins to double check before I take this further.