### PR TITLE
Adding annotations to Calico manifests to allow them to run on tainted k8s master

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -92,7 +92,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
@@ -214,7 +214,7 @@ metadata:
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
     scheduler.alpha.kubernetes.io/tolerations: |
-      [{"key": "role", "value": "master", "effect": "NoSchedule" },
+      [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
        {"key":"CriticalAddonsOnly", "operator":"Exists"}]
 spec:
   # The policy controller can only have a single active instance.
@@ -294,7 +294,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # Only run this pod on the master.
@@ -134,7 +134,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
@@ -239,7 +239,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
@@ -283,7 +283,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true

--- a/v1.5/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v1.5/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -53,6 +53,11 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       containers:
@@ -149,6 +154,11 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.

--- a/v1.5/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v1.5/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -253,6 +253,11 @@ spec:
   template:
     metadata:
       name: configure-calico
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       restartPolicy: OnFailure

--- a/v1.6/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v1.6/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -79,6 +79,11 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+          scheduler.alpha.kubernetes.io/critical-pod: ''
+          scheduler.alpha.kubernetes.io/tolerations: |
+            [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       containers:
@@ -201,6 +206,11 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.

--- a/v1.6/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v1.6/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -114,6 +114,11 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       containers:
@@ -214,6 +219,11 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy-controller
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
@@ -248,11 +258,16 @@ metadata:
   name: configure-calico
   namespace: kube-system
   labels:
-    k8s-app: calico 
+    k8s-app: calico
 spec:
   template:
     metadata:
       name: configure-calico
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       restartPolicy: OnFailure 

--- a/v1.6/getting-started/kubernetes/installation/policy-controller.yaml
+++ b/v1.6/getting-started/kubernetes/installation/policy-controller.yaml
@@ -20,6 +20,11 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-policy
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       containers:

--- a/v2.0/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -92,7 +92,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
@@ -214,7 +214,7 @@ metadata:
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
     scheduler.alpha.kubernetes.io/tolerations: |
-      [{"key": "role", "value": "master", "effect": "NoSchedule" },
+      [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
        {"key":"CriticalAddonsOnly", "operator":"Exists"}]
 
 spec:
@@ -295,7 +295,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true

--- a/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # Only run this pod on the master.
@@ -134,7 +134,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
@@ -239,7 +239,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller must run in the host network namespace so that
@@ -283,7 +283,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "role", "value": "master", "effect": "NoSchedule" },
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true


### PR DESCRIPTION
Added proper annotations to master, v2.0, v1.6, and v1.5 k8s manifests to allow jobs, replicasets, etc..., to run on a tainted master.