### PR TITLE
Fix tight loop if watched etcd key does not exist.

### DIFF
--- a/calico/felix/test/__init__.py
+++ b/calico/felix/test/__init__.py
@@ -1,5 +1,19 @@
-# Copyright (c) Metaswitch Networks 2015. All rights reserved.
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+from calico.test import lib
 import logging
 
 _log = logging.getLogger(__name__)

--- a/calico/felix/test/base.py
+++ b/calico/felix/test/base.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-
 import logging
 import sys
-import gevent
 import gc
+
+import gevent
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -138,7 +138,7 @@ class TestEtcdWatcher(BaseTestCase):
         self.watcher = _FelixEtcdWatcher(self.m_config, self.m_hosts_ipset)
         self.m_splitter = Mock(spec=UpdateSplitter)
         self.watcher.splitter = self.m_splitter
-        self.client = Mock(spec=etcd.Client)
+        self.client = Mock()
         self.watcher.client = self.client
 
     @patch("gevent.sleep", autospec=True)

--- a/calico/openstack/test/__init__.py
+++ b/calico/openstack/test/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from calico.test import lib

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -19,39 +19,17 @@ openstack.test.test_plugin_etcd
 Unit test for the Calico/OpenStack Plugin using etcd transport.
 """
 import copy
-import eventlet
 import json
-import mock
 import unittest
 
-import calico.openstack.test.lib as lib
+import eventlet
+import mock
+
+import calico.test.lib as lib
 import calico.openstack.mech_calico as mech_calico
 import calico.openstack.t_etcd as t_etcd
-
 from calico import common
 from calico.datamodel_v1 import FELIX_STATUS_DIR
-
-
-class EtcdException(Exception):
-    pass
-
-
-class EtcdKeyNotFound(EtcdException):
-    pass
-
-
-class EtcdClusterIdChanged(EtcdException):
-    pass
-
-
-class EtcdEventIndexCleared(EtcdException):
-    pass
-
-
-lib.m_etcd.EtcdException = EtcdException
-lib.m_etcd.EtcdKeyNotFound = EtcdKeyNotFound
-lib.m_etcd.EtcdClusterIdChanged = EtcdClusterIdChanged
-lib.m_etcd.EtcdEventIndexCleared = EtcdEventIndexCleared
 
 
 class TestPluginEtcd(lib.Lib, unittest.TestCase):
@@ -135,7 +113,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
             try:
                 del self.etcd_data[key]
             except KeyError:
-                raise EtcdKeyNotFound()
+                raise lib.EtcdKeyNotFound()
             self.recent_deletes.add(key)
 
     def assertEtcdWrites(self, expected):

--- a/calico/test/__init__.py
+++ b/calico/test/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from calico.test import lib

--- a/calico/test/lib.py
+++ b/calico/test/lib.py
@@ -76,6 +76,28 @@ port3 = {'binding:vif_type': 'tap',
          'status': 'ACTIVE'}
 
 
+class EtcdException(Exception):
+    pass
+
+
+class EtcdKeyNotFound(EtcdException):
+    pass
+
+
+class EtcdClusterIdChanged(EtcdException):
+    pass
+
+
+class EtcdEventIndexCleared(EtcdException):
+    pass
+
+
+m_etcd.EtcdException = EtcdException
+m_etcd.EtcdKeyNotFound = EtcdKeyNotFound
+m_etcd.EtcdClusterIdChanged = EtcdClusterIdChanged
+m_etcd.EtcdEventIndexCleared = EtcdEventIndexCleared
+
+
 # Define a stub class, that we will use as the base class for
 # CalicoMechanismDriver.
 class DriverBase(object):


### PR DESCRIPTION
Required promotion of etcd stub library to avoid order dependence in UTs.