### PR TITLE
Resolve "Felix dies if interface missing" on Alpine

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -91,7 +91,12 @@ def interface_exists(interface):
         futils.check_call(["ip", "link", "list", interface])
         return True
     except futils.FailedSystemCall as fsc:
-        if fsc.stderr.count("does not exist") != 0:
+        # If the interface doesn't exist, the error message varies by
+        # flavor of Linux:
+        #  * Ubuntu/RHEL: "Device 'XYZ' does not exist"
+        #  * Alpine:      "ip: can't find device 'XYZ'"
+        if ("does not exist" in fsc.stderr) or \
+           ("can't find device" in fsc.stderr):
             return False
         else:
             # An error other than does not exist; just pass on up


### PR DESCRIPTION
Alpine and Ubuntu have slightly different error messages when you run `ip link show <non-existent interface>`; respectively

    ip: can't find device 'thisdoesnotexist'
    Device "thisdoesnotexist" does not exist.

We run Felix inside an Alpine container for calico/node, but the different wording meant Felix didn't recognise the missing interface as a known error, so raised an exception.  Now we catch both wordings and handle them correctly.

Fixes #899.