### PR TITLE
Add ServiceAccounts to everything

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -89,6 +89,7 @@ spec:
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      serviceAccountName: calico-node
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -236,6 +237,7 @@ spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
+      serviceAccountName: calico-policy-controller
       containers:
         - name: calico-policy-controller
           image: quay.io/calico/kube-policy-controller:{{site.data.versions[page.version].first.components["calico/kube-policy-controller"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/index.md
@@ -87,6 +87,20 @@ To use these manifests with a TLS enabled etcd cluster you must do the following
   - `etcd_key: /calico-secrets/etcd-key`
   - `etcd_cert: /calico-secrets/etcd-cert`
 
+### Authorization Options
+
+All of Calico's manifests assign the Pods two serviceaccounts.
+Depending on your cluster's authorization mode, you'll want to back these
+ServiceAccounts with the neccessary permissions.
+
+#### RBAC
+
+If using Calico with RBAC, apply the `ClusterRole` and `ClusterRoleBinding` specs:
+
+```
+kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/rbac.yaml
+```
+
 ### Other Configuration Options
 
 The following table outlines the remaining supported ConfigMap options:

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -57,6 +57,7 @@ spec:
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      serviceAccountName: calico-node
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -128,7 +128,7 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
-      serviceAccountName: calico-cni-plugin
+      serviceAccountName: calico-node
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -271,67 +271,11 @@ spec:
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: calico-cni-plugin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-cni-plugin
-subjects:
-- kind: ServiceAccount
-  name: calico-cni-plugin
-  namespace: kube-system
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: calico-cni-plugin
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-      - nodes
-    verbs:
-      - get
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: calico-cni-plugin
+  name: calico-node
   namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: calico-policy-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calico-policy-controller
-subjects:
-- kind: ServiceAccount
-  name: calico-policy-controller
-  namespace: kube-system
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: calico-policy-controller
-  namespace: kube-system
-rules:
-  - apiGroups:
-    - ""
-    - extensions
-    resources:
-      - pods
-      - namespaces
-      - networkpolicies
-    verbs:
-      - watch
-      - list
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -128,6 +128,7 @@ spec:
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      serviceAccountName: calico-node
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -249,6 +250,7 @@ spec:
       # The policy controller must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
+      serviceAccountName: calico-policy-controller
       containers:
         - name: calico-policy-controller
           image: quay.io/calico/kube-policy-controller:{{site.data.versions[page.version].first.components["calico/kube-policy-controller"].version}}
@@ -268,3 +270,15 @@ spec:
             # kubernetes.default to the correct service clusterIP.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -28,6 +28,11 @@ For Kubeadm >=1.6.0-beta with Kubernetes 1.6.x:
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
 ```
 
+Then, apply Calico's RBAC role and bindings:
+```
+kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/rbac.yaml
+```
+
 ## About
 
 This manifest deploys the standard Calico components described

--- a/master/getting-started/kubernetes/installation/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/rbac.yaml
@@ -1,0 +1,56 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+rules:
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-policy-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-policy-controller
+subjects:
+- kind: ServiceAccount
+  name: calico-policy-controller
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system


### PR DESCRIPTION
Incremental / POC fix for #635

After a bit of research, I've found that serviceaccounts are common amongst Kubernetes authorization methods. So whether using RBAC or ABAC, you'll need a ServiceAccount.

This PR removes the RBAC specific aspects into their own specific file, leaving the ServiceAccoutns where they are. This opens us up to supporting ABAC clusters as well.

This PR additionally adds ServiceAccounts to all Calico yamls. This will allow us to optionally support authorization methods on all deployments.