### PR TITLE
Update docker setup requirements

### DIFF
--- a/master/getting-started/docker/installation/manual.md
+++ b/master/getting-started/docker/installation/manual.md
@@ -5,7 +5,7 @@ title: Installing Calico for Docker
 Calico runs as a Docker container on each host. The `calicoctl` command line tool can be used to launch the `calico/node` container.
 
 > Before following the steps here ensure that you have satisfied these
-[requirements](({{site.baseurl}}/{{page.version}}/getting-started/docker/installation/requirements).
+[requirements]({{site.baseurl}}/{{page.version}}/getting-started/docker/installation/requirements).
 
 ## Using calicoctl
 

--- a/master/getting-started/docker/installation/manual.md
+++ b/master/getting-started/docker/installation/manual.md
@@ -4,6 +4,9 @@ title: Installing Calico for Docker
 
 Calico runs as a Docker container on each host. The `calicoctl` command line tool can be used to launch the `calico/node` container.
 
+> Before following the steps here ensure that you have satisfied these
+[requirements](({{site.baseurl}}/{{page.version}}/getting-started/docker/installation/requirements).
+
 ## Using calicoctl
 
 1. Download the calicoctl binary:

--- a/master/getting-started/docker/installation/requirements.md
+++ b/master/getting-started/docker/installation/requirements.md
@@ -24,7 +24,9 @@ To use Calico as a Docker network plugin, the Docker daemon must be configured
 with a cluster store.  If using etcd as a cluster store,
 configure the `cluster-store` on the Docker daemon to `etcd://<ETCD_IP>:<ETCD_PORT>`,
 replacing `<ETCD IP>` and <ETCD_PORT> with the appropriate address and client
-port for your etcd cluster.
+port for your etcd cluster.  If your etcd is configured with TLS then you must
+also add [configuration to the Docker daemon][daemon-cert-config] to allow
+access.
 
 > For Docker 1.10+, you can use the [daemon configuration file][daemon-config-file],
 > or for 1.9 see the appropriate 'Configuring Docker' section in [configuring docker][configuring-docker-1.9].
@@ -38,4 +40,5 @@ With etcd running and Docker configured, you are ready to
 [etcd]: https://coreos.com/etcd/docs/latest/
 [docker]: https://docs.docker.com/engine/installation/
 [daemon-config-file]: https://docs.docker.com/engine/reference/commandline/dockerd/#/daemon-configuration-file
+[daemon-cert-config]: https://docs.docker.com/engine/reference/commandline/dockerd/#nodes-discovery
 [configuring-docker-1.9]: https://docs.docker.com/v1.9/engine/articles/configuring/

--- a/master/getting-started/docker/installation/requirements.md
+++ b/master/getting-started/docker/installation/requirements.md
@@ -23,10 +23,10 @@ Follow the [instructions for installing Docker][docker].
 To use Calico as a Docker network plugin, the Docker daemon must be configured
 with a cluster store.  If using etcd as a cluster store,
 configure the `cluster-store` on the Docker daemon to `etcd://<ETCD_IP>:<ETCD_PORT>`,
-replacing `<ETCD IP>` and <ETCD_PORT> with the appropriate address and client
+replacing `<ETCD_IP>` and `<ETCD_PORT>` with the appropriate address and client
 port for your etcd cluster.  If your etcd is configured with TLS then you must
-also add [configuration to the Docker daemon][daemon-cert-config] to allow
-access.
+also [configure the Docker daemon][daemon-cert-config] with the correct
+certificates to allow access.
 
 > For Docker 1.10+, you can use the [daemon configuration file][daemon-config-file],
 > or for 1.9 see the appropriate 'Configuring Docker' section in [configuring docker][configuring-docker-1.9].


### PR DESCRIPTION
- Mention the need for requirements in the manual setup (Fixes #821)
- Add info about needing certs configuration on the docker daemon if
  etcd is using certs
  (https://github.com/projectcalico/calicoctl/issues/1661)
