### PR TITLE
Fix invalid yaml format for KDD manifest

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -65,8 +65,8 @@ spec:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
         # Mark the pod as a critical add-on for rescheduling.
-        - "key":"CriticalAddonsOnly"
-          "operator":"Exists"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -65,8 +65,8 @@ spec:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
         # Mark the pod as a critical add-on for rescheduling.
-        - "key":"CriticalAddonsOnly"
-          "operator":"Exists"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each


### PR DESCRIPTION
seems like we had an invalid yaml format for KDD:

```
$ kubectl apply -f http://docs.projectcalico.org/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
configmap "calico-config" created
error: yaml: line 34: did not find expected '-' indicator
```