### PR TITLE
Max width of 8in for docs content on desktop

### DIFF
--- a/_sass/_base.sass
+++ b/_sass/_base.sass
@@ -649,7 +649,7 @@ dd
 
 #docsContent
 	position: relative
-	float: right
+	float: left
 	width: 100%
 
 	$toc-margin: 15px

--- a/_sass/_desktop.sass
+++ b/_sass/_desktop.sass
@@ -80,7 +80,7 @@ $video-section-height: 550px
 			display: none
 
 	#docsContent
-		width: calc(100% - 400px)
+		width: 8in
 
 		#editPageButton
 			right: -25px


### PR DESCRIPTION
It's commonly recommended [1] that text is no wider than about 7in, or
else it becomes difficult/tiring to read.  This commit limits our doc
content, when seen on the desktop, to 8in wide.

https://www.google.co.uk/search?client=ubuntu&channel=fs&q=max+text+width+for+reading&ie=utf-8&oe=utf-8&gfe_rd=cr&ei=Rnz7V6rLGeXv8Aezlp_wCg