### PR TITLE
Fix networking-calico release links for 2.1

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -74,8 +74,8 @@ v2.1:
       version: v0.5.2
       url: https://github.com/projectcalico/k8s-policy/releases/tag/v0.5.2
     networking-calico:
-      version: 1.4.1
-      url: http://git.openstack.org/cgit/openstack/networking-calico/tree/?id=84d48fbfb
+      version: 1.4.2
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.2
 
 - title: v2.1.0-rc5
   note: |
@@ -113,4 +113,4 @@ v2.1:
       url: https://github.com/projectcalico/k8s-policy/releases/tag/v0.5.2
     networking-calico:
       version: 1.4.1
-      url: http://git.openstack.org/cgit/openstack/networking-calico/tree/?id=84d48fbfb
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.1


### PR DESCRIPTION
- 2.1.0-rc6 has networking-calico 1.4.2, not 1.4.1
- Linking to the version commit is more consistent with the GitHub
  tag-linking that we do for other components, than linking to a tree
  display.