### PR TITLE
Fix RPM pyparsing dependency.

### DIFF
--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -35,7 +35,7 @@ This package provides common files.
 %package felix
 Group:          Applications/Engineering
 Summary:        Project Calico virtual networking for cloud data centers
-Requires:       calico-common, conntrack-tools, ipset, iptables, net-tools, python-pyparsing, python-devel, python-netaddr, python-gevent, datrie, ijson, python-urllib3, python-msgpack
+Requires:       calico-common, conntrack-tools, ipset, iptables, net-tools, pyparsing, python-devel, python-netaddr, python-gevent, datrie, ijson, python-urllib3, python-msgpack
 
 
 %description felix


### PR DESCRIPTION
Package name was incorrect, should just be "pyparsing", not "python-pyparsing".