### PR TITLE
Blacklist gevent 1.1b4 for breaking PyPy UTs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,4 +22,4 @@ deps =
     unittest2
     git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
     git+https://github.com/projectcalico/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
-    gevent>=1.1a2, !=1.1b1, !=1.1b2
+    gevent>=1.1a2, !=1.1b1, !=1.1b2, !=1.1b4


### PR DESCRIPTION
1.1b4 dropped three hours ago, and now UTs are failing on PyPy; e.g. <http://calico-jenkins:8080/job/pull-request/1068/console>

I'm getting the same problems with a fresh clone that was previously passing clean.