### PR TITLE
Fix master rev of libnetwork plugin and fix test flake

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -869,7 +869,7 @@ master:
       version: v0.2.2
       url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.2
      libnetwork-plugin:
-      version: v1.1.0 
+      version: master
       url: ""
      calico/kube-policy-controller:
       version: master

--- a/calico_node/tests/st/bgp/test_node_status_resilience.py
+++ b/calico_node/tests/st/bgp/test_node_status_resilience.py
@@ -134,6 +134,9 @@ class TestNodeStatusResilience(TestBase):
                     new_workload = hosts[index].create_workload(new_workload, network=network1)
                     _log.debug("host: %s and workload: %s", hosts[index].name, new_workload.name)
 
+                    # Wait for the workload to be networked.
+                    self.assert_true(new_workload.check_can_ping(workload_host3.ip, retries=10))
+
                     # Check connectivity in both directions
                     self.assert_ip_connectivity(workload_list=[workload_host1,
                                                                workload_host2,


### PR DESCRIPTION
## Description
Update versions file to reference the master build of libnetwork-plugin and felix.
Fix a flake in the STs to ensure we are networked before attempting the matrix ping between workloads.

## Release note
```release-note
None required
```
