### PR TITLE
calico_node: Update ClusterType in startup

### DIFF
--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -31,6 +31,7 @@ The `calico/node` container is primarily configured through environment variable
 | CALICO_IPV4POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv4 Pool created at start up. | boolean | true |
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. | boolean | false |
 | CALICO_STARTUP_LOGLEVEL      | The log severity above which startup calico/node logs are sent to the stdout. | string | ERROR |
+| CLUSTER_TYPE | Contains comma delimited list of indicators about this cluster.  Expected to contain information like hosted, services, kubeadm, tectonic, or datastore type. If using Kubernetes API as the datastore then KDD will automatically be added to this list. | string | |
 | ETCD_ENDPOINTS    | A comma separated list of etcd endpoints (optional) | string | http://127.0.0.1:2379 |
 | ETCD_KEY_FILE     | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)       | string | |
 | ETCD_CERT_FILE    | Path to the etcd client cert, e.g. `/etc/calico/cert.pem` (optional)    | string | |


### PR DESCRIPTION
## Description
This change will have calico_node read CLUSTER_TYPE and update the datastore to include the types listed.

## Todos
- [x] Fix the gating of startup's `ensureDefaultConfig` 
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
```
