### PR TITLE
Truncate long stdin/stout/stderr output from failing commands.

### DIFF
--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -67,6 +67,8 @@ SHORTENED_PREFIX = "_"
 MAX_CONCURRENT_CALLS = 32
 _call_semaphore = gevent.lock.Semaphore(MAX_CONCURRENT_CALLS)
 
+DEFAULT_TRUNC_LENGTH = 1000
+
 
 class FailedSystemCall(Exception):
     def __init__(self, message, args, retcode, stdout, stderr, input=None):
@@ -84,7 +86,20 @@ class FailedSystemCall(Exception):
                 "  stderr  : %s\n"
                 "  input  : %s\n" %
                 (self.message, self.retcode, self.args,
-                 self.stdout, self.stderr, self.input))
+                 safe_truncate(self.stdout),
+                 safe_truncate(self.stderr),
+                 safe_truncate(self.input)))
+
+
+def safe_truncate(s, max_len=DEFAULT_TRUNC_LENGTH):
+    if s is None:
+        return s
+    if not isinstance(s, basestring):
+        s = str(s)
+    snip = "...<snip>..."
+    if len(s) > max_len:
+        s = s[:(max_len+1)//2] + snip + s[-(max_len//2):]
+    return s
 
 
 def call_silent(args):

--- a/calico/felix/test/test_futils.py
+++ b/calico/felix/test/test_futils.py
@@ -125,6 +125,22 @@ class TestFutils(unittest.TestCase):
                                           "%r but got %r" %
                                           (inp, length, exp, output))
 
+    def test_safe_truncate(self):
+        self.assert_safe_truncate("foobarbazb", 10, "foobarbazb")
+        # Yes, this gets longer, which is silly.  However, there's no point
+        # making the code complicated to handle this case that should never be
+        # hit.
+        self.assert_safe_truncate("foobarbazb", 9, "fooba...<snip>...bazb")
+        self.assert_safe_truncate(None, 9, None)
+        self.assert_safe_truncate(1234, 9, "1234")
+
+    def assert_safe_truncate(self, s, length, expected):
+        result = futils.safe_truncate(s, length)
+        self.assertEqual(result, expected,
+                         "Expected %r to be truncated as %r but got %r" %
+                         (s, expected, result))
+
+
 class TestStats(unittest.TestCase):
     def setUp(self):
         futils._registered_diags = []


### PR DESCRIPTION
Fixes #769.