### PR TITLE
Fix meaning of 'not in' selector

### DIFF
--- a/_includes/master/selectors.md
+++ b/_includes/master/selectors.md
@@ -10,6 +10,6 @@ primitive expressions can be combined using the logical operator `&&`.
 | has(k)              | Matches any endpoint with label 'k', independent of value.
 | !has(k)             | Matches any endpoint that does not have label 'k'
 | k in { 'v1', 'v2' } | Matches any endpoint with label 'k' and value in the given set
-| k not in { 'v1', 'v2' } | Matches any endpoint with label 'k' and value _not_ in the given set
+| k not in { 'v1', 'v2' } | Matches any endpoint without label 'k' or any with label 'k' and value _not_ in the given set
 
 

--- a/_includes/v2.0/selectors.md
+++ b/_includes/v2.0/selectors.md
@@ -10,6 +10,6 @@ primitive expressions can be combined using the logical operator `&&`.
 | has(k)              | Matches any endpoint with label 'k', independent of value.
 | !has(k)             | Matches any endpoint that does not have label 'k'
 | k in { 'v1', 'v2' } | Matches any endpoint with label 'k' and value in the given set
-| k not in { 'v1', 'v2' } | Matches any endpoint with label 'k' and value _not_ in the given set
+| k not in { 'v1', 'v2' } | Matches any endpoint without label 'k' or any with label 'k' and value _not_ in the given set
 
 


### PR DESCRIPTION
Includes workloadendpoints without the label listed in the selector

As long as it is agreed on that the docs are wrong, this change fixes the description of how the 'not in' selector behaves.