### PR TITLE
add new interface option for skipping interfaces and expand interface option to take multiple regexes

### DIFF
--- a/master/reference/calicoctl/commands/node/run.md
+++ b/master/reference/calicoctl/commands/node/run.md
@@ -65,9 +65,17 @@ Options:
                              Use the interface determined by your host routing
                              tables that will be used to reach the supplied
                              destination IP or domain name.
-                           > interface=<IFACE NAME REGEX>
+			   > interface=<IFACE NAME REGEX LIST>
                              Use the first valid IP address found on interfaces
-                             named as per the supplied interface name regex.
+                             named as per the first matching supplied interface 
+			     name regex. Regexes are separated by commas
+			     (e.g. eth.*,enp0s.*).
+			   > skip-interface=<IFACE NAME REGEX LIST>
+			     Use the first valid IP address on the first
+			     enumerated interface (same logic as first-found
+			     above) that does NOT match with any of the
+			     specified interface name regexes. Regexes are
+			     separated by commas (e.g. eth.*,enp0s.*).
                            [default: first-found]
      --ip6-autodetection-method=<IP6_AUTODETECTION_METHOD>
                            Specify the autodetection method for detecting the
@@ -211,12 +219,13 @@ sudo calicoctl node run --ip autodetect --ip-autodetection-method can-reach=8.8.
 sudo calicoctl node run --ip autodetect --ip-autodetection-method can-reach=www.google.com
 ```
 
-**interface=INTERFACE-REGEX**
+**interface=INTERFACE-REGEX,INTERFACE-REGEX,...**
 
-The `interface` method uses the supplied interface regular expression (golang
+The `interface` method uses the supplied interface regular expressions (golang
 syntax) to enumerate matching interfaces and to return the first IP address on
-the first matching interface.  The order that both the interfaces
-and the IP addresses are listed is system dependent.
+the first interface that matches any of the interface regexes provided.  The 
+order that both the interfaces and the IP addresses are listed is system 
+dependent.
 
 e.g.
 
@@ -226,7 +235,23 @@ sudo calicoctl node run --ip autodetect --ip-autodetection-method interface=eth0
 
 # IP detection on interfaces eth0, eth1, eth2 etc.
 sudo calicoctl node run --ip autodetect --ip-autodetection-method interface=eth.*
+
+# IP detection on interfaces eth0, eth1, eth2 etc. and wlp2s0
+sudo calicoctl node run --ip-autodetect --ip-autodetection-method interface=eth.*,wlp2s0
 ```
+
+**skip-interface=INTERFACE-REGEX,INTERFACE-REGEX,...**
+
+The `skip-interface` method uses the supplied interface regular expressions (golang
+syntax) to enumerate all interface IP addresses and returns the first valid IP address
+(based on IP version and type of address) that does not match the listed regular
+expressions.  Like the `first-found` option, it also skips by default certain known
+"local" interfaces such as the docker bridge.  The order that both the interfaces
+and the IP addresses are listed is system dependent.
+
+This method has the ability to take in multiple regular expressions separated by `,`.
+Specifying only one regular expression for interfaces to skip will also work and a
+terminating `,` character does not need to be specified for those cases.
 
 ### Options
 
@@ -265,9 +290,17 @@ sudo calicoctl node run --ip autodetect --ip-autodetection-method interface=eth.
                            Use the interface determined by your host routing
                            tables that will be used to reach the supplied
                            destination IP or domain name.
-                         > interface=<IFACE NAME REGEX>
+			 > interface=<IFACE NAME REGEX LIST>
                            Use the first valid IP address found on interfaces
-                           named as per the supplied interface name regex.
+                           named as per the first matching supplied interface 
+			   name regex. Regexes are separated by commas
+			   (e.g. eth.*,enp0s.*).
+			 > skip-interface=<IFACE NAME REGEX LIST>
+			   Use the first valid IP address on the first
+			   enumerated interface (same logic as first-found
+			   above) that does NOT match with any of the
+			   specified interface name regexes. Regexes are
+			   separated by commas (e.g. eth.*,enp0s.*).
                          [default: first-found]
    --ip6-autodetection-method=<IP6_AUTODETECTION_METHOD>
                          Specify the autodetection method for detecting the


### PR DESCRIPTION
## Description
Added an option to skip network interfaces specified by regexes so that users can have first-found logic without having to manually specify system/setup specific interfaces to skip by changing the code.

Requires/is required by projectcalico/calicoctl#1675

Addresses projectcalico/calicoctl#1555

Builds off of https://github.com/projectcalico/calico/pull/878

## Testing
- Added unit tests
- Ran modified calicoctl commands against an image of these changes to verify that if regexes were specified, they would not be picked up to be used.

