### PR TITLE
Fix self hosted yaml validation + new Kubeadm clusterIP range errors

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -34,15 +34,14 @@ data:
         }
     }
 
-  # The default IP Pool to be created for each node.
+  # The default IP Pool to be created for the cluster.
+  # Pod IP addresses will be assigned from this pool.
   ippool.yaml: |
       apiVersion: v1
       kind: ipPool
       metadata:
         cidr: 192.168.0.0/16
       spec:
-        ipip:
-          enabled: true
         nat-outgoing: true
         
   # If you're using TLS enabled etcd uncomment the following.

--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -34,6 +34,17 @@ data:
         }
     }
 
+  # The default IP Pool to be created for each node.
+  ippool.yaml: |
+      apiVersion: v1
+      kind: ipPool
+      metadata:
+        cidr: 192.168.0.0/16
+      spec:
+        ipip:
+          enabled: true
+        nat-outgoing: true
+        
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.
   etcd_ca: ""   # "/calico-secrets/etcd-ca"
@@ -107,6 +118,10 @@ spec:
                   key: calico_backend
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Don't configure a default pool.  This is done by the Job
+            # below.
+            - name: NO_DEFAULT_POOLS
               value: "true"
             # Location of the CA certificate for etcd.
             - name: ETCD_CA_CERT_FILE
@@ -202,7 +217,6 @@ metadata:
     scheduler.alpha.kubernetes.io/tolerations: |
       [{"key": "role", "value": "master", "effect": "NoSchedule" },
        {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-
 spec:
   # The policy controller can only have a single active instance.
   replicas: 1
@@ -262,3 +276,52 @@ spec:
         - name: etcd-certs
           secret:
             secretName: calico-etcd-secrets
+
+---
+
+## This manifest deploys a Job which performs one time
+# configuration of Calico
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configure-calico
+  namespace: kube-system
+  labels:
+    k8s-app: calico
+spec:
+  template:
+    metadata:
+      name: configure-calico
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      restartPolicy: OnFailure
+      containers:
+        # Writes basic configuration to datastore.
+        - name: configure-calico
+          image: calico/ctl:latest
+          args:
+          - apply
+          - -f
+          - /etc/config/calico/ippool.yaml
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+          env:
+            # The location of the etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+      volumes:
+       - name: config-volume
+         configMap:
+           name: calico-config
+           items:
+            - key: ippool.yaml
+              path: calico/ippool.yaml

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -33,7 +33,8 @@ data:
         }
     }
 
-  # The default IP Pool to be created for each node.
+  # The default IP Pool to be created for the cluster.
+  # Pod IP addresses will be assigned from this pool.
   ippool.yaml: |
       apiVersion: v1
       kind: ipPool

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -2,12 +2,12 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: calico-config 
+  name: calico-config
   namespace: kube-system
 data:
   # The location of your etcd cluster.  This uses the Service clusterIP
   # defined below.
-  etcd_endpoints: "http://100.78.232.136:6666"
+  etcd_endpoints: "http://10.96.232.136:6666"
 
   # True enables BGP networking, false tells Calico to enforce
   # policy only, using native networking.
@@ -33,13 +33,24 @@ data:
         }
     }
 
+  # The default IP Pool to be created for each node.
+  ippool.yaml: |
+      apiVersion: v1
+      kind: ipPool
+      metadata:
+        cidr: 192.168.0.0/16
+      spec:
+        ipip:
+          enabled: true
+        nat-outgoing: true
+
 ---
 
 # This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
 # to force it to run on the master even when the master isn't schedulable, and uses
-# nodeSelector to ensure it only runs on the master. 
-apiVersion: extensions/v1beta1 
-kind: DaemonSet 
+# nodeSelector to ensure it only runs on the master.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
 metadata:
   name: calico-etcd
   namespace: kube-system
@@ -94,15 +105,15 @@ spec:
   selector:
     k8s-app: calico-etcd
   # This ClusterIP needs to be known in advance, since we cannot rely
-  # on DNS to get access to etcd. 
-  clusterIP: 100.78.232.136
+  # on DNS to get access to etcd.
+  clusterIP: 10.96.232.136
   ports:
     - port: 6666
 
 ---
 
 # This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on 
+# as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -127,7 +138,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-        # Runs calico/node container on each Kubernetes node.  This 
+        # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
         - name: calico-node
@@ -139,7 +150,7 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            # Enable BGP.  Disable to enforce policy only. 
+            # Enable BGP.  Disable to enforce policy only.
             - name: CALICO_NETWORKING
               valueFrom:
                 configMapKeyRef:
@@ -209,7 +220,7 @@ spec:
 # This manifest deploys the Calico policy controller on Kubernetes.
 # See https://github.com/projectcalico/k8s-policy
 apiVersion: extensions/v1beta1
-kind: ReplicaSet 
+kind: ReplicaSet
 metadata:
   name: calico-policy-controller
   namespace: kube-system
@@ -224,12 +235,11 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy-controller
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ''
-      scheduler.alpha.kubernetes.io/tolerations: |
-        [{"key": "role", "value": "master", "effect": "NoSchedule" },
-         {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
@@ -248,7 +258,7 @@ spec:
             # service for API access.
             - name: K8S_API
               value: "https://kubernetes.default:443"
-            # Since we're running in the host namespace and might not have KubeDNS 
+            # Since we're running in the host namespace and might not have KubeDNS
             # access, configure the container's /etc/hosts to resolve
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
@@ -256,41 +266,49 @@ spec:
 
 ---
 
-## This manifest deploys a Job which performs one time 
-# configuration of Calico 
+## This manifest deploys a Job which performs one time
+# configuration of Calico
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: configure-calico
   namespace: kube-system
   labels:
-    k8s-app: calico 
+    k8s-app: calico
 spec:
   template:
     metadata:
       name: configure-calico
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ''
-      scheduler.alpha.kubernetes.io/tolerations: |
-        [{"key": "role", "value": "master", "effect": "NoSchedule" },
-         {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
-      restartPolicy: OnFailure 
+      restartPolicy: OnFailure
       containers:
-        # Writes basic configuration to datastore. 
+        # Writes basic configuration to datastore.
         - name: configure-calico
           image: calico/ctl:latest
-          args: 
-          - "pool"
-          - "add"
-          - "192.168.0.0/16"
-          - "--ipip"
-          - "--nat-outgoing"
+          args:
+          - apply
+          - -f
+          - /etc/config/calico/ippool.yaml
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
           env:
             # The location of the etcd cluster.
-            - name: ETCD_ENDPOINTS 
+            - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
+      volumes:
+       - name: config-volume
+         configMap:
+           name: calico-config
+           items:
+            - key: ippool.yaml
+              path: calico/ippool.yaml

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -8,7 +8,14 @@ install found [here]({{site.baseurl}}/{{page.version}}/getting-started/kubernete
 
 This install is designed to work for kubeadm clusters, or any cluster which labels 
 a single master node with `kubeadm.alpha.kubernetes.io/role: master`.  This label is used for deploying
-a single node etcd cluster.
+a single node etcd cluster. 
+
+To check if the label is applied, run the following command:
+
+```shell
+$ kubectl get node <node_name> -o yaml | grep kubeadm
+   kubeadm.alpha.kubernetes.io/role: master
+```
 
 You can easily create a compatible cluster by following [the official kubeadm guide](http://kubernetes.io/docs/getting-started-guides/kubeadm/).
 

--- a/v1.5/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v1.5/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   # The location of your etcd cluster.  This uses the Service clusterIP
   # defined below.
-  etcd_endpoints: "http://100.78.232.136:6666"
+  etcd_endpoints: "http://10.96.232.136:6666"
 
   # True enables BGP networking, false tells Calico to enforce
   # policy only, using native networking.
@@ -90,7 +90,7 @@ spec:
     k8s-app: calico-etcd
   # This ClusterIP needs to be known in advance, since we cannot rely
   # on DNS to get access to etcd.
-  clusterIP: 100.78.232.136
+  clusterIP: 10.96.232.136
   ports:
     - port: 6666
 

--- a/v1.6/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v1.6/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   # The location of your etcd cluster.  This uses the Service clusterIP
   # defined below.
-  etcd_endpoints: "http://100.78.232.136:6666"
+  etcd_endpoints: "http://10.96.232.136:6666"
 
   # True enables BGP networking, false tells Calico to enforce
   # policy only, using native networking.
@@ -90,7 +90,7 @@ spec:
     k8s-app: calico-etcd
   # This ClusterIP needs to be known in advance, since we cannot rely
   # on DNS to get access to etcd. 
-  clusterIP: 100.78.232.136
+  clusterIP: 10.96.232.136
   ports:
     - port: 6666
 

--- a/v2.0/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -34,6 +34,16 @@ data:
         }
     }
 
+  # The default IP Pool to be created for the cluster.
+  # Pod IP addresses will be assigned from this pool.
+  ippool.yaml: |
+      apiVersion: v1
+      kind: ipPool
+      metadata:
+        cidr: 192.168.0.0/16
+      spec:
+        nat-outgoing: true
+
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.
   etcd_ca: ""   # "/calico-secrets/etcd-ca"
@@ -107,6 +117,10 @@ spec:
                   key: calico_backend
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Don't configure a default pool.  This is done by the Job
+            # below.
+            - name: NO_DEFAULT_POOLS
               value: "true"
             # Location of the CA certificate for etcd.
             - name: ETCD_CA_CERT_FILE
@@ -262,3 +276,52 @@ spec:
         - name: etcd-certs
           secret:
             secretName: calico-etcd-secrets
+
+---
+
+## This manifest deploys a Job which performs one time
+# configuration of Calico
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configure-calico
+  namespace: kube-system
+  labels:
+    k8s-app: calico
+spec:
+  template:
+    metadata:
+      name: configure-calico
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      restartPolicy: OnFailure
+      containers:
+        # Writes basic configuration to datastore.
+        - name: configure-calico
+          image: calico/ctl:v1.0.0-beta
+          args:
+          - apply
+          - -f
+          - /etc/config/calico/ippool.yaml
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+          env:
+            # The location of the etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+      volumes:
+       - name: config-volume
+         configMap:
+           name: calico-config
+           items:
+            - key: ippool.yaml
+              path: calico/ippool.yaml

--- a/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   # The location of your etcd cluster.  This uses the Service clusterIP
   # defined below.
-  etcd_endpoints: "http://100.78.232.136:6666"
+  etcd_endpoints: "http://10.96.232.136:6666"
 
   # True enables BGP networking, false tells Calico to enforce
   # policy only, using native networking.
@@ -32,6 +32,17 @@ data:
             "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
         }
     }
+
+  # The default IP Pool to be created for each node.
+  ippool.yaml: |
+      apiVersion: v1
+      kind: ipPool
+      metadata:
+        cidr: 192.168.0.0/16
+      spec:
+        ipip:
+          enabled: true
+        nat-outgoing: true
 
 ---
 
@@ -95,7 +106,7 @@ spec:
     k8s-app: calico-etcd
   # This ClusterIP needs to be known in advance, since we cannot rely
   # on DNS to get access to etcd. 
-  clusterIP: 100.78.232.136
+  clusterIP: 10.96.232.136
   ports:
     - port: 6666
 
@@ -224,12 +235,11 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy-controller
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ''
-      scheduler.alpha.kubernetes.io/tolerations: |
-        [{"key": "role", "value": "master", "effect": "NoSchedule" },
-         {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
@@ -269,11 +279,11 @@ spec:
   template:
     metadata:
       name: configure-calico
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ''
-      scheduler.alpha.kubernetes.io/tolerations: |
-        [{"key": "role", "value": "master", "effect": "NoSchedule" },
-         {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       restartPolicy: OnFailure 
@@ -281,16 +291,24 @@ spec:
         # Writes basic configuration to datastore. 
         - name: configure-calico
           image: calico/ctl:v1.0.0-beta
-          args: 
-          - "pool"
-          - "add"
-          - "192.168.0.0/16"
-          - "--ipip"
-          - "--nat-outgoing"
+          args:
+          - apply
+          - -f
+          - /etc/config/calico/ippool.yaml
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
           env:
             # The location of the etcd cluster.
-            - name: ETCD_ENDPOINTS 
+            - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
+      volumes:
+       - name: config-volume
+         configMap:
+           name: calico-config
+           items:
+            - key: ippool.yaml
+              path: calico/ippool.yaml

--- a/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -33,7 +33,8 @@ data:
         }
     }
 
-  # The default IP Pool to be created for each node.
+  # The default IP Pool to be created for the cluster.
+  # Pod IP addresses will be assigned from this pool
   ippool.yaml: |
       apiVersion: v1
       kind: ipPool

--- a/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -10,6 +10,13 @@ This install is designed to work for kubeadm clusters, or any cluster which labe
 a single master node with `kubeadm.alpha.kubernetes.io/role: master`.  This label is used for deploying
 a single node etcd cluster.
 
+To check if the label is applied, run the following command:
+
+```shell
+$ kubectl get node <node_name> -o yaml | grep kubeadm
+   kubeadm.alpha.kubernetes.io/role: master
+```
+
 You can easily create a compatible cluster by following [the official kubeadm guide](http://kubernetes.io/docs/getting-started-guides/kubeadm/).
 
 - [`calico.yaml`](calico.yaml): Contains all the Calico components,


### PR DESCRIPTION
depends on https://github.com/projectcalico/calico-containers/pull/1298
fixes #137 
Fixes the following errors:
```bash
root@calico-01:/home/vagrant/kubeadm# kubectl apply -f calico.yaml
...
Error from server: error when creating "calico.yaml": Service "calico-etcd" is invalid: spec.clusterIP: Invalid value: "100.78.232.136": provided IP is not in the valid range
```
and 
```
root@calico-01:/home/vagrant/kubeadm# kubectl apply -f calico.yaml
...
error validating "calico.yaml": error validating data: found invalid field annotations for v1.PodTemplateSpec; if you choose to ignore these errors, turn validation off with --validate=false
```
