### PR TITLE
Add release note to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Description
-A few sentences describing the overall goals of the pull request's commits. 
-Please include 
+A few sentences describing the overall goals of the pull request's commits.
+Please include
 - the type of fix - (e.g. bug fix, new feature, documentation)
 - some details on _why_ this PR should be merged
 - the details of the testing you've done on it (both manual and automated)
@@ -10,4 +10,16 @@ Please include
 ## Todos
 - [ ] Tests
 - [ ] Documentation
+- [ ] Release note
 
+## Release Note
+<!-- Writing a release note:
+- By default, no release note action is required.
+- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
+- If this PR requires a release note, update the block below to include a concise note describing
+  the change and any important impacts this PR may have.
+-->
+
+```release-note
+None required
+```


### PR DESCRIPTION
## Description

Adds a release note field to the PR template, which will help us track important release information for including in the release notes of a Calico release.

## Todos
- [x] Tests
- [ ] Documentation

