### PR TITLE
Fail config validation if HTTPS is specified without a CA certificate.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -612,10 +612,16 @@ class Config(object):
                                           "must be a readable path.",
                                           self.parameters["EtcdCertFile"])
 
+            # Check we have a certificate authority file to authenticate the
+            # server against.
+            if not self.ETCD_CA_FILE:
+                raise ConfigException("HTTPS enabled but no certificate "
+                                      "authority certificate specified.",
+                                      self.parameters["EtcdCaFile"])
+
             # If Certificate Authority cert provided, check it's readable
-            if (self.ETCD_CA_FILE and
-                    not (os.path.isfile(self.ETCD_CA_FILE) and
-                         os.access(self.ETCD_CA_FILE, os.R_OK))):
+            if not (os.path.isfile(self.ETCD_CA_FILE) and
+                    os.access(self.ETCD_CA_FILE, os.R_OK)):
                 raise ConfigException("Missing CA certificate or file is "
                                       "unreadable. Value must be readable "
                                       "file path.",

--- a/calico/felix/test/data/felix_https_no_ca.cfg
+++ b/calico/felix/test/data/felix_https_no_ca.cfg
@@ -1,0 +1,4 @@
+[global]
+EtcdScheme = https
+EtcdCertFile = /path/to/cert.crt
+EtcdKeyFile = /path/to/key.pem

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -184,6 +184,19 @@ class TestConfig(unittest.TestCase):
                                          "Cannot read cert file"):
                 config = Config("calico/felix/test/data/felix_unreadable_cert.cfg")
 
+    def test_https_without_ca(self):
+        """
+        Test that validation fails if HTTPS is specified without a CA cert.
+        """
+        with mock.patch("os.path.isfile", autospec=True) as m_isfile, \
+                mock.patch("os.access", autospec=True) as m_access:
+
+            m_isfile.return_value = True
+            m_access.return_value = True
+            with self.assertRaisesRegexp(ConfigException,
+                                         "no certificate authority"):
+                config = Config("calico/felix/test/data/felix_https_no_ca.cfg")
+
     def test_unreadable_etcd_ca(self):
         """
         Test that we throw an exception when the etcd CA cert is unreadable


### PR DESCRIPTION
Fixes #1058.