### PR TITLE
Set startup calico/node log level via environment variable

### DIFF
--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -51,6 +51,9 @@ var exitFunction = os.Exit
 // -  Creating default IP Pools for quick-start use
 
 func main() {
+	// Check $CALICO_STARTUP_LOGLEVEL to capture early log statements
+	configureLogging()
+
 	// Determine the name for this node and ensure the environment is always
 	// available in the startup env file that is sourced in rc.local.
 	nodeName := determineNodeName()
@@ -106,6 +109,24 @@ func main() {
 
 	// Tell the user what the name of the node is.
 	message("Using node name: %s", nodeName)
+}
+
+func configureLogging() {
+	// Default to error logging
+	logLevel := log.ErrorLevel
+
+	rawLogLevel := os.Getenv("CALICO_STARTUP_LOGLEVEL")
+	if rawLogLevel != "" {
+		parsedLevel, err := log.ParseLevel(rawLogLevel)
+		if err == nil {
+			logLevel = parsedLevel
+		} else {
+			log.WithError(err).Error("Failed to parse log level, defaulting to error.")
+		}
+	}
+
+	log.SetLevel(logLevel)
+	log.Infof("Early log level set to %v", logLevel)
 }
 
 // determineNodeName is called to determine the node name to use for this instance

--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -29,6 +29,7 @@ The `calico/node` container is primarily configured through environment variable
 | CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up. | off, always, cross-subnet | off |
 | CALICO_IPV4POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv4 Pool created at start up. | boolean | true |
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. | boolean | false |
+| CALICO_STARTUP_LOGLEVEL      | The log severity above which startup calico/node logs are sent to the stdout. | string | ERROR |
 | ETCD_ENDPOINTS    | A comma separated list of etcd endpoints (optional) | string | http://127.0.0.1:2379 |
 | ETCD_KEY_FILE     | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)       | string | |
 | ETCD_CERT_FILE    | Path to the etcd client cert, e.g. `/etc/calico/cert.pem` (optional)    | string | |


### PR DESCRIPTION
Calico/node now checks the environment variable CALICO_STARTUP_LOGLEVEL to set startup logging level.
- Testing: verified this env variable changes logging level and that logging level continues to default to ERROR if the env variable is not set or is set to an invalid string.
- Doc testing: verified the page renders correctly
- See issue: https://github.com/projectcalico/calico/issues/876

## Todos
- [x] Tests
- [x] Documentation
