### PR TITLE
Document --use-docker-networking-container-labels flag in docker installation

### DIFF
--- a/master/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/master/getting-started/docker/installation/vagrant-coreos/index.md
@@ -70,7 +70,10 @@ The Vagrant machines already have `calicoctl` installed. Use it to launch `calic
 
     sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.title}}
 
-This will start the `calico/node` container on this host. Check it is running:
+Append the `--use-docker-networking-container-labels` flag to the `calicoctl node run` command if you're combining
+[Docker Labels and Calico Policy]({{site.baseurl}}/{{page.version}}/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy).
+
+Check that the `calico/node` container is running on this host:
 
     docker ps
 

--- a/master/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/master/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -67,7 +67,10 @@ The Vagrant machines already have `calicoctl` installed. Use it to launch `calic
 
     sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.title}}
 
-This will start the `calico/node` container on this host. Check it is running:
+Append the `--use-docker-networking-container-labels` flag to the `calicoctl node run` command if you're combining
+[Docker Labels and Calico Policy]({{site.baseurl}}/{{page.version}}/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy).
+
+Check that the `calico/node` container is running on this host:
 
     docker ps
 

--- a/v2.4/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.4/getting-started/docker/installation/vagrant-coreos/index.md
@@ -70,7 +70,10 @@ The Vagrant machines already have `calicoctl` installed. Use it to launch `calic
 
     sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.title}}
 
-This will start the `calico/node` container on this host. Check it is running:
+Append the `--use-docker-networking-container-labels` flag to the `calicoctl node run` command if you're combining
+[Docker Labels and Calico Policy]({{site.baseurl}}/{{page.version}}/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy).
+
+Check that the `calico/node` container is running on this host:
 
     docker ps
 

--- a/v2.4/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.4/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -67,7 +67,10 @@ The Vagrant machines already have `calicoctl` installed. Use it to launch `calic
 
     sudo ETCD_ENDPOINTS=http://172.17.8.101:2379 calicoctl node run --node-image=quay.io/calico/node:{{site.data.versions[page.version].first.title}}
 
-This will start the `calico/node` container on this host. Check it is running:
+Append the `--use-docker-networking-container-labels` flag to the `calicoctl node run` command if you're combining
+[Docker Labels and Calico Policy]({{site.baseurl}}/{{page.version}}/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy).
+
+Check that the `calico/node` container is running on this host:
 
     docker ps
 


### PR DESCRIPTION
## Description
I had to backtrack and reinstall calico/node when running the Docker Label/Calico Policy tutorial and add the --use-docker-networking-container-labels flag. This PR documents the flag during docker install, hopefully helping people avoid the mistake. 

## Todos
- [x ] Tests - make htmlproofer

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
