### PR TITLE
Add coveralls coverage status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Coverage Status](https://coveralls.io/repos/projectcalico/calico/badge.svg?branch=HEAD&service=github)](https://coveralls.io/github/projectcalico/calico?branch=HEAD)
 # Project Calico
 
 Project Calico represents a new approach to virtual networking, based on the


### PR DESCRIPTION
@lwr20 thought we could try out coveralls, which the calico-docker team seem to be using.  It puts our coverage number in a badge on github and gives us a graph over time.