### PR TITLE
Fix that a config section called [DEFAULT] was ignored.

### DIFF
--- a/calico/felix/test/base.py
+++ b/calico/felix/test/base.py
@@ -91,7 +91,7 @@ def load_config(filename, path="calico/felix/test/data/", env_dict=None,
 
     with mock.patch.dict("os.environ", env_dict):
         with mock.patch('calico.common.complete_logging'):
-            config = Config(path+filename)
+            config = Config(path + filename)
 
     with mock.patch('calico.common.complete_logging'):
         config.report_etcd_config(host_dict, global_dict)

--- a/calico/felix/test/data/felix_default_section.cfg
+++ b/calico/felix/test/data/felix_default_section.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+InterfacePrefix=cali
+EtcdAddr=192.168.15.7:2379


### PR DESCRIPTION
The config parser treats a section called [DEFAULT] as a special-case
section that is used as default values for other sections.  If there
happen to be no other sections then we would miss the config values in
the default section.

Bypass that behaviour and add logging to early startup, enabled via
environment variable.

Fixes #1036.