### PR TITLE
Add batch labels to tests

### DIFF
--- a/calico_node/tests/st/bgp/test_global_peers.py
+++ b/calico_node/tests/st/bgp/test_global_peers.py
@@ -82,3 +82,6 @@ class TestGlobalPeers(TestBase):
     @attr('slow')
     def test_gobgp_node_peers(self):
         self._test_global_peers(backend='gobgp')
+
+TestGlobalPeers.batchnumber = 1  # Adds a batch number for parallel testing
+

--- a/calico_node/tests/st/bgp/test_ipip.py
+++ b/calico_node/tests/st/bgp/test_ipip.py
@@ -417,3 +417,5 @@ class TestIPIP(TestBase):
             # Flip the IP-in-IP state for the next iteration.
             with_ipip = not with_ipip
             host1.set_ipip_enabled(with_ipip)
+
+TestIPIP.batchnumber = 4  # Add batch label to these tests for parallel running

--- a/calico_node/tests/st/bgp/test_node_peers.py
+++ b/calico_node/tests/st/bgp/test_node_peers.py
@@ -79,3 +79,5 @@ class TestNodePeers(TestBase):
     @attr('slow')
     def test_gobgp_node_peers(self):
         self._test_node_peers(backend='gobgp')
+
+TestNodePeers.batchnumber = 1  # Adds a batch number for parallel testing

--- a/calico_node/tests/st/bgp/test_node_status_resilience.py
+++ b/calico_node/tests/st/bgp/test_node_status_resilience.py
@@ -145,3 +145,5 @@ class TestNodeStatusResilience(TestBase):
                                                               new_workload.ip])
                     delete_workload(hosts[index], new_workload)
                     index += 1
+
+TestNodeStatusResilience.batchnumber = 2  # Adds a batch number for parallel testing

--- a/calico_node/tests/st/bgp/test_route_reflector_cluster.py
+++ b/calico_node/tests/st/bgp/test_route_reflector_cluster.py
@@ -84,3 +84,5 @@ class TestRouteReflectorCluster(TestBase):
     @attr('slow')
     def test_gobgp_route_reflector_cluster(self):
         self._test_route_reflector_cluster(backend='gobgp')
+
+TestRouteReflectorCluster.batchnumber = 3  # Adds a batch number for parallel testing

--- a/calico_node/tests/st/bgp/test_single_route_reflector.py
+++ b/calico_node/tests/st/bgp/test_single_route_reflector.py
@@ -76,3 +76,5 @@ class TestSingleRouteReflector(TestBase):
     @attr('slow')
     def test_gobgp_single_route_reflector(self):
         self._test_single_route_reflector(backend='gobgp')
+
+TestSingleRouteReflector.batchnumber = 1  # Adds a batch number for parallel testing

--- a/calico_node/tests/st/ipam/test_ipam.py
+++ b/calico_node/tests/st/ipam/test_ipam.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class MultiHostIpam(TestBase):
     @classmethod
     def setUpClass(cls):
-        super(TestBase, cls).setUpClass()
+        super(MultiHostIpam, cls).setUpClass()
         cls.hosts = []
         cls.hosts.append(DockerHost("host1",
                                     additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,

--- a/calico_node/tests/st/ipam/test_ipam.py
+++ b/calico_node/tests/st/ipam/test_ipam.py
@@ -223,3 +223,5 @@ class MultiHostIpam(TestBase):
         host.calicoctl("ipam release --ip=%s" % workload.ip)
         host.execute("docker rm -f %s" % workload.name)
         host.workloads.remove(workload)
+
+MultiHostIpam.batchnumber = 2  # Adds a batch number for parallel testing

--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -325,3 +325,5 @@ class MultiHostMainline(TestBase):
         self.assert_connectivity(pass_list=n2_workloads,
                                  fail_list=n1_workloads,
                                  type_list=types)
+
+MultiHostMainline.batchnumber = 1  # Adds a batch number for parallel testing

--- a/calico_node/tests/st/test_base.py
+++ b/calico_node/tests/st/test_base.py
@@ -43,7 +43,6 @@ class TestBase(TestCase):
     """
     Base class for test-wide methods.
     """
-
     def setUp(self):
         """
         Clean up before every test.
@@ -303,3 +302,6 @@ class TestBase(TestCase):
                    banner + "\n"
                             "| " + msg + " |\n" +
                    banner)
+
+# Add a default batch number to all tests (used for running tests in parallel)
+TestBase.batchnumber = 0

--- a/calico_node/tests/st/test_base.py
+++ b/calico_node/tests/st/test_base.py
@@ -43,6 +43,10 @@ class TestBase(TestCase):
     """
     Base class for test-wide methods.
     """
+    @classmethod
+    def setUpClass(cls):
+        wipe_etcd(HOST_IPV4)
+
     def setUp(self):
         """
         Clean up before every test.


### PR DESCRIPTION
## Description
Add batch labels to tests so that we can run the batches in parallel on Semaphore and speed up testing.

## Todos
- [x] Label Tests
- [x] Update Semaphore job config
