### PR TITLE
Update calicoctl config file example to use the correct field

### DIFF
--- a/master/reference/calicoctl/setup/kubernetes.md
+++ b/master/reference/calicoctl/setup/kubernetes.md
@@ -28,7 +28,7 @@ kind: calicoApiConfig
 metadata:
 spec:
   datastoreType: "kubernetes"
-  k8sKubeconfig: "/path/to/kubeconfig"
+  kubeconfig: "/path/to/kubeconfig"
   ...
 ```
 
@@ -75,7 +75,7 @@ kind: calicoApiConfig
 metadata:
 spec:
   datastoreType: "kubernetes"
-  k8sKubeconfig: "/path/to/.kube/config"
+  kubeconfig: "/path/to/.kube/config"
 ```
 
 #### Example using environment variables 

--- a/v2.0/reference/calicoctl/setup/kubernetes.md
+++ b/v2.0/reference/calicoctl/setup/kubernetes.md
@@ -28,7 +28,7 @@ kind: calicoApiConfig
 metadata:
 spec:
   datastoreType: "kubernetes"
-  k8sKubeconfig: "/path/to/kubeconfig"
+  kubeconfig: "/path/to/kubeconfig"
   ...
 ```
 
@@ -75,7 +75,7 @@ kind: calicoApiConfig
 metadata:
 spec:
   datastoreType: "kubernetes"
-  k8sKubeconfig: "/path/to/.kube/config"
+  kubeconfig: "/path/to/.kube/config"
 ```
 
 #### Example using environment variables 


### PR DESCRIPTION
Update the `calicoctl` docs to use the correct field `kubeconfig` in the configuration file examples.