### PR TITLE
Ignore post-unreference calls to LocalEndpoint._finish_msg_batch()

### DIFF
--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -343,8 +343,7 @@ class TestLocalEndpoint(BaseTestCase):
             self.step_actor(local_ep)
             m_set_routes.assert_called_once_with(ip_type, set(),
                                                  data["name"], None)
-            self.assertRaises(AssertionError,
-                              local_ep._finish_msg_batch, [], [])
+            local_ep._finish_msg_batch([], [])  # Should be ignored
             self.m_manager.on_object_cleanup_complete.assert_called_once_with(
                 local_ep._id,
                 local_ep,


### PR DESCRIPTION
Move the assert to the individual methods, which should not be called, to allow for messages received via the RefHelper.

Fixes #945.