### PR TITLE
add acceptance test for calico/node versions

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -422,6 +422,19 @@ node-test-containerized: vendor run-etcd-host
 	--net=host \
 	$(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && make node-fv'
 
+.PHONY: node-test-at
+## Run calico/node docker-image acceptance tests
+node-test-at:
+	docker run -v $(CALICO_NODE_DIR)tests/at/calico_node_goss.yaml:/tmp/goss.yaml \
+        -e CALICO_BGP_DAEMON_VER=$(GOBGPD_VER) \
+        -e CALICO_FELIX_VER=$(FELIX_VER) \
+        -e CONFD_VER=$(CONFD_VER) \
+	calico/node:$(CALICO_VER) /bin/sh -c 'apk --no-cache add wget ca-certificates && \
+	wget -q -O /tmp/goss \
+	https://github.com/aelsabbahy/goss/releases/download/v0.3.4/goss-linux-amd64 && \
+	chmod +rx /tmp/goss && \
+	/tmp/goss --gossfile /tmp/goss.yaml validate'
+
 # This depends on clean to ensure that dependent images get untagged and repulled
 # THIS JOB DELETES LOTS OF THINGS - DO NOT RUN IT ON YOUR LOCAL DEV MACHINE.
 .PHONY: semaphore

--- a/calico_node/tests/at/calico_node_goss.yaml
+++ b/calico_node/tests/at/calico_node_goss.yaml
@@ -1,0 +1,52 @@
+file:
+  /etc/calico:
+    exists: true
+    mode: "0755"
+    owner: root
+    group: root
+    filetype: directory
+    contains: []
+  /etc/rc.local:
+    exists: true
+    mode: "0755"
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+  /sbin/start_runit:
+    exists: true
+    mode: "0755"
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+package:
+  conntrack-tools:
+    installed: true
+  ip6tables:
+    installed: true
+  iproute2:
+    installed: true
+  ipset:
+    installed: true
+  iputils:
+    installed: true
+command:
+  /bin/calico-bgp-daemon -v:
+    exit-status: 0
+    stdout:
+    - {{.Env.CALICO_BGP_DAEMON_VER}} 
+    stderr: []
+    timeout: 10000
+  /bin/calico-felix --version:
+    exit-status: 0
+    stdout:
+    - {{.Env.CALICO_FELIX_VER}}
+    stderr: []
+    timeout: 10000
+  /bin/confd -version:
+    exit-status: 0
+    stdout:
+    - {{.Env.CONFD_VER}}
+    stderr: []
+    timeout: 10000


### PR DESCRIPTION
## Description

New approach to validating calico/node bundled versions using [goss](https://github.com/aelsabbahy/goss) as a make command.

1. Use existing Makefile cmds to grab component versions and set them as ENV vars
2. Add goss and the test-case.yaml to the calico/node docker-image on-the-fly
3. The test-case.yaml, tests/at/calico_node_goss.yaml, uses ENV params for expected versions

an example off of master...
```make node-test-at
...
Starting with UID : 9001
docker run -v /Users/erichoffmann/src/2ffs2nns/calico/calico_node/tests/at/calico_node_goss.yaml:/tmp/goss.yaml \
        -e CALICO_BGP_DAEMON_VER=v0.2.1 \
        -e CALICO_FELIX_VER=2.5.0-rc1 \
        -e CONFD_VER=v0.12.1-calico-0.3.0 \
	calico/node:v2.5.0-rc2 /bin/sh -c 'apk --no-cache add wget ca-certificates && \
	wget -q -O /tmp/goss \
	https://github.com/aelsabbahy/goss/releases/download/v0.3.4/goss-linux-amd64 && \
	chmod +rx /tmp/goss && \
	/tmp/goss --gossfile /tmp/goss.yaml validate'
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.6/community/x86_64/APKINDEX.tar.gz
(1/1) Installing wget (1.19.1-r2)
Executing busybox-1.26.2-r5.trigger
OK: 17 MiB in 32 packages
..........................

Total Duration: 0.186s
```

## Todos
- pull into semaphoreci

## Release-note
None required
