### PR TITLE
Fix semaphore builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
+# jekyll 3.4 has some permissions issue on semaphore, so stick with 3.2 for now.
+
 serve:
-	docker run --rm -p 4000:4000 -v $$PWD:/srv/jekyll jekyll/jekyll
+	docker run --rm -p 4000:4000 -v $$PWD:/srv/jekyll jekyll/jekyll:3.2
 
 # Be careful - this doesn't specify all the deps
 _site:
-	docker run --rm -v $$PWD:/srv/jekyll jekyll/jekyll jekyll build
+	docker run --rm -v $$PWD:/srv/jekyll jekyll/jekyll:3.2 jekyll build
 
 clean:
-	docker run --rm -v $$PWD:/srv/jekyll jekyll/jekyll jekyll clean
+	docker run --rm -v $$PWD:/srv/jekyll jekyll/jekyll:3.2 jekyll clean
 
 
 htmlproofer: _site


### PR DESCRIPTION
Semaphore builds are broken ever since Jekyll pushed a new `jekyll/jekyll:3.4` dockerhub image.

This image has some permissions issue when run on semaphore where the uid used in the container is different than the uid of the files on the host, so it doesn't have permission to write to `_site/`.

This PR is a bandaid fix to use the old 3.2 image we were using before. Github itself is using [jekyll v3.3.1](https://pages.github.com/versions/), but a 3.3 dockerhub jekyll image doesn't even exist, so I think it's fine to stay with 3.2 at least until github pages their jekyll version or a 3.3 image becomes available.