### PR TITLE
Update calico-cni links to latest release in master.

### DIFF
--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -94,8 +94,8 @@ The Kubernetes `kubelet` calls out to the `calico` and `calico-ipam` plugins.
 Download the binaries and make sure they're executable
 
 ```bash
-wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico
-wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico-ipam
+wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico
+wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico-ipam
 chmod +x /opt/cni/bin/calico /opt/cni/bin/calico-ipam
 ```
 
@@ -210,9 +210,9 @@ Requires=calico-node.service
 [Service]
 ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.4.0/bin/linux/amd64/kubelet
 ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
-ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico
+ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico
 ExecStartPre=/usr/bin/chmod +x /opt/cni/bin/calico
-ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico-ipam
+ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico-ipam
 ExecStartPre=/usr/bin/chmod +x /opt/cni/bin/calico-ipam
 ExecStart=/opt/bin/kubelet \
 --address=0.0.0.0 \

--- a/master/getting-started/mesos/installation/dc-os/framework.md
+++ b/master/getting-started/mesos/installation/dc-os/framework.md
@@ -139,8 +139,8 @@ can perform the Framework Installation steps manually (etcd, docker cluster-stor
 3. **Install Calico-CNI.**
 
    ```shell
-   curl -L -o /opt/mesosphere/active/cni/calico  https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico
-   curl -L -o /opt/mesosphere/active/cni/calico-ipam https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico-ipam
+   curl -L -o /opt/mesosphere/active/cni/calico  https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico
+   curl -L -o /opt/mesosphere/active/cni/calico-ipam https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico-ipam
    cat <<EOF > /opt/mesosphere/etc/dcos/network/cni/calico.conf
    {
        "name": "calico",

--- a/master/getting-started/mesos/installation/unified.md
+++ b/master/getting-started/mesos/installation/unified.md
@@ -22,7 +22,7 @@ Run the following steps on **each agent**.
 
 ```shell
 curl -L -o $NETWORK_CNI_PLUGINS_DIR/calico \
-    https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico
+    https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico
 chmod +x $NETWORK_CNI_PLUGINS_DIR/calico
 ln -s $NETWORK_CNI_PLUGINS_DIR/calico $NETWORK_CNI_PLUGINS_DIR/calico-ipam
 ```

--- a/master/getting-started/rkt/vagrant/cloud-config/master-config.yaml
+++ b/master/getting-started/rkt/vagrant/cloud-config/master-config.yaml
@@ -28,8 +28,8 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/rkt/net.d
         ExecStartPre=/usr/bin/wget -N -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
-        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico
-        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico-ipam
+        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico
+        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico-ipam
         ExecStartPre=/usr/bin/chmod a+w -R /etc/rkt/net.d
         ExecStartPre=/usr/bin/chmod +x /etc/rkt/net.d/calico
         ExecStartPre=/usr/bin/chmod +x /etc/rkt/net.d/calico-ipam

--- a/master/getting-started/rkt/vagrant/cloud-config/node-config.yaml
+++ b/master/getting-started/rkt/vagrant/cloud-config/node-config.yaml
@@ -24,8 +24,8 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /opt/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/rkt/net.d
         ExecStartPre=/usr/bin/wget -N -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
-        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico
-        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.0/calico-ipam
+        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico
+        ExecStartPre=/usr/bin/wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.1/calico-ipam
         ExecStartPre=/usr/bin/chmod a+w -R /etc/rkt/net.d
         ExecStartPre=/usr/bin/chmod +x /etc/rkt/net.d/calico
         ExecStartPre=/usr/bin/chmod +x /etc/rkt/net.d/calico-ipam


### PR DESCRIPTION
As a result of  #147 , we need to update links to CNI artifacts in master docs every time we cut a calico-cni release.