### PR TITLE
Releasing: Update release process with release archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 
 
 htmlproofer: clean _site
-	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --file-ignore /v1.5/,/v1.6/,/v2.0/ --assume-extension --check-html --empty-alt-ignore --url-ignore "/docs.openshift.org/,#"
+	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --file-ignore /v1.5/,/v1.6/,/v2.0/ --assume-extension --check-html --empty-alt-ignore --url-ignore "/docs.openshift.org/,#,/github.com\/projectcalico\/calico\/releases\/download/"
 	-docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --assume-extension --check-html --empty-alt-ignore --url-ignore "#"
 	# Rerun htmlproofer across _all_ files, but ignore failure, allowing us to notice legacy docs issues without failing CI
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,23 +20,24 @@ that a release candidate will be created, published and tested before the final
 release is announced.
 
 1. Run release-scripts/do_release.py to copy master directory to the new version directory
-2. Add the new version to `_data/versions.yaml` (add the date of the release in the description)
+1. Add the new version to `_data/versions.yaml` (add the date of the release in the description)
    - Add new versions that are a release candidate to the end of the file.
      If a release is added to the top of the file it will become the 'Latest Release'.
-3. Add a section in `_config.yaml` so that `page.version` will be set correctly in the new subdirectory:
-````
-   -
-     scope:
-       path: vX.Y
-     values:
-       version: vX.Y
-````
-4. Update the `RELEASE_STREAM` variable at the top of calico_node/Makefile to the new major/minor version.
-2. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
-3. Create a git tag and docker images by running `make -C calico_node release`. Follow the instructions to push the images but DO NOT PUSH THE TAG YET.
-4. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).
-5. Push the tag.
-6. Edit the [Calico Docs Custom Search Engine](cse.google.com/).
+1. Add a section in `_config.yaml` so that `page.version` will be set correctly in the new subdirectory:
+    ```
+       -
+         scope:
+           path: vX.Y
+         values:
+           version: vX.Y
+    ```
+1. Update the `RELEASE_STREAM` variable at the top of calico_node/Makefile to the new major/minor version.
+1. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
+1. Create a git tag, docker images, and release file by running `make -C calico_node release`. Follow the instructions to push the images but DO NOT PUSH THE TAG YET.
+1. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).
+1. Push the tag.
+1. Create a GitHub release on the Calico repo, and upload the release file (calico_node/release-<VERSION>.tgz)
+1. Edit the [Calico Docs Custom Search Engine](cse.google.com/).
    1. Navigate to: search engine -> Search Features -> Refinements -> Add
    2. Add a new refinement name: vX.Y
    3. Navigate to: Setup -> Basics
@@ -45,18 +46,20 @@ release is announced.
 
 ### Promoting a release candidate to a final release
 1. Add a new `<option>` entry to the `<span class="dropdown">` in `_layouts/docwithnav.html` file. This step should NOT be performed until testing of the release is complete.
-2. Modify the redirect in `/index.html` to point to your new release.. 
-3. Move the section for the release in `_data/versions.yaml` to the top of the file so that it will be the 'Latest Release'.
-4. Run `make add_redirects_for_latest VERSION=vX.Y` to update the redirects.
-2. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
-3. Create a git tag and docker images by running `make -C calico_node release`. Follow the instructions to push the images but DO NOT PUSH THE TAG YET.
-4. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).
-5. Finally, push the tag.
+1. Modify the redirect in `/index.html` to point to your new release.. 
+1. Move the section for the release in `_data/versions.yaml` to the top of the file so that it will be the 'Latest Release'.
+1. Run `make add_redirects_for_latest VERSION=vX.Y` to update the redirects.
+1. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
+1. Create a git tag, docker images, and release file by running `make -C calico_node release`. Follow the instructions to push the images but DO NOT PUSH THE TAG YET.
+1. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).
+1. Push the tag.
+1. Create a GitHub release on the Calico repo, and upload the release file (calico_node/release-<VERSION>.tgz)
 
 ### Performing a "patch" release
 Patch releases shouldn't include any new functionality, just bug fixes (expect during pre-release testing).
 1. Add the new version to `_data/versions.yaml` (Remember to add the date in the description)
-2. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
-3. Create a git tag and docker images by running `make -C calico_node release`. Follow the instructions to push the images but DO NOT PUSH THE TAG YET.
-4. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).
-5. Finally, push the tag.
+1. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
+1. Create a git tag, docker images, and release file by running `make -C calico_node release`. Follow the instructions to push the images but DO NOT PUSH THE TAG YET.
+1. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).
+1. Push the tag.
+1. Create a GitHub release on the Calico repo, and upload the release file (calico_node/release-<VERSION>.tgz)

--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -436,6 +436,9 @@ release: clean
 	# Build the calico/node images.
 	$(MAKE) $(NODE_CONTAINER_NAME)
 
+	# Create the release archive
+	$(MAKE) release-archive
+
 	# Retag images with corect version and quay
 	docker tag $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_NAME):$(CALICO_VER)
 	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):$(CALICO_VER)

--- a/master/releases/index.md
+++ b/master/releases/index.md
@@ -8,6 +8,9 @@ Use the version selector at the top-right of this page to view a different relea
 
 {% for release in site.data.versions[page.version] %}
 ## {{ release.title }}
+{% unless release.title == "master" %}
+[Release archive](https://github.com/projectcalico/calico/releases/download/{{ release.title }}/release-{{ release.title }}.tgz) with Kubernetes manifests, Docker images and binaries.
+{% endunless %}
 
 {{ release.note }}
 


### PR DESCRIPTION
Build the release archive as part of make release
Update the instructions to say that it should be uploaded
Reference the file from the releases page.

Fixes #893 