### PR TITLE
Add code formatting to k8s hosted flags.

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -18,9 +18,9 @@ pod CIDRs for each node.
 
 You must have a cluster which meets the following requirements:
 
-- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing --network-plugin=cni to the kubelet)
-- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing --allocate-node-cidrs=true to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing --cluster-cidr=10.244.0.0/16, which the manifest expects by default).
+- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing `--network-plugin=cni` to the kubelet)
+- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing `--allocate-node-cidrs=true` to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing `--cluster-cidr=10.244.0.0/16`, which the manifest expects by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation
@@ -121,4 +121,3 @@ The above manifest deploys Calico such that Felix uses the Kubernetes API direct
 removing Calico's dependency on etcd and the need for the Calico kubernetes policy controller.
 
 The Calico CNI plugin is still required to configure each pod's virtual ethernet device and network namespace.
-

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -17,9 +17,9 @@ pod CIDRs for each node.
 
 You must have a cluster which meets the following requirements:
 
-- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing --network-plugin=cni to the kubelet)
-- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing --allocate-node-cidrs=true to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing --cluster-cidr=10.244.0.0/16, which the manifest expects by default).
+- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing `--network-plugin=cni` to the kubelet)
+- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing `--allocate-node-cidrs=true` to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing `--cluster-cidr=10.244.0.0/16`, which the manifest expects by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation
@@ -135,4 +135,3 @@ The above manifest deploys Calico such that Felix uses the Kubernetes API direct
 removing Calico's dependency on etcd and the need for the Calico kubernetes policy controller.
 
 The Calico CNI plugin is still required to configure each pod's virtual ethernet device and network namespace.
-

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -18,9 +18,9 @@ pod CIDRs for each node.
 
 You must have a cluster which meets the following requirements:
 
-- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing --network-plugin=cni to the kubelet)
-- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing --allocate-node-cidrs=true to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing --cluster-cidr=10.244.0.0/16, which the manifest expects by default).
+- You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing `--network-plugin=cni` to the kubelet)
+- Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing `--allocate-node-cidrs=true` to the controller manager)
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing `--cluster-cidr=10.244.0.0/16`, which the manifest expects by default).
 - You have configured your network to route pod traffic based on pod CIDR allocations, either through static routes, a Kubernetes cloud-provider integration, or flannel.
 
 ## Installation
@@ -121,4 +121,3 @@ The above manifest deploys Calico such that Felix uses the Kubernetes API direct
 removing Calico's dependency on etcd and the need for the Calico kubernetes policy controller.
 
 The Calico CNI plugin is still required to configure each pod's virtual ethernet device and network namespace.
-


### PR DESCRIPTION
Makes the params look better in http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/