### PR TITLE
Update jekyll url to https

### DIFF
--- a/BUILDING_CALICO.md
+++ b/BUILDING_CALICO.md
@@ -42,7 +42,7 @@ mkdir -p $BASEDIR
 These instructions describe how to build a particular release or Calico.  This comprises
 of multiple sub components each individually versioned.  To determine which
 particular tag (version) of code to checkout for each repo, consult the Releases page of the
-appropriate version of the [Calico documentation](http://docs.projectcalico.org)
+appropriate version of the [Calico documentation](https://docs.projectcalico.org)
 
 Define the following environment variables that describe the versions of each of the
 components that you are building (the instruction below use these):

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Note that the README in this repo is targeted at Calico docs contributors.
 </blockquote>
 
 
-For information on `calico/node`, see the [documentation on calico/node architecture](http://docs.projectcalico.org/master/reference/architecture/components).
+For information on `calico/node`, see the [documentation on calico/node architecture](https://docs.projectcalico.org/master/reference/architecture/components).
 
 ### Developing
 
 Print useful actions with `make help`.
 
-![Project Calico logo](http://docs.projectcalico.org/images/felix.png)
+![Project Calico logo](https://docs.projectcalico.org/images/felix.png)
 
 
 ### Building `calico/node`

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ permalink:     /:title.html
 gems:
   - jekyll-redirect-from
 
+url: https://docs.projectcalico.org
+
 exclude:
   - release-scripts
   - LICENSE

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -852,8 +852,8 @@ master:
       url: ""
      calicoctl:
       version: master
-      url: "http://www.projectcalico.org/builds/calicoctl"
-      download_url: "http://www.projectcalico.org/builds/calicoctl"
+      url: "https://www.projectcalico.org/builds/calicoctl"
+      download_url: "https://www.projectcalico.org/builds/calicoctl"
      calico/node:
       version: master
       url: ""

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -41,7 +41,7 @@ The code is a little roundabout for a few reasons:
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- <link rel="canonical" href="http://www.projectcalico.org/docs{{page.url}}" /> -->
+    <!-- <link rel="canonical" href="https://www.projectcalico.org/docs{{page.url}}" /> -->
     <link rel="shortcut icon" type="image/png" href="{{site.baseurl}}/images/favicon.png">
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
@@ -98,7 +98,7 @@ The code is a little roundabout for a few reasons:
               <li><a href="https://www.projectcalico.org/community">Community</a>
                 <ul>
                     <li><a href="https://slack.projectcalico.org/"><i class="fa fa-slack" aria-hidden="true"></i> &nbsp; Slack</a></li>
-                    <!--<li><a href="http://stackoverflow.com/questions/tagged/project-calico" target="_blank"><i class="fa fa-stack-overflow" aria-hidden="true"></i> &nbsp; StackOverflow</a></li>-->
+                    <!--<li><a href="https://stackoverflow.com/questions/tagged/project-calico" target="_blank"><i class="fa fa-stack-overflow" aria-hidden="true"></i> &nbsp; StackOverflow</a></li>-->
                     <li><a href="https://www.projectcalico.org/mvp"><i class="fa fa-star" aria-hidden="true"></i> &nbsp; MVP Program</a></li>
                     <li><a href="https://www.projectcalico.org/community#events"><i class="fa fa-calendar" aria-hidden="true"></i> &nbsp; Upcoming Events</a></li>
                     <li><a href="https://www.projectcalico.org/newsletters"><i class="fa fa-envelope-o" aria-hidden="true"></i> &nbsp; Newsletter</a></li>

--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/calicoctl.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/master/getting-started/kubernetes/installation/policy-controller.yaml
+++ b/master/getting-started/kubernetes/installation/policy-controller.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/kube-policy-controller:{{site.data.versions[page.version].first.components["calico/kube-policy-controller"].version}}
 

--- a/master/getting-started/kubernetes/installation/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/rbac.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 
 ---
 kind: ClusterRole

--- a/master/getting-started/openstack/installation/juju.md
+++ b/master/getting-started/openstack/installation/juju.md
@@ -24,4 +24,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -35,7 +35,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/master/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
+++ b/master/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 ---

--- a/master/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
+++ b/master/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 ---

--- a/master/reference/calicoctl/commands/get.md
+++ b/master/reference/calicoctl/commands/get.md
@@ -94,7 +94,7 @@ Description:
   input to all of the resource management commands (create, apply, replace,
   delete, get).
 
-  Please refer to the docs at http://docs.projectcalico.org for more details on
+  Please refer to the docs at https://docs.projectcalico.org for more details on
   the output formats, including example outputs, resource structure (required
   for the golang template definitions) and the valid column names (required for
   the custom-columns option).

--- a/master/reference/contribute.md
+++ b/master/reference/contribute.md
@@ -13,7 +13,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/master/reference/private-cloud/l2-interconnect-fabric.md
+++ b/master/reference/private-cloud/l2-interconnect-fabric.md
@@ -30,8 +30,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -145,7 +145,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/master/reference/private-cloud/l3-interconnect-fabric.md
+++ b/master/reference/private-cloud/l3-interconnect-fabric.md
@@ -53,7 +53,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -83,7 +83,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -115,7 +115,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/master/usage/external-connectivity.md
+++ b/master/usage/external-connectivity.md
@@ -72,7 +72,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/master/usage/troubleshooting/faq.md
+++ b/master/usage/troubleshooting/faq.md
@@ -21,7 +21,7 @@ policy that is automatically rendered into distributed firewall rules
 across a cluster of containers, VMs, and/or servers.
 
 For a more detailed discussion of this topic, see our blog post at
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 
@@ -255,7 +255,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?

--- a/v1.5/getting-started/openstack/installation/juju.md
+++ b/v1.5/getting-started/openstack/installation/juju.md
@@ -24,4 +24,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/v1.5/getting-started/openstack/installation/redhat.md
+++ b/v1.5/getting-started/openstack/installation/redhat.md
@@ -17,7 +17,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/v1.5/reference/contribute.md
+++ b/v1.5/reference/contribute.md
@@ -13,7 +13,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/v1.5/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v1.5/reference/private-cloud/l2-interconnect-fabric.md
@@ -30,8 +30,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -145,7 +145,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/v1.5/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v1.5/reference/private-cloud/l3-interconnect-fabric.md
@@ -53,7 +53,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -83,7 +83,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -115,7 +115,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/v1.5/usage/external-connectivity.md
+++ b/v1.5/usage/external-connectivity.md
@@ -60,7 +60,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/private-cloud).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/v1.5/usage/troubleshooting/faq-2.md
+++ b/v1.5/usage/troubleshooting/faq-2.md
@@ -44,7 +44,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?

--- a/v1.5/usage/troubleshooting/faq.md
+++ b/v1.5/usage/troubleshooting/faq.md
@@ -16,7 +16,7 @@ you should look into it if you have more than a handful of nodes on a
 single site.
 
 For a more detailed discussion of this topic, see our blog post at 
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 

--- a/v1.6/getting-started/openstack/installation/juju.md
+++ b/v1.6/getting-started/openstack/installation/juju.md
@@ -24,4 +24,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/v1.6/getting-started/openstack/installation/redhat.md
+++ b/v1.6/getting-started/openstack/installation/redhat.md
@@ -17,7 +17,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/v1.6/reference/contribute.md
+++ b/v1.6/reference/contribute.md
@@ -13,7 +13,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/v1.6/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v1.6/reference/private-cloud/l2-interconnect-fabric.md
@@ -30,8 +30,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -145,7 +145,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/v1.6/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v1.6/reference/private-cloud/l3-interconnect-fabric.md
@@ -53,7 +53,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -83,7 +83,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -115,7 +115,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/v1.6/usage/external-connectivity.md
+++ b/v1.6/usage/external-connectivity.md
@@ -60,7 +60,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/private-cloud).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/v1.6/usage/troubleshooting/faq-2.md
+++ b/v1.6/usage/troubleshooting/faq-2.md
@@ -44,7 +44,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?

--- a/v1.6/usage/troubleshooting/faq.md
+++ b/v1.6/usage/troubleshooting/faq.md
@@ -16,7 +16,7 @@ you should look into it if you have more than a handful of nodes on a
 single site.
 
 For a more detailed discussion of this topic, see our blog post at 
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -28,7 +28,7 @@ You must have a cluster which meets the following requirements:
 To install Calico, ensure you have a cluster which meets the above requirements and run the following command:
 
 ```
-kubectl apply -f http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+kubectl apply -f https://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
 ```
 
 Once installed, you can try out NetworkPolicy by following the [simple policy guide](../../../tutorials/simple-policy).
@@ -44,8 +44,8 @@ exist in the cluster. The following lines need to be run on the master of
 Kubernetes cluster with addon-manager installed:
 
 ```
-curl -sL -o /etc/kubernetes/addons/calico-configmap.yaml http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-configmap.yaml
-curl -sL -o /etc/kubernetes/addons/calico-daemonset.yaml http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml
+curl -sL -o /etc/kubernetes/addons/calico-configmap.yaml https://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-configmap.yaml
+curl -sL -o /etc/kubernetes/addons/calico-daemonset.yaml https://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml
 ```
 
 #### Example: kubeadm + flannel
@@ -64,7 +64,7 @@ kubeadm init --pod-network-cidr=10.244.0.0/16
 Then run the following command to install Calico.
 
 ```
-kubectl apply -f http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+kubectl apply -f https://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
 ```
 
 Then continue following the guide, following the instructions for installing flannel as the pod network.
@@ -93,7 +93,7 @@ curl -sS https://get.k8s.io | bash
 Once the cluster is running, install Calico:
 
 ```
-kubectl apply -f http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+kubectl apply -f https://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
 ```
 
 You should see all pods enter "Running" state.

--- a/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -21,7 +21,7 @@ or higher.
 To install this Calico and a single node etcd, run the following command:
 
 ```
-kubectl apply -f http://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+kubectl apply -f https://docs.projectcalico.org/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
 ```
 
 You can download the addon manfiest [here](calico.yaml)

--- a/v2.0/getting-started/openstack/installation/juju.md
+++ b/v2.0/getting-started/openstack/installation/juju.md
@@ -24,4 +24,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/v2.0/getting-started/openstack/installation/redhat.md
+++ b/v2.0/getting-started/openstack/installation/redhat.md
@@ -17,7 +17,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/v2.0/getting-started/rkt/installation/manual.md
+++ b/v2.0/getting-started/rkt/installation/manual.md
@@ -94,7 +94,7 @@ b52bba11  node  quay.io/calico/node:v1.0.2  running 10 seconds ago  10 seconds a
    Download the calicoctl binary:
 
    ```
-   sudo wget -O /usr/local/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+   sudo wget -O /usr/local/bin/calicoctl https://www.projectcalico.org/builds/calicoctl
    sudo chmod +x calicoctl
    ```
 

--- a/v2.0/reference/contribute.md
+++ b/v2.0/reference/contribute.md
@@ -13,7 +13,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/v2.0/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.0/reference/private-cloud/l2-interconnect-fabric.md
@@ -30,8 +30,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -145,7 +145,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/v2.0/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.0/reference/private-cloud/l3-interconnect-fabric.md
@@ -53,7 +53,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -83,7 +83,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -115,7 +115,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/v2.0/usage/external-connectivity.md
+++ b/v2.0/usage/external-connectivity.md
@@ -71,7 +71,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/v2.0/usage/troubleshooting/faq.md
+++ b/v2.0/usage/troubleshooting/faq.md
@@ -21,7 +21,7 @@ policy that is automatically rendered into distributed firewall rules
 across a cluster of containers, VMs, and/or servers.
 
 For a more detailed discussion of this topic, see our blog post at
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 
@@ -255,7 +255,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?

--- a/v2.1/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+++ b/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.1/getting-started/kubernetes/installation/policy-controller.yaml
+++ b/v2.1/getting-started/kubernetes/installation/policy-controller.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/kube-policy-controller:{{site.data.versions[page.version].first.components["calico/kube-policy-controller"].version}}
 

--- a/v2.1/getting-started/openstack/installation/juju.md
+++ b/v2.1/getting-started/openstack/installation/juju.md
@@ -24,4 +24,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/v2.1/getting-started/openstack/installation/redhat.md
+++ b/v2.1/getting-started/openstack/installation/redhat.md
@@ -35,7 +35,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/v2.1/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
+++ b/v2.1/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 ---

--- a/v2.1/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
+++ b/v2.1/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 ---

--- a/v2.1/reference/contribute.md
+++ b/v2.1/reference/contribute.md
@@ -13,7 +13,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/v2.1/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.1/reference/private-cloud/l2-interconnect-fabric.md
@@ -30,8 +30,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -145,7 +145,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/v2.1/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.1/reference/private-cloud/l3-interconnect-fabric.md
@@ -53,7 +53,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -83,7 +83,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -115,7 +115,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/v2.1/usage/external-connectivity.md
+++ b/v2.1/usage/external-connectivity.md
@@ -72,7 +72,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/v2.1/usage/troubleshooting/faq.md
+++ b/v2.1/usage/troubleshooting/faq.md
@@ -21,7 +21,7 @@ policy that is automatically rendered into distributed firewall rules
 across a cluster of containers, VMs, and/or servers.
 
 For a more detailed discussion of this topic, see our blog post at
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 
@@ -255,7 +255,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?

--- a/v2.2/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.2/getting-started/kubernetes/installation/hosted/calicoctl.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.2/getting-started/kubernetes/installation/hosted/rbac.yaml
+++ b/v2.2/getting-started/kubernetes/installation/hosted/rbac.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/v2.2/getting-started/kubernetes/installation/policy-controller.yaml
+++ b/v2.2/getting-started/kubernetes/installation/policy-controller.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/kube-policy-controller:{{site.data.versions[page.version].first.components["calico/kube-policy-controller"].version}}
 

--- a/v2.2/getting-started/kubernetes/installation/rbac.yaml
+++ b/v2.2/getting-started/kubernetes/installation/rbac.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 
 ---
 kind: ClusterRole

--- a/v2.2/getting-started/openstack/installation/juju.md
+++ b/v2.2/getting-started/openstack/installation/juju.md
@@ -24,4 +24,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/v2.2/getting-started/openstack/installation/redhat.md
+++ b/v2.2/getting-started/openstack/installation/redhat.md
@@ -35,7 +35,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/v2.2/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
+++ b/v2.2/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 ---

--- a/v2.2/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
+++ b/v2.2/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 ---

--- a/v2.2/reference/contribute.md
+++ b/v2.2/reference/contribute.md
@@ -13,7 +13,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/v2.2/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.2/reference/private-cloud/l2-interconnect-fabric.md
@@ -30,8 +30,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -145,7 +145,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/v2.2/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.2/reference/private-cloud/l3-interconnect-fabric.md
@@ -53,7 +53,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -83,7 +83,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -115,7 +115,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/v2.2/usage/external-connectivity.md
+++ b/v2.2/usage/external-connectivity.md
@@ -72,7 +72,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/v2.2/usage/troubleshooting/faq.md
+++ b/v2.2/usage/troubleshooting/faq.md
@@ -21,7 +21,7 @@ policy that is automatically rendered into distributed firewall rules
 across a cluster of containers, VMs, and/or servers.
 
 For a more detailed discussion of this topic, see our blog post at
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 
@@ -255,7 +255,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?

--- a/v2.3/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.3/getting-started/kubernetes/installation/hosted/calicoctl.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.3/getting-started/kubernetes/installation/hosted/rbac.yaml
+++ b/v2.3/getting-started/kubernetes/installation/hosted/rbac.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/v2.3/getting-started/kubernetes/installation/policy-controller.yaml
+++ b/v2.3/getting-started/kubernetes/installation/policy-controller.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/kube-policy-controller:{{site.data.versions[page.version].first.components["calico/kube-policy-controller"].version}}
 

--- a/v2.3/getting-started/kubernetes/installation/rbac.yaml
+++ b/v2.3/getting-started/kubernetes/installation/rbac.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 
 ---
 kind: ClusterRole

--- a/v2.3/getting-started/openstack/installation/juju.md
+++ b/v2.3/getting-started/openstack/installation/juju.md
@@ -24,4 +24,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/v2.3/getting-started/openstack/installation/redhat.md
+++ b/v2.3/getting-started/openstack/installation/redhat.md
@@ -35,7 +35,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/v2.3/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
+++ b/v2.3/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 ---

--- a/v2.3/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
+++ b/v2.3/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.components["calico/node"].version}}
 ---

--- a/v2.3/reference/contribute.md
+++ b/v2.3/reference/contribute.md
@@ -13,7 +13,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/v2.3/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.3/reference/private-cloud/l2-interconnect-fabric.md
@@ -30,8 +30,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -145,7 +145,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/v2.3/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.3/reference/private-cloud/l3-interconnect-fabric.md
@@ -53,7 +53,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -83,7 +83,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -115,7 +115,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/v2.3/usage/external-connectivity.md
+++ b/v2.3/usage/external-connectivity.md
@@ -72,7 +72,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/v2.3/usage/troubleshooting/faq.md
+++ b/v2.3/usage/troubleshooting/faq.md
@@ -21,7 +21,7 @@ policy that is automatically rendered into distributed firewall rules
 across a cluster of containers, VMs, and/or servers.
 
 For a more detailed discussion of this topic, see our blog post at
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 
@@ -255,7 +255,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?

--- a/v2.4/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.4/getting-started/kubernetes/installation/hosted/calicoctl.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.5/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.6/calico.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}

--- a/v2.4/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/v2.4/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/v2.4/getting-started/kubernetes/installation/policy-controller.yaml
+++ b/v2.4/getting-started/kubernetes/installation/policy-controller.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/kube-policy-controller:{{site.data.versions[page.version].first.components["calico/kube-policy-controller"].version}}
 

--- a/v2.4/getting-started/kubernetes/installation/rbac.yaml
+++ b/v2.4/getting-started/kubernetes/installation/rbac.yaml
@@ -2,7 +2,7 @@
 layout: null
 ---
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 
 ---
 kind: ClusterRole

--- a/v2.4/getting-started/openstack/installation/juju.md
+++ b/v2.4/getting-started/openstack/installation/juju.md
@@ -25,4 +25,4 @@ The default admin password for these deployments is "openstack" - you may wish
 to update this in the bundle (search for the keystone "admin-password" option).
 
 For more detailed information, please see [this blog
-post](http://www.projectcalico.org/exploring-juju/) on the Calico blog.
+post](https://www.projectcalico.org/exploring-juju/) on the Calico blog.

--- a/v2.4/getting-started/openstack/installation/redhat.md
+++ b/v2.4/getting-started/openstack/installation/redhat.md
@@ -36,7 +36,7 @@ sections.
 > Following the upgrade to use etcd as a data store, Calico
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
-> us know](http://www.projectcalico.org/contact/).
+> us know](https://www.projectcalico.org/contact/).
 >
 
 ## Prerequisites

--- a/v2.4/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
+++ b/v2.4/getting-started/rkt/installation/vagrant-coreos/first-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 ---

--- a/v2.4/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
+++ b/v2.4/getting-started/rkt/installation/vagrant-coreos/other-node-config.yaml
@@ -3,7 +3,7 @@ layout: null
 ---
 #cloud-config
 # Calico Version {{site.data.versions[page.version].first.title}}
-# http://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
+# https://docs.projectcalico.org/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 ---

--- a/v2.4/reference/contribute.md
+++ b/v2.4/reference/contribute.md
@@ -14,7 +14,7 @@ Features or any changes to the codebase should be done as follows:
         "fixes \#123" in at least one of your commit messages. This
         ensures the pull request is attached to the existing issue (see
         [How do you attach a new pull request to an existing issue on
-        GitHub?](http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
+        GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
 3.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our

--- a/v2.4/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.4/reference/private-cloud/l2-interconnect-fabric.md
@@ -31,8 +31,8 @@ deployments.
 It has been acknowledged by the industry for years that, beyond a
 certain size, classical Ethernet networks are unsuitable for production
 deployment. Although there have been
-[multiple](http://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
-[attempts](http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
+[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering)
+[attempts](https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html) [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service)
 these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
@@ -146,7 +146,7 @@ but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
-[ECMP](http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
+[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing) to
 distribute traffic across multiple links (instead of using Ethernet
 techniques such as MLAG). By leveraging ECMP load balancing on the
 Calico compute servers, it is possible to build the fabric out of

--- a/v2.4/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.4/reference/private-cloud/l3-interconnect-fabric.md
@@ -54,7 +54,7 @@ through a vRouter. Each vRouter announces all of the endpoints it is
 attached to to all the other vRouters and other routers on the
 infrastructure fabric, using BGP, usually with BGP route reflectors to
 increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](http://www.projectcalico.org/why-bgp/) blog post.
+BGP?](https://www.projectcalico.org/why-bgp/) blog post.
 
 Access control lists (ACLs) enforce security (and other) policy as
 directed by whatever cloud orchestrator is in use. There are other
@@ -84,7 +84,7 @@ in use, we would be happy to host a guest technical note.
 
 1.  The routing infrastructure is based on some form of IGP. Due to the
     limitations in scale of IGP networks (see the [why BGP
-    post](http://www.projectcalico.org/why-bgp/) for discussion of this
+    post](https://www.projectcalico.org/why-bgp/) for discussion of this
     topic), the project Calico team does not believe that using an IGP
     to distribute endpoint reachability information will adequately
     scale in a Calico environment. However, it is possible to use a
@@ -116,7 +116,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](http://en.wikipedia.org/wiki/Autonomous_System_(Internet))
+    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet))
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/v2.4/usage/external-connectivity.md
+++ b/v2.4/usage/external-connectivity.md
@@ -73,7 +73,7 @@ If you have a small number of hosts, you can configure BGP sessions between your
 route reflector or set up a Layer 3 topology.
 
 There's further advice on network topologies in the [private cloud reference documentation]({{site.baseurl}}/{{page.version}}/reference/).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### Orchestrator specific

--- a/v2.4/usage/troubleshooting/faq.md
+++ b/v2.4/usage/troubleshooting/faq.md
@@ -22,7 +22,7 @@ policy that is automatically rendered into distributed firewall rules
 across a cluster of containers, VMs, and/or servers.
 
 For a more detailed discussion of this topic, see our blog post at
-[Why Calico?](http://www.projectcalico.org/why-calico/).
+[Why Calico?](https://www.projectcalico.org/why-calico/).
 
 ## "Does Calico work with IPv6?"
 
@@ -256,7 +256,7 @@ If this describes your infrastructure, the
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in the main [this article]({{site.baseurl}}/{{page.version}}/reference/private-cloud/l3-interconnect-fabric).
-We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
+We'd also encourage you to [get in touch](https://www.projectcalico.org/contact/)
 to discuss your environment.
 
 ### How can I enable NAT for outgoing traffic from containers with private IP addresses?


### PR DESCRIPTION
## Description

Fixes #1001 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Important part is in the first commit: Override jekyll url parameter with https address. 

I tested locally, and it seems that `site.url` still resolves to `localhost` when running a local `jekyll serve`, which is great, and means the site is getting `https://docs.projectcalico.org` on the real site, and `http://localhost` when run locally.

Rest of the changes are updating hardcoded links for *projectcalico.org as well as other external sites to https.

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
