### PR TITLE
Relax restriction on rules being mandatory.

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -670,7 +670,7 @@ def _validate_rules(rules_dict, issues):
     """
     for dirn in ("inbound_rules", "outbound_rules"):
         if dirn not in rules_dict:
-            issues.append("No %s in rules." % dirn)
+            rules_dict[dirn] = []
             continue
 
         if not isinstance(rules_dict[dirn], list):

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -591,7 +591,7 @@ class TestEtcdWatcher(BaseTestCase):
 
     def test_rules_set_invalid(self):
         self.dispatch("/calico/v1/policy/profile/prof1/rules", "set",
-                      value='{}')
+                      value='[]')
         self.m_splitter.on_rules_update.assert_called_once_with("prof1",
                                                                 None,)
 

--- a/calico/test/test_common.py
+++ b/calico/test/test_common.py
@@ -235,12 +235,9 @@ class TestCommon(unittest.TestCase):
                                    rules.copy())
 
         # No rules.
-        with self.assertRaisesRegexp(ValidationFailed,
-                                     "No outbound_rules"):
-            common.validate_profile(profile_id, {'inbound_rules': []})
-        with self.assertRaisesRegexp(ValidationFailed,
-                                     "No inbound_rules"):
-            common.validate_profile(profile_id, {'outbound_rules': []})
+        prof = {}
+        common.validate_profile("prof1", prof)
+        self.assertEqual(prof, {"inbound_rules": [], "outbound_rules": []})
 
         rules = {'inbound_rules': 3,
                  'outbound_rules': []}

--- a/docs/source/etcd-data-model.rst
+++ b/docs/source/etcd-data-model.rst
@@ -437,7 +437,8 @@ The 'rules' key contains the following JSON-encoded data:
 
 Two lists of rules objects, one applying to traffic destined for that endpoint
 (``inbound_rules``), one applying to traffic emitted by that endpoint
-(``outbound_rules``).
+(``outbound_rules``).  If either list of rules is omitted, it defaults to
+an empty list ``[]``.
 
 Each rule sub-object has the following JSON-encoded structure:
 


### PR DESCRIPTION
This has bitten us a few times, and it's annoying when hand-crafting debug data for etcdctl.