### PR TITLE
Release 2.4.0

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,3 +1,134 @@
+v2.4:
+
+- title: v2.4.0
+  note: |
+    31 July 2017
+
+    Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
+
+  components:
+    felix:
+      version: 2.4.0
+      url: https://github.com/projectcalico/felix/releases/tag/2.4.0
+    typha:
+      version: v0.3.1
+      url: https://github.com/projectcalico/typha/releases/tag/v0.3.1
+    calicoctl:
+      version: v1.4.0
+      url: https://github.com/projectcalico/calicoctl/releases/tag/v1.4.0
+      download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.4.0/calicoctl
+    calico/node:
+      version: v2.4.0
+    calico/cni:
+      version: v1.10.0
+      url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.10.0
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
+    calico-bird:
+      version: v0.3.1
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
+    calico-bgp-daemon:
+      version: v0.2.1
+      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
+    libnetwork-plugin:
+      version: v1.1.0
+      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
+    calico/kube-policy-controller:
+      version: v0.7.0
+      url: https://github.com/projectcalico/k8s-policy/releases/tag/v0.7.0
+    networking-calico:
+      version: 1.4.2
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.2
+    calico/routereflector:
+      version: v0.4.0
+      url: ""
+
+- title: v2.4.0-rc2
+  note: |
+    27 July 2017
+
+    Work-in-progress release notes for the upcoming v2.4.0 release can be found on GitHub.
+
+  components:
+    felix:
+      version: 2.4.0-rc2
+      url: https://github.com/projectcalico/felix/releases/tag/2.4.0-rc2
+    typha:
+      version: v0.3.1
+      url: https://github.com/projectcalico/typha/releases/tag/v0.3.1
+    calicoctl:
+      version: v1.4.0-rc2
+      url: https://github.com/projectcalico/calicoctl/releases/tag/v1.4.0-rc2
+      download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.4.0-rc2/calicoctl
+    calico/node:
+      version: v2.4.0-rc2
+    calico/cni:
+      version: v1.10.0
+      url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.10.0
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
+    calico-bird:
+      version: v0.3.1
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
+    calico-bgp-daemon:
+      version: v0.2.1
+      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
+    libnetwork-plugin:
+      version: v1.1.0
+      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
+    calico/kube-policy-controller:
+      version: v0.7.0
+      url: https://github.com/projectcalico/k8s-policy/releases/tag/v0.7.0
+    networking-calico:
+      version: 1.4.2
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.2
+    calico/routereflector:
+      version: v0.4.0
+      url: ""
+
+- title: v2.4.0-rc1
+  note: |
+    24 July 2017
+
+    Work-in-progress release notes for the upcoming v2.4.0 release can be found on GitHub.
+
+  components:
+    felix:
+      version: 2.4.0-rc1
+      url: https://github.com/projectcalico/felix/releases/tag/2.4.0-rc1
+    typha:
+      version: v0.3.0
+      url: https://github.com/projectcalico/typha/releases/tag/v0.3.0
+    calicoctl:
+      version: v1.4.0-rc1
+      url: https://github.com/projectcalico/calicoctl/releases/tag/v1.4.0-rc1
+      download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.4.0-rc1/calicoctl
+    calico/node:
+      version: v2.4.0-rc1
+    calico/cni:
+      version: v1.10.0
+      url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.10.0
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
+    calico-bird:
+      version: v0.3.1
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
+    calico-bgp-daemon:
+      version: v0.2.1
+      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
+    libnetwork-plugin:
+      version: v1.1.0
+      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
+    calico/kube-policy-controller:
+      version: v0.7.0
+      url: https://github.com/projectcalico/k8s-policy/releases/tag/v0.7.0
+    networking-calico:
+      version: 1.4.2
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.2
+    calico/routereflector:
+      version: v0.4.0
+      url: ""
+
 v2.3:
 - title: v2.3.0
   note: |
@@ -707,100 +838,6 @@ v2.1:
     networking-calico:
       version: 1.4.1
       url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.1
-
-
-v2.4:
-
-- title: v2.4.0-rc2
-  note: |
-    27 July 2017
-
-    ### Changes / New Features
-
-    Work-in-progress release notes for the upcoming v2.4.0 release can be found on GitHub.
-
-  components:
-    felix:
-      version: 2.4.0-rc2
-      url: https://github.com/projectcalico/felix/releases/tag/2.4.0-rc2
-    typha:
-      version: v0.3.1
-      url: https://github.com/projectcalico/typha/releases/tag/v0.3.1
-    calicoctl:
-      version: v1.4.0-rc2
-      url: https://github.com/projectcalico/calicoctl/releases/tag/v1.4.0-rc2
-      download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.4.0-rc2/calicoctl
-    calico/node:
-      version: v2.4.0-rc2
-    calico/cni:
-      version: v1.10.0
-      url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.10.0
-      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
-      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
-    calico-bird:
-      version: v0.3.1
-      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
-    calico-bgp-daemon:
-      version: v0.2.1
-      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
-    libnetwork-plugin:
-      version: v1.1.0
-      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
-    calico/kube-policy-controller:
-      version: v0.7.0
-      url: https://github.com/projectcalico/k8s-policy/releases/tag/v0.7.0
-    networking-calico:
-      version: 1.4.2
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.2
-    calico/routereflector:
-      version: v0.4.0
-      url: ""
-
-
-- title: v2.4.0-rc1
-  note: |
-    24 July 2017
-
-    ### Changes / New Features
-
-    Work-in-progress release notes for the upcoming v2.4.0 release can be found on GitHub.
-
-  components:
-    felix:
-      version: 2.4.0-rc1
-      url: https://github.com/projectcalico/felix/releases/tag/2.4.0-rc1
-    typha:
-      version: v0.3.0
-      url: https://github.com/projectcalico/typha/releases/tag/v0.3.0
-    calicoctl:
-      version: v1.4.0-rc1
-      url: https://github.com/projectcalico/calicoctl/releases/tag/v1.4.0-rc1
-      download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.4.0-rc1/calicoctl
-    calico/node:
-      version: v2.4.0-rc1
-    calico/cni:
-      version: v1.10.0
-      url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.10.0
-      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
-      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
-    calico-bird:
-      version: v0.3.1
-      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
-    calico-bgp-daemon:
-      version: v0.2.1
-      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
-    libnetwork-plugin:
-      version: v1.1.0
-      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
-    calico/kube-policy-controller:
-      version: v0.7.0
-      url: https://github.com/projectcalico/k8s-policy/releases/tag/v0.7.0
-    networking-calico:
-      version: 1.4.2
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.2
-    calico/routereflector:
-      version: v0.4.0
-      url: ""
 
 
 # The master release stream is used to generate the master version of the docs,

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -848,7 +848,7 @@ master:
   note: ""
   components:
      felix:
-      version: 2.4.0-rc2 
+      version: 2.4.0
       url: ""
      calicoctl:
       version: master
@@ -860,8 +860,8 @@ master:
      calico/cni:
       version: master 
       url: ""
-      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.9.1/calico
-      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.9.1/calico-ipam
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
      calico-bird:
       version: v0.3.1
       url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -103,7 +103,8 @@ The code is a little roundabout for a few reasons:
              <li class="dropdown">
                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Version ({{page.version}})<span class="caret"></span></a>
                <ul class="dropdown-menu">
-                 <li><a href="{{site.baseurl}}/v2.3/introduction">v2.3 (latest)</a></li>
+                 <li><a href="{{site.baseurl}}/v2.4/introduction">v2.4 (latest)</a></li>
+                 <li><a href="{{site.baseurl}}/v2.3/introduction">v2.3</a></li>
                  <li><a href="{{site.baseurl}}/v2.2/introduction">v2.2</a></li>
                  <li><a href="{{site.baseurl}}/v2.1/introduction">v2.1</a></li>
                  <li><a href="{{site.baseurl}}/v2.0/introduction">v2.0</a></li>
@@ -127,7 +128,8 @@ The code is a little roundabout for a few reasons:
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Version ({{page.version}})<span class="caret"></span></a>
                 <ul class="dropdown-menu">
-                   <li><a href="{{site.baseurl}}/v2.3/introduction">v2.3 (latest)</a></li>
+                   <li><a href="{{site.baseurl}}/v2.4/introduction">v2.4 (latest)</a></li>
+                   <li><a href="{{site.baseurl}}/v2.3/introduction">v2.3</a></li>
                    <li><a href="{{site.baseurl}}/v2.2/introduction">v2.2</a></li>
                    <li><a href="{{site.baseurl}}/v2.1/introduction">v2.1</a></li>
                    <li><a href="{{site.baseurl}}/v2.0/introduction">v2.0</a></li>

--- a/index.html
+++ b/index.html
@@ -5,5 +5,5 @@ layout: docwithnav
 ---
 <p>You are being redirected to the latest release of Calico Docs.</p>
 <script type="text/javascript">
-window.location = "v2.3/introduction"
+window.location = "v2.4/introduction"
 </script>

--- a/v2.3/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.3/getting-started/bare-metal/bare-metal-install.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Felix as a static binary
-redirect_from: latest/getting-started/bare-metal/bare-metal-install
 ---
 
 These instructions will take you through a first-time install of

--- a/v2.3/getting-started/bare-metal/bare-metal.md
+++ b/v2.3/getting-started/bare-metal/bare-metal.md
@@ -1,6 +1,5 @@
 ---
 title: Using Calico to Secure Host Interfaces
-redirect_from: latest/getting-started/bare-metal/bare-metal
 ---
 
 This guide describes how to use Calico to secure the network interfaces

--- a/v2.3/getting-started/docker/index.md
+++ b/v2.3/getting-started/docker/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico with Docker
-redirect_from: latest/getting-started/docker/index
 ---
 
 Calico implements a Docker network plugin that can be used to provide routing and advanced network policy for Docker containers.

--- a/v2.3/getting-started/docker/installation/manual.md
+++ b/v2.3/getting-started/docker/installation/manual.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Calico for Docker
-redirect_from: latest/getting-started/docker/installation/manual
 ---
 
 Calico runs as a Docker container on each host. The `calicoctl` command line tool can be used to launch the `calico/node` container.

--- a/v2.3/getting-started/docker/installation/requirements.md
+++ b/v2.3/getting-started/docker/installation/requirements.md
@@ -1,6 +1,5 @@
 ---
 title:  Requirements
-redirect_from: latest/getting-started/docker/installation/requirements
 ---
 
 The following information details basic prerequisites that must be met

--- a/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,6 +1,5 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
-redirect_from: latest/getting-started/docker/installation/vagrant-coreos/index
 ---
 
 These instructions allow you to set up a CoreOS Container Linux cluster ready to network Docker containers with

--- a/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,6 +1,5 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
-redirect_from: latest/getting-started/docker/installation/vagrant-ubuntu/index
 ---
 
 These instructions allow you to set up an Ubuntu cluster ready to network Docker containers with

--- a/v2.3/getting-started/docker/troubleshooting.md
+++ b/v2.3/getting-started/docker/troubleshooting.md
@@ -1,5 +1,4 @@
 ---
 title: Troubleshooting Calico for Docker
-redirect_from: latest/getting-started/docker/troubleshooting
 ---
 Information coming soon!

--- a/v2.3/getting-started/docker/tutorials/ipam.md
+++ b/v2.3/getting-started/docker/tutorials/ipam.md
@@ -1,6 +1,5 @@
 ---
 title: IPAM
-redirect_from: latest/getting-started/docker/tutorials/ipam
 ---
 
 With the release of Docker 1.10, support has been added to allow users to

--- a/v2.3/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.3/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Security using Calico Profiles and Policy
-redirect_from: latest/getting-started/docker/tutorials/security-using-calico-profiles-and-policy
 ---
 
 ## Background

--- a/v2.3/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.3/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,6 +1,5 @@
 ---
 title: Security using Calico Profiles
-redirect_from: latest/getting-started/docker/tutorials/security-using-calico-profiles
 ---
 
 ## Background

--- a/v2.3/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.3/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Security using Docker Labels and Calico Policy
-redirect_from: latest/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy
 ---
 
 ## Background

--- a/v2.3/getting-started/docker/upgrade.md
+++ b/v2.3/getting-started/docker/upgrade.md
@@ -1,5 +1,4 @@
 ---
 title: Upgrading Calico for Docker
-redirect_from: latest/getting-started/docker/upgrade
 ---
 Information coming soon!

--- a/v2.3/getting-started/index.md
+++ b/v2.3/getting-started/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Integrations
-redirect_from: latest/getting-started/index
 ---
 
 To get started using Calico, we recommend running through one or more of the

--- a/v2.3/getting-started/kubernetes/index.md
+++ b/v2.3/getting-started/kubernetes/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico for Kubernetes
-redirect_from: latest/getting-started/kubernetes/index
 ---
 
 Calico enables networking and network policy in Kubernetes clusters across the cloud.  Calico works

--- a/v2.3/getting-started/kubernetes/installation/aws.md
+++ b/v2.3/getting-started/kubernetes/installation/aws.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
-redirect_from: latest/getting-started/kubernetes/installation/aws
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on AWS.  We recommend taking

--- a/v2.3/getting-started/kubernetes/installation/gce.md
+++ b/v2.3/getting-started/kubernetes/installation/gce.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
-redirect_from: latest/getting-started/kubernetes/installation/gce
 ---
 
 See [this page]({{site.baseurl}}/{{page.version}}/reference/public-cloud/gce)

--- a/v2.3/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,6 +1,5 @@
 ---
 title: Standard Hosted Install 
-redirect_from: latest/getting-started/kubernetes/installation/hosted/hosted
 ---
 
 To install Calico as a Kubernetes add-on using your own etcd cluster:

--- a/v2.3/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Kubernetes Hosted Install
-redirect_from: latest/getting-started/kubernetes/installation/hosted/index
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,6 +1,5 @@
 ---
 title: Kubeadm Hosted Install
-redirect_from: latest/getting-started/kubernetes/installation/hosted/kubeadm/index
 ---
 
 This document outlines how to install Calico, as well as a as single node

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,6 +1,5 @@
 ---
 title: Kubernetes Datastore
-redirect_from: latest/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.  

--- a/v2.3/getting-started/kubernetes/installation/index.md
+++ b/v2.3/getting-started/kubernetes/installation/index.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Calico on Kubernetes
-redirect_from: latest/getting-started/kubernetes/installation/index
 ---
 
 Calico can be installed on a Kubernetes cluster in a number of configurations.  This document

--- a/v2.3/getting-started/kubernetes/installation/integration.md
+++ b/v2.3/getting-started/kubernetes/installation/integration.md
@@ -1,6 +1,5 @@
 ---
 title: Integration Guide
-redirect_from: latest/getting-started/kubernetes/installation/integration
 ---
 
 

--- a/v2.3/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.3/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
-redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 
 These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not setup TLS between Kubernetes components.

--- a/v2.3/getting-started/kubernetes/troubleshooting.md
+++ b/v2.3/getting-started/kubernetes/troubleshooting.md
@@ -1,6 +1,5 @@
 ---
 title: Troubleshooting Calico for Kubernetes
-redirect_from: latest/getting-started/kubernetes/troubleshooting
 ---
 
 This article contains Kubernetes specific troubleshooting advice for Calico and

--- a/v2.3/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.3/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
-redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 
 The Kubernetes NetworkPolicy API allows users to express ingress policy to Kubernetes pods

--- a/v2.3/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.3/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Simple Policy Demo
-redirect_from: latest/getting-started/kubernetes/tutorials/simple-policy
 ---
 
 This guide provides a simple way to try out Kubernetes NetworkPolicy with Calico.  It requires a Kubernetes cluster configured with Calico networking, and expects that you have `kubectl` configured to interact with the cluster.

--- a/v2.3/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.3/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,6 +1,5 @@
 ---
 title: Stars Policy Demo
-redirect_from: latest/getting-started/kubernetes/tutorials/stars-policy/index
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all
 running on Kubernetes.  It then configures network policy on each service.

--- a/v2.3/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.3/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,6 +1,5 @@
 ---
 title: Using calicoctl in Kubernetes
-redirect_from: latest/getting-started/kubernetes/tutorials/using-calicoctl
 ---
 
 There are two ways to run `calicoctl` in Kubernetes:

--- a/v2.3/getting-started/mesos/index.md
+++ b/v2.3/getting-started/mesos/index.md
@@ -1,6 +1,5 @@
 ---
 title: Integration Guide
-redirect_from: latest/getting-started/mesos/index
 ---
 
 Calico introduces IP-per-container & fine-grained security policies to Mesos, while

--- a/v2.3/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.3/getting-started/mesos/installation/dc-os/custom.md
@@ -1,6 +1,5 @@
 ---
 title: Customizing the Calico Universe Framework
-redirect_from: latest/getting-started/mesos/installation/dc-os/custom
 ---
 
 The the Calico Universe Framework includes customization options which support

--- a/v2.3/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.3/getting-started/mesos/installation/dc-os/framework.md
@@ -1,6 +1,5 @@
 ---
 title: Calico DC/OS Installation Guide
-redirect_from: latest/getting-started/mesos/installation/dc-os/framework
 ---
 
 The following guide walks through installing Calico for DC/OS using the Universe

--- a/v2.3/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.3/getting-started/mesos/installation/dc-os/index.md
@@ -1,6 +1,5 @@
 ---
 title: Overview of Calico for DC/OS
-redirect_from: latest/getting-started/mesos/installation/dc-os/index
 ---
 
 The following information details Calico's installation and runtime dependencies

--- a/v2.3/getting-started/mesos/installation/integration.md
+++ b/v2.3/getting-started/mesos/installation/integration.md
@@ -1,6 +1,5 @@
 ---
 title: Integration Guide
-redirect_from: latest/getting-started/mesos/installation/integration
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing

--- a/v2.3/getting-started/mesos/installation/prerequisites.md
+++ b/v2.3/getting-started/mesos/installation/prerequisites.md
@@ -1,6 +1,5 @@
 ---
 title: Requirements for Calico with Mesos
-redirect_from: latest/getting-started/mesos/installation/prerequisites
 ---
 
 #### 1. etcd

--- a/v2.3/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.3/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,6 +1,5 @@
 ---
 title: Connecting to Tasks
-redirect_from: latest/getting-started/mesos/tutorials/connecting-tasks
 ---
 
 When Calico is used to network Mesos tasks,

--- a/v2.3/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.3/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,6 +1,5 @@
 ---
 title: Launching Tasks
-redirect_from: latest/getting-started/mesos/tutorials/launching-tasks
 ---
 
 The following information describes how to launch Calico networked tasks in Mesos

--- a/v2.3/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/v2.3/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,6 +1,5 @@
 ---
 title: Network Policy (Docker Containerizer)
-redirect_from: latest/getting-started/mesos/tutorials/policy/docker-containerizer
 ---
 
 The Docker Containerizer uses Docker directly to launch tasks.

--- a/v2.3/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.3/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,6 +1,5 @@
 ---
 title: Network Policy (Universal Containerizer)
-redirect_from: latest/getting-started/mesos/tutorials/policy/universal-containerizer
 ---
 
 This document will demonstrate how to manipulate policy for Calico using

--- a/v2.3/getting-started/mesos/vagrant/index.md
+++ b/v2.3/getting-started/mesos/vagrant/index.md
@@ -1,6 +1,5 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
-redirect_from: latest/getting-started/mesos/vagrant/index
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster
 with Calico installed and ready to network Docker Containerizer tasks.

--- a/v2.3/getting-started/openstack/connectivity.md
+++ b/v2.3/getting-started/openstack/connectivity.md
@@ -1,6 +1,5 @@
 ---
 title: Connectivity in OpenStack
-redirect_from: latest/getting-started/openstack/connectivity
 ---
 
 An OpenStack deployment is of limited use if its VMs cannot reach and be

--- a/v2.3/getting-started/openstack/index.md
+++ b/v2.3/getting-started/openstack/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico for OpenStack
-redirect_from: latest/getting-started/openstack/index
 ---
 
 Calico's integration with OpenStack consists of the following pieces.

--- a/v2.3/getting-started/openstack/installation/chef.md
+++ b/v2.3/getting-started/openstack/installation/chef.md
@@ -1,6 +1,5 @@
 ---
 title: Chef Trial Install
-redirect_from: latest/getting-started/openstack/installation/chef
 ...
 
 > **WARNING**

--- a/v2.3/getting-started/openstack/installation/devstack.md
+++ b/v2.3/getting-started/openstack/installation/devstack.md
@@ -1,6 +1,5 @@
 ---
 title: DevStack plugin for Calico
-redirect_from: latest/getting-started/openstack/installation/devstack
 ---
 
 The networking-calico project provides a DevStack plugin.  The following

--- a/v2.3/getting-started/openstack/installation/fuel.md
+++ b/v2.3/getting-started/openstack/installation/fuel.md
@@ -1,6 +1,5 @@
 ---
 title: Integration with Fuel
-redirect_from: latest/getting-started/openstack/installation/fuel
 ---
 
 Calico plugins are available for Fuel 6.1 and 7.0, and work is in progress for

--- a/v2.3/getting-started/openstack/installation/index.md
+++ b/v2.3/getting-started/openstack/installation/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico with OpenStack
-redirect_from: latest/getting-started/openstack/installation/index
 ---
 
 There are many ways to try out Calico with OpenStack, because OpenStack

--- a/v2.3/getting-started/openstack/installation/juju.md
+++ b/v2.3/getting-started/openstack/installation/juju.md
@@ -1,6 +1,5 @@
 ---
 title: Juju Install
-redirect_from: latest/getting-started/openstack/installation/juju
 ---
 
 You can use Ubuntu's [Juju Charms](https://jujucharms.com/) to quickly deploy a

--- a/v2.3/getting-started/openstack/installation/redhat.md
+++ b/v2.3/getting-started/openstack/installation/redhat.md
@@ -1,6 +1,5 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
-redirect_from: latest/getting-started/openstack/installation/redhat
 ---
 
 For this version of Calico, with OpenStack on RHEL 7 or CentOS 7, we recommend

--- a/v2.3/getting-started/openstack/installation/ubuntu.md
+++ b/v2.3/getting-started/openstack/installation/ubuntu.md
@@ -1,6 +1,5 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
-redirect_from: latest/getting-started/openstack/installation/ubuntu
 ---
 
 For this version of Calico, with OpenStack on Ubuntu Trusty or Xenial, we

--- a/v2.3/getting-started/openstack/neutron-api.md
+++ b/v2.3/getting-started/openstack/neutron-api.md
@@ -1,6 +1,5 @@
 ---
 title: How Calico Interprets Neutron API Calls
-redirect_from: latest/getting-started/openstack/neutron-api
 ---
 
 When running in an OpenStack deployment, Calico receives and interprets

--- a/v2.3/getting-started/openstack/tutorials.md
+++ b/v2.3/getting-started/openstack/tutorials.md
@@ -1,6 +1,5 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
-redirect_from: latest/getting-started/openstack/tutorials
 ---
 
 Here are a few worked examples for common Calico on OpenStack deployment

--- a/v2.3/getting-started/openstack/upgrade.md
+++ b/v2.3/getting-started/openstack/upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
-redirect_from: latest/getting-started/openstack/upgrade
 ---
 
 This document details the procedure for upgrading a Calico-based

--- a/v2.3/getting-started/openstack/verification.md
+++ b/v2.3/getting-started/openstack/verification.md
@@ -1,6 +1,5 @@
 ---
 title: Verifying your Calico on OpenStack deployment
-redirect_from: latest/getting-started/openstack/verification
 ---
 
 This document takes you through the steps you can perform to verify that

--- a/v2.3/getting-started/rkt/index.md
+++ b/v2.3/getting-started/rkt/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico with rkt
-redirect_from: latest/getting-started/rkt/index
 ---
 
 Calico supports networking and network policy in a pure rkt container environment.

--- a/v2.3/getting-started/rkt/installation/manual.md
+++ b/v2.3/getting-started/rkt/installation/manual.md
@@ -1,6 +1,5 @@
 ---
 title:  Manual Installation of Calico with rkt
-redirect_from: latest/getting-started/rkt/installation/manual
 ---
 
 This tutorial describes how to manually configure a working environment for

--- a/v2.3/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.3/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,6 +1,5 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
-redirect_from: latest/getting-started/rkt/installation/vagrant-coreos/index
 ---
 
 This is a Quick Start guide that uses Vagrant and VirtualBox to create a two-node

--- a/v2.3/getting-started/rkt/troubleshooting.md
+++ b/v2.3/getting-started/rkt/troubleshooting.md
@@ -1,6 +1,5 @@
 ---
 title: Troubleshooting Calico for rkt
-redirect_from: latest/getting-started/rkt/troubleshooting
 ---
 
 This article contains rkt specific troubleshooting advice for Calico and 

--- a/v2.3/getting-started/rkt/tutorials/basic.md
+++ b/v2.3/getting-started/rkt/tutorials/basic.md
@@ -1,6 +1,5 @@
 ---
 title: Basic Network Isolation
-redirect_from: latest/getting-started/rkt/tutorials/basic
 ---
 
 This guide provides a simple way to try out rkt network isolation with Calico.

--- a/v2.3/index.html
+++ b/v2.3/index.html
@@ -1,6 +1,5 @@
 ---
 title: Project Calico Documentation
-redirect_from: latest/index.html
 description: Home
 layout: docwithnav
 ---

--- a/v2.3/introduction/index.html
+++ b/v2.3/introduction/index.html
@@ -1,6 +1,5 @@
 ---
 title: Project Calico Documentation
-redirect_from: latest/introduction/index.html
 description: Home
 layout: docwithnav
 ---

--- a/v2.3/reference/advanced/etcd-rbac.md
+++ b/v2.3/reference/advanced/etcd-rbac.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a Calico Role for etcdv2 RBAC
-redirect_from: latest/reference/advanced/etcd-rbac
 ---
 
 Calico writes all of its data in a `/calico/` directory of etcd.

--- a/v2.3/reference/architecture/components.md
+++ b/v2.3/reference/architecture/components.md
@@ -1,6 +1,5 @@
 ---
 title: Anatomy of a calico-node container
-redirect_from: latest/reference/architecture/components
 ---
 
 `calico/node` can be regarded as a helper container that bundles together the

--- a/v2.3/reference/architecture/data-path.md
+++ b/v2.3/reference/architecture/data-path.md
@@ -1,6 +1,5 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
-redirect_from: latest/reference/architecture/data-path
 ---
 
 

--- a/v2.3/reference/architecture/index.md
+++ b/v2.3/reference/architecture/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Architecture
-redirect_from: latest/reference/architecture/index
 ---
 
 This document discusses the various pieces of the Calico's architecture, 

--- a/v2.3/reference/calicoctl/commands/apply.md
+++ b/v2.3/reference/calicoctl/commands/apply.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl apply
-redirect_from: latest/reference/calicoctl/commands/apply
 ---
 
 This sections describes the `calicoctl apply` command.

--- a/v2.3/reference/calicoctl/commands/config.md
+++ b/v2.3/reference/calicoctl/commands/config.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl config
-redirect_from: latest/reference/calicoctl/commands/config
 ---
 
 This sections describes the `calicoctl config` commands.

--- a/v2.3/reference/calicoctl/commands/create.md
+++ b/v2.3/reference/calicoctl/commands/create.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl create
-redirect_from: latest/reference/calicoctl/commands/create
 ---
 
 This sections describes the `calicoctl create` command.

--- a/v2.3/reference/calicoctl/commands/delete.md
+++ b/v2.3/reference/calicoctl/commands/delete.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl delete
-redirect_from: latest/reference/calicoctl/commands/delete
 ---
 
 This sections describes the `calicoctl delete` command.

--- a/v2.3/reference/calicoctl/commands/get.md
+++ b/v2.3/reference/calicoctl/commands/get.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl get
-redirect_from: latest/reference/calicoctl/commands/get
 ---
 
 This sections describes the `calicoctl get` command.

--- a/v2.3/reference/calicoctl/commands/index.md
+++ b/v2.3/reference/calicoctl/commands/index.md
@@ -1,6 +1,5 @@
 ---
 title: Command Reference
-redirect_from: latest/reference/calicoctl/commands/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage Calico network

--- a/v2.3/reference/calicoctl/commands/ipam/index.md
+++ b/v2.3/reference/calicoctl/commands/ipam/index.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl ipam
-redirect_from: latest/reference/calicoctl/commands/ipam/index
 ---
 
 This section describes the `calicoctl ipam` commands.

--- a/v2.3/reference/calicoctl/commands/ipam/release.md
+++ b/v2.3/reference/calicoctl/commands/ipam/release.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl ipam
-redirect_from: latest/reference/calicoctl/commands/ipam/release
 ---
 
 This section describes the `calicoctl ipam release` command.

--- a/v2.3/reference/calicoctl/commands/ipam/show.md
+++ b/v2.3/reference/calicoctl/commands/ipam/show.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl ipam
-redirect_from: latest/reference/calicoctl/commands/ipam/show
 ---
 
 This section describes the `calicoctl ipam show` command.

--- a/v2.3/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.3/reference/calicoctl/commands/node/checksystem.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node checksystem
-redirect_from: latest/reference/calicoctl/commands/node/checksystem
 ---
 
 This section describes the `calicoctl node checksystem` command.

--- a/v2.3/reference/calicoctl/commands/node/diags.md
+++ b/v2.3/reference/calicoctl/commands/node/diags.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node diags
-redirect_from: latest/reference/calicoctl/commands/node/diags
 ---
 
 This section describes the `calicoctl node diags` command.

--- a/v2.3/reference/calicoctl/commands/node/index.md
+++ b/v2.3/reference/calicoctl/commands/node/index.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node
-redirect_from: latest/reference/calicoctl/commands/node/index
 ---
 
 This section describes the `calicoctl node` commands.

--- a/v2.3/reference/calicoctl/commands/node/run.md
+++ b/v2.3/reference/calicoctl/commands/node/run.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node run
-redirect_from: latest/reference/calicoctl/commands/node/run
 ---
 
 This sections describes the `calicoctl node run` command.

--- a/v2.3/reference/calicoctl/commands/node/status.md
+++ b/v2.3/reference/calicoctl/commands/node/status.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node status
-redirect_from: latest/reference/calicoctl/commands/node/status
 ---
 
 This sections describes the `calicoctl node status` command.

--- a/v2.3/reference/calicoctl/commands/replace.md
+++ b/v2.3/reference/calicoctl/commands/replace.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl replace
-redirect_from: latest/reference/calicoctl/commands/replace
 ---
 
 This sections describes the `calicoctl replace` command.

--- a/v2.3/reference/calicoctl/commands/version.md
+++ b/v2.3/reference/calicoctl/commands/version.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl version
-redirect_from: latest/reference/calicoctl/commands/version
 ---
 
 This sections describes the `calicoctl version` command.

--- a/v2.3/reference/calicoctl/index.md
+++ b/v2.3/reference/calicoctl/index.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl user reference
-redirect_from: latest/reference/calicoctl/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage Calico network

--- a/v2.3/reference/calicoctl/resources/bgppeer.md
+++ b/v2.3/reference/calicoctl/resources/bgppeer.md
@@ -1,6 +1,5 @@
 ---
 title: BGP Peer Resource (bgpPeer)
-redirect_from: latest/reference/calicoctl/resources/bgppeer
 ---
 
 A BGP Peer resource (bgpPeer) represents a remote BGP peer with which the node(s) in a Calico 

--- a/v2.3/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.3/reference/calicoctl/resources/hostendpoint.md
@@ -1,6 +1,5 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
-redirect_from: latest/reference/calicoctl/resources/hostendpoint
 ---
 
 A Host Endpoint resource (hostEndpoint) represents an interface attached to a host that is running Calico.

--- a/v2.3/reference/calicoctl/resources/index.md
+++ b/v2.3/reference/calicoctl/resources/index.md
@@ -1,6 +1,5 @@
 ---
 title: Resource Definitions
-redirect_from: latest/reference/calicoctl/resources/index
 ---
 
 This section describes the set of valid resource types that can be managed

--- a/v2.3/reference/calicoctl/resources/ippool.md
+++ b/v2.3/reference/calicoctl/resources/ippool.md
@@ -1,6 +1,5 @@
 ---
 title: IP Pool Resource (ipPool)
-redirect_from: latest/reference/calicoctl/resources/ippool
 ---
 
 An IP pool resource (ipPool) represents a collection of IP addresses from which Calico expects

--- a/v2.3/reference/calicoctl/resources/node.md
+++ b/v2.3/reference/calicoctl/resources/node.md
@@ -1,6 +1,5 @@
 ---
 title: Node Resource (node)
-redirect_from: latest/reference/calicoctl/resources/node
 ---
 
 An Node resource (node) represents a node running Calico.  When adding a host

--- a/v2.3/reference/calicoctl/resources/policy.md
+++ b/v2.3/reference/calicoctl/resources/policy.md
@@ -1,6 +1,5 @@
 ---
 title: Policy Resource (policy)
-redirect_from: latest/reference/calicoctl/resources/policy
 ---
 
 A Policy resource (policy) represents an ordered set of rules which are applied

--- a/v2.3/reference/calicoctl/resources/profile.md
+++ b/v2.3/reference/calicoctl/resources/profile.md
@@ -1,6 +1,5 @@
 ---
 title: Profile Resource (profile)
-redirect_from: latest/reference/calicoctl/resources/profile
 ---
 
 A Profile resource (profile) represents a set of rules which are applied 

--- a/v2.3/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.3/reference/calicoctl/resources/workloadendpoint.md
@@ -1,6 +1,5 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
-redirect_from: latest/reference/calicoctl/resources/workloadendpoint
 ---
 
 A Workload Endpoint resource (workloadEndpoint) represents an interface 

--- a/v2.3/reference/calicoctl/setup/etcdv2.md
+++ b/v2.3/reference/calicoctl/setup/etcdv2.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
-redirect_from: latest/reference/calicoctl/setup/etcdv2
 ---
 
 This document covers the configuration options for calicoctl when using an etcdv2 datastore.

--- a/v2.3/reference/calicoctl/setup/index.md
+++ b/v2.3/reference/calicoctl/setup/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calicoctl Configuration Overview 
-redirect_from: latest/reference/calicoctl/setup/index
 ---
 
 The `calicoctl` command line tool needs to be configured with details of

--- a/v2.3/reference/calicoctl/setup/kubernetes.md
+++ b/v2.3/reference/calicoctl/setup/kubernetes.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
-redirect_from: latest/reference/calicoctl/setup/kubernetes
 layout: docwithnav
 ---
 

--- a/v2.3/reference/cni-plugin/configuration.md
+++ b/v2.3/reference/cni-plugin/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring the Calico CNI plugins
-redirect_from: latest/reference/cni-plugin/configuration
 ---
 
 The Calico CNI plugin is configured through the standard CNI [configuration mechanism](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration)

--- a/v2.3/reference/contribute.md
+++ b/v2.3/reference/contribute.md
@@ -1,6 +1,5 @@
 ---
 title: Contribution Guidelines
-redirect_from: latest/reference/contribute
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.3/reference/felix/configuration.md
+++ b/v2.3/reference/felix/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Felix
-redirect_from: latest/reference/felix/configuration
 ---
 
 Configuration for Felix is read from one of four possible locations, in

--- a/v2.3/reference/felix/prometheus.md
+++ b/v2.3/reference/felix/prometheus.md
@@ -1,6 +1,5 @@
 ---
 title: Felix Prometheus Statistics
-redirect_from: latest/reference/felix/prometheus
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the

--- a/v2.3/reference/index.md
+++ b/v2.3/reference/index.md
@@ -1,6 +1,5 @@
 ---
 title: Reference
-redirect_from: latest/reference/index
 noversion: yes
 ---
 

--- a/v2.3/reference/involved.md
+++ b/v2.3/reference/involved.md
@@ -1,6 +1,5 @@
 ---
 title: Getting Involved
-redirect_from: latest/reference/involved
 ---
 
 Calico is an open source project, and we'd love you to get involved.

--- a/v2.3/reference/license.md
+++ b/v2.3/reference/license.md
@@ -1,6 +1,5 @@
 ---
 title: Third Party Software Attributions
-redirect_from: latest/reference/license
 ---
 
 

--- a/v2.3/reference/node/configuration.md
+++ b/v2.3/reference/node/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring calico/node
-redirect_from: latest/reference/node/configuration
 ---
 
 The `calico/node` container is primarily configured through environment variables.

--- a/v2.3/reference/policy-controller/configuration.md
+++ b/v2.3/reference/policy-controller/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring the Calico policy controller 
-redirect_from: latest/reference/policy-controller/configuration
 ---
 
 The policy controller is primarily configured through environment variables.  When running

--- a/v2.3/reference/previous-releases.md
+++ b/v2.3/reference/previous-releases.md
@@ -1,6 +1,5 @@
 ---
 title: Previous releases
-redirect_from: latest/reference/previous-releases
 ---
 
 

--- a/v2.3/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.3/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,7 +1,6 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
-redirect_from: latest/reference/private-cloud/l2-interconnect-fabric
 ---
 
 

--- a/v2.3/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.3/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,6 +1,5 @@
 ---
 title: IP Interconnect Fabrics in Calico
-redirect_from: latest/reference/private-cloud/l3-interconnect-fabric
 lead_text: 'Where large-scale IP networks and hardware collide'
 ---
 

--- a/v2.3/reference/public-cloud/aws.md
+++ b/v2.3/reference/public-cloud/aws.md
@@ -1,6 +1,5 @@
 ---
 title: AWS
-redirect_from: latest/reference/public-cloud/aws
 ---
 
 Calico provides the following advantages when running in AWS:

--- a/v2.3/reference/public-cloud/gce.md
+++ b/v2.3/reference/public-cloud/gce.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico on GCE
-redirect_from: latest/reference/public-cloud/gce
 ---
 
 To deploy Calico in [Google Compute Engine][GCE], you must ensure that the

--- a/v2.3/reference/repo-structure.md
+++ b/v2.3/reference/repo-structure.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Repositories
-redirect_from: latest/reference/repo-structure
 ---
 
 The following information details which artifacts are built from which

--- a/v2.3/reference/requirements.md
+++ b/v2.3/reference/requirements.md
@@ -1,6 +1,5 @@
 ---
 title: Calico System Requirements
-redirect_from: latest/reference/requirements
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v2.3/reference/supported-platforms.md
+++ b/v2.3/reference/supported-platforms.md
@@ -1,6 +1,5 @@
 ---
 title: Supported Platforms
-redirect_from: latest/reference/supported-platforms
 ---
 
 Calico version {{ page.version }} has supported integration with the following platforms.

--- a/v2.3/releases/index.md
+++ b/v2.3/releases/index.md
@@ -1,6 +1,5 @@
 ---
 title: Releases
-redirect_from: latest/releases/index
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.3/usage/calicoctl/container.md
+++ b/v2.3/usage/calicoctl/container.md
@@ -1,6 +1,5 @@
 ---
 title: calico/ctl container
-redirect_from: latest/usage/calicoctl/container
 ---
 
 With each release of calicoctl the docker container `calico/ctl` is released to

--- a/v2.3/usage/calicoctl/install-and-configuration.md
+++ b/v2.3/usage/calicoctl/install-and-configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Installing and Configuring calicoctl
-redirect_from: latest/usage/calicoctl/install-and-configuration
 ---
 
 This document outlines how to install and configure calicoctl which is the

--- a/v2.3/usage/configuration/as-service.md
+++ b/v2.3/usage/configuration/as-service.md
@@ -1,6 +1,5 @@
 ---
 title: Running Calico Node Container as a Service
-redirect_from: latest/usage/configuration/as-service
 ---
 
 This guide explains how to run Calico as a system process or service,

--- a/v2.3/usage/configuration/bgp.md
+++ b/v2.3/usage/configuration/bgp.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring BGP Peers
-redirect_from: latest/usage/configuration/bgp
 ---
 
 This document describes the commands available in `calicoctl` for managing BGP.  It

--- a/v2.3/usage/configuration/conntrack.md
+++ b/v2.3/usage/configuration/conntrack.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Conntrack
-redirect_from: latest/usage/configuration/conntrack
 ---
 
 A common problem on Linux systems is running out of space in the

--- a/v2.3/usage/configuration/ip-in-ip.md
+++ b/v2.3/usage/configuration/ip-in-ip.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring IP-in-IP
-redirect_from: latest/usage/configuration/ip-in-ip
 ---
 
 If your network fabric performs source/destination address checks 

--- a/v2.3/usage/configuration/mtu.md
+++ b/v2.3/usage/configuration/mtu.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring MTU
-redirect_from: latest/usage/configuration/mtu
 ---
 
 Depending on the environment Calico is being deployed into it may be

--- a/v2.3/usage/configuration/node.md
+++ b/v2.3/usage/configuration/node.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a Node IP Address and Subnet
-redirect_from: latest/usage/configuration/node
 ---
 
 By default, Calico automatically detects each Node's IP address and subnet.  In most cases, 

--- a/v2.3/usage/decommissioning-a-node.md
+++ b/v2.3/usage/decommissioning-a-node.md
@@ -1,6 +1,5 @@
 ---
 title: Decommissioning a Node
-redirect_from: latest/usage/decommissioning-a-node
 ---
 
 ### Why you might be interested in this guide

--- a/v2.3/usage/external-connectivity.md
+++ b/v2.3/usage/external-connectivity.md
@@ -1,6 +1,5 @@
 ---
 title: External Connectivity
-redirect_from: latest/usage/external-connectivity
 ---
 Calico creates a routed network on which your containers look like normal IP
 speakers. You can connect to them from a host in your cluster (assuming the

--- a/v2.3/usage/index.md
+++ b/v2.3/usage/index.md
@@ -1,6 +1,5 @@
 ---
 title: Using Calico
-redirect_from: latest/usage/index
 ---
 
 This section contains information on using Calico.

--- a/v2.3/usage/ipv6.md
+++ b/v2.3/usage/ipv6.md
@@ -1,6 +1,5 @@
 ---
 title: IPv6 Support
-redirect_from: latest/usage/ipv6
 ---
 
 Calico supports connectivity over IPv6, between compute hosts, and

--- a/v2.3/usage/openstack/configuration.md
+++ b/v2.3/usage/openstack/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Systems for use with Calico
-redirect_from: latest/usage/openstack/configuration
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.3/usage/openstack/floating-ips.md
+++ b/v2.3/usage/openstack/floating-ips.md
@@ -1,6 +1,5 @@
 ---
 title: Floating IPs
-redirect_from: latest/usage/openstack/floating-ips
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.3/usage/openstack/host-routes.md
+++ b/v2.3/usage/openstack/host-routes.md
@@ -1,6 +1,5 @@
 ---
 title: Host routes
-redirect_from: latest/usage/openstack/host-routes
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.3/usage/openstack/kuryr.md
+++ b/v2.3/usage/openstack/kuryr.md
@@ -1,6 +1,5 @@
 ---
 title: Kuryr
-redirect_from: latest/usage/openstack/kuryr
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.3/usage/openstack/semantics.md
+++ b/v2.3/usage/openstack/semantics.md
@@ -1,6 +1,5 @@
 ---
 title: Detailed Semantics
-redirect_from: latest/usage/openstack/semantics
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.3/usage/openstack/service-ips.md
+++ b/v2.3/usage/openstack/service-ips.md
@@ -1,6 +1,5 @@
 ---
 title: Service IPs
-redirect_from: latest/usage/openstack/service-ips
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.3/usage/routereflector/bird-rr-config.md
+++ b/v2.3/usage/routereflector/bird-rr-config.md
@@ -1,6 +1,5 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
-redirect_from: latest/usage/routereflector/bird-rr-config
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required. 

--- a/v2.3/usage/routereflector/calico-routereflector.md
+++ b/v2.3/usage/routereflector/calico-routereflector.md
@@ -1,6 +1,5 @@
 ---
 title: 'Calico BIRD Route Reflector container'
-redirect_from: latest/usage/routereflector/calico-routereflector
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required. 

--- a/v2.3/usage/troubleshooting/faq.md
+++ b/v2.3/usage/troubleshooting/faq.md
@@ -1,6 +1,5 @@
 ---
 title: Frequently Asked Questions
-redirect_from: latest/usage/troubleshooting/faq
 layout: docwithnav
 ---
 

--- a/v2.3/usage/troubleshooting/index.md
+++ b/v2.3/usage/troubleshooting/index.md
@@ -1,6 +1,5 @@
 ---
 title: Troubleshooting
-redirect_from: latest/usage/troubleshooting/index
 ---
 
 ## Running `sudo calicoctl ...` with Environment Variables

--- a/v2.3/usage/troubleshooting/logging.md
+++ b/v2.3/usage/troubleshooting/logging.md
@@ -1,6 +1,5 @@
 ---
 title: Logging
-redirect_from: latest/usage/troubleshooting/logging
 ---
 
 ## The calico-node container

--- a/v2.4/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.4/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+redirect_from: latest/getting-started/bare-metal/bare-metal-install
 ---
 
 These instructions will take you through a first-time install of

--- a/v2.4/getting-started/bare-metal/bare-metal.md
+++ b/v2.4/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+redirect_from: latest/getting-started/bare-metal/bare-metal
 ---
 
 This guide describes how to use Calico to secure the network interfaces

--- a/v2.4/getting-started/docker/index.md
+++ b/v2.4/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+redirect_from: latest/getting-started/docker/index
 ---
 
 Calico implements a Docker network plugin that can be used to provide routing and advanced network policy for Docker containers.

--- a/v2.4/getting-started/docker/installation/manual.md
+++ b/v2.4/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+redirect_from: latest/getting-started/docker/installation/manual
 ---
 
 Calico runs as a Docker container on each host. The `calicoctl` command line tool can be used to launch the `calico/node` container.

--- a/v2.4/getting-started/docker/installation/requirements.md
+++ b/v2.4/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+redirect_from: latest/getting-started/docker/installation/requirements
 ---
 
 The following information details basic prerequisites that must be met

--- a/v2.4/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.4/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+redirect_from: latest/getting-started/docker/installation/vagrant-coreos/index
 ---
 
 These instructions allow you to set up a CoreOS Container Linux cluster ready to network Docker containers with

--- a/v2.4/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.4/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+redirect_from: latest/getting-started/docker/installation/vagrant-ubuntu/index
 ---
 
 These instructions allow you to set up an Ubuntu cluster ready to network Docker containers with

--- a/v2.4/getting-started/docker/troubleshooting.md
+++ b/v2.4/getting-started/docker/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Docker
+redirect_from: latest/getting-started/docker/troubleshooting
 ---
 Information coming soon!

--- a/v2.4/getting-started/docker/tutorials/ipam.md
+++ b/v2.4/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+redirect_from: latest/getting-started/docker/tutorials/ipam
 ---
 
 With the release of Docker 1.10, support has been added to allow users to

--- a/v2.4/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.4/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles and Policy
+redirect_from: latest/getting-started/docker/tutorials/security-using-calico-profiles-and-policy
 ---
 
 ## Background

--- a/v2.4/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.4/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles
+redirect_from: latest/getting-started/docker/tutorials/security-using-calico-profiles
 ---
 
 ## Background

--- a/v2.4/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.4/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Docker Labels and Calico Policy
+redirect_from: latest/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy
 ---
 
 ## Background

--- a/v2.4/getting-started/docker/upgrade.md
+++ b/v2.4/getting-started/docker/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Docker
+redirect_from: latest/getting-started/docker/upgrade
 ---
 Information coming soon!

--- a/v2.4/getting-started/index.md
+++ b/v2.4/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+redirect_from: latest/getting-started/index
 ---
 
 To get started using Calico, we recommend running through one or more of the

--- a/v2.4/getting-started/kubernetes/index.md
+++ b/v2.4/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for Kubernetes
+redirect_from: latest/getting-started/kubernetes/index
 ---
 
 Calico enables networking and network policy in Kubernetes clusters across the cloud.  Calico works

--- a/v2.4/getting-started/kubernetes/installation/aws.md
+++ b/v2.4/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+redirect_from: latest/getting-started/kubernetes/installation/aws
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on AWS.  We recommend taking

--- a/v2.4/getting-started/kubernetes/installation/azure.md
+++ b/v2.4/getting-started/kubernetes/installation/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
+redirect_from: latest/getting-started/kubernetes/installation/azure
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on Azure.  We recommend taking

--- a/v2.4/getting-started/kubernetes/installation/gce.md
+++ b/v2.4/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+redirect_from: latest/getting-started/kubernetes/installation/gce
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on GCE.  We recommend taking

--- a/v2.4/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+redirect_from: latest/getting-started/kubernetes/installation/hosted/hosted
 ---
 
 The following steps install Calico as a Kubernetes add-on using your own etcd cluster.

--- a/v2.4/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+redirect_from: latest/getting-started/kubernetes/installation/hosted/index
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubeadm Hosted Install
+redirect_from: latest/getting-started/kubernetes/installation/hosted/kubeadm/index
 ---
 
 This document outlines how to install Calico, as well as a as single node

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Datastore
+redirect_from: latest/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.

--- a/v2.4/getting-started/kubernetes/installation/index.md
+++ b/v2.4/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+redirect_from: latest/getting-started/kubernetes/installation/index
 ---
 
 Calico can be installed on a Kubernetes cluster in a number of configurations.  This document

--- a/v2.4/getting-started/kubernetes/installation/integration.md
+++ b/v2.4/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+redirect_from: latest/getting-started/kubernetes/installation/integration
 ---
 
 

--- a/v2.4/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.4/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 
 These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not setup TLS between Kubernetes components.

--- a/v2.4/getting-started/kubernetes/troubleshooting.md
+++ b/v2.4/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+redirect_from: latest/getting-started/kubernetes/troubleshooting
 ---
 
 This article contains Kubernetes specific troubleshooting advice for Calico and

--- a/v2.4/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.4/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
+redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 
 The Kubernetes NetworkPolicy API allows users to express ingress policy to Kubernetes pods

--- a/v2.4/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.4/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+redirect_from: latest/getting-started/kubernetes/tutorials/simple-policy
 ---
 
 This guide provides a simple way to try out Kubernetes NetworkPolicy with Calico.  It requires a Kubernetes cluster configured with Calico networking, and expects that you have `kubectl` configured to interact with the cluster.

--- a/v2.4/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.4/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+redirect_from: latest/getting-started/kubernetes/tutorials/stars-policy/index
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all
 running on Kubernetes.  It then configures network policy on each service.

--- a/v2.4/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.4/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+redirect_from: latest/getting-started/kubernetes/tutorials/using-calicoctl
 ---
 
 There are two ways to run `calicoctl` in Kubernetes:

--- a/v2.4/getting-started/kubernetes/upgrade.md
+++ b/v2.4/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+redirect_from: latest/getting-started/kubernetes/upgrade
 ---
 
 This document covers upgrading the Calico components in a Kubernetes deployment.  This

--- a/v2.4/getting-started/mesos/index.md
+++ b/v2.4/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+redirect_from: latest/getting-started/mesos/index
 ---
 
 Calico introduces IP-per-container & fine-grained security policies to Mesos, while

--- a/v2.4/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.4/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+redirect_from: latest/getting-started/mesos/installation/dc-os/custom
 ---
 
 The the Calico Universe Framework includes customization options which support

--- a/v2.4/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.4/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+redirect_from: latest/getting-started/mesos/installation/dc-os/framework
 ---
 
 The following guide walks through installing Calico for DC/OS using the Universe

--- a/v2.4/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.4/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+redirect_from: latest/getting-started/mesos/installation/dc-os/index
 ---
 
 The following information details Calico's installation and runtime dependencies

--- a/v2.4/getting-started/mesos/installation/integration.md
+++ b/v2.4/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+redirect_from: latest/getting-started/mesos/installation/integration
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing

--- a/v2.4/getting-started/mesos/installation/prerequisites.md
+++ b/v2.4/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+redirect_from: latest/getting-started/mesos/installation/prerequisites
 ---
 
 #### 1. etcd

--- a/v2.4/getting-started/mesos/installation/vagrant-centos/index.md
+++ b/v2.4/getting-started/mesos/installation/vagrant-centos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+redirect_from: latest/getting-started/mesos/installation/vagrant-centos/index
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster
 with Calico installed and ready to network Docker Containerizer tasks.

--- a/v2.4/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.4/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting to Tasks
+redirect_from: latest/getting-started/mesos/tutorials/connecting-tasks
 ---
 
 When Calico is used to network Mesos tasks,

--- a/v2.4/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.4/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Launching Tasks
+redirect_from: latest/getting-started/mesos/tutorials/launching-tasks
 ---
 
 The following information describes how to launch Calico networked tasks in Mesos

--- a/v2.4/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/v2.4/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Docker Containerizer)
+redirect_from: latest/getting-started/mesos/tutorials/policy/docker-containerizer
 ---
 
 The Docker Containerizer uses Docker directly to launch tasks.

--- a/v2.4/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.4/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Universal Containerizer)
+redirect_from: latest/getting-started/mesos/tutorials/policy/universal-containerizer
 ---
 
 This document will demonstrate how to manipulate policy for Calico using

--- a/v2.4/getting-started/openshift/installation.md
+++ b/v2.4/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+redirect_from: latest/getting-started/openshift/installation
 ---
 
 Installation of Calico in OpenShift is integrated in openshift-ansible v3.6.

--- a/v2.4/getting-started/openstack/connectivity.md
+++ b/v2.4/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+redirect_from: latest/getting-started/openstack/connectivity
 ---
 
 An OpenStack deployment is of limited use if its VMs cannot reach and be

--- a/v2.4/getting-started/openstack/index.md
+++ b/v2.4/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+redirect_from: latest/getting-started/openstack/index
 ---
 
 Calico's integration with OpenStack consists of the following pieces.

--- a/v2.4/getting-started/openstack/installation/chef.md
+++ b/v2.4/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+redirect_from: latest/getting-started/openstack/installation/chef
 ...
 
 > **WARNING**

--- a/v2.4/getting-started/openstack/installation/devstack.md
+++ b/v2.4/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+redirect_from: latest/getting-started/openstack/installation/devstack
 ---
 
 The networking-calico project provides a DevStack plugin.  The following

--- a/v2.4/getting-started/openstack/installation/fuel.md
+++ b/v2.4/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+redirect_from: latest/getting-started/openstack/installation/fuel
 ---
 
 Calico plugins are available for Fuel 6.1 and 7.0, and work is in progress for

--- a/v2.4/getting-started/openstack/installation/index.md
+++ b/v2.4/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+redirect_from: latest/getting-started/openstack/installation/index
 ---
 
 There are many ways to try out Calico with OpenStack, because OpenStack

--- a/v2.4/getting-started/openstack/installation/juju.md
+++ b/v2.4/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+redirect_from: latest/getting-started/openstack/installation/juju
 ---
 
 You can use Ubuntu's [Juju Charms](https://jujucharms.com/) to quickly deploy a

--- a/v2.4/getting-started/openstack/installation/redhat.md
+++ b/v2.4/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+redirect_from: latest/getting-started/openstack/installation/redhat
 ---
 
 For this version of Calico, with OpenStack on RHEL 7 or CentOS 7, we recommend

--- a/v2.4/getting-started/openstack/installation/ubuntu.md
+++ b/v2.4/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+redirect_from: latest/getting-started/openstack/installation/ubuntu
 ---
 
 For this version of Calico, with OpenStack on Ubuntu Trusty or Xenial, we

--- a/v2.4/getting-started/openstack/neutron-api.md
+++ b/v2.4/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+redirect_from: latest/getting-started/openstack/neutron-api
 ---
 
 When running in an OpenStack deployment, Calico receives and interprets

--- a/v2.4/getting-started/openstack/tutorials.md
+++ b/v2.4/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+redirect_from: latest/getting-started/openstack/tutorials
 ---
 
 Here are a few worked examples for common Calico on OpenStack deployment

--- a/v2.4/getting-started/openstack/upgrade.md
+++ b/v2.4/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+redirect_from: latest/getting-started/openstack/upgrade
 ---
 
 This document details the procedure for upgrading a Calico-based

--- a/v2.4/getting-started/openstack/verification.md
+++ b/v2.4/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+redirect_from: latest/getting-started/openstack/verification
 ---
 
 This document takes you through the steps you can perform to verify that

--- a/v2.4/getting-started/rkt/index.md
+++ b/v2.4/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+redirect_from: latest/getting-started/rkt/index
 ---
 
 Calico supports networking and network policy in a pure rkt container environment.

--- a/v2.4/getting-started/rkt/installation/manual.md
+++ b/v2.4/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+redirect_from: latest/getting-started/rkt/installation/manual
 ---
 
 This tutorial describes how to manually configure a working environment for

--- a/v2.4/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.4/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+redirect_from: latest/getting-started/rkt/installation/vagrant-coreos/index
 ---
 
 This is a Quick Start guide that uses Vagrant and VirtualBox to create a two-node

--- a/v2.4/getting-started/rkt/troubleshooting.md
+++ b/v2.4/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+redirect_from: latest/getting-started/rkt/troubleshooting
 ---
 
 This article contains rkt specific troubleshooting advice for Calico and 

--- a/v2.4/getting-started/rkt/tutorials/basic.md
+++ b/v2.4/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+redirect_from: latest/getting-started/rkt/tutorials/basic
 ---
 
 This guide provides a simple way to try out rkt network isolation with Calico.

--- a/v2.4/index.html
+++ b/v2.4/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+redirect_from: latest/index.html
 description: Home
 layout: docwithnav
 ---

--- a/v2.4/introduction/index.html
+++ b/v2.4/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+redirect_from: latest/introduction/index.html
 description: Home
 layout: docwithnav
 ---

--- a/v2.4/reference/advanced/etcd-rbac.md
+++ b/v2.4/reference/advanced/etcd-rbac.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Calico Role for etcdv2 RBAC
+redirect_from: latest/reference/advanced/etcd-rbac
 ---
 
 Calico writes all of its data in a `/calico/` directory of etcd.

--- a/v2.4/reference/architecture/components.md
+++ b/v2.4/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+redirect_from: latest/reference/architecture/components
 ---
 
 `calico/node` can be regarded as a helper container that bundles together the

--- a/v2.4/reference/architecture/data-path.md
+++ b/v2.4/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+redirect_from: latest/reference/architecture/data-path
 ---
 
 

--- a/v2.4/reference/architecture/index.md
+++ b/v2.4/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+redirect_from: latest/reference/architecture/index
 ---
 
 This document discusses the various pieces of the Calico's architecture, 

--- a/v2.4/reference/calicoctl/commands/apply.md
+++ b/v2.4/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+redirect_from: latest/reference/calicoctl/commands/apply
 ---
 
 This sections describes the `calicoctl apply` command.

--- a/v2.4/reference/calicoctl/commands/config.md
+++ b/v2.4/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+redirect_from: latest/reference/calicoctl/commands/config
 ---
 
 This sections describes the `calicoctl config` commands.

--- a/v2.4/reference/calicoctl/commands/create.md
+++ b/v2.4/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+redirect_from: latest/reference/calicoctl/commands/create
 ---
 
 This sections describes the `calicoctl create` command.

--- a/v2.4/reference/calicoctl/commands/delete.md
+++ b/v2.4/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+redirect_from: latest/reference/calicoctl/commands/delete
 ---
 
 This sections describes the `calicoctl delete` command.

--- a/v2.4/reference/calicoctl/commands/get.md
+++ b/v2.4/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+redirect_from: latest/reference/calicoctl/commands/get
 ---
 
 This sections describes the `calicoctl get` command.

--- a/v2.4/reference/calicoctl/commands/index.md
+++ b/v2.4/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+redirect_from: latest/reference/calicoctl/commands/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage Calico network

--- a/v2.4/reference/calicoctl/commands/ipam/index.md
+++ b/v2.4/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+redirect_from: latest/reference/calicoctl/commands/ipam/index
 ---
 
 This section describes the `calicoctl ipam` commands.

--- a/v2.4/reference/calicoctl/commands/ipam/release.md
+++ b/v2.4/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+redirect_from: latest/reference/calicoctl/commands/ipam/release
 ---
 
 This section describes the `calicoctl ipam release` command.

--- a/v2.4/reference/calicoctl/commands/ipam/show.md
+++ b/v2.4/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+redirect_from: latest/reference/calicoctl/commands/ipam/show
 ---
 
 This section describes the `calicoctl ipam show` command.

--- a/v2.4/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.4/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+redirect_from: latest/reference/calicoctl/commands/node/checksystem
 ---
 
 This section describes the `calicoctl node checksystem` command.

--- a/v2.4/reference/calicoctl/commands/node/diags.md
+++ b/v2.4/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+redirect_from: latest/reference/calicoctl/commands/node/diags
 ---
 
 This section describes the `calicoctl node diags` command.

--- a/v2.4/reference/calicoctl/commands/node/index.md
+++ b/v2.4/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+redirect_from: latest/reference/calicoctl/commands/node/index
 ---
 
 This section describes the `calicoctl node` commands.

--- a/v2.4/reference/calicoctl/commands/node/run.md
+++ b/v2.4/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+redirect_from: latest/reference/calicoctl/commands/node/run
 ---
 
 This sections describes the `calicoctl node run` command.

--- a/v2.4/reference/calicoctl/commands/node/status.md
+++ b/v2.4/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+redirect_from: latest/reference/calicoctl/commands/node/status
 ---
 
 This sections describes the `calicoctl node status` command.

--- a/v2.4/reference/calicoctl/commands/replace.md
+++ b/v2.4/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+redirect_from: latest/reference/calicoctl/commands/replace
 ---
 
 This sections describes the `calicoctl replace` command.

--- a/v2.4/reference/calicoctl/commands/version.md
+++ b/v2.4/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+redirect_from: latest/reference/calicoctl/commands/version
 ---
 
 This sections describes the `calicoctl version` command.

--- a/v2.4/reference/calicoctl/index.md
+++ b/v2.4/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+redirect_from: latest/reference/calicoctl/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage Calico network

--- a/v2.4/reference/calicoctl/resources/bgppeer.md
+++ b/v2.4/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+redirect_from: latest/reference/calicoctl/resources/bgppeer
 ---
 
 A BGP Peer resource (bgpPeer) represents a remote BGP peer with which the node(s) in a Calico 

--- a/v2.4/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.4/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+redirect_from: latest/reference/calicoctl/resources/hostendpoint
 ---
 
 A Host Endpoint resource (hostEndpoint) represents an interface attached to a host that is running Calico.

--- a/v2.4/reference/calicoctl/resources/index.md
+++ b/v2.4/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+redirect_from: latest/reference/calicoctl/resources/index
 ---
 
 This section describes the set of valid resource types that can be managed

--- a/v2.4/reference/calicoctl/resources/ippool.md
+++ b/v2.4/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+redirect_from: latest/reference/calicoctl/resources/ippool
 ---
 
 An IP pool resource (ipPool) represents a collection of IP addresses from which Calico expects

--- a/v2.4/reference/calicoctl/resources/node.md
+++ b/v2.4/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+redirect_from: latest/reference/calicoctl/resources/node
 ---
 
 An Node resource (node) represents a node running Calico.  When adding a host

--- a/v2.4/reference/calicoctl/resources/policy.md
+++ b/v2.4/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+redirect_from: latest/reference/calicoctl/resources/policy
 ---
 
 A Policy resource (policy) represents an ordered set of rules which are applied

--- a/v2.4/reference/calicoctl/resources/profile.md
+++ b/v2.4/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+redirect_from: latest/reference/calicoctl/resources/profile
 ---
 
 A Profile resource (profile) represents a set of rules which are applied 

--- a/v2.4/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.4/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+redirect_from: latest/reference/calicoctl/resources/workloadendpoint
 ---
 
 A Workload Endpoint resource (workloadEndpoint) represents an interface 

--- a/v2.4/reference/calicoctl/setup/etcdv2.md
+++ b/v2.4/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+redirect_from: latest/reference/calicoctl/setup/etcdv2
 ---
 
 This document covers the configuration options for calicoctl when using an etcdv2 datastore.

--- a/v2.4/reference/calicoctl/setup/index.md
+++ b/v2.4/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+redirect_from: latest/reference/calicoctl/setup/index
 ---
 
 The `calicoctl` command line tool needs to be configured with details of

--- a/v2.4/reference/calicoctl/setup/kubernetes.md
+++ b/v2.4/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
+redirect_from: latest/reference/calicoctl/setup/kubernetes
 layout: docwithnav
 ---
 

--- a/v2.4/reference/cni-plugin/configuration.md
+++ b/v2.4/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+redirect_from: latest/reference/cni-plugin/configuration
 ---
 
 The Calico CNI plugin is configured through the standard CNI [configuration mechanism](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration)

--- a/v2.4/reference/contribute.md
+++ b/v2.4/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+redirect_from: latest/reference/contribute
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.4/reference/felix/configuration.md
+++ b/v2.4/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+redirect_from: latest/reference/felix/configuration
 ---
 
 Configuration for Felix is read from one of four possible locations, in

--- a/v2.4/reference/felix/prometheus.md
+++ b/v2.4/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+redirect_from: latest/reference/felix/prometheus
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the

--- a/v2.4/reference/index.md
+++ b/v2.4/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+redirect_from: latest/reference/index
 noversion: yes
 ---
 

--- a/v2.4/reference/involved.md
+++ b/v2.4/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+redirect_from: latest/reference/involved
 ---
 
 Calico is an open source project, and we'd love you to get involved.

--- a/v2.4/reference/license.md
+++ b/v2.4/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+redirect_from: latest/reference/license
 ---
 
 

--- a/v2.4/reference/node/configuration.md
+++ b/v2.4/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+redirect_from: latest/reference/node/configuration
 ---
 
 The `calico/node` container is primarily configured through environment variables.

--- a/v2.4/reference/policy-controller/configuration.md
+++ b/v2.4/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller 
+redirect_from: latest/reference/policy-controller/configuration
 ---
 
 The policy controller is primarily configured through environment variables.  When running

--- a/v2.4/reference/previous-releases.md
+++ b/v2.4/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+redirect_from: latest/reference/previous-releases
 ---
 
 

--- a/v2.4/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.4/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+redirect_from: latest/reference/private-cloud/l2-interconnect-fabric
 ---
 
 

--- a/v2.4/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.4/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+redirect_from: latest/reference/private-cloud/l3-interconnect-fabric
 lead_text: 'Where large-scale IP networks and hardware collide'
 ---
 

--- a/v2.4/reference/public-cloud/aws.md
+++ b/v2.4/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+redirect_from: latest/reference/public-cloud/aws
 ---
 
 Calico provides the following advantages when running in AWS:

--- a/v2.4/reference/public-cloud/gce.md
+++ b/v2.4/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+redirect_from: latest/reference/public-cloud/gce
 ---
 
 To deploy Calico in [Google Compute Engine][GCE], you must ensure that the

--- a/v2.4/reference/repo-structure.md
+++ b/v2.4/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+redirect_from: latest/reference/repo-structure
 ---
 
 The following information details which artifacts are built from which

--- a/v2.4/reference/requirements.md
+++ b/v2.4/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+redirect_from: latest/reference/requirements
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v2.4/reference/supported-platforms.md
+++ b/v2.4/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+redirect_from: latest/reference/supported-platforms
 ---
 
 Calico version {{ page.version }} has supported integration with the following platforms.

--- a/v2.4/releases/index.md
+++ b/v2.4/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+redirect_from: latest/releases/index
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.4/usage/calicoctl/container.md
+++ b/v2.4/usage/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calico/ctl container
+redirect_from: latest/usage/calicoctl/container
 ---
 
 With each release of calicoctl the docker container `calico/ctl` is released to

--- a/v2.4/usage/calicoctl/install-and-configuration.md
+++ b/v2.4/usage/calicoctl/install-and-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and Configuring calicoctl
+redirect_from: latest/usage/calicoctl/install-and-configuration
 ---
 
 This document outlines how to install and configure calicoctl which is the

--- a/v2.4/usage/configuration/as-service.md
+++ b/v2.4/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+redirect_from: latest/usage/configuration/as-service
 ---
 
 This guide explains how to run Calico as a system process or service,

--- a/v2.4/usage/configuration/bgp.md
+++ b/v2.4/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+redirect_from: latest/usage/configuration/bgp
 ---
 
 This document describes the commands available in `calicoctl` for managing BGP.  It

--- a/v2.4/usage/configuration/conntrack.md
+++ b/v2.4/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+redirect_from: latest/usage/configuration/conntrack
 ---
 
 A common problem on Linux systems is running out of space in the

--- a/v2.4/usage/configuration/ip-in-ip.md
+++ b/v2.4/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+redirect_from: latest/usage/configuration/ip-in-ip
 ---
 
 If your network fabric performs source/destination address checks 

--- a/v2.4/usage/configuration/mtu.md
+++ b/v2.4/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+redirect_from: latest/usage/configuration/mtu
 ---
 
 Depending on the environment Calico is being deployed into it may be

--- a/v2.4/usage/configuration/node.md
+++ b/v2.4/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+redirect_from: latest/usage/configuration/node
 ---
 
 By default, Calico automatically detects each Node's IP address and subnet.  In most cases, 

--- a/v2.4/usage/decommissioning-a-node.md
+++ b/v2.4/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+redirect_from: latest/usage/decommissioning-a-node
 ---
 
 ### Why you might be interested in this guide

--- a/v2.4/usage/external-connectivity.md
+++ b/v2.4/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+redirect_from: latest/usage/external-connectivity
 ---
 Calico creates a routed network on which your containers look like normal IP
 speakers. You can connect to them from a host in your cluster (assuming the

--- a/v2.4/usage/index.md
+++ b/v2.4/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+redirect_from: latest/usage/index
 ---
 
 This section contains information on using Calico.

--- a/v2.4/usage/ipv6.md
+++ b/v2.4/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+redirect_from: latest/usage/ipv6
 ---
 
 Calico supports connectivity over IPv6, between compute hosts, and

--- a/v2.4/usage/openstack/configuration.md
+++ b/v2.4/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+redirect_from: latest/usage/openstack/configuration
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.4/usage/openstack/floating-ips.md
+++ b/v2.4/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+redirect_from: latest/usage/openstack/floating-ips
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.4/usage/openstack/host-routes.md
+++ b/v2.4/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+redirect_from: latest/usage/openstack/host-routes
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.4/usage/openstack/kuryr.md
+++ b/v2.4/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+redirect_from: latest/usage/openstack/kuryr
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.4/usage/openstack/semantics.md
+++ b/v2.4/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+redirect_from: latest/usage/openstack/semantics
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.4/usage/openstack/service-ips.md
+++ b/v2.4/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+redirect_from: latest/usage/openstack/service-ips
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.4/usage/routereflector/bird-rr-config.md
+++ b/v2.4/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+redirect_from: latest/usage/routereflector/bird-rr-config
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required. 

--- a/v2.4/usage/routereflector/calico-routereflector.md
+++ b/v2.4/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+redirect_from: latest/usage/routereflector/calico-routereflector
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required. 

--- a/v2.4/usage/troubleshooting/faq.md
+++ b/v2.4/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+redirect_from: latest/usage/troubleshooting/faq
 layout: docwithnav
 ---
 

--- a/v2.4/usage/troubleshooting/index.md
+++ b/v2.4/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+redirect_from: latest/usage/troubleshooting/index
 ---
 
 ## Running `sudo calicoctl ...` with Environment Variables

--- a/v2.4/usage/troubleshooting/logging.md
+++ b/v2.4/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+redirect_from: latest/usage/troubleshooting/logging
 ---
 
 ## The calico-node container


### PR DESCRIPTION
# Description

Calico v2.4.0

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

# Proposed Release notes for Calico v2.4.0

## Changes to [typha](https://github.com/projectcalico/typha)
 - [#27](https://github.com/projectcalico/typha/pull/27): Implement health endpoints for Typha (@neiljerram)

## Changes to [calicoctl](https://github.com/projectcalico/calicoctl)
 - [#1687](https://github.com/projectcalico/calicoctl/pull/1687): The calicoctl version command now includes the CalicoVersion and ClusterType as retrieved from the datastore. (@tmjd)
 - [#1680](https://github.com/projectcalico/calicoctl/pull/1680): Added functionality for calicoctl commands to read in multiple yaml documents specified in the same file/input and separated by `---`. (@mgleung)
 - [#1673](https://github.com/projectcalico/calicoctl/pull/1673): The calico/ctl container's default working directory has changed to `/root` (@caseydavenport)

## Changes to [felix](https://github.com/projectcalico/felix)
 - [#1500](https://github.com/projectcalico/felix/pull/1500): Improve performance of dataplane driver by reducing number of conntrack deletions. (@fasaxc)
 - [#1498](https://github.com/projectcalico/felix/pull/1498): Improve performance when the conntrack table contains many entries by doing conntrack deletions in the background. (@fasaxc)

## Changes to [cni-plugin](https://github.com/projectcalico/cni-plugin)
 - [#341](https://github.com/projectcalico/cni-plugin/pull/341): The calico/cni container now supports setting `SKIP_CNI_BINARIES` to skip installation of certain binaries. (@abhinavdahiya)

## Changes to [calico](https://github.com/projectcalico/calico)
 - [#964](https://github.com/projectcalico/calico/pull/964): Felix now supports a health check endpoint, and the Kubernetes self-hosted installation manifests now enable liveness and readiness probes which report Felix health. (@gunjan5)
 - [#952](https://github.com/projectcalico/calico/pull/952): [beta feature] Add global and per-node BGP peer configuration and global BGP configuration support when using Kubernetes API as the Calico datastore. (@robbrockbank)
 - [#924](https://github.com/projectcalico/calico/pull/924): The version of etcd included in the Calico kubeadm manifests has been revved to v3.1.10. (@caseydavenport)
 - [#935](https://github.com/projectcalico/calico/pull/935): Felix now (optionally) acquires the iptables lock while manipulating iptables.  This prevents 
conflicts with other applications, such as kube-proxy (as long as they also honor the lock).  
    - **Note**: to be effective if Felix is running in a container, this feature requires the 
directory containing the iptables lock file, "/run/", to be mounted into the container. (@fasaxc)
 - [#915](https://github.com/projectcalico/calico/pull/915): calico/node will now only check for conflicting Node IPs when initially getting an IP or when a change in IP is detected.  This should reduce the load on the cluster when a large number of nodes are restarting. (@heschlie)
 - [#910](https://github.com/projectcalico/calico/pull/910): Pre-DNAT Policy - a new flavor of Calico Policy that is enforced before any DNAT that a cluster node may do (for example kube-proxy).  Pre-DNAT Policy is useful for securing the perimeter of a cluster against incoming traffic, except for pinholes that are expressed in terms of particular IP addresses and/or ports that external clients are allowed to connect in to.  For more information please see http://docs.projectcalico.org/v2.4/getting-started/bare-metal/bare-metal#pre-dnat-policy. (@neiljerram)
 - [#898](https://github.com/projectcalico/calico/pull/898): Calico releases now produce a release archive including Kubernetes manifests, docker images, and binaries. (@tomdee)
 - [#885](https://github.com/projectcalico/calico/pull/885): Added new option that takes interface regexes to skip interfaces during ip auto detection. (@mgleung)
 - [#885](https://github.com/projectcalico/calico/pull/885): Added support for specifying multiple interface regexes to attempt to match on during ip auto detection. (@mgleung)
 - [#861](https://github.com/projectcalico/calico/pull/861): Ability to enable / disable outgoing NAT on the default IP Pool using an environment variable. (@VincentS)

## Changes to [k8s-policy](https://github.com/projectcalico/k8s-policy)
 - [#105](https://github.com/projectcalico/k8s-policy/pull/105): Calico now implements the networking.k8s.io/NetworkPolicy API semantics [as defined by Kubernetes](https://github.com/kubernetes/kubernetes/pull/39164#issue-197243974) when using the etcd datastore
    - **Note:** This represents a change in how existing Kubernetes NetworkPolicies are enforced by Calico. To maintain existing behavior when upgrading, follow these steps: 
        - In Namespaces that previously did not have the “DefaultDeny” annotation, you should delete any existing NetworkPolicy objects. 
        - In Namespaces that previously did have the “DefaultDeny” annotation, you can create the equivalent semantics by creating a NetworkPolicy that selects all pods but does not allow any traffic. (@caseydavenport)

## Changes to [libcalico-go](https://github.com/projectcalico/libcalico-go)
 - [#471](https://github.com/projectcalico/libcalico-go/pull/471): Policy objects now support arbitrary key/value annotations. (@caseydavenport)
 - [#470](https://github.com/projectcalico/libcalico-go/pull/470): Add new Source.Nets and Destination.Nets fields (and their negated couterparts) 
to rules, allowing multiple CIDRs to be matched in a single rule.  The Source.Net 
and Destination.Net fields are now deprecated; when reading back data that 
contains a Net field, it will be converted to a single-entry Nets field.  Felix (and 
Typha, if in use) should be upgraded before using the new Nets fields in a rule. (@fasaxc)