### PR TITLE
Add configuration for IPIP tunnel local address.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   this dramatically increases scale when under load.
 - Removed support for Python 2.6.  python-etcd no longer supports 2.6
   as of 0.4.3.
+- Add IpInIpTunnelAddr configuration parameter to allow the IP address of
+  the IPIP tunnel device to be set.
 
 ## 1.2.2
 

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -212,6 +212,9 @@ class Config(object):
         self.add_parameter("IpInIpMtu",
                            "MTU to set on the IP-in-IP device", 1440,
                            value_is_int=True)
+        self.add_parameter("IpInIpTunnelAddr",
+                           "IPv4 address to set on the IP-in-IP device",
+                           "none")
         self.add_parameter("ReportingIntervalSecs",
                            "Status reporting interval in seconds",
                            30, value_is_int=True)
@@ -311,6 +314,7 @@ class Config(object):
         self.LOGLEVSCR = self.parameters["LogSeverityScreen"].value
         self.IP_IN_IP_ENABLED = self.parameters["IpInIpEnabled"].value
         self.IP_IN_IP_MTU = self.parameters["IpInIpMtu"].value
+        self.IP_IN_IP_ADDR = self.parameters["IpInIpTunnelAddr"].value
         self.REPORTING_INTERVAL_SECS = \
             self.parameters["ReportingIntervalSecs"].value
         self.REPORTING_TTL_SECS = self.parameters["ReportingTTLSecs"].value
@@ -512,6 +516,15 @@ class Config(object):
             if not common.validate_port(self.METADATA_PORT):
                 raise ConfigException("Invalid field value",
                                       self.parameters["MetadataPort"])
+
+        if self.IP_IN_IP_ADDR.lower() == "none":
+            # IP-in-IP tunnel address is not required.
+            self.IP_IN_IP_ADDR = None
+        else:
+            # IP-in-IP tunnel address must be a valid IP address if
+            # supplied.
+            self.IP_IN_IP_ADDR = self._validate_addr("IpInIpTunnelAddr",
+                                                     self.IP_IN_IP_ADDR)
 
         if self.DEFAULT_INPUT_CHAIN_ACTION not in ("DROP", "RETURN", "ACCEPT"):
             raise ConfigException(

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -265,6 +265,13 @@ def _configure_ipip_device(config):
     if not devices.interface_up(IP_IN_IP_DEV_NAME):
         _log.info("Tunnel device wasn't up; enabling.")
         futils.check_call(["ip", "link", "set", IP_IN_IP_DEV_NAME, "up"])
+    # Allow an IP address to be added to the tunnel.  This is useful to
+    # allow the host to have an IP on a private IPIP network so that it can
+    # originate traffic and have it routed correctly.
+    _log.info("Setting IPIP device IP to %s", config.IP_IN_IP_ADDR)
+    tunnel_addrs = [config.IP_IN_IP_ADDR] if config.IP_IN_IP_ADDR else []
+    devices.set_interface_ips(futils.IPV4, IP_IN_IP_DEV_NAME,
+                              set(tunnel_addrs))
     _log.info("Configured IPIP device.")
 
 

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -233,6 +233,27 @@ class TestConfig(unittest.TestCase):
             load_config("felix_missing.cfg", host_dict=cfg_dict)
         self.m_gethostbyname.assert_has_calls([mock.call("bloop")])
 
+    def test_bad_ipip_addr(self):
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "IpInIpTunnelAddr": "bloop"}
+        with self.assertRaisesRegexp(
+                ConfigException,
+                "Invalid or unresolvable.*IpInIpTunnelAddr"):
+            load_config("felix_missing.cfg", host_dict=cfg_dict)
+        self.m_gethostbyname.assert_has_calls([mock.call("bloop")])
+
+    def test_none_string_ipip_addr(self):
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "IpInIpTunnelAddr": "none"}
+        conf = load_config("felix_missing.cfg", host_dict=cfg_dict)
+        self.assertEqual(conf.IP_IN_IP_ADDR, None)
+
+    def test_none_ipip_addr(self):
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "IpInIpTunnelAddr": None}
+        conf = load_config("felix_missing.cfg", host_dict=cfg_dict)
+        self.assertEqual(conf.IP_IN_IP_ADDR, None)
+
     def test_bad_log_level(self):
         for field in ("LogSeverityFile", "LogSeverityScreen", "LogSeveritySys"):
             cfg_dict = { "LogInterfacePrefix": "blah",

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -48,6 +48,7 @@ class TestBasic(BaseTestCase):
         else:
             sys.modules['etcd'] = self._real_etcd
 
+    @mock.patch("calico.felix.devices.list_interface_ips", autospec=True)
     @mock.patch("calico.felix.devices.configure_global_kernel_config",
                 autospec=True)
     @mock.patch("calico.felix.devices.interface_up",
@@ -66,10 +67,12 @@ class TestBasic(BaseTestCase):
                            m_IptablesUpdater, m_UpdateSplitter,
                            m_start, m_load,
                            m_ipset_4, m_check_call, m_iface_exists,
-                           m_iface_up, m_configure_global_kernel_config):
+                           m_iface_up, m_configure_global_kernel_config,
+                           m_list_interface_ips):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
         m_MasqueradeManager.return_value.greenlet = mock.Mock()
         m_UpdateSplitter.return_value.greenlet = mock.Mock()
+        m_list_interface_ips.return_value = set()
         env_dict = {
             "FELIX_ETCDADDR": "localhost:4001",
             "FELIX_ETCDSCHEME": "http",


### PR DESCRIPTION
When configured with an address in the IPIP pool, this allows the host to originate packets to IPIP-tunneled addresses.