### PR TITLE
Minor Mesos text tweaks.

### DIFF
--- a/master/getting-started/mesos/installation/dc-os/index.md
+++ b/master/getting-started/mesos/installation/dc-os/index.md
@@ -92,7 +92,7 @@ can disable modification of the docker daemon altogether.
 
 To perform networking on Unified Containerizer tasks, Calico's CNI binaries and
 configuration file must be installed on every agent, and the slave process must
-be restarted to pick up the change. This step of the Framework performs the following steps:
+be restarted to pick up the change. The Framework then performs the following steps:
 
 1. Download [`calico`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_url}}) to `/opt/mesosphere/active/cni/`
 2. Download [`calico-ipam`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_ipam_url}}) to `/opt/mesosphere/active/cni/`

--- a/master/getting-started/mesos/installation/integration.md
+++ b/master/getting-started/mesos/installation/integration.md
@@ -3,7 +3,7 @@ title: Integration Guide
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing
-Mesos cluster. These instruction should be followed on each **Agent**.
+Mesos cluster. These instructions should be followed on each **Agent**.
 
 Ensure you've met the [prerequisites](prerequisites) before continuing, namely that
 you have etcd running.

--- a/master/getting-started/mesos/installation/prerequisites.md
+++ b/master/getting-started/mesos/installation/prerequisites.md
@@ -7,7 +7,7 @@ title: Requirements for Calico with Mesos
 Calico uses etcd as its datastore. Ensure you have an instance of etcd running,
 and that it is accessible from all Agents in your cluster.
 
-For maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
+In order to maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
 and run etcd across the masters or other dedicated hosts.
 
 For simplicity, you can quickly get started by running a single instance of etcd
@@ -49,7 +49,7 @@ etcd cluster.
 Restart docker, then ensure it has picked up the changes:
 
 ```
-docker info | grep -i "cluster store"
+$ docker info | grep -i "cluster store"
 Cluster Store: etcd://10.0.0.1:2379
 ```
 

--- a/master/getting-started/mesos/tutorials/launching-tasks.md
+++ b/master/getting-started/mesos/tutorials/launching-tasks.md
@@ -52,19 +52,19 @@ set `network` to `USER`, and set `networkName` to the name of your Calico networ
 }
 ```
 
-## Enabling Healthchecks
+## Enabling Health Checks
 
-Marathon supports Healthchecks for IP per container applications. Healthchecks
+Marathon supports Health Checks for IP per container applications. Health Checks
 should specify a `port` (instead of the `portIndex` field which is commonly used
 for port-mapped applications).
 
-For the Healthcheck to succeed, the following conditions must be met:
+For the Health Check to succeed, the following conditions must be met:
 
 1. The host running Marathon will need routes to Calico tasks. If you are running
 Marathon as a Mesos task, and have already installed Calico on each Agent,
 you have met this requirement.
 
-2. Calico Networking Policy should permit the healthcheck from Marathon to the
+2. Calico Networking Policy should permit the health check from Marathon to the
 target application.
 
 The following sample application launches a nginx webserver with healtchecks:
@@ -90,7 +90,7 @@ The following sample application launches a nginx webserver with healtchecks:
 }
 ```
 
-The following Calico Profile yaml will allow the healthcheck from an instance
+The following Calico Profile yaml will allow the health check from an instance
 of Marathon running at 172.24.197.101:
 
 ```yaml

--- a/v1.6/getting-started/mesos/installation/dc-os/index.md
+++ b/v1.6/getting-started/mesos/installation/dc-os/index.md
@@ -84,7 +84,7 @@ can disable modification of the docker daemon altogether.
 
 To perform networking on Unified Containerizer tasks, Calico's CNI binaries and
 configuration file must be installed on every agent, and the slave process must
-be restarted to pick up the change. This step of the Framework performs the following steps:
+be restarted to pick up the change. The Framework then performs the following steps:
 
 1. Download [`calico`](https://github.com/projectcalico/calico-cni/releases/latest) to `/opt/mesosphere/active/cni/`
 2. Download [`calico-ipam`](https://github.com/projectcalico/calico-cni/releases/latest) to `/opt/mesosphere/active/cni/`

--- a/v2.0/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.0/getting-started/mesos/installation/dc-os/index.md
@@ -92,7 +92,7 @@ can disable modification of the docker daemon altogether.
 
 To perform networking on Unified Containerizer tasks, Calico's CNI binaries and
 configuration file must be installed on every agent, and the slave process must
-be restarted to pick up the change. This step of the Framework performs the following steps:
+be restarted to pick up the change. The Framework then performs the following steps:
 
 1. Download [`calico`](https://github.com/projectcalico/calico-cni/releases/download/v1.5.6/calico) to `/opt/mesosphere/active/cni/`
 2. Download [`calico-ipam`](https://github.com/projectcalico/calico-cni/releases/download/v1.5.6/calico-ipam) to `/opt/mesosphere/active/cni/`

--- a/v2.0/getting-started/mesos/installation/prerequisites.md
+++ b/v2.0/getting-started/mesos/installation/prerequisites.md
@@ -7,7 +7,7 @@ title: Requirements for Calico with Mesos
 Calico uses etcd as its datastore. Ensure you have an instance of etcd running,
 and that it is accessible from all Agents in your cluster.
 
-For maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
+In order to maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
 and run etcd across the masters or other dedicated hosts.
 
 For simplicity, you can quickly get started by running a single instance of etcd

--- a/v2.1/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.1/getting-started/mesos/installation/dc-os/index.md
@@ -92,7 +92,7 @@ can disable modification of the docker daemon altogether.
 
 To perform networking on Unified Containerizer tasks, Calico's CNI binaries and
 configuration file must be installed on every agent, and the slave process must
-be restarted to pick up the change. This step of the Framework performs the following steps:
+be restarted to pick up the change. The Framework then performs the following steps:
 
 1. Download [`calico`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_url}}) to `/opt/mesosphere/active/cni/`
 2. Download [`calico-ipam`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_ipam_url}}) to `/opt/mesosphere/active/cni/`

--- a/v2.1/getting-started/mesos/installation/prerequisites.md
+++ b/v2.1/getting-started/mesos/installation/prerequisites.md
@@ -7,7 +7,7 @@ title: Requirements for Calico with Mesos
 Calico uses etcd as its datastore. Ensure you have an instance of etcd running,
 and that it is accessible from all Agents in your cluster.
 
-For maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
+In order to maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
 and run etcd across the masters or other dedicated hosts.
 
 For simplicity, you can quickly get started by running a single instance of etcd

--- a/v2.2/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.2/getting-started/mesos/installation/dc-os/index.md
@@ -92,7 +92,7 @@ can disable modification of the docker daemon altogether.
 
 To perform networking on Unified Containerizer tasks, Calico's CNI binaries and
 configuration file must be installed on every agent, and the slave process must
-be restarted to pick up the change. This step of the Framework performs the following steps:
+be restarted to pick up the change. The Framework then performs the following steps:
 
 1. Download [`calico`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_url}}) to `/opt/mesosphere/active/cni/`
 2. Download [`calico-ipam`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_ipam_url}}) to `/opt/mesosphere/active/cni/`

--- a/v2.2/getting-started/mesos/installation/integration.md
+++ b/v2.2/getting-started/mesos/installation/integration.md
@@ -3,7 +3,7 @@ title: Integration Guide
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing
-Mesos cluster. These instruction should be followed on each **Agent**.
+Mesos cluster. These instructions should be followed on each **Agent**.
 
 Ensure you've met the [prerequisites](prerequisites) before continuing, namely that
 you have etcd running.

--- a/v2.2/getting-started/mesos/installation/prerequisites.md
+++ b/v2.2/getting-started/mesos/installation/prerequisites.md
@@ -7,7 +7,7 @@ title: Requirements for Calico with Mesos
 Calico uses etcd as its datastore. Ensure you have an instance of etcd running,
 and that it is accessible from all Agents in your cluster.
 
-For maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
+In order to maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
 and run etcd across the masters or other dedicated hosts.
 
 For simplicity, you can quickly get started by running a single instance of etcd

--- a/v2.2/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.2/getting-started/mesos/tutorials/launching-tasks.md
@@ -52,19 +52,19 @@ set `network` to `USER`, and set `networkName` to the name of your Calico networ
 }
 ```
 
-## Enabling Healthchecks
+## Enabling Health Checks
 
-Marathon supports Healthchecks for IP per container applications. Healthchecks
+Marathon supports Health Checks for IP per container applications. Health Checks
 should specify a `port` (instead of the `portIndex` field which is commonly used
 for port-mapped applications).
 
-For the Healthcheck to succeed, the following conditions must be met:
+For the Health Check to succeed, the following conditions must be met:
 
 1. The host running Marathon will need routes to Calico tasks. If you are running
 Marathon as a Mesos task, and have already installed Calico on each Agent,
 you have met this requirement.
 
-2. Calico Networking Policy should permit the healthcheck from Marathon to the
+2. Calico Networking Policy should permit the health check from Marathon to the
 target application.
 
 The following sample application launches a nginx webserver with healtchecks:

--- a/v2.3/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.3/getting-started/mesos/installation/dc-os/index.md
@@ -93,7 +93,7 @@ can disable modification of the docker daemon altogether.
 
 To perform networking on Unified Containerizer tasks, Calico's CNI binaries and
 configuration file must be installed on every agent, and the slave process must
-be restarted to pick up the change. This step of the Framework performs the following steps:
+be restarted to pick up the change. The Framework then performs the following steps:
 
 1. Download [`calico`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_url}}) to `/opt/mesosphere/active/cni/`
 2. Download [`calico-ipam`]({{site.data.versions[page.version].first.components["calico/cni"].download_calico_ipam_url}}) to `/opt/mesosphere/active/cni/`

--- a/v2.3/getting-started/mesos/installation/integration.md
+++ b/v2.3/getting-started/mesos/installation/integration.md
@@ -4,7 +4,7 @@ redirect_from: latest/getting-started/mesos/installation/integration
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing
-Mesos cluster. These instruction should be followed on each **Agent**.
+Mesos cluster. These instructions should be followed on each **Agent**.
 
 Ensure you've met the [prerequisites](prerequisites) before continuing, namely that
 you have etcd running.

--- a/v2.3/getting-started/mesos/installation/prerequisites.md
+++ b/v2.3/getting-started/mesos/installation/prerequisites.md
@@ -8,7 +8,7 @@ redirect_from: latest/getting-started/mesos/installation/prerequisites
 Calico uses etcd as its datastore. Ensure you have an instance of etcd running,
 and that it is accessible from all Agents in your cluster.
 
-For maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
+In order to maximize availability, use [etcd's clustering guide](https://coreos.com/os/docs/latest/cluster-architectures.html)
 and run etcd across the masters or other dedicated hosts.
 
 For simplicity, you can quickly get started by running a single instance of etcd

--- a/v2.3/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.3/getting-started/mesos/tutorials/launching-tasks.md
@@ -53,19 +53,19 @@ set `network` to `USER`, and set `networkName` to the name of your Calico networ
 }
 ```
 
-## Enabling Healthchecks
+## Enabling Health Checks
 
-Marathon supports Healthchecks for IP per container applications. Healthchecks
+Marathon supports Health Checks for IP per container applications. Health Checks
 should specify a `port` (instead of the `portIndex` field which is commonly used
 for port-mapped applications).
 
-For the Healthcheck to succeed, the following conditions must be met:
+For the Health Check to succeed, the following conditions must be met:
 
 1. The host running Marathon will need routes to Calico tasks. If you are running
 Marathon as a Mesos task, and have already installed Calico on each Agent,
 you have met this requirement.
 
-2. Calico Networking Policy should permit the healthcheck from Marathon to the
+2. Calico Networking Policy should permit the health check from Marathon to the
 target application.
 
 The following sample application launches a nginx webserver with healtchecks:


### PR DESCRIPTION
## Description
Minor text tweaks to the Mesos section of "getting started."
- type of fix: documentation only
- intent is to improve readability of the (already very good) Mesos text.
- affects only "getting-started/mesos" 

## Todos
- [x] Tests - ran "make htmlproofer"
- [x] Documentation - manually inspected all versions of the doc

