### PR TITLE
Remove Confusion/Redundancy in Calico-Node Service File

### DIFF
--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -85,8 +85,6 @@ ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -e IP= \
   -e NO_DEFAULT_POOLS= \
   -e AS= \
-  -e ETCD_AUTHORITY=127.0.0.1:2379 \
-  -e ETCD_SCHEME=http \
   -e CALICO_LIBNETWORK_ENABLED=true \
   -e IP6= \
   -e CALICO_NETWORKING_BACKEND=bird \

--- a/v2.0/getting-started/kubernetes/installation/integration.md
+++ b/v2.0/getting-started/kubernetes/installation/integration.md
@@ -85,8 +85,6 @@ ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -e IP= \
   -e NO_DEFAULT_POOLS= \
   -e AS= \
-  -e ETCD_AUTHORITY=127.0.0.1:2379 \
-  -e ETCD_SCHEME=http \
   -e CALICO_LIBNETWORK_ENABLED=true \
   -e IP6= \
   -e CALICO_NETWORKING_BACKEND=bird \


### PR DESCRIPTION
The omitted lines are confusing because of the usage of port `2379`. This port implies that the ectd cluster for k8s is to be used an not the port for the etcd cluster for calico which is `6666` throughout the calico documentation. Of course a separate etcd cluster doesn't have to be created but the tone of the documentation suggests that one is. Also, in other integration guides (e.g. the kubeadm hosted install), port `6666` is used. 

Also, in the configuration, `ECTD_ENDPOINTS` is used which from my understanding makes `ETCD_SCHEME` and `ETCD_AUTHORITY` redundant.

Right below the configuration the below wording is already present which should, on its own, be enough to avoid confusion regardless of whether a separate etcd cluster is deployed or not:

`Replace `<ETCD_IP>:<ETCD_PORT>` with your etcd configuration.`