### PR TITLE
Update self-hosted Calico manifest to support TLS etcd

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
 data:
   # Configure this with the location of your etcd cluster.
-  # This must also be configured in the cni_network_config below.
   etcd_endpoints: "http://127.0.0.1:2379"
 
   # True enables BGP networking, false tells Calico to enforce
@@ -19,21 +18,49 @@ data:
         "name": "k8s-pod-network",
         "type": "calico",
         "etcd_endpoints": "__ETCD_ENDPOINTS__",
+        "etcd_key_file": "__ETCD_KEY_FILE__",
+        "etcd_cert_file": "__ETCD_CERT_FILE__",
+        "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
         "log_level": "info",
         "ipam": {
             "type": "calico-ipam"
         },
         "policy": {
             "type": "k8s",
-             "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
         },
         "kubernetes": {
-            "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
         }
     }
 
+  # If you're using TLS enabled etcd uncomment the following.
+  # You must also populate the Secret below with these files.
+  etcd_ca: ""   # "/calico-secrets/etcd-ca"
+  etcd_cert: "" # "/calico-secrets/etcd-cert"
+  etcd_key: ""  # "/calico-secrets/etcd-key"
+
 ---
+
+# The following contains k8s Secrets for use with a TLS enabled etcd cluster.
+# For information on populating Secrets, see http://kubernetes.io/docs/user-guide/secrets/
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: calico-etcd-secrets
+  namespace: kube-system
+data:
+  # Populate the following files with etcd TLS configuration if desired, but leave blank if
+  # not using TLS for etcd.
+  # This self-hosted install expects three files with the following names.  The values 
+  # should be base64 encoded strings of the entire contents of each file.
+  # etcd-key: null
+  # etcd-cert: null
+  # etcd-ca: null
+
+---  
 
 # This manifest installs the calico/node container, as well
 # as the Calico CNI plugins and network config on 
@@ -77,6 +104,24 @@ spec:
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
@@ -89,6 +134,8 @@ spec:
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
+            - mountPath: /calico-secrets
+              name: etcd-certs
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -113,6 +160,8 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+            - mountPath: /calico-secrets
+              name: etcd-certs
       volumes:
         # Used by calico/node.
         - name: lib-modules
@@ -128,6 +177,10 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        # Mount in the etcd TLS secrets.
+        - name: etcd-certs
+          secret:
+            secretName: calico-etcd-secrets
 
 ---
 
@@ -163,6 +216,24 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
             # The location of the Kubernetes API.  Use the default Kubernetes
             # service for API access.
             - name: K8S_API
@@ -172,3 +243,12 @@ spec:
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
+          volumeMounts:
+            # Mount in the etcd TLS secrets.
+            - mountPath: /calico-secrets
+              name: etcd-certs
+      volumes:
+        # Mount in the etcd TLS secrets.
+        - name: etcd-certs
+          secret:
+            secretName: calico-etcd-secrets

--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -8,9 +8,8 @@ data:
   # Configure this with the location of your etcd cluster.
   etcd_endpoints: "http://127.0.0.1:2379"
 
-  # True enables BGP networking, false tells Calico to enforce
-  # policy only, using native networking.
-  enable_bgp: "true"
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
 
   # The CNI network configuration to install on each node.
   cni_network_config: |-
@@ -95,12 +94,12 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            # Enable BGP.  Disable to enforce policy only. 
-            - name: CALICO_NETWORKING
+            # Choose the backend to use. 
+            - name: CALICO_NETWORKING_BACKEND 
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
-                  key: enable_bgp
+                  key: calico_backend
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/master/getting-started/kubernetes/installation/hosted/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/index.md
@@ -4,9 +4,9 @@ title: Calico Kubernetes Hosted Install
 
 This document describes deploying Calico on Kubernetes using Kubernetes manifests.  Note that the Kubernetes hosted installation method is experimental and subject to change.
 
-- [`calico.yaml`](calico.yaml): Contains a Kubernetes DaemonSet
-which installs and runs Calico on each Kubernetes master and node. This also includes a ReplicaSet which deploys
-the Calico Kubernetes policy controller, and a ConfigMap which allows for configuration of the install.
+- [`calico.yaml`](calico.yaml): Contains a Kubernetes DaemonSet which installs and runs Calico 
+on each Kubernetes master and node. This also includes a ReplicaSet which deploys the Calico Kubernetes 
+policy controller, and a ConfigMap which allows for configuration of the install.
 
 To install Calico, download [calico.yaml](calico.yaml) and run the following command:
 
@@ -14,37 +14,78 @@ To install Calico, download [calico.yaml](calico.yaml) and run the following com
 kubectl apply -f calico.yaml
 ```
 
+> **NOTE**
+>
+> Make sure you configure the provided ConfigMap with the location of your etcd cluster before running the above command. 
+
+
 ## How it works
 
 The `calico.yaml` file contains all the necessary resources for installing Calico on each node in your Kubernetes cluster.
 
-It does the following things:
+It installs the following Kubernetes resources: 
 
 - The `calico-config` ConfigMap, which contains parameters for configuring the install.
 - Installs the `calico/node` container on each host using a DaemonSet.
 - Installs the Calico CNI binaries and network config on each host using a DaemonSet.
 - Runs the `calico/kube-policy-controller` pod as a ReplicaSet.
+- The `calico-etcd-secrets` Secret, which optionally allows for providing etcd TLS assets.
 
 ## Configuration options
 
 The ConfigMap in `calico.yaml` provides a way to configure a Calico self-hosted installation.  It exposes
 the following configuration parameters:
 
+## Etcd Configuration
+
+By default, these manifests do not configure secure access to etcd and assume an etcd proxy is running on each host.  The following configuration
+options let you specify custom etcd cluster endpoints as well as TLS.  
+
+To use these manifests with a TLS enabled etcd cluster you must do the following:
+
+- Populate the `calico-etcd-secrets` Secret with the following files: `etcd-ca`, `etcd-key`, `etcd-cert`.
+- Populate the following options in the ConfigMap which will trigger the various services to expect the provided TLS assets: `etcd_ca`, `etcd_key`, `etcd_cert`
+
 ### etcd_endpoints
 
-The location of your etcd cluster.  The default in the provided manifest assumes that an etcd proxy is running on each node.
+A comma separated list of etcd nodes. e.g `https://etcd0:2379,...` 
 
-### enable_bgp
+The default in the provided manifest uses localhost, and assumes that an etcd proxy is running on each node.
+
+### etcd_ca 
+
+The location of the CA mounted in the pods deployed by the DaemonSet. 
+
+To enable, set to `/calico-secrets/etcd-ca`
+
+### etcd_key
+
+`etcd_key`: The location of the client cert mounted in the pods deployed by the DaemonSet. 
+
+To enable, set to `/calico-secrets/etcd-cert`
+
+### etcd_cert
+
+The location of the client key mounted in the pods deployed by the DaemonSet. 
+
+To enable, set to `/calico-secrets/etcd-key`
+
+## Other Configuration Options
+
+### enable_bgp 
 
 Whether or not to run Calico BGP.  If false, then BGP will be disabled and Calico will enforce policy only.
 
 ### cni_network_config
 
-The CNI network configuration to install on each node.  This field supports the following template fields, which will
+The CNI network configuration to install on each node.  This field supports the following template fields, which will 
 be filled in automatically by the `calico/cni` container:
 
-- `__KUBERNETES_SERVICE_HOST__`: This will be replaced with the Kubernetes Service clusterIP. e.g 10.0.0.1
+- `__KUBERNETES_SERVICE_HOST__`: This will be replaced with the Kubernetes Service clusterIP. e.g 10.0.0.1 
 - `__KUBERNETES_SERVICE_PORT__`: This will be replaced with the Kubernetes Service port. e.g 443
 - `__SERVICEACCOUNT_TOKEN__`: This will be replaced with the serviceaccount token for the namespace.  Requires that Kubernetes be configured to create serviceaccount tokens.
 - `__ETCD_ENDPOINTS__`: This will be replaced with the etcd cluster specified in the ETCD_ENDPOINTS environment variable. e.g http://127.0.0.1:2379
-- `__KUBECONFIG_FILENAME__`: The name of the automatically generated kubeconfig file in the same directory as the CNI network config file.
+- `__KUBECONFIG_FILEPATH__`: The path to the automatically generated kubeconfig file in the same directory as the CNI network config file.
+- `__ETCD_KEY_FILE__`: The path to the etcd key file installed to the host, empty if no key present.
+- `__ETCD_CERT_FILE__`: The path to the etcd cert file installed to the host, empty if no cert present.
+- `__ETCD_CA_CERT_FILE__`: The path to the etcd CA file installed to the host, empty if no CA present.

--- a/master/getting-started/kubernetes/installation/hosted/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/index.md
@@ -41,51 +41,49 @@ the following configuration parameters:
 By default, these manifests do not configure secure access to etcd and assume an etcd proxy is running on each host.  The following configuration
 options let you specify custom etcd cluster endpoints as well as TLS.  
 
+The following table outlines the supported ConfigMap options for etcd:
+ 
+| Option                 | Description    | Default 
+|------------------------|----------------|----------
+| etcd_endpoints         | A comma separated list of etcd nodes. | http://127.0.0.1:2379
+| etcd_ca                | The location of the CA mounted in the pods deployed by the DaemonSet. | None
+| etcd_key               | The location of the client cert mounted in the pods deployed by the DaemonSet. | None
+| etcd_cert              | The location of the client key mounted in the pods deployed by the DaemonSet. | None
+
 To use these manifests with a TLS enabled etcd cluster you must do the following:
 
-- Populate the `calico-etcd-secrets` Secret with the following files: `etcd-ca`, `etcd-key`, `etcd-cert`.
-- Populate the following options in the ConfigMap which will trigger the various services to expect the provided TLS assets: `etcd_ca`, `etcd_key`, `etcd_cert`
+- Populate the `calico-etcd-secrets` Secret with the contents of the following files: 
+  - `etcd-ca`
+  - `etcd-key`
+  - `etcd-cert`
+- Populate the following options in the ConfigMap which will trigger the various services to expect the provided TLS assets: 
+  - `etcd_ca: /calico-secrets/etcd-ca`
+  - `etcd_key: /calico-secrets/etcd-key`
+  - `etcd_cert: /calico-secrets/etcd-cert`
 
-### etcd_endpoints
-
-A comma separated list of etcd nodes. e.g `https://etcd0:2379,...` 
-
-The default in the provided manifest uses localhost, and assumes that an etcd proxy is running on each node.
-
-### etcd_ca 
-
-The location of the CA mounted in the pods deployed by the DaemonSet. 
-
-To enable, set to `/calico-secrets/etcd-ca`
-
-### etcd_key
-
-`etcd_key`: The location of the client cert mounted in the pods deployed by the DaemonSet. 
-
-To enable, set to `/calico-secrets/etcd-cert`
-
-### etcd_cert
-
-The location of the client key mounted in the pods deployed by the DaemonSet. 
-
-To enable, set to `/calico-secrets/etcd-key`
 
 ## Other Configuration Options
 
-### enable_bgp 
+The following table outlines the remaining supported ConfigMap options: 
 
-Whether or not to run Calico BGP.  If false, then BGP will be disabled and Calico will enforce policy only.
+| Option                 | Description         | Default 
+|------------------------|---------------------|----------
+| calico_backend         | The backend to use. | bird 
+| cni_network_config     | The CNI Network config to install on each node.  Supports templating as described below. | 
 
-### cni_network_config
 
-The CNI network configuration to install on each node.  This field supports the following template fields, which will 
+### CNI Network Config Template Support
+
+The `cni_network_config` configuration option supports the following template fields, which will 
 be filled in automatically by the `calico/cni` container:
 
-- `__KUBERNETES_SERVICE_HOST__`: This will be replaced with the Kubernetes Service clusterIP. e.g 10.0.0.1 
-- `__KUBERNETES_SERVICE_PORT__`: This will be replaced with the Kubernetes Service port. e.g 443
-- `__SERVICEACCOUNT_TOKEN__`: This will be replaced with the serviceaccount token for the namespace.  Requires that Kubernetes be configured to create serviceaccount tokens.
-- `__ETCD_ENDPOINTS__`: This will be replaced with the etcd cluster specified in the ETCD_ENDPOINTS environment variable. e.g http://127.0.0.1:2379
-- `__KUBECONFIG_FILEPATH__`: The path to the automatically generated kubeconfig file in the same directory as the CNI network config file.
-- `__ETCD_KEY_FILE__`: The path to the etcd key file installed to the host, empty if no key present.
-- `__ETCD_CERT_FILE__`: The path to the etcd cert file installed to the host, empty if no cert present.
-- `__ETCD_CA_CERT_FILE__`: The path to the etcd CA file installed to the host, empty if no CA present.
+| Field                                 | Substituted with 
+|---------------------------------------|----------------------------------
+| `__KUBERNETES_SERVICE_HOST__`         | The Kubernetes Service ClusterIP. e.g 10.0.0.1 
+| `__KUBERNETES_SERVICE_PORT__`         | The Kubernetes Service port. e.g 443
+| `__SERVICEACCOUNT_TOKEN__`            | The serviceaccount token for the namespace, if one exists.
+| `__ETCD_ENDPOINTS__`                  | The etcd endpoints specified in etcd_endpoints. 
+| `__KUBECONFIG_FILEPATH__`             | The path to the automatically generated kubeconfig file in the same directory as the CNI network config file.
+| `__ETCD_KEY_FILE__`                   | The path to the etcd key file installed to the host, empty if no key present.
+| `__ETCD_CERT_FILE__`                  | The path to the etcd cert file installed to the host, empty if no cert present.
+| `__ETCD_CA_CERT_FILE__`               | The path to the etcd CA file installed to the host, empty if no CA present.

--- a/master/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -17,7 +17,6 @@ Then, change into the directory for this guide:
 
     cd calico/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy
 
-
 ## Running the stars example
 
 ### 1) Create the frontend, backend, client, and management-ui apps.


### PR DESCRIPTION
This can go into master - relies on latest versions of code.