### PR TITLE
Update bird route reflector install instructions on RHEL7

### DIFF
--- a/master/usage/routereflector/bird-rr-config.md
+++ b/master/usage/routereflector/bird-rr-config.md
@@ -50,8 +50,7 @@ be sufficient:
 
 If that fails, try the following instead:
 
-    wget https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
-    sudo yum install epel-release-7-9.noarch.rpm
+    sudo yum install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 
 With that complete, you can now install BIRD:
 

--- a/master/usage/routereflector/bird-rr-config.md
+++ b/master/usage/routereflector/bird-rr-config.md
@@ -50,11 +50,11 @@ be sufficient:
 
 If that fails, try the following instead:
 
-    sudo yum install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+    sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 With that complete, you can now install BIRD:
 
-    yum install -y bird bird6
+    yum install -y bird{,6}
 
 ### Step 2: Set your BIRD IPv4 configuration
 


### PR DESCRIPTION
* Use `yum install http:///` instead of wget and then yum install for the epel release rpm
* Use a fancy bash parameter expansion to the `yum install bird...` to reduce duplication
* Install the latest epel-7 release rpm as they remove old packages from the epel repos regularly