### PR TITLE
Fixed path to calicoctl to be correct

### DIFF
--- a/master/getting-started/mesos/vagrant/Vagrantfile
+++ b/master/getting-started/mesos/vagrant/Vagrantfile
@@ -13,7 +13,7 @@ mesos_version = "1.0.0"
 mesos_dns_url = "https://github.com/mesosphere/mesos-dns/releases/download/v0.5.0/mesos-dns-v0.5.0-linux-amd64"
 
 # The calicoctl download URL.
-calicoctl_url = "http://www.projectcalico.org/builds/calicoctl"
+calicoctl_url = "https://github.com/projectcalico/calicoctl/releases/download/v1.0.0/calicoctl"
 
 # The version of the calico docker images to install.  This is used to pre-load
 # the calico/node image which slows down the install process, but speeds up the tutorial.


### PR DESCRIPTION
The path in the Vagrantfile is currently returning a zero byte file, which causes vagrant up to fail. Found the correct url from the project calico webpage, and updated the script.
Vagrant now completes successfully.