### PR TITLE
Rev confd to latest version

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -16,7 +16,7 @@ TYPHA_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREA
 K8S_POLICY_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico/kube-policy-controller.version')
 CNI_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico/cni.version')
 # TODO - Why isn't confd in versions.yaml
-CONFD_VER := v0.12.1-calico0.1.0
+CONFD_VER := v0.12.1-calico0.2.0
 
 SYSTEMTEST_CONTAINER_VER := latest
 GO_BUILD_VER:=v0.7


### PR DESCRIPTION
## Description
Rev confd for calico/node

Note that this is hard-coded rather than using the versions file.  We could and probably should add to the versions file although (a) we don't expect people to install confd separately and (b) it would break the master stream build of calico/node since there isn't a confd master download link (and we haven't containerized the release of confd)