### PR TITLE
Fix YAML_CMD in Makefile.  Use CALICO_BUILD variable and --rm.

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -1,10 +1,15 @@
 ###############################################################################
 # Versions:
 RELEASE_STREAM?=v2.3
+
+GO_BUILD_VER:=v0.7
+CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
+
 CALICO_NODE_DIR=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSIONS_FILE?=$(CALICO_NODE_DIR)/../_data/versions.yml
+
 # For local builds this can be made faster by running "go get github.com/mikefarah/yaml" and changing YAML_CMD to "yaml"
-YAML_CMD?=$(shell which yaml || echo docker run -i calico/go-build yaml)
+YAML_CMD?=$(shell which yaml || echo docker run --rm -i $(CALICO_BUILD) yaml)
 CALICO_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].title')
 CALICO_GIT_VER ?= $(shell git describe --tags --dirty --always)
 BIRD_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico-bird.version')
@@ -19,7 +24,6 @@ CNI_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)
 CONFD_VER := v0.12.1-calico0.1.0
 
 SYSTEMTEST_CONTAINER_VER := latest
-GO_BUILD_VER:=v0.7
 # we can use "custom" build image and test image name
 SYSTEMTEST_CONTAINER?=calico/test:$(SYSTEMTEST_CONTAINER_VER)
 
@@ -62,7 +66,6 @@ ALLOCATE_IPIP_FILES=$(shell find $(ALLOCATE_IPIP_DIR) -name '*.go')
 TEST_CONTAINER_NAME?=calico/test:latest
 TEST_CONTAINER_FILES=$(shell find tests/ -type f ! -name '*.created')
 
-CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
 LOCAL_USER_ID?=$(shell id -u $$USER)
 
 LDFLAGS=-ldflags "-X main.VERSION=$(CALICO_GIT_VER)"


### PR DESCRIPTION
## Description
Ran out of disk space after a few test runs; spotted that the yaml container wasn't being cleaned up.

- Add `--rm` to tell docker to clean up the container when it exits.
- Use the CALICO_BUILD env var rather than hard-coding `calico/go-build:latest`

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
