### PR TITLE
Optimization: use logging.disable() to set logging level.

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -282,6 +282,15 @@ def complete_logging(logfile=None,
             file_handler.setFormatter(formatter)
             root_logger.addHandler(file_handler)
 
+    # Optimization: disable all logging below the minimum level that we care
+    # about.  The global "disable" setting is the first thing that gets checked
+    # in the logging framework so it's the fastest way to disable logging.
+    levels = [file_level, syslog_level, stream_level]
+    # Map None to something greater than the highest logging level.
+    levels = [l if l is not None else logging.CRITICAL + 1 for l in levels]
+    min_log_level = min(levels)
+    logging.disable(min_log_level - 1)
+
     _log.info("Logging initialized")
 
 


### PR DESCRIPTION
This reduces the overhead of each logging call.