### PR TITLE
Rev python-etcd to 0.4.1+calico.1.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 - Add liveness reporting to Felix.  Felix now reports its liveness into
   etcd and the neutron driver copies that information to the Neutron DB.
 - Performance enhancements to ipset manipulation.
+- Rev python-etcd dependency to 0.4.1.  Our patched python-etcd version
+  (which contains additional patches) is still required.
 
 ## 1.1.0
 

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -23,8 +23,6 @@ from collections import defaultdict
 import functools
 import os
 import random
-from socket import timeout as SocketTimeout
-import httplib
 import json
 import logging
 from calico.monotonic import monotonic_time
@@ -33,8 +31,6 @@ from etcd import EtcdException, EtcdKeyNotFound
 import gevent
 import sys
 from gevent.event import Event
-import urllib3.exceptions
-from urllib3.exceptions import ReadTimeoutError, ConnectTimeoutError
 
 from calico import common
 from calico.common import ValidationFailed, validate_ip_addr, canonicalise_ip
@@ -169,12 +165,7 @@ class EtcdAPI(EtcdClientOwner, Actor):
         while True:
             try:
                 self._update_felix_status(ttl)
-            except (ReadTimeoutError,
-                    SocketTimeout,
-                    ConnectTimeoutError,
-                    urllib3.exceptions.HTTPError,
-                    httplib.HTTPException,
-                    EtcdException) as e:
+            except EtcdException as e:
                 # Sadly, we can get exceptions from any one of the layers
                 # below python-etcd or from python-etcd itself.  Catch them
                 # all and keep trying...

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -20,7 +20,6 @@
 # Standard Python library imports.
 from collections import namedtuple
 import functools
-import httplib
 import json
 import re
 import socket
@@ -42,7 +41,6 @@ except ImportError:  # Kilo
 # Calico imports.
 from eventlet.semaphore import Semaphore
 import etcd
-import urllib3.exceptions
 from calico.datamodel_v1 import (READY_KEY, CONFIG_DIR, TAGS_KEY_RE, HOST_DIR,
                                  key_for_endpoint, PROFILE_DIR, RULES_KEY_RE,
                                  key_for_profile, key_for_profile_rules,
@@ -107,10 +105,7 @@ def _handling_etcd_exceptions(fn):
     def wrapped(self, *args, **kwargs):
         try:
             return fn(self, *args, **kwargs)
-        except (etcd.EtcdException,
-                urllib3.exceptions.HTTPError,
-                httplib.HTTPException,
-                socket.error):
+        except etcd.EtcdException:
             LOG.exception("Request to etcd failed. This will cause the "
                           "current API call to fail.")
             self._on_etcd_request_failed()

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -30,8 +30,6 @@ import calico.openstack.t_etcd as t_etcd
 
 from calico import common
 from calico.datamodel_v1 import FELIX_STATUS_DIR
-from socket import timeout as SocketTimeout
-from urllib3.exceptions import ReadTimeoutError
 
 
 class EtcdException(Exception):
@@ -157,7 +155,8 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         """
         self.maybe_reset_etcd()
 
-        # Slow down reading from etcd status subtree to allow threads to run more often
+        # Slow down reading from etcd status subtree to allow threads to run
+        # more often
         if wait and key == FELIX_STATUS_DIR:
             eventlet.sleep(30)
             self.driver.db.create_or_update_agent = mock.Mock()

--- a/calico/test/stub_etcd.py
+++ b/calico/test/stub_etcd.py
@@ -34,6 +34,9 @@ class EtcdKeyNotFound(EtcdException):
 class EtcdClusterIdChanged(EtcdException):
     pass
 
+class EtcdConnectionFailed(EtcdException):
+    pass
+
 class EtcdEventIndexCleared(EtcdException):
     pass
 

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Architecture: all
 Depends:
  calico-common (= ${binary:Version}),
  python-six,
- python-etcd (>= 0.3.3-1calico0.15),
+ python-etcd (>= 0.4.1+calico.1),
  ${misc:Depends},
  ${python:Depends}
 Description: Project Calico virtual networking for cloud data centers.
@@ -73,7 +73,7 @@ Depends:
  net-tools,
  python-netaddr,
  python-gevent,
- python-etcd (>= 0.3.3-1calico0.15),
+ python-etcd (>= 0.4.1+calico.1),
  python-posix-spawn,
  ${misc:Depends},
  ${python:Depends},

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,5 +1,5 @@
 gevent
 greenlet
 netaddr
-python-etcd>=0.3.3-calico-2
+python-etcd>=0.4.1
 posix-spawn>=0.2.post6

--- a/openstack_plugin_requirements.txt
+++ b/openstack_plugin_requirements.txt
@@ -1,3 +1,3 @@
 eventlet
 six
-python-etcd
+python-etcd>=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,10 @@ def collect_requirements():
     return reqs
 
 setuptools.setup(
-    name = "calico",
-    version = "1.1.0",
-    packages = setuptools.find_packages(),
-    entry_points = {
+    name="calico",
+    version="1.1.0",
+    packages=setuptools.find_packages(),
+    entry_points={
         'console_scripts': [
             'calico-felix = calico.felix.felix:main',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     coverage==4.0a5
     unittest2
     git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
-    git+https://github.com/projectcalico/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
+    git+https://github.com/projectcalico/python-etcd.git@160f62a20dd0daaf66ba1ef52362b38ee0074ff5#egg=python-etcd
 commands=nosetests --with-coverage
 
 [testenv:pypy]
@@ -21,5 +21,5 @@ deps =
     coverage==4.0a5
     unittest2
     git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
-    git+https://github.com/projectcalico/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
+    git+https://github.com/projectcalico/python-etcd.git@160f62a20dd0daaf66ba1ef52362b38ee0074ff5#egg=python-etcd
     gevent>=1.1a2, !=1.1b1, !=1.1b2, !=1.1b4


### PR DESCRIPTION
Main change in the API is that exceptions are now wrapped, which allows us
to combine a lot of except clauses.