### PR TITLE
Squash warning log if interface doesn't exist yet.

### DIFF
--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -430,7 +430,10 @@ class LocalEndpoint(RefCountedActor):
                 if self._device_is_up is None:
                     _log.debug("Learned interface name, checking if device "
                                "is up.")
-                    self._device_is_up = devices.interface_up(self._iface_name)
+                    self._device_is_up = (
+                        devices.interface_exists(self._iface_name) and
+                        devices.interface_up(self._iface_name)
+                    )
 
             # Check if the profile ID or IP addresses have changed, requiring
             # a refresh of the dataplane.

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -88,11 +88,15 @@ class TestLocalEndpoint(BaseTestCase):
         with nested(
                 mock.patch('calico.felix.devices.set_routes'),
                 mock.patch('calico.felix.devices.configure_interface_ipv4'),
+                mock.patch('calico.felix.devices.interface_exists'),
                 mock.patch('calico.felix.devices.interface_up'),
-        ) as [m_set_routes, m_conf, m_iface_up]:
+        ) as [m_set_routes, m_conf, m_iface_exists, m_iface_up]:
+            m_iface_exists.return_value = True
             m_iface_up.return_value = True
+
             local_ep.on_endpoint_update(data, async=True)
             self.step_actor(local_ep)
+
             self.assertEqual(local_ep._mac, data['mac'])
             m_conf.assert_called_once_with(iface)
             m_set_routes.assert_called_once_with(ip_type,
@@ -161,8 +165,10 @@ class TestLocalEndpoint(BaseTestCase):
         with nested(
                 mock.patch('calico.felix.devices.set_routes'),
                 mock.patch('calico.felix.devices.configure_interface_ipv6'),
+                mock.patch('calico.felix.devices.interface_exists'),
                 mock.patch('calico.felix.devices.interface_up'),
-        ) as [m_set_routes, m_conf, m_iface_up]:
+        ) as [m_set_routes, m_conf, m_iface_exists, m_iface_up]:
+                m_iface_exists.return_value = True
                 m_iface_up.return_value = True
                 local_ep.on_endpoint_update(data, async=True)
                 self.step_actor(local_ep)


### PR DESCRIPTION
Avoid checking flags for non-existent interface.

Spotted this while doing my dummy scale testing.  We spew (benign) warning logs, one for each interface that isn't present.