### PR TITLE
Update etcd version referenced in docs, manifests

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
@@ -73,7 +73,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-etcd
-          image: gcr.io/google_containers/etcd:2.2.1
+          image: quay.io/coreos/etcd:v3.1.10
           env:
             - name: CALICO_ETCD_IP
               valueFrom:

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -80,7 +80,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-etcd
-          image: gcr.io/google_containers/etcd:2.2.1
+          image: quay.io/coreos/etcd:v3.1.10
           env:
             - name: CALICO_ETCD_IP
               valueFrom:

--- a/master/getting-started/mesos/installation/dc-os/custom.md
+++ b/master/getting-started/mesos/installation/dc-os/custom.md
@@ -23,7 +23,7 @@ the need for etcd-proxy:
    (available at http://m1.dcos:2379):
 
    ```shell
-   docker run -d --net=host --name=etcd quay.io/coreos/etcd:v2.0.11 \
+   docker run -d --net=host --name=etcd quay.io/coreos/etcd:v3.1.10 \
    --advertise-client-urls "http://m1.dcos:2379" \
    --listen-client-urls "http://m1.dcos:2379,http://127.0.0.1:2379" \
    ```

--- a/master/getting-started/mesos/installation/prerequisites.md
+++ b/master/getting-started/mesos/installation/prerequisites.md
@@ -17,7 +17,7 @@ or replaced `$ETCD_IP` and `$ETCD_PORT`:
 ```shell
 docker run --detach \
 	--net=host \
-	--name etcd quay.io/coreos/etcd:v2.0.11 \
+	--name etcd quay.io/coreos/etcd:v3.1.10 \
 	--advertise-client-urls "http://$ETCD_IP:$ETCD_PORT" \
 	--listen-client-urls "http://$ETCD_IP:$ETCD_PORT,http://127.0.0.1:$ETCD_PORT"
 ```


### PR DESCRIPTION
## Description

Update remaining references in docs, manifests to etcdv3 images.

Fixes https://github.com/projectcalico/calico/issues/313

## Todos
- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The version of etcd included in the Calico kubeadm manifests has been revved to v3.1.10.
```
