### PR TITLE
Re-work rkt guides to be more k8s-like

### DIFF
--- a/_data/master/navbars/getting-started.yml
+++ b/_data/master/navbars/getting-started.yml
@@ -149,7 +149,7 @@ toc:
       path: /getting-started/rkt/installation/vagrant-coreos/
   - title: Tutorials
     section:
-    - title: Basic network isolation with rkt
+    - title: Basic network isolation
       path: /getting-started/rkt/tutorials/basic
   - title: Troubleshooting
     path: /getting-started/rkt/troubleshooting

--- a/_data/master/navbars/getting-started.yml
+++ b/_data/master/navbars/getting-started.yml
@@ -143,11 +143,13 @@ toc:
     path: /getting-started/rkt/
   - title: Installation
     section:
+    - title: 'Manual installation'
+      path: /getting-started/rkt/installation/manual
     - title: 'Vagrant/VirtualBox: CoreOS'
       path: /getting-started/rkt/installation/vagrant-coreos/
   - title: Tutorials
     section:
-    - title: Calico networking with rkt
+    - title: Basic network isolation with rkt
       path: /getting-started/rkt/tutorials/basic
   - title: Troubleshooting
     path: /getting-started/rkt/troubleshooting

--- a/_data/v2_0/navbars/getting-started.yml
+++ b/_data/v2_0/navbars/getting-started.yml
@@ -149,7 +149,7 @@ toc:
       path: /getting-started/rkt/installation/vagrant-coreos/
   - title: Tutorials
     section:
-    - title: Basic network isolation with rkt
+    - title: Basic network isolation
       path: /getting-started/rkt/tutorials/basic
   - title: Troubleshooting
     path: /getting-started/rkt/troubleshooting

--- a/_data/v2_0/navbars/getting-started.yml
+++ b/_data/v2_0/navbars/getting-started.yml
@@ -142,12 +142,14 @@ toc:
   - title: Overview
     path: /getting-started/rkt/
   - title: Installation
-    section: 
+    section:
+    - title: 'Manual installation'
+      path: /getting-started/rkt/installation/manual
     - title: 'Vagrant/VirtualBox: CoreOS'
       path: /getting-started/rkt/installation/vagrant-coreos/
   - title: Tutorials
     section:
-    - title: Calico networking with rkt
+    - title: Basic network isolation with rkt
       path: /getting-started/rkt/tutorials/basic
   - title: Troubleshooting
     path: /getting-started/rkt/troubleshooting

--- a/master/getting-started/index.md
+++ b/master/getting-started/index.md
@@ -11,8 +11,9 @@ your own servers, a quick set-up in a virtualized environment using Vagrant and
 a number of cloud services.
 
 - [Calico with Kubernetes](kubernetes)
-- [Calico with Docker](docker)
-- [Calico with rkt](rkt)
 - [Calico with Mesos](mesos)
   - [Calico with DC/OS](mesos/installation/dc-os)
+- [Calico with Docker](docker)
 - [Calico with OpenStack](openstack)
+- [Calico with rkt](rkt)
+- [Host protection](bare-metal/bare-metal)

--- a/master/getting-started/rkt/index.md
+++ b/master/getting-started/rkt/index.md
@@ -1,4 +1,38 @@
 ---
-title: rkt
+title: Calico with rkt
 ---
-Information coming soon!
+
+Calico supports networking and network policy in a pure rkt container environment. 
+
+Use the navigation bar on the left to view information on Calico with rkt,
+or continue reading for recommended guides to get started.
+
+## Installation Guides
+
+#### [Manual Install Guide]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/manual)
+
+This method walks through the necessary manual steps to integrate Calico in a rkt environment.  Follow 
+this guide if you're integrating Calico with your own rkt orchestration environment.
+
+## Quick Start Guides 
+
+#### [CoreOS Vagrant]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant/)
+
+This guide uses Vagrant and VirtualBox to locally run a rkt-Calico enabled cluster.
+
+## Tutorials
+
+The following tutorials walk through policy configurations for rkt with Calico.
+
+Before following these tutorials, ensure you've used the above guides to launch
+a cluster of nodes with Calico installed.
+
+#### [Basic network isolation]({{site.baseurl}}/{{page.version}}/getting-started/rkt/tutorials/basic)
+
+The Basic network isolation tutorial shows how to use a Calico CNI network to 
+secure applications within the same rkt network.
+
+## Troubleshooting
+
+For rkt-specific troubleshooting information, view the 
+[rkt troubleshooting guide]({{site.baseurl}}/{{page.version}}/getting-started/rkt/troubleshooting).

--- a/master/getting-started/rkt/index.md
+++ b/master/getting-started/rkt/index.md
@@ -16,7 +16,7 @@ this guide if you're integrating Calico with your own rkt orchestration environm
 
 ## Quick Start Guides 
 
-#### [CoreOS Vagrant]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant/)
+#### [CoreOS Vagrant]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant-coreos/)
 
 This guide uses Vagrant and VirtualBox to locally run a rkt-Calico enabled cluster.
 

--- a/master/getting-started/rkt/installation/manual.md
+++ b/master/getting-started/rkt/installation/manual.md
@@ -1,0 +1,173 @@
+---
+title:  Manual installation of Calico with rkt
+---
+
+This tutorial describes how to manually configure a working environment for
+a cluster of Calico-rkt enabled nodes.
+
+To run through the tutorials, you will require at least two nodes, which we have
+named `calico-01` and `calico-02`.  These names are not required to run the tutorials
+but you may need to adapt the tutorial instructions based on your actual node names.
+
+* TOC
+{:toc}
+
+## System requirements
+
+- A cluster of bare metal servers or VMs (nodes) with a modern 64-bit Linux OS and IP connectivity
+  between them.
+- A recent version of [`rkt`][https://github.com/coreos/rkt/releases/latest] installed on each node in the cluster.  We recommend
+  version > 1.20.0 as this is contains important fixes that prevent leaking IP addresses
+  when containers are deleted.
+- An [`etcd`][https://coreos.com/etcd/docs/latest/] cluster accessible by all nodes in the cluster
+
+## About the Calico Components
+
+There are three components of a Calico / rkt integration.
+
+- The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags)
+- The [`calicoctl`](https://github.com/projectcalico/calico-containers) binary used to manage network
+  policy.
+- The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries.
+  - This is the combination of two binary executables and a configuration file.
+
+The `calico/node` rkt container must be run on node in your cluster.  It contains 
+the BGP agent necessary for Calico routing to occur, and the Felix agent which programs 
+network policy rules.
+
+The `calicoctl` binary is a command line utility that can be used to manage network
+policy for your rkt containers, and can be used to monitor the status of your
+Calico services.
+
+The `calico-cni` plugin binaries integrate directly with the rkt container lifecycle 
+hooks on each node to configure the container interfaces, manage IP addresses and 
+configure the containers to use Calico policy.
+
+## Installing `calico/node` 
+
+### Prepare host directory structure
+
+The `calicoctl` binary uses certain known directories for service diagnostics and
+status discovery.  In addition, this tutorial assumes binaries and CNI network
+configuration will be placed in a particular location.
+
+Ensure the following directories are created by running the following commands on
+each node:
+
+```
+mkdir -p /var/run/calico
+mkdir -p /var/log/calico
+mkdir -p /opt/bin
+mkdir -p /etc/rkt/net.d
+```
+
+### Run `calico/node` and configure the node.
+
+Each Calico-rkt enabled node requires the `calico/node` container to be running.
+
+The calico/node container can be run directly through rkt and needs to be run as
+as fly stage-1 container.
+
+```shell
+sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
+  --set-env ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> \
+  --set-env IP=autodetect \
+  --insecure-options image \
+  --volume birdctl,kind=host,source=/var/run/calico,readOnly=false \
+  --mount volume=birdctl,target=/var/run/calico \
+  --volume mods,kind=host,source=/lib/modules,readOnly=false  \
+  --mount volume=mods,target=/lib/modules \
+  --volume logs,kind=host,source=/var/log/calico,readOnly=false \
+  --mount volume=logs,target=/var/log/calico \
+  --net host \
+  quay.io/calico/node:latest &
+```
+
+> Replace `<ETCD_IP>:<ETCD_PORT>` with your etcd configuration.  The `ETCD_ENDPOINTS`
+> environment may contain a comma separated list of endpoints of your etcd cluster.
+> If the environment is omitted, Calico defaults to a single etcd 
+> endpoint at http://127.0.0.1:2379.
+
+You can check that it's running using `sudo rkt list`.
+
+```shell
+$ sudo rkt list
+UUID      APP	IMAGE NAME                  STATE   CREATED         STARTED         NETWORKS
+b52bba11  node  quay.io/calico/node:latest  running 10 seconds ago  10 seconds ago
+```
+
+## Intalling the calicoctl CLI tool
+
+Download the calicoctl binary and ensure it is writeable.  We download to the 
+/opt/bin directory to ensure it is accessible in your path (you may download 
+wherever convenient though):
+
+```
+# Download and install `calicoctl`
+wget -N -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+chmod +x /opt/bin/calicoctl
+```
+
+See the [`calicoctl` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
+for more information on this CLI tool.
+
+## Installing the Calico CNI plugins
+ 
+You can configure multiple networks when using rkt. Each network is represented by a configuration file in
+`/etc/rkt/net.d/`.   To use Calico networking and policy, create a network that uses the Calico
+CNI binaries for handling networking, policy and IP address management.
+
+### Install the Calico plugins
+
+Download the binaries and make sure they're executable.  We download to the 
+`/etc/rkt/net.d` directory since it is one of the default locations that rkt uses
+for config discovery.  You may change the location and override the rkt configuration
+if desired.
+
+```bash
+wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.3/calico
+wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.3/calico-ipam
+chmod +x /etc/rkt/net.d/calico /etc/rkt/net.d/calico-ipam
+```
+
+The Calico CNI plugins require a standard CNI config file.
+
+### Create a Calico network
+
+By default, when using Calico CNI, connections to a given container are only allowed 
+from containers on the same network. This can be changed by applying additional Calico policy - which will 
+be discussed in advanced tutorials.
+
+To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
+
+- Each network should be given a unique "name".
+- To use Calico networking, specify "type": "calico"
+- To use Calico IPAM, specify "type": "calico-ipam" in the "ipam" section.
+
+Calico will create an identically named profile for each Calico-rkt network, by
+default the policy specific in the profile allows full communication between containers within the same 
+network (i.e. using the same profile) but prohibits ingress traffic from containers
+on other networks.
+
+The same network configuration needs to be added to each node for the network
+to be discoverable on that node.
+
+For example, run the following to create a network called "mynet"
+
+```shell
+cat >/etc/rkt/net.d/10-calico-mynet.conf <<EOF
+{
+    "name": "mynet",
+    "etcd_endpoints": "http://<ETCD_IP>:<ETCD_PORT>",
+    "type": "calico",
+    "ipam": {
+        "type": "calico-ipam"
+    }
+}
+EOF
+```
+
+> Replace `<ETCD_IP>:<ETCD_PORT>` with your etcd configuration.  The `etcd_endpoints`
+> paramater may contain a comma separated list of endpoints of your etcd cluster.
+> If the parameter is omitted from the config file, Calico defaults to a single etcd 
+> endpoint at http://127.0.0.1:2379.

--- a/master/getting-started/rkt/installation/manual.md
+++ b/master/getting-started/rkt/installation/manual.md
@@ -164,3 +164,8 @@ EOF
 > paramater may contain a comma separated list of endpoints of your etcd cluster.
 > If the parameter is omitted from the config file, Calico defaults to a single etcd 
 > endpoint at http://127.0.0.1:2379.
+
+## Next steps
+
+With your deployment ready we recommend you follow the [tutorials]({{site.baseurl}}/{{page.version}}/getting-started/rkt#tutorials) 
+to run through examples of managing Calico policy with your rkt containers.

--- a/master/getting-started/rkt/installation/manual.md
+++ b/master/getting-started/rkt/installation/manual.md
@@ -21,28 +21,27 @@ a cluster of Calico-rkt enabled nodes.
 
 There are three components of a Calico / rkt integration.
 
-#### 1. The calico/node container
+- The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags)
+- The [`calicoctl`](https://github.com/projectcalico/calico-containers) command line tool.
+- The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries.
+  - This is the combination of two binary executables and a configuration file.
+- When using Kubernetes NetworkPolicy, the Calico policy controller is also required.
 
-The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags),
-must be run on every node in your cluster.  It contains the BGP agent which provides Calico routing,
-and the Felix agent which programs network policy rules.
+The `calico/node` docker container must be run on each node in your cluster.  It contains
+the BGP agent which provides Calico routing, and the Felix agent which programs network policy
+rules.
 
-#### 2. The calicoctl CLI tool
+The `calicoctl` binary is a command line utility that can be used to manage network policy
+for your rkt containers, and can be used to monitor the status of your Calico services.
 
-The [`calicoctl`](https://github.com/projectcalico/calico-containers) binary is
-a command line utility that can be used to manage network policy for your rkt 
-containers, and can be used to monitor the status of your Calico services.
+The `calico-cni` network plugin binaries are a combination of two binary executables.
+These binaries are invoked from the rkt container lifecycle hooks on each node to configure
+the container interfaces,  manage IP addresses and enable Calico policy on the containers.
 
-#### 3. The calico-cni plugin binaries
-
-The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries
-are a combination of two binary executables.  These binaries are invoked from  
-the rkt container lifecycle hooks on each node to configure the container interfaces, 
-manage IP addresses and enable Calico policy on the containers.
 
 ## Installing `calico/node` 
 
-### Prepare host directory structure
+#### Prepare host directory structure
 
 The `calicoctl` binary uses certain known directories for service diagnostics and
 status discovery.  In addition, this tutorial assumes binaries and CNI network
@@ -58,7 +57,7 @@ mkdir -p /opt/bin
 mkdir -p /etc/rkt/net.d
 ```
 
-### Run `calico/node` and configure the node.
+#### Run `calico/node` and configure the node.
 
 Each Calico-rkt enabled node requires the `calico/node` container to be running.
 
@@ -93,7 +92,7 @@ UUID      APP	IMAGE NAME                  STATE   CREATED         STARTED       
 b52bba11  node  quay.io/calico/node:latest  running 10 seconds ago  10 seconds ago
 ```
 
-## Intalling the calicoctl CLI tool
+## Installing the calicoctl CLI tool
 
 Download the calicoctl binary and ensure it is executable.  We download to the 
 /opt/bin directory to ensure it is accessible in your path (you may download 
@@ -114,7 +113,7 @@ To install Calico as a CNI plugin used by rkt, we need to first install the
 actual plugin binaries, and then once installed create any CNI networks that you
 require with the appropriate Calico CNI plugin references.
 
-### Install the Calico plugin binaries
+#### Install the Calico plugin binaries
 
 Download the binaries and make sure they're executable.  We download to the 
 `/etc/rkt/net.d` directory since it is one of the default locations that rkt uses
@@ -129,7 +128,7 @@ chmod +x /etc/rkt/net.d/calico /etc/rkt/net.d/calico-ipam
 
 The Calico CNI plugins require a standard CNI config file.
 
-### Create a Calico network
+#### Create a Calico network
 
 To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
 

--- a/master/getting-started/rkt/installation/manual.md
+++ b/master/getting-started/rkt/installation/manual.md
@@ -5,10 +5,6 @@ title:  Manual installation of Calico with rkt
 This tutorial describes how to manually configure a working environment for
 a cluster of Calico-rkt enabled nodes.
 
-To run through the tutorials, you will require at least two nodes, which we have
-named `calico-01` and `calico-02`.  These names are not required to run the tutorials
-but you may need to adapt the tutorial instructions based on your actual node names.
-
 * TOC
 {:toc}
 
@@ -16,32 +12,33 @@ but you may need to adapt the tutorial instructions based on your actual node na
 
 - A cluster of bare metal servers or VMs (nodes) with a modern 64-bit Linux OS and IP connectivity
   between them.
-- A recent version of [`rkt`][https://github.com/coreos/rkt/releases/latest] installed on each node in the cluster.  We recommend
+- A recent version of [`rkt`](https://github.com/coreos/rkt/releases/latest) installed on each node in the cluster.  We recommend
   version > 1.20.0 as this is contains important fixes that prevent leaking IP addresses
   when containers are deleted.
-- An [`etcd`][https://coreos.com/etcd/docs/latest/] cluster accessible by all nodes in the cluster
+- An [`etcd`](https://coreos.com/etcd/docs/latest/) cluster accessible by all nodes in the cluster
 
 ## About the Calico Components
 
 There are three components of a Calico / rkt integration.
 
-- The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags)
-- The [`calicoctl`](https://github.com/projectcalico/calico-containers) binary used to manage network
-  policy.
-- The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries.
-  - This is the combination of two binary executables and a configuration file.
+#### 1. The calico/node container
 
-The `calico/node` rkt container must be run on node in your cluster.  It contains 
-the BGP agent necessary for Calico routing to occur, and the Felix agent which programs 
-network policy rules.
+The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags),
+must be run on every node in your cluster.  It contains the BGP agent which provides Calico routing,
+and the Felix agent which programs network policy rules.
 
-The `calicoctl` binary is a command line utility that can be used to manage network
-policy for your rkt containers, and can be used to monitor the status of your
-Calico services.
+#### 2. The calicoctl CLI tool
 
-The `calico-cni` plugin binaries integrate directly with the rkt container lifecycle 
-hooks on each node to configure the container interfaces, manage IP addresses and 
-configure the containers to use Calico policy.
+The [`calicoctl`](https://github.com/projectcalico/calico-containers) binary is
+a command line utility that can be used to manage network policy for your rkt 
+containers, and can be used to monitor the status of your Calico services.
+
+#### 3. The calico-cni plugin binaries
+
+The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries
+are a combination of two binary executables.  These binaries are invoked from  
+the rkt container lifecycle hooks on each node to configure the container interfaces, 
+manage IP addresses and enable Calico policy on the containers.
 
 ## Installing `calico/node` 
 
@@ -98,7 +95,7 @@ b52bba11  node  quay.io/calico/node:latest  running 10 seconds ago  10 seconds a
 
 ## Intalling the calicoctl CLI tool
 
-Download the calicoctl binary and ensure it is writeable.  We download to the 
+Download the calicoctl binary and ensure it is executable.  We download to the 
 /opt/bin directory to ensure it is accessible in your path (you may download 
 wherever convenient though):
 
@@ -111,13 +108,13 @@ chmod +x /opt/bin/calicoctl
 See the [`calicoctl` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
 for more information on this CLI tool.
 
-## Installing the Calico CNI plugins
- 
-You can configure multiple networks when using rkt. Each network is represented by a configuration file in
-`/etc/rkt/net.d/`.   To use Calico networking and policy, create a network that uses the Calico
-CNI binaries for handling networking, policy and IP address management.
+## Installing Calico as a CNI plugin
 
-### Install the Calico plugins
+To install Calico as a CNI plugin used by rkt, we need to first install the
+actual plugin binaries, and then once installed create any CNI networks that you
+require with the appropriate Calico CNI plugin references.
+
+### Install the Calico plugin binaries
 
 Download the binaries and make sure they're executable.  We download to the 
 `/etc/rkt/net.d` directory since it is one of the default locations that rkt uses
@@ -134,23 +131,19 @@ The Calico CNI plugins require a standard CNI config file.
 
 ### Create a Calico network
 
-By default, when using Calico CNI, connections to a given container are only allowed 
-from containers on the same network. This can be changed by applying additional Calico policy - which will 
-be discussed in advanced tutorials.
-
 To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
 
 - Each network should be given a unique "name".
 - To use Calico networking, specify "type": "calico"
 - To use Calico IPAM, specify "type": "calico-ipam" in the "ipam" section.
 
-Calico will create an identically named profile for each Calico-rkt network, by
-default the policy specific in the profile allows full communication between containers within the same 
-network (i.e. using the same profile) but prohibits ingress traffic from containers
+Calico will create an identically named profile for each Calico-rkt network which, by
+default, contains policy to allow full communication between containers within the same 
+network (i.e. using the same profile) but prohibit ingress traffic from containers
 on other networks.
 
 The same network configuration needs to be added to each node for the network
-to be discoverable on that node.
+to be discoverable on that node.  Mutliple networks may be created using unique names.
 
 For example, run the following to create a network called "mynet"
 

--- a/master/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/master/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -106,8 +106,9 @@ b52bba11  node  quay.io/calico/node:latest  running 10 seconds ago  10 seconds a
 
 ## Try out Calico networking
 
-Now that you have a basic two node CoreOS cluster setup, see the 
-[Calico with rkt tutorials]({{site.baseurl}}/{{page.version}}/getting-started/rkt#tutorials)
+Now that you have a basic two node CoreOS cluster setup we recommend you follow
+the [tutorials]({{site.baseurl}}/{{page.version}}/getting-started/rkt#tutorials) 
+to run through examples of managing Calico policy with your rkt containers.
 
 [virtualbox]: https://www.virtualbox.org/
 [vagrant]: https://www.vagrantup.com/downloads.html

--- a/master/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/master/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -2,24 +2,30 @@
 title: Running the Calico rkt tutorials on CoreOS using Vagrant and VirtualBox
 ---
 
-This tutorial describes how to set up a Calico cluster in a pure rkt environment.
-rkt is used for running both the Calico components and the workloads.
+This is a Quick Start guide that uses Vagrant and VirtualBox to create a two-node
+Calico cluster that can be used to run through the tutorial for Calico in a 
+pure rkt environment.
 
-## 1. Environment setup
+## Environment setup
 
-This tutorial walks through getting a cluster set up with Vagrant.
+This section contains the requirements and steps required to ensure your local
+environment is correctly configured.
 
-### 1.1 Install dependencies
+### 1. Install dependencies
+
+You will need to install the following software:
 
 * [VirtualBox][virtualbox] 5.0.0 or greater.
 * [Vagrant][vagrant] 1.8.5 or greater.
 * [Git][git]
 
-### 1.2 Clone this project
+### 2. Clone this project
+
+Clone the calico project into a suitable location on your local host.
 
     git clone https://github.com/projectcalico/calico.git
 
-### 1.3 Startup and SSH
+### 3. Startup and SSH
 
 Change into the directory for this guide:
 
@@ -29,15 +35,15 @@ Run
 
     vagrant up
 
-To connect to your servers
+to start the cluster.  To connect to your servers:
 
 * Linux/Mac OS X
     * run `vagrant ssh <hostname>`
 * Windows
     * Follow instructions from https://github.com/nickryand/vagrant-multi-putty
     * run `vagrant putty <hostname>`
-
-### 1.4 Verify environment
+    
+### 4. Verify environment
 
 You should now have two CoreOS servers. The servers are named calico-01 and calico-02
 and have IP addresses 172.18.18.101 and 172.18.18.102.
@@ -60,13 +66,48 @@ You should also verify each host can access etcd.  The following will return an 
 
     curl -L http://172.18.18.101:2379/version
 
-And finally check that `rkt` is running on both hosts by running
+Check that `rkt` is running on both hosts by running
 
     sudo rkt list
+    
+Verify that `calicoctl` (the Calico CLI) is installed by running
 
-## 2. Try out Calico Networking
+    calicoctl version
+    
 
-Now that you have a basic two node CoreOS cluster setup, see the [Calico networking with rkt]({{site.baseurl}}/{{page.version}}/getting-started/rkt/tutorials/basic)
+### 5. Start the Calico service
+
+Start the Calico service on *both* hosts
+
+```shell
+sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
+  --set-env ETCD_ENDPOINTS=http://172.18.18.101:2379 \
+  --insecure-options image \
+  --volume birdctl,kind=host,source=/var/run/calico,readOnly=false \
+  --mount volume=birdctl,target=/var/run/calico \
+  --volume mods,kind=host,source=/lib/modules,readOnly=false  \
+  --mount volume=mods,target=/lib/modules \
+  --volume logs,kind=host,source=/var/log/calico,readOnly=false \
+  --mount volume=logs,target=/var/log/calico \
+  --set-env IP=autodetect \
+  --net host \
+  quay.io/calico/node:latest &
+```
+
+This will create a calico/node rkt container.
+
+You can check that it's running using `sudo rkt list`.
+
+```shell
+$ sudo rkt list
+UUID      APP	IMAGE NAME                  STATE   CREATED         STARTED         NETWORKS
+b52bba11  node  quay.io/calico/node:latest  running 10 seconds ago  10 seconds ago
+```
+
+## Try out Calico networking
+
+Now that you have a basic two node CoreOS cluster setup, see the 
+[Calico with rkt tutorials]({{site.baseurl}}/{{page.version}}/getting-started/rkt#tutorials)
 
 [virtualbox]: https://www.virtualbox.org/
 [vagrant]: https://www.vagrantup.com/downloads.html

--- a/master/getting-started/rkt/troubleshooting.md
+++ b/master/getting-started/rkt/troubleshooting.md
@@ -11,10 +11,7 @@ See also the [main Calico troubleshooting](../../usage/troubleshooting) pages.
 #### Why am I seeing Calico errors deleting a rkt container
 
 There were known issues with earlier versions of rkt that prevent clean
-tidyup of IP addresses when deleting a container.  The version of rkt used in
-the tutorial is >1.20.0 which addresses this problem.
+tidyup of IP addresses when deleting a container.
 
 If you are seeing errors that only occur during container deletion, check your
-rkt version.
-
-
+rkt version.  We recommend a version of rkt 1.20.0 and higher.

--- a/master/getting-started/rkt/troubleshooting.md
+++ b/master/getting-started/rkt/troubleshooting.md
@@ -1,4 +1,20 @@
 ---
 title: Troubleshooting Calico for rkt
 ---
-Information coming soon!
+
+This article contains rkt specific troubleshooting advice for Calico and 
+frequently asked questions. 
+See also the [main Calico troubleshooting](../../usage/troubleshooting) pages.
+
+## Frequently Asked Questions
+
+#### Why am I seeing Calico errors deleting a rkt container
+
+There were known issues with earlier versions of rkt that prevent clean
+tidyup of IP addresses when deleting a container.  The version of rkt used in
+the tutorial is >1.20.0 which addresses this problem.
+
+If you are seeing errors that only occur during container deletion, check your
+rkt version.
+
+

--- a/master/getting-started/rkt/tutorials/basic.md
+++ b/master/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,5 @@
 ---
-title: Basic network isolation with rkt
+title: Basic network isolation
 ---
 
 This guide provides a simple way to try out rkt network isolation with Calico.

--- a/master/getting-started/rkt/tutorials/basic.md
+++ b/master/getting-started/rkt/tutorials/basic.md
@@ -1,46 +1,23 @@
 ---
-title: Calico networking with rkt
+title: Basic network isolation with rkt
 ---
 
-This tutorial describes how to set up a Calico cluster in a pure rkt environment
-using CNI with Calico specific network and IPAM drivers.
+This guide provides a simple way to try out rkt network isolation with Calico.
+It requires a cluster of nodes configured with Calico networking, and expects 
+that you have `rkt` installed and `calicoctl` configured to interact with the 
+cluster.
 
-## 1. Environment setup
+You can quickly and easily deploy such a cluster by following one of the 
+[getting started guides]({{site.baseurl}}/{{page.version}}/getting-started/rkt#installation-guides)
 
-To run through the worked example in this tutorial you will need to set up two hosts
-with a number of installation dependencies.
+For simplicity, we assume you have a two node cluster with the node names 
+`calico-01` and `calico-02`.  If your nodes have different names, adjust the
+instructions accordingly.
 
-Follow the instructions in the tutorial below to set up a virtualized
-environment using Vagrant - be sure to follow the appropriate instructions
-for _Running the Calico rkt tutorials on CoreOS using Vagrant and VirtualBox_.
+## 1. Verify Calico service is running
 
-- [Vagrant install with CoreOS]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant-coreos/)
-
-If you have everything set up properly you should have `calicoctl` in your
-`$PATH`, and two hosts called `calico-01` and `calico-02`.  The exact
-choice of hostname is not important although you will need to adjust these
-instructions accordingly based on your actual hostnames.
-
-## 2. Starting Calico services
-
-Once you have your cluster up and running, start Calico on both hosts
-
-```shell
-sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
-  --set-env=ETCD_ENDPOINTS=http://172.18.18.101:2379 \
-  --insecure-options=image \
-  --volume=birdctl,kind=host,source=/var/run/calico,readOnly=false \
-  --mount volume=birdctl,target=/var/run/calico \
-  --volume=mods,kind=host,source=/lib/modules,readOnly=false  \
-  --mount volume=mods,target=/lib/modules \
-  --volume=logs,kind=host,source=/var/log/calico,readOnly=false \
-  --mount volume=logs,target=/var/log/calico \
-  --set-env=IP=autodetect --net=host quay.io/calico/node:latest &
-```
-
-This will create a calico/node rkt container.
-
-You can check that it's running using `sudo rkt list`.
+Your installation should have installed and started the Calico service on each node.  You 
+can check that it's running using `sudo rkt list`.
 
 ```shell
 $ sudo rkt list
@@ -48,27 +25,30 @@ UUID      APP	IMAGE NAME                  STATE   CREATED         STARTED       
 b52bba11  node  quay.io/calico/node:latest  running 10 seconds ago  10 seconds ago
 ```
 
-## 3. Create the networks
+## 2. Create the networks
 
 You can configure multiple networks when using rkt. Each network is represented by a configuration file in
-`/etc/rkt/net.d/`. By default, connections to a given container are only allowed from containers on the same network.
-This can be changed by applying additional Calico policy.
-
-Containers on multiple networks can be accessed by containers on each network that it is connected to.
-- The container only gets a single Calico IP address and single ethernet interface.
-- The container is associated with the Calico profiles for each of the networks.
+`/etc/rkt/net.d/`. By default, when using Calico CNI, connections to a given container are only allowed 
+from containers on the same network. This can be changed by applying additional Calico policy - which will 
+be discussed in advanced tutorials.
 
 To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
-- Each network should be given a unique "name". This corresponds to a "profile" in Calico.
+
+- Each network should be given a unique "name".
 - To use Calico networking, specify "type": "calico"
 - To use Calico IPAM, specify "type": "calico-ipam" in the "ipam" section.
+
+Calico will create an identically named profile for each Calico-rkt network, by
+default the policy specified in the profile allows full communication between containers within the same 
+network (i.e. using the same profile) but prohibits ingress traffic from containers
+on other networks.
 
 This worked example creates two rkt networks. Run these commands on both `calico-01` and `calico-02`
 
 ```shell
-cat >/etc/rkt/net.d/10-calico-backend.conf <<EOF
+cat >/etc/rkt/net.d/10-calico-network1.conf <<EOF
 {
-    "name": "backend",
+    "name": "network1",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -76,9 +56,9 @@ cat >/etc/rkt/net.d/10-calico-backend.conf <<EOF
 }
 EOF
 
-cat >/etc/rkt/net.d/10-calico-frontend.conf <<EOF
+cat >/etc/rkt/net.d/10-calico-network2.conf <<EOF
 {
-    "name": "frontend",
+    "name": "network2",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -87,23 +67,24 @@ cat >/etc/rkt/net.d/10-calico-frontend.conf <<EOF
 EOF
 ```
 
-## 4. Create containers
+## 3. Create test container
 
-With the networks created, let's start some containers. We'll create a "frontend" 
-container on `calico-01` and a "backend" container on `calico-02`.
-Both containers will just be a `busybox` image running a simple HTTP daemon `httpd`
+With the networks created, let's start some containers. We'll create a  
+container on `calico-01` in `network1`, and then create containers on `calico-02` 
+in each network to check connectivity to the first container.  For this tutorial, 
+the container we create on `calico-01` will be a `busybox` image running a simple HTTP daemon `httpd`
 serving up the containers local filesystem over HTTP.
 
 ### On calico-01
 
-Create the "frontend" container.  Note that we include a suffix `:IP=192.168.0.0`, this
-is used to pass in the IP environment through to the frontend network plugin which
-Calico IPAM uses to assign a specific IP address.  This may be omitted, in which case
-Calico IPAM will automatically select an IP address to use from it's configured
-IP Pools - however, to simplify this worked we use fixed IP addresses.
+Create the container in `network1`.  Note that we include a suffix `:IP=192.168.0.0`, this
+is used to pass the IP environment through to the network plugin which
+Calico IPAM uses to assign a specific IP address.  We use a fixed IP address to 
+simplify the steps in this tutorial, however if the suffix is omitted, Calico IPAM will 
+automatically select an IP address to use from it's configured IP Pools.
 
 ```shell
-sudo rkt run --net=frontend:IP=192.168.0.0 docker://busybox --exec httpd -- -f -h / &
+sudo rkt run --net=network1:IP=192.168.0.0 docker://busybox --exec httpd -- -f -h / &
 ```
 
 Use `rkt list` to see the IP.
@@ -111,45 +92,26 @@ Use `rkt list` to see the IP.
 ```shell
 $ sudo rkt list
 UUID      APP      IMAGE NAME                                   STATE   CREATED         STARTED         NETWORKS
-6876aae5  busybox  registry-1.docker.io/library/busybox:latest  running 11 seconds ago  11 seconds ago  frontend:ip4=192.168.0.0, default-restricted:ip4=172.16.28.2
+6876aae5  busybox  registry-1.docker.io/library/busybox:latest  running 11 seconds ago  11 seconds ago  network1:ip4=192.168.0.0, default-restricted:ip4=172.16.28.2
 b52bba11  node     quay.io/calico/node:latest                   running 2 minutes ago   2 minutes ago   
 ```
 
-We now have a `busybox` container running on the network `frontend` with an IP 
+We now have a `busybox` container running on the network `network1` with an IP 
 address of `192.168.0.0`.  You will see that rkt also creates a second network
 called `default-restricted` - this is used for communication with the rkt 
 metadata service running on the host and is discussed in the
 [rkt documentation](https://github.com/coreos/rkt/blob/master/Documentation/networking/overview.md#the-default-restricted-network).
 
-### On calico-02
+## 4. Validate intra-network connectivity
 
-Repeat for a "backend" container on `calico-02`
+Now that we have created the container on `calico-01` and we know its IP address.
+We can access it using `wget` from containers running on
+either host, as long as they are created in the same network.
 
-```shell
-sudo rkt run --net=backend:IP=192.168.100.0 docker://busybox --exec httpd -- -f -h / &
-```
-
-Use `rkt list` to see the container IP.
+e.g. On `calico-02` use wget to access the container running on `calico-01`
 
 ```shell
-$ sudo rkt list
-UUID      APP      IMAGE NAME                                   STATE   CREATED        STARTED         NETWORKS
-72ce148c  node     quay.io/calico/node:latest                   running 4 minutes ago  4 minutes ago   
-a2c7ca32  busybox  registry-1.docker.io/library/busybox:latest  running 13 seconds ago 12 seconds ago  backend:ip4=192.168.100.0, default-restricted:ip4=172.16.28.2
-```
-
-We now have a `busybox` container running on the network `backend` with an IP
-address of `192.168.100.0`.
-
-## 5. Validate access to containers
-
-Now that we have created the containers and we know their IP addresses, we can access them using `wget` from containers running on
-either host, as long as they are created on the same network.
-
-e.g. On `calico-02` use wget to access the frontend container which is running on `calico-01`
-
-```shell
-sudo rkt run --net=frontend docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
+sudo rkt run --net=network1 docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
 ```
 
 Expected output:
@@ -159,17 +121,20 @@ Expected output:
 [  576.046836] busybox[5]: passwd               100% |*******************************|   334   0:00:00 ETA
 ```
 
-This command runs the `wget` command in a busybox container to fetch the `passwd` file from our host. '-T 3' tells wget to only wait for 3 seconds for a response.
-Stderr is redirected to `/dev/null` as we're not interested in the logs from `rkt` for this command.
+This command runs the `wget` command in a busybox container to fetch the `passwd` file from our host.
+'-T 3' tells wget to only wait for 3 seconds for a response. Stderr is redirected to `/dev/null` as we're 
+not interested in the logs from `rkt` for this command.
 
-You can repeat this command on `calico-01` and check that access works the same from any server in your cluster.
+You can repeat this command on `calico-01` and check that access works the same
+from any server in your cluster.
 
-### 5 Checking network isolation
+### 5. Checking inter-network isolation
 
-Repeat the above command but try to access the backend from the frontend. Because we've not allowed access between these networks, the command will fail.
+Repeat the above command but try to access the container on `calico-01` from network2.
+Because we've not allowed access between these networks, the command will fail.
 
 ```shell
-sudo rkt run --net=backend docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
+sudo rkt run --net=network2 docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
 ```
 
 Expected output:
@@ -179,15 +144,27 @@ Expected output:
 [  624.120081] busybox[5]: wget: download timed out
 ```
 
-## 6. Resetting/Cleanup up
+### 6. Verify Calico profiles were created
+
+You can use the `calicoctl get profiles` command line tool to verify that the Calico CNI
+plugin created two profiles, `network1` and `network2`:
+
+```shell
+$ calicoctl get profiles
+NAME       
+network1   
+network2   
+```
+
+## 7. Resetting/Cleanup
 
 If you want to start again from the beginning, then run the following commands on both hosts to ensure that all the rkt containers are removed.
 
-	# Stop the frontend/backend containers
-	sudo rkt stop --force <Container_UUID>
+```shell
+# Stop the network1/network2 containers
+sudo rkt stop --force <Container_UUID>
 
-	# Remove the stopped containers
-	sudo rkt list --no-legend | cut -f1 | sudo xargs rkt rm
+# Remove the stopped containers
+sudo rkt list --no-legend | cut -f1 | sudo xargs rkt rm
+```
 
-	# Wipe Calico data from etcd
-	etcdctl rm --recursive /calico

--- a/v2.0/getting-started/index.md
+++ b/v2.0/getting-started/index.md
@@ -11,8 +11,9 @@ your own servers, a quick set-up in a virtualized environment using Vagrant and
 a number of cloud services.
 
 - [Calico with Kubernetes](kubernetes)
-- [Calico with Docker](docker)
-- [Calico with rkt](rkt)
 - [Calico with Mesos](mesos)
   - [Calico with DC/OS](mesos/installation/dc-os)
+- [Calico with Docker](docker)
 - [Calico with OpenStack](openstack)
+- [Calico with rkt](rkt)
+- [Host protection](bare-metal/bare-metal)

--- a/v2.0/getting-started/rkt/index.md
+++ b/v2.0/getting-started/rkt/index.md
@@ -1,4 +1,38 @@
 ---
-title: rkt
+title: Calico with rkt
 ---
-Information coming soon!
+
+Calico supports networking and network policy in a pure rkt container environment. 
+
+Use the navigation bar on the left to view information on Calico with rkt,
+or continue reading for recommended guides to get started.
+
+## Installation Guides
+
+#### [Manual Install Guide]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/manual)
+
+This method walks through the necessary manual steps to integrate Calico in a rkt environment.  Follow 
+this guide if you're integrating Calico with your own rkt orchestration environment.
+
+## Quick Start Guides 
+
+#### [CoreOS Vagrant]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant/)
+
+This guide uses Vagrant and VirtualBox to locally run a rkt-Calico enabled cluster.
+
+## Tutorials
+
+The following tutorials walk through policy configurations for rkt with Calico.
+
+Before following these tutorials, ensure you've used the above guides to launch
+a cluster of nodes with Calico installed.
+
+#### [Basic network isolation]({{site.baseurl}}/{{page.version}}/getting-started/rkt/tutorials/basic)
+
+The Basic network isolation tutorial shows how to use a Calico CNI network to 
+secure applications within the same rkt network.
+
+## Troubleshooting
+
+For rkt-specific troubleshooting information, view the 
+[rkt troubleshooting guide]({{site.baseurl}}/{{page.version}}/getting-started/rkt/troubleshooting).

--- a/v2.0/getting-started/rkt/index.md
+++ b/v2.0/getting-started/rkt/index.md
@@ -16,7 +16,7 @@ this guide if you're integrating Calico with your own rkt orchestration environm
 
 ## Quick Start Guides 
 
-#### [CoreOS Vagrant]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant/)
+#### [CoreOS Vagrant]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant-coreos/)
 
 This guide uses Vagrant and VirtualBox to locally run a rkt-Calico enabled cluster.
 

--- a/v2.0/getting-started/rkt/installation/manual.md
+++ b/v2.0/getting-started/rkt/installation/manual.md
@@ -21,28 +21,26 @@ a cluster of Calico-rkt enabled nodes.
 
 There are three components of a Calico / rkt integration.
 
-#### 1. The calico/node container
+- The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags)
+- The [`calicoctl`](https://github.com/projectcalico/calico-containers) command line tool.
+- The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries.
+  - This is the combination of two binary executables and a configuration file.
+- When using Kubernetes NetworkPolicy, the Calico policy controller is also required.
 
-The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags),
-must be run on every node in your cluster.  It contains the BGP agent which provides Calico routing,
-and the Felix agent which programs network policy rules.
+The `calico/node` docker container must be run on each node in your cluster.  It contains
+the BGP agent which provides Calico routing, and the Felix agent which programs network policy
+rules.
 
-#### 2. The calicoctl CLI tool
+The `calicoctl` binary is a command line utility that can be used to manage network policy
+for your rkt containers, and can be used to monitor the status of your Calico services.
 
-The [`calicoctl`](https://github.com/projectcalico/calico-containers) binary is
-a command line utility that can be used to manage network policy for your rkt 
-containers, and can be used to monitor the status of your Calico services.
-
-#### 3. The calico-cni plugin binaries
-
-The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries
-are a combination of two binary executables.  These binaries are invoked from  
-the rkt container lifecycle hooks on each node to configure the container interfaces, 
-manage IP addresses and enable Calico policy on the containers.
+The `calico-cni` network plugin binaries are a combination of two binary executables.
+These binaries are invoked from the rkt container lifecycle hooks on each node to configure
+the container interfaces,  manage IP addresses and enable Calico policy on the containers.
 
 ## Installing `calico/node` 
 
-### Prepare host directory structure
+#### Prepare host directory structure
 
 The `calicoctl` binary uses certain known directories for service diagnostics and
 status discovery.  In addition, this tutorial assumes binaries and CNI network
@@ -58,7 +56,7 @@ mkdir -p /opt/bin
 mkdir -p /etc/rkt/net.d
 ```
 
-### Run `calico/node` and configure the node.
+#### Run `calico/node` and configure the node.
 
 Each Calico-rkt enabled node requires the `calico/node` container to be running.
 
@@ -93,7 +91,7 @@ UUID      APP	IMAGE NAME                      STATE   CREATED         STARTED   
 b52bba11  node  quay.io/calico/node:v1.0.0-rc2  running 10 seconds ago  10 seconds ago
 ```
 
-## Intalling the calicoctl CLI tool
+## Installing the calicoctl CLI tool
 
 Download the calicoctl binary and ensure it is executable.  We download to the 
 /opt/bin directory to ensure it is accessible in your path (you may download 
@@ -114,7 +112,7 @@ To install Calico as a CNI plugin used by rkt, we need to first install the
 actual plugin binaries, and then once installed create any CNI networks that you
 require with the appropriate Calico CNI plugin references.
 
-### Install the Calico plugin binaries
+#### Install the Calico plugin binaries
 
 Download the binaries and make sure they're executable.  We download to the 
 `/etc/rkt/net.d` directory since it is one of the default locations that rkt uses
@@ -129,9 +127,7 @@ chmod +x /etc/rkt/net.d/calico /etc/rkt/net.d/calico-ipam
 
 The Calico CNI plugins require a standard CNI config file.
 
-### Create a Calico network
-
-### Create a Calico network
+#### Create a Calico network
 
 To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
 

--- a/v2.0/getting-started/rkt/installation/manual.md
+++ b/v2.0/getting-started/rkt/installation/manual.md
@@ -166,3 +166,8 @@ EOF
 > paramater may contain a comma separated list of endpoints of your etcd cluster.
 > If the parameter is omitted from the config file, Calico defaults to a single etcd 
 > endpoint at http://127.0.0.1:2379.
+
+## Next steps
+
+With your deployment ready we recommend you follow the [tutorials]({{site.baseurl}}/{{page.version}}/getting-started/rkt#tutorials) 
+to run through examples of managing Calico policy with your rkt containers.

--- a/v2.0/getting-started/rkt/installation/manual.md
+++ b/v2.0/getting-started/rkt/installation/manual.md
@@ -1,0 +1,173 @@
+---
+title:  Manual installation of Calico with rkt
+---
+
+This tutorial describes how to manually configure a working environment for
+a cluster of Calico-rkt enabled nodes.
+
+To run through the tutorials, you will require at least two nodes, which we have
+named `calico-01` and `calico-02`.  These names are not required to run the tutorials
+but you may need to adapt the tutorial instructions based on your actual node names.
+
+* TOC
+{:toc}
+
+## System requirements
+
+- A cluster of bare metal servers or VMs (nodes) with a modern 64-bit Linux OS and IP connectivity
+  between them.
+- A recent version of [`rkt`][https://github.com/coreos/rkt/releases/latest] installed on each node in the cluster.  We recommend
+  version > 1.20.0 as this is contains important fixes that prevent leaking IP addresses
+  when containers are deleted.
+- An [`etcd`][https://coreos.com/etcd/docs/latest/] cluster accessible by all nodes in the cluster
+
+## About the Calico Components
+
+There are three components of a Calico / rkt integration.
+
+- The Calico per-node rkt container, [calico/node](https://quay.io/repository/calico/node?tab=tags)
+- The [`calicoctl`](https://github.com/projectcalico/calico-containers) binary used to manage network
+  policy.
+- The [calico-cni](https://github.com/projectcalico/calico-cni) network plugin binaries.
+  - This is the combination of two binary executables and a configuration file.
+
+The `calico/node` rkt container must be run on node in your cluster.  It contains 
+the BGP agent necessary for Calico routing to occur, and the Felix agent which programs 
+network policy rules.
+
+The `calicoctl` binary is a command line utility that can be used to manage network
+policy for your rkt containers, and can be used to monitor the status of your
+Calico services.
+
+The `calico-cni` plugin binaries integrate directly with the rkt container lifecycle 
+hooks on each node to configure the container interfaces, manage IP addresses and 
+configure the containers to use Calico policy.
+
+## Installing `calico/node` 
+
+### Prepare host directory structure
+
+The `calicoctl` binary uses certain known directories for service diagnostics and
+status discovery.  In addition, this tutorial assumes binaries and CNI network
+configuration will be placed in a particular location.
+
+Ensure the following directories are created by running the following commands on
+each node:
+
+```
+mkdir -p /var/run/calico
+mkdir -p /var/log/calico
+mkdir -p /opt/bin
+mkdir -p /etc/rkt/net.d
+```
+
+### Run `calico/node` and configure the node.
+
+Each Calico-rkt enabled node requires the `calico/node` container to be running.
+
+The calico/node container can be run directly through rkt and needs to be run as
+as fly stage-1 container.
+
+```shell
+sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
+  --set-env ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> \
+  --set-env IP=autodetect \
+  --insecure-options image \
+  --volume birdctl,kind=host,source=/var/run/calico,readOnly=false \
+  --mount volume=birdctl,target=/var/run/calico \
+  --volume mods,kind=host,source=/lib/modules,readOnly=false  \
+  --mount volume=mods,target=/lib/modules \
+  --volume logs,kind=host,source=/var/log/calico,readOnly=false \
+  --mount volume=logs,target=/var/log/calico \
+  --net host \
+  quay.io/calico/node:v1.0.0-rc2 &
+```
+
+> Replace `<ETCD_IP>:<ETCD_PORT>` with your etcd configuration.  The `ETCD_ENDPOINTS`
+> environment may contain a comma separated list of endpoints of your etcd cluster.
+> If the environment is omitted, Calico defaults to a single etcd 
+> endpoint at http://127.0.0.1:2379.
+
+You can check that it's running using `sudo rkt list`.
+
+```shell
+$ sudo rkt list
+UUID      APP	IMAGE NAME                      STATE   CREATED         STARTED         NETWORKS
+b52bba11  node  quay.io/calico/node:v1.0.0-rc2  running 10 seconds ago  10 seconds ago
+```
+
+## Intalling the calicoctl CLI tool
+
+Download the calicoctl binary and ensure it is writeable.  We download to the 
+/opt/bin directory to ensure it is accessible in your path (you may download 
+wherever convenient though):
+
+```
+# Download and install `calicoctl`
+wget -N -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v1.0.0-rc2/calicoctl
+chmod +x /opt/bin/calicoctl
+```
+
+See the [`calicoctl` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
+for more information on this CLI tool.
+
+## Installing the Calico CNI plugins
+ 
+You can configure multiple networks when using rkt. Each network is represented by a configuration file in
+`/etc/rkt/net.d/`.   To use Calico networking and policy, create a network that uses the Calico
+CNI binaries for handling networking, policy and IP address management.
+
+### Install the Calico plugins
+
+Download the binaries and make sure they're executable.  We download to the 
+`/etc/rkt/net.d` directory since it is one of the default locations that rkt uses
+for config discovery.  You may change the location and override the rkt configuration
+if desired.
+
+```bash
+wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.3/calico
+wget -N -P /etc/rkt/net.d https://github.com/projectcalico/calico-cni/releases/download/v1.5.3/calico-ipam
+chmod +x /etc/rkt/net.d/calico /etc/rkt/net.d/calico-ipam
+```
+
+The Calico CNI plugins require a standard CNI config file.
+
+### Create a Calico network
+
+By default, when using Calico CNI, connections to a given container are only allowed 
+from containers on the same network. This can be changed by applying additional Calico policy - which will 
+be discussed in advanced tutorials.
+
+To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
+
+- Each network should be given a unique "name".
+- To use Calico networking, specify "type": "calico"
+- To use Calico IPAM, specify "type": "calico-ipam" in the "ipam" section.
+
+Calico will create an identically named profile for each Calico-rkt network, by
+default the policy specific in the profile allows full communication between containers within the same 
+network (i.e. using the same profile) but prohibits ingress traffic from containers
+on other networks.
+
+The same network configuration needs to be added to each node for the network
+to be discoverable on that node.
+
+For example, run the following to create a network called "mynet"
+
+```shell
+cat >/etc/rkt/net.d/10-calico-mynet.conf <<EOF
+{
+    "name": "mynet",
+    "etcd_endpoints": "http://<ETCD_IP>:<ETCD_PORT>",
+    "type": "calico",
+    "ipam": {
+        "type": "calico-ipam"
+    }
+}
+EOF
+```
+
+> Replace `<ETCD_IP>:<ETCD_PORT>` with your etcd configuration.  The `etcd_endpoints`
+> paramater may contain a comma separated list of endpoints of your etcd cluster.
+> If the parameter is omitted from the config file, Calico defaults to a single etcd 
+> endpoint at http://127.0.0.1:2379.

--- a/v2.0/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.0/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -106,8 +106,9 @@ b52bba11  node  quay.io/calico/node:v1.0.0-rc2  running 10 seconds ago  10 secon
 
 ## Try out Calico networking
 
-Now that you have a basic two node CoreOS cluster setup, see the 
-[Calico with rkt tutorials]({{site.baseurl}}/{{page.version}}/getting-started/rkt#tutorials)
+Now that you have a basic two node CoreOS cluster setup we recommend you follow
+the [tutorials]({{site.baseurl}}/{{page.version}}/getting-started/rkt#tutorials) 
+to run through examples of managing Calico policy with your rkt containers.
 
 [virtualbox]: https://www.virtualbox.org/
 [vagrant]: https://www.vagrantup.com/downloads.html

--- a/v2.0/getting-started/rkt/troubleshooting.md
+++ b/v2.0/getting-started/rkt/troubleshooting.md
@@ -11,10 +11,9 @@ See also the [main Calico troubleshooting](../../usage/troubleshooting) pages.
 #### Why am I seeing Calico errors deleting a rkt container
 
 There were known issues with earlier versions of rkt that prevent clean
-tidyup of IP addresses when deleting a container.  The version of rkt used in
-the tutorial is >1.20.0 which addresses this problem.
+tidyup of IP addresses when deleting a container.
 
 If you are seeing errors that only occur during container deletion, check your
-rkt version.
+rkt version.  We recommend a version of rkt 1.20.0 and higher.
 
 

--- a/v2.0/getting-started/rkt/troubleshooting.md
+++ b/v2.0/getting-started/rkt/troubleshooting.md
@@ -1,4 +1,20 @@
 ---
 title: Troubleshooting Calico for rkt
 ---
-Information coming soon!
+
+This article contains rkt specific troubleshooting advice for Calico and 
+frequently asked questions. 
+See also the [main Calico troubleshooting](../../usage/troubleshooting) pages.
+
+## Frequently Asked Questions
+
+#### Why am I seeing Calico errors deleting a rkt container
+
+There were known issues with earlier versions of rkt that prevent clean
+tidyup of IP addresses when deleting a container.  The version of rkt used in
+the tutorial is >1.20.0 which addresses this problem.
+
+If you are seeing errors that only occur during container deletion, check your
+rkt version.
+
+

--- a/v2.0/getting-started/rkt/tutorials/basic.md
+++ b/v2.0/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,5 @@
 ---
-title: Basic network isolation with rkt
+title: Basic network isolation
 ---
 
 This guide provides a simple way to try out rkt network isolation with Calico.

--- a/v2.0/getting-started/rkt/tutorials/basic.md
+++ b/v2.0/getting-started/rkt/tutorials/basic.md
@@ -1,46 +1,23 @@
 ---
-title: Calico networking with rkt
+title: Basic network isolation with rkt
 ---
 
-This tutorial describes how to set up a Calico cluster in a pure rkt environment
-using CNI with Calico specific network and IPAM drivers.
+This guide provides a simple way to try out rkt network isolation with Calico.
+It requires a cluster of nodes configured with Calico networking, and expects 
+that you have `rkt` installed and `calicoctl` configured to interact with the 
+cluster.
 
-## 1. Environment setup
+You can quickly and easily deploy such a cluster by following one of the 
+[getting started guides]({{site.baseurl}}/{{page.version}}/getting-started/rkt#installation-guides)
 
-To run through the worked example in this tutorial you will need to set up two hosts
-with a number of installation dependencies.
+For simplicity, we assume you have a two node cluster with the node names 
+`calico-01` and `calico-02`.  If your nodes have different names, adjust the
+instructions accordingly.
 
-Follow the instructions in the tutorial below to set up a virtualized
-environment using Vagrant - be sure to follow the appropriate instructions
-for _Running the Calico rkt tutorials on CoreOS using Vagrant and VirtualBox_.
+## 1. Verify Calico service is running
 
-- [Vagrant install with CoreOS]({{site.baseurl}}/{{page.version}}/getting-started/rkt/installation/vagrant-coreos/)
-
-If you have everything set up properly you should have `calicoctl` in your
-`$PATH`, and two hosts called `calico-01` and `calico-02`.  The exact
-choice of hostname is not important although you will need to adjust these
-instructions accordingly based on your actual hostnames.
-
-## 2. Starting Calico services
-
-Once you have your cluster up and running, start Calico on both hosts
-
-```shell
-sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
-  --set-env=ETCD_ENDPOINTS=http://172.18.18.101:2379 \
-  --insecure-options=image \
-  --volume=birdctl,kind=host,source=/var/run/calico,readOnly=false \
-  --mount volume=birdctl,target=/var/run/calico \
-  --volume=mods,kind=host,source=/lib/modules,readOnly=false  \
-  --mount volume=mods,target=/lib/modules \
-  --volume=logs,kind=host,source=/var/log/calico,readOnly=false \
-  --mount volume=logs,target=/var/log/calico \
-  --set-env=IP=autodetect --net=host quay.io/calico/node:v1.0.0-rc2 &
-```
-
-This will create a calico/node rkt container.
-
-You can check that it's running using `sudo rkt list`.
+Your installation should have installed and started the Calico service on each node.  You 
+can check that it's running using `sudo rkt list`.
 
 ```shell
 $ sudo rkt list
@@ -48,27 +25,30 @@ UUID      APP	IMAGE NAME                      STATE   CREATED         STARTED   
 b52bba11  node  quay.io/calico/node:v1.0.0-rc2  running 10 seconds ago  10 seconds ago
 ```
 
-## 3. Create the networks
+## 2. Create the networks
 
 You can configure multiple networks when using rkt. Each network is represented by a configuration file in
-`/etc/rkt/net.d/`. By default, connections to a given container are only allowed from containers on the same network.
-This can be changed by applying additional Calico policy.
-
-Containers on multiple networks can be accessed by containers on each network that it is connected to.
-- The container only gets a single Calico IP address and single ethernet interface.
-- The container is associated with the Calico profiles for each of the networks.
+`/etc/rkt/net.d/`. By default, when using Calico CNI, connections to a given container are only allowed 
+from containers on the same network. This can be changed by applying additional Calico policy - which will 
+be discussed in advanced tutorials.
 
 To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
-- Each network should be given a unique "name". This corresponds to a "profile" in Calico.
+
+- Each network should be given a unique "name".
 - To use Calico networking, specify "type": "calico"
 - To use Calico IPAM, specify "type": "calico-ipam" in the "ipam" section.
+
+Calico will create an identically named profile for each Calico-rkt network, by
+default the policy specified in the profile allows full communication between containers within the same 
+network (i.e. using the same profile) but prohibits ingress traffic from containers
+on other networks.
 
 This worked example creates two rkt networks. Run these commands on both `calico-01` and `calico-02`
 
 ```shell
-cat >/etc/rkt/net.d/10-calico-backend.conf <<EOF
+cat >/etc/rkt/net.d/10-calico-network1.conf <<EOF
 {
-    "name": "backend",
+    "name": "network1",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -76,9 +56,9 @@ cat >/etc/rkt/net.d/10-calico-backend.conf <<EOF
 }
 EOF
 
-cat >/etc/rkt/net.d/10-calico-frontend.conf <<EOF
+cat >/etc/rkt/net.d/10-calico-network2.conf <<EOF
 {
-    "name": "frontend",
+    "name": "network2",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -87,23 +67,24 @@ cat >/etc/rkt/net.d/10-calico-frontend.conf <<EOF
 EOF
 ```
 
-## 4. Create containers
+## 3. Create test container
 
-With the networks created, let's start some containers. We'll create a "frontend" 
-container on `calico-01` and a "backend" container on `calico-02`.
-Both containers will just be a `busybox` image running a simple HTTP daemon `httpd`
+With the networks created, let's start some containers. We'll create a  
+container on `calico-01` in `network1`, and then create containers on `calico-02` 
+in each network to check connectivity to the first container.  For this tutorial, 
+the container we create on `calico-01` will be a `busybox` image running a simple HTTP daemon `httpd`
 serving up the containers local filesystem over HTTP.
 
 ### On calico-01
 
-Create the "frontend" container.  Note that we include a suffix `:IP=192.168.0.0`, this
-is used to pass in the IP environment through to the frontend network plugin which
-Calico IPAM uses to assign a specific IP address.  This may be omitted, in which case
-Calico IPAM will automatically select an IP address to use from it's configured
-IP Pools - however, to simplify this worked we use fixed IP addresses.
+Create the container in `network1`.  Note that we include a suffix `:IP=192.168.0.0`, this
+is used to pass the IP environment through to the network plugin which
+Calico IPAM uses to assign a specific IP address.  We use a fixed IP address to 
+simplify the steps in this tutorial, however if the suffix is omitted, Calico IPAM will 
+automatically select an IP address to use from it's configured IP Pools.
 
 ```shell
-sudo rkt run --net=frontend:IP=192.168.0.0 docker://busybox --exec httpd -- -f -h / &
+sudo rkt run --net=network1:IP=192.168.0.0 docker://busybox --exec httpd -- -f -h / &
 ```
 
 Use `rkt list` to see the IP.
@@ -111,45 +92,26 @@ Use `rkt list` to see the IP.
 ```shell
 $ sudo rkt list
 UUID      APP      IMAGE NAME                                       STATE   CREATED         STARTED         NETWORKS
-6876aae5  busybox  registry-1.docker.io/library/busybox:v1.0.0-rc2  running 11 seconds ago  11 seconds ago  frontend:ip4=192.168.0.0, default-restricted:ip4=172.16.28.2
+6876aae5  busybox  registry-1.docker.io/library/busybox:v1.0.0-rc2  running 11 seconds ago  11 seconds ago  network1:ip4=192.168.0.0, default-restricted:ip4=172.16.28.2
 b52bba11  node     quay.io/calico/node:v1.0.0-rc2                   running 2 minutes ago   2 minutes ago   
 ```
 
-We now have a `busybox` container running on the network `frontend` with an IP 
+We now have a `busybox` container running on the network `network1` with an IP 
 address of `192.168.0.0`.  You will see that rkt also creates a second network
 called `default-restricted` - this is used for communication with the rkt 
 metadata service running on the host and is discussed in the
 [rkt documentation](https://github.com/coreos/rkt/blob/master/Documentation/networking/overview.md#the-default-restricted-network).
 
-### On calico-02
+## 4. Validate intra-network connectivity
 
-Repeat for a "backend" container on `calico-02`
+Now that we have created the container on `calico-01` and we know its IP address.
+We can access it using `wget` from containers running on
+either host, as long as they are created in the same network.
 
-```shell
-sudo rkt run --net=backend:IP=192.168.100.0 docker://busybox --exec httpd -- -f -h / &
-```
-
-Use `rkt list` to see the container IP.
+e.g. On `calico-02` use wget to access the container running on `calico-01`
 
 ```shell
-$ sudo rkt list
-UUID      APP      IMAGE NAME                                       STATE   CREATED        STARTED         NETWORKS
-72ce148c  node     quay.io/calico/node:v1.0.0-rc2                   running 4 minutes ago  4 minutes ago   
-a2c7ca32  busybox  registry-1.docker.io/library/busybox:v1.0.0-rc2  running 13 seconds ago 12 seconds ago  backend:ip4=192.168.100.0, default-restricted:ip4=172.16.28.2
-```
-
-We now have a `busybox` container running on the network `backend` with an IP
-address of `192.168.100.0`.
-
-## 5. Validate access to containers
-
-Now that we have created the containers and we know their IP addresses, we can access them using `wget` from containers running on
-either host, as long as they are created on the same network.
-
-e.g. On `calico-02` use wget to access the frontend container which is running on `calico-01`
-
-```shell
-sudo rkt run --net=frontend docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
+sudo rkt run --net=network1 docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
 ```
 
 Expected output:
@@ -159,17 +121,20 @@ Expected output:
 [  576.046836] busybox[5]: passwd               100% |*******************************|   334   0:00:00 ETA
 ```
 
-This command runs the `wget` command in a busybox container to fetch the `passwd` file from our host. '-T 3' tells wget to only wait for 3 seconds for a response.
-Stderr is redirected to `/dev/null` as we're not interested in the logs from `rkt` for this command.
+This command runs the `wget` command in a busybox container to fetch the `passwd` file from our host.
+'-T 3' tells wget to only wait for 3 seconds for a response. Stderr is redirected to `/dev/null` as we're 
+not interested in the logs from `rkt` for this command.
 
-You can repeat this command on `calico-01` and check that access works the same from any server in your cluster.
+You can repeat this command on `calico-01` and check that access works the same
+from any server in your cluster.
 
-### 5 Checking network isolation
+### 5. Checking inter-network isolation
 
-Repeat the above command but try to access the backend from the frontend. Because we've not allowed access between these networks, the command will fail.
+Repeat the above command but try to access the container on `calico-01` from network2.
+Because we've not allowed access between these networks, the command will fail.
 
 ```shell
-sudo rkt run --net=backend docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
+sudo rkt run --net=network2 docker://busybox --exec=/bin/wget -- -T 3 192.168.0.0/etc/passwd 2>/dev/null
 ```
 
 Expected output:
@@ -179,15 +144,27 @@ Expected output:
 [  624.120081] busybox[5]: wget: download timed out
 ```
 
-## 6. Resetting/Cleanup up
+### 6. Verify Calico profiles were created
+
+You can use the `calicoctl get profiles` command line tool to verify that the Calico CNI
+plugin created two profiles, `network1` and `network2`:
+
+```shell
+$ calicoctl get profiles
+NAME       
+network1   
+network2   
+```
+
+## 7. Resetting/Cleanup
 
 If you want to start again from the beginning, then run the following commands on both hosts to ensure that all the rkt containers are removed.
 
-	# Stop the frontend/backend containers
-	sudo rkt stop --force <Container_UUID>
+```shell
+# Stop the network1/network2 containers
+sudo rkt stop --force <Container_UUID>
 
-	# Remove the stopped containers
-	sudo rkt list --no-legend | cut -f1 | sudo xargs rkt rm
+# Remove the stopped containers
+sudo rkt list --no-legend | cut -f1 | sudo xargs rkt rm
+```
 
-	# Wipe Calico data from etcd
-	etcdctl rm --recursive /calico


### PR DESCRIPTION
This adds:
-  Manual installation (still needs some work to talk about systemd, but I think we should wait until we aren't using fly stage1 ... requires rkt updates)
-  Move the starting of calico into the installation steps
-  Simplifying the basic network isolation tutorial (not creating a second container on host 2 ... we never used it)
-  Some minor tweaks to top level index
