### PR TITLE
Add per-port status reporting to Felix and Neutron driver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 - Add liveness reporting to Felix.  Felix now reports its liveness into
   etcd and the neutron driver copies that information to the Neutron DB.
+  If Felix is down on a host, Neutron will not try to schedule a VM on 
+  that host.
+- Add endpoint status reporting to Felix.  Felix now reports the state of 
+  endpoints into etcd so that the OpenStack plugin can reprort this 
+  information into Neutron.  If Felix fails to configure a port, this now
+  causes VM creation to fail.
 - Performance enhancements to ipset manipulation.
 - Rev python-etcd dependency to 0.4.1.  Our patched python-etcd version
   (which contains additional patches) is still required.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
   If Felix is down on a host, Neutron will not try to schedule a VM on 
   that host.
 - Add endpoint status reporting to Felix.  Felix now reports the state of 
-  endpoints into etcd so that the OpenStack plugin can reprort this 
+  endpoints into etcd so that the OpenStack plugin can report this 
   information into Neutron.  If Felix fails to configure a port, this now
   causes VM creation to fail.
 - Performance enhancements to ipset manipulation.

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -65,7 +65,8 @@ RULES_KEY_RE = re.compile(
 # "profile_id".
 TAGS_KEY_RE = re.compile(
     r'^' + PROFILE_DIR + r'/(?P<profile_id>[^/]+)/tags')
-# Regex to match endpoints, captures "hostname" and "endpoint_id".
+# Regex to match endpoints, captures "hostname" and "endpoint_id".  Works for
+# endpoint configuration and endpoint status paths.
 ENDPOINT_KEY_RE = re.compile(
     r'^(?:' + HOST_DIR + r'|' + FELIX_STATUS_DIR + r')'
     r'/(?P<hostname>[^/]+)/'

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -67,7 +67,7 @@ TAGS_KEY_RE = re.compile(
     r'^' + PROFILE_DIR + r'/(?P<profile_id>[^/]+)/tags')
 # Regex to match endpoints, captures "hostname" and "endpoint_id".
 ENDPOINT_KEY_RE = re.compile(
-    r'^' + HOST_DIR +
+    r'^(?:' + HOST_DIR + r'|' + FELIX_STATUS_DIR + r')'
     r'/(?P<hostname>[^/]+)/'
     r'workload/'
     r'(?P<orchestrator>[^/]+)/'
@@ -79,6 +79,7 @@ HOST_IP_KEY_RE = re.compile(r'^' + HOST_DIR +
 
 IPAM_V4_CIDR_KEY_RE = re.compile(r'^' + VERSION_DIR +
                                  r'/ipam/v4/pool/(?P<encoded_cidr>[^/]+)')
+
 
 def dir_for_host(hostname):
     return HOST_DIR+ "/%s" % hostname
@@ -133,6 +134,20 @@ def get_profile_id_for_profile_dir(key):
     return final_node if prefix == PROFILE_DIR else None
 
 
+def get_endpoint_id_from_key(key):
+    m = ENDPOINT_KEY_RE.match(key)
+    if m:
+        # Got an endpoint.
+        host = m.group("hostname")
+        orch = m.group("orchestrator")
+        workload_id = m.group("workload_id")
+        endpoint_id = m.group("endpoint_id")
+        combined_id = EndpointId(host, orch, workload_id, endpoint_id)
+        return combined_id
+    else:
+        return None
+
+
 def hostname_from_status_key(key):
     """
     Get hostname from a status key (or None if this is not a status key).
@@ -160,6 +175,12 @@ class EndpointId(object):
         self.orchestrator = intern(orchestrator.encode("utf8"))
         self.workload = intern(workload.encode("utf8"))
         self.endpoint = intern(endpoint.encode("utf8"))
+
+    @property
+    def path_for_status(self):
+        return "/".join([FELIX_STATUS_DIR, self.host,
+                         "workload", self.orchestrator, self.workload,
+                         "endpoint", self.endpoint])
 
     def __str__(self):
         return self.__class__.__name__ + ("<%s>" % self.endpoint)

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -158,7 +158,7 @@ def hostname_from_status_key(key):
 
     :param: key for felix status
             expected key format: FELIX_STATUS_DIR/<hostname>/
-                                           <some path or not>/<actual key name>
+                                                      <some path or not>/status
     """
     if not key.startswith(FELIX_STATUS_DIR) or not key.endswith("/status"):
         return None

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -80,6 +80,10 @@ HOST_IP_KEY_RE = re.compile(r'^' + HOST_DIR +
 IPAM_V4_CIDR_KEY_RE = re.compile(r'^' + VERSION_DIR +
                                  r'/ipam/v4/pool/(?P<encoded_cidr>[^/]+)')
 
+ENDPOINT_STATUS_UP = "up"
+ENDPOINT_STATUS_DOWN = "down"
+ENDPOINT_STATUS_ERROR = "error"
+
 
 def dir_for_host(hostname):
     return HOST_DIR+ "/%s" % hostname

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -86,7 +86,7 @@ ENDPOINT_STATUS_ERROR = "error"
 
 
 def dir_for_host(hostname):
-    return HOST_DIR+ "/%s" % hostname
+    return HOST_DIR + "/%s" % hostname
 
 
 def dir_for_per_host_config(hostname):

--- a/calico/etcdutils.py
+++ b/calico/etcdutils.py
@@ -325,24 +325,27 @@ class EtcdWatcher(EtcdClientOwner):
         pass
 
 
-def delete_empty_parents(client, child_key, root_key, timeout=DEFAULT_TIMEOUT):
+def delete_empty_parents(client, child_dir, root_key, timeout=DEFAULT_TIMEOUT):
     """
-    Attempts to delete child_key and any empty parent directories.
+    Attempts to delete child_dir and any empty parent directories.
 
     Makes a best effort.  If any of the deletes fail, gives up.  This
     method is safe, even if another client is writing to the directory (the
     delete will fail if the directory becomes non-empty).
 
     :param client: EtcdClient
-    :param child_key: Key to delete, along with its parents.
+    :param child_dir: Key to delete, along with its parents, should be a
+           directory.
     :param root_key: Prefix of child_key to stop at.  Will not be deleted.
     :param timeout: Timeout to use on the etcd delete operation.
     """
-    path_segments = child_key.strip("/").split("/")
+    _log.debug("Deleting empty directories from %s down to %s", child_dir,
+               root_key)
+    path_segments = child_dir.strip("/").split("/")
     root_path_segments = root_key.strip("/").split("/")
     if path_segments[:len(root_path_segments)] != root_path_segments:
         raise ValueError("child_key %r must start with root key %r" %
-                         (child_key, root_key))
+                         (child_dir, root_key))
     for num_seg_to_strip in xrange(len(path_segments) -
                                    len(root_path_segments)):
         key_segments = path_segments[:len(path_segments) - num_seg_to_strip]

--- a/calico/etcdutils.py
+++ b/calico/etcdutils.py
@@ -341,7 +341,8 @@ def delete_empty_parents(client, child_key, root_key, timeout=DEFAULT_TIMEOUT):
     path_segments = child_key.strip("/").split("/")
     root_path_segments = root_key.strip("/").split("/")
     if path_segments[:len(root_path_segments)] != root_path_segments:
-        raise ValueError("child_key must start with root key")
+        raise ValueError("child_key %r must start with root key %r" %
+                         (child_key, root_key))
     for num_seg_to_strip in xrange(len(path_segments) -
                                    len(root_path_segments)):
         key_segments = path_segments[:len(path_segments) - num_seg_to_strip]

--- a/calico/etcdutils.py
+++ b/calico/etcdutils.py
@@ -27,6 +27,9 @@ ACTION_MAPPING = {
 }
 
 
+DEFAULT_TIMEOUT = 5
+
+
 class PathDispatcher(object):
     def __init__(self):
         self.handler_root = {}
@@ -320,6 +323,41 @@ class EtcdWatcher(EtcdClientOwner):
         :param etcd_snapshot_response: Etcd response containing a complete dump.
         """
         pass
+
+
+def delete_empty_parents(client, child_key, root_key, timeout=DEFAULT_TIMEOUT):
+    """
+    Attempts to delete child_key and any empty parent directories.
+
+    Makes a best effort.  If any of the deletes fail, gives up.  This
+    method is safe, even if another client is writing to the directory (the
+    delete will fail if the directory becomes non-empty).
+
+    :param client: EtcdClient
+    :param child_key: Key to delete, along with its parents.
+    :param root_key: Prefix of child_key to stop at.  Will not be deleted.
+    :param timeout: Timeout to use on the etcd delete operation.
+    """
+    path_segments = child_key.strip("/").split("/")
+    root_path_segments = root_key.strip("/").split("/")
+    if path_segments[:len(root_path_segments)] != root_path_segments:
+        raise ValueError("child_key must start with root key")
+    for num_seg_to_strip in xrange(len(path_segments) -
+                                   len(root_path_segments)):
+        key_segments = path_segments[:len(path_segments) - num_seg_to_strip]
+        key_to_delete = "/".join(key_segments)
+        try:
+            client.delete(key_to_delete, dir=True, timeout=timeout)
+        except etcd.EtcdKeyNotFound:
+            _log.debug("Key %s already deleted", key_to_delete)
+            continue
+        except etcd.EtcdDirNotEmpty:
+            _log.debug("Directory %s not empty, giving up", key_to_delete)
+            break
+        except etcd.EtcdException as e:
+            _log.warning("Failed to delete %s (%r), skipping.",
+                         key_to_delete, e)
+            break
 
 
 class ResyncRequired(Exception):

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -203,6 +203,13 @@ class Config(object):
         self.add_parameter("ReportingTTLSecs",
                            "Status report time to live in seconds",
                            90, value_is_int=True)
+        self.add_parameter("EndpointReportingEnabled",
+                           "Whether Felix should report per-endpoint status "
+                           "into etcd",
+                           False, value_is_bool=True)
+        self.add_parameter("EndpointReportingDelaySecs",
+                           "Minimum delay between per-endpoint status reports",
+                           1, value_is_int=True)
 
         # Read the environment variables, then the configuration file.
         self._read_env_vars()
@@ -255,6 +262,10 @@ class Config(object):
         self.IP_IN_IP_MTU = self.parameters["IpInIpMtu"].value
         self.REPORTING_INTERVAL_SECS = self.parameters["ReportingIntervalSecs"].value
         self.REPORTING_TTL_SECS = self.parameters["ReportingTTLSecs"].value
+        self.REPORT_ENPOINT_STATUS = \
+            self.parameters["EndpointReportingEnabled"].value
+        self.ENDPOINT_REPORT_DELAY = \
+            self.parameters["EndpointReportingDelaySecs"].value
 
         self._validate_cfg(final=final)
 
@@ -405,6 +416,10 @@ class Config(object):
                 self.REPORTING_TTL_SECS == 0):
             log.warning("Reporting TTL set to %s.", self.REPORTING_TTL_SECS)
             self.REPORTING_TTL_SECS = self.REPORTING_INTERVAL_SECS * 5/2
+
+        if self.ENDPOINT_REPORT_DELAY < 0:
+            log.warning("Endpoint status delay is negative, defaulting to 1.")
+            self.ENDPOINT_REPORT_DELAY = 1
 
         if not final:
             # Do not check that unset parameters are defaulted; we have more

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -262,7 +262,7 @@ class Config(object):
         self.IP_IN_IP_MTU = self.parameters["IpInIpMtu"].value
         self.REPORTING_INTERVAL_SECS = self.parameters["ReportingIntervalSecs"].value
         self.REPORTING_TTL_SECS = self.parameters["ReportingTTLSecs"].value
-        self.REPORT_ENPOINT_STATUS = \
+        self.REPORT_ENDPOINT_STATUS = \
             self.parameters["EndpointReportingEnabled"].value
         self.ENDPOINT_REPORT_DELAY = \
             self.parameters["EndpointReportingDelaySecs"].value

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -417,11 +417,14 @@ class InterfaceWatcher(Actor):
                         _log.debug("IFLA_OPERSTATE: %s", operstate)
 
                 if (ifname and
-                    ifname in if_last_flags and
-                    (msg_type == RTM_DELLINK or operstate != IF_OPER_UP)):
+                        ifname in if_last_flags and
+                        (msg_type == RTM_DELLINK or operstate != IF_OPER_UP)):
                     # An interface that we've previously signalled is
                     # being deleted or oper down, so remove our record
                     # of it.
+                    self.update_splitter.on_interface_update(ifname,
+                                                             iface_up=False,
+                                                             async=True)
                     del if_last_flags[ifname]
 
                 if (ifname and
@@ -438,6 +441,7 @@ class InterfaceWatcher(Actor):
                     _log.debug("New network interface : %s %x", ifname, flags)
                     if_last_flags[ifname] = flags
                     self.update_splitter.on_interface_update(ifname,
+                                                             iface_up=True,
                                                              async=True)
 
 

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -446,6 +446,7 @@ class LocalEndpoint(RefCountedActor):
                 if self.endpoint.get("state") != pending_endpoint.get("state"):
                     _log.debug("Desired interface state updated.")
                     self._device_in_sync = False
+                    self._iptables_in_sync = False
                 if (self.endpoint[self.nets_key] !=
                         pending_endpoint[self.nets_key]):
                     # IP addresses have changed, need to update the routing

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -328,14 +328,17 @@ class LocalEndpoint(RefCountedActor):
 
     def _maybe_update_status(self):
         # Work out what status we should report back to the orchestrator.
-        if self._missing_deps:
+        if self._missing_deps or not self._device_in_sync:
             # We're not ready yet, say we're down.
+            # FIXME: device not being in sync could be an error
             status = ENDPOINT_STATUS_DOWN
         elif self._iptables_in_sync and self._device_in_sync:
             # We're in-sync and have all our dependencies, we're up.
             status = ENDPOINT_STATUS_UP
         else:
             # We have our dependencies but we're not in sync, must be an error.
+            _log.warning("Failed to bring iptables into sync, endpoint is"
+                         "in error.")
             status = ENDPOINT_STATUS_ERROR
         if self._unreferenced or status != self._last_status:
             if self._unreferenced:

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -340,7 +340,8 @@ class LocalEndpoint(RefCountedActor):
             _log.warning("Failed to bring iptables into sync, endpoint is"
                          "in error.")
             status = ENDPOINT_STATUS_ERROR
-        if self._unreferenced or status != self._last_status:
+        if (self.config.REPORT_ENDPOINT_STATUS and
+                (self._unreferenced or status != self._last_status)):
             if self._unreferenced:
                 _log.debug("Unreferenced, reporting status = None")
                 status_dict = None

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -357,7 +357,7 @@ class LocalEndpoint(RefCountedActor):
                 _log.debug("Endpoint oper state changed to %s", status)
                 status_dict = {"status": status}
             self.datastore_api.on_endpoint_status_changed(
-                self._id,
+                self.combined_id,
                 status_dict,
                 async=True,
             )

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -334,6 +334,9 @@ class LocalEndpoint(RefCountedActor):
         self._maybe_update_status()
 
     def _maybe_update_status(self):
+        if not self.config.REPORT_ENDPOINT_STATUS:
+            _log.debug("Status reporting disabled. Not reporting status.")
+            return
         # Work out what status we should report back to the orchestrator.
         if self._missing_deps or not self._device_in_sync:
             # We're not ready yet, say we're down.
@@ -358,8 +361,7 @@ class LocalEndpoint(RefCountedActor):
             _log.warning("Failed to bring iptables into sync, endpoint is"
                          "in error.")
             status = ENDPOINT_STATUS_ERROR
-        if (self.config.REPORT_ENDPOINT_STATUS and
-                (self._unreferenced or status != self._last_status)):
+        if self._unreferenced or status != self._last_status:
             if self._unreferenced:
                 _log.debug("Unreferenced, reporting status = None")
                 status_dict = None

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -43,7 +43,7 @@ class EndpointManager(ReferenceManager):
                  iptables_updater,
                  dispatch_chains,
                  rules_manager,
-                 datastore_api):
+                 status_reporter):
         super(EndpointManager, self).__init__(qualifier=ip_type)
 
         # Configuration and version to use
@@ -55,7 +55,7 @@ class EndpointManager(ReferenceManager):
         self.iptables_updater = iptables_updater
         self.dispatch_chains = dispatch_chains
         self.rules_mgr = rules_manager
-        self.datastore_api = datastore_api
+        self.status_reporter = status_reporter
 
         # All endpoint dicts that are on this host.
         self.endpoints_by_id = {}
@@ -76,7 +76,7 @@ class EndpointManager(ReferenceManager):
                              self.iptables_updater,
                              self.dispatch_chains,
                              self.rules_mgr,
-                             self.datastore_api)
+                             self.status_reporter)
 
     def _on_object_started(self, endpoint_id, obj):
         """
@@ -175,7 +175,7 @@ class EndpointManager(ReferenceManager):
 class LocalEndpoint(RefCountedActor):
 
     def __init__(self, config, combined_id, ip_type, iptables_updater,
-                 dispatch_chains, rules_manager, datastore_api):
+                 dispatch_chains, rules_manager, status_reporter):
         """
         Controls a single local endpoint.
 
@@ -201,7 +201,7 @@ class LocalEndpoint(RefCountedActor):
 
         self.rules_ref_helper = RefHelper(self, rules_manager,
                                           self._on_profiles_ready)
-        self.datastore_api = datastore_api
+        self.status_reporter = status_reporter
 
         self._pending_endpoint = None
         self._endpoint_update_pending = False
@@ -366,7 +366,7 @@ class LocalEndpoint(RefCountedActor):
             else:
                 _log.debug("Endpoint oper state changed to %s", status)
                 status_dict = {"status": status}
-            self.datastore_api.on_endpoint_status_changed(
+            self.status_reporter.on_endpoint_status_changed(
                 self.combined_id,
                 status_dict,
                 async=True,

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -370,6 +370,7 @@ class LocalEndpoint(RefCountedActor):
                 status_dict = {"status": status}
             self.status_reporter.on_endpoint_status_changed(
                 self.combined_id,
+                self.ip_type,
                 status_dict,
                 async=True,
             )

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -83,7 +83,8 @@ def _main_greenlet(config):
                                         IPV4,
                                         v4_filter_updater,
                                         v4_dispatch_chains,
-                                        v4_rules_manager)
+                                        v4_rules_manager,
+                                        etcd_api)
 
         v6_raw_updater = IptablesUpdater("raw", ip_version=6, config=config)
         v6_filter_updater = IptablesUpdater("filter", ip_version=6,
@@ -95,7 +96,8 @@ def _main_greenlet(config):
                                         IPV6,
                                         v6_filter_updater,
                                         v6_dispatch_chains,
-                                        v6_rules_manager)
+                                        v6_rules_manager,
+                                        etcd_api)
 
         update_splitter = UpdateSplitter(config,
                                          [v4_ipset_mgr, v6_ipset_mgr],

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -84,7 +84,7 @@ def _main_greenlet(config):
                                         v4_filter_updater,
                                         v4_dispatch_chains,
                                         v4_rules_manager,
-                                        etcd_api)
+                                        etcd_api.status_reporter)
 
         v6_raw_updater = IptablesUpdater("raw", ip_version=6, config=config)
         v6_filter_updater = IptablesUpdater("filter", ip_version=6,
@@ -97,7 +97,7 @@ def _main_greenlet(config):
                                         v6_filter_updater,
                                         v6_dispatch_chains,
                                         v6_rules_manager,
-                                        etcd_api)
+                                        etcd_api.status_reporter)
 
         update_splitter = UpdateSplitter(config,
                                          [v4_ipset_mgr, v6_ipset_mgr],

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -579,6 +579,9 @@ class _FelixEtcdWatcher(EtcdWatcher, gevent.Greenlet):
             for node in response.leaves:
                 combined_id = get_endpoint_id_from_key(node.key)
                 if combined_id and combined_id not in our_endpoints_ids:
+                    # We found an endpoint in our status reporting tree that
+                    # wasn't in the main tree.  Mark it as dirty so the status
+                    # reporting thread will clean it up.
                     _log.debug("Endpoint %s removed by resync, marking "
                                "status key for cleanup",
                                combined_id)

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -180,9 +180,6 @@ class EtcdAPI(EtcdClientOwner, Actor):
             try:
                 self._update_felix_status(ttl)
             except EtcdException as e:
-                # Sadly, we can get exceptions from any one of the layers
-                # below python-etcd or from python-etcd itself.  Catch them
-                # all and keep trying...
                 _log.warning("Error when trying to check into etcd (%r), "
                              "retrying after %s seconds.", e, RETRY_DELAY)
                 self.reconnect()

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -733,6 +733,7 @@ class EtcdStatusReporter(EtcdClientOwner, Actor):
         """
         Triggers a rewrite of all endpoint statuses.
         """
+        # Loop over IPv4 and IPv6 statuses.
         for statuses in self._endpoint_status.itervalues():
             for ep_id in statuses.iterkeys():
                 self._mark_endpoint_dirty(ep_id)

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -721,6 +721,7 @@ class EtcdStatusReporter(EtcdClientOwner, Actor):
 
     @actor_message()
     def on_endpoint_status_changed(self, endpoint_id, ip_type, status):
+        assert isinstance(endpoint_id, EndpointId)
         if status is not None:
             self._endpoint_status[ip_type][endpoint_id] = status
         else:
@@ -732,8 +733,9 @@ class EtcdStatusReporter(EtcdClientOwner, Actor):
         """
         Triggers a rewrite of all endpoint statuses.
         """
-        for ep_id in self._endpoint_status.iterkeys():
-            self._mark_endpoint_dirty(ep_id)
+        for statuses in self._endpoint_status.itervalues():
+            for ep_id in statuses.iterkeys():
+                self._mark_endpoint_dirty(ep_id)
 
     @actor_message()
     def _on_timer_pop(self):
@@ -746,6 +748,7 @@ class EtcdStatusReporter(EtcdClientOwner, Actor):
         self._mark_endpoint_dirty(endpoint_id)
 
     def _mark_endpoint_dirty(self, endpoint_id):
+        assert isinstance(endpoint_id, EndpointId)
         if endpoint_id in self._older_dirty_endpoints:
             # Optimization: if the endpoint is already queued up in
             # _older_dirty_endpoints then there's no point in queueing it up a

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -235,9 +235,7 @@ class EtcdAPI(EtcdClientOwner, Actor):
 
     def write_endpoint_status_to_etcd(self, ep_id, status):
         if status:
-            self.client.set("/".join([FELIX_STATUS_DIR,
-                                      self._config.HOSTNAME,
-                                      "workload"]),
+            self.client.set(ep_id.path_for_status,
                             json.dumps(status))
         else:
             try:

--- a/calico/felix/splitter.py
+++ b/calico/felix/splitter.py
@@ -144,7 +144,7 @@ class UpdateSplitter(Actor):
             ipset_mgr.on_tags_update(profile_id, tags, async=True)
 
     @actor_message()
-    def on_interface_update(self, name):
+    def on_interface_update(self, name, iface_up):
         """
         Called when an interface state has changed.
 
@@ -152,7 +152,7 @@ class UpdateSplitter(Actor):
         """
         _log.info("Interface %s state changed", name)
         for endpoint_mgr in self.endpoint_mgrs:
-            endpoint_mgr.on_interface_update(name, async=True)
+            endpoint_mgr.on_interface_update(name, iface_up, async=True)
 
     @actor_message()
     def on_endpoint_update(self, endpoint_id, endpoint):

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -371,17 +371,19 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep._pending_endpoint = data.copy()
         local_ep._pending_endpoint["state"] = "inactive"
         local_ep._apply_endpoint_update()
-        self.assertTrue(local_ep._iptables_in_sync)
+        self.assertFalse(local_ep._iptables_in_sync)
         self.assertFalse(local_ep._device_in_sync)
         local_ep._device_in_sync = True
+        local_ep._iptables_in_sync = True
 
         # Set the state back again...
         local_ep._pending_endpoint = data.copy()
         local_ep._pending_endpoint["state"] = "active"
         local_ep._apply_endpoint_update()
-        self.assertTrue(local_ep._iptables_in_sync)
+        self.assertFalse(local_ep._iptables_in_sync)
         self.assertFalse(local_ep._device_in_sync)
         local_ep._device_in_sync = True
+        local_ep._iptables_in_sync = True
 
         # Profiles update.  Should update iptables.
         data = {'endpoint': "endpoint_id", 'mac': mac,

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -44,6 +44,7 @@ class TestLocalEndpoint(BaseTestCase):
         super(TestLocalEndpoint, self).setUp()
         self.m_config = Mock(spec=config.Config)
         self.m_config.IFACE_PREFIX = "tap"
+        self.m_config.REPORT_ENDPOINT_STATUS = False
         self.m_iptables_updater = Mock(spec=IptablesUpdater)
         self.m_dispatch_chains = Mock(spec=DispatchChains)
         self.m_rules_mgr = Mock(spec=RulesManager)

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -20,6 +20,7 @@ Tests of endpoint module.
 """
 import logging
 from calico.felix.endpoint import EndpointManager
+from calico.felix.fetcd import EtcdAPI
 from calico.felix.fiptables import IptablesUpdater
 from calico.felix.dispatch import DispatchChains
 from calico.felix.futils import FailedSystemCall
@@ -47,6 +48,7 @@ class TestLocalEndpoint(BaseTestCase):
         self.m_dispatch_chains = Mock(spec=DispatchChains)
         self.m_rules_mgr = Mock(spec=RulesManager)
         self.m_manager = Mock(spec=EndpointManager)
+        self.m_etcd_api = Mock(spec=EtcdAPI)
 
     def get_local_endpoint(self, combined_id, ip_type):
         local_endpoint = endpoint.LocalEndpoint(self.m_config,
@@ -54,7 +56,8 @@ class TestLocalEndpoint(BaseTestCase):
                                                 ip_type,
                                                 self.m_iptables_updater,
                                                 self.m_dispatch_chains,
-                                                self.m_rules_mgr)
+                                                self.m_rules_mgr,
+                                                self.m_etcd_api)
         local_endpoint._manager = self.m_manager
         return local_endpoint
 

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -418,7 +418,7 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep = self.get_local_endpoint(combined_id, ip_type)
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
-            combined_id, {'status': 'down'}, async=True
+            combined_id, futils.IPV4, {'status': 'down'}, async=True
         )
 
     def test_maybe_update_status_iptables_failure(self):
@@ -433,7 +433,7 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep._device_has_been_in_sync = True
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
-            combined_id, {'status': 'error'}, async=True
+            combined_id, futils.IPV4, {'status': 'error'}, async=True
         )
 
     def test_maybe_update_status_iptables_up(self):
@@ -450,7 +450,7 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep._device_has_been_in_sync = True
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
-            combined_id, {'status': 'up'}, async=True
+            combined_id, futils.IPV4, {'status': 'up'}, async=True
         )
 
     def test_maybe_update_status_iptables_unreferenced(self):
@@ -462,7 +462,7 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep.on_unreferenced(async=True)
         self.step_actor(local_ep)
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
-            combined_id, None, async=True
+            combined_id, futils.IPV4, None, async=True
         )
 
 

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -115,6 +115,7 @@ class TestEtcdAPI(BaseTestCase):
     def test_force_resync(self, m_spawn, m_etcd_watcher):
         m_config = Mock(spec=Config)
         m_config.ETCD_ADDR = ETCD_ADDRESS
+        m_config.REPORT_ENDPOINT_STATUS = False
         m_hosts_ipset = Mock(spec=IpsetActor)
         api = EtcdAPI(m_config, m_hosts_ipset)
         api.force_resync(async=True)

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -714,6 +714,10 @@ class TestEtcdStatusReporter(BaseTestCase):
             m_spawn.mock_calls,
             [call(ANY, self.rep._on_timer_pop, async=True)]
         )
+        spawn_delay = m_spawn.call_args[0][0]
+        self.assertTrue(spawn_delay >= 0.89999)
+        self.assertTrue(spawn_delay <= 1.10001)
+
         self.assertTrue(self.rep._timer_scheduled)
         self.assertFalse(self.rep._reporting_allowed)
         # Cache should be cleaned up.

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -135,7 +135,10 @@ class TestEtcdWatcher(BaseTestCase):
         self.m_config.IFACE_PREFIX = "tap"
         self.m_config.ETCD_ADDR = ETCD_ADDRESS
         self.m_hosts_ipset = Mock(spec=IpsetActor)
-        self.watcher = _FelixEtcdWatcher(self.m_config, self.m_hosts_ipset)
+        self.m_api = Mock(spec=EtcdAPI)
+        self.watcher = _FelixEtcdWatcher(self.m_config,
+                                         self.m_api,
+                                         self.m_hosts_ipset)
         self.m_splitter = Mock(spec=UpdateSplitter)
         self.watcher.splitter = self.m_splitter
         self.client = Mock()

--- a/calico/felix/test/test_splitter.py
+++ b/calico/felix/test/test_splitter.py
@@ -229,7 +229,7 @@ class TestUpdateSplitter(BaseTestCase):
         interface = 'tapABCDEF'
 
         # Apply the interface update
-        s.on_interface_update(interface, async=True)
+        s.on_interface_update(interface, iface_up=True, async=True)
         self.step_actor(s)
 
         # Confirm that the interface update propagates.

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -29,7 +29,8 @@ import eventlet
 
 from collections import namedtuple
 from functools import wraps
-from sqlalchemy.orm import exc
+from sqlalchemy.orm import exc as orm_exc
+from sqlalchemy import exc as sa_exc
 
 # OpenStack imports.
 from neutron.common import constants
@@ -301,13 +302,14 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                             with_lockmode("update").
                             filter(models_v2.Port.id.startswith(port_id)).
                             one())
-                except exc.NoResultFound:
+                except orm_exc.NoResultFound:
                     LOG.info("Port %s not found, nothing to do", port_id)
                 else:
                     self.db.update_port_status(self._db_context,
                                                port_id,
                                                port_status)
-        except db_exc.DBError:
+        except (db_exc.DBError,
+                sa_exc.SQLAlchemyError):
             LOG.exception("Failed to update port status for %s. Giving up.",
                           port_id)
 

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -267,7 +267,11 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             port_status = PORT_STATUS_MAPPING.get(status.get("status"),
                                                   constants.PORT_STATUS_ERROR)
         else:
-            port_status = constants.PORT_STATUS_DOWN
+            # Report deletion as error.  Either the port has genuinely been
+            # deleted, in which case this update is ignored by
+            # update_port_status or the port still exists but we disagree,
+            # which is an error.
+            port_status = constants.PORT_STATUS_ERROR
         self.db.update_port_status(self._db_context,
                                    port_id,
                                    port_status)

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -46,10 +46,20 @@ from calico.datamodel_v1 import ENDPOINT_STATUS_UP, ENDPOINT_STATUS_DOWN, \
 
 try:  # Icehouse, Juno
     from neutron.openstack.common import log
-    from neutron.openstack.common.db import exception as db_exc
 except ImportError:  # Kilo
     from oslo_log import log
-    from oslo_db import exception as db_exc
+
+try:
+    # Icehouse.
+    from neutron.openstack.common.db import exception as db_exc
+except ImportError:
+    try:
+        # Juno.
+        from oslo.db import exception as db_exc
+    except ImportError:
+        # Latest.
+        from oslo_db import exception as db_exc
+
 
 # Calico imports.
 import etcd

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -739,12 +739,14 @@ class CalicoEtcdWatcher(EtcdWatcher):
         statuses is deleted.  Cleans up either the specific workload
         or the whole host.
         """
-        LOG.info("One of the per-host directories for host %s, workload "
-                 "%s deleted.", hostname, workload)
+        LOG.debug("One of the per-host directories for host %s, workload "
+                  "%s deleted.", hostname, workload)
         endpoints_on_host = self._endpoints_by_host[hostname]
         for endpoint_id in [ep_id for ep_id in endpoints_on_host if
                             workload is None or workload == ep_id.workload]:
-            LOG.info("Status report for %s deleted", endpoint_id)
+            LOG.info("Directory containing status report for %s deleted;"
+                     "updating port status",
+                     endpoint_id)
             endpoints_on_host.discard(endpoint_id)
             self.calico_driver.on_port_status_changed(
                 hostname,

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -668,7 +668,7 @@ class CalicoEtcdWatcher(EtcdWatcher):
         Called when Felix's status key expires.  Implies felix is dead.
         """
         LOG.error("Felix on host %s failed to check in.  Marking the "
-                  "ports it was managing as in-error.")
+                  "ports it was managing as in-error.", hostname)
         for endpoint_id in self._endpoints_by_host[hostname]:
             # Flag all the ports as being in error.  They're no longer
             # receiving security updates.

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -268,10 +268,13 @@ class CalicoTransportEtcd(object):
         # First read the config values, so as to avoid unnecessary
         # writes.
         prefix = None
+        reporting_enabled = None
         ready = None
         iface_pfx_key = key_for_config('InterfacePrefix')
+        reporting_key = key_for_config('EndpointReportingEnabled')
         try:
             prefix = self.client.read(iface_pfx_key).value
+            reporting_enabled = self.client.read(reporting_key).value
             ready = self.client.read(READY_KEY).value
         except etcd.EtcdKeyNotFound:
             LOG.info('%s values are missing', CONFIG_DIR)
@@ -280,6 +283,9 @@ class CalicoTransportEtcd(object):
         if prefix != 'tap':
             LOG.info('%s -> tap', iface_pfx_key)
             self.client.write(iface_pfx_key, 'tap')
+        if reporting_enabled != "true":
+            LOG.info('%s -> true', reporting_enabled)
+            self.client.write(reporting_key, 'true')
         if ready != 'true':
             # TODO Set this flag only once we're really ready!
             LOG.info('%s -> true', READY_KEY)

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -567,7 +567,8 @@ class CalicoEtcdWatcher(EtcdWatcher):
 
         # Register for felix uptime updates.
         self.register_path(FELIX_STATUS_DIR + "/<hostname>/status",
-                           on_set=self._on_status_set)
+                           on_set=self._on_status_set,
+                           on_del=self._on_status_del)
         # Register for per-port status updates.
         self.register_path(FELIX_STATUS_DIR + "/<hostname>/workload/openstack/"
                                               "<workload>/endpoint/<endpoint>",

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -735,7 +735,7 @@ class CalicoEtcdWatcher(EtcdWatcher):
 
     def _on_per_host_dir_delete(self, response, hostname, workload=None):
         """
-        Called when one the the directories that may contain endpoint
+        Called when one of the directories that may contain endpoint
         statuses is deleted.  Cleans up either the specific workload
         or the whole host.
         """

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -749,7 +749,7 @@ class CalicoEtcdWatcher(EtcdWatcher):
             self.calico_driver.on_port_status_changed(
                 hostname,
                 endpoint_id.endpoint,
-                None,
+                None
             )
         if not endpoints_on_host:
             del self._endpoints_by_host[hostname]

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -903,12 +903,13 @@ class TestDriverStatusReporting(lib.Lib, unittest.TestCase):
     def test_on_port_status_changed(self):
         self.driver._get_db()
         self.driver._db_context = mock.Mock()
-        self.db.update_port_status.side_effect = [lib.DBError(), None]
+        self.driver._db_context.session = mock.MagicMock()
+        self.db.update_port_status.side_effect = lib.DBError()
         self.driver.on_port_status_changed("host",
                                            "port_id",
                                            {"status": "up"})
 
-        self.db.update_port_status.side_effect = [lib.DBError(), lib.DBError()]
+        self.db.update_port_status.side_effect = None
         self.driver.on_port_status_changed("host",
                                            "port_id",
                                            None)
@@ -916,10 +917,10 @@ class TestDriverStatusReporting(lib.Lib, unittest.TestCase):
             self.db.update_port_status.mock_calls,
             [mock.call(self.driver._db_context,
                        "port_id",
-                       lib.m_constants.PORT_STATUS_ACTIVE)] * 2 +
-            [mock.call(self.driver._db_context,
+                       lib.m_constants.PORT_STATUS_ACTIVE),
+             mock.call(self.driver._db_context,
                        "port_id",
-                       lib.m_constants.PORT_STATUS_ERROR)] * 2
+                       lib.m_constants.PORT_STATUS_ERROR)]
         )
 
 

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -922,6 +922,19 @@ class TestDriverStatusReporting(lib.Lib, unittest.TestCase):
                        "port_id",
                        lib.m_constants.PORT_STATUS_ERROR)]
         )
+        self.db.update_port_status.reset_mock()
+
+    def test_on_port_status_changed_not_found(self):
+        self.driver._get_db()
+        self.driver._db_context = mock.Mock()
+        self.driver._db_context.session = mock.MagicMock()
+        self.driver._db_context.session.query.side_effect = lib.NoResultFound()
+        self.db.update_port_status.side_effect = RuntimeError()
+        self.driver.on_port_status_changed("host",
+                                           "port_id",
+                                           {"status": "up"})
+        self.assertEqual(self.db.update_port_status.mock_calls, [])
+        self.db.update_port_status.reset_mock()
 
 
 class TestCalicoEtcdWatcher(unittest.TestCase):

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -193,6 +193,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         self.simulated_time_advance(31)
         self.assertEtcdWrites(
             {'/calico/v1/config/InterfacePrefix': 'tap',
+             '/calico/v1/config/EndpointReportingEnabled': True,
              '/calico/v1/Ready': True,
              '/calico/v1/policy/profile/SGID-default/rules':
                  {"outbound_rules": [{"dst_ports": ["1:65535"],
@@ -229,6 +230,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         self.simulated_time_advance(31)
         expected_writes = {
             '/calico/v1/config/InterfacePrefix': 'tap',
+            '/calico/v1/config/EndpointReportingEnabled': True,
             '/calico/v1/Ready': True,
             '/calico/v1/host/felix-host-1/workload/openstack/instance-1/endpoint/DEADBEEF-1234-5678':
                 {"name": "tapDEADBEEF-12",
@@ -318,7 +320,6 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         }
         self.assertEtcdWrites(expected_writes)
         self.assertEtcdDeletes(set())
-        self.check_update_port_status_called(context)
 
         # Migrate port1 to a different host.
         context._port = lib.port1.copy()
@@ -338,7 +339,6 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         }
         self.assertEtcdWrites(expected_writes)
         self.assertEtcdDeletes(set(['/calico/v1/host/felix-host-1/workload/openstack/instance-1/endpoint/DEADBEEF-1234-5678']))
-        self.check_update_port_status_called(context)
 
         # Now resync again, moving self.osdb_ports to move port 1 back to the
         # old host felix-host-1.  The effect will be as though we've
@@ -392,7 +392,6 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         }
         self.assertEtcdWrites(expected_writes)
         self.assertEtcdDeletes(set())
-        self.check_update_port_status_called(context)
         self.osdb_ports = [lib.port1, lib.port2, context._port]
 
         # Create a new security group.
@@ -527,8 +526,6 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
                 ["SG-1"]
         }
         self.assertEtcdWrites(expected_writes)
-        self.check_update_port_status_called(context)
-
 
         # Resync with all latest data - expect no etcd writes or deletes.
         print "\nResync with existing etcd data\n"

--- a/calico/test/lib.py
+++ b/calico/test/lib.py
@@ -27,10 +27,14 @@ import sys
 sys.modules['etcd'] = m_etcd = mock.MagicMock()
 sys.modules['neutron'] = m_neutron = mock.MagicMock()
 sys.modules['neutron.common'] = m_neutron.common
+sys.modules['neutron.common.constants'] = m_constants = m_neutron.common.constants
 sys.modules['neutron.common.exceptions'] = m_neutron.common.exceptions
 sys.modules['neutron.db'] = m_neutron.db
 sys.modules['neutron.openstack'] = m_neutron.openstack
 sys.modules['neutron.openstack.common'] = m_neutron.openstack.common
+sys.modules['neutron.openstack.common.db'] = m_neutron.openstack.common.db
+sys.modules['neutron.openstack.common.db.exception'] = \
+    m_neutron.openstack.common.db.exception
 sys.modules['neutron.plugins'] = m_neutron.plugins
 sys.modules['neutron.plugins.ml2'] = m_neutron.plugins.ml2
 sys.modules['neutron.plugins.ml2.drivers'] = m_neutron.plugins.ml2.drivers
@@ -106,6 +110,13 @@ m_etcd.EtcdClusterIdChanged = EtcdClusterIdChanged
 m_etcd.EtcdEventIndexCleared = EtcdEventIndexCleared
 m_etcd.EtcdValueError = EtcdValueError
 m_etcd.EtcdDirNotEmpty = EtcdDirNotEmpty
+
+
+class DBError(Exception):
+    pass
+
+
+m_neutron.openstack.common.db.exception.DBError = DBError
 
 
 # Define a stub class, that we will use as the base class for

--- a/calico/test/lib.py
+++ b/calico/test/lib.py
@@ -41,6 +41,9 @@ sys.modules['neutron.plugins.ml2.drivers'] = m_neutron.plugins.ml2.drivers
 sys.modules['neutron.plugins.ml2.rpc'] = m_neutron.plugins.ml2.rpc
 sys.modules['oslo'] = m_oslo = mock.Mock()
 sys.modules['oslo.config'] = m_oslo.config
+sys.modules['sqlalchemy'] = m_sqlalchemy = mock.Mock()
+sys.modules['sqlalchemy.orm'] = m_sqlalchemy.orm
+sys.modules['sqlalchemy.orm.exc'] = m_sqlalchemy.orm.exc
 
 port1 = {'binding:vif_type': 'tap',
          'binding:host_id': 'felix-host-1',
@@ -117,6 +120,13 @@ class DBError(Exception):
 
 
 m_neutron.openstack.common.db.exception.DBError = DBError
+
+
+class NoResultFound(Exception):
+    pass
+
+
+m_sqlalchemy.orm.exc.NoResultFound = NoResultFound
 
 
 # Define a stub class, that we will use as the base class for

--- a/calico/test/lib.py
+++ b/calico/test/lib.py
@@ -92,10 +92,20 @@ class EtcdEventIndexCleared(EtcdException):
     pass
 
 
+class EtcdValueError(EtcdException):
+    pass
+
+
+class EtcdDirNotEmpty(EtcdValueError):
+    pass
+
+
 m_etcd.EtcdException = EtcdException
 m_etcd.EtcdKeyNotFound = EtcdKeyNotFound
 m_etcd.EtcdClusterIdChanged = EtcdClusterIdChanged
 m_etcd.EtcdEventIndexCleared = EtcdEventIndexCleared
+m_etcd.EtcdValueError = EtcdValueError
+m_etcd.EtcdDirNotEmpty = EtcdDirNotEmpty
 
 
 # Define a stub class, that we will use as the base class for


### PR DESCRIPTION
Note: rebased onto branch smc-fix-status-tight-loop, which was needed to fix up the UTs.

* [x] Add worker thread to EtcdAPI to report port status.
* [x] Add logic to LocalEndpoint to track whether port programming succeeded or not and report to EtcdAPI
* [x] Implement cleanup logic in felix to sync keys and refresh status on resync.
* [x] Add watches in neutron driver to listen for status updates and apply them to the Neutron database. 
* ~~[ ] Add cleanup logic in neutron driver to remove outdated port statuses.~~
* [x] Make it configurable in Felix so it is disabled in environments that don't use it yet (containers)
* [x] UTs for Felix
* [x] UTs for Neutron
* [x] Report interfaces going down
* [x] Fix issues with IPv6 and IPv4 interfaces clobbering each other