### PR TITLE
Disable IPv6 support for Kubernetes hosted installs.

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -145,6 +145,9 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
+            # Don't use IPv6.  Kubernetes doesn't support it.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
           securityContext:
             privileged: true
           volumeMounts:

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -167,6 +167,9 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
+            # Don't use IPv6.  Kubernetes doesn't support it.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
           securityContext:
             privileged: true
           volumeMounts:

--- a/v2.0/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -145,6 +145,9 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
+            # Don't use IPv6.  Kubernetes doesn't support it.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
           securityContext:
             privileged: true
           volumeMounts:

--- a/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -167,6 +167,9 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
+            # Don't use IPv6.  Kubernetes doesn't support it.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
As discussed here https://github.com/projectcalico/calico-containers/issues/1242#event-844153070