### PR TITLE
Fix up k8s 1.6 manifests.

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -51,13 +51,22 @@ spec:
       labels:
         k8s-app: calico-node
       annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       serviceAccountName: calico-node
+      tolerations:
+        # Allow the pod to run on the master.  This is required for
+        # the master to communicate with pods.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        # Mark the pod as a critical add-on for rescheduling.
+        - "key":"CriticalAddonsOnly"
+          "operator":"Exists"
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -57,6 +57,7 @@ spec:
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      serviceAccountName: calico-node
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -51,13 +51,22 @@ spec:
       labels:
         k8s-app: calico-node
       annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       serviceAccountName: calico-node
+      tolerations:
+        # Allow the pod to run on the master.  This is required for
+        # the master to communicate with pods.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        # Mark the pod as a critical add-on for rescheduling.
+        - "key":"CriticalAddonsOnly"
+          "operator":"Exists"
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -57,6 +57,7 @@ spec:
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
+      serviceAccountName: calico-node
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each


### PR DESCRIPTION
Add `serviceAcccountName`, without that, the calico-node container doesn't pick up the RBAC config.

Also, fix up the tolerations to 1.6 format.

Fixes #695