### PR TITLE
Default to using system certificate store.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -200,7 +200,8 @@ class Config(object):
         self.add_parameter("EtcdCertFile", "Path to etcd certificate file",
                            "none", sources=[ENV, FILE])
         self.add_parameter("EtcdCaFile", "Path to etcd CA certificate file",
-                           "none", sources=[ENV, FILE])
+                           "/etc/ssl/certs/ca-certificates.crt",
+                           sources=[ENV, FILE])
         self.add_parameter("EtcdEndpoints", "Comma separated list of etcd "
                            "endpoints, of the form scheme://address:port.  "
                            "For example "

--- a/calico/felix/test/data/felix_none_ca.cfg
+++ b/calico/felix/test/data/felix_none_ca.cfg
@@ -1,0 +1,5 @@
+[global]
+EtcdScheme = https
+EtcdCertFile = /path/to/cert.crt
+EtcdKeyFile = /path/to/key.pem
+EtcdCaFile = none

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -86,7 +86,8 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config.ETCD_SCHEME, "http")
             self.assertEqual(config.ETCD_KEY_FILE, None)
             self.assertEqual(config.ETCD_CERT_FILE, None)
-            self.assertEqual(config.ETCD_CA_FILE, None)
+            self.assertEqual(config.ETCD_CA_FILE,
+                             "/etc/ssl/certs/ca-certificates.crt")
             self.assertEqual(config.HOSTNAME, socket.gethostname())
             self.assertEqual(config.IFACE_PREFIX, "blah")
             self.assertEqual(config.METADATA_PORT, 123)
@@ -197,6 +198,19 @@ class TestConfig(unittest.TestCase):
             with self.assertRaisesRegexp(ConfigException,
                                          "Missing CA certificate"):
                 config = Config("calico/felix/test/data/felix_unreadable_ca.cfg")
+
+    def test_none_ca(self):
+        """
+        Test that the CA can be overriden to None.
+        """
+        with nested(mock.patch("os.path.isfile", autospec=True),
+                    mock.patch("os.access", autospec=True)) \
+             as (m_isfile, m_access):
+
+            m_isfile.return_value = True
+            m_access.return_value = True
+            config = load_config("felix_none_ca.cfg")
+            self.assertEqual(config.ETCD_CA_FILE, None)
 
     def test_no_logfile(self):
         # Logging to file can be excluded by explicitly saying "none" -

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -73,91 +73,92 @@ environment variables or etcd is often more convenient.
 
 The full list of parameters which can be set is as follows.
 
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| Setting                          | Default                        | Meaning                                                                                   |
-+==================================+================================+===========================================================================================+
-| EtcdAddr                         | localhost:4001                 | The location (IP / hostname and port) of the etcd node or proxy that Felix should connect |
-|                                  |                                | to.                                                                                       |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdScheme                       | http                           | The protocol type (http or https) of the etcd node or proxy that Felix connects to.       |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdKeyFile                      | None                           | The full path to the etcd public key file, as described in :ref:`usingtlswithetcd`        |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdCertFile                     | None                           | The full path to the etcd certificate file, as described in :ref:`usingtlswithetcd`       |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdCaFile                       | None                           | The full path to the etcd Certificate Authority certificate file, as described in         |
-|                                  |                                | :ref:`usingtlswithetcd`                                                                   |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| DefaultEndpointToHostAction      | DROP                           | By default Calico blocks traffic from endpoints to the host itself by using an iptables   |
-|                                  |                                | DROP action.  If you want to allow some or all traffic from endpoint to host then set     |
-|                                  |                                | this parameter to "RETURN" (which causes the rest of the iptables INPUT chain to be       |
-|                                  |                                | processed) or "ACCEPT" (which immediately accepts packets).                               |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| FelixHostname                    | socket.gethostname()           | The hostname Felix reports to the plugin. Should be used if the hostname Felix            |
-|                                  |                                | autodetects is incorrect or does not match what the plugin will expect.                   |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| MetadataAddr                     | 127.0.0.1                      | The IP address or domain name of the server that can answer VM queries for cloud-init     |
-|                                  |                                | metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu,   |
-|                                  |                                | nova-api-metadata). A value of 'None' (case insensitive) means that Felix should not set  |
-|                                  |                                | up any NAT rule for the metadata path.                                                    |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| MetadataPort                     | 8775                           | The port of the metadata server. This, combined with global.MetadataAddr (if not 'None'), |
-|                                  |                                | is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort. In    |
-|                                  |                                | most cases this should not need to be changed.                                            |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| InterfacePrefix                  | cali                           | The expected prefix for interface names for workload interfaces.  For example, in         |
-|                                  |                                | OpenStack deployments, this should be set to "tap".  Calico polices all traffic to/from   |
-|                                  |                                | interfaces with this prefix.  Calico blocks traffic to/from such interfaces by default.   |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogFilePath                      | /var/log/calico/felix.log      | The full path to the felix log. Set to "none" to disable file logging.                    |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdDriverLogFilePath            | /var/log/calico/felix-etcd.log | Felix's etcd driver has its own log file. This parameter contains its full path.          |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogSeveritySys                   | ERROR                          | The log severity above which logs are sent to the syslog. Valid values are DEBUG, INFO,   |
-|                                  |                                | WARNING, ERROR and CRITICAL, or NONE for no logging to syslog (all values case            |
-|                                  |                                | insensitive).                                                                             |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogSeverityFile                  | INFO                           | The log severity above which logs are sent to the log file. Valid values as for           |
-|                                  |                                | LogSeveritySys.                                                                           |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| LogSeverityScreen                | ERROR                          | The log severity above which logs are sent to the stdout. Valid values as for             |
-|                                  |                                | LogSeveritySys.                                                                           |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| StartupCleanupDelay              | 30                             | Delay, in seconds, before felix does its start-of-day cleanup to remove orphaned iptables |
-|                                  |                                | chains and ipsets.   Before the first cleanup, felix operates in "graceful restart" mode, |
-|                                  |                                | during which it preserves any pre-existing chains and ipsets.                             |
-|                                  |                                |                                                                                           |
-|                                  |                                | In a large deployment you may want to increase this value to give felix more time to      |
-|                                  |                                | load the initial snapshot from etcd before cleaning up.                                   |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| PeriodicResyncInterval           | 3600                           | Period, in seconds, at which felix does a full resync with etcd and reprograms            |
-|                                  |                                | iptables/ipsets.  Set to 0 to disable periodic resync.                                    |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| IptablesRefreshInterval          | 60                             | Period, in seconds, at which felix re-applies all iptables state to ensure that no other  |
-|                                  |                                | process has accidentally broken Calico's rules.  Set to 0 to disable iptables refresh.    |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| MaxIpsetSize                     | 1048576                        | Maximum size for the ipsets used by Felix to implement tags.  Should be set to a number   |
-|                                  |                                | that is greater than the maximum number of IP addresses that are ever expected in a tag.  |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| IptablesMarkMask                 | 0xff000000                     | Mask that Felix selects its IPTables Mark bits from.  Should be a 32 bit hexadecimal      |
-|                                  |                                | number with at least 8 bits set, none of which clash with any other mark bits in use on   |
-|                                  |                                | the system.                                                                               |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| PrometheusMetricsEnabled         | "false"                        | Set to "true" to enable the experimental Prometheus metrics server in Felix.              |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| PrometheusMetricsPort            | 9091                           | TCP port that the Prometheus metrics server should bind to.                               |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| EtcdDriverPrometheusMetricsPort  | 9092                           | TCP port that the Prometheus metrics server in the etcd driver process should bind to.    |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| FailsafeInboundHostPorts         | 22                             | Comma-delimited list of TCP ports that Felix will allow incoming traffic to host          |
-|                                  |                                | endpoints on irrespective of the security policy.  This is useful to avoid accidently     |
-|                                  |                                | cutting off a host with incorrect configuration.  The default value allows ssh access.    |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
-| FailsafeOutboundHostPorts        | 2379,2380,4001,7001            | Comma-delimited list of TCP ports that Felix will allow outgoing from traffic from host   |
-|                                  |                                | endpoints to irrespective of the security policy.  This is useful to avoid accidently     |
-|                                  |                                | cutting off a host with incorrect configuration.  The default value opens etcd's standard |
-|                                  |                                | ports to ensure that Felix does not get cut off from etcd.                                |
-+----------------------------------+--------------------------------+-------------------------------------------------------------------------------------------+
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| Setting                          | Default                               | Meaning                                                                                   |
++==================================+=======================================+===========================================================================================+
+| EtcdAddr                         | localhost:4001                        | The location (IP / hostname and port) of the etcd node or proxy that Felix should connect |
+|                                  |                                       | to.                                                                                       |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdScheme                       | http                                  | The protocol type (http or https) of the etcd node or proxy that Felix connects to.       |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdKeyFile                      | None                                  | The full path to the etcd public key file, as described in :ref:`usingtlswithetcd`        |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdCertFile                     | None                                  | The full path to the etcd certificate file, as described in :ref:`usingtlswithetcd`       |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdCaFile                       | "/etc/ssl/certs/ca-certificates.crt"  | The full path to the etcd Certificate Authority certificate file, as described in         |
+|                                  |                                       | :ref:`usingtlswithetcd`.  The default value is the standard location of the system trust  |
+|                                  |                                       | store.  To disable authentication of the server by Felix, set the value to "none".        |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| DefaultEndpointToHostAction      | DROP                                  | By default Calico blocks traffic from endpoints to the host itself by using an iptables   |
+|                                  |                                       | DROP action.  If you want to allow some or all traffic from endpoint to host then set     |
+|                                  |                                       | this parameter to "RETURN" (which causes the rest of the iptables INPUT chain to be       |
+|                                  |                                       | processed) or "ACCEPT" (which immediately accepts packets).                               |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| FelixHostname                    | socket.gethostname()                  | The hostname Felix reports to the plugin. Should be used if the hostname Felix            |
+|                                  |                                       | autodetects is incorrect or does not match what the plugin will expect.                   |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| MetadataAddr                     | 127.0.0.1                             | The IP address or domain name of the server that can answer VM queries for cloud-init     |
+|                                  |                                       | metadata. In OpenStack, this corresponds to the machine running nova-api (or in Ubuntu,   |
+|                                  |                                       | nova-api-metadata). A value of 'None' (case insensitive) means that Felix should not set  |
+|                                  |                                       | up any NAT rule for the metadata path.                                                    |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| MetadataPort                     | 8775                                  | The port of the metadata server. This, combined with global.MetadataAddr (if not 'None'), |
+|                                  |                                       | is used to set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort. In    |
+|                                  |                                       | most cases this should not need to be changed.                                            |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| InterfacePrefix                  | cali                                  | The expected prefix for interface names for workload interfaces.  For example, in         |
+|                                  |                                       | OpenStack deployments, this should be set to "tap".  Calico polices all traffic to/from   |
+|                                  |                                       | interfaces with this prefix.  Calico blocks traffic to/from such interfaces by default.   |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| LogFilePath                      | /var/log/calico/felix.log             | The full path to the felix log. Set to "none" to disable file logging.                    |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdDriverLogFilePath            | /var/log/calico/felix-etcd.log        | Felix's etcd driver has its own log file. This parameter contains its full path.          |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| LogSeveritySys                   | ERROR                                 | The log severity above which logs are sent to the syslog. Valid values are DEBUG, INFO,   |
+|                                  |                                       | WARNING, ERROR and CRITICAL, or NONE for no logging to syslog (all values case            |
+|                                  |                                       | insensitive).                                                                             |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| LogSeverityFile                  | INFO                                  | The log severity above which logs are sent to the log file. Valid values as for           |
+|                                  |                                       | LogSeveritySys.                                                                           |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| LogSeverityScreen                | ERROR                                 | The log severity above which logs are sent to the stdout. Valid values as for             |
+|                                  |                                       | LogSeveritySys.                                                                           |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| StartupCleanupDelay              | 30                                    | Delay, in seconds, before felix does its start-of-day cleanup to remove orphaned iptables |
+|                                  |                                       | chains and ipsets.   Before the first cleanup, felix operates in "graceful restart" mode, |
+|                                  |                                       | during which it preserves any pre-existing chains and ipsets.                             |
+|                                  |                                       |                                                                                           |
+|                                  |                                       | In a large deployment you may want to increase this value to give felix more time to      |
+|                                  |                                       | load the initial snapshot from etcd before cleaning up.                                   |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| PeriodicResyncInterval           | 3600                                  | Period, in seconds, at which felix does a full resync with etcd and reprograms            |
+|                                  |                                       | iptables/ipsets.  Set to 0 to disable periodic resync.                                    |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| IptablesRefreshInterval          | 60                                    | Period, in seconds, at which felix re-applies all iptables state to ensure that no other  |
+|                                  |                                       | process has accidentally broken Calico's rules.  Set to 0 to disable iptables refresh.    |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| MaxIpsetSize                     | 1048576                               | Maximum size for the ipsets used by Felix to implement tags.  Should be set to a number   |
+|                                  |                                       | that is greater than the maximum number of IP addresses that are ever expected in a tag.  |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| IptablesMarkMask                 | 0xff000000                            | Mask that Felix selects its IPTables Mark bits from.  Should be a 32 bit hexadecimal      |
+|                                  |                                       | number with at least 8 bits set, none of which clash with any other mark bits in use on   |
+|                                  |                                       | the system.                                                                               |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| PrometheusMetricsEnabled         | "false"                               | Set to "true" to enable the experimental Prometheus metrics server in Felix.              |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| PrometheusMetricsPort            | 9091                                  | TCP port that the Prometheus metrics server should bind to.                               |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| EtcdDriverPrometheusMetricsPort  | 9092                                  | TCP port that the Prometheus metrics server in the etcd driver process should bind to.    |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| FailsafeInboundHostPorts         | 22                                    | Comma-delimited list of TCP ports that Felix will allow incoming traffic to host          |
+|                                  |                                       | endpoints on irrespective of the security policy.  This is useful to avoid accidently     |
+|                                  |                                       | cutting off a host with incorrect configuration.  The default value allows ssh access.    |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| FailsafeOutboundHostPorts        | 2379,2380,4001,7001                   | Comma-delimited list of TCP ports that Felix will allow outgoing from traffic from host   |
+|                                  |                                       | endpoints to irrespective of the security policy.  This is useful to avoid accidently     |
+|                                  |                                       | cutting off a host with incorrect configuration.  The default value opens etcd's standard |
+|                                  |                                       | ports to ensure that Felix does not get cut off from etcd.                                |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
 
 
 Environment variables


### PR DESCRIPTION
Change the default CA certificate file to use the system store.  

This means
- we'll support system-wide trust settings without config 
- the user will have to explicitly set the value to "none" if they don't want to authenticate the server.

Fixes #1058 