### PR TITLE
Add --numeric to iptables command to avoid DNS lookups.

### DIFF
--- a/calico/felix/fiptables.py
+++ b/calico/felix/fiptables.py
@@ -196,7 +196,11 @@ class IptablesUpdater(Actor):
             are not referenced by other chains.
         """
         raw_ipt_output = subprocess.check_output(
-            [self._iptables_cmd, "--wait", "--list", "--table", self.table])
+            [self._iptables_cmd,
+             "--wait",  # Wait for the xtables lock.
+             "--list",  # Action to perform.
+             "--numeric",  # Avoid DNS lookups.
+             "--table", self.table])
         return _extract_our_unreffed_chains(raw_ipt_output)
 
     @actor_message()

--- a/calico/felix/test/test_fiptables.py
+++ b/calico/felix/test/test_fiptables.py
@@ -82,7 +82,8 @@ class TestIptablesUpdater(BaseTestCase):
         _log.info("Stubbing out call to %s", cmd)
         if cmd == ["iptables-save", "--table", "filter"]:
             return self.stub.generate_iptables_save()
-        elif cmd == ['iptables', '--wait', '--list', '--table', 'filter']:
+        elif cmd == ['iptables', '--wait', '--list', '--numeric',
+                     '--table', 'filter']:
             return self.stub.generate_iptables_list()
         else:
             raise AssertionError("Unexpected call %r" % cmd)


### PR DESCRIPTION
Fixes #879 