### PR TITLE
Fix table definitions for supported operations on resources pages

### DIFF
--- a/master/reference/calicoctl/resources/bgppeer.md
+++ b/master/reference/calicoctl/resources/bgppeer.md
@@ -59,6 +59,6 @@ to inform Calico which node this peer is targeting.
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | Yes           | Yes    | Yes      |

--- a/master/reference/calicoctl/resources/hostendpoint.md
+++ b/master/reference/calicoctl/resources/hostendpoint.md
@@ -54,6 +54,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | No     | No       |

--- a/master/reference/calicoctl/resources/ippool.md
+++ b/master/reference/calicoctl/resources/ippool.md
@@ -66,6 +66,6 @@ Hosts running Calico is asymmetric and may cause traffic to be filtered due to
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | Yes           | Yes    | Yes      |

--- a/master/reference/calicoctl/resources/node.md
+++ b/master/reference/calicoctl/resources/node.md
@@ -54,6 +54,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | Yes    | Yes      | Calico Node data is directly tied to the Kubernetes nodes.

--- a/master/reference/calicoctl/resources/policy.md
+++ b/master/reference/calicoctl/resources/policy.md
@@ -116,6 +116,6 @@ applied action is deny.
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | No     | Yes      | Policy is determined from Kubernetes NetworkPolicy resources.

--- a/master/reference/calicoctl/resources/profile.md
+++ b/master/reference/calicoctl/resources/profile.md
@@ -102,6 +102,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | No     | Yes      | Calico profiles are pre-assigned for each Namespace.

--- a/master/reference/calicoctl/resources/workloadendpoint.md
+++ b/master/reference/calicoctl/resources/workloadendpoint.md
@@ -66,6 +66,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | Yes    | Yes      | WorkloadEndpoints are directly tied to a Kuberenetes Pod.

--- a/v2.4/reference/calicoctl/resources/bgppeer.md
+++ b/v2.4/reference/calicoctl/resources/bgppeer.md
@@ -60,6 +60,6 @@ to inform Calico which node this peer is targeting.
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | Yes           | Yes    | Yes      |

--- a/v2.4/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.4/reference/calicoctl/resources/hostendpoint.md
@@ -55,6 +55,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | No     | No       |

--- a/v2.4/reference/calicoctl/resources/ippool.md
+++ b/v2.4/reference/calicoctl/resources/ippool.md
@@ -67,6 +67,6 @@ Hosts running Calico is asymmetric and may cause traffic to be filtered due to
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | Yes           | Yes    | Yes      |

--- a/v2.4/reference/calicoctl/resources/node.md
+++ b/v2.4/reference/calicoctl/resources/node.md
@@ -55,6 +55,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | Yes    | Yes      | Calico Node data is directly tied to the Kubernetes nodes.

--- a/v2.4/reference/calicoctl/resources/policy.md
+++ b/v2.4/reference/calicoctl/resources/policy.md
@@ -117,6 +117,6 @@ applied action is deny.
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | No     | Yes      | Policy is determined from Kubernetes NetworkPolicy resources.

--- a/v2.4/reference/calicoctl/resources/profile.md
+++ b/v2.4/reference/calicoctl/resources/profile.md
@@ -103,6 +103,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | No     | Yes      | Calico profiles are pre-assigned for each Namespace.

--- a/v2.4/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.4/reference/calicoctl/resources/workloadendpoint.md
@@ -67,6 +67,6 @@ spec:
 ### Supported operations
 
 | Datastore type        | Create/Delete | Update | Get/List | Notes
-+-----------------------+---------------+--------+----------+------
+|-----------------------|---------------|--------|----------|------
 | etcdv2                | Yes           | Yes    | Yes      |
 | Kubernetes API server | No            | Yes    | Yes      | WorkloadEndpoints are directly tied to a Kuberenetes Pod.


### PR DESCRIPTION
## Description
Fix the table definitions for the Supported Operations section in each of the resource definitions.

## Release Note

```release-note
None required
```