### PR TITLE
Points to Kubernetes docs for kubectl install

### DIFF
--- a/master/getting-started/kubernetes/installation/vagrant/index.md
+++ b/master/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,8 +1,9 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 
-These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not setup TLS between Kubernetes components.
+These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not set up TLS between Kubernetes components.
 
 ## 1. Deploy cluster using Vagrant
 
@@ -24,9 +25,7 @@ Run
 
     vagrant up
 
-> **NOTE**
->
-> This will deploy a Kubernetes master and two Kubernetes nodes.  To run more nodes, modify the value `num_instances` in the Vagrantfile before running `vagrant up`.
+> *Note*: This will deploy a Kubernetes master and two Kubernetes nodes. To run more nodes, modify the value `num_instances` in the Vagrantfile before running `vagrant up`.
 
 To connect to your servers
 
@@ -63,11 +62,11 @@ From k8s-node-02
     ping 172.18.18.101
     ping 172.18.18.102
 
-If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs.  You should
+If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs. You should
 check that each host is connected to the same virtual network adapter in VirtualBox and rebooting the host may also
-help.  Remember to shut down the VMs with `vagrant halt` before you reboot.
+help. Remember to shut down the VMs with `vagrant halt` before you reboot.
 
-You should also verify each host can access etcd.  The following will return an error if etcd is not available.
+You should also verify each host can access etcd. The following will return an error if etcd is not available.
 
     curl -L http://172.18.18.101:2379/version
 
@@ -77,23 +76,9 @@ And finally check that Docker is running on both hosts by running
 
 ## 2. Configuring the Cluster and `kubectl`
 
-Let's configure `kubectl` so you can access the cluster from your local machine. Make sure you have `kubectl` installed locally.  The version you choose depends on your host OS.
+Prequisite: [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-For Mac:
-
-```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/darwin/amd64/kubectl
-chmod +x ./kubectl
-```
-
-For Linux:
-
-```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl
-chmod +x ./kubectl
-```
-
-Then, tell `kubectl` to use the Vagrant cluster we just created.
+Let's configure `kubectl` so you can access the cluster from your local machine. 
 
 ```shell
 kubectl config set-cluster vagrant-cluster --server=http://172.18.18.101:8080
@@ -107,7 +92,7 @@ kubectl config use-context vagrant-system
 
 ## Next Steps
 
-You should now have a fully functioning Kubernetes cluster using Calico for networking.  You're ready to use your cluster.
+You should now have a fully functioning Kubernetes cluster using Calico for networking. You're ready to use your cluster.
 
 We recommend you try using [Calico for Kubernetes NetworkPolicy]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/tutorials/simple-policy).
 

--- a/v2.4/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.4/getting-started/kubernetes/installation/vagrant/index.md
@@ -3,7 +3,7 @@ title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagran
 redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 
-These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not setup TLS between Kubernetes components.
+These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not set up TLS between Kubernetes components.
 
 ## 1. Deploy cluster using Vagrant
 
@@ -25,7 +25,7 @@ Run
 
     vagrant up
 
-> *Note*: This will deploy a Kubernetes master and two Kubernetes nodes.  To run more nodes, modify the value `num_instances` in the Vagrantfile before running `vagrant up`.
+> *Note*: This will deploy a Kubernetes master and two Kubernetes nodes. To run more nodes, modify the value `num_instances` in the Vagrantfile before running `vagrant up`.
 
 To connect to your servers
 
@@ -62,11 +62,11 @@ From k8s-node-02
     ping 172.18.18.101
     ping 172.18.18.102
 
-If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs.  You should
+If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs. You should
 check that each host is connected to the same virtual network adapter in VirtualBox and rebooting the host may also
-help.  Remember to shut down the VMs with `vagrant halt` before you reboot.
+help. Remember to shut down the VMs with `vagrant halt` before you reboot.
 
-You should also verify each host can access etcd.  The following will return an error if etcd is not available.
+You should also verify each host can access etcd. The following will return an error if etcd is not available.
 
     curl -L http://172.18.18.101:2379/version
 
@@ -76,23 +76,9 @@ And finally check that Docker is running on both hosts by running
 
 ## 2. Configuring the Cluster and `kubectl`
 
-Let's configure `kubectl` so you can access the cluster from your local machine. Make sure you have `kubectl` installed locally.  The version you choose depends on your host OS.
+Prequisite: [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-For Mac:
-
-```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/darwin/amd64/kubectl
-chmod +x ./kubectl
-```
-
-For Linux:
-
-```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl
-chmod +x ./kubectl
-```
-
-Then, tell `kubectl` to use the Vagrant cluster we just created.
+Let's configure `kubectl` so you can access the cluster from your local machine. 
 
 ```shell
 kubectl config set-cluster vagrant-cluster --server=http://172.18.18.101:8080
@@ -106,7 +92,7 @@ kubectl config use-context vagrant-system
 
 ## Next Steps
 
-You should now have a fully functioning Kubernetes cluster using Calico for networking.  You're ready to use your cluster.
+You should now have a fully functioning Kubernetes cluster using Calico for networking. You're ready to use your cluster.
 
 We recommend you try using [Calico for Kubernetes NetworkPolicy]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/tutorials/simple-policy).
 

--- a/v2.5/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.5/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,8 +1,9 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 
-These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not setup TLS between Kubernetes components.
+These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not set up TLS between Kubernetes components.
 
 ## 1. Deploy cluster using Vagrant
 
@@ -24,7 +25,7 @@ Run
 
     vagrant up
 
-> *Note*: This will deploy a Kubernetes master and two Kubernetes nodes.  To run more nodes, modify the value `num_instances` in the Vagrantfile before running `vagrant up`.
+> *Note*: This will deploy a Kubernetes master and two Kubernetes nodes. To run more nodes, modify the value `num_instances` in the Vagrantfile before running `vagrant up`.
 
 To connect to your servers
 
@@ -61,11 +62,11 @@ From k8s-node-02
     ping 172.18.18.101
     ping 172.18.18.102
 
-If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs.  You should
+If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs. You should
 check that each host is connected to the same virtual network adapter in VirtualBox and rebooting the host may also
-help.  Remember to shut down the VMs with `vagrant halt` before you reboot.
+help. Remember to shut down the VMs with `vagrant halt` before you reboot.
 
-You should also verify each host can access etcd.  The following will return an error if etcd is not available.
+You should also verify each host can access etcd. The following will return an error if etcd is not available.
 
     curl -L http://172.18.18.101:2379/version
 
@@ -75,23 +76,9 @@ And finally check that Docker is running on both hosts by running
 
 ## 2. Configuring the Cluster and `kubectl`
 
-Let's configure `kubectl` so you can access the cluster from your local machine. Make sure you have `kubectl` installed locally.  The version you choose depends on your host OS.
+Prequisite: [`kubectl` installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-For Mac:
-
-```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/darwin/amd64/kubectl
-chmod +x ./kubectl
-```
-
-For Linux:
-
-```shell
-wget http://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl
-chmod +x ./kubectl
-```
-
-Then, tell `kubectl` to use the Vagrant cluster we just created.
+Let's configure `kubectl` so you can access the cluster from your local machine. 
 
 ```shell
 kubectl config set-cluster vagrant-cluster --server=http://172.18.18.101:8080
@@ -105,7 +92,7 @@ kubectl config use-context vagrant-system
 
 ## Next Steps
 
-You should now have a fully functioning Kubernetes cluster using Calico for networking.  You're ready to use your cluster.
+You should now have a fully functioning Kubernetes cluster using Calico for networking. You're ready to use your cluster.
 
 We recommend you try using [Calico for Kubernetes NetworkPolicy]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/tutorials/simple-policy).
 


### PR DESCRIPTION
I think it will be better to point people to the official Kubernetes documentation for the kubectl install.

## Description

Points people to the Kubernetes docs for the kubectl install. The procedure is much better documented there and this is also more maintainable.



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
