### PR TITLE
Multinode devstack

### DIFF
--- a/debian/calico-compute.install
+++ b/debian/calico-compute.install
@@ -1,3 +1,4 @@
 usr/bin/calico-gen-bird-conf.sh usr/bin
 usr/bin/calico-gen-bird6-conf.sh usr/bin
+usr/bin/calico-gen-bird-mesh-conf.sh usr/bin
 usr/share/calico/* usr/share/calico

--- a/etc/bird/calico-bird-peer.conf.template
+++ b/etc/bird/calico-bird-peer.conf.template
@@ -1,0 +1,14 @@
+
+# Peer with route reflector.
+protocol bgp @ID@ {
+  description "@DESCRIPTION@";
+  local as @AS_NUMBER@;
+  neighbor @PEER_IP_ADDRESS@ as @AS_NUMBER@;
+  multihop;
+  import all;
+  graceful restart;
+  export filter export_bgp;
+  next hop self;    # Disable next hop processing and always advertise our
+                    # local address as nexthop
+  source address @MY_IP_ADDRESS@;  # The local address we use for the TCP connection
+}

--- a/etc/bird/calico-bird-peer.conf.template
+++ b/etc/bird/calico-bird-peer.conf.template
@@ -1,6 +1,6 @@
 
 # Peer with route reflector.
-protocol bgp @ID@ {
+protocol bgp '@ID@' {
   description "@DESCRIPTION@";
   local as @AS_NUMBER@;
   neighbor @PEER_IP_ADDRESS@ as @AS_NUMBER@;

--- a/etc/bird/calico-bird.conf.template
+++ b/etc/bird/calico-bird.conf.template
@@ -40,17 +40,3 @@ protocol direct {
    debug all;
    interface "-dummy0", "dummy1", "eth*", "em*", "en*", "br-mgmt";
 }
-
-# Peer with route reflector.
-protocol bgp N1 {
-  description "Connection to BGP route reflector";
-  local as @AS_NUMBER@;
-  neighbor @RR_IP_ADDRESS@ as @AS_NUMBER@;
-  multihop;
-  import all;
-  graceful restart;
-  export filter export_bgp;
-  next hop self;    # Disable next hop processing and always advertise our
-                    # local address as nexthop
-  source address @MY_IP_ADDRESS@;  # The local address we use for the TCP connection
-}

--- a/etc/calico-gen-bird-conf.sh
+++ b/etc/calico-gen-bird-conf.sh
@@ -18,7 +18,7 @@ where
   <my-ip-address> is the external IP address of the local machine
   <rr-ip-address> is the IP address of the route reflector that
       the local BIRD should peer with
-  <as-number> is the BGP AS number that the route relector is using.
+  <as-number> is the BGP AS number that the route reflector is using.
 
 Please specify exactly these 3 required arguments.
 

--- a/etc/calico-gen-bird-conf.sh
+++ b/etc/calico-gen-bird-conf.sh
@@ -8,6 +8,7 @@ else
 fi
 
 BIRD_CONF_TEMPLATE=/usr/share/calico/bird/calico-bird.conf.template
+BIRD_CONF_PEER_TEMPLATE=/usr/share/calico/bird/calico-bird-peer.conf.template
 
 # Require 3 arguments.
 [ $# -eq 3 ] || cat <<EOF
@@ -30,13 +31,20 @@ my_ip_address=$1
 rr_ip_address=$2
 as_number=$3
 
-# Generate BIRD config file.
+# Generate peer-independent BIRD config.
 mkdir -p $(dirname $BIRD_CONF)
 sed -e "
 s/@MY_IP_ADDRESS@/$my_ip_address/;
-s/@RR_IP_ADDRESS@/$rr_ip_address/;
-s/@AS_NUMBER@/$as_number/;
 " < $BIRD_CONF_TEMPLATE > $BIRD_CONF
+
+# Generate config to peer with route reflector.
+sed -e "
+s/@ID@/N1/;
+s/@DESCRIPTION@/Connection to BGP route reflector/;
+s/@MY_IP_ADDRESS@/$my_ip_address/;
+s/@PEER_IP_ADDRESS@/$rr_ip_address/;
+s/@AS_NUMBER@/$as_number/;
+" < $BIRD_CONF_PEER_TEMPLATE >> $BIRD_CONF
 
 echo BIRD configuration generated at $BIRD_CONF
 

--- a/etc/calico-gen-bird-mesh-conf.sh
+++ b/etc/calico-gen-bird-mesh-conf.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+# The bird config file path is different for Red Hat and Debian/Ubuntu.
+if [ -f /etc/bird.conf ]; then
+    BIRD_CONF=/etc/bird.conf
+else
+    BIRD_CONF=/etc/bird/bird.conf
+fi
+
+BIRD_CONF_TEMPLATE=/usr/share/calico/bird/calico-bird.conf.template
+BIRD_CONF_PEER_TEMPLATE=/usr/share/calico/bird/calico-bird-peer.conf.template
+
+# Require at least 3 arguments.
+[ $# -ge 3 ] || cat <<EOF
+
+Usage: $0 <my-ip-address> <as-number> <peer-ip-address> ...
+
+where
+  <my-ip-address> is the external IP address of the local machine
+  <as-number> is the BGP AS number that we should use
+  each <peer-ip-address> is the IP address of another BGP speaker that
+      the local BIRD should peer with.
+
+EOF
+[ $# -eq 3 ] || exit -1
+
+# Name the arguments.
+my_ip_address=$1
+shift
+as_number=$1
+shift
+peer_ips="$@"
+
+# Generate peer-independent BIRD config.
+mkdir -p $(dirname $BIRD_CONF)
+sed -e "
+s/@MY_IP_ADDRESS@/$my_ip_address/;
+" < $BIRD_CONF_TEMPLATE > $BIRD_CONF
+
+# Generate peering config.
+for peer_ip in $peer_ips; do
+    sed -e "
+s/@ID@/$peer_ip/;
+s/@DESCRIPTION@/Connection to $peer_ip/;
+s/@MY_IP_ADDRESS@/$my_ip_address/;
+s/@PEER_IP_ADDRESS@/$peer_ip/;
+s/@AS_NUMBER@/$as_number/;
+" < $BIRD_CONF_PEER_TEMPLATE >> $BIRD_CONF
+done
+
+echo BIRD configuration generated at $BIRD_CONF
+
+service bird restart
+echo BIRD restarted

--- a/etc/calico-gen-bird-mesh-conf.sh
+++ b/etc/calico-gen-bird-mesh-conf.sh
@@ -7,8 +7,9 @@ else
     BIRD_CONF=/etc/bird/bird.conf
 fi
 
-BIRD_CONF_TEMPLATE=/usr/share/calico/bird/calico-bird.conf.template
-BIRD_CONF_PEER_TEMPLATE=/usr/share/calico/bird/calico-bird-peer.conf.template
+TEMPLATE_DIR=${TEMPLATE_DIR:-/usr/share/calico/bird}
+BIRD_CONF_TEMPLATE=${TEMPLATE_DIR}/calico-bird.conf.template
+BIRD_CONF_PEER_TEMPLATE=${TEMPLATE_DIR}/calico-bird-peer.conf.template
 
 # Require at least 3 arguments.
 [ $# -ge 2 ] || cat <<EOF

--- a/etc/calico-gen-bird-mesh-conf.sh
+++ b/etc/calico-gen-bird-mesh-conf.sh
@@ -11,7 +11,7 @@ BIRD_CONF_TEMPLATE=/usr/share/calico/bird/calico-bird.conf.template
 BIRD_CONF_PEER_TEMPLATE=/usr/share/calico/bird/calico-bird-peer.conf.template
 
 # Require at least 3 arguments.
-[ $# -ge 3 ] || cat <<EOF
+[ $# -ge 2 ] || cat <<EOF
 
 Usage: $0 <my-ip-address> <as-number> <peer-ip-address> ...
 
@@ -22,7 +22,7 @@ where
       the local BIRD should peer with.
 
 EOF
-[ $# -eq 3 ] || exit -1
+[ $# -ge 2 ] || exit -1
 
 # Name the arguments.
 my_ip_address=$1

--- a/etc/calico-gen-bird6-conf.sh
+++ b/etc/calico-gen-bird6-conf.sh
@@ -18,7 +18,7 @@ where
   <my-ipv6-address> is the external IPv6 address of the local machine
   <rr-ipv6-address> is the IPv6 address of the route reflector that
       the local BIRD6 should peer with
-  <as-number> is the BGP AS number that the route relector is using.
+  <as-number> is the BGP AS number that the route reflector is using.
 
 Please specify exactly these 4 required arguments.
 

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -187,6 +187,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 /usr/bin/calico-gen-bird-conf.sh
 /usr/bin/calico-gen-bird6-conf.sh
+/usr/bin/calico-gen-bird-mesh-conf.sh
 /usr/share/calico/bird/*
 %doc
 


### PR DESCRIPTION
Enhance Calico's BIRD config generation scripts and templates so that they can be used for a full mesh as well as for a route reflector topology.

A script [1] in networking-calico's DevStack plugin will then use this, to automatically generate and maintain full mesh BIRD config for a Calico/DevStack cluster.

[1] https://review.openstack.org/#/c/227248/6/devstack/auto-bird-conf.sh

I'm still testing this, so please don't merge yet.  But on the other hand I'm keen to get early feedback if there is any.