### PR TITLE
standardize table columns, part deux

### DIFF
--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -7,41 +7,41 @@ The `calico/node` container is primarily configured through environment variable
 
 ## Environment Variables
 
-| Environment | Description                              | Schema | Default |
-| ------------- | -------- | ------ | ----- |
-| NODENAME | A unique identifier for this host. | string | |
-| NO_DEFAULT_POOLS | Prevents Calico from creating a default pool if one does not exist. | string | |
-| HOSTNAME [Deprecated] | The Hostname of this host. This is used as a unique identifier for the node. This value is overridden by NODENAME. When omitted, if NODENAME has not been specified, this value defaults to the actual hostname of this host. | string | |
-| IP | The IPv4 address to assign this host. When specified, the address is saved in the [node resource configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/node) for this host, overriding any previously configured value. When omitted, if an address **has** been saved in the node resource, then that value will be used. When omitted, if an address **has not** yet been configured in the node resource, the node will auto-detect an IPv4 address and configure the node resource with that address. This autodetection can be forced (even if a value has already been set in the node resource) by setting IP to "autodetect". Doing so will overwrite any value configured in the node resource. | IPv4 | |
-| IP6 | The IPv6 address for Calico will bind to. When specified, the address is saved in the  [node resource configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/node) for this host, overriding any previously configured value. When omitted, if an address has not yet been configured in the node resource, IPv6 routing is not enabled. When omitted, if an IPv6 address has been previously configured in the node resource, IPv6 is enabled using the already configured address. | IPv6 | |
-| IP_AUTODETECTION_METHOD| The method to use to autodetect the IPv4 address for this host. This is only used when the IPv4 address is being autodetected. See [IP Autodetection methods](#ip-autodetection-methods) for details of the valid methods. | string | first-found |
-| IP6_AUTODETECTION_METHOD| The method to use to autodetect the IPv6 address for this host. This is only used when the IPv6 address is being autodetected. See [IP Autodetection methods](#ip-autodetection-methods) for details of the valid methods. | string | first-found |
-| DISABLE_NODE_IP_CHECK| Skips checks for duplicate Node IPs. This can reduce the load on the cluster when a large number of Nodes are restarting. | bool | false |
-| AS | The AS number for this node. When specified, the value is saved in the node resource configuration for this host, overriding any previously configured value. When omitted, if an AS number has been previously configured in the node resource, that AS number is used for the peering.  When omitted, if an AS number has not yet been configured in the node resource, the node will use the global value (managed through `calicoctl config set/get asnumber`). | int | |
-| DATASTORE_TYPE | Type of datastore. | kubernetes, etcdv2 | etcdv2 |
-| WAIT_FOR_DATASTORE | Wait for connection to datastore before starting. If a successful connection is not made, node will shutdown. | boolean | false |
-| CALICO_LIBNETWORK_CREATE_PROFILES | Enables creating a Calico profile resource for each Docker network.  When disabled, no profiles will be processed even if manually created. | boolean | true |
-| CALICO_LIBNETWORK_LABEL_ENDPOINTS | Enables copying a subset of the Docker container labels for use as Calico labels on workloadendpoints. | boolean | false |
-| CALICO_LIBNETWORK_ENABLED | Enables running the docker-libnetwork plugin directly in the calico/node container. | boolean | true |
-| CALICO_LIBNETWORK_IFPREFIX | Interface prefix to use for the network interface within the Docker containers that have been networked by the Calico driver. | string | cali |
-| CALICO_NETWORKING_BACKEND | Describes which BGP networking backend to use| gobgp, bird, none | bird |
-| CALICO_IPV4POOL_CIDR | The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. | IPv4 CIDR | 192.168.0.0/16 |
-| CALICO_IPV6POOL_CIDR | The IPv6 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. | IPv6 CIDR | fd80:24e2:f998:72d6::/64 |
-| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up. | off, always, cross-subnet | off |
-| CALICO_IPV4POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv4 Pool created at start up. | boolean | true |
-| CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. | boolean | false |
-| CALICO_STARTUP_LOGLEVEL      | The log severity above which startup calico/node logs are sent to the stdout. | string | ERROR |
-| CLUSTER_TYPE | Contains comma delimited list of indicators about this cluster.  Expected to contain information like hosted, services, kubeadm, tectonic, or datastore type. If using Kubernetes API as the datastore then KDD will automatically be added to this list. | k8s, policy, KDD, canal, mesos, docker, rkt, acs, acse, dcos, kubeadm, kubespray, kops, tectonic | |
-| ETCD_ENDPOINTS    | A comma separated list of etcd endpoints (optional) | string | http://127.0.0.1:2379 |
-| ETCD_KEY_FILE     | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)       | string | |
-| ETCD_CERT_FILE    | Path to the etcd client cert, e.g. `/etc/calico/cert.pem` (optional)    | string | |
-| ETCD_CA_CERT_FILE | Path to the etcd CA file, e.g. `/etc/calico/ca.pem` (optional)        | string | |
-| KUBECONFIG | When using the kubernetes datastore, the location of a kubeconfig file to use. | string | |
-| K8S_API_ENDPOINT | Location of the Kubernetes API.  Not required if using kubeconfig. | string | |
-| K8S_CERT_FILE | Location of a client certificate for accessing the Kubernetes API. | string | |
-| K8S_KEY_FILE | Location of a client key for accessing the Kubernetes API. | string | |
-| K8S_CA_FILE | Location of a CA for accessing the Kubernetes API. | string | |
-| K8S_TOKEN | Token to be used for accessing the Kubernetes API. | string | |
+| Environment   | Description | Schema |
+| ------------- | ----------- | ------ |
+| NODENAME | A unique identifier for this host. | string |
+| NO_DEFAULT_POOLS | Prevents Calico from creating a default pool if one does not exist. [Default: `false`] | boolean |
+| HOSTNAME [Deprecated] | The Hostname of this host. This is used as a unique identifier for the node. This value is overridden by NODENAME. When omitted, if NODENAME has not been specified, this value defaults to the actual hostname of this host. | string |
+| IP | The IPv4 address to assign this host. When specified, the address is saved in the [node resource configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/node) for this host, overriding any previously configured value. When omitted, if an address **has** been saved in the node resource, then that value will be used. When omitted, if an address **has not** yet been configured in the node resource, the node will auto-detect an IPv4 address and configure the node resource with that address. This autodetection can be forced (even if a value has already been set in the node resource) by setting IP to "autodetect". Doing so will overwrite any value configured in the node resource. | IPv4 |
+| IP6 | The IPv6 address for Calico will bind to. When specified, the address is saved in the  [node resource configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/node) for this host, overriding any previously configured value. When omitted, if an address has not yet been configured in the node resource, IPv6 routing is not enabled. When omitted, if an IPv6 address has been previously configured in the node resource, IPv6 is enabled using the already configured address. | IPv6 |
+| IP_AUTODETECTION_METHOD | The method to use to autodetect the IPv4 address for this host. This is only used when the IPv4 address is being autodetected. See [IP Autodetection methods](#ip-autodetection-methods) for details of the valid methods. [Default: `first-found`] | string |
+| IP6_AUTODETECTION_METHOD | The method to use to autodetect the IPv6 address for this host. This is only used when the IPv6 address is being autodetected. See [IP Autodetection methods](#ip-autodetection-methods) for details of the valid methods. [Default: `first-found`] | string |
+| DISABLE_NODE_IP_CHECK | Skips checks for duplicate Node IPs. This can reduce the load on the cluster when a large number of Nodes are restarting. [Default: `false`] | boolean |
+| AS | The AS number for this node. When specified, the value is saved in the node resource configuration for this host, overriding any previously configured value. When omitted, if an AS number has been previously configured in the node resource, that AS number is used for the peering.  When omitted, if an AS number has not yet been configured in the node resource, the node will use the global value (managed through `calicoctl config set/get asnumber`). | int |
+| DATASTORE_TYPE | Type of datastore. [Default: `etcdv2`] | kubernetes, etcdv2 |
+| WAIT_FOR_DATASTORE | Wait for connection to datastore before starting. If a successful connection is not made, node will shutdown. [Default: `false`] | boolean |
+| CALICO_LIBNETWORK_CREATE_PROFILES | Enables creating a Calico profile resource for each Docker network.  When disabled, no profiles will be processed even if manually created. [Default: `true`] | boolean |
+| CALICO_LIBNETWORK_LABEL_ENDPOINTS | Enables copying a subset of the Docker container labels for use as Calico labels on workloadendpoints. [Default: `false`] | boolean |
+| CALICO_LIBNETWORK_ENABLED | Enables running the docker-libnetwork plugin directly in the calico/node container. [Default: `true`] | boolean |
+| CALICO_LIBNETWORK_IFPREFIX | Interface prefix to use for the network interface within the Docker containers that have been networked by the Calico driver. [Default: `cali`] | string |
+| CALICO_NETWORKING_BACKEND | Describes which BGP networking backend to use [Default: `bird`] | gobgp, bird, none |
+| CALICO_IPV4POOL_CIDR | The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. [Default: `192.168.0.0/16`] | IPv4 CIDR |
+| CALICO_IPV6POOL_CIDR | The IPv6 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. [Default: `fd80:24e2:f998:72d6::/64`] | IPv6 CIDR |
+| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up. [Default: `off`] | off, always, cross-subnet |
+| CALICO_IPV4POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv4 Pool created at start up. [Default: `true`] | boolean |
+| CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. [Default: `false`] | boolean |
+| CALICO_STARTUP_LOGLEVEL      | The log severity above which startup calico/node logs are sent to the stdout. [Default: `Error`] | DEBUG, INFO, WARNING, ERROR, CRITICAL, or NONE (case-insensitive) |
+| CLUSTER_TYPE | Contains comma delimited list of indicators about this cluster.  Expected to contain information like hosted, services, kubeadm, tectonic, or datastore type. If using Kubernetes API as the datastore then KDD will automatically be added to this list. | k8s, policy, KDD, canal, mesos, docker, rkt, acs, acse, dcos, kubeadm, kubespray, kops, tectonic |
+| ETCD_ENDPOINTS    | A comma separated list of etcd endpoints [Default: `http://127.0.0.1:2379`] (optional) | string |
+| ETCD_KEY_FILE     | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)        | string |
+| ETCD_CERT_FILE    | Path to the etcd client cert, e.g. `/etc/calico/cert.pem` (optional)    | string |
+| ETCD_CA_CERT_FILE | Path to the etcd CA file, e.g. `/etc/calico/ca.pem` (optional)          | string |
+| KUBECONFIG | When using the kubernetes datastore, the location of a kubeconfig file to use. | string |
+| K8S_API_ENDPOINT | Location of the Kubernetes API.  Not required if using kubeconfig.       | string |
+| K8S_CERT_FILE | Location of a client certificate for accessing the Kubernetes API.          | string |
+| K8S_KEY_FILE | Location of a client key for accessing the Kubernetes API.                   | string |
+| K8S_CA_FILE | Location of a CA for accessing the Kubernetes API.                            | string |
+| K8S_TOKEN | Token to be used for accessing the Kubernetes API.                              | string |
 
 In addition to the above, `calico/node` also supports [the standard Felix configuration environment variables](../felix/configuration).
 


### PR DESCRIPTION
## Description
Fold the default value into the description column in order to standardize table layout.
- See issue #https://github.com/projectcalico/calico/pull/939
- documentation only

## Todos
- [x] Tests - htmlproofer

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
For preview, see: http://pr980.splitix.co.uk/master/reference/node/configuration.html