### PR TITLE
Kubernetes backend: add example installation links using kubeadm and kube-flannel

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -1,8 +1,8 @@
 ---
-title: Calico without etcd 
+title: Calico without etcd
 ---
 
-This document describes a way of installing Calico on Kubernetes without requiring access to an etcd cluster for Calico.  Note that this feature is 
+This document describes a way of installing Calico on Kubernetes without requiring access to an etcd cluster for Calico.  Note that this feature is
 still experimental and currently comes with a number of limitations, namely:
 
 - Calico without etcd performs policy enforcement only and does not yet support Calico BGP networking.
@@ -14,13 +14,15 @@ still experimental and currently comes with a number of limitations, namely:
 ## Try it out
 
 The provided manifest configures Calico to use host-local IPAM in conjunction with the Kubernetes assigned
-pod CIDRs for each node.  
+pod CIDRs for each node.
 
-Firt, ensure the following:
+First, ensure the following:
 
 - You have a Kubernetes cluster configured to use CNI network plugins (i.e by passing `--network-plugin=cni`)
 - Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e by passing `--allocate-node-cidrs=true`)
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes or a Kubernetes cloud-provder integration.
+
+For example, you could install Kubernetes with Flannel using [kubeadm](http://kubernetes.io/docs/getting-started-guides/kubeadm/) and [kube-flannel](https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml).
 
 Then to install Calico, download [calico.yaml](calico.yaml) and run the following command:
 
@@ -36,13 +38,13 @@ The following environment variable configuration options are supported by the va
 
 | Option                 | Description    | Examples
 |------------------------|----------------|----------
-| DATASTORE_TYPE         | Indicates the datastore to use | kubernetes, etcdv2 
-| KUBECONFIG             | When using the kubernetes datastore, the location of a kubeconfig file to use. | /path/to/kube/config 
-| K8S_API_ENDPOINT       | Location of the Kubernetes API.  Not required if using kubeconfig. | https://kubernetes-api:443 
-| K8S_CERT_FILE          | Location of a client certificate for accessing the Kubernetes API. | /path/to/cert 
-| K8S_KEY_FILE           | Location of a client key for accessing the Kubernetes API. | /path/to/key 
-| K8S_CA_FILE            | Location of a CA for accessing the Kubernetes API. | /path/to/ca 
-| K8S_TOKEN              | Token to be used for accessing the Kubernetes API. |  
+| DATASTORE_TYPE         | Indicates the datastore to use | kubernetes, etcdv2
+| KUBECONFIG             | When using the kubernetes datastore, the location of a kubeconfig file to use. | /path/to/kube/config
+| K8S_API_ENDPOINT       | Location of the Kubernetes API.  Not required if using kubeconfig. | https://kubernetes-api:443
+| K8S_CERT_FILE          | Location of a client certificate for accessing the Kubernetes API. | /path/to/cert
+| K8S_KEY_FILE           | Location of a client key for accessing the Kubernetes API. | /path/to/key
+| K8S_CA_FILE            | Location of a CA for accessing the Kubernetes API. | /path/to/ca
+| K8S_TOKEN              | Token to be used for accessing the Kubernetes API. |
 
 An example using `calicoctl`:
 
@@ -59,11 +61,11 @@ kubernetes-minion-group-x7ce   k8s            kube-system.kubernetes-dashboard-v
 ## How it works
 
 Calico typically uses `etcd` to store information about Kubernetes Pods, Namespaces, and NetworkPolicies.  This information
-is populated to etcd by the Calico CNI plugin and policy controller, and is interpreted by Felix and BIRD to program the dataplane on 
+is populated to etcd by the Calico CNI plugin and policy controller, and is interpreted by Felix and BIRD to program the dataplane on
 each host in the cluster.
 
-The above manifest deploys Calico such that Felix uses the Kubernetes API directly to learn the required information to enforce policy, 
-removing Calico's dependency on etcd and the need for the Calico kubernetes policy controller. 
+The above manifest deploys Calico such that Felix uses the Kubernetes API directly to learn the required information to enforce policy,
+removing Calico's dependency on etcd and the need for the Calico kubernetes policy controller.
 
 The Calico CNI plugin is still required to configure each pod's virtual ethernet device and network namespace.
 


### PR DESCRIPTION
Nothing fancy; we don't want to maintain length kubernetes install guides.

These yamls would be good candidates for combining into a future single etcdless canal yaml.