### PR TITLE
Adds necessary labels and file per component for kube-addons-manager

### DIFF
--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-configmap.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-configmap.yaml
@@ -1,0 +1,30 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+data:
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml
@@ -1,0 +1,102 @@
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on 
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This 
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: calico/node:v1.0.2
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix debug logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "debug"
+            # Don't enable BGP.
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Set the hostname based on the k8s node name.
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # No IP address needed.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: calico/cni:v1.5.6
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/index.md
@@ -1,0 +1,5 @@
+---
+title: Etcdless Hosted Install using Kube Addon Manager
+---
+
+See [Etcdless Hosted Install](../k8s-backend)

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -22,6 +22,8 @@ You must have a cluster which meets the following requirements:
 
 ## Installation
 
+### Using single YAML file
+
 To install Calico, ensure you have a cluster which meets the above requirements and run the following command:
 
 ```
@@ -31,6 +33,19 @@ kubectl apply -f http://docs.projectcalico.org/{{page.version}}/getting-started/
 Once installed, you can try out NetworkPolicy by following the [simple policy guide](../../../tutorials/simple-policy).
 
 Below are a few examples for how to get started.
+
+### Using Kubernetes' addon-manager
+
+Kubernetes' [addon-manager](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager)
+can be used for deploying Calico alongside with other cluster addons. It takes
+YAML manifests from the `/etc/kubernetes/addons` directory and ensures they
+exist in the cluster. The following lines need to be run on the master of
+Kubernetes cluster with addon-manager installed:
+
+```
+curl -sL -o /etc/kubernetes/addons/calico-configmap.yaml http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-configmap.yaml
+curl -sL -o /etc/kubernetes/addons/calico-daemonset.yaml http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml
+```
 
 #### Example: kubeadm + flannel
 


### PR DESCRIPTION
Have separate files for kube-addons-manager based deployments

compare https://github.com/Azure/acs-engine/pull/151

@lxpollitt @gunjan5 