### PR TITLE
Various leader election improvements:

### DIFF
--- a/calico/election.py
+++ b/calico/election.py
@@ -20,14 +20,15 @@ calico.election
 
 Calico election code.
 """
-from greenlet import GreenletExit
+import logging
 import random
+import os
+import re
+
 import etcd
 import eventlet
-import logging
+from greenlet import GreenletExit
 from urllib3 import Timeout
-
-import os
 
 _log = logging.getLogger(__name__)
 
@@ -93,7 +94,7 @@ class Elector(object):
                     pass
                 # In case we're repeatedly failing, sleep a little before we
                 # retry.
-                retry_time = 1 + (5 * random.random())
+                retry_time = 1 + random.random()
                 _log.info("Retrying leader election in %.1f seconds",
                           retry_time)
                 eventlet.sleep(retry_time)
@@ -125,6 +126,10 @@ class Elector(object):
             return
 
         _log.debug("ID of elected master is : %s", response.value)
+        if response.value:
+            # If we happen to be on the same server, check if the master
+            # process is still alive.
+            self._check_master_process(response.value)
 
         while not self._stopped:
             # We know another instance is the master. Wait until something
@@ -148,13 +153,44 @@ class Elector(object):
                 # Something bad and unexpected. Log and reconnect.
                 self._log_exception("wait for master change", e)
                 return
-
+            _log.debug("Election key action: %s; new value %s",
+                       response.action, response.value)
             if (response.action in ETCD_DELETE_ACTIONS or
                     response.value is None):
                 # Deleted - try and become the master.
                 _log.info("Leader etcd key went away, attempting to become "
                           "the elected master")
                 self._become_master()
+
+    def _check_master_process(self, master_id):
+        """
+        If the master happens to be on our host, checks if its process is
+        still alive.  If it is not, cleans up the now-stale election key.
+
+        :param master_id: Value loaded from the election key.
+        """
+        # Defensive. In case we ever change the master ID format, only parse
+        # it if it looks like what we expect.
+        match = re.match(r"^(?P<host>[^:]+):(?P<pid>\d+)$", master_id)
+        if match:
+            host = match.group("host")
+            pid = int(match.group("pid"))
+            _log.debug("Parsed key as host = %s, PID = %s", host, pid)
+            if host == self._server_id:
+                # Check if the PID is still running.
+                _log.debug("Previous master was on this server %s", host)
+                if os.path.exists("/proc/%s" % pid):
+                    _log.debug("Master still running")
+                else:
+                    _log.warn("Master was on this server but cannot find its "
+                              "PID in /proc.  Removing stale election key.")
+                    try:
+                        self._etcd_client.delete(self._key,
+                                                 prevValue=master_id)
+                    except etcd.EtcdException as e:
+                        _log.warn("Failed to remove stale key from dead "
+                                  "master: %r", e)
+                    raise RestartElection()
 
     def _become_master(self):
         """
@@ -184,22 +220,26 @@ class Elector(object):
                   self._key, self.id_string)
 
         self._master = True
-
-        while not self._stopped:
-            try:
-                self._etcd_client.write(self._key,
-                                        self.id_string,
-                                        ttl=self._ttl,
-                                        prevValue=self.id_string,
-                                        timeout=self._interval)
-            except Exception as e:
-                # This is a pretty broad except statement, but anything going
-                # wrong means this instance gives up being the master.
-                self._master = False
-                self._log_exception("renew master role", e)
-                raise RestartElection()
-
-            eventlet.sleep(self._interval)
+        try:
+            while not self._stopped:
+                try:
+                    _log.info("Refreshing master role")
+                    self._etcd_client.write(self._key,
+                                            self.id_string,
+                                            ttl=self._ttl,
+                                            prevValue=self.id_string,
+                                            timeout=self._interval/3)
+                    _log.info("Refreshed master role")
+                except Exception as e:
+                    # This is a pretty broad except statement, but anything
+                    # going wrong means this instance gives up being the
+                    # master.
+                    self._log_exception("renew master role", e)
+                    raise RestartElection()
+                eventlet.sleep(self._interval)
+        finally:
+            _log.info("Exiting master refresh loop, no longer the master")
+            self._master = False
         raise RestartElection()
 
     def _log_exception(self, failed_to, exc):
@@ -226,6 +266,7 @@ class Elector(object):
         return "%s:%d" % (self._server_id, os.getpid())
 
     def _attempt_step_down(self):
+        self._master = False
         try:
             self._etcd_client.delete(self._key,
                                      prevValue=self.id_string,

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -92,7 +92,7 @@ MASTER_CHECK_INTERVAL_SECS = 5
 
 # We wait for a short period of time before we initialize our state to avoid
 # problems with Neutron forking.
-STARTUP_DELAY_SECS = 30
+STARTUP_DELAY_SECS = 10
 
 # A single security profile.
 SecurityProfile = namedtuple(


### PR DESCRIPTION
* Reduce startup timer to reduce time without a leader after restart;
  this is sensible now that we're relying on leader election to
  nominate the status reporting thread.
* Opportunistically check if the previous master is still alive if
  we happen to start o the same server.  Reduces time to get a new
  master after restarting neutron.
* Add additional diags in hope of diagnosing election bouncing seen
  in #775 and #869.  Possible starvation of elector?