### PR TITLE
Remove some unused imports

### DIFF
--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -35,7 +35,6 @@ import gevent.lock
 from gevent import subprocess
 from gevent.subprocess import Popen
 import tempfile
-import time
 import pkg_resources
 from posix_spawn import posix_spawnp, FileActions
 

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -19,7 +19,6 @@ felix.test.test_config
 Top level tests for Felix configuration.
 """
 
-from collections import namedtuple
 import logging
 import re
 import mock

--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -20,7 +20,6 @@ Test the device handling code.
 """
 import logging
 import mock
-import os
 import sys
 import uuid
 from contextlib import nested

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -23,10 +23,8 @@ import gevent
 from calico.felix import config
 import mock
 import sys
-import time
 
 import calico.felix.test.stub_etcd as stub_etcd
-import calico.felix.futils as futils
 import calico.felix.felix as felix
 from calico.felix.test.base import BaseTestCase
 

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -19,7 +19,7 @@ felix.test.test_frules
 Tests of iptables rules generation function.
 """
 import logging
-from mock import Mock, patch, call, ANY
+from mock import Mock, patch, call
 from calico.felix import frules
 from calico.felix.config import Config
 from calico.felix.fiptables import IptablesUpdater

--- a/calico/felix/test/test_futils.py
+++ b/calico/felix/test/test_futils.py
@@ -20,9 +20,7 @@ Test Felix utils.
 """
 import logging
 import mock
-import os
 import sys
-import uuid
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/calico/felix/test/test_masq.py
+++ b/calico/felix/test/test_masq.py
@@ -18,8 +18,6 @@ felix.test.test_masq
 
 Unit tests for the MasqueradeManager.
 """
-from collections import defaultdict
-
 import logging
 from mock import *
 from calico.felix.fiptables import IptablesUpdater

--- a/calico/felix/test/test_refcount.py
+++ b/calico/felix/test/test_refcount.py
@@ -7,7 +7,6 @@ from calico.felix.refcount import ReferenceManager, RefCountedActor, \
 from calico.felix.test.base import BaseTestCase
 from calico.felix.test.test_actor import ActorForTesting
 from gevent.event import AsyncResult
-import mock
 
 _log = logging.getLogger(__name__)
 

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -20,11 +20,9 @@ Common code for Neutron driver UT.
 """
 import eventlet
 import eventlet.queue
-from eventlet.support import greenlets as greenlet
 import inspect
 import mock
 import sys
-import traceback
 
 sys.modules['etcd'] = m_etcd = mock.MagicMock()
 sys.modules['neutron'] = m_neutron = mock.MagicMock()

--- a/calico/test/test_common.py
+++ b/calico/test/test_common.py
@@ -23,7 +23,6 @@ from collections import namedtuple
 import eventlet
 import logging
 import mock
-import os
 import sys
 
 if sys.version_info < (2, 7):

--- a/calico/test/test_datamodel_v1.py
+++ b/calico/test/test_datamodel_v1.py
@@ -20,7 +20,6 @@ Test data model key calculations etc.
 """
 
 import logging
-import mock
 import unittest
 
 from calico.datamodel_v1 import *


### PR DESCRIPTION
I ran `flake8 *.py **/*.py` over the entire repo, and corrected all
the reports of unused imports.