### PR TITLE
Remove Job for configuring Pool, enable IPIP

### DIFF
--- a/master/getting-started/kubernetes/installation/gce.md
+++ b/master/getting-started/kubernetes/installation/gce.md
@@ -130,27 +130,6 @@ NAME          STATUS                     AGE
 
 {% include {{page.version}}/install-k8s-addons.md %}
 
-## 5. Configure the Calico IP pool
-
-To enable connectivity to the internet for our Pods, we'll use `calicoctl`:
-
-```
-# Log into the master instance.
-gcloud compute ssh kubernetes-master
-
-# Enable outgoing NAT and ipip on the Calico pool.
-docker run -i --rm --net=host quay.io/calico/ctl:{{site.data.versions[page.version].first.components.calicoctl.version}} apply -f -<<EOF
-apiVersion: v1
-kind: ipPool
-metadata:
-  cidr: 192.168.0.0/16
-spec:
-  ipip:
-    enabled: true
-  nat-outgoing: true
-EOF
-```
-
 ## Next Steps
 
 You should now have a fully functioning Kubernetes cluster using Calico for networking.  You're ready to use your cluster.

--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -37,16 +37,6 @@ data:
         }
     }
 
-  # The default IP Pool to be created for the cluster.
-  # Pod IP addresses will be assigned from this pool.
-  ippool.yaml: |
-      apiVersion: v1
-      kind: ipPool
-      metadata:
-        cidr: 192.168.0.0/16
-      spec:
-        nat-outgoing: true
-
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.
   etcd_ca: ""   # "/calico-secrets/etcd-ca"
@@ -124,10 +114,15 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
-            # Don't configure a default pool.  This is done by the Job
-            # below.
-            - name: NO_DEFAULT_POOLS
-              value: "true"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
             # Location of the CA certificate for etcd.
@@ -280,80 +275,6 @@ spec:
             - mountPath: /calico-secrets
               name: etcd-certs
       volumes:
-        # Mount in the etcd TLS secrets.
-        - name: etcd-certs
-          secret:
-            secretName: calico-etcd-secrets
-
----
-
-## This manifest deploys a Job which performs one time
-# configuration of Calico
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: configure-calico
-  namespace: kube-system
-  labels:
-    k8s-app: calico
-spec:
-  template:
-    metadata:
-      name: configure-calico
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-    spec:
-      hostNetwork: true
-      restartPolicy: OnFailure
-      containers:
-        # Writes basic configuration to datastore.
-        - name: configure-calico
-          image: quay.io/calico/ctl:{{site.data.versions[page.version].first.components.calicoctl.version}}
-          args:
-          - apply
-          - -f
-          - /etc/config/calico/ippool.yaml
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-            # Mount in the etcd TLS secrets.
-            - mountPath: /calico-secrets
-              name: etcd-certs
-          env:
-            # The location of the etcd cluster.
-            - name: ETCD_ENDPOINTS
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_endpoints
-            # Location of the CA certificate for etcd.
-            - name: ETCD_CA_CERT_FILE
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_ca
-            # Location of the client key for etcd.
-            - name: ETCD_KEY_FILE
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_key
-            # Location of the client certificate for etcd.
-            - name: ETCD_CERT_FILE
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_cert
-      volumes:
-        - name: config-volume
-          configMap:
-            name: calico-config
-            items:
-            - key: ippool.yaml
-              path: calico/ippool.yaml
         # Mount in the etcd TLS secrets.
         - name: etcd-certs
           secret:

--- a/master/getting-started/kubernetes/installation/hosted/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/index.md
@@ -45,21 +45,22 @@ the following configuration parameters:
 
 ### Configuring the Pod IP range
 
-Calico IPAM assigns IP addresses from
-[IP pools]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/ippool). The
-[standard](hosted) and [kubeadm](kubeadm/) manifests include an `ippool.yaml` file which
-configures the default IP pool used by Calico.
+Calico IPAM assigns IP addresses from [IP pools]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/ippool).
 
-To change the default IP range used for pods, modify the `cidr` section of the IP pool.
+To change the default IP range used for pods, modify the `CALICO_IPV4POOL_CIDR` section of the calico.yaml manifest.  For more
+information, see the [calico/node configuration reference]({{site.baseurl}}/{{page.version}}/reference/node/configuration).
 
-> **NOTE**
->
-> The etcdless Calico manifest does not include an IP pool configuration, as IP allocation is done based on
-the Kubernetes node.PodCIDR field, not Calico IP pools.
+### Configuring IP-in-IP
 
-> **NOTE**
->
-> The kubeadm Calico manifest also configures ipip encapsulation on the pool by default.
+By default, the self-hosted manifests enable IP-in-IP encapsulation across subnets.  Many users may
+want to disable IP-in-IP encapsulation, for example if:
+
+- Their cluster is [running in a properly configured AWS VPC]({{site.baseurl}}/{{page.version}}/reference/public-cloud/aws).
+- All their Kubernetes nodes are connected to the same L2 network.
+- They intend to use BGP peering to make their underlying infrastructure aware of Pod IP addresses.
+
+To disable IP-in-IP encapsulation, modify the `CALICO_IPV4POOL_IPIP` section of the manifest.  For more
+information, see the [calico/node configuration reference]({{site.baseurl}}/{{page.version}}/reference/node/configuration).
 
 ### Etcd Configuration
 

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -36,18 +36,6 @@ data:
         }
     }
 
-  # The default IP Pool to be created for the cluster.
-  # Pod IP addresses will be assigned from this pool.
-  ippool.yaml: |
-      apiVersion: v1
-      kind: ipPool
-      metadata:
-        cidr: 192.168.0.0/16
-      spec:
-        ipip:
-          enabled: true
-        nat-outgoing: true
-
 ---
 
 # This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
@@ -166,10 +154,17 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
-            # Don't configure a default pool.  This is done by the Job
-            # below.
-            - name: NO_DEFAULT_POOLS
-              value: "true"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
@@ -271,52 +266,3 @@ spec:
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
-
----
-
-## This manifest deploys a Job which performs one time
-# configuration of Calico
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: configure-calico
-  namespace: kube-system
-  labels:
-    k8s-app: calico
-spec:
-  template:
-    metadata:
-      name: configure-calico
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-    spec:
-      hostNetwork: true
-      restartPolicy: OnFailure
-      containers:
-        # Writes basic configuration to datastore.
-        - name: configure-calico
-          image: quay.io/calico/ctl:{{site.data.versions[page.version].first.components.calicoctl.version}}
-          args:
-          - apply
-          - -f
-          - /etc/config/calico/ippool.yaml
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-          env:
-            # The location of the etcd cluster.
-            - name: ETCD_ENDPOINTS
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_endpoints
-      volumes:
-       - name: config-volume
-         configMap:
-           name: calico-config
-           items:
-            - key: ippool.yaml
-              path: calico/ippool.yaml

--- a/v2.1/getting-started/kubernetes/installation/gce.md
+++ b/v2.1/getting-started/kubernetes/installation/gce.md
@@ -130,27 +130,6 @@ NAME          STATUS                     AGE
 
 {% include {{page.version}}/install-k8s-addons.md %}
 
-## 5. Configure the Calico IP pool
-
-To enable connectivity to the internet for our Pods, we'll use `calicoctl`:
-
-```
-# Log into the master instance.
-gcloud compute ssh kubernetes-master
-
-# Enable outgoing NAT and ipip on the Calico pool.
-docker run -i --rm --net=host quay.io/calico/ctl:{{site.data.versions[page.version].first.components.calicoctl.version}} apply -f -<<EOF
-apiVersion: v1
-kind: ipPool
-metadata:
-  cidr: 192.168.0.0/16
-spec:
-  ipip:
-    enabled: true
-  nat-outgoing: true
-EOF
-```
-
 ## Next Steps
 
 You should now have a fully functioning Kubernetes cluster using Calico for networking.  You're ready to use your cluster.

--- a/v2.1/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -37,16 +37,6 @@ data:
         }
     }
 
-  # The default IP Pool to be created for the cluster.
-  # Pod IP addresses will be assigned from this pool.
-  ippool.yaml: |
-      apiVersion: v1
-      kind: ipPool
-      metadata:
-        cidr: 192.168.0.0/16
-      spec:
-        nat-outgoing: true
-
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.
   etcd_ca: ""   # "/calico-secrets/etcd-ca"
@@ -124,10 +114,15 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
-            # Don't configure a default pool.  This is done by the Job
-            # below.
-            - name: NO_DEFAULT_POOLS
-              value: "true"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
             # Location of the CA certificate for etcd.
@@ -280,80 +275,6 @@ spec:
             - mountPath: /calico-secrets
               name: etcd-certs
       volumes:
-        # Mount in the etcd TLS secrets.
-        - name: etcd-certs
-          secret:
-            secretName: calico-etcd-secrets
-
----
-
-## This manifest deploys a Job which performs one time
-# configuration of Calico
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: configure-calico
-  namespace: kube-system
-  labels:
-    k8s-app: calico
-spec:
-  template:
-    metadata:
-      name: configure-calico
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-    spec:
-      hostNetwork: true
-      restartPolicy: OnFailure
-      containers:
-        # Writes basic configuration to datastore.
-        - name: configure-calico
-          image: quay.io/calico/ctl:{{site.data.versions[page.version].first.components.calicoctl.version}}
-          args:
-          - apply
-          - -f
-          - /etc/config/calico/ippool.yaml
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-            # Mount in the etcd TLS secrets.
-            - mountPath: /calico-secrets
-              name: etcd-certs
-          env:
-            # The location of the etcd cluster.
-            - name: ETCD_ENDPOINTS
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_endpoints
-            # Location of the CA certificate for etcd.
-            - name: ETCD_CA_CERT_FILE
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_ca
-            # Location of the client key for etcd.
-            - name: ETCD_KEY_FILE
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_key
-            # Location of the client certificate for etcd.
-            - name: ETCD_CERT_FILE
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_cert
-      volumes:
-        - name: config-volume
-          configMap:
-            name: calico-config
-            items:
-            - key: ippool.yaml
-              path: calico/ippool.yaml
         # Mount in the etcd TLS secrets.
         - name: etcd-certs
           secret:

--- a/v2.1/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/index.md
@@ -45,21 +45,22 @@ the following configuration parameters:
 
 ### Configuring the Pod IP range
 
-Calico IPAM assigns IP addresses from
-[IP pools]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/ippool). The
-[standard](hosted) and [kubeadm](kubeadm/) manifests include an `ippool.yaml` file which
-configures the default IP pool used by Calico.
+Calico IPAM assigns IP addresses from [IP pools]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/ippool).
 
-To change the default IP range used for pods, modify the `cidr` section of the IP pool.
+To change the default IP range used for pods, modify the `CALICO_IPV4POOL_CIDR` section of the calico.yaml manifest.  For more
+information, see the [calico/node configuration reference]({{site.baseurl}}/{{page.version}}/reference/node/configuration).
 
-> **NOTE**
->
-> The etcdless Calico manifest does not include an IP pool configuration, as IP allocation is done based on
-the Kubernetes node.PodCIDR field, not Calico IP pools.
+### Configuring IP-in-IP
 
-> **NOTE**
->
-> The kubeadm Calico manifest also configures ipip encapsulation on the pool by default.
+By default, the self-hosted manifests enable IP-in-IP encapsulation across subnets.  Many users may
+want to disable IP-in-IP encapsulation, for example if:
+
+- Their cluster is [running in a properly configured AWS VPC]({{site.baseurl}}/{{page.version}}/reference/public-cloud/aws).
+- All their Kubernetes nodes are connected to the same L2 network.
+- They intend to use BGP peering to make their underlying infrastructure aware of Pod IP addresses.
+
+To disable IP-in-IP encapsulation, modify the `CALICO_IPV4POOL_IPIP` section of the manifest.  For more
+information, see the [calico/node configuration reference]({{site.baseurl}}/{{page.version}}/reference/node/configuration).
 
 ### Etcd Configuration
 

--- a/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -36,18 +36,6 @@ data:
         }
     }
 
-  # The default IP Pool to be created for the cluster.
-  # Pod IP addresses will be assigned from this pool.
-  ippool.yaml: |
-      apiVersion: v1
-      kind: ipPool
-      metadata:
-        cidr: 192.168.0.0/16
-      spec:
-        ipip:
-          enabled: true
-        nat-outgoing: true
-
 ---
 
 # This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
@@ -166,10 +154,17 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
-            # Don't configure a default pool.  This is done by the Job
-            # below.
-            - name: NO_DEFAULT_POOLS
-              value: "true"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
             # Auto-detect the BGP IP address.
             - name: IP
               value: ""
@@ -271,52 +266,3 @@ spec:
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
-
----
-
-## This manifest deploys a Job which performs one time
-# configuration of Calico
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: configure-calico
-  namespace: kube-system
-  labels:
-    k8s-app: calico
-spec:
-  template:
-    metadata:
-      name: configure-calico
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
-    spec:
-      hostNetwork: true
-      restartPolicy: OnFailure
-      containers:
-        # Writes basic configuration to datastore.
-        - name: configure-calico
-          image: quay.io/calico/ctl:{{site.data.versions[page.version].first.components.calicoctl.version}}
-          args:
-          - apply
-          - -f
-          - /etc/config/calico/ippool.yaml
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-          env:
-            # The location of the etcd cluster.
-            - name: ETCD_ENDPOINTS
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: etcd_endpoints
-      volumes:
-       - name: config-volume
-         configMap:
-           name: calico-config
-           items:
-            - key: ippool.yaml
-              path: calico/ippool.yaml


### PR DESCRIPTION
Includes #525, so review + merge that first.

This removes the Job used for configuring IP Pools and instead uses the new IPV4POOL_* environment variables.

It also enables IPIP encap by default in the self-hosted manifests for a better "getting started" experience.  Not sure if we want to keep this change, so can be reverted if we think otherwise.