### PR TITLE
Update docs for GA NetworkPolicy in etcd

### DIFF
--- a/master/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/master/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -29,10 +29,18 @@ We'll use a new namespace for this guide.  Run the following command to create i
 kubectl create ns advanced-policy-demo
 ```
 
-And then enable isolation on the Namespace.
+And then enable isolation on the Namespace using a [default policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-policies).
 
 ```
-kubectl annotate ns advanced-policy-demo "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+kubectl create -f - <<EOF
+kind: NetworkPolicy
+apiVersion: extensions/v1beta1
+metadata:
+  name: default-deny
+  namespace: policy-demo
+spec:
+  podSelector:
+EOF
 ```
 
 #### Run an nginx Service

--- a/master/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/master/getting-started/kubernetes/tutorials/simple-policy.md
@@ -46,13 +46,7 @@ You should see a response from `nginx`.  Great! Our Service is accessible.  You 
 
 Let's turn on isolation in our policy-demo Namespace.  Calico will then prevent connections to pods in this Namespace.
 
-#### When using the etcd datastore
-
-```
-kubectl annotate ns policy-demo "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
-```
-
-#### When using the Kubernetes API datastore
+Running the following command creates a NetworkPolicy which implements a default deny behavior for all pods in the `policy-demo` Namespace.
 
 ```
 kubectl create -f - <<EOF

--- a/master/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -7,7 +7,7 @@ running on Kubernetes.  It then configures network policy on each service.
 ## Pre-requisites
 
 To create a Kubernetes cluster which supports the Kubernetes network policy API, follow
-one of our [getting started guides]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes).  
+one of our [getting started guides]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes).
 
 ## Running the stars example
 
@@ -42,16 +42,7 @@ represented by a single node in the graph.
 
 ### 2) Enable isolation
 
-The following will prevent all access to the frontend, backend, and client Services.
-
-#### When using the etcd datastore
-
-```shell
-kubectl annotate ns stars "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
-kubectl annotate ns client "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
-```
-
-#### When using the Kubernetes API datastore
+Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
 kubectl create -n stars -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml

--- a/master/getting-started/kubernetes/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade.md
@@ -24,7 +24,8 @@ impact on Calico.
 > **NOTE**
 >
 > When upgrading Calico using the Kubernetes datastore driver from a version < v2.3.0
-> to a version >= v2.3.0, you should follow the steps for [upgrading to v1 NetworkPolicy semantics](#upgrading-to-v1-networkpolicy-semantics)
+> to a version >= v2.3.0, or when upgrading Calico using the etcd datastore from a version < v2.4.0
+> to a version >= v2.4.0, you should follow the steps for [upgrading to v1 NetworkPolicy semantics](#upgrading-to-v1-networkpolicy-semantics)
 
 ## Upgrading a Hosted Installation of Calico
 
@@ -175,12 +176,11 @@ standard [Deployment mechanism](http://kubernetes.io/docs/user-guide/deployments
 
 ## Upgrading to v1 NetworkPolicy semantics
 
-Calico v2.3.0 (when using the Kubernetes datastore driver) interprets the Kubernetes `NetworkPolicy` differently
-than previous releases, as specified in [upstream Kubernetes](https://github.com/kubernetes/kubernetes/pull/39164#issue-197243974).
+Calico v2.3.0 (when using the Kubernetes datastore driver) and Calico v2.4.0 (when using the etcd datastore driver)
+interpret the Kubernetes `NetworkPolicy` differently than previous releases, as specified
+in [upstream Kubernetes](https://github.com/kubernetes/kubernetes/pull/39164#issue-197243974).
 
-**If your Calico deployment uses the etcd datastore driver, there is no change in behavior in v2.3.0+ (this change is planned for a future release).**
-
-To maintain behavior when upgrading to Calico v2.3.0+, you should follow these steps prior to upgrading Calico to ensure your configured policy is
+To maintain behavior when upgrading, you should follow these steps prior to upgrading Calico to ensure your configured policy is
 enforced consistently throughout the upgrade process.
 
 - In any Namespace that previously did _not_ have a "DefaultDeny" annotation:
@@ -202,4 +202,5 @@ spec:
 > **Note**:
 >
 > The above steps should be followed when upgrading to Calico v2.3.0+ using the Kubernetes
-> datastore driver, independent of the Kubernetes version being used.
+> datastore driver, and Calico v2.4.0+ using the etcd datastore,
+> independent of the Kubernetes version being used.


### PR DESCRIPTION
## Description

Documentation for updating the policy controller to implement GA NetworkPolicy behavior.

This is the corresponding documentation for https://github.com/projectcalico/k8s-policy/pull/105.

## Todos

- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
