### PR TITLE
Add a delay to Actor scheduling when under load.

### DIFF
--- a/calico/felix/test/test_actor.py
+++ b/calico/felix/test/test_actor.py
@@ -206,7 +206,7 @@ class TestActor(BaseTestCase):
         self._actor.do_a(async=False)
         self._actor.do_a(async=False)
         self._actor.do_a(async=False)
-        m_sleep.assert_called_once_with()
+        m_sleep.assert_called_once_with(0.000001)
 
     def test_wait_and_check_no_input(self):
         actor.wait_and_check([])


### PR DESCRIPTION
This limits the maximum frequency at which we'll schedule each actor.  This:

* Encourages batching when we're under load (while processing messages immediately when we're not).
* Reduces starvation.

In addition:

* work around gevent issue where sleep() does not necessarily yield to another greenlet by calling sleep(0.000001) instead
* reduce number of loop iterations before yielding to reduce starvation.