### PR TITLE
Use a different conntrack command to trigger module load.

### DIFF
--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -224,10 +224,12 @@ def load_nf_conntrack():
     _log.info("Running conntrack command to force load of "
               "nf_conntrack_netlink module.")
     try:
-        # Running the stats command is enough to make conntrack load the
-        # kernel module if needed.  We don't use modprobe here because it's
-        # not smart enough to tell if the module is compiled in.
-        futils.check_call(["conntrack", "-S"])
+        # Run a conntrack command to trigger it to load the kernel module if
+        # it's not already compiled in.  We list rules with a randomly-chosen
+        # link local address.  That makes it very unlikely that we generate
+        # any wasteful output.  We used to use "-S" (show stats) here but it
+        # seems to be bugged on some platforms, generating an error.
+        futils.check_call(["conntrack", "-L", "-s", "169.254.45.169"])
     except FailedSystemCall:
         _log.exception("Failed to execute conntrack command to force load of "
                        "nf_conntrack_netlink module.  conntrack commands may "

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -474,13 +474,20 @@ class TestRules(BaseTestCase):
     def test_load_nf_conntrack(self):
         with patch("calico.felix.futils.check_call", autospec=True) as m_call:
             frules.load_nf_conntrack()
-        m_call.assert_called_once_with(["conntrack", "-S"])
+        m_call.assert_called_once_with(
+            ["conntrack", "-L", "-s", "169.254.45.169"]
+        )
 
     def test_load_nf_conntrack_fail(self):
         with patch("calico.felix.futils.check_call", autospec=True) as m_call:
-            m_call.side_effect = FailedSystemCall(message="bad call",
-                                                  args=["conntrack", "-S"],
-                                                  retcode=1,
-                                                  stdout="", stderr="")
+            m_call.side_effect = FailedSystemCall(
+                message="bad call",
+                args=["conntrack", "-L",
+                      "-s",
+                      "169.254.45.169"],
+                retcode=1,
+                stdout="", stderr="")
             frules.load_nf_conntrack()  # Exception should be caught
-        m_call.assert_called_once_with(["conntrack", "-S"])
+        m_call.assert_called_once_with(
+            ["conntrack", "-L", "-s", "169.254.45.169"]
+        )


### PR DESCRIPTION
Old -S command caused error on SL6.5 with conntrack 1.4.3.