### PR TITLE
Rework endpoint status calculation.

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -833,11 +833,11 @@ class EtcdStatusReporter(EtcdClientOwner, Actor):
         _stats.increment("Per-port status report etcd writes")
         status_key = ep_id.path_for_status
         if status:
-            _log.debug("Writing endpoint status %s = %s", ep_id, status)
+            _log.info("Writing endpoint status %s = %s", ep_id, status)
             self.client.set(status_key,
                             json.dumps(status))
         else:
-            _log.debug("Removing endpoint status %s", ep_id)
+            _log.info("Removing endpoint status %s", ep_id)
             try:
                 self.client.delete(status_key)
             except EtcdKeyNotFound:

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -549,6 +549,18 @@ class TestLocalEndpoint(BaseTestCase):
             combined_id, futils.IPV4, {'status': 'down'}, async=True
         )
 
+    def test_maybe_update_status_missing_endpoint(self):
+        self.m_config.REPORT_ENDPOINT_STATUS = True
+        combined_id = EndpointId("host_id", "orchestrator_id",
+                                 "workload_id", "endpoint_id")
+        ip_type = futils.IPV4
+        local_ep = self.get_local_endpoint(combined_id, ip_type)
+        local_ep._device_is_up = True
+        local_ep._maybe_update_status()
+        self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
+            combined_id, futils.IPV4, {'status': 'down'}, async=True
+        )
+
     def test_maybe_update_status_iptables_failure(self):
         self.m_config.REPORT_ENDPOINT_STATUS = True
         combined_id = EndpointId("host_id", "orchestrator_id",
@@ -556,9 +568,9 @@ class TestLocalEndpoint(BaseTestCase):
         ip_type = futils.IPV4
         local_ep = self.get_local_endpoint(combined_id, ip_type)
         local_ep.endpoint = {"state": "active"}
+        local_ep._device_is_up = True
         local_ep._iptables_in_sync = False
         local_ep._device_in_sync = True
-        local_ep._device_has_been_in_sync = True
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
             combined_id, futils.IPV4, {'status': 'error'}, async=True
@@ -572,26 +584,11 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep = self.get_local_endpoint(combined_id, ip_type)
         local_ep.endpoint = {"state": "active"}
         local_ep._iptables_in_sync = True
+        local_ep._device_is_up = True
         local_ep._device_in_sync = False
-        local_ep._device_has_been_in_sync = True
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
             combined_id, futils.IPV4, {'status': 'error'}, async=True
-        )
-
-    def test_maybe_update_status_device_failure_first_time(self):
-        self.m_config.REPORT_ENDPOINT_STATUS = True
-        combined_id = EndpointId("host_id", "orchestrator_id",
-                                 "workload_id", "endpoint_id")
-        ip_type = futils.IPV4
-        local_ep = self.get_local_endpoint(combined_id, ip_type)
-        local_ep.endpoint = {"state": "active"}
-        local_ep._iptables_in_sync = True
-        local_ep._device_in_sync = False
-        local_ep._device_has_been_in_sync = False
-        local_ep._maybe_update_status()
-        self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
-            combined_id, futils.IPV4, {'status': 'down'}, async=True
         )
 
     def test_maybe_update_status_iptables_up(self):
@@ -604,7 +601,6 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep._device_is_up = True
         local_ep._iptables_in_sync = True
         local_ep._device_in_sync = True
-        local_ep._device_has_been_in_sync = True
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
             combined_id, futils.IPV4, {'status': 'up'}, async=True
@@ -620,7 +616,6 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep._device_is_up = True
         local_ep._iptables_in_sync = True
         local_ep._device_in_sync = True
-        local_ep._device_has_been_in_sync = True
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
             combined_id, futils.IPV4, {'status': 'down'}, async=True
@@ -635,8 +630,7 @@ class TestLocalEndpoint(BaseTestCase):
         local_ep.endpoint = {"state": "active"}
         local_ep._device_is_up = False
         local_ep._iptables_in_sync = True
-        local_ep._device_in_sync = True
-        local_ep._device_has_been_in_sync = True
+        local_ep._device_in_sync = False
         local_ep._maybe_update_status()
         self.m_status_rep.on_endpoint_status_changed.assert_called_once_with(
             combined_id, futils.IPV4, {'status': 'down'}, async=True

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -854,7 +854,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                     self.transport.write_port_to_etcd(
                         port, prev_index=endpoint.modified_index
                     )
-                except etcd.EtcdCompareFailed:
+                except (etcd.EtcdCompareFailed, etcd.EtcdKeyNotFound):
                     # If someone wrote to etcd they probably have more recent
                     # data than us, let it go.
                     LOG.info("Atomic CAS failed, no action.")
@@ -981,7 +981,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                         prev_rules_index=etcd_profile.rules_modified_index,
                         prev_tags_index=etcd_profile.tags_modified_index,
                     )
-                except etcd.EtcdCompareFailed:
+                except (etcd.EtcdCompareFailed, etcd.EtcdKeyNotFound):
                     # If someone wrote to etcd they probably have more recent
                     # data than us, let it go.
                     LOG.info("Atomic CAS failed, no action.")


### PR DESCRIPTION
* Simplify conditional to prioritise checks.
* Explicitly check `self._device_is_up` flag rather than relying on confusing fall-through.
* Log reason for any changes.
* Remove the `_device_has_been_up` flag, which no-longer seems to be hittable after the rework of devices.py to report the device's oper-state.

Fixes #912.