### PR TITLE
Add log to connection check

### DIFF
--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -191,6 +191,7 @@ func waitForConnection(c *client.Client) {
 				fatal("Connection to the datastore is unauthorized")
 				terminate()
 			case errors.ErrorDatastoreError:
+				log.WithError(err).Info("Hit error connecting to datastore - retry")
 				time.Sleep(1000 * time.Millisecond)
 				continue
 			}


### PR DESCRIPTION
When the connection check fails in the startup processing we don't log the problem.  This PR adds an info log.
