### PR TITLE
Update docs for 1.3.0.

### DIFF
--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -433,14 +433,15 @@ On each compute node, perform the following steps:
        service neutron-dhcp-agent restart
        chkconfig neutron-dhcp-agent on
 
-   For OpenStack Liberty or later, stop and disable the Neutron DHCP agent, as
-   Calico will install and use its own DHCP agent (as part of the
-   ``calico-compute`` step below):
+   For OpenStack Liberty or later, stop and disable the Neutron DHCP agent,
+   and install the Calico DHCP agent (which uses etcd, allowing it to scale
+   to higher numbers of hosts):
 
    ::
 
        service neutron-dhcp-agent stop
        chkconfig neutron-dhcp-agent off
+       yum install calico-dhcp-agent
 
 7.  Stop and disable any other routing/bridging agents such as the L3
     routing agent or the Linux bridging agent.  These conflict with Calico.

--- a/docs/source/ubuntu-opens-install.rst
+++ b/docs/source/ubuntu-opens-install.rst
@@ -68,9 +68,10 @@ Add the Calico PPA.
 Where ``<release>`` is icehouse, juno, kilo or stable (choose stable for
 Liberty onwards, because we no longer require patches to OpenStack).
 
-If you're not using OpenStack Liberty, edit ``/etc/apt/preferences`` to add the
-following lines, whose effect is to prefer Calico-provided packages for Nova
-and Neutron even if later versions of those packages are released by Ubuntu.
+If you're using a version of OpenStack prior to Liberty, edit
+``/etc/apt/preferences`` to add the following lines, whose effect is to prefer
+Calico-provided packages for Nova and Neutron even if later versions of those
+packages are released by Ubuntu.
 
 ::
 
@@ -351,13 +352,15 @@ perform the following steps:
 
        sudo service neutron-dhcp-agent restart
 
-   For OpenStack Liberty or later, stop the Neutron DHCP agent, as Calico will
-   install and use its own DHCP agent (as part of the following
-   ``calico-compute`` step):
+   For OpenStack Liberty and later, install the Calico DHCP agent (which
+   uses etcd, allowing it to scale to higher numbers of hosts) and disable
+   the Neutron-provided one:
 
    ::
 
        sudo service neutron-dhcp-agent stop
+       echo manual | sudo tee /etc/init/neutron-dhcp-agent.override
+       sudo apt-get install calico-dhcp-agent
 
 7. Install the ``calico-compute`` package:
 


### PR DESCRIPTION
* Prefer individual package updates over dist-upgrade.
* Manually install calico-dhcp-agent in this release.