### PR TITLE
Update kube installation intro with ref to rbac details

### DIFF
--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -15,7 +15,8 @@ Calico can run on any Kubernetes cluster which meets the following criteria.
 - The kube-proxy must be started without the `--masquerade-all` flag, which conflicts with Calico policy.
 - The Kubernetes NetworkPolicy API requires at least Kubernetes version v1.3.0.
 - When RBAC is enabled, the proper accounts, roles, and bindings must be defined
-  and utilized by the Calico components.
+  and utilized by the Calico components.  See the cluster roles and bindings used
+  in the [hosted](hosted#rbac) approach for an example.
 
 ## [Calico Hosted Install](hosted)
 

--- a/v2.2/getting-started/kubernetes/installation/index.md
+++ b/v2.2/getting-started/kubernetes/installation/index.md
@@ -15,7 +15,8 @@ Calico can run on any Kubernetes cluster which meets the following criteria.
 - The kube-proxy must be started without the `--masquerade-all` flag, which conflicts with Calico policy.
 - The Kubernetes NetworkPolicy API requires at least Kubernetes version v1.3.0.
 - When RBAC is enabled, the proper accounts, roles, and bindings must be defined
-  and utilized by the Calico components.
+  and utilized by the Calico components.  See the cluster roles and bindings used
+  in the [hosted](hosted#rbac) approach for an example.
 
 ## [Calico Hosted Install](hosted)
 

--- a/v2.3/getting-started/kubernetes/installation/index.md
+++ b/v2.3/getting-started/kubernetes/installation/index.md
@@ -16,7 +16,8 @@ Calico can run on any Kubernetes cluster which meets the following criteria.
 - The kube-proxy must be started without the `--masquerade-all` flag, which conflicts with Calico policy.
 - The Kubernetes NetworkPolicy API requires at least Kubernetes version v1.3.0.
 - When RBAC is enabled, the proper accounts, roles, and bindings must be defined
-  and utilized by the Calico components.
+  and utilized by the Calico components.  See the cluster roles and bindings used
+  in the [hosted](hosted#rbac) approach for an example.
 
 ## [Calico Hosted Install](hosted)
 


### PR DESCRIPTION
## Description

Doc fix.
Updated v2.X/getting-started/kubernetes/installation/index.md to
augment the vague remark about RBAC requirements with a pointer to the
concrete details in the hosted instructions, as a way of elaborating
for general consumption.

Addresses #912

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
