### PR TITLE
Ensure node image is specified on node run command

### DIFF
--- a/master/getting-started/bare-metal/bare-metal.md
+++ b/master/getting-started/bare-metal/bare-metal.md
@@ -125,7 +125,7 @@ There are several ways to install Felix.
     [this document](bare-metal-install) to use the calico-felix binary
     directly.
 
--   if you want to run under docker, you can use `calicoctl node run` to start
+-   if you want to run under docker, you can use `calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}` to start
     the calico/node container image.  This container packages up the core Calico
     components to provide both Calico networking and network policy.  Running
     the container automatically pre-initializes the etcd database (which the

--- a/master/getting-started/docker/installation/manual.md
+++ b/master/getting-started/docker/installation/manual.md
@@ -17,7 +17,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo calicoctl node run
+   sudo calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
    ```
 
 Check that `calico/node` is now running:
@@ -45,10 +45,10 @@ To print the command `calicoctl node run` uses to launch Calico on this host,
 run the command with the `--init-system` and `--dry-run` flags:
 
 ```
-$ calicoctl node run --init-system --dryrun
+$ calicoctl node run --init-system --dryrun --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 Use the following command to start the calico/node container:
 
-docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock quay.io/calico/node:master
+docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 
 Use the following command to stop the calico/node container:
 

--- a/master/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/master/getting-started/docker/installation/vagrant-coreos/index.md
@@ -68,7 +68,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 
 This will start the `calico/node` container on this host. Check it is running:
 
@@ -78,7 +78,7 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-    408bd2b9ba53        quay.io/calico/node:latest   "start_runit"       About an hour ago   Up About an hour                        calico-node
+    408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 
 ## Next Steps
 

--- a/master/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/master/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -65,7 +65,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 
 This will start the `calico/node` container on this host. Check it is running:
 

--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -58,7 +58,7 @@ wget {{site.data.versions[page.version].first.components.calicoctl.download_url}
 sudo chmod +x calicoctl
 
 # Run the calico/node container
-sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run
+sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 ```
 
 See the [`calicoctl node run` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/)

--- a/master/getting-started/mesos/installation/integration.md
+++ b/master/getting-started/mesos/installation/integration.md
@@ -20,7 +20,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run
+   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
    ```
 
    >Note: Ensure you've set or replaced `$ETCD_IP` and `$ETCD_PORT` to point to

--- a/v2.3/getting-started/bare-metal/bare-metal.md
+++ b/v2.3/getting-started/bare-metal/bare-metal.md
@@ -125,7 +125,7 @@ There are several ways to install Felix.
     [this document](bare-metal-install) to use the calico-felix binary
     directly.
 
--   if you want to run under docker, you can use `calicoctl node run` to start
+-   if you want to run under docker, you can use `calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}` to start
     the calico/node container image.  This container packages up the core Calico
     components to provide both Calico networking and network policy.  Running
     the container automatically pre-initializes the etcd database (which the

--- a/v2.3/getting-started/docker/installation/manual.md
+++ b/v2.3/getting-started/docker/installation/manual.md
@@ -17,7 +17,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo calicoctl node run
+   sudo calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
    ```
 
 Check that `calico/node` is now running:
@@ -45,10 +45,10 @@ To print the command `calicoctl node run` uses to launch Calico on this host,
 run the command with the `--init-system` and `--dry-run` flags:
 
 ```
-$ calicoctl node run --init-system --dryrun
+$ calicoctl node run --init-system --dryrun --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 Use the following command to start the calico/node container:
 
-docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock quay.io/calico/node:master
+docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 
 Use the following command to stop the calico/node container:
 

--- a/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
@@ -68,7 +68,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 
 This will start the `calico/node` container on this host. Check it is running:
 
@@ -78,7 +78,7 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-    408bd2b9ba53        quay.io/calico/node:latest   "start_runit"       About an hour ago   Up About an hour                        calico-node
+    408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 
 ## Next Steps
 

--- a/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -65,7 +65,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 
 This will start the `calico/node` container on this host. Check it is running:
 

--- a/v2.3/getting-started/kubernetes/installation/integration.md
+++ b/v2.3/getting-started/kubernetes/installation/integration.md
@@ -58,7 +58,7 @@ wget {{site.data.versions[page.version].first.components.calicoctl.download_url}
 sudo chmod +x calicoctl
 
 # Run the calico/node container
-sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run
+sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
 ```
 
 See the [`calicoctl node run` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/)

--- a/v2.3/getting-started/mesos/installation/integration.md
+++ b/v2.3/getting-started/mesos/installation/integration.md
@@ -20,7 +20,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run
+   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
    ```
 
    >Note: Ensure you've set or replaced `$ETCD_IP` and `$ETCD_PORT` to point to


### PR DESCRIPTION
The `calicoctl node run` no longer defaults the node image to the same version as calicoctl (since the node and calicoctl are becoming un-linked).

This updates the guides that use `calicoctl node run` to include the node image.

Required for v2.3 and master.
