### PR TITLE
Bugfix manifests: env vars must be strings

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -137,7 +137,7 @@ spec:
               value: "info"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
-              value: 1440
+              value: "1440"
             # Location of the CA certificate for etcd.
             - name: ETCD_CA_CERT_FILE
               valueFrom:

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
@@ -172,7 +172,7 @@ spec:
               value: "false"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
-              value: 1440
+              value: "1440"
             # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -187,7 +187,7 @@ spec:
               value: "false"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
-              value: 1440
+              value: "1440"
             # Set Felix logging to "info"
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
@@ -89,7 +89,7 @@ spec:
               value: "false"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
-              value: 1440
+              value: "1440"
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
@@ -99,7 +99,7 @@ spec:
               value: "false"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
-              value: 1440
+              value: "1440"
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"


### PR DESCRIPTION
env var for container is incorrectly an integer which causes the following error:

```
configmap "calico-config" created
daemonset "calico-etcd" created
service "calico-etcd" created
deployment "calico-policy-controller" created
clusterrolebinding "calico-cni-plugin" created
clusterrole "calico-cni-plugin" created
serviceaccount "calico-cni-plugin" created
clusterrolebinding "calico-policy-controller" created
clusterrole "calico-policy-controller" created
serviceaccount "calico-policy-controller" created
Error from server (BadRequest): error when creating "http://docs.projectcalico.org/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml": DaemonSet in version "v1beta1" cannot be handled as a DaemonSet: [pos 3455]: json: expect char '"' but got char '1'
```

Fixed by turning into string