### PR TITLE
Add vbguest workaround

### DIFF
--- a/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/master/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
+++ b/master/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v1.5/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/v1.5/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/v1.5/getting-started/rkt/Vagrantfile
+++ b/v1.5/getting-started/rkt/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v1.6/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/v1.6/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/v1.6/getting-started/rkt/Vagrantfile
+++ b/v1.6/getting-started/rkt/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v2.0/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/v2.0/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/v2.0/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
+++ b/v2.0/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
@@ -25,6 +25,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v2.1/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/v2.1/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/v2.1/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
+++ b/v2.1/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v2.2/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/v2.2/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/v2.2/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
+++ b/v2.2/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v2.3/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/v2.3/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/v2.3/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
+++ b/v2.3/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]

--- a/v2.4/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/v2.4/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -24,6 +24,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1

--- a/v2.4/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
+++ b/v2.4/getting-started/rkt/installation/vagrant-coreos/Vagrantfile
@@ -22,6 +22,11 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
+
   # Set up each box
   (1..num_instances).each do |i|
     vm_name = "%s-%02d" % [instance_name_prefix, i]


### PR DESCRIPTION
This workaround was merged upstream https://github.com/coreos/coreos-vagrant/pull/34
and made its way into the docker vagrantfiles in this repo but not into the rkt
or kubernetes folders. Fixed in master and all released versions.