### PR TITLE
Automate updating Calico-version-dependent PPA and RPM repo refs

### DIFF
--- a/master/getting-started/bare-metal/bare-metal.md
+++ b/master/getting-started/bare-metal/bare-metal.md
@@ -9,8 +9,8 @@ to distinguish them from "workload endpoints" (such as containers or VMs).
 
 Calico supports the same rich security policy model for host endpoints
 that it supports for workload endpoints.  Host endpoints can have labels, and
-their labels are in the same "namespace" as those of workload endpoints. This 
-allows security rules for either type of endpoint to refer to the other type 
+their labels are in the same "namespace" as those of workload endpoints. This
+allows security rules for either type of endpoint to refer to the other type
 (or a mix of the two) using labels and selectors.
 
 Calico does not support setting IPs or policing MAC addresses for host
@@ -83,15 +83,12 @@ To create a production cluster, you should follow the guidance in the
 
 There are several ways to install Felix.
 
--   if you are running Ubuntu 14.04, then you can install a version from
-    our PPA:
+-   if you are running Ubuntu 14.04 or 16.04, you can install from our PPA:
 
-        sudo apt-add-repository ppa:project-calico/calico-<version>
+        sudo apt-add-repository ppa:project-calico/calico-2.0
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix
-
-    As of writing, &lt;version&gt; should be 2.0.
 
 -   if you are running a RedHat 7-derived distribution, you can install
     from our RPM repository:
@@ -99,11 +96,11 @@ There are several ways to install Felix.
         cat > /etc/yum.repos.d/calico.repo <<EOF
         [calico]
         name=Calico Repository
-        baseurl=http://binaries.projectcalico.org/rpm_stable/
+        baseurl=http://binaries.projectcalico.org/rpm/calico-2.0/
         enabled=1
         skip_if_unavailable=0
         gpgcheck=1
-        gpgkey=http://binaries.projectcalico.org/rpm/key
+        gpgkey=http://binaries.projectcalico.org/rpm/calico-2.0/key
         priority=97
         EOF
 
@@ -289,7 +286,7 @@ key/value pairs that can be used in selector expressions.
 
 > **Warning**
 >
-> When rendering security rules on other hosts, Calico uses the 
+> When rendering security rules on other hosts, Calico uses the
 > `expectedIPs` field to resolve label selectors
 > to IP addresses. If the `expectedIPs` field is omitted
 > then security rules that use labels will fail to match

--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -2,8 +2,13 @@
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
 ---
 
-These instructions will take you through a first-time install of Calico.
-If you are upgrading an existing system, please see the [Calico on OpenStack upgrade]({{site.baseurl}}/{{page.version}}/getting-started/openstack/upgrade) document instead for upgrade instructions.
+For this version of Calico, with OpenStack on RHEL 7 or CentOS 7, we recommend
+using OpenStack Liberty or later.
+
+These instructions will take you through a first-time install of Calico.  If
+you are upgrading an existing system, please see the [Calico on OpenStack
+upgrade]({{site.baseurl}}/{{page.version}}/getting-started/openstack/upgrade)
+document instead for upgrade instructions.
 
 There are three sections to the install: installing etcd, upgrading
 control nodes to use Calico, and upgrading compute nodes to use Calico.
@@ -24,8 +29,8 @@ sections.
 
 Before starting this you will need the following:
 
--   One or more machines running RHEL 7, with OpenStack Juno, Kilo,
-    Liberty or Mitaka installed.
+-   One or more machines running RHEL 7, with OpenStack Liberty or Mitaka
+    installed.
 -   SSH access to these machines.
 -   Working DNS between these machines (use `/etc/hosts` if you don't
     have DNS on your network).
@@ -39,39 +44,14 @@ These steps are detailed in this section.
 
 If you haven't already done so, install Openstack with Neutron and ML2
 networking. Instructions for installing OpenStack on RHEL can be found
-here
---[Juno](http://docs.openstack.org/juno/install-guide/install/yum/content/index.html)
-/
-[Kilo](http://docs.openstack.org/kilo/install-guide/install/yum/content/index.html)
-/ [Liberty](http://docs.openstack.org/liberty/index.html).
+[here](http://docs.openstack.org/liberty/index.html).
 
 ### Configure YUM repositories
-
-The latest version of Calico for OpenStack is 2.0, and we recommend using it
-with OpenStack Liberty or later.  Other possible combinations are shown by the
-following table.
-
-| OpenStack release | Calico version | Repository     |
-|-------------------+----------------+----------------|
-| Mitaka            |            2.0 | rpm/calico-2.0 |
-| Liberty           |            2.0 | rpm/calico-2.0 |
-| Mitaka            |            1.4 | rpm/calico-1.4 |
-| Liberty           |            1.4 | rpm/calico-1.4 |
-| (deprecated) Kilo |            1.3 | rpm_kilo       |
-| (deprecated) Juno |            1.3 | rpm_juno       |
-
-If you're using CentOS with Juno or Kilo, check the yum priorities
-plugin is installed:
-
-```
-    yum install yum-plugin-priorities
-```
 
 Add the EPEL repository -- see <https://fedoraproject.org/wiki/EPEL>.
 You may have already added this to install OpenStack.
 
-Configure the Calico repository as indicated above for your chosen OpenStack
-release.  For example, for Mitaka:
+Configure the Calico repository:
 
 ```
     cat > /etc/yum.repos.d/calico.repo <<EOF
@@ -85,10 +65,6 @@ release.  For example, for Mitaka:
     priority=97
     EOF
 ```
-
-**NOTE**: With OpenStack Juno or Kilo, the priority setting in `calico.repo` is
-needed so that the Calico repository can install Calico-enhanced versions of
-some of the OpenStack Nova and Neutron packages.
 
 ## Etcd Install
 
@@ -284,31 +260,20 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. (OpenStack updates are not
-    needed for Liberty.)
+2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
     -   Find the line beginning with `core_plugin`, and change it to
         read `core_plugin = calico`.
 
-4.  With OpenStack releases earlier than Liberty, edit the
-    `/etc/neutron/neutron.conf` file. In the \[DEFAULT\] section:
-    -   Find the line for the `dhcp_agents_per_network` setting,
-        uncomment it, and set its value to the number of compute nodes
-        that you will have (or any number larger than that). This allows
-        a DHCP agent to run on every compute node, which Calico requires
-        because the networks on different compute nodes are not
-        bridged together.
-
-5.  Install the `calico-control` package:
+4.  Install the `calico-control` package:
 
     ```
         yum install calico-control
     ```
 
-6.  Restart the neutron server process:
+5.  Restart the neutron server process:
 
     ```
         service neutron-server restart
@@ -413,9 +378,7 @@ On each compute node, perform the following steps:
         neutron agent-delete <agent-id>
     ```
 
-4.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. For OpenStack Liberty, this
-    step only upgrades `dnsmasq`.
+4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 
@@ -423,24 +386,8 @@ On each compute node, perform the following steps:
         yum install openstack-neutron
     ```
 
-6.  For OpenStack Juno or Kilo, open `/etc/neutron/dhcp_agent.ini`, and
-    in the `[DEFAULT]` section add the following line (removing any
-    existing `interface_driver =` line):
-
-    ```
-        interface_driver = neutron.agent.linux.interface.RoutedInterfaceDriver
-    ```
-
-    then restart and enable the Neutron DHCP agent:
-
-    ```
-        service neutron-dhcp-agent restart
-        chkconfig neutron-dhcp-agent on
-    ```
-
-    For OpenStack Liberty or later, modify `/etc/neutron/neutron.conf`.
-    In the `[oslo_concurrency]` section, ensure that the `lock_path`
-    variable is uncommented and set as follows:
+6.  Modify `/etc/neutron/neutron.conf`.  In the `[oslo_concurrency]` section,
+    ensure that the `lock_path` variable is uncommented and set as follows:
 
     ```
         # Directory to use for lock files. For security, the specified directory should

--- a/master/getting-started/openstack/installation/ubuntu.md
+++ b/master/getting-started/openstack/installation/ubuntu.md
@@ -2,11 +2,16 @@
 title: 'Ubuntu Packaged Install Instructions'
 ---
 
+For this version of Calico, with OpenStack on Ubuntu Trusty or Xenial, we
+recommend using OpenStack Liberty or later; Kilo is also known to work on
+Ubuntu Trusty.
+
 These instructions will take you through a first-time install of Calico using
 the latest packages on a system running Ubuntu 14.04 (Trusty) or 16.04
-(Xenial), with OpenStack Icehouse, Juno, Kilo, Liberty or Mitaka. If you are
-upgrading an existing system, please see [this document]({{site.baseurl}}/{{page.version}}/getting-started/openstack/upgrade) instead
-for upgrade instructions.
+(Xenial), with OpenStack Kilo, Liberty or Mitaka. If you are upgrading an
+existing system, please see [this
+document]({{site.baseurl}}/{{page.version}}/getting-started/openstack/upgrade)
+instead for upgrade instructions.
 
 There are three sections to the install: installing etcd, upgrading
 control nodes to use Calico, and upgrading compute nodes to use Calico.
@@ -32,35 +37,24 @@ If you haven't already done so, you should install OpenStack with
 Neutron and ML2 networking. Instructions for installing OpenStack can be
 found at <http://docs.openstack.org>.
 
-### Configuring the APT software sources
+### Configuring APT software sources
 
-The latest version of Calico for OpenStack is 2.0, and we recommend using it
-with OpenStack Liberty or later.  Other possible combinations are shown by the
-following table.
-
-| OpenStack release     | Calico version | Ubuntu versions | PPAs             |
-|-----------------------+----------------+-----------------+------------------|
-| Mitaka                |            2.0 | Xenial, Trusty  | calico-2.0       |
-| Liberty               |            2.0 | Xenial, Trusty  | calico-2.0       |
-| Mitaka                |            1.4 | Xenial, Trusty  | calico-1.4       |
-| Liberty               |            1.4 | Xenial, Trusty  | calico-1.4       |
-| Kilo                  |            1.4 | Trusty          | calico-1.4, kilo |
-| (deprecated) Kilo     |            1.3 | Trusty          | kilo             |
-| (deprecated) Juno     |            1.3 | Trusty          | juno             |
-| (deprecated) Icehouse |            1.3 | Trusty          | icehouse         |
-
-For your chosen combination, you need to configure APT to use the corresponding
-PPA(s).  For example, for Calico 2.0 with Liberty or later:
+Configure APT to use the Calico PPA:
 
 ```shell
     $ sudo apt-add-repository ppa:project-calico/calico-2.0
 ```
 
-Before OpenStack Liberty, Calico needed patched versions of Nova and Neutron.
-If you're using a version of OpenStack prior to Liberty, edit
-`/etc/apt/preferences` to add the following lines, whose effect is to prefer
-Calico-provided packages for Nova and Neutron even if later versions of those
-packages are released by Ubuntu.
+With Kilo, Calico also needs patched versions of Nova and Neutron that are
+provided by our 'kilo' PPA.  So if you are using Kilo:
+
+```shell
+    $ sudo apt-add-repository ppa:project-calico/kilo
+```
+
+and also edit `/etc/apt/preferences` to add the following lines, whose effect
+is to prefer the Calico-provided packages for Nova and Neutron even if later
+versions of those packages are released by Ubuntu.
 
 ```
     Package: *
@@ -328,9 +322,8 @@ perform the following steps:
     >      $ sudo apt-get upgrade
         ```
 
-6.  If you're using OpenStack Icehouse, Juno or Kilo, open
-    `/etc/neutron/dhcp_agent.ini` in your preferred text editor, and set
-    the following in the `[DEFAULT]` section:
+6.  If you're using OpenStack Kilo, open `/etc/neutron/dhcp_agent.ini` in your
+    preferred text editor, and set the following in the `[DEFAULT]` section:
 
     ```shell
         interface_driver = neutron.agent.linux.interface.RoutedInterfaceDriver

--- a/release-scripts/do_release.py
+++ b/release-scripts/do_release.py
@@ -84,7 +84,14 @@ VERSION_REPLACE = [
      'calico/kube-policy-controller:{kube-policy-controller-version}'),
 
     (re.compile(r'calico/cni:latest'),
-     'calico/cni:{calico-cni-version}')
+     'calico/cni:{calico-cni-version}'),
+
+    (re.compile(r'binaries.projectcalico.org/rpm/calico-[0-9.]+/'),
+     'binaries.projectcalico.org/rpm/calico-{calico-version-no-v}/'),
+
+    (re.compile(r'ppa:project-calico/calico-[0-9.]+'),
+     'ppa:project-calico/calico-{calico-version-no-v}'),
+
 ]
 
 
@@ -147,6 +154,7 @@ def start_release():
 
     versions = {
         "calico-version": new_version,
+        "calico-version-no-v": new_version[1:],
         "calico-containers-version": calico_containers_version,
         "calico-containers-version-no-v": calico_containers_version[1:],
         "felix-version": felix_version,


### PR DESCRIPTION
Fixes #328.

In the process, I've also simplified the master text in the following
ways.

- No need to talk about <version> as a variable, or of possible Calico
  versions that can be used, when we are already (by definition) in the
  context of a specific Calico version.

- Current Calico is only known to work with Kilo or later on Ubuntu, and
  with Liberty or later on RHEL/CentOS - so say this and trim our
  OpenStack-release-dependent instructions accordingly.