### PR TITLE
Remove UT support for Python 2.6 (and pypy).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 - Felix now parses the etcd snapshot in parallel with the event stream;
   this dramatically increases scale when under load.
+- Removed support for Python 2.6.  python-etcd no longer supports 2.6
+  as of 0.4.3.
 
 ## 1.2.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27, pypy
+# TODO: Reinstate pypy once gevent segfault is resolved.
+envlist = py27
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy
+envlist = py27, pypy
 
 [testenv]
 deps =
@@ -7,8 +7,6 @@ deps =
     mock==1.0.1
     coverage>=4.0.2
     unittest2
-    git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
-    git+https://github.com/projectcalico/python-etcd.git@160f62a20dd0daaf66ba1ef52362b38ee0074ff5#egg=python-etcd
 # Each of our components uses a different scheme of
 # thread monkey-patching so run each separately.  We'd like to
 # use "nosetests --with-coverage" but there's no way to pass
@@ -33,6 +31,4 @@ deps =
     mock==1.0.1
     coverage>=4.0.2
     unittest2
-    git+https://github.com/projectcalico/python-posix-spawn.git@1f74fbedb569d4e45f11e9e32d3dca74623f432c#egg=posix-spawn
-    git+https://github.com/projectcalico/python-etcd.git@160f62a20dd0daaf66ba1ef52362b38ee0074ff5#egg=python-etcd
     gevent>=1.1b6


### PR DESCRIPTION
Also remove now-unneeded pins in tox.ini.

As of python-etcd 0.4.3, python-etcd fails at install time on Python 2.6.

Impacts difficulty of re-instating RHEL6.5 support: #455.