### PR TITLE
Enable caching K8s binaries for K8s Vagrant install

### DIFF
--- a/_includes/master/kubernetes/fetch_k8s_binaries.sh
+++ b/_includes/master/kubernetes/fetch_k8s_binaries.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+k8s_ver="v1.7.0"
+
+download_path="k8s"
+binaries="kubectl kube-apiserver kube-controller-manager kubelet kube-proxy kube-scheduler"
+install_binaries="false"
+
+while [[ $# -gt 0 ]]; do
+	key="$1"
+	case $key in
+		--dl-dir)
+			download_path="$2"
+			shift
+			;;
+		--install)
+			install_binaries="true"
+			;;
+		--binaries)
+			shift
+			binaries="$@"
+			break
+			;;
+	esac
+	shift
+done
+
+if [ ! -d $download_path ]; then
+  mkdir -p $download_path
+fi
+
+for x in $binaries; do
+  ver_binary=${x}-$k8s_ver
+  if [ ! -f $download_path/${ver_binary}.downloaded ]; then
+    /usr/bin/wget -O $download_path/${ver_binary} https://storage.googleapis.com/kubernetes-release/release/$k8s_ver/bin/linux/amd64/$x
+    if [ $? -eq 0 ]; then
+      touch $download_path/${ver_binary}.downloaded
+    fi
+  else
+    echo "$x ($k8s_ver) already downloaded"
+  fi
+done
+
+if [ "$install_binaries" == "true" ]; then
+  echo "Installing binaries"
+  mkdir -p /opt/bin
+
+  for x in $binaries; do
+    binary=$x
+    ver_binary=${binary}-$k8s_ver
+    if [ ! -f $download_path/${ver_binary}.downloaded ]; then
+      echo "ERROR: $binary version $k8s_ver was not downloaded"
+      exit 1
+    fi
+    cp $download_path/${ver_binary} /opt/bin/$binary
+    /usr/bin/chmod +x /opt/bin/$binary
+  done
+fi

--- a/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -1,3 +1,7 @@
+---
+layout: null
+---
+
 # Size of the cluster created by Vagrant
 num_instances=3
 
@@ -29,6 +33,28 @@ Vagrant.configure("2") do |config|
     config.vbguest.auto_update = false
   end
 
+  # To speed up multiple runs of 'vagrant up' or when experiencing failures
+  # of the systemd service 'user-data', the Kubernetes binaries can be
+  # pre-downloaded.  To download the binaries, downloaded the script
+  # {{site.url}}{{page.dir}}fetch_k8s_binaries.sh
+  # into the same directory as this Vagrantfile, make it executable with
+  # `chmod +x fetch_k8s_binaries.sh`, and then run it to create a k8s directory
+  # and download the needed k8s binaries.
+  #
+  # If the environment variable K8S_CACHED is set to true and if the directory
+  # exists in the same folder as this Vagrantfile it will be mounted into
+  # each VM.  (This requires nfsd in Linux and may prompt for superuser
+  # permissions. This has only been tested on linux.)
+  if ENV['K8S_CACHED'] == "true"
+    if File.directory?(File.expand_path("./k8s"))
+      config.vm.synced_folder "./k8s", "/k8s", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp,ro']
+    end
+  end
+
+  $k8s_binary_init = <<SCRIPT
+{% include {{page.version}}/kubernetes/fetch_k8s_binaries.sh %}
+SCRIPT
+
   # Set up each box
   (1..num_instances).each do |i|
     if i == 1
@@ -45,6 +71,11 @@ Vagrant.configure("2") do |config|
       # Workaround VirtualBox issue where eth1 has 2 IP Addresses at startup
       host.vm.provision :shell, :inline => "sudo /usr/bin/ip addr flush dev eth1"
       host.vm.provision :shell, :inline => "sudo /usr/bin/ip addr add #{ip}/24 dev eth1"
+
+      host.vm.provision :shell, :inline => "sudo mkdir -p /opt/k8s/setup"
+      host.vm.provision :shell, :inline => "echo '#{$k8s_binary_init}' > /opt/k8s/setup/fetch_k8s_binaries.sh"
+      host.vm.provision :shell, :inline => "sudo chmod +x /opt/k8s/setup/*"
+
 
       if i == 1
         # Configure the master.

--- a/master/getting-started/kubernetes/installation/vagrant/fetch_k8s_binaries.sh
+++ b/master/getting-started/kubernetes/installation/vagrant/fetch_k8s_binaries.sh
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{% include {{page.version}}/kubernetes/fetch_k8s_binaries.sh %}

--- a/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/master-config.yaml
@@ -1,9 +1,24 @@
 #cloud-config
 ---
+
 coreos:
   update:
     reboot-strategy: off
   units:
+    - name: k8s-binary-installation.service
+      command: start
+      content: |
+        [Unit]
+        Description=Downloads Kubernetes binaries
+        Before=kube-apiserver.service kube-controller-manager.service kube-scheduler.service kubelet.service kube-proxy.service
+
+        [Service]
+        Type=oneshot
+        TimeoutStartSec=1800
+        ExecStart=/opt/k8s/setup/fetch_k8s_binaries.sh --install --dl-dir /k8s
+        # Ensure that this service remains running so the dependent
+        # services are not blocked waiting for this service.
+        RemainAfterExit=true
     - name: etcd-member.service
       command: start
       drop-ins:
@@ -23,10 +38,6 @@ coreos:
         After=etcd-member.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-apiserver
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubectl
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
         --allow-privileged=true \
         --etcd-servers=http://$private_ipv4:2379 \
@@ -49,8 +60,6 @@ coreos:
         After=kube-apiserver.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-controller-manager
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
@@ -72,8 +81,6 @@ coreos:
         After=kube-apiserver.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-scheduler
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler
         ExecStart=/opt/bin/kube-scheduler --master=$private_ipv4:8080
         Restart=always
         RestartSec=10
@@ -90,8 +97,6 @@ coreos:
 
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubelet
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
         --allow-privileged=true \
@@ -118,8 +123,6 @@ coreos:
         After=kubelet.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-proxy
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://$private_ipv4:8080 \

--- a/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
+++ b/master/getting-started/kubernetes/installation/vagrant/node-config.yaml
@@ -25,6 +25,20 @@ coreos:
   update:
     reboot-strategy: off
   units:
+    - name: k8s-binary-installation.service
+      command: start
+      content: |
+        [Unit]
+        Description=Downloads Kubernetes binaries
+        Before=kubelet.service kube-proxy.service
+
+        [Service]
+        Type=oneshot
+        TimeoutStartSec=1800
+        ExecStart=/opt/k8s/setup/fetch_k8s_binaries.sh --install --dl-dir /k8s --binaries kubelet kube-proxy
+        # Ensure that this service remains running so the dependent
+        # services are not blocked waiting for this service.
+        RemainAfterExit=true
     - name: etcd-member.service
       command: start
       drop-ins:
@@ -47,8 +61,6 @@ coreos:
         TimeoutStartSec=1800
         ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/containernetworking/cni/releases/download/v0.5.1/cni-v0.5.1.tgz
         ExecStartPre=/usr/bin/tar -xvf /opt/cni/bin/cni-v0.5.1.tgz -C /opt/cni/bin
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubelet
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
@@ -75,8 +87,6 @@ coreos:
         After=kubelet.service
         [Service]
         TimeoutStartSec=1800
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kube-proxy
-        ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         # --cluster-cidr must match the IP Pool defined in the manifest
         ExecStart=/opt/bin/kube-proxy \
         --master=http://172.18.18.101:8080 \


### PR DESCRIPTION
## Description

Added feature to K8s vagrant install where it is possible to
pre-download the K8s binaries and mount them into the VMs.
To do this a script was created that can be used to download the
binaries (either locally or in VMs) and then install them if
specified.  The mounting of the cache directory is only attemped
if the K8S_CACHED env variable is set true.

## Todos

- [x] Tests - tested locally
- [x] Documentation - Added some notes to the Vagrantfile, I think that is all that's needed
- [ ] Release note - I doubt one needs to be added for this.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
