### PR TITLE
Port cloud-provider changes to v2.4

### DIFF
--- a/_data/v2_4/navbars/getting-started.yml
+++ b/_data/v2_4/navbars/getting-started.yml
@@ -29,6 +29,8 @@ toc:
       path: /getting-started/kubernetes/installation/aws
     - title: GCE
       path: /getting-started/kubernetes/installation/gce
+    - title: Azure
+      path: /getting-started/kubernetes/installation/azure
     - title: 'Vagrant/VirtualBox: CoreOS'
       path: /getting-started/kubernetes/installation/vagrant/
   - title: Tutorials

--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -34,6 +34,9 @@ to integrate Calico into your own installation or deployment scripts.
 ## Third Party Integrations
 
 A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
-Here are a few, listed alphabetically.
 
-- [Container Linux by CoreOS](https://coreos.com/kubernetes/docs/latest/)
+You can find some of them here, organized by cloud provider.
+
+- [Amazon Web Services](aws)
+- [Google Compute Engine](gce)
+- [Microsoft Azure](azure)

--- a/v2.4/getting-started/kubernetes/installation/aws.md
+++ b/v2.4/getting-started/kubernetes/installation/aws.md
@@ -12,13 +12,15 @@ Make sure you've read the [Calico AWS reference guide][aws-reference] for detail
 **[Heptio AWS Quickstart][heptio]** uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using Calico
 for networking and network policy enforcement.
 
-
 **[Kops][kops]** is a popular Kubernetes project for launching production-ready clusters on AWS,
 as well as other public and private cloud environments.
 
+**[CoreOS Kubernetes][coreos]** documentation to learn how to install, run and use Kubernetes on CoreOS Container Linux on AWS.
 
-**[kube-aws][kube-aws]** is a command-line tool by CoreOS to create, update, and destroy production-ready
-container-linux based Kubernetes clusters on AWS.
+**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on AWS and other clouds.
+
+**[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to AWS in 3 steps using a web-based interface.
+
 
 #### More installation options
 
@@ -27,7 +29,9 @@ on AWS using one of our [self-hosted manifests][self-hosted], or by [integrating
 
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
-[kube-aws]: https://github.com/coreos/kube-aws/#getting-started
+[ket]: https://apprenda.com/kismatic/
+[stackpoint]: https://stackpoint.io/#/
+[coreos]: https://coreos.com/kubernetes/docs/latest/
 
 [self-hosted]: hosted
 [integration-guide]: integration

--- a/v2.4/getting-started/kubernetes/installation/azure.md
+++ b/v2.4/getting-started/kubernetes/installation/azure.md
@@ -1,0 +1,20 @@
+---
+title: Deploying Calico and Kubernetes on Azure
+---
+
+There are a number of solutions for deploying Calico and Kubernetes on Azure.  We recommend taking
+a look at the following solutions and guides which install Calico for network policy on Azure.
+
+#### Popular guides and tools
+
+**[ACS Engine][acs-engine]** configures and deploys Kubernetes clusters on Azure with an option to enable Calico policy.
+
+#### More installation options
+
+If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
+on Azure using one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
+
+[acs-engine]: https://github.com/Azure/acs-engine/blob/master/docs/kubernetes.md
+
+[self-hosted]: hosted
+[integration-guide]: integration

--- a/v2.4/getting-started/kubernetes/installation/gce.md
+++ b/v2.4/getting-started/kubernetes/installation/gce.md
@@ -2,5 +2,32 @@
 title: Deploying Calico and Kubernetes on GCE
 ---
 
-See [this page]({{site.baseurl}}/{{page.version}}/reference/public-cloud/gce)
-for info on running Calico on GCE.
+There are a number of solutions for deploying Calico and Kubernetes on GCE.  We recommend taking
+a look at the following solutions and guides which install Calico for networking and network policy on GCE.
+
+Make sure you've read the [Calico GCE reference guide][gce-reference] for details on how to configure Calico and GCE.
+
+#### Popular guides and tools
+
+**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on GCE and other clouds.
+
+**[Kubernetes kube-up][kube-up]** deploys Calico on GCE using the same underlying open-source infrastructure as Google's GKE platform.
+
+**[Kubespray][kubespray]** is a Kubernetes incubator project for deploying Kubernetes on GCE.
+
+**[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to GCE in 3 steps using a web-based interface.
+
+#### More installation options
+
+If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
+on GCEusing one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
+
+[ket]: https://apprenda.com/kismatic/
+[kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
+[kubespray]: https://github.com/kubernetes-incubator/kubespray
+[stackpoint]: https://stackpoint.io/#/
+
+[self-hosted]: hosted
+[integration-guide]: integration
+
+[gce-reference]: {{site.baseurl}}/{{page.version}}/reference/public-cloud/gce

--- a/v2.4/getting-started/kubernetes/installation/index.md
+++ b/v2.4/getting-started/kubernetes/installation/index.md
@@ -34,12 +34,9 @@ to integrate Calico into your own installation or deployment scripts.
 ## Third Party Integrations
 
 A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
-Here are a few, listed alphabetically.
 
-- [Apprenda Kismatic Enterprise Toolkit](https://github.com/apprenda/kismatic)
-- [Container Linux by CoreOS](https://coreos.com/kubernetes/docs/latest/)
-- [GCE](http://kubernetes.io/docs/getting-started-guides/network-policy/calico/)
-- [Gravitational Telekube](http://gravitational.com/blog/gravitational-tigera-partnership/)
-- [Kargo](https://github.com/kubernetes-incubator/kargo)
-- [Kops](https://github.com/kubernetes/kops)
-- [StackPointCloud](https://stackpoint.io)
+You can find some of them here, organized by cloud provider.
+
+- [Amazon Web Services](aws)
+- [Google Compute Engine](gce)
+- [Microsoft Azure](azure)


### PR DESCRIPTION
## Description

Port changes from #954 to v2.4

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
