### PR TITLE
Use "nodename" instead of "hostname" in CNI configs

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -21,7 +21,7 @@ data:
         "type": "calico",
         "log_level": "debug",
         "datastore_type": "kubernetes",
-        "hostname": "__KUBERNETES_NODE_NAME__",
+        "nodename": "__KUBERNETES_NODE_NAME__",
         "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
@@ -22,7 +22,7 @@ data:
         "type": "calico",
         "log_level": "debug",
         "datastore_type": "kubernetes",
-        "hostname": "__KUBERNETES_NODE_NAME__",
+        "nodename": "__KUBERNETES_NODE_NAME__",
         "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -21,7 +21,7 @@ data:
         "type": "calico",
         "log_level": "debug",
         "datastore_type": "kubernetes",
-        "hostname": "__KUBERNETES_NODE_NAME__",
+        "nodename": "__KUBERNETES_NODE_NAME__",
         "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
@@ -22,7 +22,7 @@ data:
         "type": "calico",
         "log_level": "debug",
         "datastore_type": "kubernetes",
-        "hostname": "__KUBERNETES_NODE_NAME__",
+        "nodename": "__KUBERNETES_NODE_NAME__",
         "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"


### PR DESCRIPTION
hostname is deprecated

fixes #743