### PR TITLE
Update instructions for etcd install on CentOS/RHEL

### DIFF
--- a/master/getting-started/openstack/upgrade.md
+++ b/master/getting-started/openstack/upgrade.md
@@ -53,12 +53,9 @@ Stop the etcd process:
 
     systemctl stop etcd
 
-Then, download the tested binary (currently 2.0.11) and install it:
+Then upgrade:
 
-    curl -L  https://github.com/coreos/etcd/releases/download/v2.0.11/etcd-v2.0.11-linux-amd64.tar.gz -o etcd-v2.0.11-linux-amd64.tar.gz
-    tar xvf etcd-v2.0.11-linux-amd64.tar.gz
-    cd etcd-v2.0.11-linux-amd64
-    mv etcd* /usr/local/bin/
+    yum update etcd
 
 Now, restart etcd:
 

--- a/v2.1/getting-started/openstack/upgrade.md
+++ b/v2.1/getting-started/openstack/upgrade.md
@@ -53,12 +53,9 @@ Stop the etcd process:
 
     systemctl stop etcd
 
-Then, download the tested binary (currently 2.0.11) and install it:
+Then upgrade:
 
-    curl -L  https://github.com/coreos/etcd/releases/download/v2.0.11/etcd-v2.0.11-linux-amd64.tar.gz -o etcd-v2.0.11-linux-amd64.tar.gz
-    tar xvf etcd-v2.0.11-linux-amd64.tar.gz
-    cd etcd-v2.0.11-linux-amd64
-    mv etcd* /usr/local/bin/
+    yum update etcd
 
 Now, restart etcd:
 


### PR DESCRIPTION
CentOS/RHEL 7 now has a packaged version of etcd (v3) that works well
with Calico, so use that (including its systemd framework) instead of
manually downloading and configuring a tarball.