### PR TITLE
Fix PPA and RPM repo naming and release-time processing

### DIFF
--- a/_includes/ppa_repo_name
+++ b/_includes/ppa_repo_name
@@ -1,0 +1,5 @@
+{% if page.version == 'master' %}
+{% assign ppa_repo_name = "master" %}
+{% else %}
+{% assign ppa_repo_name = page.version | replace_first: "v" | prepend: "calico-" %}
+{% endif %}

--- a/master/getting-started/bare-metal/bare-metal.md
+++ b/master/getting-started/bare-metal/bare-metal.md
@@ -90,7 +90,7 @@ There are several ways to install Felix.
 
 -   if you are running Ubuntu 14.04 or 16.04, you can install from our PPA:
 
-        sudo apt-add-repository ppa:project-calico/calico-{{ page.version }}
+        sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix

--- a/master/getting-started/bare-metal/bare-metal.md
+++ b/master/getting-started/bare-metal/bare-metal.md
@@ -86,11 +86,13 @@ To create a production cluster, you should follow the guidance in the
 
 ## Installing Felix
 
+{% include ppa_repo_name %}
+
 There are several ways to install Felix.
 
 -   if you are running Ubuntu 14.04 or 16.04, you can install from our PPA:
 
-        sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
+        sudo add-apt-repository ppa:project-calico/{{ ppa_repo_name }}
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix
@@ -101,11 +103,11 @@ There are several ways to install Felix.
         cat > /etc/yum.repos.d/calico.repo <<EOF
         [calico]
         name=Calico Repository
-        baseurl=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/
+        baseurl=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/
         enabled=1
         skip_if_unavailable=0
         gpgcheck=1
-        gpgkey=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/key
+        gpgkey=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/key
         priority=97
         EOF
 

--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -48,6 +48,8 @@ networking. Instructions for installing OpenStack on RHEL can be found
 
 ### Configure YUM repositories
 
+{% include ppa_repo_name %}
+
 Add the EPEL repository -- see <https://fedoraproject.org/wiki/EPEL>.
 You may have already added this to install OpenStack.
 
@@ -57,11 +59,11 @@ Configure the Calico repository:
     cat > /etc/yum.repos.d/calico.repo <<EOF
     [calico]
     name=Calico Repository
-    baseurl=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/
+    baseurl=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/
     enabled=1
     skip_if_unavailable=0
     gpgcheck=1
-    gpgkey=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/key
+    gpgkey=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/key
     priority=97
     EOF
 ```

--- a/master/getting-started/openstack/installation/ubuntu.md
+++ b/master/getting-started/openstack/installation/ubuntu.md
@@ -39,10 +39,12 @@ found at <http://docs.openstack.org>.
 
 ### Configuring APT software sources
 
+{% include ppa_repo_name %}
+
 Configure APT to use the Calico PPA:
 
 ```shell
-    $ sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
+    $ sudo add-apt-repository ppa:project-calico/{{ ppa_repo_name }}
 ```
 
 With Kilo, Calico also needs patched versions of Nova and Neutron that are

--- a/master/getting-started/openstack/installation/ubuntu.md
+++ b/master/getting-started/openstack/installation/ubuntu.md
@@ -42,14 +42,14 @@ found at <http://docs.openstack.org>.
 Configure APT to use the Calico PPA:
 
 ```shell
-    $ sudo apt-add-repository ppa:project-calico/calico-{{ page.version }}
+    $ sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
 ```
 
 With Kilo, Calico also needs patched versions of Nova and Neutron that are
 provided by our 'kilo' PPA.  So if you are using Kilo:
 
 ```shell
-    $ sudo apt-add-repository ppa:project-calico/kilo
+    $ sudo add-apt-repository ppa:project-calico/kilo
 ```
 
 and also edit `/etc/apt/preferences` to add the following lines, whose effect

--- a/v1.5/getting-started/bare-metal/bare-metal.md
+++ b/v1.5/getting-started/bare-metal/bare-metal.md
@@ -79,7 +79,7 @@ There are several ways to install Felix.
 -   if you are running Ubuntu 14.04, then you can install a version from
     our PPA:
 
-        sudo apt-add-repository ppa:project-calico/calico-<version>
+        sudo add-apt-repository ppa:project-calico/calico-<version>
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix
@@ -177,15 +177,15 @@ example of how you might do that; the commands:
 Once you have such a policy in place, you may want to disable the
 [failsafe rules](#failsafe-rules).
 
-> **NOTE** 
+> **NOTE**
 >
 > Packets that reach the end of the list of rules fall-through to the next policy (sorted by the order field).
 >
-> :   The selector in the policy, `all()`, will match *all* endpoints, 
->     including any workload endpoints. If you have workload endpoints as 
->     well as host endpoints then you may wish to use a more restrictive 
->     selector. For example, you could label management interfaces with 
->     label `endpoint_type = management` and then use selector 
+> :   The selector in the policy, `all()`, will match *all* endpoints,
+>     including any workload endpoints. If you have workload endpoints as
+>     well as host endpoints then you may wish to use a more restrictive
+>     selector. For example, you could label management interfaces with
+>     label `endpoint_type = management` and then use selector
 >     `endpoint_type == "management"`
 >
 > :   If you are using Calico for networking workloads, you should add
@@ -240,7 +240,7 @@ the following data:
 
 Where `<list of profile IDs>` is an optional list of security profiles
 to apply to the endpoint and labels contains a set of arbitrary
-key/value pairs that can be used in selector expressions. 
+key/value pairs that can be used in selector expressions.
 
 <!-- TODO(smc) data-model: Link to new data model docs. -->
 
@@ -272,7 +272,7 @@ place, then you should see traffic being dropped on the interface.
 > **NOTE**
 >
 > :   By default, Calico has a failsafe in place that whitelists certain
->     traffic such as ssh. See below for more details on 
+>     traffic such as ssh. See below for more details on
 >     disabling/configuring the failsafe rules.
 >
 
@@ -294,8 +294,8 @@ address must be specified.
 
 ## Creating more security policy
 
-The Calico team recommend using selector-based security policy with 
-bare-metal workloads. This allows ordered policy to be applied to 
+The Calico team recommend using selector-based security policy with
+bare-metal workloads. This allows ordered policy to be applied to
 endpoints that match particular label selectors.
 
 +For example, you could add a second policy for webserver access:

--- a/v1.5/getting-started/openstack/installation/ubuntu.md
+++ b/v1.5/getting-started/openstack/installation/ubuntu.md
@@ -51,7 +51,7 @@ For your chosen combination, you need to configure APT to use the corresponding
 PPA(s).  For example, for Calico 1.4 with Liberty or later:
 
 ```shell
-    $ sudo apt-add-repository ppa:project-calico/calico-1.4
+    $ sudo add-apt-repository ppa:project-calico/calico-1.4
 ```
 
 Before OpenStack Liberty, Calico needed patched versions of Nova and Neutron.

--- a/v1.6/getting-started/bare-metal/bare-metal.md
+++ b/v1.6/getting-started/bare-metal/bare-metal.md
@@ -79,7 +79,7 @@ There are several ways to install Felix.
 -   if you are running Ubuntu 14.04, then you can install a version from
     our PPA:
 
-        sudo apt-add-repository ppa:project-calico/calico-<version>
+        sudo add-apt-repository ppa:project-calico/calico-<version>
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix
@@ -177,15 +177,15 @@ example of how you might do that; the commands:
 Once you have such a policy in place, you may want to disable the
 [failsafe rules](#failsafe-rules).
 
-> **NOTE** 
+> **NOTE**
 >
 > Packets that reach the end of the list of rules fall-through to the next policy (sorted by the order field).
 >
-> :   The selector in the policy, `all()`, will match *all* endpoints, 
->     including any workload endpoints. If you have workload endpoints as 
->     well as host endpoints then you may wish to use a more restrictive 
->     selector. For example, you could label management interfaces with 
->     label `endpoint_type = management` and then use selector 
+> :   The selector in the policy, `all()`, will match *all* endpoints,
+>     including any workload endpoints. If you have workload endpoints as
+>     well as host endpoints then you may wish to use a more restrictive
+>     selector. For example, you could label management interfaces with
+>     label `endpoint_type = management` and then use selector
 >     `endpoint_type == "management"`
 >
 > :   If you are using Calico for networking workloads, you should add
@@ -240,7 +240,7 @@ the following data:
 
 Where `<list of profile IDs>` is an optional list of security profiles
 to apply to the endpoint and labels contains a set of arbitrary
-key/value pairs that can be used in selector expressions. 
+key/value pairs that can be used in selector expressions.
 
 <!-- TODO(smc) data-model: Link to new data model docs. -->
 
@@ -272,7 +272,7 @@ place, then you should see traffic being dropped on the interface.
 > **NOTE**
 >
 > :   By default, Calico has a failsafe in place that whitelists certain
->     traffic such as ssh. See below for more details on 
+>     traffic such as ssh. See below for more details on
 >     disabling/configuring the failsafe rules.
 >
 
@@ -294,8 +294,8 @@ address must be specified.
 
 ## Creating more security policy
 
-The Calico team recommend using selector-based security policy with 
-bare-metal workloads. This allows ordered policy to be applied to 
+The Calico team recommend using selector-based security policy with
+bare-metal workloads. This allows ordered policy to be applied to
 endpoints that match particular label selectors.
 
 +For example, you could add a second policy for webserver access:

--- a/v1.6/getting-started/openstack/installation/ubuntu.md
+++ b/v1.6/getting-started/openstack/installation/ubuntu.md
@@ -51,7 +51,7 @@ For your chosen combination, you need to configure APT to use the corresponding
 PPA(s).  For example, for Calico 1.4 with Liberty or later:
 
 ```shell
-    $ sudo apt-add-repository ppa:project-calico/calico-1.6
+    $ sudo add-apt-repository ppa:project-calico/calico-1.6
 ```
 
 Before OpenStack Liberty, Calico needed patched versions of Nova and Neutron.

--- a/v2.0/getting-started/bare-metal/bare-metal.md
+++ b/v2.0/getting-started/bare-metal/bare-metal.md
@@ -86,7 +86,7 @@ There are several ways to install Felix.
 -   if you are running Ubuntu 14.04, then you can install a version from
     our PPA:
 
-        sudo apt-add-repository ppa:project-calico/calico-<version>
+        sudo add-apt-repository ppa:project-calico/calico-<version>
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix

--- a/v2.0/getting-started/openstack/installation/ubuntu.md
+++ b/v2.0/getting-started/openstack/installation/ubuntu.md
@@ -53,7 +53,7 @@ For your chosen combination, you need to configure APT to use the corresponding
 PPA(s).  For example, for Calico 2.0 with Liberty or later:
 
 ```shell
-    $ sudo apt-add-repository ppa:project-calico/calico-2.0
+    $ sudo add-apt-repository ppa:project-calico/calico-2.0
 ```
 
 Before OpenStack Liberty, Calico needed patched versions of Nova and Neutron.

--- a/v2.1/getting-started/bare-metal/bare-metal.md
+++ b/v2.1/getting-started/bare-metal/bare-metal.md
@@ -87,7 +87,7 @@ There are several ways to install Felix.
 
 -   if you are running Ubuntu 14.04 or 16.04, you can install from our PPA:
 
-        sudo apt-add-repository ppa:project-calico/calico-{{ page.version }}
+        sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix

--- a/v2.1/getting-started/bare-metal/bare-metal.md
+++ b/v2.1/getting-started/bare-metal/bare-metal.md
@@ -83,11 +83,13 @@ To create a production cluster, you should follow the guidance in the
 
 ## Installing Felix
 
+{% include ppa_repo_name %}
+
 There are several ways to install Felix.
 
 -   if you are running Ubuntu 14.04 or 16.04, you can install from our PPA:
 
-        sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
+        sudo add-apt-repository ppa:project-calico/{{ ppa_repo_name }}
         sudo apt-get update
         sudo apt-get upgrade
         sudo apt-get install calico-felix
@@ -98,11 +100,11 @@ There are several ways to install Felix.
         cat > /etc/yum.repos.d/calico.repo <<EOF
         [calico]
         name=Calico Repository
-        baseurl=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/
+        baseurl=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/
         enabled=1
         skip_if_unavailable=0
         gpgcheck=1
-        gpgkey=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/key
+        gpgkey=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/key
         priority=97
         EOF
 

--- a/v2.1/getting-started/openstack/installation/redhat.md
+++ b/v2.1/getting-started/openstack/installation/redhat.md
@@ -48,6 +48,8 @@ networking. Instructions for installing OpenStack on RHEL can be found
 
 ### Configure YUM repositories
 
+{% include ppa_repo_name %}
+
 Add the EPEL repository -- see <https://fedoraproject.org/wiki/EPEL>.
 You may have already added this to install OpenStack.
 
@@ -57,11 +59,11 @@ Configure the Calico repository:
     cat > /etc/yum.repos.d/calico.repo <<EOF
     [calico]
     name=Calico Repository
-    baseurl=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/
+    baseurl=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/
     enabled=1
     skip_if_unavailable=0
     gpgcheck=1
-    gpgkey=http://binaries.projectcalico.org/rpm/calico-{{ page.version }}/key
+    gpgkey=http://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/key
     priority=97
     EOF
 ```

--- a/v2.1/getting-started/openstack/installation/ubuntu.md
+++ b/v2.1/getting-started/openstack/installation/ubuntu.md
@@ -39,10 +39,12 @@ found at <http://docs.openstack.org>.
 
 ### Configuring APT software sources
 
+{% include ppa_repo_name %}
+
 Configure APT to use the Calico PPA:
 
 ```shell
-    $ sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
+    $ sudo add-apt-repository ppa:project-calico/{{ ppa_repo_name }}
 ```
 
 With Kilo, Calico also needs patched versions of Nova and Neutron that are

--- a/v2.1/getting-started/openstack/installation/ubuntu.md
+++ b/v2.1/getting-started/openstack/installation/ubuntu.md
@@ -42,14 +42,14 @@ found at <http://docs.openstack.org>.
 Configure APT to use the Calico PPA:
 
 ```shell
-    $ sudo apt-add-repository ppa:project-calico/calico-{{ page.version }}
+    $ sudo add-apt-repository ppa:project-calico/calico-{{ page.version }}
 ```
 
 With Kilo, Calico also needs patched versions of Nova and Neutron that are
 provided by our 'kilo' PPA.  So if you are using Kilo:
 
 ```shell
-    $ sudo apt-add-repository ppa:project-calico/kilo
+    $ sudo add-apt-repository ppa:project-calico/kilo
 ```
 
 and also edit `/etc/apt/preferences` to add the following lines, whose effect


### PR DESCRIPTION
Needed for two reasons:

1. Our PPAs and RPM repos are named 'calico-2.0', not 'calico-v2.0'.  This has
already been the case for some time, and I think it would be messy to change
now.

2. Our master PPA and RPM repo are named 'master', not 'calico-master', in
order to add an extra element of distinguishing those from PPAs/repos that
contain Calico code that has been properly QA'd and released.