### PR TITLE
ExecStart needs to be cleared in docker.conf

### DIFF
--- a/master/getting-started/mesos/vagrant/units/docker.service.d/docker.conf
+++ b/master/getting-started/mesos/vagrant/units/docker.service.d/docker.conf
@@ -1,3 +1,4 @@
 [Service]
 EnvironmentFile=/etc/sysconfig/calico
+ExecStart= 
 ExecStart=/usr/bin/dockerd --cluster-store=etcd://172.18.18.101:2379


### PR DESCRIPTION
in docker.service.d/docker.conf, added line "ExecStart= " (to 'clear' ExecStart) before the line where it is set in docker.serice.d/docker.conf. If ExecStart is not cleared the following error is displayed: `Failed to restart docker.service: Unit is not loaded properly: Invalid argument.`, and the viewing the full error log:`'docker.service has more than one ExecStart= setting, which is only allowed for Type=oneshot services. Refusing.`