### PR TITLE
Add 1.6 compliant k8s-backend manifests

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/1.6/calico.yaml
@@ -86,7 +86,7 @@ spec:
               value: "false"
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
-              value: "true"
+              value: "false"
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/1.6/calico.yaml
@@ -1,0 +1,157 @@
+---
+layout: null
+---
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      # Tolerate the taint placed on masters in kubeadm 1.6
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      hostNetwork: true
+      serviceAccountName: calico-node
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix debug logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "debug"
+            # Don't enable BGP.
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
+            - name: CALICO_IPV4POOL_CIDR
+              value: "10.244.0.0/16"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # No IP address needed.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -25,13 +25,36 @@ You must have a cluster which meets the following requirements:
 
 ## Installation
 
-To install Calico, ensure you have a cluster which meets the above requirements and run the following command:
+To install Calico, ensure you have a cluster which meets the above requirements and run the following command.
+
+For kubernetes 1.6 clusters:
+
+```
+kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/1.6/calico.yaml
+```
+
+>[Click here to view the above yaml directly.](1.6/calico.yaml)
+
+For Kubernetes 1.5 clusters:
 
 ```
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
 ```
 
 >[Click here to view the above yaml directly.](calico.yaml)
+
+### RBAC
+
+If your Kubernetes cluster has RBAC enabled, you'll need to create RBAC roles for Calico.
+Apply the following manifest to create these RBAC roles.
+
+>Note: Currently, only the above 1.6 manifest assigns service accounts to Calico components.
+
+```
+kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/rbac.yaml
+```
+
+>[Click here to view the above yaml directly.](rbac.yaml)
 
 Once installed, you can try out NetworkPolicy by following the [simple policy guide](../../../tutorials/simple-policy).
 

--- a/master/getting-started/kubernetes/installation/hosted/k8s-backend/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/k8s-backend/rbac.yaml
@@ -1,0 +1,78 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - thirdpartyresources
+    verbs:
+      - get
+      - create
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+      - get
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - globalconfigs
+    verbs:
+      - create
+      - get
+      - update
+      - watch
+      - list
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - create
+      - list
+      - get
+      - update
+      - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system


### PR DESCRIPTION
Fixes #654 (including temp workaround for https://github.com/projectcalico/calicoctl/issues/1596 )

- Tolerations moved from annotations to toleration field
- Added serviceaccounts
- RBAC roles via additional yaml file
- add workaround for WAITFORDATASTOREISSUE ( https://github.com/projectcalico/calicoctl/issues/1596 )

RBAC file is separate from core yaml as this is not kubeadm specific YAMLS, but general k8s-datstore yamls which should work on any 1.6+ cluster (kubeadm or not).