### PR TITLE
Allow customization of 'etcdctl' for calico-diags

### DIFF
--- a/utils/calico-diags
+++ b/utils/calico-diags
@@ -9,6 +9,7 @@ fi
 echo "Collecting diags"
 echo "This script attempts to collect a wide range of diagnostics, some of which may not be available on your system - don't worry if this script produces warning messages for these."
 
+ETCDCTL=${ETCDCTL:-etcdctl}
 ROUTE_FILE=route
 CALICO_CFG=/etc/calico
 CALICO_DIR=/var/log/calico
@@ -60,8 +61,8 @@ rabbitmqctl status rabbitmq_status 2>&1
 
 echo "  copying contents of etcd..."
 
-etcdctl ls --recursive -p > etcdctl_ls 2>&1
-etcdctl ls --recursive -p | grep -v '/$' | xargs -n1 -t etcdctl get > etcdctl_get
+${ETCDCTL} ls --recursive -p > etcdctl_ls 2>&1
+${ETCDCTL} ls --recursive -p | grep -v '/$' | xargs -n1 -t ${ETCDCTL} get > etcdctl_get
 
 echo "  copying config files..."
 


### PR DESCRIPTION
Specifically, if we're using TLS between a local etcd proxy and the main etcd
cluster, but not for access to the local etcd proxy, then every
'etcdctl ...' invocation needs to be 'etcdctl --no-sync ...'.  This
change makes that possible.