### PR TITLE
Update iptables references from protocol names to numbers

### DIFF
--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -507,8 +507,10 @@ def _build_input_chain(iface_match, metadata_addr, metadata_port,
         # IP-in-IP enabled, drop any IP-in-IP packets that are not from other
         # Calico hosts.
         _log.info("IPIP enabled, dropping IPIP packets from non-Calico hosts.")
+        # The ipencap proctol uses the ID "4". Some versions of iptables can't
+        # understand protocol names.
         chain.append(
-            "--append %s --protocol ipencap "
+            "--append %s --protocol 4 "
             "--match set ! --match-set %s src --jump DROP" %
             (CHAIN_INPUT, hosts_set_name)
         )

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -177,7 +177,7 @@ class TestRules(BaseTestCase):
                                                 "DROP",
                                                 "felix-hosts")
         self.assertEqual(chain, [
-            '--append felix-INPUT --protocol ipencap --match set ! --match-set felix-hosts src --jump DROP',
+            '--append felix-INPUT --protocol 4 --match set ! --match-set felix-hosts src --jump DROP',
             '--append felix-INPUT ! --in-interface tap+ --jump RETURN',
             '--append felix-INPUT --match conntrack --ctstate INVALID --jump DROP',
             '--append felix-INPUT --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',


### PR DESCRIPTION
Some versions of iptables don't understand protocol names
(such as ipencap). Instead, protocol numbers are safer.