### PR TITLE
Add a Dockerfile for felix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile*
+*.sh
+docs
+debian
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# edge is required to get the fix for https://bugs.alpinelinux.org/issues/4451
+FROM alpine:edge
+MAINTAINER Tom Denham <tom@projectcalico.org>
+
+# The final container is slightly bloated by having the source code
+# But it's only a couple of MB (kept down using .dockerignore)
+ADD . /code
+WORKDIR /code
+
+RUN apk -U add python py-setuptools libffi ip6tables ipset iputils && \
+    apk add --virtual temp python-dev libffi-dev py-pip alpine-sdk && \
+    pip install -e . && \
+    apk del temp && rm -rf /var/cache/apk/*
+RUN mkdir /etc/calico && echo -e "[global]\nMetadataAddr = None\nLogFilePath = None\nLogSeverityFile = None" >/etc/calico/felix.cfg
+CMD ["calico-felix"]

--- a/README.md
+++ b/README.md
@@ -114,4 +114,8 @@ dependencies for.
 For example, if you want to work on Felix, you will want to set it to `felix`.
 With that set, you can then run `pip install -e .`, which will install the
 subset of the dependencies needed for those components.
+
+### Docker
+
+Felix can be run inside Docker. See the `docker_build_and_run.sh` script for details on building and running it.
 [![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docker_build_and_run.sh
+++ b/docker_build_and_run.sh
@@ -1,0 +1,2 @@
+docker build -t calico/felix -f Dockerfile .
+docker run --privileged --net=host -ti --rm calico/felix calico-felix


### PR DESCRIPTION
- Build felix (and deps) inside the container
- Resulting container is ~60MB (mostly python and deps)
