### PR TITLE
Revert the cniVersion to v0.1.0

### DIFF
--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -132,7 +132,7 @@ mkdir -p /etc/cni/net.d
 cat >/etc/cni/net.d/10-calico.conf <<EOF
 {
     "name": "calico-k8s-network",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "etcd_endpoints": "http://<ETCD_IP>:<ETCD_PORT>",
     "log_level": "info",

--- a/master/getting-started/mesos/installation/dc-os/custom.md
+++ b/master/getting-started/mesos/installation/dc-os/custom.md
@@ -96,7 +96,7 @@ on each agent:
    cat <<EOF > /opt/mesosphere/etc/dcos/network/cni/calico.conf
    {
        "name": "calico",
-       "cniVersion": "0.3.1",
+       "cniVersion": "0.1.0",
        "type": "calico",
        "ipam": {
            "type": "calico-ipam"

--- a/master/getting-started/mesos/installation/integration.md
+++ b/master/getting-started/mesos/installation/integration.md
@@ -61,7 +61,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
    cat > $NETWORK_CNI_CONF_DIR/calico.conf <<EOF
    {
       "name": "calico",
-      "cniVersion": "0.3.1",
+      "cniVersion": "0.1.0",
       "type": "calico",
       "ipam": {
           "type": "calico-ipam"

--- a/master/getting-started/rkt/installation/manual.md
+++ b/master/getting-started/rkt/installation/manual.md
@@ -140,7 +140,7 @@ The Calico CNI plugins require a standard CNI config file.
 To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
 
 - Each network should be given a unique "name".
-- Specify the CNI specification version with "cniVersion", for example "cniVersion": "0.3.1".
+- Specify the CNI specification version with "cniVersion", for example "cniVersion": "0.1.0".
 - To use Calico networking, specify "type": "calico"
 - To use Calico IPAM, specify "type": "calico-ipam" in the "ipam" section.
 
@@ -158,7 +158,7 @@ For example, run the following to create a network called "mynet"
 cat >/etc/rkt/net.d/10-calico-mynet.conf <<EOF
 {
     "name": "mynet",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "etcd_endpoints": "http://<ETCD_IP>:<ETCD_PORT>",
     "type": "calico",
     "ipam": {

--- a/master/getting-started/rkt/tutorials/basic.md
+++ b/master/getting-started/rkt/tutorials/basic.md
@@ -49,7 +49,7 @@ This worked example creates two rkt networks. Run these commands on both `calico
 cat >/etc/rkt/net.d/10-calico-network1.conf <<EOF
 {
     "name": "network1",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -60,7 +60,7 @@ EOF
 cat >/etc/rkt/net.d/10-calico-network2.conf <<EOF
 {
     "name": "network2",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"

--- a/master/reference/cni-plugin/configuration.md
+++ b/master/reference/cni-plugin/configuration.md
@@ -9,7 +9,7 @@ A minimal configuration file that uses Calico for networking and IPAM looks like
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -73,7 +73,7 @@ The following deprecated options are also supported
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "log_level": "DEBUG",
     "ipam": {
@@ -103,7 +103,7 @@ Example CNI config:
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam",
@@ -128,7 +128,7 @@ When using the Calico CNI plugin with Kubernetes, the plugin must be able to acc
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "kubernetes": {
         "kubeconfig": "/path/to/kubeconfig"
@@ -144,7 +144,7 @@ As a convenience, the API location location can also be configured directly, e.g
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "kubernetes": {
         "k8s_api_root": "http://127.0.0.1:8080"
@@ -163,7 +163,7 @@ There is a single supported policy type, `k8s` which uses the Kubernetes Network
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "policy": {
       "type": "k8s",
@@ -202,7 +202,7 @@ When using the CNI `host-local` IPAM plugin, a special value `usePodCidr` is all
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "kubernetes": {
         "kubeconfig": "/path/to/kubeconfig",

--- a/v2.2/getting-started/kubernetes/installation/integration.md
+++ b/v2.2/getting-started/kubernetes/installation/integration.md
@@ -132,7 +132,7 @@ mkdir -p /etc/cni/net.d
 cat >/etc/cni/net.d/10-calico.conf <<EOF
 {
     "name": "calico-k8s-network",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "etcd_endpoints": "http://<ETCD_IP>:<ETCD_PORT>",
     "log_level": "info",

--- a/v2.2/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.2/getting-started/mesos/installation/dc-os/custom.md
@@ -96,7 +96,7 @@ on each agent:
    cat <<EOF > /opt/mesosphere/etc/dcos/network/cni/calico.conf
    {
        "name": "calico",
-       "cniVersion": "0.3.1",
+       "cniVersion": "0.1.0",
        "type": "calico",
        "ipam": {
            "type": "calico-ipam"

--- a/v2.2/getting-started/mesos/installation/integration.md
+++ b/v2.2/getting-started/mesos/installation/integration.md
@@ -61,7 +61,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
    cat > $NETWORK_CNI_CONF_DIR/calico.conf <<EOF
    {
       "name": "calico",
-      "cniVersion": "0.3.1",
+      "cniVersion": "0.1.0",
       "type": "calico",
       "ipam": {
           "type": "calico-ipam"

--- a/v2.2/getting-started/rkt/installation/manual.md
+++ b/v2.2/getting-started/rkt/installation/manual.md
@@ -140,7 +140,7 @@ The Calico CNI plugins require a standard CNI config file.
 To define a rkt network for Calico, create a configuration file in `/etc/rkt/net.d/`.
 
 - Each network should be given a unique "name".
-- Specify the CNI specification version with "cniVersion", for example "cniVersion": "0.3.1".
+- Specify the CNI specification version with "cniVersion", for example "cniVersion": "0.1.0".
 - To use Calico networking, specify "type": "calico"
 - To use Calico IPAM, specify "type": "calico-ipam" in the "ipam" section.
 
@@ -158,7 +158,7 @@ For example, run the following to create a network called "mynet"
 cat >/etc/rkt/net.d/10-calico-mynet.conf <<EOF
 {
     "name": "mynet",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "etcd_endpoints": "http://<ETCD_IP>:<ETCD_PORT>",
     "type": "calico",
     "ipam": {

--- a/v2.2/getting-started/rkt/tutorials/basic.md
+++ b/v2.2/getting-started/rkt/tutorials/basic.md
@@ -49,7 +49,7 @@ This worked example creates two rkt networks. Run these commands on both `calico
 cat >/etc/rkt/net.d/10-calico-network1.conf <<EOF
 {
     "name": "network1",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -60,7 +60,7 @@ EOF
 cat >/etc/rkt/net.d/10-calico-network2.conf <<EOF
 {
     "name": "network2",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"

--- a/v2.2/reference/cni-plugin/configuration.md
+++ b/v2.2/reference/cni-plugin/configuration.md
@@ -9,7 +9,7 @@ A minimal configuration file that uses Calico for networking and IPAM looks like
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam"
@@ -73,7 +73,7 @@ The following deprecated options are also supported
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "log_level": "DEBUG",
     "ipam": {
@@ -103,7 +103,7 @@ Example CNI config:
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "ipam": {
         "type": "calico-ipam",
@@ -128,7 +128,7 @@ When using the Calico CNI plugin with Kubernetes, the plugin must be able to acc
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "kubernetes": {
         "kubeconfig": "/path/to/kubeconfig"
@@ -144,7 +144,7 @@ As a convenience, the API location location can also be configured directly, e.g
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "kubernetes": {
         "k8s_api_root": "http://127.0.0.1:8080"
@@ -163,7 +163,7 @@ There is a single supported policy type, `k8s` which uses the Kubernetes Network
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "policy": {
       "type": "k8s",
@@ -202,7 +202,7 @@ When using the CNI `host-local` IPAM plugin, a special value `usePodCidr` is all
 ```json
 {
     "name": "any_name",
-    "cniVersion": "0.3.1",
+    "cniVersion": "0.1.0",
     "type": "calico",
     "kubernetes": {
         "kubeconfig": "/path/to/kubeconfig",


### PR DESCRIPTION
We can run into problems if we put a newer version and the IPAM plugin
(e.g. host-local) doesn't support. We don't need a newer version so
let's stick with the older one for now.

Fixes #742