### PR TITLE
Add support for negated match criteria.

### DIFF
--- a/calico/etcdutils.py
+++ b/calico/etcdutils.py
@@ -501,8 +501,11 @@ FIELDS_TO_INTERN = set([
 
     # Rules dicts.
     "protocol",
+    "!protocol",
     "src_tag",
+    "!src_tag",
     "dst_tag",
+    "!dst_tag",
     "action",
 ])
 json_decoder = json.JSONDecoder(

--- a/calico/felix/profilerules.py
+++ b/calico/felix/profilerules.py
@@ -296,9 +296,12 @@ def extract_tags_and_selectors_from_profile(profile):
     tags_and_sels = set()
     for in_or_out in ["inbound_rules", "outbound_rules"]:
         for rule in profile.get(in_or_out, []):
-            for key in ["src_tag", "dst_tag", "src_selector", "dst_selector"]:
-                if key in rule:
-                    tags_and_sels.add(rule[key])
+            for neg_pfx in ["", "!"]:
+                for suffix in ["src_tag", "dst_tag",
+                               "src_selector", "dst_selector"]:
+                    key = neg_pfx + suffix
+                    if key in rule:
+                        tags_and_sels.add(rule[key])
     return tags_and_sels
 
 

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -21,6 +21,7 @@ Tests of iptables rules generation function.
 
 import logging
 from collections import OrderedDict
+from pprint import pformat
 
 from calico.felix.selectors import parse_selector
 from mock import Mock
@@ -71,6 +72,7 @@ INPUT_CHAINS = {
 }
 
 SELECTOR_A_EQ_B = parse_selector("a == 'b'")
+
 RULES_TESTS = [
     {
         "ip_version": 4,
@@ -105,6 +107,105 @@ RULES_TESTS = [
                     '--mark 0x2000000/0x2000000 --jump RETURN',
                 ]
         },
+    },
+    {
+        "ip_version": 4,
+        "tag_to_ipset": {"tag1": "t1", "tag2": "t2"},
+        "sel_to_ipset": {SELECTOR_A_EQ_B: "a-eq-b"},
+        "profile": {
+            "id": "prof1",
+            "inbound_rules": [
+                {"protocol": "tcp",
+                 "src_net": "10.0.0.0/8",
+                 "src_tag": "tag1",
+                 "src_selector": SELECTOR_A_EQ_B,
+                 "src_ports": [1, "2:3"],
+                 "!src_net": "11.0.0.0/8",
+                 "!src_tag": "tag2",
+                 "!src_selector": SELECTOR_A_EQ_B,
+                 "!src_ports": [1, "2:3", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+                                14, 15, 16, 17],
+                 "action": "next-tier",}
+            ],
+            "outbound_rules": [
+                {"protocol": "udp",
+                 "dst_net": "10.0.0.0/8",
+                 "dst_tag": "tag1",
+                 "dst_selector": SELECTOR_A_EQ_B,
+                 "dst_ports": [1, "2:3"],
+                 "!dst_net": "11.0.0.0/8",
+                 "!dst_tag": "tag2",
+                 "!dst_selector": SELECTOR_A_EQ_B,
+                 "!dst_ports": [1, "2:3", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+                                14, 15, 16, 17],
+                 "action": "next-tier",}
+            ]
+        },
+        "updates": {
+            'felix-p-prof1-i': [
+                '--append felix-p-prof1-i'
+                ' --protocol tcp'
+                ' --source 10.0.0.0/8'
+                ' --match set --match-set t1 src'
+                ' --match set --match-set a-eq-b src'
+                ' --match multiport --source-ports 1,2:3'
+                ' ! --source 11.0.0.0/8'
+                ' --match set ! --match-set t2 src'
+                ' --match set ! --match-set a-eq-b src'
+                ' --match multiport ! --source-ports'
+                ' 1,2:3,4,5,6,7,8,9,10,11,12,13,14,15'
+                ' --match multiport ! --source-ports 16,17'
+                ' --jump MARK --set-mark 0x2000000/0x2000000',
+
+                '--append felix-p-prof1-i'
+                ' --match mark --mark 0x2000000/0x2000000 --jump RETURN',
+            ],
+            'felix-p-prof1-o': [
+                '--append felix-p-prof1-o'
+                ' --protocol udp'
+                ' --destination 10.0.0.0/8'
+                ' --match set --match-set t1 dst'
+                ' --match set --match-set a-eq-b dst'
+                ' --match multiport --destination-ports 1,2:3'
+                ' ! --destination 11.0.0.0/8'
+                ' --match set ! --match-set t2 dst'
+                ' --match set ! --match-set a-eq-b dst'
+                ' --match multiport ! --destination-ports'
+                ' 1,2:3,4,5,6,7,8,9,10,11,12,13,14,15'
+                ' --match multiport ! --destination-ports 16,17'
+                ' --jump MARK --set-mark 0x2000000/0x2000000',
+
+                '--append felix-p-prof1-o'
+                ' --match mark --mark 0x2000000/0x2000000 --jump RETURN',
+            ]
+        }
+    },
+    {
+        "ip_version": 4,
+        "tag_to_ipset": {"tag1": "t1", "tag2": "t2"},
+        "sel_to_ipset": {SELECTOR_A_EQ_B: "a-eq-b"},
+        "profile": {
+            "id": "prof1",
+            "inbound_rules": [
+                {"protocol": "icmp",
+                 "!icmp_type": 7,
+                 "!icmp_code": 123}
+            ],
+            "outbound_rules": [
+            ]
+        },
+        "updates": {
+            'felix-p-prof1-i': [
+                '--append felix-p-prof1-i'
+                ' --protocol icmp'
+                ' --match icmp ! --icmp-type 7/123'
+                ' --jump MARK --set-mark 0x1000000/0x1000000',
+                '--append felix-p-prof1-i'
+                ' --match mark --mark 0x1000000/0x1000000 --jump RETURN',
+            ],
+            'felix-p-prof1-o': [
+            ]
+        }
     },
     {
         "ip_version": 4,
@@ -227,7 +328,6 @@ RULES_TESTS = [
         },
     },
 ]
-
 FROM_ENDPOINT_CHAIN = [
     # Always start with a 0 MARK.
     '--append felix-from-abcd --jump MARK --set-mark 0/0x1000000',
@@ -430,6 +530,7 @@ class TestRules(BaseTestCase):
 
     def test_rules_generation(self):
         for test in RULES_TESTS:
+            _log.info("Running rules test\n%s", pformat(test))
             updates, deps = self.iptables_generator.profile_updates(
                 test["profile"]["id"],
                 test["profile"],
@@ -439,6 +540,8 @@ class TestRules(BaseTestCase):
                 on_allow=test.get("on_allow", "RETURN"),
                 on_deny=test.get("on_deny", "DROP")
             )
+            _log.info("Updates:\n%s", pformat(updates))
+            _log.info("Deps:\n%s", pformat(deps))
             self.assertEqual((updates, deps), (test["updates"], {}))
 
     def test_unknown_action(self):

--- a/calico/felix/test/test_profilerules.py
+++ b/calico/felix/test/test_profilerules.py
@@ -66,8 +66,10 @@ SELECTOR_1 = parse_selector("a == 'a1'")
 RULES_2 = {
     "id": "prof1",
     "inbound_rules": [
-        {"src_tag": "src-tag-added",
-         "src_selector": SELECTOR_1}
+        # Use negated matches to ensure we extract dependencies for negated
+        # matches.
+        {"!src_tag": "src-tag-added",
+         "!src_selector": SELECTOR_1}
     ],
     "outbound_rules": [
         {"dst_tag": "dst-tag"}
@@ -77,9 +79,9 @@ RULES_2 = {
 RULES_2_CHAINS = {
     'felix-p-prof1-i': [
         '--append felix-p-prof1-i --match set '
-            '--match-set src-tag-added-name src '
+            '! --match-set src-tag-added-name src '
             '--match set '
-            '--match-set selector-1-name src '
+            '! --match-set selector-1-name src '
             '--jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-i --match mark '
             '--mark 0x1000000/0x1000000 --jump RETURN',

--- a/docs/source/etcd-data-model.rst
+++ b/docs/source/etcd-data-model.rst
@@ -370,10 +370,8 @@ match criteria within a rule must be satisfied for a packet to match.
 A single rule can contain the positive and negative version of a match and
 both must be satisfied for the rule to match.
 
-The properties in the rules object have the following meaning. Each can be
-prefixed with ``"!"`` to invert the match.  All of these properties are
-optional but some have dependencies (such as requiring the
-protocol to be specified):
+All of these properties are optional but some have dependencies (such as
+requiring the protocol to be specified):
 
 ``protocol``
   if present, restricts the rule to only apply to traffic of a specific IP
@@ -396,6 +394,24 @@ protocol to be specified):
   :ref:`security-policy-data`.  Only traffic that originates from endpoints
   matching the selector will be matched.
 
+  .. warning:: In addition to the negative version of "src_selector" (which
+               is "!src_selector") the selector expression syntax itself
+               supports negation.  The two types of negation are subtly
+               different.  One negates the set of matched endpoints, the other
+               negates the whole match:
+
+               ``"src_selector": !has(my_label)`` matches packets that are
+               from other Calico-controlled endpoints that **do not** have the
+               label "my_label".
+
+               ``"!src_selector": has(my_label)`` matches packets that are
+               not from Calico-controlled endpoints that **do** have the
+               label "my_label".
+
+               The effect is that the latter will accept packets from
+               non-Calico sources whereas the former is limited to packets
+               from Calico-controlled endpoints.
+
 ``src_ports``
   if present, restricts the rule to only apply to traffic that has a source
   port that matches one of these ranges/values. This value is a list of
@@ -412,6 +428,9 @@ protocol to be specified):
   if present, contains a selector expression as described in
   :ref:`security-policy-data`.  Only traffic that is destined for endpoints
   matching the selector will be matched.
+
+  .. warning:: The subtlety described above around negating ``"src_selector"``
+               also applies to ``"dst_selector"``.
 
 ``dst_net``
   if present, restricts the rule to only apply to traffic that is destined for


### PR DESCRIPTION
For example, in addition to `src_tag`, we now allow `!src_tag`, which matches if the source IP is not a member of the tag.

Note:

- Even negated matches for, for example, ports, require a non-negated protocol match.  This is because a port match is only valid (negated or not) if the protocol has ports.
- `!icmp_type` and `!icmp_code` are treated together as one match, meaning `not(icmp_type==<type> && icmp_code==<code>)` rather than the more obvious `not(icmp_type==<type>) && not(icmp_code==<code>)`.  This is a kernel limitation; the kernel can only match on ICMP type and code together.