### PR TITLE
Fix calico/node version for v2.4.1

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -18,7 +18,7 @@ v2.4:
       url: https://github.com/projectcalico/calicoctl/releases/tag/v1.4.0
       download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.4.0/calicoctl
     calico/node:
-      version: v2.4.0
+      version: v2.4.1
     calico/cni:
       version: v1.10.0
       url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.10.0


### PR DESCRIPTION
## Description

The version of calico/node was not updated on the release page.  The manifests already had the correct version because they pull their version from the page.version title, instead of the specific calico/node version field.
