### PR TITLE
Fix UTs with PyPy + cryptography

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,3 +23,4 @@ deps =
     git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
     git+https://github.com/projectcalico/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
     gevent>=1.1a2, !=1.1b1, !=1.1b2, !=1.1b4
+    cryptography<=1.0


### PR DESCRIPTION
cryptography 1.0.1 only supports PyPy 2.6 and higher, but our CI rig only has PyPy 2.2. This is a quick test to confirm that it really is cryptography causing the failures, not a separate regression.