### PR TITLE
Add KDD specific default deny to k8s tutorials

### DIFF
--- a/master/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/master/getting-started/kubernetes/tutorials/simple-policy.md
@@ -46,9 +46,27 @@ You should see a response from `nginx`.  Great! Our Service is accessible.  You 
 
 Let's turn on isolation in our policy-demo Namespace.  Calico will then prevent connections to pods in this Namespace.
 
+#### When using the etcd datastore
+
 ```
 kubectl annotate ns policy-demo "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
 ```
+
+#### When using the Kubernetes API datastore
+
+```
+kubectl create -f - <<EOF
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: default-deny
+  namespace: policy-demo
+spec:
+  podSelector:
+EOF
+```
+
+#### Test Isolation
 
 This will prevent all access to the nginx Service.  We can see the effect by trying to access the Service again.
 

--- a/master/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -42,12 +42,23 @@ represented by a single node in the graph.
 
 ### 2) Enable isolation
 
+The following will prevent all access to the frontend, backend, and client Services.
+
+#### When using the etcd datastore
+
 ```shell
 kubectl annotate ns stars "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
 kubectl annotate ns client "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
 ```
 
-This will prevent all access to the frontend, backend, and client Services.
+#### When using the Kubernetes API datastore
+
+```shell
+kubectl create -n stars -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+kubectl create -n client -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+```
+
+#### Confirm isolation
 
 Refresh the management UI (it may take up to 10 seconds for changes to be reflected in the UI).
 Now that we've enabled isolation, the UI can no longer access the pods, and so they will no longer show up in the UI.

--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
@@ -1,0 +1,6 @@
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: default-deny
+spec:
+  podSelector:

--- a/v2.3/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.3/getting-started/kubernetes/tutorials/simple-policy.md
@@ -46,9 +46,27 @@ You should see a response from `nginx`.  Great! Our Service is accessible.  You 
 
 Let's turn on isolation in our policy-demo Namespace.  Calico will then prevent connections to pods in this Namespace.
 
+#### When using the etcd datastore
+
 ```
 kubectl annotate ns policy-demo "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
 ```
+
+#### When using the Kubernetes API datastore
+
+```
+kubectl create -f - <<EOF
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: default-deny
+  namespace: policy-demo
+spec:
+  podSelector:
+EOF
+```
+
+#### Test Isolation
 
 This will prevent all access to the nginx Service.  We can see the effect by trying to access the Service again.
 

--- a/v2.3/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.3/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -42,12 +42,23 @@ represented by a single node in the graph.
 
 ### 2) Enable isolation
 
+The following will prevent all access to the frontend, backend, and client Services.
+
+#### When using the etcd datastore
+
 ```shell
 kubectl annotate ns stars "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
 kubectl annotate ns client "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
 ```
 
-This will prevent all access to the frontend, backend, and client Services.
+#### When using the Kubernetes API datastore
+
+```shell
+kubectl create -n stars -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+kubectl create -n client -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+```
+
+#### Confirm isolation
 
 Refresh the management UI (it may take up to 10 seconds for changes to be reflected in the UI).
 Now that we've enabled isolation, the UI can no longer access the pods, and so they will no longer show up in the UI.

--- a/v2.3/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+++ b/v2.3/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
@@ -1,0 +1,6 @@
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: default-deny
+spec:
+  podSelector:


### PR DESCRIPTION
The DefaultDeny is no longer implemented with an annotation on the namespace when using KDD.  This PR creates a Policy that matches all pods in a Namespace which causes incoming traffic to be denied by default.

Fixes #839 
