### PR TITLE
Allow missing or "default" for tier order.

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -112,6 +112,8 @@ VALID_LINUX_IFACE_NAME_RE = re.compile(r'^[a-zA-Z0-9_-]{1,15}$')
 VALID_IPAM_POOL_ID_RE = re.compile(r'^[0-9\.:a-fA-F\-]{1,43}$')
 EXPECTED_IPAM_POOL_KEYS = set(["cidr", "masquerade"])
 
+INFINITY = float("inf")
+
 
 def validate_port(port):
     """
@@ -540,12 +542,13 @@ def validate_tier_data(tier, data):
     if not isinstance(data, dict):
         raise ValidationFailed("Expected tier data to be a dict not %r" % data)
 
-    if "order" in data:
+    if "order" not in data or data["order"] == "default":
+        data["order"] = INFINITY
+    else:
         order = data["order"]
         if not isinstance(order, numbers.Number):
-            issues.append("Tier data contained non-numeric order field")
-    else:
-        issues.append("Missing 'order' field in tier data")
+            issues.append('Tier data "order" field should be number or '
+                          '"default"')
 
     if issues:
         raise ValidationFailed(" ".join(issues))
@@ -599,12 +602,12 @@ def validate_policy(policy_id, policy):
     else:
         issues.append("Profile missing required selector field")
 
-    if "order" in policy:
-        if not isinstance(policy["order"], numbers.Number):
-            issues.append("Order should be a number, not %s" %
-                          policy["order"])
+    if "order" not in policy or policy["order"] == "default":
+        policy["order"] = INFINITY
     else:
-        issues.append("Profile missing required order field")
+        if not isinstance(policy["order"], numbers.Number):
+            issues.append('Order should be a number, or "default", not %s' %
+                          policy["order"])
 
     if issues:
         raise ValidationFailed(" ".join(issues))

--- a/calico/test/test_common.py
+++ b/calico/test/test_common.py
@@ -195,11 +195,18 @@ class TestCommon(unittest.TestCase):
             # Bad order value
             common.validate_tier_data("abc", {"order": "10"})
         with self.assertRaises(ValidationFailed):
-            # Missing order.
-            common.validate_tier_data("abc", {})
-        with self.assertRaises(ValidationFailed):
             # Non-dict.
             common.validate_tier_data("abc", "foo")
+        # Missing order.
+        tier = {}
+        common.validate_tier_data("abc", tier)
+        self.assertEqual(tier["order"], common.INFINITY)
+        self.assertGreater(tier["order"], 999999999999999999999999999999999999)
+        # "default" order.
+        tier = {"order": "default"}
+        common.validate_tier_data("abc", tier)
+        self.assertEqual(tier["order"], common.INFINITY)
+        self.assertGreater(tier["order"], 999999999999999999999999999999999999)
 
     def test_validate_rules(self):
         profile_id = "valid_name-ok."
@@ -490,8 +497,19 @@ class TestCommon(unittest.TestCase):
             "inbound_rules": [],
             "outbound_rules": [],
         }
-        with self.assertRaises(ValidationFailed):
-            common.validate_policy(TieredPolicyId("a", "b"), policy)
+        common.validate_policy(TieredPolicyId("a", "b"), policy)
+        self.assertEqual(policy["order"], common.INFINITY)
+        self.assertGreater(policy["order"], 9999999999999999999999999999999999)
+
+        policy = {
+            "selector": "a == 'b'",
+            "inbound_rules": [],
+            "outbound_rules": [],
+            "order": "default",
+        }
+        common.validate_policy(TieredPolicyId("a", "b"), policy)
+        self.assertEqual(policy["order"], common.INFINITY)
+        self.assertGreater(policy["order"], 9999999999999999999999999999999999)
 
         policy = {
             "order": 10,

--- a/docs/source/etcd-data-model.rst
+++ b/docs/source/etcd-data-model.rst
@@ -357,17 +357,19 @@ a metadata key inside it::
 The metadata key contains a JSON dict, which currently contains only the order
 for the tier::
 
-    {"order": <number>}
+    {"order": <number>|"default"}
 
 
 Tiers with higher "order" values are applied after those with lower numbers.
+If the ``order`` is omitted or set to "default" then the tier effectively
+has infinite order, it will be applied after any other tiers.
 
 The security policy itself is very similar to the ``rules`` JSON dict that is
 used for policy, with the addition of a selector and order of its own::
 
     {
         "selector": "<selector-expression>",
-        "order": <number>,
+        "order": <number>|"default",
         "inbound_rules": [{<rule>}, ...],
         "outbound_rules": [{<rule>}, ...]
     }


### PR DESCRIPTION
The "default" order maps an infinite order so it is applied after any other policy.