### PR TITLE
Remove HOSTNAME and IP/IP6 env vars

### DIFF
--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -205,17 +205,6 @@ func waitForConnection(c *client.Client) {
 func writeStartupEnv(nodeName string, ip, ip6 *net.IPNet) {
 	text := "export NODENAME=" + nodeName + "\n"
 
-	// TODO:  See https://github.com/projectcalico/calico-bgp-daemon/issues/18
-	// The following entries are required for go-bgp.  Once updated to use
-	// NODENAME and the node IP parameters, these entries can be removed.
-	text += "export HOSTNAME=" + nodeName + "\n"
-	if ip != nil {
-		text += "export IP=" + ip.IP.String() + "\n"
-	}
-	if ip6 != nil {
-		text += "export IP6=" + ip6.IP.String() + "\n"
-	}
-
 	// Write out the startup.env file to ensure required environments are
 	// set (which they might not otherwise be).
 	if err := ioutil.WriteFile("startup.env", []byte(text), 0666); err != nil {


### PR DESCRIPTION
## Description
No longer set HOSTNAME or IP/IP6 environment variables because they've been replaced by NODENAME and Node resource, respectively.
- this is an enhancement: https://github.com/projectcalico/calico-bgp-daemon/issues/18
- part of a bigger feature, e.g. https://github.com/projectcalico/calicoctl/pull/1453
- successfully ran calico_node STs for BGP
- manually verified the k8s on vagrant/coreos setup has reachability between containers on different nodes
- updated the run command's documentation which mentions these variables

I don't see a release note mentioning this change. @caseydavenport , can you confirm?

## Todos
- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
