### PR TITLE
Fix link to cse.google.com & update PR template with comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,24 @@
 ## Description
-A few sentences describing the overall goals of the pull request's commits.
+
+<!-- A few sentences describing the overall goals of the pull request's commits.
 Please include
 - the type of fix - (e.g. bug fix, new feature, documentation)
 - some details on _why_ this PR should be merged
 - the details of the testing you've done on it (both manual and automated)
 - which components are affected by this PR
 - links to issues that this PR addresses
+-->
+
+
 
 ## Todos
+
 - [ ] Tests
 - [ ] Documentation
 - [ ] Release note
 
 ## Release Note
+
 <!-- Writing a release note:
 - By default, no release note action is required.
 - If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ release is announced.
 1. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).
 1. Push the tag.
 1. Create a GitHub release on the Calico repo, and upload the release file (calico_node/release-<VERSION>.tgz)
-1. Edit the [Calico Docs Custom Search Engine](cse.google.com/).
+1. Edit the [Calico Docs Custom Search Engine](https://cse.google.com/).
    1. Navigate to: search engine -> Search Features -> Refinements -> Add
    2. Add a new refinement name: vX.Y
    3. Navigate to: Setup -> Basics


### PR DESCRIPTION
## Description

- Fix link to CSE in releasing.md
- update PR template so that description is comment. (same as https://github.com/projectcalico/cni-plugin/pull/365)

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
