### PR TITLE
Add config parameter to disable loose RPF check.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -240,6 +240,14 @@ class Config(object):
                            "One of 'DROP', 'ACCEPT', 'LOG-and-DROP', "
                            "'LOG-and-ACCEPT'.",
                            "DROP")
+        self.add_parameter("IgnoreLooseRPF",
+                           "If set to true, Felix will ignore the kernel's "
+                           "RPF check setting.  If set to false, Felix will "
+                           "abort if the RPF setting is not 'strict'.  Should "
+                           "only be set to true if workloads are incapable of "
+                           "spoofing their source IP.  (For example, "
+                           "unprivileged containers.)",
+                           False, value_is_bool=True)
         self.add_parameter("LogFilePath",
                            "Path to log file", "/var/log/calico/felix.log")
         self.add_parameter("EtcdDriverLogFilePath",
@@ -419,6 +427,7 @@ class Config(object):
         self.FAILSAFE_OUTBOUND_PORTS = \
             self.parameters["FailsafeOutboundHostPorts"].value
         self.ACTION_ON_DROP = self.parameters["DropActionOverride"].value
+        self.IGNORE_LOOSE_RPF = self.parameters["IgnoreLooseRPF"].value
 
         self._validate_cfg(final=final)
 

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -76,7 +76,7 @@ def _main_greenlet(config):
 
         # Ensure the Kernel's global options are correctly configured for
         # Calico.
-        devices.configure_global_kernel_config()
+        devices.configure_global_kernel_config(config)
 
         # Check the commands we require are present.
         futils.check_command_deps()

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -111,7 +111,7 @@ class TestBasic(BaseTestCase):
         m_load.assert_called_once_with(async=False)
         m_iface_exists.assert_called_once_with("tunl0")
         m_iface_up.assert_called_once_with("tunl0")
-        m_configure_global_kernel_config.assert_called_once_with()
+        m_configure_global_kernel_config.assert_called_once_with(config)
         m_conntrack.assert_called_once_with()
         m_http_server.assert_called_once_with(("0.0.0.0", 9091),
                                               felix.MetricsHandler)
@@ -170,7 +170,7 @@ class TestBasic(BaseTestCase):
             self.assertRaises(TestException,
                               felix._main_greenlet, config)
         m_load.assert_called_once_with(async=False)
-        m_configure_global_kernel_config.assert_called_once_with()
+        m_configure_global_kernel_config.assert_called_once_with(config)
         m_install_globals.assert_called_once_with(mock.ANY, mock.ANY, mock.ANY,
                                                   ip_version=4)
         m_conntrack.assert_called_once_with()


### PR DESCRIPTION
Should make it possible to work around https://github.com/projectcalico/calico-containers/issues/1082