### PR TITLE
Match with calicoctl doc in getting-started/docker/installation/manual

### DIFF
--- a/master/getting-started/rkt/installation/manual.md
+++ b/master/getting-started/rkt/installation/manual.md
@@ -90,20 +90,15 @@ UUID      APP	IMAGE NAME                  STATE   CREATED         STARTED       
 b52bba11  node  quay.io/calico/node:latest  running 10 seconds ago  10 seconds ago
 ```
 
-## Installing the calicoctl CLI tool
+## Installing calicoctl
+   Download the calicoctl binary:
 
-Download the calicoctl binary and ensure it is executable.  We download to the
-/opt/bin directory to ensure it is accessible in your path (you may download
-wherever convenient though):
+   ```
+   sudo wget -O /usr/local/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+   sudo chmod +x calicoctl
+   ```
 
-```
-# Download and install `calicoctl`
-wget -N -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
-chmod +x /opt/bin/calicoctl
-```
-
-See the [`calicoctl` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
-for more information on this CLI tool.
+The [`calicoctl` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) has commandline options and configuration.
 
 ## Installing Calico as a CNI plugin
 

--- a/v2.0/getting-started/rkt/installation/manual.md
+++ b/v2.0/getting-started/rkt/installation/manual.md
@@ -90,20 +90,15 @@ UUID      APP	IMAGE NAME                  STATE   CREATED         STARTED       
 b52bba11  node  quay.io/calico/node:v1.0.0  running 10 seconds ago  10 seconds ago
 ```
 
-## Installing the calicoctl CLI tool
+## Installing calicoctl
+   Download the calicoctl binary:
 
-Download the calicoctl binary and ensure it is executable.  We download to the
-/opt/bin directory to ensure it is accessible in your path (you may download
-wherever convenient though):
+   ```
+   sudo wget -O /usr/local/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+   sudo chmod +x calicoctl
+   ```
 
-```
-# Download and install `calicoctl`
-wget -N -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v1.0.0/calicoctl
-chmod +x /opt/bin/calicoctl
-```
-
-See the [`calicoctl` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
-for more information on this CLI tool.
+The [`calicoctl` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/) has commandline options and configuration.
 
 ## Installing Calico as a CNI plugin
 


### PR DESCRIPTION
Improve the format and wording to match the docker manual installation section for calicoctl.