### PR TITLE
Explicitly track which IPs should be removed from conntrack

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -293,7 +293,6 @@ def set_routes(ip_type, ips, interface, mac=None, reset_arp=False):
     removed_ips = (current_ips - ips)
     for ip in removed_ips:
         del_route(ip_type, ip, interface)
-    remove_conntrack_flows(removed_ips, 4 if ip_type == futils.IPV4 else 6)
     for ip in (ips - current_ips):
         add_route(ip_type, ip, interface, mac)
     if reset_arp:

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -38,7 +38,7 @@ from calico.felix import futils
 from calico.felix.fiptables import IptablesUpdater
 from calico.felix.dispatch import DispatchChains
 from calico.felix.profilerules import RulesManager
-from calico.felix.frules import install_global_rules
+from calico.felix.frules import install_global_rules, load_nf_conntrack
 from calico.felix.splitter import UpdateSplitter, CleanupManager
 from calico.felix.config import Config
 from calico.felix.futils import IPV4, IPV6
@@ -189,6 +189,12 @@ def _main_greenlet(config):
             ]
 
         monitored_items = [actor.greenlet for actor in top_level_actors]
+
+        # Try to ensure that the nf_conntrack_netlink kernel module is present.
+        # This works around an issue[1] where the first call to the "conntrack"
+        # command fails while waiting for the module to load.
+        # [1] https://github.com/projectcalico/calico/issues/986
+        load_nf_conntrack()
 
         # Install the global rules before we start polling for updates.
         _log.info("Installing global rules.")

--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -165,8 +165,7 @@ class TestDevices(unittest.TestCase):
             devices.set_routes(futils.IPV6, ips, interface, mac=mac,
                                reset_arp=True)
 
-    @mock.patch("calico.felix.devices.remove_conntrack_flows", autospec=True)
-    def test_set_routes_mainline(self, m_remove_conntrack):
+    def test_set_routes_mainline(self):
         type = futils.IPV4
         ips = set(["1.2.3.4", "2.3.4.5"])
         interface = "tapabcdef"
@@ -183,10 +182,8 @@ class TestDevices(unittest.TestCase):
                 devices.set_routes(type, ips, interface, mac)
                 self.assertEqual(futils.check_call.call_count, len(calls))
                 futils.check_call.assert_has_calls(calls, any_order=True)
-                m_remove_conntrack.assert_called_once_with(set(), 4)
 
-    @mock.patch("calico.felix.devices.remove_conntrack_flows", autospec=True)
-    def test_set_routes_nothing_to_do(self, m_remove_conntrack):
+    def test_set_routes_nothing_to_do(self):
         type = futils.IPV4
         ips = set(["1.2.3.4", "2.3.4.5"])
         retcode = futils.CommandOutput("", "")
@@ -198,10 +195,8 @@ class TestDevices(unittest.TestCase):
                             return_value=ips):
                 devices.set_routes(type, ips, interface, mac)
                 self.assertEqual(futils.check_call.call_count, 0)
-                m_remove_conntrack.assert_called_once_with(set(), 4)
 
-    @mock.patch("calico.felix.devices.remove_conntrack_flows", autospec=True)
-    def test_set_routes_changed_ips(self, m_remove_conntrack):
+    def test_set_routes_changed_ips(self):
         ip_type = futils.IPV4
         current_ips = set(["2.3.4.5", "3.4.5.6"])
         ips = set(["1.2.3.4", "2.3.4.5"])
@@ -221,10 +216,8 @@ class TestDevices(unittest.TestCase):
                 devices.set_routes(ip_type, ips, interface, mac)
                 self.assertEqual(futils.check_call.call_count, len(calls))
                 futils.check_call.assert_has_calls(calls, any_order=True)
-                m_remove_conntrack.assert_called_once_with(set(["3.4.5.6"]), 4)
 
-    @mock.patch("calico.felix.devices.remove_conntrack_flows", autospec=True)
-    def test_set_routes_changed_ips_reset_arp(self, m_remove_conntrack):
+    def test_set_routes_changed_ips_reset_arp(self):
         type = futils.IPV4
         ips = set(["1.2.3.4", "2.3.4.5"])
         interface = "tapabcdef"
@@ -242,10 +235,8 @@ class TestDevices(unittest.TestCase):
                 devices.set_routes(type, ips, interface, mac, reset_arp=True)
                 self.assertEqual(futils.check_call.call_count, len(calls))
                 futils.check_call.assert_has_calls(calls, any_order=True)
-                m_remove_conntrack.assert_called_once_with(set(["3.4.5.6"]), 4)
 
-    @mock.patch("calico.felix.devices.remove_conntrack_flows", autospec=True)
-    def test_set_routes_add_ips(self, m_remove_conntrack):
+    def test_set_routes_add_ips(self):
         type = futils.IPV4
         ips = set(["1.2.3.4", "2.3.4.5"])
         interface = "tapabcdef"
@@ -265,7 +256,6 @@ class TestDevices(unittest.TestCase):
                 devices.set_routes(type, ips, interface, mac, reset_arp=True)
                 self.assertEqual(futils.check_call.call_count, len(calls))
                 futils.check_call.assert_has_calls(calls, any_order=True)
-                m_remove_conntrack.assert_called_once_with(set(), 4)
 
     def test_list_interface_no_ips(self):
         retcode = futils.CommandOutput(

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -48,6 +48,7 @@ class TestBasic(BaseTestCase):
         else:
             sys.modules['etcd'] = self._real_etcd
 
+    @mock.patch("calico.felix.felix.load_nf_conntrack", autospec=True)
     @mock.patch("os.path.exists", autospec=True, return_value=True)
     @mock.patch("calico.felix.devices.list_interface_ips", autospec=True)
     @mock.patch("calico.felix.devices.configure_global_kernel_config",
@@ -69,7 +70,7 @@ class TestBasic(BaseTestCase):
                            m_start, m_load,
                            m_ipset_4, m_check_call, m_iface_exists,
                            m_iface_up, m_configure_global_kernel_config,
-                           m_list_interface_ips, m_path_exists):
+                           m_list_interface_ips, m_path_exists, m_conntrack):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
         m_MasqueradeManager.return_value.greenlet = mock.Mock()
         m_UpdateSplitter.return_value.greenlet = mock.Mock()
@@ -97,7 +98,9 @@ class TestBasic(BaseTestCase):
         m_iface_exists.assert_called_once_with("tunl0")
         m_iface_up.assert_called_once_with("tunl0")
         m_configure_global_kernel_config.assert_called_once_with()
+        m_conntrack.assert_called_once_with()
 
+    @mock.patch("calico.felix.felix.load_nf_conntrack", autospec=True)
     @mock.patch("calico.felix.felix.install_global_rules", autospec=True)
     @mock.patch("os.path.exists", autospec=True, return_value=False)
     @mock.patch("calico.felix.devices.list_interface_ips", autospec=True)
@@ -117,7 +120,7 @@ class TestBasic(BaseTestCase):
                                    m_ipset_4, m_check_call,
                                    m_configure_global_kernel_config,
                                    m_list_interface_ips, m_path_exists,
-                                   m_install_globals):
+                                   m_install_globals, m_conntrack):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
         m_MasqueradeManager.return_value.greenlet = mock.Mock()
         m_UpdateSplitter.return_value.greenlet = mock.Mock()
@@ -145,4 +148,5 @@ class TestBasic(BaseTestCase):
         m_configure_global_kernel_config.assert_called_once_with()
         m_install_globals.assert_called_once_with(mock.ANY, mock.ANY, mock.ANY,
                                                   ip_version=4)
+        m_conntrack.assert_called_once_with()
 

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -468,3 +468,17 @@ class TestRules(BaseTestCase):
                                  call(m_config),
                                  call(m_config)
                              ])
+
+    def test_load_nf_conntrack(self):
+        with patch("calico.felix.futils.check_call", autospec=True) as m_call:
+            frules.load_nf_conntrack()
+        m_call.assert_called_once_with(["conntrack", "-S"])
+
+    def test_load_nf_conntrack_fail(self):
+        with patch("calico.felix.futils.check_call", autospec=True) as m_call:
+            m_call.side_effect = FailedSystemCall(message="bad call",
+                                                  args=["conntrack", "-S"],
+                                                  retcode=1,
+                                                  stdout="", stderr="")
+            frules.load_nf_conntrack()  # Exception should be caught
+        m_call.assert_called_once_with(["conntrack", "-S"])


### PR DESCRIPTION
Previously we relied on loading the IPs from the routing table, but that's not sound when an interface is being torn down because its routes may have already gone by the time we read them.  (Fixes #987.)

In addition, pre-load the `nf_conntrack_netlink` kernel module to work around #986 (Fixes #986).