### PR TITLE
Update epel-release download package

### DIFF
--- a/master/usage/bird-rr-config.md
+++ b/master/usage/bird-rr-config.md
@@ -43,8 +43,8 @@ be sufficient:
 
 If that fails, try the following instead:
 
-    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-    sudo yum install epel-release-7-5.noarch.rpm
+    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+    sudo yum install epel-release-7-9.noarch.rpm
 
 With that complete, you can now install BIRD:
 

--- a/v1.5/usage/bird-rr-config.md
+++ b/v1.5/usage/bird-rr-config.md
@@ -43,8 +43,8 @@ be sufficient:
 
 If that fails, try the following instead:
 
-    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-    sudo yum install epel-release-7-5.noarch.rpm
+    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+    sudo yum install epel-release-7-9.noarch.rpm
 
 With that complete, you can now install BIRD:
 

--- a/v1.6/usage/bird-rr-config.md
+++ b/v1.6/usage/bird-rr-config.md
@@ -43,8 +43,8 @@ be sufficient:
 
 If that fails, try the following instead:
 
-    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-    sudo yum install epel-release-7-5.noarch.rpm
+    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+    sudo yum install epel-release-7-9.noarch.rpm
 
 With that complete, you can now install BIRD:
 

--- a/v2.0/usage/bird-rr-config.md
+++ b/v2.0/usage/bird-rr-config.md
@@ -43,8 +43,8 @@ be sufficient:
 
 If that fails, try the following instead:
 
-    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-    sudo yum install epel-release-7-5.noarch.rpm
+    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+    sudo yum install epel-release-7-9.noarch.rpm
 
 With that complete, you can now install BIRD:
 


### PR DESCRIPTION
I wasn't reading the directions very closely and ended up trying to download the epel-release package and found that it did not exist anymore so I updated the directions to the version that exists.