### PR TITLE
Stop failing for broken links in v2.0 docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ clean:
 
 
 htmlproofer: clean _site
-	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --file-ignore /v1.5/,/v1.6/ --assume-extension --check-html --empty-alt-ignore --url-ignore "/docs.openshift.org/,#"
-	-docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --assume-extension --check-html --empty-alt-ignore --url-ignore "#" 
+	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --file-ignore /v1.5/,/v1.6/,/v2.0/ --assume-extension --check-html --empty-alt-ignore --url-ignore "/docs.openshift.org/,#"
+	-docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --assume-extension --check-html --empty-alt-ignore --url-ignore "#"
 	# Rerun htmlproofer across _all_ files, but ignore failure, allowing us to notice legacy docs issues without failing CI
 
 strip_redirects:


### PR DESCRIPTION
Specifically, networking-calico docs were just removed from
docs.openstack.org, so
http://docs.openstack.org/developer/networking-calico/ now no longer
exists, but the v2.0 docs include a reference to that.

(As do the v1.5 and v1.6 docs, for which we already regard broken links
as non-blocking.  For v2.1 the doc was updated so as to remove that
link, so this problem finishes with v2.0.)
