### PR TITLE
Fix missing : in calico/node image name

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -309,6 +309,7 @@ v2.3:
     calico/node:
       version: v1.3.0-rc1
       url: https://github.com/projectcalico/calicoctl/releases/tag/v1.3.0-rc1
+      img: quay.io/calico/node:v1.3.0-rc1
     calico/cni:
       version: v1.9.1
       url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.9.1
@@ -707,6 +708,7 @@ master:
      calico/node:
       version: master
       url: ""
+      img: quay.io/calico/node:master
      calico/cni:
       version: master
       url: ""

--- a/master/getting-started/bare-metal/bare-metal.md
+++ b/master/getting-started/bare-metal/bare-metal.md
@@ -125,7 +125,7 @@ There are several ways to install Felix.
     [this document](bare-metal-install) to use the calico-felix binary
     directly.
 
--   if you want to run under docker, you can use `calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}` to start
+-   if you want to run under docker, you can use `calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}` to start
     the calico/node container image.  This container packages up the core Calico
     components to provide both Calico networking and network policy.  Running
     the container automatically pre-initializes the etcd database (which the

--- a/master/getting-started/docker/installation/manual.md
+++ b/master/getting-started/docker/installation/manual.md
@@ -17,7 +17,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+   sudo calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
    ```
 
 Check that `calico/node` is now running:
@@ -25,7 +25,7 @@ Check that `calico/node` is now running:
 ```
 vagrant@calico-01:~$ docker ps
 CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
+408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 ```
 
 Furthermore, check that the `calico/node` container is functioning properly
@@ -45,10 +45,10 @@ To print the command `calicoctl node run` uses to launch Calico on this host,
 run the command with the `--init-system` and `--dry-run` flags:
 
 ```
-$ calicoctl node run --init-system --dryrun --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+$ calicoctl node run --init-system --dryrun --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 Use the following command to start the calico/node container:
 
-docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock {{site.data.versions[page.version].first.components["calico/node"].img}}
 
 Use the following command to stop the calico/node container:
 

--- a/master/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/master/getting-started/docker/installation/vagrant-coreos/index.md
@@ -68,7 +68,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 
 This will start the `calico/node` container on this host. Check it is running:
 
@@ -78,7 +78,7 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-    408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
+    408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 
 ## Next Steps
 

--- a/master/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/master/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -65,7 +65,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 
 This will start the `calico/node` container on this host. Check it is running:
 
@@ -75,7 +75,7 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-    408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
+    408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 
 ## Next Steps
 

--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -58,7 +58,7 @@ wget {{site.data.versions[page.version].first.components.calicoctl.download_url}
 sudo chmod +x calicoctl
 
 # Run the calico/node container
-sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 ```
 
 See the [`calicoctl node run` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/)
@@ -93,7 +93,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -v /run/docker/plugins:/run/docker/plugins \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /var/log/calico:/var/log/calico \
-  quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
+  {{site.data.versions[page.version].first.components["calico/node"].img}}
 ExecStop=/usr/bin/docker rm -f calico-node
 Restart=always
 RestartSec=10

--- a/master/getting-started/mesos/installation/integration.md
+++ b/master/getting-started/mesos/installation/integration.md
@@ -20,7 +20,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
    ```
 
    >Note: Ensure you've set or replaced `$ETCD_IP` and `$ETCD_PORT` to point to
@@ -31,7 +31,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
    ```
    vagrant@calico-01:~$ docker ps
    CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-   408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       3 seconds ago       Up 2 seconds                            calico-node
+   408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       3 seconds ago       Up 2 seconds                            calico-node
    ```
 
    Furthermore, check that the `calico/node` container is functioning properly

--- a/master/reference/calicoctl/commands/node/run.md
+++ b/master/reference/calicoctl/commands/node/run.md
@@ -78,7 +78,7 @@ Options:
                            [default: /var/log/calico]
      --node-image=<DOCKER_IMAGE_NAME>
                            Docker image to use for Calico's per-node container.
-                           [default: quay.io/calico/node:%s]
+                           [default: quay.io/calico/node:latest]
      --backend=(bird|gobgp|none)
                            Specify which networking backend to use.  When set
                            to "none", Calico node runs in policy only mode.
@@ -135,7 +135,7 @@ Enabling IPv6 forwarding
 Increasing conntrack limit
 Running the following command:
 
-docker run --net=host --privileged --name=calico-node -d --restart=always -e ETCD_SCHEME=http -e HOSTNAME=calico -e CALICO_LIBNETWORK_ENABLED=true -e ETCD_AUTHORITY=127.0.0.1:2379 -e AS= -e NO_DEFAULT_POOLS= -e ETCD_ENDPOINTS= -e IP= -e IP6= -e CALICO_NETWORKING_BACKEND=bird -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
+docker run --net=host --privileged --name=calico-node -d --restart=always -e ETCD_SCHEME=http -e HOSTNAME=calico -e CALICO_LIBNETWORK_ENABLED=true -e ETCD_AUTHORITY=127.0.0.1:2379 -e AS= -e NO_DEFAULT_POOLS= -e ETCD_ENDPOINTS= -e IP= -e IP6= -e CALICO_NETWORKING_BACKEND=bird -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins quay.io/calico/node:latest
 
 Waiting for etcd connection...
 Using configured IPv4 address: 192.0.2.0
@@ -278,7 +278,7 @@ sudo calicoctl node run --ip autodetect --ip-autodetection-method interface=eth.
                          [default: /var/log/calico]
    --node-image=<DOCKER_IMAGE_NAME>
                          Docker image to use for Calico's per-node container.
-                         [default: quay.io/calico/node:%s]
+                         [default: quay.io/calico/node:latest]
    --backend=(bird|gobgp|none)
                          Specify which networking backend to use.  When set
                          to "none", Calico node runs in policy only mode.

--- a/v2.3/getting-started/bare-metal/bare-metal.md
+++ b/v2.3/getting-started/bare-metal/bare-metal.md
@@ -125,7 +125,7 @@ There are several ways to install Felix.
     [this document](bare-metal-install) to use the calico-felix binary
     directly.
 
--   if you want to run under docker, you can use `calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}` to start
+-   if you want to run under docker, you can use `calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}` to start
     the calico/node container image.  This container packages up the core Calico
     components to provide both Calico networking and network policy.  Running
     the container automatically pre-initializes the etcd database (which the

--- a/v2.3/getting-started/docker/installation/manual.md
+++ b/v2.3/getting-started/docker/installation/manual.md
@@ -17,7 +17,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+   sudo calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
    ```
 
 Check that `calico/node` is now running:
@@ -25,7 +25,7 @@ Check that `calico/node` is now running:
 ```
 vagrant@calico-01:~$ docker ps
 CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
+408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 ```
 
 Furthermore, check that the `calico/node` container is functioning properly
@@ -45,10 +45,10 @@ To print the command `calicoctl node run` uses to launch Calico on this host,
 run the command with the `--init-system` and `--dry-run` flags:
 
 ```
-$ calicoctl node run --init-system --dryrun --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+$ calicoctl node run --init-system --dryrun --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 Use the following command to start the calico/node container:
 
-docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+docker run --net=host --privileged --name=calico-node --rm -e ETCD_AUTHORITY=127.0.0.1:2379 -e ETCD_SCHEME=http -e ETCD_ENDPOINTS= -e NODENAME=calico -e CALICO_NETWORKING_BACKEND=bird -e NO_DEFAULT_POOLS= -e CALICO_LIBNETWORK_ENABLED=true -e CALICO_LIBNETWORK_IFPREFIX=cali -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins -v /var/run/docker.sock:/var/run/docker.sock {{site.data.versions[page.version].first.components["calico/node"].img}}
 
 Use the following command to stop the calico/node container:
 

--- a/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
@@ -68,7 +68,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 
 This will start the `calico/node` container on this host. Check it is running:
 
@@ -78,7 +78,7 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-    408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
+    408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 
 ## Next Steps
 

--- a/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -65,7 +65,7 @@ it is time to launch `calico/node`.
 
 The Vagrant machines already have `calicoctl` installed. Use it to launch `calico/node`:
 
-    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+    sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 
 This will start the `calico/node` container on this host. Check it is running:
 
@@ -75,7 +75,7 @@ You should see output like this on each node
 
     vagrant@calico-01:~$ docker ps
     CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-    408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
+    408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       About an hour ago   Up About an hour                        calico-node
 
 ## Next Steps
 

--- a/v2.3/getting-started/kubernetes/installation/integration.md
+++ b/v2.3/getting-started/kubernetes/installation/integration.md
@@ -58,7 +58,7 @@ wget {{site.data.versions[page.version].first.components.calicoctl.download_url}
 sudo chmod +x calicoctl
 
 # Run the calico/node container
-sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+sudo ETCD_ENDPOINTS=http://<ETCD_IP>:<ETCD_PORT> ./calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
 ```
 
 See the [`calicoctl node run` documentation]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node/)
@@ -93,7 +93,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -v /run/docker/plugins:/run/docker/plugins \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /var/log/calico:/var/log/calico \
-  quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
+  {{site.data.versions[page.version].first.components["calico/node"].img}}
 ExecStop=/usr/bin/docker rm -f calico-node
 Restart=always
 RestartSec=10

--- a/v2.3/getting-started/mesos/installation/integration.md
+++ b/v2.3/getting-started/mesos/installation/integration.md
@@ -20,7 +20,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
 3. Launch `calico/node`:
 
    ```
-   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run --node-image=quay.io/calico/node{{site.data.versions[page.version].first.components["calico/node"].version}}
+   sudo ETCD_ENDPOINTS=http://$ETCD_IP:$ETCD_PORT calicoctl node run --node-image={{site.data.versions[page.version].first.components["calico/node"].img}}
    ```
 
    >Note: Ensure you've set or replaced `$ETCD_IP` and `$ETCD_PORT` to point to
@@ -31,7 +31,7 @@ Calico runs as a Docker container on each host. The `calicoctl` command line too
    ```
    vagrant@calico-01:~$ docker ps
    CONTAINER ID        IMAGE                        COMMAND             CREATED             STATUS              PORTS               NAMES
-   408bd2b9ba53        quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}   "start_runit"       3 seconds ago       Up 2 seconds                            calico-node
+   408bd2b9ba53        {{site.data.versions[page.version].first.components["calico/node"].img}}   "start_runit"       3 seconds ago       Up 2 seconds                            calico-node
    ```
 
    Furthermore, check that the `calico/node` container is functioning properly

--- a/v2.3/reference/calicoctl/commands/node/run.md
+++ b/v2.3/reference/calicoctl/commands/node/run.md
@@ -78,7 +78,7 @@ Options:
                            [default: /var/log/calico]
      --node-image=<DOCKER_IMAGE_NAME>
                            Docker image to use for Calico's per-node container.
-                           [default: quay.io/calico/node:%s]
+                           [default: quay.io/calico/node:latest]
      --backend=(bird|gobgp|none)
                            Specify which networking backend to use.  When set
                            to "none", Calico node runs in policy only mode.
@@ -135,7 +135,7 @@ Enabling IPv6 forwarding
 Increasing conntrack limit
 Running the following command:
 
-docker run --net=host --privileged --name=calico-node -d --restart=always -e ETCD_SCHEME=http -e HOSTNAME=calico -e CALICO_LIBNETWORK_ENABLED=true -e ETCD_AUTHORITY=127.0.0.1:2379 -e AS= -e NO_DEFAULT_POOLS= -e ETCD_ENDPOINTS= -e IP= -e IP6= -e CALICO_NETWORKING_BACKEND=bird -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins quay.io/calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
+docker run --net=host --privileged --name=calico-node -d --restart=always -e ETCD_SCHEME=http -e HOSTNAME=calico -e CALICO_LIBNETWORK_ENABLED=true -e ETCD_AUTHORITY=127.0.0.1:2379 -e AS= -e NO_DEFAULT_POOLS= -e ETCD_ENDPOINTS= -e IP= -e IP6= -e CALICO_NETWORKING_BACKEND=bird -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/calico:/var/run/calico -v /lib/modules:/lib/modules -v /var/log/calico:/var/log/calico -v /run/docker/plugins:/run/docker/plugins quay.io/calico/node:latest
 
 Waiting for etcd connection...
 Using configured IPv4 address: 192.0.2.0
@@ -278,7 +278,7 @@ sudo calicoctl node run --ip autodetect --ip-autodetection-method interface=eth.
                          [default: /var/log/calico]
    --node-image=<DOCKER_IMAGE_NAME>
                          Docker image to use for Calico's per-node container.
-                         [default: quay.io/calico/node:%s]
+                         [default: quay.io/calico/node:latest]
    --backend=(bird|gobgp|none)
                          Specify which networking backend to use.  When set
                          to "none", Calico node runs in policy only mode.


### PR DESCRIPTION
Typo in calico/node image name (missing :) ... Have updated some files to use a new variable in the versions file (so that we declare once).

TODO:
Update remaining instances (but not planning to do that in this PR since that would require a full QA).