### PR TITLE
Add diff-cover output to run-unit-test.sh output.

### DIFF
--- a/run-unit-test.sh
+++ b/run-unit-test.sh
@@ -20,4 +20,6 @@ tox "$@"
 # coverage.
 source .tox/py27/bin/activate
 coverage html
+coverage xml
+diff-cover coverage.xml --compare-branch=origin/master
 deactivate

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     mock>=1.3.0
     coverage>=4.0.2
     unittest2
+    diff_cover
 # Each of our components uses a different scheme of
 # thread monkey-patching so run each separately.  We'd like to
 # use "nosetests --with-coverage" but there's no way to pass


### PR DESCRIPTION
Shows which lines of coverage you've missed in your patch.