### PR TITLE
Unify k8s ip pool (restore cluster-cidr to previous value)

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -100,7 +100,7 @@ spec:
               value: "true"
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
-              value: "10.244.0.0/16"
+              value: "192.168.0.0/16"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "always"

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
@@ -91,7 +91,7 @@ spec:
               value: "true"
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
-              value: "10.244.0.0/16"
+              value: "192.168.0.0/16"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "always"

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -20,7 +20,7 @@ You must have a cluster which meets the following requirements:
 
 - You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing `--network-plugin=cni` to the kubelet)
 - Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing `--allocate-node-cidrs=true` to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing `--cluster-cidr=10.244.0.0/16`, which the manifest expects by default).
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing `--cluster-cidr=192.168.0.0/16`, which the manifest expects by default).
 
 ## Installation
 
@@ -69,7 +69,7 @@ steps that require it.
 To initialize the master run
 
 ```
-kubeadm init --pod-network-cidr=10.244.0.0/16
+kubeadm init --pod-network-cidr=192.168.0.0/16
 ```
 
 Then run the following command to install Calico.

--- a/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -50,13 +50,14 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kube-controller-manager
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
+        # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
         --service-account-private-key-file=/var/run/kubernetes/apiserver.key \
         --root-ca-file=/var/run/kubernetes/apiserver.crt \
         --logtostderr=true \
         --allocate-node-cidrs=true \
-        --cluster-cidr="10.244.0.0/16"
+        --cluster-cidr="192.168.0.0/16"
         Restart=always
         RestartSec=10
 
@@ -118,9 +119,10 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
+        # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://$private_ipv4:8080 \
-        --cluster-cidr="10.244.0.0/16" \
+        --cluster-cidr="192.168.0.0/16" \
         --proxy-mode=iptables \
         --logtostderr=true
         Restart=always

--- a/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -76,9 +76,10 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
+        # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://172.18.18.101:8080 \
-        --cluster-cidr="10.244.0.0/16" \
+        --cluster-cidr="192.168.0.0/16" \
         --proxy-mode=iptables \
         --logtostderr=true
         Restart=always

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/1.6/calico.yaml
@@ -100,7 +100,7 @@ spec:
               value: "true"
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
-              value: "10.244.0.0/16"
+              value: "192.168.0.0/16"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "always"

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico.yaml
@@ -91,7 +91,7 @@ spec:
               value: "true"
             # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
-              value: "10.244.0.0/16"
+              value: "192.168.0.0/16"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "always"

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -20,7 +20,7 @@ You must have a cluster which meets the following requirements:
 
 - You have a Kubernetes cluster configured to use CNI network plugins (i.e. by passing `--network-plugin=cni` to the kubelet)
 - Your Kubernetes controller manager is configured to allocate pod CIDRs (i.e. by passing `--allocate-node-cidrs=true` to the controller manager)
-- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing `--cluster-cidr=10.244.0.0/16`, which the manifest expects by default).
+- Your Kubernetes controller manager has been provided a cluster-cidr (i.e. by passing `--cluster-cidr=192.168.0.0/16`, which the manifest expects by default).
 
 ## Installation
 
@@ -69,7 +69,7 @@ steps that require it.
 To initialize the master run
 
 ```
-kubeadm init --pod-network-cidr=10.244.0.0/16
+kubeadm init --pod-network-cidr=192.168.0.0/16
 ```
 
 Then run the following command to install Calico.

--- a/v2.2/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/v2.2/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -50,13 +50,14 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kube-controller-manager
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
+        # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
         --service-account-private-key-file=/var/run/kubernetes/apiserver.key \
         --root-ca-file=/var/run/kubernetes/apiserver.crt \
         --logtostderr=true \
         --allocate-node-cidrs=true \
-        --cluster-cidr="10.244.0.0/16"
+        --cluster-cidr="192.168.0.0/16"
         Restart=always
         RestartSec=10
 
@@ -118,9 +119,10 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
+        # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://$private_ipv4:8080 \
-        --cluster-cidr="10.244.0.0/16" \
+        --cluster-cidr="192.168.0.0/16" \
         --proxy-mode=iptables \
         --logtostderr=true
         Restart=always

--- a/v2.2/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/v2.2/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -76,9 +76,10 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.6.0/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
+        # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://172.18.18.101:8080 \
-        --cluster-cidr="10.244.0.0/16" \
+        --cluster-cidr="192.168.0.0/16" \
         --proxy-mode=iptables \
         --logtostderr=true
         Restart=always


### PR DESCRIPTION
Fixes #741 
The `cluster-cidr` expected by the K8s etcd manifests is `192.168.0.0/16` (the default if no `cluster-cidr`) is specified.  A value of `10.244.0.0/16` was explicitly set which broke accessing a k8s service when using the etcd manifests.  This change restores that value to the default (though sets it explicitly) and changes the kdd manifests to match that value.