### PR TITLE
rkt doesn't like spaces ¯\_(ツ)_/¯

### DIFF
--- a/master/getting-started/rkt/installation/manual.md
+++ b/master/getting-started/rkt/installation/manual.md
@@ -64,16 +64,16 @@ as fly stage-1 container.
 
 ```shell
 sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
-  --set-env ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> \
-  --set-env IP=autodetect \
-  --insecure-options image \
-  --volume birdctl,kind=host,source=/var/run/calico,readOnly=false \
-  --mount volume=birdctl,target=/var/run/calico \
-  --volume mods,kind=host,source=/lib/modules,readOnly=false  \
-  --mount volume=mods,target=/lib/modules \
-  --volume logs,kind=host,source=/var/log/calico,readOnly=false \
-  --mount volume=logs,target=/var/log/calico \
-  --net host \
+  --set-env=ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> \
+  --set-env=IP=autodetect \
+  --insecure-options=image \
+  --volume=birdctl,kind=host,source=/var/run/calico,readOnly=false \
+  --mount=volume=birdctl,target=/var/run/calico \
+  --volume=mods,kind=host,source=/lib/modules,readOnly=false  \
+  --mount=volume=mods,target=/lib/modules \
+  --volume=logs,kind=host,source=/var/log/calico,readOnly=false \
+  --mount=volume=logs,target=/var/log/calico \
+  --net=host \
   quay.io/calico/node:latest &
 ```
 

--- a/master/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/master/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -81,16 +81,16 @@ Start the Calico service on *both* hosts
 
 ```shell
 sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
-  --set-env ETCD_ENDPOINTS=http://172.18.18.101:2379 \
-  --insecure-options image \
-  --volume birdctl,kind=host,source=/var/run/calico,readOnly=false \
-  --mount volume=birdctl,target=/var/run/calico \
-  --volume mods,kind=host,source=/lib/modules,readOnly=false  \
-  --mount volume=mods,target=/lib/modules \
-  --volume logs,kind=host,source=/var/log/calico,readOnly=false \
-  --mount volume=logs,target=/var/log/calico \
-  --set-env IP=autodetect \
-  --net host \
+  --set-env=ETCD_ENDPOINTS=http://172.18.18.101:2379 \
+  --insecure-options=image \
+  --volume=birdctl,kind=host,source=/var/run/calico,readOnly=false \
+  --mount=volume=birdctl,target=/var/run/calico \
+  --volume=mods,kind=host,source=/lib/modules,readOnly=false  \
+  --mount=volume=mods,target=/lib/modules \
+  --volume=logs,kind=host,source=/var/log/calico,readOnly=false \
+  --mount=volume=logs,target=/var/log/calico \
+  --set-env=IP=autodetect \
+  --net=host \
   quay.io/calico/node:latest &
 ```
 

--- a/v2.0/getting-started/rkt/installation/manual.md
+++ b/v2.0/getting-started/rkt/installation/manual.md
@@ -64,16 +64,16 @@ as fly stage-1 container.
 
 ```shell
 sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
-  --set-env ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> \
-  --set-env IP=autodetect \
-  --insecure-options image \
-  --volume birdctl,kind=host,source=/var/run/calico,readOnly=false \
-  --mount volume=birdctl,target=/var/run/calico \
-  --volume mods,kind=host,source=/lib/modules,readOnly=false  \
-  --mount volume=mods,target=/lib/modules \
-  --volume logs,kind=host,source=/var/log/calico,readOnly=false \
-  --mount volume=logs,target=/var/log/calico \
-  --net host \
+  --set-env=ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> \
+  --set-env=IP=autodetect \
+  --insecure-options=image \
+  --volume=birdctl,kind=host,source=/var/run/calico,readOnly=false \
+  --mount=volume=birdctl,target=/var/run/calico \
+  --volume=mods,kind=host,source=/lib/modules,readOnly=false  \
+  --mount=volume=mods,target=/lib/modules \
+  --volume=logs,kind=host,source=/var/log/calico,readOnly=false \
+  --mount=volume=logs,target=/var/log/calico \
+  --net=host \
   quay.io/calico/node:v1.0.0-rc4 &
 ```
 

--- a/v2.0/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.0/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -81,16 +81,16 @@ Start the Calico service on *both* hosts
 
 ```shell
 sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
-  --set-env ETCD_ENDPOINTS=http://172.18.18.101:2379 \
-  --insecure-options image \
-  --volume birdctl,kind=host,source=/var/run/calico,readOnly=false \
-  --mount volume=birdctl,target=/var/run/calico \
-  --volume mods,kind=host,source=/lib/modules,readOnly=false  \
-  --mount volume=mods,target=/lib/modules \
-  --volume logs,kind=host,source=/var/log/calico,readOnly=false \
-  --mount volume=logs,target=/var/log/calico \
-  --set-env IP=autodetect \
-  --net host \
+  --set-env=ETCD_ENDPOINTS=http://172.18.18.101:2379 \
+  --insecure-options=image \
+  --volume=birdctl,kind=host,source=/var/run/calico,readOnly=false \
+  --mount=volume=birdctl,target=/var/run/calico \
+  --volume=mods,kind=host,source=/lib/modules,readOnly=false  \
+  --mount=volume=mods,target=/lib/modules \
+  --volume=logs,kind=host,source=/var/log/calico,readOnly=false \
+  --mount=volume=logs,target=/var/log/calico \
+  --set-env=IP=autodetect \
+  --net=host \
   quay.io/calico/node:v1.0.0-rc4 &
 ```
 


### PR DESCRIPTION
apparently it thinks we're trying to pull `host` image when we have `--net host` (space instead of a `=`)