### PR TITLE
Fix that we were using the chain name suffix as the interface suffix.

### DIFF
--- a/calico/felix/dispatch.py
+++ b/calico/felix/dispatch.py
@@ -25,7 +25,7 @@ from calico.felix.actor import Actor, actor_message, wait_and_check
 from calico.felix.frules import (
     CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT, CHAIN_FROM_LEAF, CHAIN_TO_LEAF,
     CHAIN_TO_PREFIX, CHAIN_FROM_PREFIX,
-    interface_to_suffix
+    interface_to_chain_suffix
 )
 
 _log = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ class DispatchChains(Actor):
         # and decide whether to program a leaf chain or not.
         interfaces_by_prefix = defaultdict(set)
         for iface in ifaces:
-            ep_suffix = interface_to_suffix(self.config, iface)
+            ep_suffix = iface[len(self.config.IFACE_PREFIX):]
             prefix = ep_suffix[:1]
             interfaces_by_prefix[prefix].add(iface)
 
@@ -222,7 +222,7 @@ class DispatchChains(Actor):
                 # endpoint-specific one.  Note that we use --goto, which means
                 # that the endpoint-specific chain will return to our parent
                 # rather than to this chain.
-                ep_suffix = interface_to_suffix(self.config, iface)
+                ep_suffix = interface_to_chain_suffix(self.config, iface)
 
                 to_chain_name = CHAIN_TO_PREFIX + ep_suffix
                 from_chain_name = CHAIN_FROM_PREFIX + ep_suffix

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -35,7 +35,7 @@ from calico.felix.labels import LabelValueIndex, LabelInheritanceIndex
 from calico.felix.refcount import ReferenceManager, RefCountedActor, RefHelper
 from calico.felix.dispatch import DispatchChains
 from calico.felix.profilerules import RulesManager
-from calico.felix.frules import interface_to_suffix
+from calico.felix.frules import interface_to_chain_suffix
 
 _log = logging.getLogger(__name__)
 
@@ -638,8 +638,8 @@ class LocalEndpoint(RefCountedActor):
                 # This is the first time we have seen the endpoint, so extract
                 # the interface name and endpoint ID.
                 self._iface_name = pending_endpoint["name"]
-                self._suffix = interface_to_suffix(self.config,
-                                                   self._iface_name)
+                self._suffix = interface_to_chain_suffix(self.config,
+                                                         self._iface_name)
                 _log.debug("Learned interface name/suffix: %s/%s",
                            self._iface_name, self._suffix)
                 # First time through, need to program everything.

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -353,7 +353,7 @@ def _configure_ipip_device(config):
     _log.info("Configured IPIP device.")
 
 
-def interface_to_suffix(config, iface_name):
+def interface_to_chain_suffix(config, iface_name):
     """
     Extracts the suffix from a given interface name, uniquely shortening it
     to 16 characters if necessary.

--- a/calico/felix/test/test_dispatch.py
+++ b/calico/felix/test/test_dispatch.py
@@ -106,23 +106,28 @@ class TestDispatchChains(BaseTestCase):
         d.programmed_leaf_chains.add("felix-FROM-EP-PFX-a")
         d.programmed_leaf_chains.add("felix-FROM-EP-PFX-z")
         ifaces = ['tapa1', 'tapa2', 'tapa3',
-                  'tapb1', 'tapb2',
+                  'tapb1', 'tapb20123456789012345',
                   'tapc']
         to_delete, deps, updates, new_leaf_chains = d._calculate_update(ifaces)
         self.assertEqual(to_delete, set(["felix-FROM-EP-PFX-z"]))
+        print "Deps", pformat(deps)
         self.assertEqual(deps, {
             'felix-TO-ENDPOINT': set(
                 ['felix-FROM-EP-PFX-a', 'felix-FROM-EP-PFX-b', 'felix-to-c']),
             'felix-FROM-ENDPOINT': set(
                 ['felix-TO-EP-PFX-a', 'felix-TO-EP-PFX-b', 'felix-from-c']),
 
-            'felix-TO-EP-PFX-a': set(['felix-to-a1', 'felix-to-a2', 'felix-to-a3']),
-            'felix-TO-EP-PFX-b': set(['felix-to-b1', 'felix-to-b2']),
+            'felix-TO-EP-PFX-a': set(['felix-to-a1',
+                                      'felix-to-a2',
+                                      'felix-to-a3']),
+            'felix-TO-EP-PFX-b': set(['felix-to-b1',
+                                      'felix-to-_62629f0db434d57']),
 
             'felix-FROM-EP-PFX-a': set(['felix-from-a1',
-                                      'felix-from-a2',
-                                      'felix-from-a3']),
-            'felix-FROM-EP-PFX-b': set(['felix-from-b2', 'felix-from-b1']),
+                                        'felix-from-a2',
+                                        'felix-from-a3']),
+            'felix-FROM-EP-PFX-b': set(['felix-from-b1',
+                                        'felix-from-_62629f0db434d57']),
         })
         for chain_name, chain_updates in updates.items():
             chain_updates[:] = sorted(chain_updates[:-1]) + chain_updates[-1:]
@@ -150,7 +155,7 @@ class TestDispatchChains(BaseTestCase):
                 '--append felix-FROM-EP-PFX-a --jump DROP -m comment --comment "From unknown endpoint"'],
             'felix-FROM-EP-PFX-b': [
                 '--append felix-FROM-EP-PFX-b --in-interface tapb1 --goto felix-from-b1',
-                '--append felix-FROM-EP-PFX-b --in-interface tapb2 --goto felix-from-b2',
+                '--append felix-FROM-EP-PFX-b --in-interface tapb20123456789012345 --goto felix-from-_62629f0db434d57',
                 '--append felix-FROM-EP-PFX-b --jump DROP -m comment --comment "From unknown endpoint"'],
             'felix-TO-EP-PFX-a': [
                 '--append felix-TO-EP-PFX-a --out-interface tapa1 --goto felix-to-a1',
@@ -159,7 +164,7 @@ class TestDispatchChains(BaseTestCase):
                 '--append felix-TO-EP-PFX-a --jump DROP -m comment --comment "To unknown endpoint"'],
             'felix-TO-EP-PFX-b': [
                 '--append felix-TO-EP-PFX-b --out-interface tapb1 --goto felix-to-b1',
-                '--append felix-TO-EP-PFX-b --out-interface tapb2 --goto felix-to-b2',
+                '--append felix-TO-EP-PFX-b --out-interface tapb20123456789012345 --goto felix-to-_62629f0db434d57',
                 '--append felix-TO-EP-PFX-b --jump DROP -m comment --comment "To unknown endpoint"']
         })
 


### PR DESCRIPTION
We were using a utility function to calculate the suffix part of an interface name but, apart from extracting the suffix, the utility function also scrambled it if the name was too long.

That behaviour was correct for a chain name, but not for calculating the suffix of the interface name.