### PR TITLE
IP Pool Configuration for the Kubernetes datastore driver manifest

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -32,6 +32,7 @@ master:
   - name: networking-calico
     version: master
     url: ""
+
 v2.1:
 - title: v2.1.0-rc5
   note: |

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -88,8 +88,8 @@ spec:
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"
-            # Set the hostname based on the k8s node name.
-            - name: HOSTNAME
+            # Set based on the k8s node name.
+            - name: NODENAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -79,6 +79,12 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -79,6 +79,9 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
+            - name: CALICO_IPV4POOL_CIDR
+              value: "10.244.0.0/16"
             # Set the hostname based on the k8s node name.
             - name: HOSTNAME
               valueFrom:

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -18,6 +18,7 @@ You must have a cluster which meets the following requirements:
 
 - You have a Kubernetes cluster configured to use CNI network plugins (i.e by passing --network-plugin=cni to the kubelet)
 - Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e by passing --allocate-node-cidrs=true to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (the manifest expects --cluster-cidr=10.244.0.0/16 by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -16,9 +16,9 @@ pod CIDRs for each node.
 
 You must have a cluster which meets the following requirements:
 
-- You have a Kubernetes cluster configured to use CNI network plugins (i.e by passing --network-plugin=cni to the kubelet)
-- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e by passing --allocate-node-cidrs=true to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (the manifest expects --cluster-cidr=10.244.0.0/16 by default).
+- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing --network-plugin=cni to the kubelet)
+- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing --allocate-node-cidrs=true to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing --cluster-cidr=10.244.0.0/16, which the manifest expects by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -27,6 +27,16 @@ data:
         }
     }
 
+  # The default IP Pool to be created for the cluster.
+  # This should match the configured Kubernetes --cluster-cidr.
+  ippool.yaml: |
+      apiVersion: v1
+      kind: ipPool
+      metadata:
+        cidr: 10.244.0.0/16
+      spec:
+        nat-outgoing: true
+
 ---
 
 # This manifest installs the calico/node container, as well
@@ -130,3 +140,48 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+
+---
+
+## This manifest deploys a Job which performs one time
+# configuration of Calico
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configure-calico
+  namespace: kube-system
+  labels:
+    k8s-app: calico
+spec:
+  template:
+    metadata:
+      name: configure-calico
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      restartPolicy: OnFailure
+      containers:
+        # Writes basic configuration to datastore.
+        - name: configure-calico
+          image: quay.io/calico/ctl:{% include version component="calico/node" %}
+          args:
+            - apply
+            - -f
+            - /etc/config/calico/ippool.yaml
+          env:
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: calico-config
+            items:
+            - key: ippool.yaml
+              path: calico/ippool.yaml

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -86,6 +86,9 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
             # Set the hostname based on the k8s node name.
             - name: HOSTNAME
               valueFrom:

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -1,5 +1,5 @@
 ---
-title: Etcdless Hosted Install 
+title: Etcdless Hosted Install
 ---
 
 This document describes installing Calico on Kubernetes in a mode that does not require access to an etcd cluster.  Note that this feature is
@@ -9,7 +9,7 @@ still experimental and currently comes with a number of limitations, namely:
 - Calico without etcd does not yet support Calico IPAM.  It is recommended to use `host-local` IPAM in conjunction with Kubernetes pod CIDR assignments.
 - Calico without etcd does not yet support the full set of `calicoctl` commands.
 
-## Requirements 
+## Requirements
 
 The provided manifest configures Calico to use host-local IPAM in conjunction with the Kubernetes assigned
 pod CIDRs for each node.
@@ -18,6 +18,7 @@ You must have a cluster which meets the following requirements:
 
 - You have a Kubernetes cluster configured to use CNI network plugins (i.e by passing --network-plugin=cni to the kubelet)
 - Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e by passing --allocate-node-cidrs=true to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (the manifest expects --cluster-cidr=10.244.0.0/16 by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation
@@ -51,10 +52,10 @@ curl -sL -o /etc/kubernetes/addons/calico-daemonset.yaml http://docs.projectcali
 
 This example explains how to install Calico on kubeadm with flannel for routing.
 
-Follow the [official kubeadm guide](http://kubernetes.io/docs/getting-started-guides/kubeadm/).  For 
+Follow the [official kubeadm guide](http://kubernetes.io/docs/getting-started-guides/kubeadm/).  For
 steps that require it, follow the instructions for installing flannel as the pod network.
 
-To initialize the master run 
+To initialize the master run
 
 ```
 kubeadm init --pod-network-cidr=10.244.0.0/16
@@ -72,7 +73,7 @@ Then continue following the guide, following the instructions for installing fla
 
 This example explains how to install Calico for NetworkPolicy on GCE using kube-up.
 
-See the [GCE documentation](http://kubernetes.io/docs/getting-started-guides/gce/#prerequisites) for 
+See the [GCE documentation](http://kubernetes.io/docs/getting-started-guides/gce/#prerequisites) for
 a list of requirements before starting.
 
 ##### 1) Start a Kubernetes cluster

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -16,9 +16,9 @@ pod CIDRs for each node.
 
 You must have a cluster which meets the following requirements:
 
-- You have a Kubernetes cluster configured to use CNI network plugins (i.e by passing --network-plugin=cni to the kubelet)
-- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e by passing --allocate-node-cidrs=true to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (the manifest expects --cluster-cidr=10.244.0.0/16 by default).
+- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing --network-plugin=cni to the kubelet)
+- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing --allocate-node-cidrs=true to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing --cluster-cidr=10.244.0.0/16, which the manifest expects by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -88,8 +88,8 @@ spec:
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"
-            # Set the hostname based on the k8s node name.
-            - name: HOSTNAME
+            # Set based on the k8s node name.
+            - name: NODENAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -79,6 +79,12 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -79,6 +79,9 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
+            - name: CALICO_IPV4POOL_CIDR
+              value: "10.244.0.0/16"
             # Set the hostname based on the k8s node name.
             - name: HOSTNAME
               valueFrom:

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -18,6 +18,7 @@ You must have a cluster which meets the following requirements:
 
 - You have a Kubernetes cluster configured to use CNI network plugins (i.e by passing --network-plugin=cni to the kubelet)
 - Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e by passing --allocate-node-cidrs=true to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (the manifest expects --cluster-cidr=10.244.0.0/16 by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -16,9 +16,9 @@ pod CIDRs for each node.
 
 You must have a cluster which meets the following requirements:
 
-- You have a Kubernetes cluster configured to use CNI network plugins (i.e by passing --network-plugin=cni to the kubelet)
-- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e by passing --allocate-node-cidrs=true to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (the manifest expects --cluster-cidr=10.244.0.0/16 by default).
+- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing --network-plugin=cni to the kubelet)
+- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing --allocate-node-cidrs=true to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing --cluster-cidr=10.244.0.0/16, which the manifest expects by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation


### PR DESCRIPTION
This PR adds IP Pool configuration to the Kubernetes datastore driver manifest.

For `master/` and `v2.1`, this is done through the `CALICO_IPV4POOL_CIDR` environment variable.
For `v2.0/`, this is done through a Kubernetes Job since the above env var isn't supported.

