### PR TITLE
Updating etcdless docs

### DIFF
--- a/_data/master/navbars/getting-started.yml
+++ b/_data/master/navbars/getting-started.yml
@@ -21,8 +21,8 @@ toc:
         path: /getting-started/kubernetes/installation/hosted/hosted
       - title: Kubeadm Hosted Install
         path: /getting-started/kubernetes/installation/hosted/kubeadm/
-      - title: Etcdless Hosted Install
-        path: /getting-started/kubernetes/installation/hosted/k8s-backend/
+      - title: Kubernetes Datastore Hosted Install
+        path: /getting-started/kubernetes/installation/hosted/kubernetes-datastore/
     - title: Integration Guide
       path: /getting-started/kubernetes/installation/integration
     - title: AWS

--- a/master/getting-started/kubernetes/installation/hosted/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/index.md
@@ -21,7 +21,7 @@ the recommended hosted approach for deploying Calico in production.
 This manifest installs Calico as well as a single node etcd cluster.  This is the recommended hosted approach
 for getting started quickly with Calico in conjunction with tools like kubeadm.
 
-#### [Etcdless Hosted Install](k8s-backend/)
+#### [Kubernetes Datastore](kubernetes-datastore/)
 
 This manifest installs Calico in a mode where it does not require its own etcd cluster.  This is an experimental
 mode in which the Kubernetes API is used by Calico as its datastore.
@@ -130,8 +130,8 @@ be filled in automatically by the `calico/cni` container:
 
 > **NOTE**
 >
-> The following information applies to the etcdv2 backend only. See the [etcdless hosted install](k8s-backend/)
-for how to run calicoctl in an etcdless installation.
+> The following information applies to the etcdv2 backend only. See the [Kubernetes datastore install](kubernetes-datastore/)
+for how to run calicoctl in an Kubernetes datastore driver installation.
 
 Using calicoctl is no different on a self-hosted installation.  However, the manifests above do not
 install calicoctl.

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -12,7 +12,6 @@ data:
   cni_network_config: |-
     {
         "name": "k8s-pod-network",
-        "cniVersion": "0.3.1",
         "type": "calico",
         "log_level": "debug",
         "datastore_type": "kubernetes",
@@ -71,9 +70,6 @@ spec:
             # Enable felix debug logging.
             - name: FELIX_LOGSEVERITYSCREEN
               value: "debug"
-            # Don't enable BGP.
-            - name: CALICO_NETWORKING_BACKEND
-              value: "none"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -89,6 +85,9 @@ spec:
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "10.244.0.0/16"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
             # Set based on the k8s node name.
             - name: NODENAME
               valueFrom:
@@ -146,3 +145,11 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
@@ -1,0 +1,148 @@
+---
+layout: null
+---
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "cniVersion": "0.3.1",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix debug logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "debug"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
+            - name: CALICO_IPV4POOL_CIDR
+              value: "10.244.0.0/16"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # No IP address needed.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d

--- a/master/getting-started/kubernetes/installation/hosted/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/rbac.yaml
@@ -1,0 +1,78 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - thirdpartyresources
+    verbs:
+      - get
+      - create
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+      - get
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - globalconfigs
+    verbs:
+      - create
+      - get
+      - update
+      - watch
+      - list
+  - apiGroups: ["projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - create
+      - list
+      - get
+      - update
+      - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system

--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -21,7 +21,7 @@ for most users.
 
 > **NOTE:**
 >
-> Calico can also enforce network policy [without a dependency on etcd](hosted/k8s-backend/). This feature is currently experimental
+> Calico can also enforce network policy [without a dependency on etcd](hosted/kubernetes-datastore/). This feature is currently experimental
 and is currently only supported as via hosted install.
 
 ## About the Calico Components

--- a/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -54,7 +54,9 @@ coreos:
         --master=$private_ipv4:8080 \
         --service-account-private-key-file=/var/run/kubernetes/apiserver.key \
         --root-ca-file=/var/run/kubernetes/apiserver.crt \
-        --logtostderr=true
+        --logtostderr=true \
+        --allocate-node-cidrs=true \
+        --cluster-cidr="10.244.0.0/16"
         Restart=always
         RestartSec=10
 
@@ -118,7 +120,7 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         ExecStart=/opt/bin/kube-proxy \
         --master=http://$private_ipv4:8080 \
-        --cluster-cidr="192.168.0.0/16" \
+        --cluster-cidr="10.244.0.0/16" \
         --proxy-mode=iptables \
         --logtostderr=true
         Restart=always

--- a/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -78,7 +78,7 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         ExecStart=/opt/bin/kube-proxy \
         --master=http://172.18.18.101:8080 \
-        --cluster-cidr="192.168.0.0/16" \
+        --cluster-cidr="10.244.0.0/16" \
         --proxy-mode=iptables \
         --logtostderr=true
         Restart=always

--- a/master/reference/calicoctl/setup/kubernetes.md
+++ b/master/reference/calicoctl/setup/kubernetes.md
@@ -8,7 +8,7 @@ This document covers the configuration options for calicoctl when using the Kube
 > **Note**
 >
 > This is an experimental feature. If running Calico on Kubernetes with the etcdv2 datastore, see the [etcdv2 configuration document](etcdv2) instead.
-> For more information on running with the Kubernetes datastore, see [the installation guide](/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/)
+> For more information on running with the Kubernetes datastore, see [the installation guide](/{{page.version}}/getting-started/kubernetes/installation/hosted/kubernetes-datastore/)
 
 There are two ways to configure calicoctl with your Kubernetes API details: 
 configuration file or environment variables.

--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -31,6 +31,12 @@ The `calico/node` container is primarily configured through environment variable
 | ETCD_KEY_FILE     | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)       | string | |
 | ETCD_CERT_FILE    | Path to the etcd client cert, e.g. `/etc/calico/cert.pem` (optional)    | string | |
 | ETCD_CA_CERT_FILE | Path to the etcd CA file, e.g. `/etc/calico/ca.pem` (optional)        | string | |
+| KUBECONFIG | When using the kubernetes datastore, the location of a kubeconfig file to use. | string | |
+| K8S_API_ENDPOINT | Location of the Kubernetes API.  Not required if using kubeconfig. | string | |
+| K8S_CERT_FILE | Location of a client certificate for accessing the Kubernetes API. | string | |
+| K8S_KEY_FILE | Location of a client key for accessing the Kubernetes API. | string | |
+| K8S_CA_FILE | Location of a CA for accessing the Kubernetes API. | string | |
+| K8S_TOKEN | Token to be used for accessing the Kubernetes API. | string | |
 
 In addition to the above, `calico/node` also supports [the standard Felix configuration environment variables](../felix/configuration).
 


### PR DESCRIPTION
Fixes #661 
Fixes #660 
Fixes #654 

- Renamed page to "Kubernetes Datastore Driver"
- Updating to be more inline with new BGP features in KDD
  - Removed Flannel references in kbeadm section
  - Removed routing limitation
- Updated calico.yaml manifest to use BGP routing