### PR TITLE
Add option to override DROP rules for debugging policy.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -230,6 +230,16 @@ class Config(object):
         self.add_parameter("DefaultEndpointToHostAction",
                            "Action to take for packets that arrive from"
                            "an endpoint to the host.", "DROP")
+        self.add_parameter("DropActionOverride",
+                           "Override for the action taken when a packet would "
+                           "normally be dropped by Calico's firewall rules. "
+                           "This setting is useful when prototyping policy. "
+                           "Note: if the policy is set to 'ACCEPT' or "
+                           "'LOG-and-ACCEPT'; Calico's security is "
+                           "disabled! "
+                           "One of 'DROP', 'ACCEPT', 'LOG-and-DROP', "
+                           "'LOG-and-ACCEPT'.",
+                           "DROP")
         self.add_parameter("LogFilePath",
                            "Path to log file", "/var/log/calico/felix.log")
         self.add_parameter("EtcdDriverLogFilePath",
@@ -408,6 +418,7 @@ class Config(object):
             self.parameters["FailsafeInboundHostPorts"].value
         self.FAILSAFE_OUTBOUND_PORTS = \
             self.parameters["FailsafeOutboundHostPorts"].value
+        self.ACTION_ON_DROP = self.parameters["DropActionOverride"].value
 
         self._validate_cfg(final=final)
 
@@ -678,6 +689,12 @@ class Config(object):
                 "Invalid field value",
                 self.parameters["DefaultEndpointToHostAction"]
             )
+
+        if self.ACTION_ON_DROP not in ("DROP", "LOG-and-DROP", "ACCEPT",
+                                       "LOG-and-ACCEPT"):
+            log.warning("Unknown setting for DropActionOverride setting: %s, "
+                        "defaulting to 'DROP'.", self.ACTION_ON_DROP)
+            self.ACTION_ON_DROP = "DROP"
 
         # For non-positive time values of reporting interval we set both
         # interval and ttl to 0 - i.e. status reporting is disabled.

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -695,6 +695,10 @@ class Config(object):
             log.warning("Unknown setting for DropActionOverride setting: %s, "
                         "defaulting to 'DROP'.", self.ACTION_ON_DROP)
             self.ACTION_ON_DROP = "DROP"
+        if self.ACTION_ON_DROP.endswith("ACCEPT"):
+            log.warning("Security disabled! DropActionOverride set to ACCEPT "
+                        "or LOG-and-ACCEPT.  DROP rules will be replaced with"
+                        "ACCEPT rules. ")
 
         # For non-positive time values of reporting interval we set both
         # interval and ttl to 0 - i.e. status reporting is disabled.

--- a/calico/felix/plugins/fiptgenerator.py
+++ b/calico/felix/plugins/fiptgenerator.py
@@ -582,7 +582,7 @@ class FelixIptablesGenerator(FelixPlugin):
 
         if self.ACTION_ON_DROP.startswith("LOG-"):
             # log-and-accept, log-and-drop.
-            log_spec = '--jump LOG --log-prefix "CalicoDrop" --log-level 4'
+            log_spec = '--jump LOG --log-prefix "calico-drop: " --log-level 4'
             log_rule = " ".join(
                 [p for p in [ipt_action, chain_name, rule_spec, log_spec,
                              comment_str] if p is not None]
@@ -590,7 +590,10 @@ class FelixIptablesGenerator(FelixPlugin):
             rules.append(log_rule)
 
         if self.ACTION_ON_DROP.endswith("ACCEPT"):
-            action_spec = "--jump ACCEPT"
+            action_spec = (
+                '--jump ACCEPT -m comment '
+                '--comment "!SECURITY DISABLED! DROP overridden to ACCEPT"'
+            )
         else:
             assert self.ACTION_ON_DROP.endswith("DROP")
             action_spec = "--jump DROP"

--- a/calico/felix/plugins/fiptgenerator.py
+++ b/calico/felix/plugins/fiptgenerator.py
@@ -698,16 +698,13 @@ class FelixIptablesGenerator(FelixPlugin):
                                  "chain": chain_name,
                                  "mark": self.IPTABLES_MARK_ACCEPT,
                              })
-            # If the next-tier mark bit is still clear then no policy
-            # in the tier allowed the packet through, drop it.
-            chain.append('--append %(chain)s --match mark --mark 0/%(mark)s '
-                         '--match comment '
-                         '--comment "Drop if no policy in tier passed" '
-                         '--jump DROP' %
-                         {
-                             "chain": chain_name,
-                             "mark": self.IPTABLES_MARK_NEXT_TIER,
-                         })
+
+            chain.extend(self.drop_rules(
+                ip_version,
+                chain_name,
+                "--match mark --mark 0/%s" % self.IPTABLES_MARK_NEXT_TIER,
+                comment="Drop if no policy in tier passed"
+            ))
 
         # Then, jump to each directly-referenced profile in turn.  The profile
         # will do one of the following:

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -645,3 +645,18 @@ class TestConfig(unittest.TestCase):
         }
         self.assertRaises(ConfigException, load_config,
                           "felix_missing.cfg", host_dict=cfg_dict)
+
+    def test_drop_action_defaulting(self):
+        cfg_dict = {
+            "DropActionOverride": "foobar",
+        }
+        config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+        self.assertEqual(config.ACTION_ON_DROP, "DROP")
+
+    def test_drop_valid(self):
+        for value in ("DROP", "LOG-and-DROP", "ACCEPT", "LOG-and-ACCEPT"):
+            cfg_dict = {
+                "DropActionOverride": value,
+            }
+            config = load_config("felix_missing.cfg", host_dict=cfg_dict)
+            self.assertEqual(config.ACTION_ON_DROP, value)

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -689,6 +689,40 @@ class TestRules(BaseTestCase):
             }
         )
 
+    def test_drop_rules_log_accept(self):
+        self.iptables_generator.ACTION_ON_DROP = "LOG-and-ACCEPT"
+        drop_rules = self.iptables_generator.drop_rules(
+            4, "foo", "--rulespec", "comment"
+        )
+        self.assertEqual(drop_rules, [
+            '--append foo --rulespec --jump LOG --log-prefix "CalicoDrop" '
+            '--log-level 4 -m comment --comment "comment"',
+            '--append foo --rulespec --jump ACCEPT -m comment '
+            '--comment "comment"'
+        ])
+
+    def test_drop_rules_log_accept(self):
+        self.iptables_generator.ACTION_ON_DROP = "ACCEPT"
+        drop_rules = self.iptables_generator.drop_rules(
+            4, "foo", "--rulespec", "comment"
+        )
+        self.assertEqual(drop_rules, [
+            '--append foo --rulespec --jump ACCEPT -m comment '
+            '--comment "comment"'
+        ])
+
+    def test_drop_rules_log_drop(self):
+        self.iptables_generator.ACTION_ON_DROP = "LOG-and-DROP"
+        drop_rules = self.iptables_generator.drop_rules(
+            4, "foo", "--rulespec", "comment"
+        )
+        self.assertEqual(drop_rules, [
+            '--append foo --rulespec --jump LOG --log-prefix "CalicoDrop" '
+            '--log-level 4 -m comment --comment "comment"',
+            '--append foo --rulespec --jump DROP -m comment '
+            '--comment "comment"'
+        ])
+
     def test_bad_icmp_type(self):
         with self.assertRaises(UnsupportedICMPType):
             self.iptables_generator._rule_to_iptables_fragments_inner(

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -355,9 +355,8 @@ FROM_ENDPOINT_CHAIN = [
     # Then, at the end of the tier, drop if nothing in the tier did a
     # "next-tier"
     '--append felix-from-abcd '
-              '--match mark --mark 0/0x2000000 '
-              '--match comment --comment "Drop if no policy in tier passed" '
-              '--jump DROP',
+              '--match mark --mark 0/0x2000000 --jump DROP '
+              '-m comment --comment "Drop if no policy in tier passed"',
 
     # Now the second tier...
     '--append felix-from-abcd '
@@ -369,8 +368,8 @@ FROM_ENDPOINT_CHAIN = [
               '--match mark --mark 0x1000000/0x1000000 --match comment '
               '--comment "Return if policy accepted" --jump RETURN',
     '--append felix-from-abcd '
-              '--match mark --mark 0/0x2000000 --match comment '
-              '--comment "Drop if no policy in tier passed" --jump DROP',
+              '--match mark --mark 0/0x2000000 --jump DROP -m comment '
+              '--comment "Drop if no policy in tier passed"',
 
     # Jump to the first profile.
     '--append felix-from-abcd --jump felix-p-prof-1-o',
@@ -406,9 +405,8 @@ TO_ENDPOINT_CHAIN = [
             '--jump felix-p-t1p2-i',
     '--append felix-to-abcd --match mark --mark 0x1000000/0x1000000 '
             '--match comment --comment "Return if policy accepted" --jump RETURN',
-    '--append felix-to-abcd --match mark --mark 0/0x2000000 '
-            '--match comment --comment "Drop if no policy in tier passed" '
-            '--jump DROP',
+    '--append felix-to-abcd --match mark --mark 0/0x2000000 --jump DROP '
+            '-m comment --comment "Drop if no policy in tier passed"',
     # Tier 2:
     '--append felix-to-abcd --jump MARK --set-mark 0/0x2000000 '
             '--match comment --comment "Start of tier tier_2"',
@@ -417,9 +415,8 @@ TO_ENDPOINT_CHAIN = [
     '--append felix-to-abcd --match mark --mark 0x1000000/0x1000000 '
             '--match comment --comment "Return if policy accepted" '
             '--jump RETURN',
-    '--append felix-to-abcd --match mark --mark 0/0x2000000 '
-            '--match comment --comment "Drop if no policy in tier passed" '
-            '--jump DROP',
+    '--append felix-to-abcd --match mark --mark 0/0x2000000 --jump DROP '
+            '-m comment --comment "Drop if no policy in tier passed"',
 
     # Jump to first profile and return iff it matched.
     '--append felix-to-abcd --jump felix-p-prof-1-i',
@@ -466,9 +463,8 @@ FROM_HOST_ENDPOINT_CHAIN = [
     # Then, at the end of the tier, drop if nothing in the tier did a
     # "next-tier"
     '--append felix-from-abcd '
-              '--match mark --mark 0/0x2000000 '
-              '--match comment --comment "Drop if no policy in tier passed" '
-              '--jump DROP',
+              '--match mark --mark 0/0x2000000 --jump DROP '
+              '-m comment --comment "Drop if no policy in tier passed"',
 
     # Now the second tier...
     '--append felix-from-abcd '
@@ -480,8 +476,8 @@ FROM_HOST_ENDPOINT_CHAIN = [
               '--match mark --mark 0x1000000/0x1000000 --match comment '
               '--comment "Return if policy accepted" --jump RETURN',
     '--append felix-from-abcd '
-              '--match mark --mark 0/0x2000000 --match comment '
-              '--comment "Drop if no policy in tier passed" --jump DROP',
+              '--match mark --mark 0/0x2000000 --jump DROP -m comment '
+              '--comment "Drop if no policy in tier passed"',
 
     # Jump to the first profile.
     '--append felix-from-abcd --jump felix-p-prof-1-i',
@@ -520,9 +516,8 @@ TO_HOST_ENDPOINT_CHAIN = [
             '--jump felix-p-t1p2-o',
     '--append felix-to-abcd --match mark --mark 0x1000000/0x1000000 '
             '--match comment --comment "Return if policy accepted" --jump RETURN',
-    '--append felix-to-abcd --match mark --mark 0/0x2000000 '
-            '--match comment --comment "Drop if no policy in tier passed" '
-            '--jump DROP',
+    '--append felix-to-abcd --match mark --mark 0/0x2000000 --jump DROP '
+            '-m comment --comment "Drop if no policy in tier passed"',
     # Tier 2:
     '--append felix-to-abcd --jump MARK --set-mark 0/0x2000000 '
             '--match comment --comment "Start of tier tier_2"',
@@ -531,9 +526,8 @@ TO_HOST_ENDPOINT_CHAIN = [
     '--append felix-to-abcd --match mark --mark 0x1000000/0x1000000 '
             '--match comment --comment "Return if policy accepted" '
             '--jump RETURN',
-    '--append felix-to-abcd --match mark --mark 0/0x2000000 '
-            '--match comment --comment "Drop if no policy in tier passed" '
-            '--jump DROP',
+    '--append felix-to-abcd --match mark --mark 0/0x2000000 --jump DROP '
+            '-m comment --comment "Drop if no policy in tier passed"',
 
     # Jump to first profile and return iff it matched.
     '--append felix-to-abcd --jump felix-p-prof-1-o',

--- a/calico/felix/test/test_fiptgenerator.py
+++ b/calico/felix/test/test_fiptgenerator.py
@@ -695,20 +695,23 @@ class TestRules(BaseTestCase):
             4, "foo", "--rulespec", "comment"
         )
         self.assertEqual(drop_rules, [
-            '--append foo --rulespec --jump LOG --log-prefix "CalicoDrop" '
-            '--log-level 4 -m comment --comment "comment"',
-            '--append foo --rulespec --jump ACCEPT -m comment '
-            '--comment "comment"'
+            '--append foo --rulespec --jump LOG '
+            '--log-prefix "calico-drop: " --log-level 4 -m comment '
+            '--comment "comment"',
+            '--append foo --rulespec --jump ACCEPT -m comment --comment '
+            '"!SECURITY DISABLED! DROP overridden to ACCEPT" '
+            '-m comment --comment "comment"'
         ])
 
-    def test_drop_rules_log_accept(self):
+    def test_drop_rules_accept(self):
         self.iptables_generator.ACTION_ON_DROP = "ACCEPT"
         drop_rules = self.iptables_generator.drop_rules(
             4, "foo", "--rulespec", "comment"
         )
         self.assertEqual(drop_rules, [
-            '--append foo --rulespec --jump ACCEPT -m comment '
-            '--comment "comment"'
+            '--append foo --rulespec --jump ACCEPT -m comment --comment '
+            '"!SECURITY DISABLED! DROP overridden to ACCEPT" '
+            '-m comment --comment "comment"'
         ])
 
     def test_drop_rules_log_drop(self):
@@ -717,7 +720,7 @@ class TestRules(BaseTestCase):
             4, "foo", "--rulespec", "comment"
         )
         self.assertEqual(drop_rules, [
-            '--append foo --rulespec --jump LOG --log-prefix "CalicoDrop" '
+            '--append foo --rulespec --jump LOG --log-prefix "calico-drop: " '
             '--log-level 4 -m comment --comment "comment"',
             '--append foo --rulespec --jump DROP -m comment '
             '--comment "comment"'

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -94,6 +94,15 @@ The full list of parameters which can be set is as follows.
 |                                  |                                       | this parameter to "RETURN" (which causes the rest of the iptables INPUT chain to be       |
 |                                  |                                       | processed) or "ACCEPT" (which immediately accepts packets).                               |
 +----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
+| DropActionOverride               | DROP                                  | Override for the action taken when a packet would normally be dropped by Calico's         |
+|                                  |                                       | firewall rules. This setting is useful when prototyping policy. Note: if the policy is    |
+|                                  |                                       | set to 'ACCEPT' or 'LOG-and-ACCEPT'; Calico's security is disabled!                       |
+|                                  |                                       |                                                                                           |
+|                                  |                                       | In the current implementation, the LOG-and-XXX actions use an iptables LOG action,        |
+|                                  |                                       | which logs to syslog.                                                                     |
+|                                  |                                       |                                                                                           |
+|                                  |                                       | Should be set to one of 'DROP', 'ACCEPT', 'LOG-and-DROP', 'LOG-and-ACCEPT'.               |
++----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+
 | FelixHostname                    | socket.gethostname()                  | The hostname Felix reports to the plugin. Should be used if the hostname Felix            |
 |                                  |                                       | autodetects is incorrect or does not match what the plugin will expect.                   |
 +----------------------------------+---------------------------------------+-------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Add a "DropActionOverride" config param, which can be set to "DROP", "LOG-and-DROP", ""ACCEPT or "LOG-and-ACCEPT".

The "LOG-" options use an iptables LOG action to log the packet before either ACCEPTing or DROPping the packet.