### PR TITLE
Do not include gobgp binary in calico-node

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache --repository "http://alpine.gliderlabs.com/alpine/edge/co
 # Install remaining runtime deps required for felix from the global repository
 RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools
 
-# Copy in the filesystem - this contains felix, bird, gobgp etc...
+# Copy in the filesystem - this contains felix, bird, calico-bgp-daemon etc...
 COPY filesystem /
 
 CMD ["start_runit"]

--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -39,7 +39,6 @@ BIRD_URL?=https://github.com/projectcalico/calico-bird/releases/download/$(BIRD_
 BIRD6_URL?=https://github.com/projectcalico/calico-bird/releases/download/$(BIRD_VER)/bird6
 BIRDCL_URL?=https://github.com/projectcalico/calico-bird/releases/download/$(BIRD_VER)/birdcl
 CALICO_BGP_DAEMON_URL?=https://github.com/projectcalico/calico-bgp-daemon/releases/download/$(GOBGPD_VER)/calico-bgp-daemon
-GOBGP_URL?=https://github.com/projectcalico/calico-bgp-daemon/releases/download/$(GOBGPD_VER)/gobgp
 
 ###############################################################################
 # calico/node build. Contains the following areas
@@ -159,7 +158,6 @@ $(NODE_CONTAINER_BIN_DIR)/confd:
 
 # Get the calico-bgp-daemon binary
 $(NODE_CONTAINER_BIN_DIR)/calico-bgp-daemon:
-	$(CURL) -L $(GOBGP_URL) -o $(@D)/gobgp
 	$(CURL) -L $(CALICO_BGP_DAEMON_URL) -o $@
 	chmod +x $(@D)/*
 


### PR DESCRIPTION
calico-bgp-daemon has all the functionality and gobgpd isn't executed.

This is the same as https://github.com/projectcalico/calico/pull/879 but has a clean git history.