### PR TITLE
Add experimental Prometheus metrics endpoints

### DIFF
--- a/calico/etcddriver/__main__.py
+++ b/calico/etcddriver/__main__.py
@@ -28,6 +28,8 @@ import os
 import socket
 import sys
 
+from prometheus_client import start_http_server
+
 from calico.etcddriver import driver
 from calico import common
 

--- a/calico/etcddriver/protocol.py
+++ b/calico/etcddriver/protocol.py
@@ -36,6 +36,7 @@ MSG_KEY_HOSTNAME = "hostname"
 MSG_KEY_KEY_FILE = "etcd_key_file"
 MSG_KEY_CERT_FILE = "etcd_cert_file"
 MSG_KEY_CA_FILE = "etcd_ca_file"
+MSG_KEY_PROM_PORT = "prom_port"
 
 # Config loaded message Driver -> Felix.
 MSG_TYPE_CONFIG_LOADED = "config_loaded"

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -255,6 +255,16 @@ class Config(object):
                            "at least 8 bits set, none of which clash with any "
                            "other mark bits in use on the system.",
                            0xff000000, value_is_int=True)
+        self.add_parameter("PrometheusMetricsEnabled",
+                           "Whether to enable prometheus metrics.",
+                           False, value_is_bool=True)
+        self.add_parameter("PrometheusMetricsPort",
+                           "Port on which to export Prometheus metrics.",
+                           9091, value_is_int=True)
+        self.add_parameter("EtcdDriverPrometheusMetricsPort",
+                           "Port on which to export Prometheus metrics from "
+                           "the etcd driver process.",
+                           9092, value_is_int=True)
 
         # The following setting determines which flavour of Iptables Generator
         # plugin is loaded.  Note: this plugin support is currently highly
@@ -349,6 +359,12 @@ class Config(object):
             self.parameters["IptablesGeneratorPlugin"].value
         self.IPTABLES_MARK_MASK =\
             self.parameters["IptablesMarkMask"].value
+        self.PROM_METRICS_ENABLED = \
+            self.parameters["PrometheusMetricsEnabled"].value
+        self.PROM_METRICS_PORT = \
+            self.parameters["PrometheusMetricsPort"].value
+        self.PROM_METRICS_DRIVER_PORT = \
+            self.parameters["EtcdDriverPrometheusMetricsPort"].value
 
         self._validate_cfg(final=final)
 
@@ -639,6 +655,15 @@ class Config(object):
             log.warning("Iptables mark mask out of range, "
                         "defaulting to 0xff000000")
             self.IPTABLES_MARK_MASK = 0xff000000
+
+        if not 0 < self.PROM_METRICS_PORT < 65536:
+            log.warning("Prometheus port out-of-range, defaulting to 9091")
+            self.PROM_METRICS_PORT = 9091
+
+        if not 0 < self.PROM_METRICS_DRIVER_PORT < 65536:
+            log.warning("Etcd driver Prometheus port out-of-range, "
+                        "defaulting to 9092")
+            self.PROM_METRICS_DRIVER_PORT = 9092
 
         if not final:
             # Do not check that unset parameters are defaulted; we have more

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -46,7 +46,7 @@ from calico.etcddriver.protocol import (
     MSG_TYPE_CONFIG_LOADED, MSG_KEY_GLOBAL_CONFIG, MSG_KEY_HOST_CONFIG,
     MSG_TYPE_UPDATE, MSG_KEY_KEY, MSG_KEY_VALUE, MessageWriter,
     MSG_TYPE_STATUS, MSG_KEY_STATUS, MSG_KEY_KEY_FILE, MSG_KEY_CERT_FILE,
-    MSG_KEY_CA_FILE, SocketClosed)
+    MSG_KEY_CA_FILE, SocketClosed, MSG_KEY_PROM_PORT)
 from calico.etcdutils import (
     EtcdClientOwner, delete_empty_parents, PathDispatcher, EtcdEvent,
     safe_decode_json, intern_list
@@ -505,6 +505,9 @@ class _FelixEtcdWatcher(gevent.Greenlet):
                     MSG_KEY_SEV_FILE: self._config.LOGLEVFILE,
                     MSG_KEY_SEV_SCREEN: self._config.LOGLEVSCR,
                     MSG_KEY_SEV_SYSLOG: self._config.LOGLEVSYS,
+                    MSG_KEY_PROM_PORT:
+                        self._config.PROM_METRICS_DRIVER_PORT if
+                        self._config.PROM_METRICS_ENABLED else None
                 }
             )
             self.configured.set()
@@ -588,7 +591,7 @@ class _FelixEtcdWatcher(gevent.Greenlet):
                 MSG_KEY_HOSTNAME: self._config.HOSTNAME,
                 MSG_KEY_KEY_FILE: self._config.ETCD_KEY_FILE,
                 MSG_KEY_CERT_FILE: self._config.ETCD_CERT_FILE,
-                MSG_KEY_CA_FILE: self._config.ETCD_CA_FILE
+                MSG_KEY_CA_FILE: self._config.ETCD_CA_FILE,
             }
         )
         return reader, writer

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -536,3 +536,34 @@ class TestConfig(unittest.TestCase):
             config.report_etcd_config({}, cfg_dict)
 
         self.assertEqual(config.MAX_IPSET_SIZE, 2**20)
+
+    def test_prometheus_port_valid(self):
+        cfg_dict = {"InterfacePrefix": "blah",
+                    "PrometheusMetricsEnabled": True,
+                    "PrometheusMetricsPort": 9123,
+                    "EtcdDriverPrometheusMetricsPort": 9124}
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+
+        self.assertEqual(config.PROM_METRICS_PORT, 9123)
+        self.assertEqual(config.PROM_METRICS_DRIVER_PORT, 9124)
+        self.assertEqual(config.PROM_METRICS_ENABLED, True)
+
+    def test_prometheus_port_invalid(self):
+        cfg_dict = {"InterfacePrefix": "blah",
+                    "PrometheusMetricsEnabled": False,
+                    "PrometheusMetricsPort": -1,
+                    "EtcdDriverPrometheusMetricsPort": 65536}
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+
+        self.assertEqual(config.PROM_METRICS_PORT, 9091)
+        self.assertEqual(config.PROM_METRICS_DRIVER_PORT, 9092)
+        self.assertEqual(config.PROM_METRICS_ENABLED, False)
+
+    def test_prometheus_port_defaults(self):
+        cfg_dict = {"InterfacePrefix": "blah"}
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+
+        self.assertEqual(config.PROM_METRICS_PORT, 9091)
+        self.assertEqual(config.PROM_METRICS_DRIVER_PORT, 9092)
+        self.assertEqual(config.PROM_METRICS_ENABLED, False)
+

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -48,6 +48,7 @@ class TestBasic(BaseTestCase):
         else:
             sys.modules['etcd'] = self._real_etcd
 
+    @mock.patch("calico.felix.felix.HTTPServer", autospec=True)
     @mock.patch("calico.felix.felix.load_nf_conntrack", autospec=True)
     @mock.patch("os.path.exists", autospec=True, return_value=True)
     @mock.patch("calico.felix.devices.list_interface_ips", autospec=True)
@@ -70,7 +71,8 @@ class TestBasic(BaseTestCase):
                            m_start, m_load,
                            m_ipset_4, m_check_call, m_iface_exists,
                            m_iface_up, m_configure_global_kernel_config,
-                           m_list_interface_ips, m_path_exists, m_conntrack):
+                           m_list_interface_ips, m_path_exists, m_conntrack,
+                           m_http_server):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
         m_MasqueradeManager.return_value.greenlet = mock.Mock()
         m_UpdateSplitter.return_value.greenlet = mock.Mock()
@@ -87,7 +89,8 @@ class TestBasic(BaseTestCase):
             "FELIX_METADATAPORT": "1234",
             "FELIX_IPINIPENABLED": "True",
             "FELIX_IPINIPMTU": "1480",
-            "FELIX_DEFAULTINPUTCHAINACTION": "RETURN"
+            "FELIX_DEFAULTINPUTCHAINACTION": "RETURN",
+            "FELIX_PROMETHEUSMETRICSENABLED": "True",
         }
         config = load_config("felix_missing.cfg", env_dict=env_dict)
 
@@ -99,6 +102,8 @@ class TestBasic(BaseTestCase):
         m_iface_up.assert_called_once_with("tunl0")
         m_configure_global_kernel_config.assert_called_once_with()
         m_conntrack.assert_called_once_with()
+        m_http_server.assert_called_once_with(("0.0.0.0", 9091),
+                                              felix.MetricsHandler)
 
     @mock.patch("calico.felix.felix.load_nf_conntrack", autospec=True)
     @mock.patch("calico.felix.felix.install_global_rules", autospec=True)

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -31,7 +31,7 @@ from calico.etcddriver.protocol import MessageReader, MessageWriter, \
     MSG_TYPE_UPDATE, MSG_KEY_KEY, MSG_KEY_VALUE, MSG_KEY_TYPE, \
     MSG_KEY_HOST_CONFIG, MSG_KEY_GLOBAL_CONFIG, MSG_TYPE_CONFIG, \
     MSG_KEY_LOG_FILE, MSG_KEY_SEV_FILE, MSG_KEY_SEV_SCREEN, MSG_KEY_SEV_SYSLOG, \
-    STATUS_IN_SYNC, SocketClosed
+    STATUS_IN_SYNC, SocketClosed, MSG_KEY_PROM_PORT
 from calico.felix.config import Config
 from calico.felix.futils import IPV4, IPV6
 from calico.felix.ipsets import IpsetActor
@@ -282,6 +282,8 @@ class TestEtcdWatcher(BaseTestCase):
     @patch("calico.felix.fetcd.die_and_restart", autospec=True)
     def test_on_config_loaded(self, m_die):
         self.m_config.DRIVERLOGFILE = "/tmp/driver.log"
+        self.m_config.PROM_METRICS_DRIVER_PORT = 9092
+        self.m_config.PROM_METRICS_ENABLED = True
         global_config = {"InterfacePrefix": "tap"}
         local_config = {"LogSeverityFile": "DEBUG"}
         self.watcher._on_config_loaded_from_driver({
@@ -301,6 +303,7 @@ class TestEtcdWatcher(BaseTestCase):
                       MSG_KEY_SEV_FILE: self.m_config.LOGLEVFILE,
                       MSG_KEY_SEV_SCREEN: self.m_config.LOGLEVSCR,
                       MSG_KEY_SEV_SYSLOG: self.m_config.LOGLEVSYS,
+                      MSG_KEY_PROM_PORT: 9092,
                   })]
         )
         self.assertEqual(m_die.mock_calls, [])

--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Depends:
  python-etcd (>= 0.4.1+calico.1),
  python-ijson (>= 2.2-1),
  python-datrie (>= 0.7-1),
+ python-prometheus-client (>= 0.0.13-1~ubuntu14.04.1~ppa1),
  libyajl2 (>= 2.0.4-4),
  libdatrie1 (>= 0.2.8-1),
  python-msgpack (>= 0.3.0-1ubuntu3)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -73,75 +73,81 @@ environment variables or etcd is often more convenient.
 
 The full list of parameters which can be set is as follows.
 
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| Setting                     | Default                        | Meaning                                                                                   |
-+=============================+================================+===========================================================================================+
-| EtcdAddr                    | localhost:4001                 | The location (IP / hostname and port) of the etcd node or proxy that Felix should connect |
-|                             |                                | to.                                                                                       |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdScheme                  | http                           | The protocol type (http or https) of the etcd node or proxy that Felix connects to.       |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdKeyFile                 | None                           | The full path to the etcd public key file, as described in :ref:`usingtlswithetcd`        |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdCertFile                | None                           | The full path to the etcd certificate file, as described in :ref:`usingtlswithetcd`       |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdCaFile                  | None                           | The full path to the etcd Certificate Authority certificate file, as described in         |
-|                             |                                | :ref:`usingtlswithetcd`                                                                   |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| DefaultEndpointToHostAction | DROP                           | By default Calico blocks traffic from endpoints to the host itself by using an iptables   |
-|                             |                                | DROP action.  If you want to allow some or all traffic from endpoint to host then set     |
-|                             |                                | this parameter to "RETURN" (which causes the rest of the iptables INPUT chain to be       |
-|                             |                                | processed) or "ACCEPT" (which immediately accepts packets).                               |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| FelixHostname               | socket.gethostname()           | The hostname Felix reports to the plugin. Should be used if the hostname Felix            |
-|                             |                                | autodetects is incorrect or does not match what the plugin will expect.                   |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| MetadataAddr                | 127.0.0.1                      | The IP address or domain name of the server that can answer VM queries for cloud-init     |
-|                             |                                | metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu,   |
-|                             |                                | nova-api-metadata). A value of 'None' (case insensitive) means that Felix should not set  |
-|                             |                                | up any NAT rule for the metadata path.                                                    |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| MetadataPort                | 8775                           | The port of the metadata server. This, combined with global.MetadataAddr (if not 'None'), |
-|                             |                                | is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort. In    |
-|                             |                                | most cases this should not need to be changed.                                            |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| InterfacePrefix             | None                           | The start of the interface name for all interfaces. This is set to "tap" on OpenStack     |
-|                             |                                | by the plugin, but must be set to "veth" on most Docker deployments.                      |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogFilePath                 | /var/log/calico/felix.log      | The full path to the felix log. Set to "none" to disable file logging.                    |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdDriverLogFilePath       | /var/log/calico/felix-etcd.log | Felix's etcd driver has its own log file. This parameter contains its full path.          |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogSeveritySys              | ERROR                          | The log severity above which logs are sent to the syslog. Valid values are DEBUG, INFO,   |
-|                             |                                | WARNING, ERROR and CRITICAL, or NONE for no logging to syslog (all values case            |
-|                             |                                | insensitive).                                                                             |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogSeverityFile             | INFO                           | The log severity above which logs are sent to the log file. Valid values as for           |
-|                             |                                | LogSeveritySys.                                                                           |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogSeverityScreen           | ERROR                          | The log severity above which logs are sent to the stdout. Valid values as for             |
-|                             |                                | LogSeveritySys.                                                                           |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| StartupCleanupDelay         | 30                             | Delay, in seconds, before felix does its start-of-day cleanup to remove orphaned iptables |
-|                             |                                | chains and ipsets.   Before the first cleanup, felix operates in "graceful restart" mode, |
-|                             |                                | during which it preserves any pre-existing chains and ipsets.                             |
-|                             |                                |                                                                                           |
-|                             |                                | In a large deployment you may want to increase this value to give felix more time to      |
-|                             |                                | load the initial snapshot from etcd before cleaning up.                                   |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| PeriodicResyncInterval      | 3600                           | Period, in seconds, at which felix does a full resync with etcd and reprograms            |
-|                             |                                | iptables/ipsets.  Set to 0 to disable periodic resync.                                    |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| IptablesRefreshInterval     | 60                             | Period, in seconds, at which felix re-applies all iptables state to ensure that no other  |
-|                             |                                | process has accidentally broken Calico's rules.  Set to 0 to disable iptables refresh.    |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| MaxIpsetSize                | 1048576                        | Maximum size for the ipsets used by Felix to implement tags.  Should be set to a number   |
-|                             |                                | that is greater than the maximum number of IP addresses that are ever expected in a tag.  |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| IptablesMarkMask            | 0xff000000                     | Mask that Felix selects its IPTables Mark bits from.  Should be a 32 bit hexadecimal      |
-|                             |                                | number with at least 8 bits set, none of which clash with any other mark bits in use on   |
-|                             |                                | the system.                                                                               |
-+-----------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| Setting                          | Default                        | Meaning                                                                                   |
++==================================+================================+===========================================================================================+
+| EtcdAddr                         | localhost:4001                 | The location (IP / hostname and port) of the etcd node or proxy that Felix should connect |
+|                                  |                                | to.                                                                                       |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdScheme                       | http                           | The protocol type (http or https) of the etcd node or proxy that Felix connects to.       |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdKeyFile                      | None                           | The full path to the etcd public key file, as described in :ref:`usingtlswithetcd`        |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdCertFile                     | None                           | The full path to the etcd certificate file, as described in :ref:`usingtlswithetcd`       |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdCaFile                       | None                           | The full path to the etcd Certificate Authority certificate file, as described in         |
+|                                  |                                | :ref:`usingtlswithetcd`                                                                   |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| DefaultEndpointToHostAction      | DROP                           | By default Calico blocks traffic from endpoints to the host itself by using an iptables   |
+|                                  |                                | DROP action.  If you want to allow some or all traffic from endpoint to host then set     |
+|                                  |                                | this parameter to "RETURN" (which causes the rest of the iptables INPUT chain to be       |
+|                                  |                                | processed) or "ACCEPT" (which immediately accepts packets).                               |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| FelixHostname                    | socket.gethostname()           | The hostname Felix reports to the plugin. Should be used if the hostname Felix            |
+|                                  |                                | autodetects is incorrect or does not match what the plugin will expect.                   |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| MetadataAddr                     | 127.0.0.1                      | The IP address or domain name of the server that can answer VM queries for cloud-init     |
+|                                  |                                | metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu,   |
+|                                  |                                | nova-api-metadata). A value of 'None' (case insensitive) means that Felix should not set  |
+|                                  |                                | up any NAT rule for the metadata path.                                                    |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| MetadataPort                     | 8775                           | The port of the metadata server. This, combined with global.MetadataAddr (if not 'None'), |
+|                                  |                                | is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort. In    |
+|                                  |                                | most cases this should not need to be changed.                                            |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| InterfacePrefix                  | None                           | The start of the interface name for all interfaces. This is set to "tap" on OpenStack     |
+|                                  |                                | by the plugin, but must be set to "veth" on most Docker deployments.                      |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| LogFilePath                      | /var/log/calico/felix.log      | The full path to the felix log. Set to "none" to disable file logging.                    |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdDriverLogFilePath            | /var/log/calico/felix-etcd.log | Felix's etcd driver has its own log file. This parameter contains its full path.          |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| LogSeveritySys                   | ERROR                          | The log severity above which logs are sent to the syslog. Valid values are DEBUG, INFO,   |
+|                                  |                                | WARNING, ERROR and CRITICAL, or NONE for no logging to syslog (all values case            |
+|                                  |                                | insensitive).                                                                             |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| LogSeverityFile                  | INFO                           | The log severity above which logs are sent to the log file. Valid values as for           |
+|                                  |                                | LogSeveritySys.                                                                           |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| LogSeverityScreen                | ERROR                          | The log severity above which logs are sent to the stdout. Valid values as for             |
+|                                  |                                | LogSeveritySys.                                                                           |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| StartupCleanupDelay              | 30                             | Delay, in seconds, before felix does its start-of-day cleanup to remove orphaned iptables |
+|                                  |                                | chains and ipsets.   Before the first cleanup, felix operates in "graceful restart" mode, |
+|                                  |                                | during which it preserves any pre-existing chains and ipsets.                             |
+|                                  |                                |                                                                                           |
+|                                  |                                | In a large deployment you may want to increase this value to give felix more time to      |
+|                                  |                                | load the initial snapshot from etcd before cleaning up.                                   |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| PeriodicResyncInterval           | 3600                           | Period, in seconds, at which felix does a full resync with etcd and reprograms            |
+|                                  |                                | iptables/ipsets.  Set to 0 to disable periodic resync.                                    |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| IptablesRefreshInterval          | 60                             | Period, in seconds, at which felix re-applies all iptables state to ensure that no other  |
+|                                  |                                | process has accidentally broken Calico's rules.  Set to 0 to disable iptables refresh.    |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| MaxIpsetSize                     | 1048576                        | Maximum size for the ipsets used by Felix to implement tags.  Should be set to a number   |
+|                                  |                                | that is greater than the maximum number of IP addresses that are ever expected in a tag.  |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| IptablesMarkMask                 | 0xff000000                     | Mask that Felix selects its IPTables Mark bits from.  Should be a 32 bit hexadecimal      |
+|                                  |                                | number with at least 8 bits set, none of which clash with any other mark bits in use on   |
+|                                  |                                | the system.                                                                               |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| PrometheusMetricsEnabled         | "false"                        | Set to "true" to enable the experiemental Prometheus metrics server in Felix.             |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| PrometheusMetricsPort            | 9091                           | TCP port that the Prometheus metrics server should bind to.                               |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdDriverPrometheusMetricsPort  | 9092                           | TCP port that the Prometheus metrics server in the etcd driver process should bind to.    |
++----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
 
 
 Environment variables

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -7,4 +7,5 @@ datrie>=0.7
 ijson>=2.2
 msgpack-python>=0.3
 pyparsing>=2.0.0
+prometheus_client>=0.0.13
 urllib3>=1.7.1

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -35,7 +35,7 @@ This package provides common files.
 %package felix
 Group:          Applications/Engineering
 Summary:        Project Calico virtual networking for cloud data centers
-Requires:       calico-common, conntrack-tools, ipset, iptables, net-tools, pyparsing, python-devel, python-netaddr, python-gevent, datrie, ijson, python-urllib3, python-msgpack
+Requires:       calico-common, conntrack-tools, ipset, iptables, net-tools, pyparsing, python-devel, python-netaddr, python-gevent, datrie, ijson, python-urllib3, python-msgpack, prometheus_client
 
 
 %description felix


### PR DESCRIPTION
Todo:

- [x] Expose existing metrics
- [x] Add metrics around resync
- [x] Add config to enable.  Diasabled by default to avoid port binding clash.
- [x] Docs.
- [x] Package prometheus client library
  - [x] Ubuntu (already existed in Xenial, so used backport tool)
  - [x] RH (added to Jenkins)
- [x] UT