### PR TITLE
Make calico manifests critical addons

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -79,6 +79,9 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       hostNetwork: true
       containers:
@@ -192,6 +195,9 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-policy
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+    scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
 spec:
   # The policy controller can only have a single active instance.
   replicas: 1

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -46,6 +46,9 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       hostNetwork: true
       containers:

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -50,6 +50,9 @@ spec:
     metadata:
       labels:
         k8s-app: calico-etcd
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       # Only run this pod on the master.
       nodeSelector:
@@ -114,6 +117,9 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       hostNetwork: true
       containers:
@@ -214,6 +220,9 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy-controller
+    annotations:
+      scheduler.alpha.kubernetes.io/critical-pod: ''
+      scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
@@ -253,6 +262,9 @@ spec:
   template:
     metadata:
       name: configure-calico
+    annotations:
+      scheduler.alpha.kubernetes.io/critical-pod: ''
+      scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       hostNetwork: true
       restartPolicy: OnFailure 


### PR DESCRIPTION
As described here: http://kubernetes.io/docs/admin/rescheduler/

Fixes #150 