### PR TITLE
Fixes to docs about Liberty+ DHCP agent install

### DIFF
--- a/docs/source/opens-upgrade.rst
+++ b/docs/source/opens-upgrade.rst
@@ -104,6 +104,7 @@ process when the binary has been updated since it started running::
 
 Then if you are using OpenStack Liberty or later::
 
+    service neutron-dhcp-agent stop
     service calico-dhcp-agent restart
 
 Or if you are using an earlier OpenStack release::
@@ -132,6 +133,7 @@ the binary has been updated since it started running::
 
 Then if you are using OpenStack Liberty or later::
 
+    service neutron-dhcp-agent stop
     service calico-dhcp-agent restart
 
 Or if you are using an earlier OpenStack release::

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -412,13 +412,13 @@ On each compute node, perform the following steps:
    OpenStack packages and to ``dnsmasq``.  For OpenStack Liberty, this step
    only upgrades ``dnsmasq``.
 
-5. Install and configure the DHCP agent on the compute host:
+5. Install Neutron infrastructure code on the compute host:
 
    ::
 
        yum install openstack-neutron
 
-   For OpenStack Juno or Kilo, open ``/etc/neutron/dhcp_agent.ini``, and in the
+6. For OpenStack Juno or Kilo, open ``/etc/neutron/dhcp_agent.ini``, and in the
    ``[DEFAULT]`` section add the following line (removing any existing
    ``interface_driver =`` line):
 
@@ -426,19 +426,21 @@ On each compute node, perform the following steps:
 
            interface_driver = neutron.agent.linux.interface.RoutedInterfaceDriver
 
-6.  Restart and enable the DHCP agent.  For OpenStack Liberty or later:
+   then restart and enable the Neutron DHCP agent:
 
-    ::
+   ::
 
-        service calico-dhcp-agent restart
-        chkconfig calico-dhcp-agent on
+       service neutron-dhcp-agent restart
+       chkconfig neutron-dhcp-agent on
 
-    For earlier OpenStack releases:
+   For OpenStack Liberty or later, stop and disable the Neutron DHCP agent, as
+   Calico will install and use its own DHCP agent (as part of the
+   ``calico-compute`` step below):
 
-    ::
+   ::
 
-        service neutron-dhcp-agent restart
-        chkconfig neutron-dhcp-agent on
+       service neutron-dhcp-agent stop
+       chkconfig neutron-dhcp-agent off
 
 7.  Stop and disable any other routing/bridging agents such as the L3
     routing agent or the Linux bridging agent.  These conflict with Calico.

--- a/docs/source/ubuntu-opens-install.rst
+++ b/docs/source/ubuntu-opens-install.rst
@@ -345,17 +345,19 @@ perform the following steps:
 
        interface_driver = neutron.agent.linux.interface.RoutedInterfaceDriver
 
-   Now restart the DHCP agent.  For OpenStack Liberty or later:
-
-   ::
-
-       sudo service calico-dhcp-agent restart
-
-   For earlier OpenStack releases:
+   and then restart the DHCP agent:
 
    ::
 
        sudo service neutron-dhcp-agent restart
+
+   For OpenStack Liberty or later, stop the Neutron DHCP agent, as Calico will
+   install and use its own DHCP agent (as part of the following
+   ``calico-compute`` step):
+
+   ::
+
+       sudo service neutron-dhcp-agent stop
 
 7. Install the ``calico-compute`` package:
 


### PR DESCRIPTION
- Delete any instructions to restart calico-dhcp-agent before
  calico-compute has been installed.

- Actually, if you're using calico-dhcp-agent, restarting isn't needed
  at all, as we don't have to edit any of its config.

- When using calico-dhcp-agent, also do 'service neutron-dhcp-agent
  stop'.

(No further changes are needed to the upgrade doc.)