### PR TITLE
Improve K8s vagrant experience for slow connections

### DIFF
--- a/_includes/master/kubernetes/fetch_k8s_binaries.sh
+++ b/_includes/master/kubernetes/fetch_k8s_binaries.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+k8s_ver="v1.6.2"
+
+if [ $# -eq 0 ]; then
+    binaries="kubectl kube-apiserver kube-controller-manager kubelet kube-proxy kube-scheduler"
+else
+    binaries="$@"
+fi
+
+mkdir -p k8s
+
+for x in $binaries; do
+  ver_binary=${x}-$k8s_ver
+  if [ ! -f k8s/${ver_binary}.downloaded ]; then
+    /usr/bin/wget -O k8s/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/$k8s_ver/bin/linux/amd64/$x
+    if [ $? -eq 0 ]; then
+      touch k8s/${ver_binary}.downloaded
+    fi
+  else
+    echo "$x ($k8s_ver) already downloaded"
+  fi
+done

--- a/_includes/master/kubernetes/k8s_binary_init.sh
+++ b/_includes/master/kubernetes/k8s_binary_init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+k8s_ver="v1.6.2"
+
+if [ ! -d /k8s ]; then
+  mkdir /k8s
+  # fetch_k8s_binaries.sh downloads to a subdirectory k8s so cd to the the
+  # parent directory
+  cd /
+  /opt/k8s/setup/fetch_k8s_binaries.sh $@
+fi
+
+mkdir -p /opt/bin
+
+for x in $@; do
+  binary=$x
+  ver_binary=${binary}-$k8s_ver
+  if [ ! -f /k8s/${ver_binary}.downloaded ]; then
+    echo "ERROR: $binary version $k8s_ver was not downloaded"
+    exit 1
+  fi
+  cp /k8s/${ver_binary} /opt/bin/$binary
+  /usr/bin/chmod +x /opt/bin/$binary
+done

--- a/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -28,16 +28,22 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
-  # To speed up multiple 'vagrant up' commands or when experiencing failures
-  # of the systemd service 'user-data' a 'k8s' directory can be created to cache
-  # the Kubernetes binaries.  The binaries can be pre-downloaded but refer
-  # to the cloud-config's for the expected format of the downloaded files.
+  # To speed up multiple runs of 'vagrant up' or when experiencing failures
+  # of the systemd service 'user-data', the Kubernetes binaries can be
+  # pre-downloaded.  To download the binaries, downloaded the script
+  # {{site.url}}{{page.dir}}fetch_k8s_binaries.sh
+  # into the same directory as this Vagrantfile, make it executable with
+  # `chmod +x fetch_k8s_binaries.sh`, and then run it to create a k8s directory
+  # and download the needed k8s binaries.
   #
-  # If the directory exists in the same folder as the Vagrant file
-  # it will be mounted into each VM.  (This requires nfsd in Linux and
-  # may prompt for superuser permissions.)
-  if File.directory?(File.expand_path("./k8s"))
-    config.vm.synced_folder "./k8s", "/k8s", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp,ro']
+  # If the environment variable K8S_CACHED is set to true and if the directory
+  # exists in the same folder as this Vagrantfile it will be mounted into
+  # each VM.  (This requires nfsd in Linux and may prompt for superuser
+  # permissions. This has only been tested on linux.)
+  if ENV['K8S_CACHED'] == "true"
+    if File.directory?(File.expand_path("./k8s"))
+      config.vm.synced_folder "./k8s", "/k8s", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp,ro']
+    end
   end
 
   $fetch_k8s= <<SCRIPT

--- a/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,18 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # To speed up multiple 'vagrant up' commands or when experiencing failures
+  # of the systemd service 'user-data' a 'k8s' directory can be created to cache
+  # the Kubernetes binaries.  The binaries can be pre-downloaded but refer
+  # to the cloud-config's for the expected format of the downloaded files.
+  #
+  # If the directory exists in the same folder as the Vagrant file
+  # it will be mounted into each VM.  (This requires nfsd in Linux and
+  # may prompt for superuser permissions.)
+  if File.directory?(File.expand_path("./k8s"))
+    config.vm.synced_folder "./k8s", "/k8s", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp']
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -1,3 +1,7 @@
+---
+layout: null
+---
+
 # Size of the cluster created by Vagrant
 num_instances=3
 
@@ -33,8 +37,15 @@ Vagrant.configure("2") do |config|
   # it will be mounted into each VM.  (This requires nfsd in Linux and
   # may prompt for superuser permissions.)
   if File.directory?(File.expand_path("./k8s"))
-    config.vm.synced_folder "./k8s", "/k8s", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp']
+    config.vm.synced_folder "./k8s", "/k8s", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp,ro']
   end
+
+  $fetch_k8s= <<SCRIPT
+{% include {{page.version}}/kubernetes/fetch_k8s_binaries.sh %}
+SCRIPT
+  $init_k8s= <<SCRIPT
+{% include {{page.version}}/kubernetes/k8s_binary_init.sh %}
+SCRIPT
 
   # Set up each box
   (1..num_instances).each do |i|
@@ -53,7 +64,11 @@ Vagrant.configure("2") do |config|
       host.vm.provision :shell, :inline => "sudo /usr/bin/ip addr flush dev eth1"
       host.vm.provision :shell, :inline => "sudo /usr/bin/ip addr add #{ip}/24 dev eth1"
 
-      host.vm.provision :file, :source => "fetch_k8s_binaries.sh", :destination => "/tmp/fetch_k8s_binaries.sh"
+      host.vm.provision :shell, :inline => "sudo mkdir -p /opt/k8s/setup"
+      host.vm.provision :shell, :inline => "echo '#{$fetch_k8s}' > /opt/k8s/setup/fetch_k8s_binaries.sh"
+      host.vm.provision :shell, :inline => "echo '#{$init_k8s}' > /opt/k8s/setup/k8s_binary_init.sh"
+      host.vm.provision :shell, :inline => "sudo chmod +x /opt/k8s/setup/*"
+
 
       if i == 1
         # Configure the master.

--- a/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -53,6 +53,8 @@ Vagrant.configure("2") do |config|
       host.vm.provision :shell, :inline => "sudo /usr/bin/ip addr flush dev eth1"
       host.vm.provision :shell, :inline => "sudo /usr/bin/ip addr add #{ip}/24 dev eth1"
 
+      host.vm.provision :file, :source => "fetch_k8s_binaries.sh", :destination => "/tmp/fetch_k8s_binaries.sh"
+
       if i == 1
         # Configure the master.
         host.vm.provision :file, :source => "master-config.yaml", :destination => "/tmp/vagrantfile-user-data"

--- a/master/getting-started/kubernetes/installation/vagrant/fetch_k8s_binaries.sh
+++ b/master/getting-started/kubernetes/installation/vagrant/fetch_k8s_binaries.sh
@@ -1,22 +1,4 @@
-#!/bin/bash
-k8s_ver="v1.6.2"
-
-if [ $# -eq 0 ]; then
-    binaries="kubectl kube-apiserver kube-controller-manager kubelet kube-proxy kube-scheduler"
-else
-    binaries="$@"
-fi
-
-mkdir -p k8s
-
-for x in $binaries; do
-  ver_binary=${x}-$k8s_ver
-  if [ ! -f k8s/${ver_binary}.downloaded ]; then
-    /usr/bin/wget -O k8s/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/$k8s_ver/bin/linux/amd64/$x
-    if [ $? -eq 0 ]; then
-      touch k8s/${ver_binary}.downloaded
-    fi
-  else
-    echo "$x ($k8s_ver) already downloaded"
-  fi
-done
+---
+layout: null
+---
+{% include {{page.version}}/kubernetes/fetch_k8s_binaries.sh %}

--- a/master/getting-started/kubernetes/installation/vagrant/fetch_k8s_binaries.sh
+++ b/master/getting-started/kubernetes/installation/vagrant/fetch_k8s_binaries.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+k8s_ver="v1.6.2"
+
+if [ $# -eq 0 ]; then
+    binaries="kubectl kube-apiserver kube-controller-manager kubelet kube-proxy kube-scheduler"
+else
+    binaries="$@"
+fi
+
+mkdir -p k8s
+
+for x in $binaries; do
+  ver_binary=${x}-$k8s_ver
+  if [ ! -f k8s/${ver_binary}.downloaded ]; then
+    /usr/bin/wget -O k8s/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/$k8s_ver/bin/linux/amd64/$x
+    if [ $? -eq 0 ]; then
+      touch k8s/${ver_binary}.downloaded
+    fi
+  else
+    echo "$x ($k8s_ver) already downloaded"
+  fi
+done

--- a/master/getting-started/kubernetes/installation/vagrant/index.md
+++ b/master/getting-started/kubernetes/installation/vagrant/index.md
@@ -17,6 +17,7 @@ These instructions allow you to set up a Kubernetes cluster with Calico networki
     curl -O {{site.url}}{{page.dir}}Vagrantfile
     curl -O {{site.url}}{{page.dir}}master-config.yaml
     curl -O {{site.url}}{{page.dir}}node-config.yaml
+    curl -O {{site.url}}{{page.dir}}fetch_k8s_binaries.sh
 
 ### 1.3 Startup and SSH
 

--- a/master/getting-started/kubernetes/installation/vagrant/index.md
+++ b/master/getting-started/kubernetes/installation/vagrant/index.md
@@ -17,7 +17,6 @@ These instructions allow you to set up a Kubernetes cluster with Calico networki
     curl -O {{site.url}}{{page.dir}}Vagrantfile
     curl -O {{site.url}}{{page.dir}}master-config.yaml
     curl -O {{site.url}}{{page.dir}}node-config.yaml
-    curl -O {{site.url}}{{page.dir}}fetch_k8s_binaries.sh
 
 ### 1.3 Startup and SSH
 

--- a/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -1,23 +1,6 @@
 #cloud-config
 ---
 
-write_files:
-  - path: /load_k8s_binary.sh
-    permissions: '0755'
-    content: |
-      #!/bin/bash
-      k8s_ver=v1.6.2
-
-      binary=$1
-      ver_binary=${binary}-$k8s_ver
-      dl_path=/k8s
-      if [ ! -f $dl_path/${ver_binary}.downloaded ]; then
-        exit 1
-      fi
-      mkdir -p /opt/bin
-      cp $dl_path/${ver_binary} /opt/bin/$binary
-      /usr/bin/chmod +x /opt/bin/$binary
-
 coreos:
   update:
     reboot-strategy: off
@@ -32,7 +15,7 @@ coreos:
         [Service]
         Type=oneshot
         TimeoutStartSec=1800
-        ExecStart=/bin/sh -c "cd /; /tmp/fetch_k8s_binaries.sh"
+        ExecStart=/opt/k8s/setup/k8s_binary_init.sh kubectl kube-apiserver kube-controller-manager kubelet kube-proxy kube-scheduler
         RemainAfterExit=true
     - name: etcd-member.service
       command: start
@@ -53,8 +36,6 @@ coreos:
         After=etcd-member.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/load_k8s_binary.sh kubectl
-        ExecStartPre=/load_k8s_binary.sh kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
         --allow-privileged=true \
         --etcd-servers=http://$private_ipv4:2379 \
@@ -77,7 +58,6 @@ coreos:
         After=kube-apiserver.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/load_k8s_binary.sh kube-controller-manager
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
@@ -99,7 +79,6 @@ coreos:
         After=kube-apiserver.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/load_k8s_binary.sh kube-scheduler
         ExecStart=/opt/bin/kube-scheduler --master=$private_ipv4:8080
         Restart=always
         RestartSec=10
@@ -116,7 +95,6 @@ coreos:
 
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/load_k8s_binary.sh kubelet
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
         --allow-privileged=true \
@@ -143,7 +121,6 @@ coreos:
         After=kubelet.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/load_k8s_binary.sh kube-proxy
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://$private_ipv4:8080 \

--- a/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -1,5 +1,25 @@
 #cloud-config
 ---
+write_files:
+  - path: /load_k8s_binary.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      k8s_ver="v1.6.2"
+
+      binary=$1
+      ver_binary=${binary}-$k8s_ver
+      mkdir -p /k8s
+      if [ ! -f /k8s/${ver_binary}.downloaded ]; then
+        /usr/bin/wget -O /k8s/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/$k8s_ver/bin/linux/amd64/$binary
+        if [ $? -eq 0 ]; then
+          touch /k8s/${ver_binary}.downloaded
+        fi
+      fi
+      mkdir -p /opt/bin
+      cp /k8s/${ver_binary} /opt/bin/$binary
+      /usr/bin/chmod +x /opt/bin/$binary
+
 coreos:
   update:
     reboot-strategy: off
@@ -23,10 +43,8 @@ coreos:
         After=etcd-member.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kubectl
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kube-apiserver
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubectl
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
+        ExecStartPre=/load_k8s_binary.sh kubectl
+        ExecStartPre=/load_k8s_binary.sh kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
         --allow-privileged=true \
         --etcd-servers=http://$private_ipv4:2379 \
@@ -49,8 +67,7 @@ coreos:
         After=kube-apiserver.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kube-controller-manager
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
+        ExecStartPre=/load_k8s_binary.sh kube-controller-manager
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
@@ -72,8 +89,7 @@ coreos:
         After=kube-apiserver.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kube-scheduler
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler
+        ExecStartPre=/load_k8s_binary.sh kube-scheduler
         ExecStart=/opt/bin/kube-scheduler --master=$private_ipv4:8080
         Restart=always
         RestartSec=10
@@ -90,8 +106,7 @@ coreos:
 
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kubelet
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
+        ExecStartPre=/load_k8s_binary.sh kubelet
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
         --allow-privileged=true \
@@ -118,8 +133,7 @@ coreos:
         After=kubelet.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kube-proxy
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
+        ExecStartPre=/load_k8s_binary.sh kube-proxy
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://$private_ipv4:8080 \

--- a/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -1,29 +1,39 @@
 #cloud-config
 ---
+
 write_files:
   - path: /load_k8s_binary.sh
     permissions: '0755'
     content: |
       #!/bin/bash
-      k8s_ver="v1.6.2"
+      k8s_ver=v1.6.2
 
       binary=$1
       ver_binary=${binary}-$k8s_ver
-      mkdir -p /k8s
-      if [ ! -f /k8s/${ver_binary}.downloaded ]; then
-        /usr/bin/wget -O /k8s/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/$k8s_ver/bin/linux/amd64/$binary
-        if [ $? -eq 0 ]; then
-          touch /k8s/${ver_binary}.downloaded
-        fi
+      dl_path=/k8s
+      if [ ! -f $dl_path/${ver_binary}.downloaded ]; then
+        exit 1
       fi
       mkdir -p /opt/bin
-      cp /k8s/${ver_binary} /opt/bin/$binary
+      cp $dl_path/${ver_binary} /opt/bin/$binary
       /usr/bin/chmod +x /opt/bin/$binary
 
 coreos:
   update:
     reboot-strategy: off
   units:
+    - name: runcmd.service
+      command: start
+      content: |
+        [Unit]
+        Description=Downloads Kubernetes binaries
+        Before=kube-apiserver.service kube-controller-manager.service kube-scheduler.service kubelet.service kube-proxy.service
+
+        [Service]
+        Type=oneshot
+        TimeoutStartSec=1800
+        ExecStart=/bin/sh -c "cd /; /tmp/fetch_k8s_binaries.sh"
+        RemainAfterExit=true
     - name: etcd-member.service
       command: start
       drop-ins:

--- a/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -5,7 +5,7 @@ coreos:
   update:
     reboot-strategy: off
   units:
-    - name: runcmd.service
+    - name: k8s-binary-installation.service
       command: start
       content: |
         [Unit]
@@ -16,6 +16,8 @@ coreos:
         Type=oneshot
         TimeoutStartSec=1800
         ExecStart=/opt/k8s/setup/k8s_binary_init.sh kubectl kube-apiserver kube-controller-manager kubelet kube-proxy kube-scheduler
+        # Ensure that this service remains running so the dependent
+        # services are not blocked waiting for this service.
         RemainAfterExit=true
     - name: etcd-member.service
       command: start

--- a/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -30,18 +30,45 @@ write_files:
       ver_binary=${binary}-$k8s_ver
       dl_path=/k8s
       if [ ! -f $dl_path/${ver_binary}.downloaded ]; then
-        # On nodes do not download to same location as master does
-        dl_path=/k8s_local; mkdir -p $dl_path;
-        /usr/bin/wget -O $dl_path/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/${k8s_ver}/bin/linux/amd64/$binary
+        exit 1
       fi
       mkdir -p /opt/bin
       cp $dl_path/${ver_binary} /opt/bin/$binary
       /usr/bin/chmod +x /opt/bin/$binary
+  - path: /k8s_init_download.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      k8s_ver=v1.6.2
+
+      binaries="kubelet kube-proxy"
+
+      for x in $binaries; do
+        if [ ! -f /k8s/${x}-$k8s_ver.downloaded ]; then
+          umount /k8s
+          mkdir -p /k8s
+          break;
+        fi
+      done
+      cd /
+      /tmp/fetch_k8s_binaries.sh kubelet kube-proxy
 
 coreos:
   update:
     reboot-strategy: off
   units:
+    - name: runcmd.service
+      command: start
+      content: |
+        [Unit]
+        Description=Downloads Kubernetes binaries
+        Before=kubelet.service kube-proxy.service
+
+        [Service]
+        Type=oneshot
+        TimeoutStartSec=1800
+        ExecStart=/k8s_init_download.sh
+        RemainAfterExit=true
     - name: etcd-member.service
       command: start
       drop-ins:

--- a/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -20,6 +20,23 @@ write_files:
           user: kubelet
         name: kubelet-context
       current-context: kubelet-context
+  - path: /load_k8s_binary.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      k8s_ver=v1.6.2
+
+      binary=$1
+      ver_binary=${binary}-$k8s_ver
+      dl_path=/k8s
+      if [ ! -f $dl_path/${ver_binary}.downloaded ]; then
+        # On nodes do not download to same location as master does
+        dl_path=/k8s_local; mkdir -p $dl_path;
+        /usr/bin/wget -O $dl_path/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/${k8s_ver}/bin/linux/amd64/$binary
+      fi
+      mkdir -p /opt/bin
+      cp $dl_path/${ver_binary} /opt/bin/$binary
+      /usr/bin/chmod +x /opt/bin/$binary
 
 coreos:
   update:
@@ -47,9 +64,8 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/containernetworking/cni/releases/download/v0.5.1/cni-v0.5.1.tgz
         ExecStartPre=/usr/bin/tar -xvf /opt/cni/bin/cni-v0.5.1.tgz -C /opt/cni/bin
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kubelet
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/load_k8s_binary.sh kubelet
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
         --allow-privileged=true \
@@ -75,8 +91,7 @@ coreos:
         After=kubelet.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kube-proxy
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
+        ExecStartPre=/load_k8s_binary.sh kube-proxy
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://172.18.18.101:8080 \

--- a/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -25,7 +25,7 @@ coreos:
   update:
     reboot-strategy: off
   units:
-    - name: runcmd.service
+    - name: k8s-binary-installation.service
       command: start
       content: |
         [Unit]
@@ -36,6 +36,8 @@ coreos:
         Type=oneshot
         TimeoutStartSec=1800
         ExecStart=/opt/k8s/setup/k8s_binary_init.sh kubelet kube-proxy
+        # Ensure that this service remains running so the dependent
+        # services are not blocked waiting for this service.
         RemainAfterExit=true
     - name: etcd-member.service
       command: start

--- a/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -20,38 +20,6 @@ write_files:
           user: kubelet
         name: kubelet-context
       current-context: kubelet-context
-  - path: /load_k8s_binary.sh
-    permissions: '0755'
-    content: |
-      #!/bin/bash
-      k8s_ver=v1.6.2
-
-      binary=$1
-      ver_binary=${binary}-$k8s_ver
-      dl_path=/k8s
-      if [ ! -f $dl_path/${ver_binary}.downloaded ]; then
-        exit 1
-      fi
-      mkdir -p /opt/bin
-      cp $dl_path/${ver_binary} /opt/bin/$binary
-      /usr/bin/chmod +x /opt/bin/$binary
-  - path: /k8s_init_download.sh
-    permissions: '0755'
-    content: |
-      #!/bin/bash
-      k8s_ver=v1.6.2
-
-      binaries="kubelet kube-proxy"
-
-      for x in $binaries; do
-        if [ ! -f /k8s/${x}-$k8s_ver.downloaded ]; then
-          umount /k8s
-          mkdir -p /k8s
-          break;
-        fi
-      done
-      cd /
-      /tmp/fetch_k8s_binaries.sh kubelet kube-proxy
 
 coreos:
   update:
@@ -67,7 +35,7 @@ coreos:
         [Service]
         Type=oneshot
         TimeoutStartSec=1800
-        ExecStart=/k8s_init_download.sh
+        ExecStart=/opt/k8s/setup/k8s_binary_init.sh kubelet kube-proxy
         RemainAfterExit=true
     - name: etcd-member.service
       command: start
@@ -92,7 +60,6 @@ coreos:
         ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/containernetworking/cni/releases/download/v0.5.1/cni-v0.5.1.tgz
         ExecStartPre=/usr/bin/tar -xvf /opt/cni/bin/cni-v0.5.1.tgz -C /opt/cni/bin
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=/load_k8s_binary.sh kubelet
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
         --allow-privileged=true \
@@ -118,7 +85,6 @@ coreos:
         After=kubelet.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/load_k8s_binary.sh kube-proxy
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://172.18.18.101:8080 \


### PR DESCRIPTION
## Description
This is a new feature that improves the user experience over a slow connection or when destroying and recreating a K8s vagrant environment repeatedly.

## The changes
- Adds a folder that if present and if K8S_CACHED is set true vagrant will mount the folder into each VM
- Uses the same fetch_k8s_binaries.sh script in both the node, master, and available for direct download by the user
- If the binaries are not cached, they will all be downloaded, moved to the correct location, and set executable by one script instead of being done by each service.

## Testing
- I have ran this with the new directory created and empty, created and populated, and the directory not created.
- It would be good for someone on a Mac to test that the Vagrantfile is not broken if the k8s directory does not exist and check on the behavior if it does.