### PR TITLE
Speed up dev docs builds by excluding past releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
 JEKYLL_VERSION=3.3.1
+DEV?=false
+
+CONFIG=--config _config.yml
+ifeq ($(DEV),true)
+	CONFIG:=$(CONFIG),_config_dev.yml
+endif
+
 serve:
-	docker run --rm -ti -e JEKYLL_UID=`id -u` -p 4000:4000 -v $$PWD:/srv/jekyll jekyll/jekyll:$(JEKYLL_VERSION) jekyll serve --incremental
+	docker run --rm -ti -e JEKYLL_UID=`id -u` -p 4000:4000 -v $$PWD:/srv/jekyll jekyll/jekyll:$(JEKYLL_VERSION) jekyll serve --incremental $(CONFIG)
 
 .PHONY: build
 _site build:
-	docker run --rm -ti -e JEKYLL_UID=`id -u` -v $$PWD:/srv/jekyll jekyll/jekyll:$(JEKYLL_VERSION) jekyll build --incremental
+	docker run --rm -ti -e JEKYLL_UID=`id -u` -v $$PWD:/srv/jekyll jekyll/jekyll:$(JEKYLL_VERSION) jekyll build --incremental $(CONFIG)
 
 clean:
 	docker run --rm -ti -e JEKYLL_UID=`id -u` -v $$PWD:/srv/jekyll jekyll/jekyll:$(JEKYLL_VERSION) jekyll clean

--- a/README.md
+++ b/README.md
@@ -80,7 +80,23 @@ make serve
 
 As the output states, docs should then be viewable at http://localhost:4000/ .
 
+### Faster builds
+
+Jekyll can take a while to render every page. To speed up builds, a supplemental `_config_dev.yml` exists which excludes all
+directories except `master`. Include it in your builds:
+
+```
+jekyll serve --config _config.yml,_config_dev.yml
+```
+
+Or pass enable it in make using the environment variable:
+
+```
+DEV=true make serve
+```
+
 ### Versioning & Branches
+
 The live site is generated from the master branch of this repository.
 
 Documentation for past releases is maintained as a folder in the root of this repository.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,6 +43,7 @@ release is announced.
    3. Navigate to: Setup -> Basics
    4. Under "Sites to search", select "Add", for the url use `docs.projectcalico.org/vX.Y`
    5. Choose vX.Y from the "Label" dropdown.
+1. Edit `_config_dev.yml` to exclude the previous release.
 
 ### Promoting a release candidate to a final release
 1. Add a new `<option>` entry to the `<span class="dropdown">` in `_layouts/docwithnav.html` file. This step should NOT be performed until testing of the release is complete.

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,16 @@
+exclude:
+  - release-scripts
+  - LICENSE
+  - Makefile
+  - README.md
+  - RELEASING.md
+  - BUILDING_CALICO.md
+  - hack
+  - calico_node
+  - v1.5
+  - v1.6
+  - v2.0
+  - v2.1
+  - v2.2
+  - v2.3
+  - v2.4


### PR DESCRIPTION
## Description

Fixes #479

Docs builds are taking increasingly long. This PR adds a optional config file which excludes all past releases, allowing users to quickly iterate on master docs in a development environment

## Todos
- [n/a] Tests
- [x] Documentation
- [x] Release note