### PR TITLE
Fix usage reporting on CentOS 7

### DIFF
--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -20,7 +20,21 @@ felix.felix
 
 The main logic for Felix.
 """
-# Monkey-patch before we do anything else...
+# CentOS/RHEL 7 has a Python that thinks it is 2.7.5, but is actually heavily
+# patched with various backports, and in particular with SSL-related changes
+# for PEP 466, which in the mainline were introduced in Python 2.7.9.  gevent
+# (>= 1.0.2) has support for modifying its monkey-patching accordingly, but
+# that is conditional on whether it thinks the Python version is >= 2.7.9.
+# Happily gevent has a global variable for that, so here we set that global
+# variable to indicate that we are effectively - so far as the SSL-related
+# things that gevent patches are concerned - running on 2.7.9.
+try:
+    from gevent import hub
+    hub.PYGTE279 = True
+except (ImportError, AttributeError):
+    pass
+
+# Now monkey-patch before we do anything else...
 from gevent import monkey
 monkey.patch_all()
 

--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -669,4 +669,4 @@ def report_usage_and_get_warnings(calico_version, hostname, cluster_guid, cluste
         reply = r.data.decode('utf-8')
         _log.info("usage_report status=%s, reply=%s", r.status, reply)
     except Exception:
-        _log.info("Exception in usage_report")
+        _log.exception("Exception in usage_report")


### PR DESCRIPTION
Note - in addition to this code change, it's also necessary to install a
1.0.2 version of python-gevent - replacing the 1.0 version that is the
default in CentOS 7 - for example from
https://www.rpmfind.net/linux/RPM/fedora/23/x86_64/p/python-gevent-1.0.2-2.fc23.x86_64.html.