### PR TITLE
Move python-etcd dependence to calico-common.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,6 @@ Architecture: all
 Depends:
  calico-common (= ${binary:Version}),
  python-six,
- python-etcd (>= 0.4.1+calico.1),
  ${misc:Depends},
  ${python:Depends}
 Description: Project Calico virtual networking for cloud data centers.
@@ -52,7 +51,8 @@ Architecture: all
 Depends:
  ${misc:Depends},
  ${python:Depends},
- ${shlibs:Depends}
+ ${shlibs:Depends},
+ python-etcd (>= 0.4.1+calico.1)
 Description: Project Calico virtual networking for cloud data centers.
  Project Calico is an open source solution for virtual networking in
  cloud data centers. Its IP-centric architecture offers numerous
@@ -73,7 +73,6 @@ Depends:
  net-tools,
  python-netaddr,
  python-gevent,
- python-etcd (>= 0.4.1+calico.1),
  python-posix-spawn,
  ${misc:Depends},
  ${python:Depends},


### PR DESCRIPTION
Prevent upgrade of the actual Calico code on Ubuntu unless python-etcd
is also updated.

Fixes #812.