### PR TITLE
Link to host endpoint NodePort securing from K8s

### DIFF
--- a/master/getting-started/kubernetes/index.md
+++ b/master/getting-started/kubernetes/index.md
@@ -37,5 +37,12 @@ what can be done with the Kubernetes NetworkPolicy API like egress and CIDR base
 
 **[Configuring BGP Peering][bgp-peering]**: this guide is for users on private cloud who want to configure Calico to peer with their underlying infrastructure.
 
+##### Protecting Host Access
+
+**[Host Endpoint policy to limit NodePort access][hep-worked-example]**:
+A worked example configuring Host Endpoint policy to secure a host against
+incoming traffic from outside the cluster.
+
 [calicoctl]: {{site.baseurl}}/{{page.version}}/reference/calicoctl/
 [bgp-peering]: {{site.baseurl}}/{{page.version}}/usage/configuration/bgp
+[hep-worked-example]: {{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal#host-endpoint-policy-a-worked-example

--- a/master/getting-started/kubernetes/troubleshooting.md
+++ b/master/getting-started/kubernetes/troubleshooting.md
@@ -53,3 +53,13 @@ However, if you do need to assign a particular address to a Pod, Calico provides
 - You can request an IP using the `cni.projectcalico.org/ipAddrsNoIpam` annotation. Note that this annotation bypasses the configured IPAM plugin, and thus in most cases it is recommended to use the above annotation. 
 
 See the [Requesting a Specific IP address]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#requesting-a-specific-ip-address) section in the CNI plugin reference documentation for more details.
+
+#### How can I restrict external access to exposed services (i.e. access to a NodePort)?
+
+Limiting access to a NodePort (or any host based service) can be accomplished
+by configuring Calico Host Endpoints and Calico policy.  See
+[Using Calico to Secure Host Interfaces]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal#host-endpoint-policy-a-worked-example)
+for setting up Host Endpoints for the hosts and the
+[worked example]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal#host-endpoint-policy-a-worked-example)
+for how to set up the policy to allow the desired traffic and restrict the
+unwanted traffic.

--- a/v2.4/getting-started/kubernetes/index.md
+++ b/v2.4/getting-started/kubernetes/index.md
@@ -38,5 +38,12 @@ what can be done with the Kubernetes NetworkPolicy API like egress and CIDR base
 
 **[Configuring BGP Peering][bgp-peering]**: this guide is for users on private cloud who want to configure Calico to peer with their underlying infrastructure.
 
+##### Protecting Host Access
+
+**[Host Endpoint policy to limit NodePort access][hep-worked-example]**:
+A worked example configuring Host Endpoint policy to secure a host against
+incoming traffic from outside the cluster.
+
 [calicoctl]: {{site.baseurl}}/{{page.version}}/reference/calicoctl/
 [bgp-peering]: {{site.baseurl}}/{{page.version}}/usage/configuration/bgp
+[hep-worked-example]: {{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal#host-endpoint-policy-a-worked-example

--- a/v2.4/getting-started/kubernetes/troubleshooting.md
+++ b/v2.4/getting-started/kubernetes/troubleshooting.md
@@ -54,3 +54,13 @@ However, if you do need to assign a particular address to a Pod, Calico provides
 - You can request an IP using the `cni.projectcalico.org/ipAddrsNoIpam` annotation. Note that this annotation bypasses the configured IPAM plugin, and thus in most cases it is recommended to use the above annotation. 
 
 See the [Requesting a Specific IP address]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#requesting-a-specific-ip-address) section in the CNI plugin reference documentation for more details.
+
+#### How can I restrict external access to exposed services (i.e. access to a NodePort)?
+
+Limiting access to a NodePort (or any host based service) can be accomplished
+by configuring Calico Host Endpoints and Calico policy.  See
+[Using Calico to Secure Host Interfaces]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal#host-endpoint-policy-a-worked-example)
+for setting up Host Endpoints for the hosts and the
+[worked example]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal#host-endpoint-policy-a-worked-example)
+for how to set up the policy to allow the desired traffic and restrict the
+unwanted traffic.


### PR DESCRIPTION
## Description
With the addition of the example to the Host Endpoint docs that explains how to limit access to NodePorts from external cluster access, all that is needed in the Kubernetes section is a link.
This PR adds a link to the K8s Overview page and adds a Question to the How To section pointing there also.


Addresses #873
