### PR TITLE
Skip configuring interface if we know it's down.

### DIFF
--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -499,12 +499,11 @@ class LocalEndpoint(RefCountedActor):
     def _configure_interface(self):
         """
         Applies sysctls and routes to the interface.
-
-        :param: bool mac_changed: Has the MAC address changed since it was last
-                     configured? If so, we reconfigure ARP for the interface in
-                     IPv4 (ARP does not exist for IPv6, which uses neighbour
-                     solicitation instead).
         """
+        if not self._device_is_up:
+            _log.debug("Device is known to be down, skipping attempt to "
+                       "configure it.")
+            return
         try:
             if self.ip_type == IPV4:
                 devices.configure_interface_ipv4(self._iface_name)

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -246,13 +246,9 @@ class TestLocalEndpoint(BaseTestCase):
                 local_ep.on_endpoint_update(data, async=True)
                 self.step_actor(local_ep)
                 self.assertEqual(local_ep._mac, data['mac'])
-                m_conf.assert_called_once_with(iface)
-                m_set_routes.assert_called_once_with(ip_type,
-                                                     set(ips),
-                                                     iface,
-                                                     data['mac'],
-                                                     reset_arp=True)
-                self.assertTrue(local_ep._device_in_sync)
+                self.assertFalse(m_conf.called)
+                self.assertFalse(m_set_routes.called)
+                self.assertFalse(local_ep._device_in_sync)
 
         # Now pretend to get an interface update - does all the same work.
         with mock.patch('calico.felix.devices.set_routes') as m_set_routes:
@@ -296,12 +292,9 @@ class TestLocalEndpoint(BaseTestCase):
                 local_ep.on_endpoint_update(data, async=True)
                 self.step_actor(local_ep)
                 self.assertEqual(local_ep._mac, data['mac'])
-                m_conf.assert_called_once_with(iface, None)
-                m_set_routes.assert_called_once_with(ip_type,
-                                                     set(ips),
-                                                     iface,
-                                                     data['mac'],
-                                                     reset_arp=False)
+                self.assertFalse(m_conf.called)
+                self.assertFalse(m_set_routes.called)
+                self.assertFalse(local_ep._device_in_sync)
 
         # Now pretend to get an interface update - does all the same work.
         with mock.patch('calico.felix.devices.set_routes') as m_set_routes:


### PR DESCRIPTION
Prevents us from doing lots of shell outs when we know the interface is not ready.