### PR TITLE
Fix that next-tier action also accepted packets.

### DIFF
--- a/calico/felix/test/test_profilerules.py
+++ b/calico/felix/test/test_profilerules.py
@@ -47,22 +47,18 @@ RULES_1 = {
 
 RULES_1_CHAINS = {
     'felix-p-prof1-i': [
-        '--append felix-p-prof1-i --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-i --match set '
-            '--match-set src-tag-name src --jump RETURN',
-        '--append felix-p-prof1-i '
-            '--match comment '
-            '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0/0x1000000',
+            '--match-set src-tag-name src '
+            '--jump MARK --set-mark 0x1000000/0x1000000',
+        '--append felix-p-prof1-i --match mark '
+            '--mark 0x1000000/0x1000000 --jump RETURN',
     ],
     'felix-p-prof1-o': [
-        '--append felix-p-prof1-o --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-o --match set '
-            '--match-set dst-tag-name dst --jump RETURN',
-        '--append felix-p-prof1-o '
-            '--match comment '
-            '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0/0x1000000',
+            '--match-set dst-tag-name dst '
+            '--jump MARK --set-mark 0x1000000/0x1000000',
+        '--append felix-p-prof1-o --match mark '
+            '--mark 0x1000000/0x1000000 --jump RETURN',
     ]
 }
 
@@ -80,24 +76,20 @@ RULES_2 = {
 
 RULES_2_CHAINS = {
     'felix-p-prof1-i': [
-        '--append felix-p-prof1-i --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-i --match set '
             '--match-set src-tag-added-name src '
             '--match set '
-            '--match-set selector-1-name src --jump RETURN',
-        '--append felix-p-prof1-i '
-            '--match comment '
-            '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0/0x1000000',
+            '--match-set selector-1-name src '
+            '--jump MARK --set-mark 0x1000000/0x1000000',
+        '--append felix-p-prof1-i --match mark '
+            '--mark 0x1000000/0x1000000 --jump RETURN',
     ],
     'felix-p-prof1-o': [
-        '--append felix-p-prof1-o --jump MARK --set-mark 0x1000000/0x1000000',
         '--append felix-p-prof1-o --match set '
-            '--match-set dst-tag-name dst --jump RETURN',
-        '--append felix-p-prof1-o '
-            '--match comment '
-            '--comment "No match, fall through to next profile" '
-            '--jump MARK --set-mark 0/0x1000000',
+            '--match-set dst-tag-name dst '
+            '--jump MARK --set-mark 0x1000000/0x1000000',
+        '--append felix-p-prof1-o --match mark '
+            '--mark 0x1000000/0x1000000 --jump RETURN',
     ]
 }
 


### PR DESCRIPTION
Previously, we were setting the accept mark at the start of the profile chain and then unsetting it at the end of the chain if no rules matched.  That was correct while the only returning rule type was "allow", but it meant that when we added "next-tier" it also implicitly accepted the packet.

Fixes #1014