### PR TITLE
Update the import for logrus to use lowercasing

### DIFF
--- a/calico_node/allocateipip/allocate_ipip_addr.go
+++ b/calico_node/allocateipip/allocate_ipip_addr.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/calico_node/calicoclient"
 	"github.com/projectcalico/libcalico-go/lib/api"

--- a/calico_node/filesystem/licenses/README.md
+++ b/calico_node/filesystem/licenses/README.md
@@ -64,7 +64,7 @@
 |	[juju/ratelimit](https://github.com/juju/ratelimit)	|	[GNU Lesser General Public License v3.0 (94%)](http://github.com/juju/ratelimit/blob/77ed1c8a01217656d2080ad51981f6e99adaa177/LICENSE)	|
 |	[pelletier/go-toml](https://github.com/pelletier/go-toml)	|	[MIT License](http://github.com/pelletier/go-toml/blob/361678322880708ac144df8575e6f01144ba1404/LICENSE)	|
 |	[spf13/viper](https://github.com/spf13/viper)	|	[MIT License](http://github.com/spf13/viper/blob/7538d73b4eb9511d85a9f1dfef202eeb8ac260f4/LICENSE)	|
-|	[Sirupsen/logrus](https://github.com/Sirupsen/logrus)	|	[MIT License](http://github.com/Sirupsen/logrus/blob/0208149b40d863d2c1a2f8fe5753096a9cf2cc8b/LICENSE)	|
+|	[sirupsen/logrus](https://github.com/sirupsen/logrus)	|	[MIT License](http://github.com/sirupsen/logrus/blob/0208149b40d863d2c1a2f8fe5753096a9cf2cc8b/LICENSE)	|
 |	[golang.org/x/text](https://golang.org/x/text)	|	[BSD 3-clause 'New' or 'Revised' License (96%)](http://github.com/golang/text/blob/master/LICENSE)	|
 |	[mailru/easyjson](https://github.com/mailru/easyjson)	|	[MIT License (98%)](http://github.com/mailru/easyjson/blob/d5b7844b561a7bc640052f1b935f7b800330d7e0/LICENSE)	|
 |	[golang/glog](https://github.com/golang/glog)	|	[Apache License 2.0](http://github.com/golang/glog/blob/44145f04b68cf362d9c4df2182967c2275eaefed/LICENSE)	|
@@ -103,7 +103,6 @@
 |	[docker/distribution](https://github.com/docker/distribution)	|	[Apache License 2.0](http://github.com/docker/distribution/blob/cd27f179f2c10c5d300e6d09025b538c475b0d51/LICENSE)	|
 |	[google/gofuzz](https://github.com/google/gofuzz)	|	[Apache License 2.0](http://github.com/google/gofuzz/blob/bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5/LICENSE)	|
 |	[awslabs/aws-sdk-go](https://github.com/awslabs/aws-sdk-go)	|	[Apache License 2.0](http://github.com/awslabs/aws-sdk-go/blob/29717a72a2fc649e790ce97dc2c4d96e32950844/LICENSE.txt)	|
-|	[Sirupsen/logrus](https://github.com/Sirupsen/logrus)	|	[MIT License](http://github.com/Sirupsen/logrus/blob/092eda23b5d2ccf95fe7dfc70354493eb273487a/LICENSE)	|
 |	[go-openapi/jsonreference](https://github.com/go-openapi/jsonreference)	|	[Apache License 2.0](http://github.com/go-openapi/jsonreference/blob/13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272/LICENSE)	|
 |	[golang.org/x/net](https://golang.org/x/net)	|	[BSD 3-clause 'New' or 'Revised' License (96%)](http://github.com/golang/net/blob/master/LICENSE)	|
 |	[gogo/protobuf](https://github.com/gogo/protobuf)	|	[? (BSD 3-clause 'New' or 'Revised' License, 89%)](http://github.com/gogo/protobuf/blob/e18d7aa8f8c624c915db340349aad4c49b10d173/LICENSE)	|

--- a/calico_node/glide.lock
+++ b/calico_node/glide.lock
@@ -1,25 +1,20 @@
-hash: 5d61f4ce198ea6a2627e5e92e63547b596d08f97f8c02b4ba07554986266c427
-updated: 2017-07-21T13:31:00.971257187-07:00
+hash: 683323edc2407726e63d56e14f258e560efc9115f1e2e91a6bafe9eef6f14711
+updated: 2017-07-31T15:41:50.554082921-07:00
 imports:
 - name: github.com/coreos/etcd
-  version: d267ca9c184e953554257d0acdd1dc9c47d38229
+  version: c31bec0f29facff13f7c3e3d948e55dd6689ed42
   subpackages:
   - client
-  - pkg/fileutil
   - pkg/pathutil
+  - pkg/srv
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
-- name: github.com/coreos/go-systemd
-  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
+  - version
+- name: github.com/coreos/go-semver
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
-  - daemon
-  - journal
-  - util
-- name: github.com/coreos/pkg
-  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
-  subpackages:
-  - capnslog
+  - semver
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -35,7 +30,7 @@ imports:
   - log
   - swagger
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -68,7 +63,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/onsi/ginkgo
-  version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
+  version: 9eda700730cba42af70d53180f9dcce9266bc2bc
   subpackages:
   - config
   - extensions/table
@@ -88,11 +83,6 @@ imports:
   - reporters/stenographer/support/go-colorable
   - reporters/stenographer/support/go-isatty
   - types
-- name: github.com/projectcalico/calico
-  version: 5596ec51e0309b1bb6d7a708ea0f2c22d609137c
-  subpackages:
-  - calico_node/calicoclient
-  - calico_node/startup/autodetection
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -102,7 +92,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: e1ab5e5bf4a57ea6fa71bf4a7712af27b824a005
+  version: 93f9e49214a678551648eb9c28ce57bc286a3169
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -134,7 +124,7 @@ imports:
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
@@ -149,7 +139,7 @@ imports:
   - blowfish
   - ssh/terminal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: c8c74377599bd978aee1cf3b9b63a8634051cec2
   subpackages:
   - context
   - html
@@ -160,7 +150,7 @@ imports:
   - idna
   - lex/httplex
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: 076b546753157f758b316e59bcb51e6807c04057
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -189,7 +179,7 @@ imports:
   - unicode/norm
   - width
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
+  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2
@@ -197,7 +187,7 @@ imports:
   subpackages:
   - patricia
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 - name: k8s.io/apimachinery
   version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
   subpackages:

--- a/calico_node/glide.yaml
+++ b/calico_node/glide.yaml
@@ -1,9 +1,9 @@
 package: github.com/projectcalico/calico/calico_node
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ^0.10.0
 - package: github.com/projectcalico/libcalico-go
-  version: ^1.5.0
+  version: 93f9e49214a678551648eb9c28ce57bc286a3169
   subpackages:
   - lib/api
   - lib/client

--- a/calico_node/startup/autodetection/filtered.go
+++ b/calico_node/startup/autodetection/filtered.go
@@ -17,8 +17,8 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 // FilteredEnumeration performs basic IP and IPNetwork discovery by enumerating

--- a/calico_node/startup/autodetection/interfaces.go
+++ b/calico_node/startup/autodetection/interfaces.go
@@ -18,8 +18,8 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 // Interface contains details about an interface on the host.
@@ -59,7 +59,7 @@ func GetInterfaces(includeRegexes []string, excludeRegexes []string, version int
 
 	// Loop through interfaces filtering on the regexes.  Loop in reverse
 	// order to maintain behavior with older versions.
-	for idx := len(netIfaces)-1; idx >= 0; idx-- {
+	for idx := len(netIfaces) - 1; idx >= 0; idx-- {
 		iface := netIfaces[idx]
 		include := (includeRegexp == nil) || includeRegexp.MatchString(iface.Name)
 		exclude := (excludeRegexp != nil) && excludeRegexp.MatchString(iface.Name)

--- a/calico_node/startup/autodetection/reachaddr.go
+++ b/calico_node/startup/autodetection/reachaddr.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	gonet "net"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 // ReachDestination auto-detects the interface Network by setting up a UDP

--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/calico/calico_node/calicoclient"
 	"github.com/projectcalico/calico/calico_node/startup/autodetection"
 	"github.com/projectcalico/libcalico-go/lib/api"
@@ -31,6 +30,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/ipip"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
+	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
## Description
Updating the logrus import to use the new updated user name (which is lowercased). This will prevent import errors with vendoring going forward.

Requires projectcalico/libcalico-go#484

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
None required
```
