### PR TITLE
Proposal for calicoctl flag to enable libnetwork labels

### DIFF
--- a/master/reference/calicoctl/commands/node/run.md
+++ b/master/reference/calicoctl/commands/node/run.md
@@ -25,6 +25,7 @@ Usage:
                      [--init-system]
                      [--disable-docker-networking]
                      [--docker-networking-ifprefix=<IFPREFIX>]
+                     [--enable-docker-networking-labeling]
 
 Options:
   -h --help                Show this screen.
@@ -72,6 +73,10 @@ Options:
                            within the Docker containers that have been networked
                            by the Calico driver.
                            [default: cali]
+     --enable-docker-networking-labeling
+                           Enables adding labels to Docker containers that can
+                           be used in policies. Setting this flag also disables
+                           the default network profiles.
   -c --config=<CONFIG>     Path to the file containing connection
                            configuration in YAML or JSON format.
                            [default: /etc/calico/calicoctl.cfg]


### PR DESCRIPTION
If this flag is set then the two environment variables would be set on the node:
  * CALICO_LIBNETWORK_LABEL_ENDPOINTS=true
  * CALICO_LIBNETWORK_CREATE_PROFILES=false
If there is any way that CALICO_LIBNETWORK_ENABLED can be set false then it should be an error if this new flag and that is set too.