### PR TITLE
Fix links to calico yaml

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/master/getting-started/kubernetes/installation/hosted/hosted.md
@@ -4,7 +4,7 @@ title: Standard Hosted Install
 
 To install Calico as a Kubernetes add-on using your own etcd cluster:
 
-1. Download [`calico.yaml`](calico.yaml)
+1. Download [calico.yaml](calico.yaml)
 2. Configure `etcd_endpoints` in the provided ConfigMap to match your etcd cluster.
 
 Then simply apply the manifest:

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -31,6 +31,8 @@ To install Calico, ensure you have a cluster which meets the above requirements 
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
 ```
 
+>[Click here to view the above yaml directly.](calico.yaml)
+
 Once installed, you can try out NetworkPolicy by following the [simple policy guide](../../../tutorials/simple-policy).
 
 Below are a few examples for how to get started.

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -22,11 +22,15 @@ For Kubeadm <=1.6.0-alpha with Kubernetes 1.5.x:
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
 ```
 
+>[Click here to view the above yaml directly.](calico.yaml)
+
 For Kubeadm >=1.6.0-beta with Kubernetes 1.6.x:
 
 ```
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
 ```
+
+>[Click here to view the above yaml directly.](1.6/calico.yaml)
 
 ## About
 

--- a/v2.1/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,11 +1,11 @@
 ---
-title: Standard Hosted Install 
+title: Standard Hosted Install
 redirect_from: latest/getting-started/kubernetes/installation/hosted/hosted
 ---
 
 To install Calico as a Kubernetes add-on using your own etcd cluster:
 
-1. Download [`calico.yaml`](calico.yaml)
+1. Download [calico.yaml](calico.yaml)
 2. Configure `etcd_endpoints` in the provided ConfigMap to match your etcd cluster.
 
 Then simply apply the manifest:
@@ -16,7 +16,7 @@ kubectl apply -f calico.yaml
 
 > **NOTE**
 >
-> Make sure you configure the provided ConfigMap with the location of your etcd cluster before running the above command. 
+> Make sure you configure the provided ConfigMap with the location of your etcd cluster before running the above command.
 
 ## Configuration Options
 

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -32,6 +32,8 @@ To install Calico, ensure you have a cluster which meets the above requirements 
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
 ```
 
+>[Click here to view the above yaml directly.](calico.yaml)
+
 Once installed, you can try out NetworkPolicy by following the [simple policy guide](../../../tutorials/simple-policy).
 
 Below are a few examples for how to get started.

--- a/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -23,11 +23,15 @@ For Kubeadm <=1.6.0-alpha with Kubernetes 1.5.x:
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
 ```
 
+>[Click here to view the above yaml directly.](calico.yaml)
+
 For Kubeadm >=1.6.0-beta with Kubernetes 1.6.x:
 
 ```
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
 ```
+
+>[Click here to view the above yaml directly.](1.6/calico.yaml)
 
 ## About
 


### PR DESCRIPTION
- code links don't display well on the theme, so remove them for the filename.
- add links to other yaml instruction pages