### PR TITLE
Update calico-bgp-daemon version in master to reflect the newest release

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -866,8 +866,8 @@ master:
       version: v0.3.1
       url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
      calico-bgp-daemon:
-      version: v0.2.1
-      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
+      version: v0.2.2
+      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.2
      libnetwork-plugin:
       version: v1.1.0 
       url: ""


### PR DESCRIPTION
## Description
Updated the calico-bgp-daemon version to update the gobgp version being used as a part of https://github.com/projectcalico/calico-bgp-daemon/pull/26

Necessary for https://github.com/projectcalico/calicoctl/pull/1696 to work properly

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
None required
```
