### PR TITLE
Fix calicoctl download link from latest builds to v0.22 release.

### DIFF
--- a/v1.5/getting-started/docker/installation/cloud-config/user-data-first
+++ b/v1.5/getting-started/docker/installation/cloud-config/user-data-first
@@ -64,5 +64,5 @@ write_files:
   owner: root
   content: |
     #!/usr/bin/bash -e
-    wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+    wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
     chmod +x /opt/bin/calicoctl

--- a/v1.5/getting-started/docker/installation/cloud-config/user-data-others
+++ b/v1.5/getting-started/docker/installation/cloud-config/user-data-others
@@ -59,5 +59,5 @@ write_files:
   owner: root
   content: |
     #!/usr/bin/bash -e
-    wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+    wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
     chmod +x /opt/bin/calicoctl

--- a/v1.5/getting-started/docker/installation/manual.md
+++ b/v1.5/getting-started/docker/installation/manual.md
@@ -60,7 +60,7 @@ If you prefer not to do this you can still run the demo but remember to run
 
 Get the calicoctl binary onto each host.
 
-	wget http://www.projectcalico.org/builds/calicoctl
+	wget https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
 	chmod +x calicoctl
 
 This binary should be placed in your `$PATH` so it can be run from any
@@ -73,8 +73,8 @@ run `calicoctl node` the first time.  Select the appropriate versions of the
 `calico/node` and `calico/node-libnetwork` as required by the version of
 calicoctl:
 
-    docker pull calico/node:latest
-    docker pull calico/node-libnetwork:latest
+    docker pull calico/node:v0.22.0
+    docker pull calico/node-libnetwork:v0.9.0
 
 ### Final checks
 

--- a/v1.5/getting-started/docker/installation/vagrant-coreos/Vagrantfile
+++ b/v1.5/getting-started/docker/installation/vagrant-coreos/Vagrantfile
@@ -10,8 +10,8 @@
 #
 # This version should match the version required by calicoctl installed in the
 # cloud config files.
-calico_node_ver = "latest"
-calico_libnetwork_ver = "latest"
+calico_node_ver = "v0.22.0"
+calico_libnetwork_ver = "v0.9.0"
 
 # Size of the cluster created by Vagrant
 num_instances=2

--- a/v1.5/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
+++ b/v1.5/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # The calicoctl download URL.
-calicoctl_url = "http://www.projectcalico.org/builds/calicoctl"
+calicoctl_url = "https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl"
 
 # The version of the calico docker images to install.  This is used to pre-load
 # the calico/node and calico/node-libnetwork images which slows down the
@@ -10,8 +10,8 @@ calicoctl_url = "http://www.projectcalico.org/builds/calicoctl"
 #
 # This version should match the version required by calicoctl installed from
 # calicoctl_url.
-calico_node_ver = "latest"
-calico_libnetwork_ver = "latest"
+calico_node_ver = "v0.22.0"
+calico_libnetwork_ver = "v0.9.0"
 
 # Size of the cluster created by Vagrant
 num_instances=2

--- a/v1.5/getting-started/docker/tutorials/basic.md
+++ b/v1.5/getting-started/docker/tutorials/basic.md
@@ -66,8 +66,8 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                           COMMAND                  CREATED             STATUS              PORTS               NAMES
-    eec9ebbfb486        calico/node-libnetwork:latest   "./start.sh"             21 seconds ago      Up 19 seconds                           calico-libnetwork
-    ffe6cb403e9b        calico/node:latest              "/sbin/my_init"          21 seconds ago      Up 20 seconds                           calico-node
+    eec9ebbfb486        calico/node-libnetwork:v0.9.0   "./start.sh"             21 seconds ago      Up 19 seconds                           calico-libnetwork
+    ffe6cb403e9b        calico/node:v0.22.0             "/sbin/my_init"          21 seconds ago      Up 20 seconds                           calico-node
 
 ## 3. Create the networks
 

--- a/v1.5/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v1.5/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -2,7 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: calico-config 
+  name: calico-config
   namespace: kube-system
 data:
   # Configure this with the location of your etcd cluster.
@@ -36,7 +36,7 @@ data:
 ---
 
 # This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on 
+# as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -56,11 +56,11 @@ spec:
     spec:
       hostNetwork: true
       containers:
-        # Runs calico/node container on each Kubernetes node.  This 
+        # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:latest
+          image: quay.io/calico/node:v0.22.0
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -68,7 +68,7 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            # Enable BGP.  Disable to enforce policy only. 
+            # Enable BGP.  Disable to enforce policy only.
             - name: CALICO_NETWORKING
               valueFrom:
                 configMapKeyRef:
@@ -92,7 +92,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:latest
+          image: calico/cni:v1.4.2
           imagePullPolicy: Always
           command: ["/install-cni.sh"]
           env:
@@ -134,7 +134,7 @@ spec:
 # This manifest deploys the Calico policy controller on Kubernetes.
 # See https://github.com/projectcalico/k8s-policy
 apiVersion: extensions/v1beta1
-kind: ReplicaSet 
+kind: ReplicaSet
 metadata:
   name: calico-policy-controller
   namespace: kube-system
@@ -167,7 +167,7 @@ spec:
             # service for API access.
             - name: K8S_API
               value: "https://kubernetes.default:443"
-            # Since we're running in the host namespace and might not have KubeDNS 
+            # Since we're running in the host namespace and might not have KubeDNS
             # access, configure the container's /etc/hosts to resolve
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS

--- a/v1.5/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v1.5/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -155,7 +155,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:latest
+          image: calico/kube-policy-controller:v0.3.0
           env:
             # The location of the Calico etcd cluster.
             - name: ETCD_ENDPOINTS

--- a/v1.5/getting-started/mesos/installation/docker.md
+++ b/v1.5/getting-started/mesos/installation/docker.md
@@ -27,7 +27,7 @@ Docker Containerizer.
 1. On each Mesos Agents, download the `calicoctl` command-line tool:
 
 ```shell
-curl -o /usr/bin/calicoctl -L http://www.projectcalico.org/builds/calicoctl
+curl -o /usr/bin/calicoctl -L https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
 chmod a+x calicoctl
 ```
 
@@ -51,8 +51,8 @@ Again, be sure to set the ETCD_AUTHORITY to the correct `IP/Hostname:Port` for y
 ```shell
 $ docker ps
 CONTAINER ID        NAMES               IMAGE                           CREATED
-19263eda1810        calico-libnetwork   calico/node-libnetwork:latest   3 seconds
-f237fb21d357        calico-node         calico/node:latest              3 seconds
+19263eda1810        calico-libnetwork   calico/node-libnetwork:v0.9.0   3 seconds
+f237fb21d357        calico-node         calico/node:v0.22.0             3 seconds
 ```
 
 4. Enable Docker Containerizer in Mesos.

--- a/v1.5/getting-started/mesos/vagrant/Vagrantfile
+++ b/v1.5/getting-started/mesos/vagrant/Vagrantfile
@@ -13,7 +13,7 @@ mesos_version = "1.0.0"
 mesos_dns_url = "https://github.com/mesosphere/mesos-dns/releases/download/v0.5.0/mesos-dns-v0.5.0-linux-amd64"
 
 # The calicoctl download URL.
-calicoctl_url = "http://www.projectcalico.org/builds/calicoctl"
+calicoctl_url = "https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl"
 
 # The version of the calico docker images to install.  This is used to pre-load
 # the calico/node and calico/node-libnetwork images which slows down the
@@ -21,8 +21,8 @@ calicoctl_url = "http://www.projectcalico.org/builds/calicoctl"
 #
 # This version should match the version required by calicoctl installed from
 # calicoctl_url.
-calico_node_ver = "latest"
-calico_libnetwork_ver = "latest"
+calico_node_ver = "v0.22.0"
+calico_libnetwork_ver = "v0.9.0"
 
 # Script to write out the Calico environment file.
 $write_calico_env=<<SCRIPT

--- a/v1.5/getting-started/mesos/vagrant/units/calico-libnetwork.service
+++ b/v1.5/getting-started/mesos/vagrant/units/calico-libnetwork.service
@@ -14,7 +14,7 @@ ExecStart=/usr/bin/docker run --privileged --net=host \
  -e ETCD_CA_CERT_FILE=${ETCD_CA_CERT_FILE} \
  -e ETCD_CERT_FILE=${ETCD_CERT_FILE} \
  -e ETCD_KEY_FILE=${ETCD_KEY_FILE} \
- calico/node-libnetwork:latest
+ calico/node-libnetwork:v0.9.0
 ExecStop=-/usr/bin/docker stop calico-libnetwork
 
 [Install]

--- a/v1.5/getting-started/rkt/vagrant/cloud-config/master-config.yaml
+++ b/v1.5/getting-started/rkt/vagrant/cloud-config/master-config.yaml
@@ -27,7 +27,7 @@ coreos:
         User=root
         ExecStartPre=/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/rkt/net.d
-        ExecStartPre=/usr/bin/wget -N -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+        ExecStartPre=/usr/bin/wget -N -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
         ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico
         ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico-ipam
         ExecStartPre=/usr/bin/chmod a+w -R /etc/rkt/net.d
@@ -35,12 +35,10 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /etc/rkt/net.d/calico-ipam
         ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
         ExecStartPre=/usr/bin/rkt --insecure-options=image fetch docker://busybox
-        ExecStartPre=/usr/bin/rkt --insecure-options=image fetch docker://calico/node:latest
+        ExecStartPre=/usr/bin/rkt --insecure-options=image fetch docker://calico/node:v0.22.0
         ExecStart=/usr/bin/true
         RemainAfterExit=yes
         Type=oneshot
 
         [Install]
         WantedBy=multi-user.target
-
-

--- a/v1.5/getting-started/rkt/vagrant/cloud-config/node-config.yaml
+++ b/v1.5/getting-started/rkt/vagrant/cloud-config/node-config.yaml
@@ -23,7 +23,7 @@ coreos:
         User=root
         ExecStartPre=/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/rkt/net.d
-        ExecStartPre=/usr/bin/wget -N -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+        ExecStartPre=/usr/bin/wget -N -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
         ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico
         ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.4.1/calico-ipam
         ExecStartPre=/usr/bin/chmod a+w -R /etc/rkt/net.d
@@ -31,7 +31,7 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /etc/rkt/net.d/calico-ipam
         ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
         ExecStartPre=/usr/bin/rkt --insecure-options=image fetch docker://busybox
-        ExecStartPre=/usr/bin/rkt --insecure-options=image fetch docker://calico/node:latest
+        ExecStartPre=/usr/bin/rkt --insecure-options=image fetch docker://calico/node:v0.22.0
         ExecStart=/usr/bin/true
         RemainAfterExit=yes
         Type=oneshot

--- a/v1.5/getting-started/rkt/vagrant/index.md
+++ b/v1.5/getting-started/rkt/vagrant/index.md
@@ -71,8 +71,8 @@ This will create a systemd unit called `calico-node` which runs the Calico compo
 You can check that it's running
 
 	$ sudo rkt list
-	UUID            APP     IMAGE NAME                              STATE   NETWORKS
-	bc13af40        node    registry-1.docker.io/calico/node:latest running
+	UUID            APP     IMAGE NAME                               STATE   NETWORKS
+	bc13af40        node    registry-1.docker.io/calico/node:v0.22.0 running
 
 You can check the status and logs using normal systemd commands e.g. `systemctl status calico-node` and `journalctl -u calico-node`
 
@@ -130,7 +130,7 @@ Normal [systemd commands][systemd-run] can then be used to get the status of the
 
 	$ sudo rkt list
 	UUID		APP	IMAGE NAME					STATE	CREATED		STARTEDNETWORKS
-	05f8779a	node	registry-1.docker.io/calico/node:latest		running	1 hour ago	1 hour ago
+	05f8779a	node	registry-1.docker.io/calico/node:v0.22.0		running	1 hour ago	1 hour ago
 	c89f2f35	busybox	registry-1.docker.io/library/busybox:latest	running	2 seconds ago	1 second ago	frontend:ip4=192.168.0.0, default-restricted:ip4=172.16.28.2
 
 
@@ -145,7 +145,7 @@ Repeat for a "backend" service on `calico-02`
 
 	$ sudo rkt list
 	UUID		APP	IMAGE NAME					STATE	CREATED		STARTEDNETWORKS
-	2cc27ce1	node	registry-1.docker.io/calico/node:latest		running	1 hour ago	1 hour ago
+	2cc27ce1	node	registry-1.docker.io/calico/node:v0.22.0		running	1 hour ago	1 hour ago
 	407208a5	busybox	registry-1.docker.io/library/busybox:latest	running	11 seconds ago	10 seconds ago	backend:ip4=192.168.0.64, default-restricted:ip4=172.16.28.2
 
 We now have a `busybox` container running on the network `backend` with an IP address of `192.168.0.1`

--- a/v1.5/reference/calicoctl/node.md
+++ b/v1.5/reference/calicoctl/node.md
@@ -56,11 +56,11 @@ Options:
   --libnetwork              Use the libnetwork plugin.
   --libnetwork-image=<LIBNETWORK_IMAGE_NAME>    Docker image to use for
                             Calico's libnetwork driver.
-                            [default: calico/node-libnetwork:latest]
+                            [default: calico/node-libnetwork:v0.9.0]
   --log-dir=<LOG_DIR>       The directory for logs [default: /var/log/calico]
   --no-pull                 Prevent from pulling the Calico node Docker images.
   --node-image=<DOCKER_IMAGE_NAME>    Docker image to use for Calico's per-node
-                            container. [default: calico/node:latest]
+                            container. [default: calico/node:v0.22.0]
   --remove-endpoints        Remove the endpoint data when deleting the node
                             from the Calico network.
   --runtime=<RUNTIME>       Specify how Calico services should be

--- a/v1.5/reference/without-docker-networking/environment-setup/cloud-config/user-data-first
+++ b/v1.5/reference/without-docker-networking/environment-setup/cloud-config/user-data-first
@@ -45,5 +45,5 @@ write_files:
   owner: root
   content: |
     #!/usr/bin/bash -e
-    wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+    wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
     chmod +x /opt/bin/calicoctl

--- a/v1.5/reference/without-docker-networking/environment-setup/cloud-config/user-data-others
+++ b/v1.5/reference/without-docker-networking/environment-setup/cloud-config/user-data-others
@@ -40,5 +40,5 @@ write_files:
   owner: root
   content: |
     #!/usr/bin/bash -e
-    wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+    wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
     chmod +x /opt/bin/calicoctl

--- a/v1.5/reference/without-docker-networking/environment-setup/vagrant-coreos/Vagrantfile
+++ b/v1.5/reference/without-docker-networking/environment-setup/vagrant-coreos/Vagrantfile
@@ -10,7 +10,7 @@
 #
 # This version should match the version required by calicotl installed in the
 # cloud config files.
-calico_docker_ver = "latest"
+calico_docker_ver = "v0.22.0"
 
 # Size of the cluster created by Vagrant
 num_instances=2

--- a/v1.5/reference/without-docker-networking/environment-setup/vagrant-ubuntu/Vagrantfile
+++ b/v1.5/reference/without-docker-networking/environment-setup/vagrant-ubuntu/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # The calicoctl download URL.
-calicoctl_url = "http://www.projectcalico.org/builds/calicoctl"
+calicoctl_url = "https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl"
 
 # The version of the calico docker image to install.  This is used to pre-load
 # the calico/node image which slows down the install process, but speeds up the
@@ -10,7 +10,7 @@ calicoctl_url = "http://www.projectcalico.org/builds/calicoctl"
 #
 # This version should match the version required by calicotl installed from
 # calicoctl_url.
-calico_docker_ver = "latest"
+calico_docker_ver = "v0.22.0"
 
 # Size of the cluster created by Vagrant
 num_instances=2

--- a/v1.5/reference/without-docker-networking/installation.md
+++ b/v1.5/reference/without-docker-networking/installation.md
@@ -51,7 +51,7 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                           COMMAND                  CREATED             STATUS              PORTS               NAMES
-    ffe6cb403e9b        calico/node:latest              "/sbin/my_init"          21 seconds ago      Up 20 seconds                           calico-node
+    ffe6cb403e9b        calico/node:v0.22.0             "/sbin/my_init"          21 seconds ago      Up 20 seconds                           calico-node
 
 ## 3. Running in the cloud (AWS / DigitalOcean / GCE)
 

--- a/v1.5/reference/without-docker-networking/prerequisites.md
+++ b/v1.5/reference/without-docker-networking/prerequisites.md
@@ -50,7 +50,7 @@ If you prefer not to do this you can still run the demo but remember to run
 
 Get the calicoctl binary onto each host.
 
-	wget http://www.projectcalico.org/builds/calicoctl
+	wget https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl
 	chmod +x calicoctl
 
 This binary should be placed in your `$PATH` so it can be run from any
@@ -62,7 +62,7 @@ You can optionally preload the Calico Docker image to avoid the delay when you
 run `calicoctl node` the first time.  Select the appropriate versions of the
 `calico/node` as required by the version of calicoctl:
 
-    docker pull calico/node:latest
+    docker pull calico/node:v0.22.0
 
 ## Final checks
 

--- a/v1.5/releases/index.md
+++ b/v1.5/releases/index.md
@@ -6,14 +6,15 @@ The following table shows component versioning for Calico  **{{ page.version }}*
 
 Use the version selector at the top-right of this page to view a different release.
 
-## v1.5.0 
+## v1.5.0
 
-| Component              | Version  |
-|------------------------|----------|
-| felix                  | v1.4.1b2 |
-| calicoctl              | v0.22.0  |
-| calico/node            | v0.22.0  |
-| calico/node-libnetwork | v0.9.0   |
-| calico/cni             | v1.4.2   |
-| libcalico              | v0.17.0  |
-| calico-bird            | v0.1.0   |
+| Component                     | Version  |
+|-------------------------------|----------|
+| felix                         | v1.4.1b2 |
+| calicoctl                     | v0.22.0  |
+| calico/node                   | v0.22.0  |
+| calico/node-libnetwork        | v0.9.0   |
+| calico/cni                    | v1.4.2   |
+| libcalico                     | v0.17.0  |
+| calico-bird                   | v0.1.0   |
+| calico/kube-policy-controller | v0.3.0   |

--- a/v1.5/usage/configuration/as-service.md
+++ b/v1.5/usage/configuration/as-service.md
@@ -9,8 +9,8 @@ daemons such as upstart as well.
 
 ## Running the Calico Node Container as a Service
 This section describes how to run the Calico node as a Docker container
-in Systemd.  Included here is an EnvironmentFile that defines the Environment 
-variables for Calico and a sample systemd service file that uses the 
+in Systemd.  Included here is an EnvironmentFile that defines the Environment
+variables for Calico and a sample systemd service file that uses the
 environment file and starts the Calico node image as a service.
 
 `calico.env` - the EnvironmentFile:
@@ -90,7 +90,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -v /run/docker/plugins:/run/docker/plugins \
  -v /lib/modules:/lib/modules \
  -v /var/run/calico:/var/run/calico \
- calico/node:latest
+ calico/node:v0.22.0
 
 ExecStop=-/usr/bin/docker stop calico-node
 
@@ -109,4 +109,3 @@ The script will also stop the calico-node container when the service is stopped.
 **Note**: Depending on how you've installed Docker, the name of the Docker service
 under the `[Unit]` section may be different (such as `docker-engine.service`).
 Be sure to check this before starting the service.
-

--- a/v1.5/usage/dockerless-calico.md
+++ b/v1.5/usage/dockerless-calico.md
@@ -64,7 +64,7 @@ yum install -y posix-spawn python-gevent python-eventlet python-etcd
 
 ```shell
 # calicoctl
-curl -L http://www.projectcalico.org/builds/calicoctl -o /usr/local/bin/calicoctl
+curl -L https://github.com/projectcalico/calico-containers/releases/download/v0.22.0/calicoctl -o /usr/local/bin/calicoctl
 chmod +x /usr/local/bin/calicoctl
 
 # bird


### PR DESCRIPTION
Statically / hardcode fixes #111 and all other incorrect references to builds of calicoctl, replacing them with links to the v0.22 release.