### PR TITLE
fix broken links for calicoctl and references to calicoctl

### DIFF
--- a/_data/master/navbars/reference.yml
+++ b/_data/master/navbars/reference.yml
@@ -20,6 +20,8 @@ toc:
       path: /reference/calicoctl/commands/apply
     - title: create
       path: /reference/calicoctl/commands/create
+    - title: config
+      path: /reference/calicoctl/commands/config
     - title: delete
       path: /reference/calicoctl/commands/delete
     - title: get

--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -58,7 +58,7 @@ sudo chmod +x calicoctl
 sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node
 ```
 
-See the [`calicoctl node` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/node)
+See the [`calicoctl node` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/)
 for more information.
 
 #### Example systemd unit file (calico-node.service)

--- a/master/reference/calicoctl/commands/apply.md
+++ b/master/reference/calicoctl/commands/apply.md
@@ -4,7 +4,7 @@ title: calicoctl apply
 
 This sections describes the `calicoctl apply` command.
 
-Read the [calicoctl command line interface user reference](../calicoctl.md) 
+Read the [calicoctl command line interface user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) 
 for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl apply' command
@@ -77,8 +77,8 @@ Successfully applied 2 'policy' resource(s)
 ```
 
 ## See also
--  [Resources](../resources) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/config.md
+++ b/master/reference/calicoctl/commands/config.md
@@ -7,7 +7,7 @@ This sections describes the `calicoctl config` commands.
 The `calicoctl config` command allows users to view or modify
 low-level component configurations for Felix and BGP.
 
-Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl) for a full list of calicoctl commands.
+Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl config' commands
 
@@ -203,8 +203,8 @@ Value removed
 ```
 
 ## See also
--  [Resources](../resources) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/create.md
+++ b/master/reference/calicoctl/commands/create.md
@@ -4,7 +4,7 @@ title: calicoctl create
 
 This sections describes the `calicoctl create` command.
 
-Read the [calicoctl command line interface user reference](../calicoctl.md) 
+Read the [calicoctl command line interface user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) 
 for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl create' command
@@ -77,8 +77,8 @@ Failed to create any resources: resource already exists: Profile(name=profile1)
 ```
 
 ## See also
--  [Resources](../resources) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/delete.md
+++ b/master/reference/calicoctl/commands/delete.md
@@ -4,7 +4,7 @@ title: calicoctl delete
 
 This sections describes the `calicoctl delete` command.
 
-Read the [calicoctl command line interface user reference](../calicoctl.md) 
+Read the [calicoctl command line interface user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) 
 for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl delete' command
@@ -96,8 +96,8 @@ Successfully deleted 1 'policy' resource(s)
 ```
 
 ## See also
--  [Resources](../resources) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/get.md
+++ b/master/reference/calicoctl/commands/get.md
@@ -4,7 +4,7 @@ title: calicoctl get
 
 This sections describes the `calicoctl get` command.
 
-Read the [calicoctl command line interface user reference](../calicoctl.md) 
+Read the [calicoctl command line interface user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) 
 for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl get' command
@@ -127,7 +127,7 @@ myhost     eth0                                       profile1
 #### `custom-columns`
 Similar to the `ps` format, the `custom-columns` option displays output in ps-style table output but allows the user
 to specify and ordered, comma-separated list of columns to display in the output.  The valid heading names for each
-resource type is documented in the [Resources](../resources/README.md) guide.
+resource type is documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 Example
 ```
@@ -139,7 +139,7 @@ eth0
 
 #### `yaml` and `json`
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources](../resources/README.md) guide, or alternatively view the structure
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
 definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
 
 The output from either of these formats may be used as input for all of the resource management commands.
@@ -175,7 +175,7 @@ $ calicoctl get hostEndpoint --output=yaml
 The `go-template` and `go-template-file` options display the output using a golang template specified as a string
 on the CLI, or defined in a separate file.
 When writing a template, be aware that the data passed to the template is a golang slice of resource-lists.  The 
-resource-lists are defined in the [libcalico API](../resources/README.md) and there is a resource-list defined for
+resource-lists are defined in the [libcalico API]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) and there is a resource-list defined for
 each resource type.  A resource-list contains an Items field which is itself a slice of resources.  Thus, to output
 the "Name" field from the supplied data, it is necessary to enumerate over the slice of resource-lists and the items
 within that list.
@@ -189,8 +189,8 @@ endpoint1,eth0,
 {% endraw %}
 
 ## See also
--  [Resources](../resources) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/index.md
+++ b/master/reference/calicoctl/commands/index.md
@@ -44,10 +44,10 @@ Description:
 Details on the `calicoctl` commands are described in the documents linked below
 organized by top level command.
 
--  [calicoctl create](create.md)
--  [calicoctl replace](replace.md)
--  [calicoctl apply](apply.md)
--  [calicoctl delete](delete.md)
--  [calicoctl get](get.md)
--  [calicoctl config](config.md)
--  [calicoctl version](version.md)
+-  [calicoctl create]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/create)
+-  [calicoctl replace]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/replace)
+-  [calicoctl apply]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/apply)
+-  [calicoctl delete]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/delete)
+-  [calicoctl get]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/get)
+-  [calicoctl config]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/config)
+-  [calicoctl version]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/version)

--- a/master/reference/calicoctl/commands/ipam/index.md
+++ b/master/reference/calicoctl/commands/ipam/index.md
@@ -4,7 +4,7 @@ title: calicoctl ipam
 
 This section describes the `calicoctl ipam` commands.
 
-Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl) for a full list of calicoctl commands.
+Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl ipam' commands
 
@@ -32,5 +32,5 @@ Description:
 Details on the `calicoctl ipam` commands are described in the documents linked below
 organized by sub command.
 
--  [calicoctl ipam release](release.md)
--  [calicoctl ipam show](show.md)
+-  [calicoctl ipam release]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/ipam/release)
+-  [calicoctl ipam show]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/ipam/show)

--- a/master/reference/calicoctl/commands/ipam/release.md
+++ b/master/reference/calicoctl/commands/ipam/release.md
@@ -4,7 +4,7 @@ title: calicoctl ipam
 
 This section describes the `calicoctl ipam release` command.
 
-Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl) for a full list of calicoctl commands.
+Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl ipam release' command
 

--- a/master/reference/calicoctl/commands/ipam/show.md
+++ b/master/reference/calicoctl/commands/ipam/show.md
@@ -4,7 +4,7 @@ title: calicoctl ipam
 
 This section describes the `calicoctl ipam show` command.
 
-Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl) for a full list of calicoctl commands.
+Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl ipam show' command
 

--- a/master/reference/calicoctl/commands/node/checksystem.md
+++ b/master/reference/calicoctl/commands/node/checksystem.md
@@ -32,8 +32,8 @@ WARNING: Unable to detect the ipip module. Load with `modprobe ipip`
 ```
 
 ### See also
--  [Resources](../../resources/README.md) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/node/diags.md
+++ b/master/reference/calicoctl/commands/node/diags.md
@@ -75,8 +75,8 @@ such as transfer.sh using curl or similar.  For example:
 ```
 
 ## See also
--  [Resources](../../resources/README.md) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/node/index.md
+++ b/master/reference/calicoctl/commands/node/index.md
@@ -4,7 +4,7 @@ title: calicoctl node
 
 This section describes the `calicoctl node` commands.
 
-Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl)
+Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
 for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl node' commands
@@ -35,13 +35,13 @@ Description:
 Details on the `calicoctl node` commands are described in the documents linked below
 organized by sub command.
 
--  [calicoctl node status](status.md)
--  [calicoctl node diags](diags.md)
--  [calicoctl node checksystem](checksystem.md)
+-  [calicoctl node status]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/status)
+-  [calicoctl node diags]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/diags)
+-  [calicoctl node checksystem]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/checksystem)
 
 ## See also
--  [Resources](../../resources/README.md) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/node/status.md
+++ b/master/reference/calicoctl/commands/node/status.md
@@ -43,8 +43,8 @@ No IPv6 address configured.
 ```
 
 ## See also
--  [Resources](../../resources/README.md) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/replace.md
+++ b/master/reference/calicoctl/commands/replace.md
@@ -4,7 +4,7 @@ title: calicoctl replace
 
 This sections describes the `calicoctl replace` command.
 
-Read the [calicoctl command line interface user reference](../calicoctl.md) 
+Read the [calicoctl command line interface user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) 
 for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl replace' command
@@ -74,8 +74,8 @@ Failed to replace any 'policy' resources: resource does not exist: Policy(name=d
 ```
 
 ## See also
--  [Resources](../resources) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/commands/version.md
+++ b/master/reference/calicoctl/commands/version.md
@@ -4,7 +4,7 @@ title: calicoctl version
 
 This sections describes the `calicoctl version` command.
 
-Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl) 
+Read the [calicoctl Overview]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) 
 for a full list of calicoctl commands.
 
 ## Displaying the help text for 'calicoctl version' commands
@@ -31,8 +31,8 @@ $ calicoctl version
 ```
 
 ## See also
--  [Resources](../resources) for details on all valid resources, including file format
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
    and schema
--  [Policy](../resources/policy.md) for details on the Calico selector-based policy model
--  [calicoctl configuration](../setup/config.md) for details on configuring `calicoctl` to access
+-  [Policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy) for details on the Calico selector-based policy model
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) for details on configuring `calicoctl` to access
    the Calico datastore.

--- a/master/reference/calicoctl/index.md
+++ b/master/reference/calicoctl/index.md
@@ -5,14 +5,14 @@ title: calicoctl CLI user reference
 The command line tool, `calicoctl`, makes it easy to manage Calico network
 and security policy.
 
-Follow the setup in the [Configuing calicoctl](setup/config.md) section.
+Follow the setup in the [Configuing calicoctl]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/config) section.
 This section describes how to do the initial setup of calicoctl, configuring
 the connection information for your Calico datastore.
 
 The calicoctl command line interface allows you to manage resources in
 your Calico deployment.  The full list of commands is described in the 
-[CLI user reference](command/index.md) section.
+[CLI user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/) section.
 
-The [Resource definitions](resources/index.md) section describes each of
+The [Resource definitions]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) section describes each of
 the available resources, including an overview of each resource and field
 level details.

--- a/master/reference/calicoctl/resources/bgppeer.md
+++ b/master/reference/calicoctl/resources/bgppeer.md
@@ -2,7 +2,7 @@
 title: BGP Peer resource (bgpPeer)
 ---
 
-A BGP Peer resource represents a BGP peer which node(s) in this cluster will connect to. Configuration of BGP peers is required when configuring Calico to peer with your existing datacenter infrastructure (e.g. ToR). For more information on cluster layouts, see Calico's documentation on [L3 Topologies](http://docs.projectcalico.org/en/latest/l3-interconnectFabric.html).
+A BGP Peer resource represents a BGP peer which node(s) in this cluster will connect to. Configuration of BGP peers is required when configuring Calico to peer with your existing datacenter infrastructure (e.g. ToR). For more information on cluster layouts, see Calico's documentation on [L3 Topologies]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
 
 There are two types of BGP Peers.
 

--- a/master/reference/calicoctl/resources/index.md
+++ b/master/reference/calicoctl/resources/index.md
@@ -33,7 +33,7 @@ spec:
 | name     | description                                               | requirements                                                                     | schema |
 |----------|-----------------------------------------------------------|----------------------------------------------------------------------------------|--------|
 | apiVersion     | Indicates the version of the API that the data corresponds to.                           | Currently only `v1` is accepted. | string |
-| kind    | Specifies the type of resource described by the YAML document. | Can be [`bgppeer`](bgppeer.md), [`hostendpoint`](hostendpoint.md), [`policy`](policy.md), [`pool`](pool.md), [`profile`](profile.md), or [`workloadendpoint`](workloadendpoint.md) | string |
+| kind    | Specifies the type of resource described by the YAML document. | Can be [`bgppeer`]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/bgppeer), [`hostendpoint`]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/hostendpoint), [`policy`]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/policy), [`pool`]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/pool), [`profile`]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/profile), or [`workloadendpoint`]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/workloadendpoint) | string |
 | metadata | Contains sub-fields which are used identify the particular instance of the resource. | | YAML |
 | spec | contains the resource specification, i.e. the configuration for the resource. | | YAML |
 

--- a/master/reference/calicoctl/resources/policy.md
+++ b/master/reference/calicoctl/resources/policy.md
@@ -64,7 +64,7 @@ spec:
 | order    | The order number which indicates the order that this policy is used. | | integer |
 | ingress  | The ingress rules belonging to this policy.                          | | List of [RuleSpecs](#rulespec) |
 | egress   | The egress rules belonging to this policy.                           | | List of [RuleSpecs](#rulespec)  |
-| selector | Selector expression.                                                 | See [selector expression documentation](http://docs.projectcalico.org/en/latest/etcd-data-model.html#tiered-security-policy) | string |
+| selector | Selector expression.                                                 | See [selector expression documentation]({{site.baseurl}}/{{page.version}}/reference/etcd/data-model#tiered-security-policy) | string |
 
 #### RuleSpec
 
@@ -91,9 +91,9 @@ spec:
 |-------------|--------------------------------------------|----------------|--------|
 | tag      | Match expression on tags.                   |  | string |
 | net    | Match on cidr. |  | string representation of cidr |
-| selector    | Selector expression. | See [selector expression documentation](http://docs.projectcalico.org/en/latest/etcd-data-model.html#tiered-security-policy) | string |
+| selector    | Selector expression. | See [selector expression documentation]({{site.baseurl}}/{{page.version}}/reference/etcd/data-model#tiered-security-policy) | string |
 | ports | Restricts the rule to only apply to traffic that has a port that matches one of these ranges/values. | A list of integers and/or strings, where strings can represent a range of ports by joining the range by a colon, e.g. `'1000:2000'` | list of strings and/or integers. |
 | "!tag" | Negative match on tag. |  | string |
 | "!net" | Negative match on cidr. | | string representation of cidr |
-| "!selector" | Negative match on selector expression. | See [selector expression documentation](http://docs.projectcalico.org/en/latest/etcd-data-model.html#tiered-security-policy) | string |
+| "!selector" | Negative match on selector expression. | See [selector expression documentation]({{site.baseurl}}/{{page.version}}/reference/etcd/data-model#tiered-security-policy) | string |
 | "!ports"      | Negative match on ports. | A list of integers and/or strings, where strings can represent a range of ports by joining the range by a colon, e.g. `'1000:2000'` | list of strings and/or integers. |

--- a/master/reference/calicoctl/resources/pool.md
+++ b/master/reference/calicoctl/resources/pool.md
@@ -27,7 +27,7 @@ spec:
 
 | name     | description                 | requirements | schema  |
 |----------|-----------------------------|---------|---------|
-| ipip | Configuration for ipip tunneling for this pool.     | If not specified, ipip tunneling is disabled for this pool. | [IPIPConfiguration](#ipipconfiguration) |
+| ipip | Configuration for ipip tunneling for this pool.     | If not specified, ipip tunneling is disabled for this pool. | [IPIP Configuration](#ipip-configuration) |
 | nat-outgoing | When enabled, packets sent from calico networked containers in this pool to destinations outside of this pool will be masqueraded. | | boolean |
 | disabled | When set to true, Calico IPAM will not assign addresses from this pool. |     | boolean |
 

--- a/master/reference/calicoctl/resources/profile.md
+++ b/master/reference/calicoctl/resources/profile.md
@@ -52,7 +52,7 @@ spec:
 The above YAML spec defines almost all of possible fields for a profile specifications, with the following exceptions:
 - "egress" supports all fields that "ingress" does.
 
-See Calico's [See selector expression documentation](http://docs.projectcalico.org/en/latest/etcd-data-model.html#tiered-security-policy) for more information on valid selector expressions.
+See Calico's [See selector expression documentation]({{site.baseurl}}/{{page.version}}/reference/etcd/data-model#tiered-security-policy) for more information on valid selector expressions.
 
 
 #### Metadata
@@ -96,9 +96,9 @@ See Calico's [See selector expression documentation](http://docs.projectcalico.o
 |-------------|--------------------------------------------|----------------------------------------|-------------------------------|
 | tag         | Match expression on tags.                  |                                        | string                        |
 | net         | Match on cidr.                             |                                        | string representation of cidr |
-| selector    | Selector expression.                       | See [selector expression documentation](http://docs.projectcalico.org/en/latest/etcd-data-model.html#tiered-security-policy) | string |
+| selector    | Selector expression.                       | See [selector expression documentation]({{site.baseurl}}/{{page.version}}/reference/etcd/data-model#tiered-security-policy) | string |
 | ports       | Restricts the rule to only apply to traffic that has a port that matches one of these ranges/values. | A list of integers and/or strings, where strings can represent a range of ports by joining the range by a colon, e.g. `'1000:2000'` | list of strings and/or integers. |
 | "!tag" | Negative match on tag. |  | string |
 | "!net" | Negative match on cidr. | | string representation of cidr |
-| "!selector" | Negative match on selector expression. | See [selector expression documentation](http://docs.projectcalico.org/en/latest/etcd-data-model.html#tiered-security-policy) | string |
+| "!selector" | Negative match on selector expression. | See [selector expression documentation]({{site.baseurl}}/{{page.version}}/reference/etcd/data-model#tiered-security-policy) | string |
 | "!ports"      | Negative match on ports. | A list of integers and/or strings, where strings can represent a range of ports by joining the range by a colon, e.g. `'1000:2000'` | list of strings and/or integers. |

--- a/master/reference/without-docker-networking/docker-container-lifecycle.md
+++ b/master/reference/without-docker-networking/docker-container-lifecycle.md
@@ -170,7 +170,7 @@ on the container endpoints.
 > containers with a single interface managed using calicoctl, we treat a
 > container and endpoint as the same thing.  For more complicated scenarios,
 > calicoctl provides commands for managing actual endpoints (see the
-> [`calicoctl endpoint` reference guide]({{site.baseurl}}/{{page.version}}/reference/calicoctl/endpoint) for usage and
+> [`calicoctl endpoint` reference guide]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for usage and
 > examples).
 
 ### System Response


### PR DESCRIPTION
- fixed broken links for calicoctl
- fixed reference links TO calicoctl
- `make htmlproofer` still reports some broken links but they're not for calicoctl, rebasing `golang` branch should fix them 