### PR TITLE
update docker tutorials

### DIFF
--- a/master/getting-started/docker/tutorials/basic.md
+++ b/master/getting-started/docker/tutorials/basic.md
@@ -52,11 +52,11 @@ driver in a separate container.
 
 On calico-01
 
-    sudo calicoctl node --libnetwork
+    sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> calicoctl node --libnetwork
 
 On calico-02
 
-    sudo calicoctl node --libnetwork
+    sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> calicoctl node --libnetwork
 
 This will start a container on each host. Check they are running
 

--- a/master/reference/without-docker-networking/installation.md
+++ b/master/reference/without-docker-networking/installation.md
@@ -37,11 +37,11 @@ Once you have your cluster up and running, start calico on all the nodes
 
 On calico-01
 
-    sudo calicoctl node
+    sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> calicoctl node
 
 On calico-02
 
-    sudo calicoctl node
+    sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> calicoctl node
 
 This will start a container on each host. Check they are running
 


### PR DESCRIPTION
When start a calico-node users should set ETCD_AUTHORITY env. Otherwise
command "calicocto node" fails like this:
    "ERROR: Could not connect to etcd at 127.0.0.1:2379:
     Connection to etcd failed due to MaxRetryError..."

This problem is found when I try to deploy my environment according
to this tutorial.