### PR TITLE
Fix missing title render

### DIFF
--- a/master/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/master/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,5 @@
 ---
-Title: Simple Policy Demo
+title: Simple Policy Demo
 ---
 This guide provides a simple way to try out Kubernetes NetworkPolicy with Calico.  It requires a Kubernetes cluster configured with Calico networking, and expects that you have `kubectl` configured to interact with the cluster.
 

--- a/v1.5/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v1.5/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,5 @@
 ---
-Title: Simple Policy Demo
+title: Simple Policy Demo
 ---
 This guide provides a simple way to try out Kubernetes NetworkPolicy with Calico.  It requires a Kubernetes cluster configured with Calico networking, and expects that you have `kubectl` configured to interact with the cluster.
 


### PR DESCRIPTION
missing titles for http://docs.projectcalico.org/master/getting-started/kubernetes/tutorials/simple-policy (for `master` and `v1.5`) because `T` was uppercase