### PR TITLE
Fix cable-connected timeouts for ubuntu virtualbox demos.

### DIFF
--- a/master/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
+++ b/master/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
@@ -29,6 +29,12 @@ Vagrant.configure(2) do |config|
   # https://www.vagrantup.com/boxes.html
   config.vm.box = "bento/ubuntu-16.04"
 
+  # Workaround 16.04 issue with Virtualbox where Box waits 5 minutes to start 
+  # if network "cable" is not connected: https://github.com/chef/bento/issues/682
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v1.5/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
+++ b/v1.5/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
@@ -31,6 +31,12 @@ Vagrant.configure(2) do |config|
   # https://www.vagrantup.com/boxes.html
   config.vm.box = "bento/ubuntu-16.04"
 
+  # Workaround 16.04 issue with Virtualbox where Box waits 5 minutes to start 
+  # if network "cable" is not connected: https://github.com/chef/bento/issues/682
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v1.6/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
+++ b/v1.6/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
@@ -29,6 +29,12 @@ Vagrant.configure(2) do |config|
   # https://www.vagrantup.com/boxes.html
   config.vm.box = "bento/ubuntu-16.04"
 
+  # Workaround 16.04 issue with Virtualbox where Box waits 5 minutes to start 
+  # if network "cable" is not connected: https://github.com/chef/bento/issues/682
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v2.0/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
+++ b/v2.0/getting-started/docker/installation/vagrant-ubuntu/Vagrantfile
@@ -29,6 +29,12 @@ Vagrant.configure(2) do |config|
   # https://www.vagrantup.com/boxes.html
   config.vm.box = "bento/ubuntu-16.04"
 
+  # Workaround 16.04 issue with Virtualbox where Box waits 5 minutes to start 
+  # if network "cable" is not connected: https://github.com/chef/bento/issues/682
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]


### PR DESCRIPTION
I've tested that:

- This does not affect the old `without-docker-networking` guides as they use a different base image
- Works on both box versions 2.2.9 and 2.3.1