### PR TITLE
change the 'from' filter to 'gw' filter

### DIFF
--- a/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -15,7 +15,7 @@ filter calico_ipip {
 {{range ls "/v1/ipam/v4/pool"}}{{$data := json (getv (printf "/v1/ipam/v4/pool/%s" .))}}
   if ( net ~ {{$data.cidr}} ) then {
 {{if $data.ipip_mode}}{{if eq $data.ipip_mode "cross-subnet"}}
-    if ( from ~ {{$network}} ) then
+    if ( gw ~ {{$network}} ) then
       krt_tunnel = "";                     {{/* Destination in ipPool, mode is cross sub-net, route from-host on subnet, do not use IPIP */}}
     else
       krt_tunnel = "{{$data.ipip}}";       {{/* Destination in ipPool, mode is cross sub-net, route from-host off subnet, set the tunnel (if IPIP not enabled, value will be "") */}}


### PR DESCRIPTION
## Description
This commit can fix a bug(#907). 

When enable route reflector in a cluster and enable IPinIP in cross-subnet mode, the calico couldn't work correctly.No mater the calico/nodes were in a same subnet or different subnets, they all communicate with other calico/nodes by IPinIP.
The calico/nodes do cross-subnet check by the 'from' filter. When enable route reflector, the 'from' filter would get the route reflector's IP address not the calico/node's IP address, so we should use the 'gw' filter instead of the 'from' filter.

I have tested this commit on my private cluster(both for with route reflector and without route reflector). The calico/nodes in my cluster can create route rules for each node correctly. Only the calico/nodes in different subnet communicate by IPinIP.

I do not test this commit on any public cloud, please test it if necessary.

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
None required
```
