### PR TITLE
k8s tutorial changes

### DIFF
--- a/master/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/master/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -46,6 +46,11 @@ kubectl expose --namespace=advanced-policy-demo deployment nginx --port=80
 
 #### Check using calicoctl
 
+  > **Note:**
+  >
+  > This requires the [calicoctl tool to be configured]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/etcdv2).
+  > For example: `export ETCD_ENDPOINTS=http://10.96.232.136:6666`
+
 Now that we've created a Namespace and a set of pods, we should see those objects show up in the
 Calico API using `calicoctl`.
 

--- a/master/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -31,7 +31,7 @@ kubectl get pods --all-namespaces --watch
 The management UI runs as a `NodePort` Service on Kubernetes, and shows the connectivity
 of the Services in this example.
 
-If you're running the vagrant cluster, you can view the UI by visiting `http://172.18.18.102:30002` in a browser.  For other clusters, accessing
+If you're running the vagrant cluster, you can view the UI by visiting `http://<vagrant-ip>:30002` in a browser.  For other clusters, accessing
 the web UI may vary.
 
 Once all the pods are started, they should have full connectivity. You can see this by visiting the UI.  Each service is
@@ -85,3 +85,13 @@ The client can now access the frontend, but not the backend.  Neither the fronte
 can initiate connections to the client.  The frontend can still access the backend.
 
 To use Calico to enforce egress policy on Kubernetes pods, see [the advanced policy demo]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/tutorials/advanced-policy).
+
+### 6) (Optional) Clean up the demo environment.
+
+You can clean up the demo by deleting the demo Namespaces:
+
+```shell
+kubectl delete ns client
+kubectl delete ns stars
+kubectl delete ns management-ui
+```

--- a/master/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -31,8 +31,7 @@ kubectl get pods --all-namespaces --watch
 The management UI runs as a `NodePort` Service on Kubernetes, and shows the connectivity
 of the Services in this example.
 
-If you're running the vagrant cluster, you can view the UI by visiting `http://<vagrant-ip>:30002` in a browser.  For other clusters, accessing
-the web UI may vary.
+You can view the UI by visiting `http://<k8s-node-ip>:30002` in a browser.
 
 Once all the pods are started, they should have full connectivity. You can see this by visiting the UI.  Each service is
 represented by a single node in the graph.

--- a/master/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -91,7 +91,5 @@ To use Calico to enforce egress policy on Kubernetes pods, see [the advanced pol
 You can clean up the demo by deleting the demo Namespaces:
 
 ```shell
-kubectl delete ns client
-kubectl delete ns stars
-kubectl delete ns management-ui
+kubectl delete ns client stars management-ui
 ```

--- a/v2.1/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.1/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -47,6 +47,11 @@ kubectl expose --namespace=advanced-policy-demo deployment nginx --port=80
 
 #### Check using calicoctl
 
+  > **Note:**
+  >
+  > This requires the [calicoctl tool to be configured]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/etcdv2).
+  > For example: `export ETCD_ENDPOINTS=http://10.96.232.136:6666`
+
 Now that we've created a Namespace and a set of pods, we should see those objects show up in the
 Calico API using `calicoctl`.
 

--- a/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -32,7 +32,7 @@ kubectl get pods --all-namespaces --watch
 The management UI runs as a `NodePort` Service on Kubernetes, and shows the connectivity
 of the Services in this example.
 
-If you're running the vagrant cluster, you can view the UI by visiting `http://172.18.18.102:30002` in a browser.  For other clusters, accessing
+If you're running the vagrant cluster, you can view the UI by visiting `http://<vagrant-ip>:30002` in a browser.  For other clusters, accessing
 the web UI may vary.
 
 Once all the pods are started, they should have full connectivity. You can see this by visiting the UI.  Each service is
@@ -86,3 +86,13 @@ The client can now access the frontend, but not the backend.  Neither the fronte
 can initiate connections to the client.  The frontend can still access the backend.
 
 To use Calico to enforce egress policy on Kubernetes pods, see [the advanced policy demo]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/tutorials/advanced-policy).
+
+### 6) (Optional) Clean up the demo environment.
+
+You can clean up the demo by deleting the demo Namespaces:
+
+```shell
+kubectl delete ns client
+kubectl delete ns stars
+kubectl delete ns management-ui
+```

--- a/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -92,7 +92,5 @@ To use Calico to enforce egress policy on Kubernetes pods, see [the advanced pol
 You can clean up the demo by deleting the demo Namespaces:
 
 ```shell
-kubectl delete ns client
-kubectl delete ns stars
-kubectl delete ns management-ui
+kubectl delete ns client stars management-ui
 ```

--- a/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -32,8 +32,7 @@ kubectl get pods --all-namespaces --watch
 The management UI runs as a `NodePort` Service on Kubernetes, and shows the connectivity
 of the Services in this example.
 
-If you're running the vagrant cluster, you can view the UI by visiting `http://<vagrant-ip>:30002` in a browser.  For other clusters, accessing
-the web UI may vary.
+You can view the UI by visiting `http://<k8s-node-ip>:30002` in a browser.
 
 Once all the pods are started, they should have full connectivity. You can see this by visiting the UI.  Each service is
 represented by a single node in the graph.


### PR DESCRIPTION
- Remove the demo namespaces in stars demo (like we do in simple policy demo)
- Add a note in advanced policy demo to set ETCD_ENDPOINTS because it's really easy to miss that (as a user)
- Don't use specific vagrant IP address for the stars demo 