### PR TITLE
Add config option for Iptables Mark Masks

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -119,7 +119,7 @@ class ConfigParameter(object):
                 # the right value if / when it goes wrong.
                 self.value = value
                 try:
-                    self.value = int(value)
+                    self.value = int(value, 0)
                 except ValueError:
                     raise ConfigException("Field was not integer",
                                           self)
@@ -234,6 +234,12 @@ class Config(object):
                            "to a value larger than the expected number of "
                            "IP addresses using a single tag.",
                            2**20, value_is_int=True)
+        self.add_parameter("IptablesMarkMask",
+                           "Mask that Felix selects its IPTables Mark bits "
+			   "from.  Should be a 32 bit hexadecimal number with "
+			   "at least 8 bits set, none of which clash with any "
+			   "other mark bits in use on the system.",
+                           0xff000000, value_is_int=True)
 
         # The following setting determines which flavour of Iptables Generator
         # plugin is loaded.  Note: this plugin support is currently highly
@@ -325,8 +331,19 @@ class Config(object):
         self.MAX_IPSET_SIZE = self.parameters["MaxIpsetSize"].value
         self.IPTABLES_GENERATOR_PLUGIN = \
             self.parameters["IptablesGeneratorPlugin"].value
+	self.IPTABLES_MARK_MASK =\
+	    self.parameters["IptablesMarkMask"].value
 
         self._validate_cfg(final=final)
+
+        # Now the config has been validated, generate the IPTables mark masks
+        # we'll actually use internally.
+        mark_mask = self.IPTABLES_MARK_MASK
+
+        # Extract the least significant bit and use it as the accept mask.
+        next_mask = mark_mask & (mark_mask - 1)
+        self.IPTABLES_MARK_ACCEPT = "0x%x" % (mark_mask - next_mask)
+        mark_mask = next_mask
 
         for plugin in self.plugins.itervalues():
             # Plugins don't get loaded and registered until we've read config
@@ -553,6 +570,16 @@ class Config(object):
         if self.MAX_IPSET_SIZE <= 0:
             log.warning("Max ipset size is non-positive, defaulting to 2^20.")
             self.MAX_IPSET_SIZE = 2**20
+
+        if self.IPTABLES_MARK_MASK <= 0:
+            log.warning("Iptables mark mask contains insufficient bits, "
+                        "defaulting to 0xff000000")
+            self.IPTABLES_MARK_MASK = 0xff000000
+
+        if self.IPTABLES_MARK_MASK > 0xffffffff:
+            log.warning("Iptables mark mask out of range, "
+                        "defaulting to 0xff000000")
+            self.IPTABLES_MARK_MASK = 0xff000000
 
         if not final:
             # Do not check that unset parameters are defaulted; we have more

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -25,10 +25,12 @@ builds a singleton configuration object. That object may (once) be changed by
 etcd configuration being reported back to it.
 """
 import os
+from numbers import Number
 
 import ConfigParser
 import logging
 import socket
+
 import pkg_resources
 
 from calico import common
@@ -119,8 +121,13 @@ class ConfigParameter(object):
                 # the right value if / when it goes wrong.
                 self.value = value
                 try:
-                    self.value = int(value, 0)
-                except ValueError:
+                    # The int(..., 0) form barfs on non-strings so we need to
+                    # check if we've already got a number in-hand.
+                    if isinstance(value, Number):
+                        self.value = int(value)
+                    else:
+                        self.value = int(value, 0)
+                except (ValueError, TypeError):
                     raise ConfigException("Field was not integer",
                                           self)
             elif self.value_is_bool:
@@ -236,9 +243,9 @@ class Config(object):
                            2**20, value_is_int=True)
         self.add_parameter("IptablesMarkMask",
                            "Mask that Felix selects its IPTables Mark bits "
-			   "from.  Should be a 32 bit hexadecimal number with "
-			   "at least 8 bits set, none of which clash with any "
-			   "other mark bits in use on the system.",
+                           "from.  Should be a 32 bit hexadecimal number with "
+                           "at least 8 bits set, none of which clash with any "
+                           "other mark bits in use on the system.",
                            0xff000000, value_is_int=True)
 
         # The following setting determines which flavour of Iptables Generator
@@ -331,8 +338,8 @@ class Config(object):
         self.MAX_IPSET_SIZE = self.parameters["MaxIpsetSize"].value
         self.IPTABLES_GENERATOR_PLUGIN = \
             self.parameters["IptablesGeneratorPlugin"].value
-	self.IPTABLES_MARK_MASK =\
-	    self.parameters["IptablesMarkMask"].value
+        self.IPTABLES_MARK_MASK =\
+            self.parameters["IptablesMarkMask"].value
 
         self._validate_cfg(final=final)
 

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -106,15 +106,15 @@ profilerules.py.
 Since an endpoint may be in multiple profiles and we execute the policy
 chains of those profiles in sequence, the policy chains need to
 communicate three different "return values"; for this we use the packet
-MARK:
+Accept MARK (a configured bit in the MARK space):
 
 * Packet was matched by a deny rule.  In this case the packet is immediately
   dropped.
 * Packet was matched by an allow rule.  In this case the packet is returned
-  with MARK==1.  The calling chain can then return the packet to its caller
-  for further processing.
+  with Accept MARK==1.  The calling chain can then return the packet to its
+  caller for further processing.
 * Packet was not matched at all.  In this case, the packet is returned with
-  MARK==0.  The calling chain can then send the packet through the next
+  Accept MARK==0.  The calling chain can then send the packet through the next
   profile chain.
 
 """

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -90,7 +90,7 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config.REPORTING_INTERVAL_SECS, 30)
             self.assertEqual(config.REPORTING_TTL_SECS, 90)
             self.assertEqual(config.IPTABLES_MARK_MASK, 0xff000000)
-            self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x01000000")
+            self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x1000000")
 
     def test_bad_plugin_name(self):
         env_dict = {"FELIX_IPTABLESGENERATORPLUGIN": "unknown"}
@@ -411,7 +411,7 @@ class TestConfig(unittest.TestCase):
         config = load_config("felix_missing.cfg", host_dict=cfg_dict)
 
         self.assertEqual(config.IPTABLES_MARK_MASK, 0xff000000)
-        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x01000000")
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x1000000")
 
     def test_exact_mark_bits(self):
         """
@@ -425,7 +425,7 @@ class TestConfig(unittest.TestCase):
         config = load_config("felix_missing.cfg", host_dict=cfg_dict)
 
         self.assertEqual(config.IPTABLES_MARK_MASK, 0x00000004)
-        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x00000004")
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x4")
 
     def test_too_many_mark_bits(self):
         """
@@ -436,7 +436,7 @@ class TestConfig(unittest.TestCase):
         config = load_config("felix_missing.cfg", host_dict=cfg_dict)
 
         self.assertEqual(config.IPTABLES_MARK_MASK, 0xff000000)
-        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x01000000")
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x1000000")
 
     def test_hex_mark(self):
         """
@@ -447,7 +447,7 @@ class TestConfig(unittest.TestCase):
         config = load_config("felix_missing.cfg", host_dict=cfg_dict)
 
         self.assertEqual(config.IPTABLES_MARK_MASK, 0x00000060)
-        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x00000020")
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x20")
 
     def test_default_ttl(self):
         """

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -89,6 +89,8 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config.METADATA_IP, "1.2.3.4")
             self.assertEqual(config.REPORTING_INTERVAL_SECS, 30)
             self.assertEqual(config.REPORTING_TTL_SECS, 90)
+            self.assertEqual(config.IPTABLES_MARK_MASK, 0xff000000)
+            self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x01000000")
 
     def test_bad_plugin_name(self):
         env_dict = {"FELIX_IPTABLESGENERATORPLUGIN": "unknown"}
@@ -398,6 +400,54 @@ class TestConfig(unittest.TestCase):
 
         self.assertEqual(config.REPORTING_INTERVAL_SECS, 0)
         self.assertEqual(config.REPORTING_TTL_SECS, 0)
+
+    def test_insufficient_mark_bits(self):
+        """
+        Test that the mark masks are defaulted when there are insufficient
+        bits.
+        """
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "IptablesMarkMask": "0" }
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+
+        self.assertEqual(config.IPTABLES_MARK_MASK, 0xff000000)
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x01000000")
+
+    def test_exact_mark_bits(self):
+        """
+        Test that the IptablesMarkMask works when the minimum number of bits is
+        provided.
+        """
+        # This test is intended to catch if _validate_cfg() isn't updated when
+        # new mark bits are added.
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "IptablesMarkMask": "4" }
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+
+        self.assertEqual(config.IPTABLES_MARK_MASK, 0x00000004)
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x00000004")
+
+    def test_too_many_mark_bits(self):
+        """
+        Test that the mark masks are defaulted when the option is out of range.
+        """
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "IptablesMarkMask": "9876543210" }
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+
+        self.assertEqual(config.IPTABLES_MARK_MASK, 0xff000000)
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x01000000")
+
+    def test_hex_mark(self):
+        """
+        Test that the IptablesMarkMask accepts hexadecimal values.
+        """
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "IptablesMarkMask": "0x60" }
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+
+        self.assertEqual(config.IPTABLES_MARK_MASK, 0x00000060)
+        self.assertEqual(config.IPTABLES_MARK_ACCEPT, "0x00000020")
 
     def test_default_ttl(self):
         """

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -27,12 +27,12 @@ from calico.felix.test.base import BaseTestCase, load_config
 
 _log = logging.getLogger(__name__)
 
-DEFAULT_MARK = '--append %s --jump MARK --set-mark 1'
+DEFAULT_MARK = '--append %s --jump MARK --set-mark 0x1000000/0x1000000'
 
 DEFAULT_UNMARK = (
     '--append %s '
     '--match comment --comment "No match, fall through to next profile" '
-    '--jump MARK --set-mark 0'
+    '--jump MARK --set-mark 0/0x1000000'
 )
 
 INPUT_CHAINS = {
@@ -193,7 +193,7 @@ RULES_TESTS = [
 
 FROM_ENDPOINT_CHAIN = [
     # Always start with a 0 MARK.
-    '--append felix-from-abcd --jump MARK --set-mark 0',
+    '--append felix-from-abcd --jump MARK --set-mark 0/0x1000000',
     # From chain polices the MAC address.
     '--append felix-from-abcd --match mac ! --mac-source aa:22:33:44:55:66 '
                '--jump DROP -m comment --comment '
@@ -202,15 +202,15 @@ FROM_ENDPOINT_CHAIN = [
     # Jump to the first profile.
     '--append felix-from-abcd --jump felix-p-prof-1-o',
     # Short-circuit: return if the first profile matched.
-    '--append felix-from-abcd --match mark --mark 1/1 --match comment '
-               '--comment "Profile accepted packet" '
+    '--append felix-from-abcd --match mark --mark 0x1000000/0x1000000 '
+               '--match comment --comment "Profile accepted packet" '
                '--jump RETURN',
 
     # Jump to second profile.
     '--append felix-from-abcd --jump felix-p-prof-2-o',
     # Return if the second profile matched.
-    '--append felix-from-abcd --match mark --mark 1/1 --match comment '
-               '--comment "Profile accepted packet" '
+    '--append felix-from-abcd --match mark --mark 0x1000000/0x1000000 '
+               '--match comment --comment "Profile accepted packet" '
                '--jump RETURN',
 
     # Drop the packet if nothing matched.
@@ -220,18 +220,18 @@ FROM_ENDPOINT_CHAIN = [
 
 TO_ENDPOINT_CHAIN = [
     # Always start with a 0 MARK.
-    '--append felix-to-abcd --jump MARK --set-mark 0',
+    '--append felix-to-abcd --jump MARK --set-mark 0/0x1000000',
 
     # Jump to first profile and return iff it matched.
     '--append felix-to-abcd --jump felix-p-prof-1-i',
-    '--append felix-to-abcd --match mark --mark 1/1 --match comment '
-             '--comment "Profile accepted packet" '
+    '--append felix-to-abcd --match mark --mark 0x1000000/0x1000000 '
+             '--match comment --comment "Profile accepted packet" '
              '--jump RETURN',
 
     # Jump to second profile and return iff it matched.
     '--append felix-to-abcd --jump felix-p-prof-2-i',
-    '--append felix-to-abcd --match mark --mark 1/1 --match comment '
-             '--comment "Profile accepted packet" '
+    '--append felix-to-abcd --match mark --mark 0x1000000/0x1000000 '
+             '--match comment --comment "Profile accepted packet" '
              '--jump RETURN',
 
     # Drop anything that doesn't match.

--- a/calico/felix/test/test_profilerules.py
+++ b/calico/felix/test/test_profilerules.py
@@ -45,22 +45,22 @@ RULES_1 = {
 
 RULES_1_CHAINS = {
     'felix-p-prof1-i': [
-        '--append felix-p-prof1-i --jump MARK --set-mark 1',
+        '--append felix-p-prof1-i --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-i --match set '
             '--match-set src-tag-name src --jump RETURN',
         '--append felix-p-prof1-i '
             '--match comment '
             '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0',
+            '--jump MARK --set-mark 0/0x1000000',
     ],
     'felix-p-prof1-o': [
-        '--append felix-p-prof1-o --jump MARK --set-mark 1',
+        '--append felix-p-prof1-o --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-o --match set '
             '--match-set dst-tag-name dst --jump RETURN',
         '--append felix-p-prof1-o '
             '--match comment '
             '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0',
+            '--jump MARK --set-mark 0/0x1000000',
     ]
 }
 
@@ -77,22 +77,22 @@ RULES_2 = {
 
 RULES_2_CHAINS = {
     'felix-p-prof1-i': [
-        '--append felix-p-prof1-i --jump MARK --set-mark 1',
+        '--append felix-p-prof1-i --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-i --match set '
             '--match-set src-tag-added-name src --jump RETURN',
         '--append felix-p-prof1-i '
             '--match comment '
             '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0',
+            '--jump MARK --set-mark 0/0x1000000',
     ],
     'felix-p-prof1-o': [
-        '--append felix-p-prof1-o --jump MARK --set-mark 1',
+        '--append felix-p-prof1-o --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-o --match set '
             '--match-set dst-tag-name dst --jump RETURN',
         '--append felix-p-prof1-o '
             '--match comment '
             '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0',
+            '--jump MARK --set-mark 0/0x1000000',
     ]
 }
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -138,6 +138,10 @@ The full list of parameters which can be set is as follows.
 | MaxIpsetSize                | 1048576                        | Maximum size for the ipsets used by Felix to implement tags.  Should be set to a number   |
 |                             |                                | that is greater than the maximum number of IP addresses that are ever expected in a tag.  |
 +-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| IptablesMarkMask            | 0xff000000                     | Mask that Felix selects its IPTables Mark bits from.  Should be a 32 bit hexadecimal      |
+|                             |                                | number with at least 8 bits set, none of which clash with any other mark bits in use on   |
+|                             |                                | the system.                                                                               |
++-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
 
 
 Environment variables


### PR DESCRIPTION
We mustn't use the whole mark space, so this makes the part  we do use configurable.  The immediate requirement for this is compatibility with the Kubernetes iptables proxy.

(Fixes #964)