### PR TITLE
Tweak headings on ping test output to make it clearer.

### DIFF
--- a/calico_node/tests/st/test_base.py
+++ b/calico_node/tests/st/test_base.py
@@ -127,7 +127,7 @@ class TestBase(TestCase):
         # Check that all tests passed
         if False in results:
             # We've failed, lets put together some diags.
-            header = ["source.ip", "dest.ip", "type", "exp_result", "pass/fail"]
+            header = ["source.ip", "dest.ip", "type", "expected", "actual"]
             diagstring = "{: >18} {: >18} {: >7} {: >6} {: >6}\r\n".format(*header)
             for i in range(len(conn_check_list)):
                 source, dest, test_type, exp_result, retries = conn_check_list[i]


### PR DESCRIPTION
## Description
Tweak the ping test output column names.  `pass/fail` was ambiguous after we added expected failures.  Was it the ping that passed/failed or was it the test (which may be a negative) that passed/failed?

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
