### PR TITLE
Rev python-etcd to 0.4.2.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -52,7 +52,7 @@ Depends:
  ${misc:Depends},
  ${python:Depends},
  ${shlibs:Depends},
- python-etcd (>= 0.4.1+calico.1)
+ python-etcd (>= 0.4.2+calico.1)
 Description: Project Calico virtual networking for cloud data centers.
  Project Calico is an open source solution for virtual networking in
  cloud data centers. Its IP-centric architecture offers numerous

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -197,9 +197,9 @@ please get in touch with us and we'll be happy to help you through the process.
 
 4. Install python-etcd::
 
-        curl -L https://github.com/projectcalico/python-etcd/releases/download/0.4.1%2Bcalico.1/python-etcd_0.4.1.calico.1.tar.gz -o python-etcd.tar.gz
+        curl -L https://github.com/projectcalico/python-etcd/releases/download/0.4.2%2Bcalico.1/python-etcd_0.4.2.calico.1.tar.gz -o python-etcd.tar.gz
         tar xvf python-etcd.tar.gz
-        cd python-etcd-0.4.1+calico.1
+        cd python-etcd-0.4.2+calico.1
         python setup.py install
 
 Etcd Proxy Install
@@ -267,9 +267,9 @@ running the etcd database itself (both control and compute nodes).
 
 4. Install python-etcd::
 
-        curl -L https://github.com/projectcalico/python-etcd/releases/download/0.4.1%2Bcalico.1/python-etcd_0.4.1.calico.1.tar.gz -o python-etcd.tar.gz
+        curl -L https://github.com/projectcalico/python-etcd/releases/download/0.4.2%2Bcalico.1/python-etcd_0.4.2.calico.1.tar.gz -o python-etcd.tar.gz
         tar xvf python-etcd.tar.gz
-        cd python-etcd-0.4.1+calico.1
+        cd python-etcd-0.4.2+calico.1
         python setup.py install
 
 .. _control-node:

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,5 +1,5 @@
 gevent
 greenlet
 netaddr
-python-etcd>=0.4.1
+python-etcd>=0.4.2
 posix-spawn>=0.2.post6

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     coverage==4.0a5
     unittest2
     git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
-    git+https://github.com/projectcalico/python-etcd.git@160f62a20dd0daaf66ba1ef52362b38ee0074ff5#egg=python-etcd
+    git+https://github.com/projectcalico/python-etcd.git@dc9582b03897299a60f787a56d726f4738bbdda3#egg=python-etcd
 commands=nosetests --with-coverage
 
 [testenv:pypy]
@@ -21,5 +21,5 @@ deps =
     coverage==4.0a5
     unittest2
     git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
-    git+https://github.com/projectcalico/python-etcd.git@160f62a20dd0daaf66ba1ef52362b38ee0074ff5#egg=python-etcd
+    git+https://github.com/projectcalico/python-etcd.git@dc9582b03897299a60f787a56d726f4738bbdda3#egg=python-etcd
     gevent>=1.1a2, !=1.1b1, !=1.1b2, !=1.1b4


### PR DESCRIPTION
Remove dependency on custom build of python-etcd now that our patches are upstreamed.