### PR TITLE
Juju: Give Cinder, Keystone and Nova cloud controller their own nodes

### DIFF
--- a/docs/source/_static/juju/bundle.yaml
+++ b/docs/source/_static/juju/bundle.yaml
@@ -6,8 +6,6 @@ envExport:
       annotations:
         "gui-x": "1045.973572253264"
         "gui-y": "544.8983810601128"
-      to:
-        - "rabbitmq-server=0"
     "neutron-calico":
       charm: "cs:~project-calico/trusty/neutron-calico-4"
       num_units: 0
@@ -32,8 +30,6 @@ envExport:
       annotations:
         "gui-x": "646.4326692255784"
         "gui-y": "544.8983810601128"
-      to:
-        - "rabbitmq-server=0"
     glance:
       charm: "cs:trusty/glance-22"
       num_units: 1
@@ -74,8 +70,6 @@ envExport:
       annotations:
         "gui-x": "1045.973572253264"
         "gui-y": "198.88580918716224"
-      to:
-        - "rabbitmq-server=0"
     "neutron-api":
       charm: "cs:~project-calico/trusty/neutron-api-2"
       num_units: 1

--- a/docs/source/_static/juju/bundle.yaml
+++ b/docs/source/_static/juju/bundle.yaml
@@ -30,6 +30,8 @@ envExport:
       annotations:
         "gui-x": "646.4326692255784"
         "gui-y": "544.8983810601128"
+      options:
+        "admin-password": "openstack"
     glance:
       charm: "cs:trusty/glance-22"
       num_units: 1

--- a/docs/source/juju-opens-install.rst
+++ b/docs/source/juju-opens-install.rst
@@ -22,6 +22,9 @@ environment using `any of the standard methods`_. This will get you a simple
 OpenStack deployment with two compute nodes, which you can then easily scale
 out by adding more instances of the ``nova-compute`` charm.
 
+The default admin password for the deployment is "openstack" - you may wish to
+update this in the bundle (search for the keystone "admin-password" option).
+
 For more detailed information, please see `this blog post`_ on the Calico blog.
 
 .. _Juju Charms: https://jujucharms.com/


### PR DESCRIPTION
I was seeing haproxy problems when deploying with the old bundle - haproxy was only set up for keystone, not nova (which was on the same node).  As a result attempts to connect to nova failed because haproxy wasn't listening on the right ports.

I found a similar problem with Cinder.

It might be possible to move Keystone back onto the rabbitmq-server node, or perhaps colocate some of these services with something less picky (say etcd or BIRD, which shouldn't rely on HAProxy), but for now this bundle works for me.