### PR TITLE
Add note to IP Pool on IPIP and Host Endpoints

### DIFF
--- a/master/reference/calicoctl/resources/ippool.md
+++ b/master/reference/calicoctl/resources/ippool.md
@@ -54,3 +54,10 @@ determined when running the calico/node service).
 
 For details on configuring IP-in-IP on your deployment, please read the
 [Configuring IP-in-IP guide]({{site.baseurl}}/{{page.version}}/usage/configuration/ip-in-ip).
+
+> **NOTE**
+>
+> Setting `nat-outgoing` is recommended on any IP Pool with `ipip` enabled.
+When `ipip` is enabled without `nat-outgoing` routing between Workloads and
+Hosts running Calico is asymmetric and may cause traffic to be filtered due to
+[RPF](https://en.wikipedia.org/wiki/Reverse_path_forwarding) checks failing.


### PR DESCRIPTION
Note suggested in https://github.com/projectcalico/calicoctl/issues/1296

This note might be better added to the Host Endpoint section under Getting Started.  WDYT?