### PR TITLE
Set the kernel's default rp_filter setting for new interfaces to strict.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   (which contains additional patches) is still required.
 - Reduce occupancy of Felix's tag resolution index in the common case
   where IP addresses only have a single owner.
+- Felix now sets the default.rp_filter sysctl to ensure that endpoints
+  come up with the Kernel's RPF check enabled by default.
 
 ## 1.1.0
 

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -66,8 +66,9 @@ def _main_greenlet(config):
         config_loaded = etcd_api.load_config(async=False)
         config_loaded.wait()
 
-        # Check for any incorrect kernel configuration that would break Calico.
-        devices.check_kernel_config()
+        # Ensure the Kernel's global options are correctly configured for
+        # Calico.
+        devices.configure_global_kernel_config()
 
         _log.info("Main greenlet: Configuration loaded, starting remaining "
                   "actors...")

--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -48,16 +48,21 @@ class TestDevices(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_check_kernel_config(self):
+    def test_configure_global_kernel_config(self):
         with mock.patch("calico.felix.devices._read_proc_sys",
                         autospec=True, return_value="1") as m_read_proc_sys:
-            devices.check_kernel_config()
+            with mock.patch("calico.felix.devices._write_proc_sys",
+                            autospec=True) as m_write_proc_sys:
+                devices.configure_global_kernel_config()
+        m_write_proc_sys.assert_called_once_with(
+            "/proc/sys/net/ipv4/conf/default/rp_filter", "1"
+        )
 
-    def test_check_kernel_config_bad_rp_filter(self):
+    def test_configure_global_kernel_config_bad_rp_filter(self):
         with mock.patch("calico.felix.devices._read_proc_sys",
                         autospec=True, return_value="2") as m_read_proc_sys:
             self.assertRaises(devices.BadKernelConfig,
-                              devices.check_kernel_config)
+                              devices.configure_global_kernel_config)
 
     def test_read_proc_sys(self):
         m_open = mock.mock_open(read_data="1\n")

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -48,7 +48,8 @@ class TestBasic(BaseTestCase):
         else:
             sys.modules['etcd'] = self._real_etcd
 
-    @mock.patch("calico.felix.devices.check_kernel_config", autospec=True)
+    @mock.patch("calico.felix.devices.configure_global_kernel_config",
+                autospec=True)
     @mock.patch("calico.felix.devices.interface_up",
                 return_value=False, autospec=True)
     @mock.patch("calico.felix.devices.interface_exists",
@@ -65,7 +66,7 @@ class TestBasic(BaseTestCase):
                            m_IptablesUpdater, m_UpdateSplitter,
                            m_start, m_load,
                            m_ipset_4, m_check_call, m_iface_exists,
-                           m_iface_up, m_check_kernel_config):
+                           m_iface_up, m_configure_global_kernel_config):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
         m_MasqueradeManager.return_value.greenlet = mock.Mock()
         m_UpdateSplitter.return_value.greenlet = mock.Mock()
@@ -84,7 +85,7 @@ class TestBasic(BaseTestCase):
         m_load.assert_called_once_with(async=False)
         m_iface_exists.assert_called_once_with("tunl0")
         m_iface_up.assert_called_once_with("tunl0")
-        m_check_kernel_config.assert_called_once_with()
+        m_configure_global_kernel_config.assert_called_once_with()
 
         # Check all IptablesUpdaters get passed to the splitter, which handles
         # cleanup.


### PR DESCRIPTION
Closes a race with felix configuring the interface.

Fixes #806.