### PR TITLE
Remove the UpdateSplitter Actor.

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -414,8 +414,7 @@ class InterfaceWatcher(Actor):
                     # The interface is down; make sure the other actors know
                     # about it.
                     self.update_splitter.on_interface_update(ifname,
-                                                             iface_up=False,
-                                                             async=True)
+                                                             iface_up=False)
                     # Remove any record we had of the interface so that, when
                     # it goes back up, we'll report that.
                     if_last_flags.pop(ifname, None)
@@ -434,8 +433,7 @@ class InterfaceWatcher(Actor):
                     _log.debug("New network interface : %s %x", ifname, flags)
                     if_last_flags[ifname] = flags
                     self.update_splitter.on_interface_update(ifname,
-                                                             iface_up=True,
-                                                             async=True)
+                                                             iface_up=True)
 
 
 class BadKernelConfig(Exception):

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -521,7 +521,7 @@ class _FelixEtcdWatcher(gevent.Greenlet):
             # cleanup.
             self.begin_polling.wait()  # Make sure splitter is set.
             self._been_in_sync = True
-            self.splitter.on_datamodel_in_sync(async=True)
+            self.splitter.on_datamodel_in_sync()
             if self._config.REPORT_ENDPOINT_STATUS:
                 self._status_reporter.clean_up_endpoint_statuses(async=True)
             self._update_hosts_ipset()
@@ -588,7 +588,7 @@ class _FelixEtcdWatcher(gevent.Greenlet):
         _log.debug("Endpoint %s updated", combined_id)
         _stats.increment("Endpoint created/updated")
         endpoint = parse_endpoint(self._config, combined_id, response.value)
-        self.splitter.on_endpoint_update(combined_id, endpoint, async=True)
+        self.splitter.on_endpoint_update(combined_id, endpoint)
 
     def on_endpoint_delete(self, response, hostname, orchestrator,
                            workload_id, endpoint_id):
@@ -597,7 +597,7 @@ class _FelixEtcdWatcher(gevent.Greenlet):
                                  endpoint_id)
         _log.debug("Endpoint %s deleted", combined_id)
         _stats.increment("Endpoint deleted")
-        self.splitter.on_endpoint_update(combined_id, None, async=True)
+        self.splitter.on_endpoint_update(combined_id, None)
 
     def on_rules_set(self, response, profile_id):
         """Handler for rules updates, passes the update to the splitter."""
@@ -605,13 +605,13 @@ class _FelixEtcdWatcher(gevent.Greenlet):
         _stats.increment("Rules created/updated")
         rules = parse_rules(profile_id, response.value)
         profile_id = intern(profile_id.encode("utf8"))
-        self.splitter.on_rules_update(profile_id, rules, async=True)
+        self.splitter.on_rules_update(profile_id, rules)
 
     def on_rules_delete(self, response, profile_id):
         """Handler for rules deletes, passes the update to the splitter."""
         _log.debug("Rules for %s deleted", profile_id)
         _stats.increment("Rules deleted")
-        self.splitter.on_rules_update(profile_id, None, async=True)
+        self.splitter.on_rules_update(profile_id, None)
 
     def on_tags_set(self, response, profile_id):
         """Handler for tags updates, passes the update to the splitter."""
@@ -619,13 +619,13 @@ class _FelixEtcdWatcher(gevent.Greenlet):
         _stats.increment("Tags created/updated")
         rules = parse_tags(profile_id, response.value)
         profile_id = intern(profile_id.encode("utf8"))
-        self.splitter.on_tags_update(profile_id, rules, async=True)
+        self.splitter.on_tags_update(profile_id, rules)
 
     def on_tags_delete(self, response, profile_id):
         """Handler for tags deletes, passes the update to the splitter."""
         _log.debug("Tags for %s deleted", profile_id)
         _stats.increment("Tags deleted")
-        self.splitter.on_tags_update(profile_id, None, async=True)
+        self.splitter.on_tags_update(profile_id, None)
 
     def on_host_ip_set(self, response, hostname):
         if not self._config.IP_IN_IP_ENABLED:
@@ -682,11 +682,11 @@ class _FelixEtcdWatcher(gevent.Greenlet):
     def on_ipam_v4_pool_set(self, response, pool_id):
         _stats.increment("IPAM pool created/updated")
         pool = parse_ipam_pool(pool_id, response.value)
-        self.splitter.on_ipam_pool_update(pool_id, pool, async=True)
+        self.splitter.on_ipam_pool_update(pool_id, pool)
 
     def on_ipam_v4_pool_delete(self, response, pool_id):
         _stats.increment("IPAM pool deleted")
-        self.splitter.on_ipam_pool_update(pool_id, None, async=True)
+        self.splitter.on_ipam_pool_update(pool_id, None)
 
 
 class EtcdStatusReporter(EtcdClientOwner, Actor):

--- a/calico/felix/splitter.py
+++ b/calico/felix/splitter.py
@@ -17,73 +17,51 @@
 felix.splitter
 ~~~~~~~~~~~~~
 
-Simple object that just splits notifications out for IPv4 and IPv6.
+Function for fanning our updates to the IPv4 and IPv6 versions of
+the manager classes.
 """
-import functools
 import logging
+import os
+
+import functools
 import gevent
+
 from calico.felix.actor import Actor, actor_message
 
 _log = logging.getLogger(__name__)
 
 
-class UpdateSplitter(Actor):
+class UpdateSplitter(object):
     """
-    Actor that takes the role of message broker, farming updates out to IPv4
-    and IPv6-specific actors.
+    Fans out notifications for IPv4 and IPv6 to the relevant actors.
 
-    Users of the API should follow this contract:
+    Historical note: this used to be a fully-fledged Actor but that
+    significantly increases the number of messages we send per update.
 
-    (1) send an apply_snapshot message containing a complete and consistent
-        snapshot of the data model.
-    (2) send in-order updates via the on_xyz_update messages.
-    (3) at any point, repeat from (1)
+    Thread safety: this object is accessed from multiple threads,
+    which is safe because it doesn't have any mutable state.
     """
-    def __init__(self, config, ipsets_mgrs, rules_managers, endpoint_managers,
-                 iptables_updaters, ipv4_masq_manager):
+    def __init__(self, managers):
         super(UpdateSplitter, self).__init__()
-        self.config = config
-        self.ipsets_mgrs = ipsets_mgrs
-        self.iptables_updaters = iptables_updaters
-        self.rules_mgrs = rules_managers
-        self.endpoint_mgrs = endpoint_managers
-        self.ipv4_masq_manager = ipv4_masq_manager
-        self._cleanup_scheduled = False
+        self.managers = managers
 
-    @actor_message()
+        self.in_sync_mgrs = self._managers_with("on_datamodel_in_sync")
+        self.rules_upd_mgrs = self._managers_with("on_rules_update")
+        self.tags_upd_mgrs = self._managers_with("on_tags_update")
+        self.iface_upd_mgrs = self._managers_with("on_interface_update")
+        self.ep_upd_mgrs = self._managers_with("on_endpoint_update")
+        self.ipam_upd_mgrs = self._managers_with("on_ipam_pool_updated")
+
+    def _managers_with(self, method_name):
+        return [m for m in self.managers if hasattr(m, method_name)]
+
     def on_datamodel_in_sync(self):
         """
         Called when the data-model is known to be in-sync.
         """
-        for mgr in self.ipsets_mgrs + self.rules_mgrs + self.endpoint_mgrs:
+        for mgr in self.in_sync_mgrs:
             mgr.on_datamodel_in_sync(async=True)
 
-        # Now we're in sync, give the managers some time to get their house in
-        # order, then trigger the start-of-day cleanup.
-        if not self._cleanup_scheduled:
-            _log.info("No cleanup scheduled, scheduling one.")
-            gevent.spawn_later(self.config.STARTUP_CLEANUP_DELAY,
-                               functools.partial(self.trigger_cleanup,
-                                                 async=True))
-            self._cleanup_scheduled = True
-
-    @actor_message()
-    def trigger_cleanup(self):
-        """
-        Called from a separate greenlet, asks the managers to clean up
-        unused ipsets and iptables.
-        """
-        self._cleanup_scheduled = False
-        _log.info("Triggering a cleanup of orphaned ipsets/chains")
-        # Need to clean up iptables first because they reference ipsets
-        # and force them to stay alive.
-        for ipt_updater in self.iptables_updaters:
-            ipt_updater.cleanup(async=False)
-        # It's still worth a try to clean up any ipsets that we can.
-        for ipset_mgr in self.ipsets_mgrs:
-            ipset_mgr.cleanup(async=False)
-
-    @actor_message()
     def on_rules_update(self, profile_id, rules):
         """
         Process an update to the rules of the given profile.
@@ -92,10 +70,9 @@ class UpdateSplitter(Actor):
             or None if the rules have been deleted.
         """
         _log.info("Profile update: %s", profile_id)
-        for rules_mgr in self.rules_mgrs:
-            rules_mgr.on_rules_update(profile_id, rules, async=True)
+        for mgr in self.rules_upd_mgrs:
+            mgr.on_rules_update(profile_id, rules, async=True)
 
-    @actor_message()
     def on_tags_update(self, profile_id, tags):
         """
         Called when the given tag list has changed or been deleted.
@@ -104,21 +81,20 @@ class UpdateSplitter(Actor):
             deleted.
         """
         _log.info("Tags for profile %s updated", profile_id)
-        for ipset_mgr in self.ipsets_mgrs:
-            ipset_mgr.on_tags_update(profile_id, tags, async=True)
+        for mgr in self.tags_upd_mgrs:
+            mgr.on_tags_update(profile_id, tags, async=True)
 
-    @actor_message()
     def on_interface_update(self, name, iface_up):
         """
         Called when an interface state has changed.
 
         :param str name: Interface name
+        :param bool iface_up: True if the interface is up, False if notF.
         """
         _log.info("Interface %s state changed", name)
-        for endpoint_mgr in self.endpoint_mgrs:
-            endpoint_mgr.on_interface_update(name, iface_up, async=True)
+        for mgr in self.iface_upd_mgrs:
+            mgr.on_interface_update(name, iface_up, async=True)
 
-    @actor_message()
     def on_endpoint_update(self, endpoint_id, endpoint):
         """
         Process an update to the given endpoint.  endpoint may be None if
@@ -128,12 +104,65 @@ class UpdateSplitter(Actor):
         :param dict endpoint: Endpoint data dict
         """
         _log.debug("Endpoint update for %s.", endpoint_id)
-        for ipset_mgr in self.ipsets_mgrs:
-            ipset_mgr.on_endpoint_update(endpoint_id, endpoint, async=True)
-        for endpoint_mgr in self.endpoint_mgrs:
-            endpoint_mgr.on_endpoint_update(endpoint_id, endpoint, async=True)
+        for mgr in self.ep_upd_mgrs:
+            mgr.on_endpoint_update(endpoint_id, endpoint, async=True)
+
+    def on_ipam_pool_update(self, pool_id, pool):
+        """
+        Fan out an update to the given IPAM pool.
+
+        :param pool_id: Opaque ID of the pool
+        :param pool: Either a dict representing the pool or None for a
+               deletion.
+        """
+        _log.info("IPAM pool %s updated", pool_id)
+        for mgr in self.ipam_upd_mgrs:
+            mgr.on_ipam_pool_updated(pool_id, pool, async=True)
+
+
+class CleanupManager(Actor):
+    """
+    Manages the post-graceful restart cleanup scheduling.
+
+    This is a pretty trivial Actor in that its only state is a
+    single one-way flag but making it an Actor lets us re-use
+    the UpdateSplitter logic to fan out the on_datamodel_in_sync()
+    call.
+    """
+    def __init__(self, config, iptables_updaters, ipsets_mgrs):
+        super(CleanupManager, self).__init__()
+        self.config = config
+        self.iptables_updaters = iptables_updaters
+        self.ipsets_mgrs = ipsets_mgrs
+        self._cleanup_done = False
 
     @actor_message()
-    def on_ipam_pool_update(self, pool_id, pool):
-        _log.info("IPAM pool %s updated", pool_id)
-        self.ipv4_masq_manager.on_ipam_pool_updated(pool_id, pool, async=True)
+    def on_datamodel_in_sync(self):
+        if not self._cleanup_done:
+            # Datamodel in sync for the first time.  Give the managers some
+            # time to finish processing, then trigger cleanup.
+            self._cleanup_done = True
+            _log.info("No cleanup scheduled, scheduling one.")
+            gevent.spawn_later(self.config.STARTUP_CLEANUP_DELAY,
+                               functools.partial(self._do_cleanup,
+                                                 async=True))
+        self._cleanup_done = True
+
+    @actor_message()
+    def _do_cleanup(self):
+        try:
+            _log.info("Triggering a cleanup of orphaned ipsets/chains")
+            # Need to clean up iptables first because they reference ipsets
+            # and force them to stay alive.  Note: we use async=False to
+            # ensure that the cleanup is complete before we start the
+            # ipsets cleanup.
+            for ipt_updater in self.iptables_updaters:
+                ipt_updater.cleanup(async=False)
+            _log.info("iptables cleanup complete, moving on to ipsets")
+            for ipset_mgr in self.ipsets_mgrs:
+                ipset_mgr.cleanup(async=False)
+        except:
+            _log.exception("Failed to cleanup iptables or ipsets state, "
+                           "exiting")
+            os._exit(1)
+            raise  # Keep linter happy.

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -91,14 +91,3 @@ class TestBasic(BaseTestCase):
         m_iface_up.assert_called_once_with("tunl0")
         m_configure_global_kernel_config.assert_called_once_with()
 
-        # Check all IptablesUpdaters get passed to the splitter, which handles
-        # cleanup.
-        _, args, _ = m_UpdateSplitter.mock_calls[0]
-        updaters = args[4]  # List of IptablesUpdaters should be the 5th arg.
-        # But check that it contains what we expect.
-        self.assertEqual(updaters[0], m_IptablesUpdater.return_value)
-        num_ipt_upds = len([c for c in m_IptablesUpdater.mock_calls
-                            if c[0] == ""])
-        self.assertEqual(len(updaters), num_ipt_upds,
-                         "Number of IptablesUpdaters passed to UpdateSplitter"
-                         "not the same as number that were created.")

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -317,7 +317,7 @@ class TestEtcdWatcher(BaseTestCase):
         m_begin.wait.assert_called_once_with()
         self.assertTrue(self.watcher._been_in_sync)
         self.assertEqual(self.m_splitter.on_datamodel_in_sync.mock_calls,
-                         [call(async=True)])
+                         [call()])
         self.assertEqual(self.m_hosts_ipset.replace_members.mock_calls,
                          [call(frozenset([]), async=True)])
 
@@ -382,7 +382,6 @@ class TestEtcdWatcher(BaseTestCase):
         self.m_splitter.on_endpoint_update.assert_called_once_with(
             EndpointId("h1", "o1", "w1", "e1"),
             VALID_ENDPOINT,
-            async=True,
         )
 
     def test_endpoint_set_bad_json(self):
@@ -391,7 +390,6 @@ class TestEtcdWatcher(BaseTestCase):
         self.m_splitter.on_endpoint_update.assert_called_once_with(
             EndpointId("h1", "o1", "w1", "e1"),
             None,
-            async=True,
         )
 
     def test_endpoint_set_invalid(self):
@@ -400,58 +398,50 @@ class TestEtcdWatcher(BaseTestCase):
         self.m_splitter.on_endpoint_update.assert_called_once_with(
             EndpointId("h1", "o1", "w1", "e1"),
             None,
-            async=True,
         )
 
     def test_rules_set(self):
         self.dispatch("/calico/v1/policy/profile/prof1/rules", "set",
                       value=RULES_STR)
         self.m_splitter.on_rules_update.assert_called_once_with("prof1",
-                                                                RULES,
-                                                                async=True)
+                                                                RULES)
 
     def test_rules_set_bad_json(self):
         self.dispatch("/calico/v1/policy/profile/prof1/rules", "set",
                       value="{")
         self.m_splitter.on_rules_update.assert_called_once_with("prof1",
-                                                                None,
-                                                                async=True)
+                                                                None,)
 
     def test_rules_set_invalid(self):
         self.dispatch("/calico/v1/policy/profile/prof1/rules", "set",
                       value='{}')
         self.m_splitter.on_rules_update.assert_called_once_with("prof1",
-                                                                None,
-                                                                async=True)
+                                                                None,)
 
     def test_tags_set(self):
         self.dispatch("/calico/v1/policy/profile/prof1/tags", "set",
                       value=TAGS_STR)
         self.m_splitter.on_tags_update.assert_called_once_with("prof1",
-                                                               TAGS,
-                                                               async=True)
+                                                               TAGS)
 
     def test_tags_set_bad_json(self):
         self.dispatch("/calico/v1/policy/profile/prof1/tags", "set",
                       value="{")
         self.m_splitter.on_tags_update.assert_called_once_with("prof1",
-                                                               None,
-                                                               async=True)
+                                                               None)
 
     def test_tags_set_invalid(self):
         self.dispatch("/calico/v1/policy/profile/prof1/tags", "set",
                       value="[{}]")
         self.m_splitter.on_tags_update.assert_called_once_with("prof1",
-                                                               None,
-                                                               async=True)
+                                                               None)
 
     def test_tags_del(self):
         """
         Test tag-only deletion.
         """
         self.dispatch("/calico/v1/policy/profile/profA/tags", action="delete")
-        self.m_splitter.on_tags_update.assert_called_once_with("profA", None,
-                                                               async=True)
+        self.m_splitter.on_tags_update.assert_called_once_with("profA", None)
         self.assertFalse(self.m_splitter.on_rules_update.called)
 
     def test_rules_del(self):
@@ -459,8 +449,7 @@ class TestEtcdWatcher(BaseTestCase):
         Test rules-only deletion.
         """
         self.dispatch("/calico/v1/policy/profile/profA/rules", action="delete")
-        self.m_splitter.on_rules_update.assert_called_once_with("profA", None,
-                                                                async=True)
+        self.m_splitter.on_rules_update.assert_called_once_with("profA", None)
         self.assertFalse(self.m_splitter.on_tags_update.called)
 
     def test_endpoint_del(self):
@@ -472,7 +461,6 @@ class TestEtcdWatcher(BaseTestCase):
         self.m_splitter.on_endpoint_update.assert_called_once_with(
             EndpointId("h1", "o1", "w1", "e1"),
             None,
-            async=True,
         )
 
     def test_host_ip_set(self):
@@ -532,12 +520,12 @@ class TestEtcdWatcher(BaseTestCase):
     def test_ipam_pool_set(self):
         self.dispatch("/calico/v1/ipam/v4/pool/1234", action="set", value="{}")
         self.assertEqual(self.m_splitter.on_ipam_pool_update.mock_calls,
-                         [call("1234", None, async=True)])
+                         [call("1234", None)])
 
     def test_ipam_pool_del(self):
         self.dispatch("/calico/v1/ipam/v4/pool/1234", action="delete")
         self.assertEqual(self.m_splitter.on_ipam_pool_update.mock_calls,
-                         [call("1234", None, async=True)])
+                         [call("1234", None)])
 
     @patch("os._exit", autospec=True)
     @patch("gevent.sleep", autospec=True)

--- a/calico/felix/test/test_splitter.py
+++ b/calico/felix/test/test_splitter.py
@@ -18,18 +18,11 @@ felix.test.test_splitter
 
 Tests of the actor that splits update messages to multiple manager actors.
 """
-import collections
-
-import gevent
 import mock
 from calico.felix.masq import MasqueradeManager
 
 from calico.felix.test.base import BaseTestCase
-from calico.felix.splitter import UpdateSplitter
-
-
-# A mocked config object for use in the UpdateSplitter.
-Config = collections.namedtuple('Config', ['STARTUP_CLEANUP_DELAY'])
+from calico.felix.splitter import UpdateSplitter, CleanupManager
 
 
 class TestUpdateSplitter(BaseTestCase):
@@ -39,8 +32,6 @@ class TestUpdateSplitter(BaseTestCase):
     def setUp(self):
         super(TestUpdateSplitter, self).setUp()
 
-        # Set the cleanup delay to 0, to force immediate cleanup.
-        self.config = Config(0)
         self.ipsets_mgrs = [mock.MagicMock(), mock.MagicMock()]
         self.rules_mgrs = [mock.MagicMock(), mock.MagicMock()]
         self.endpoint_mgrs = [mock.MagicMock(), mock.MagicMock()]
@@ -49,50 +40,19 @@ class TestUpdateSplitter(BaseTestCase):
 
     def get_splitter(self):
         return UpdateSplitter(
-            self.config,
-            self.ipsets_mgrs,
-            self.rules_mgrs,
-            self.endpoint_mgrs,
-            self.iptables_updaters,
-            self.masq_manager
+            self.ipsets_mgrs +
+            self.rules_mgrs +
+            self.endpoint_mgrs +
+            self.iptables_updaters +
+            [self.masq_manager]
         )
 
     def test_on_datamodel_in_sync(self):
         s = self.get_splitter()
-        with mock.patch("gevent.spawn_later") as m_spawn:
-            s.on_datamodel_in_sync(async=True)
-            s.on_datamodel_in_sync(async=True)
-            self.step_actor(s)
-        self.assertTrue(s._cleanup_scheduled)
-        self.assertEqual(m_spawn.mock_calls,
-                         [mock.call(0, mock.ANY)])
+        s.on_datamodel_in_sync()
         for mgr in self.ipsets_mgrs + self.rules_mgrs + self.endpoint_mgrs:
             self.assertEqual(mgr.on_datamodel_in_sync.mock_calls,
-                             [mock.call(async=True), mock.call(async=True)])
-
-    def test_cleanup_give_up_on_exception(self):
-        """
-        Test that cleanup is killed by exception.
-        """
-        # No need to apply any data here.
-        s = self.get_splitter()
-
-        # However, make sure that the first ipset manager and the first
-        # iptables updater throw exceptions when called.
-        self.ipsets_mgrs[0].cleanup.side_effect = RuntimeError('Bang!')
-
-        # Start the cleanup.
-        result = s.trigger_cleanup(async=True)
-        self.step_actor(s)
-        self.assertRaises(RuntimeError, result.get)
-
-    def test_cleanup_mainline(self):
-        # No need to apply any data here.
-        s = self.get_splitter()
-        # Start the cleanup.
-        result = s.trigger_cleanup(async=True)
-        self.step_actor(s)
-        result.get()
+                             [mock.call(async=True)])
 
     def test_rule_updates_propagate(self):
         """
@@ -103,8 +63,7 @@ class TestUpdateSplitter(BaseTestCase):
         rules = ['first rule', 'second rule']
 
         # Apply the rules update
-        s.on_rules_update(profile, rules, async=True)
-        self.step_actor(s)
+        s.on_rules_update(profile, rules)
 
         # Confirm that the rules update propagates.
         for mgr in self.rules_mgrs:
@@ -121,8 +80,7 @@ class TestUpdateSplitter(BaseTestCase):
         tags = ['first tag', 'second tag']
 
         # Apply the tags update
-        s.on_tags_update(profile, tags, async=True)
-        self.step_actor(s)
+        s.on_tags_update(profile, tags)
 
         # Confirm that the rules update propagates.
         for mgr in self.ipsets_mgrs:
@@ -138,12 +96,11 @@ class TestUpdateSplitter(BaseTestCase):
         interface = 'tapABCDEF'
 
         # Apply the interface update
-        s.on_interface_update(interface, iface_up=True, async=True)
-        self.step_actor(s)
+        s.on_interface_update(interface, iface_up=True)
 
         # Confirm that the interface update propagates.
         for mgr in self.endpoint_mgrs:
-            mgr.on_interface_update.assertCalledOnceWith(interface, async=True)
+            mgr.on_interface_update.assertCalledOnceWith(interface)
 
     def test_endpoint_updates_propagate(self):
         """
@@ -154,8 +111,7 @@ class TestUpdateSplitter(BaseTestCase):
         endpoint_object = 'endpoint'
 
         # Apply the endpoint update
-        s.on_endpoint_update(endpoint, endpoint_object, async=True)
-        self.step_actor(s)
+        s.on_endpoint_update(endpoint, endpoint_object)
 
         # Confirm that the endpoint update propagates.
         for mgr in self.ipsets_mgrs:
@@ -175,17 +131,62 @@ class TestUpdateSplitter(BaseTestCase):
         pool_id = "foo"
         pool = {"cidr": "10/16", "masquerade": False}
 
-        s.ipv4_masq_manager.apply_snapshot({"foo": {"cidr": "10.0.0.0/16",
-                                                    "masquerade": True},
-                                            "bar": {"cidr": "10.1.0.0/16",
-                                                    "masquerade": False}},
-                                           async=True)
-
         # Apply the IPAM pool update
-        s.on_ipam_pool_update(pool_id, pool, async=True)
-        self.step_actor(s)
+        s.on_ipam_pool_update(pool_id, pool)
 
         # Confirm that the pool update propagates
         self.masq_manager.on_ipam_pool_updated.assertCalledOnceWith(
             pool_id, pool, async=True
         )
+
+
+class TestCleanupManager(BaseTestCase):
+    def setUp(self):
+        super(TestCleanupManager, self).setUp()
+        m_config = mock.Mock()
+        m_config.STARTUP_CLEANUP_DELAY = 12
+
+        # We need to check the order between the iptables and ipsets cleanup
+        # calls so make sure they have a common root mock.
+        self.m_root_mock = mock.Mock()
+        self.m_ipt_updr = self.m_root_mock.m_ipt_updr
+        self.m_ips_mgr = self.m_root_mock.m_ips_mgr
+
+        self.mgr = CleanupManager(m_config,
+                                  [self.m_ipt_updr],
+                                  [self.m_ips_mgr])
+
+    def test_on_datamodel_in_sync(self):
+        with mock.patch("gevent.spawn_later", autospec=True) as m_spawn_later:
+            self.mgr.on_datamodel_in_sync(async=True)
+            self.step_actor(self.mgr)
+        self.assertTrue(self.mgr._cleanup_done)
+        # Check we got only the expected call to spawn.
+        self.assertEqual(m_spawn_later.mock_calls, [mock.call(12, mock.ANY)])
+        # Grab the callable.
+        do_cleanup = m_spawn_later.call_args[0][1]
+        self.assertTrue(callable(do_cleanup))
+        # Check it really invokes the cleanup.
+        do_cleanup()
+        self.step_actor(self.mgr)
+        self.assertEqual(
+            self.m_root_mock.mock_calls,
+            [
+                # iptables call should come first.
+                mock.call.m_ipt_updr.cleanup(async=False),
+                mock.call.m_ips_mgr.cleanup(async=False),
+            ]
+        )
+        # Finally, check that subsequent in-sync calls are ignored.
+        with mock.patch("gevent.spawn_later", autospec=True) as m_spawn_later:
+            self.mgr.on_datamodel_in_sync(async=True)
+            self.step_actor(self.mgr)
+        self.assertEqual(m_spawn_later.mock_calls, [])
+
+    def test_cleanup_failure(self):
+        self.m_ips_mgr.cleanup.side_effect = RuntimeError
+        with mock.patch("os._exit") as m_exit:
+            result = self.mgr._do_cleanup(async=True)
+            self.step_actor(self.mgr)
+        self.assertEqual(m_exit.mock_calls, [mock.call(1)])
+        self.assertRaises(RuntimeError, result.get)


### PR DESCRIPTION
This improves performance by significantly reducing the number of
messages we pass around.

* [x] Finish UTs