### PR TITLE
Enhances doc and code contribution guidelines

### DIFF
--- a/CONTRIBUTING_CODE.md
+++ b/CONTRIBUTING_CODE.md
@@ -1,12 +1,12 @@
----
-title: Contribution Guidelines
----
+# Contributing to the Calico Codebase
+
+## Overview
 
 Features or any changes to the codebase should be done as follows:
 
 1.  Pull latest code in the **master** branch and create a feature
     branch off this.
-2.  Implement your feature. Commits are cheap in Git, try to split up
+1.  Implement your feature. Commits are cheap in Git; try to split up
     your code into many. It makes reviewing easier as well as for
     saner merging.
     -   If your commit fixes an existing issue \#123, include the text
@@ -15,11 +15,11 @@ Features or any changes to the codebase should be done as follows:
         [How do you attach a new pull request to an existing issue on
         GitHub?](https://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github)).
 
-3.  Push your feature branch to GitHub. Note that before we can accept
+1.  Push your feature branch to GitHub. Note that before we can accept
     your changes, you need to agree to one of our
     contributor agreements. See [below](#contributor-agreements).
-4.  Create a pull request using GitHub, from your branch to master.
-5.  Reviewer process:
+1.  Create a pull request using GitHub, from your branch to master.
+1.  Reviewer process:
     -   Receive notice of review by GitHub email, GitHub notification,
         or by checking your assigned issues.
     -   Make markups as comments on the pull request (either line
@@ -31,7 +31,7 @@ Features or any changes to the codebase should be done as follows:
         branch. Otherwise, assign the pull request to the developer and
         leave this to them.
 
-6.  Developer process:
+1.  Developer process:
     -   Await review.
     -   Address code review issues on your feature branch.
     -   Push your changes to the feature branch on GitHub. This
@@ -46,7 +46,6 @@ Features or any changes to the codebase should be done as follows:
 
 ## Contributor Agreements
 
-If you plan to contribute in the form of documentation or code, we need
-you to sign our Contributor License Agreement before we can accept your
+We need you to sign our Contributor License Agreement before we can accept your
 contribution. You will be prompted to do this as part of the PR process
-on Github.
+on GitHub.

--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -1,134 +1,142 @@
-# Contributing to Calico Docs
+# Contributing to Calico documentation
 
-## Building
+## Overview
 
-The docs require jekyll, a ruby gem. Install the `github-pages` gem which includes
-`jekyll` to ensure you are using the exact version of jekyll that github pages
-is using to serve the live site.
+We welcome contributions to the Calico documentation. 
 
-```
-gem install github-pages
-jekyll serve -I
-```
+Instead of filing a GitHub issue, consider making a PR instead. You are likely to see a much more rapid resolution.
 
->Note:As more versioned directories are created, build speeds will increase by a
-factor of 2. The `-I` is an optional flag for development that enables
-incremental builds, allowing jekyll to only rebuild changed files. This should
-keep subsequent builds down to less than one second.
+The doc contribution process works as follows.
+
+1. Fork the [Project Calico repo](https://github.com/projectcalico/calico).
+1. Create a branch in your fork off of the master branch.
+1. Give your branch a short but descriptive name.
+1. Make your changes in the `master` folder.
+1. [Build the site locally to make sure it renders as expected](#building-the-doc-site-locally).
+1. [Check for broken links](#checking-for-broken-links).
+1. Submit a pull request (PR) against the master branch of the [Project Calico repo](https://github.com/projectcalico/calico).
+1. If you haven't already signed our contributer agreement, GitHub will prompt you to do so (required).
+1. Request a review from one or more Calico maintainers. 
+1. After getting the approval of at least one Calico maintainer, we ask that you [backport the changes in the `master` folder to the folders of the last two releases](#how-to-quickly-apply-changes-in-master-to-a-previous-release), if appropriate.
+1. Squash your commits.
+1. One of the doc repo maintainers will give the PR a final look and then merge it.
+1. The merge into master will kick off a new build of the live site. You should see your changes on the live site shortly after they are merged.
+
+> **Note**: For contributions that affect just one page, you can use the **Edit this page** buttons in the doc site. This allows you to skip a few steps in the process outlined above, but is suitable only for small contributions.
+
+We also encourage you to review [Doc site organization](#doc-site-organization), [Doc site architecture](#doc-site-architecture), [Linking content](#linking-content), and [RELEASING.md](RELEASING.md) for additional information.
 
 
-Alternatively, you can easily volume mount the source files into the official jekyll docker image via using a simple makefile step:
+## Building the doc site locally
+
+We use GitHub Pages and Jekyll to serve and build our site. While there are [several ways to build the site locally](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/), we recommend using our Docker image and the Makefile in the root of the repo. These will allow you to build the site with a single command. 
+
+> **Prerequisite**: [Docker](https://docs.docker.com/engine/installation/).
+
+Navigate into the root of the repo and issue the following command from a terminal prompt.
 
 ```
 make serve
 ```
 
-As the output states, docs should then be viewable at http://localhost:4000/ .
+Once the build completes, it returns a URL as the value of `Server address:`. Copy and paste this URL into your browser to view the site.
 
-### Faster builds
+> **Note**: To view the changes that you've made in the master branch, select **nightly** from the **Version** list box.
 
-Jekyll can take a while to render every page. To speed up builds, a supplemental `_config_dev.yml` exists which excludes all
-directories except `master`. Include it in your builds:
+> **Pro tip**: Jekyll can take a while to render every page. To speed up builds, a supplemental `_config_dev.yml` exists which excludes all directories except `master`. You can include it in your builds as follows `jekyll serve --config _config.yml,_config_dev.yml`. Alternatively, you can pass enable it in `make` using the following environment variable `DEV=true make serve`.
+
+
+
+## Checking for broken links
+
+> **Prerequisite**: [Docker](https://docs.docker.com/engine/installation/).
+
+To check for broken links, navigate into the root of the repo and issue the following command from a terminal prompt.
 
 ```
-jekyll serve --config _config.yml,_config_dev.yml
+make htmlproofer
 ```
 
-Or pass enable it in make using the environment variable:
+The submission of a PR kicks off a continuous integration process which includes a `make htmlproofer` command. Any errors from `htmlproofer` will cause your PR to fail the continuous integration test, so it's best to run this locally before submitting your PR. 
 
-```
-DEV=true make serve
-```
+However, you can also run this after submitting your PR and experiencing an `htmlproofer` failure from the Semaphore job.
 
-### Versioning & Branches
 
-The live site is generated from the master branch of this repository.
+## How to quickly apply changes in master to a previous release
 
-Documentation for past releases is maintained as a folder in the root of this repository.
+Let's say there's a single commit that makes changes to the `master` directory which I want to apply to the `v1.5` directory. 
 
-Most pull requests which modify information in the docs should primarily target
-the `/master/` folder, especially if they are describing newly added features.
-However, changes should also be applied to past-release directories if they fix
-general typos or incorrect information.
+1. Generate a diff. A sample command follows which stores the diff in a file called `my-patch.diff`.
 
-##### How to Quickly Back-Apply Master Changes to a Previous Release
-Let's say there's a single commit that makes changes to Master which I want
-to apply to the v1.5 directory. First, generate a diff:
-```
-git diff f35c02fe73e6a64d187ee3f6e9298ca47ded91ab^1 f35c02fe73e6a64d187ee3f6e9298ca47ded91ab > my-patch.diff
-```
+    ```
+    git diff f35c02fe73e6a64d187ee3f6e9298ca47ded91ab^1 f35c02fe73e6a64d187ee3f6e9298ca47ded91ab > my-patch.diff
+    ```
 
-Then, apply that diff to the target version directory.
-```
-git apply -p2 --directory=v1.5 my-patch.diff
-```
-- `-p2` strips off /master on the front of the paths.
-- `--directory=v1.5` adds "v1.5" to the start of the paths.
+1. Apply the diff to the target version directory.
 
-Then simply inspect the results (`git status`, `git diff`, etc.) and commit.
+    ```
+    git apply -p2 --directory=v1.5 my-patch.diff
+    ```
+    
+    - `-p2` strips off /master on the front of the paths.
+    - `--directory=v1.5` adds "v1.5" to the start of the paths.
 
-## Navigation & Sidebar
+1. Inspect the results (`git status`, `git diff`, etc.) and commit.
 
-The docs (currently) are split into 4 main sections:
+## Doc site organization
 
-- Introduction
-- Getting Started
-- Using
-- Reference
+### Overview
+
+The docs (currently) are split into four main sections.
+
+- [Introduction](#introduction)
+- [Getting started](#getting-started)
+- [Usage](#usage)
+- [Reference](#reference)
 
 ### Introduction
 
 Landing page for new users covering Calico's purpose and high-level topics.
 
-### Getting Started
+### Getting started
 
-This should be where new users go. It includes quick-start guides, some basic
-tutorials to show off Calico's capabilities, and links to more advanced topics
-once users are comfortable with the basics.
+This should be where new users go. It includes quick-start guides, some basic tutorials to show off Calico's capabilities, and links to more advanced topics once users are comfortable with the basics.
 
-Each orchestrator has a landing page that is targeted at people who are coming
-to see Calico for the first time. It's a transition from the "marketing" type
-material (why is Calico great) to some quick commands people can run to see it
-firsthand, and then funnels people off to the usage section for more details.
+Each orchestrator has a landing page that is targeted at people who are coming to see Calico for the first time. It's a transition from the "marketing" type material (why is Calico great) to some quick commands people can run to see it firsthand, and then funnels people off to the Usage section for more details.
 
 ### Usage
 
-These should all be docs that are a "verb" and task focused. Each doc should
-contain why you want to do this, a goal, and a set of steps you can follow to
-achieve it. They should not be detailed description of components or tabulated
-configuration information.
+This section contains task-based information. All top-level titles in this section should start with a gerund. Each topic should include why you want to perform the task, a goal, and a set of steps you can follow to achieve it. 
 
 Examples:
 
-- Configuring BGP Peers
+- Configuring BGP peers
 - Enabling IP-in-IP in AWS
 - Troubleshooting Calico
 - Using calicoctl in a Kubernetes deployment
-- Configuring Egress Policy in Kubernetes
+- Configuring egress policy in Kubernetes
+
+Do not include detailed description of components or tabulated
+configuration information in this section. This type of content should be located in the [Reference](#reference) section.
 
 ### Reference
 
-These docs are complete reference for Calico. If there's a configuration
-option you're looking for, it goes here in one of the per-component
-references. Not every option has a "how to" guide, but has enough description.
-The caveats and considerations when enabling options should be listed here.
+These docs contain complete reference information for Calico. If there's a configuration option you're looking for, it goes here in one of the per-component references. Not every option has a "how to" guide, but has enough description. The caveats and considerations when enabling options should be listed here.
 
 Examples:
 
-- Fully tabulated configuration options per-component.
-- calicoctl help text.
+- Fully tabulated configuration options per-component
+- `calicoctl` help text
 - Calico API schema reference (policy, ip pool, etcd)
-- High-level Calico architecture documentation. (?)
 
-#### How It Works
 
-The naming and layout of these navbars are stored in `_data/$VERSION/navbars/*`. Jekyll automatically stores information from the `_data` dir in an accessible variable called `site.data`. The toplevel layout (`_layout/docwithnav.html`) will iterate through all the files in `site.data[version].navbars` to construct the sidebar based on which version is being viewed.
+## Doc site architecture
 
-> Note: Sidebar paths to index files (see next section) should end in a `/` in the yaml file. Sidebar paths to actual files should not end in a `/` in the yaml file.
+The naming and layout of these navbars are stored in `_data/$VERSION/navbars/*`. Jekyll automatically stores information from the `_data` directory in an accessible variable called `site.data`. The top-level layout (`_layout/docwithnav.html`) will iterate through all the files in `site.data[version].navbars` to construct the sidebar based on which version is being viewed.
 
-## Pathing
+> **Note**: Sidebar paths to index files (see [next section](#linking-content)) should end in a `/` in the yaml file. Sidebar paths to actual files should not end in a `/` in the yaml file.
 
-URL structure is important. In order to create a toplevel splash page for a URL path, simply name the file `index.md`. See the following example:
+URL structure is important. In order to create a top level splash page for a URL path, simply name the file `index.md`. See the following example:
 
 
 | URL                                           | Filepath                                         |
@@ -137,22 +145,13 @@ URL structure is important. In order to create a toplevel splash page for a URL 
 | `/getting-started/kubernetes/troubleshooting` | `/getting-started/kubernetes/troubleshooting.md` |
 
 
-## Linking Content
+## Linking content
 
 All links should be absolute links. To link to versioned content, prefix all links with: `{{site.baseurl}}/{{page.version}}/`
 
-> Tip: `page.version` will be inherited from the default set in `_config.yml` for the current page's directory.
+> **Pro tip**: `page.version` will be inherited from the default set in `_config.yml` for the current page's directory.
 
 ## Releases
 
 See [RELEASING.md](RELEASING.md)
 
-## Testing
-
-Print all broken links: `make htmlproofer`
-
-Calico/node system tests run in a container to ensure all build dependencies are met.
-
-```
-make -C calico_node st
-```

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ exclude:
   - RELEASING.md
   - BUILDING_CALICO.md
   - CONTRIBUTING_DOCS.md
+  - CONTRIBUTING_CODE.md
   - hack
   - calico_node
 

--- a/_data/master/navbars/reference.yml
+++ b/_data/master/navbars/reference.yml
@@ -132,9 +132,7 @@ toc:
   path: /reference/requirements
 - title: Repo Structure
   path: /reference/repo-structure
-- title: Contribute
-  path: /reference/contribute
-- title: Involved
+- title: Get Involved
   path: /reference/involved
 - title: License
   path: /reference/license

--- a/master/reference/involved.md
+++ b/master/reference/involved.md
@@ -18,25 +18,26 @@ in touch for help debugging any issues with Calico.
 All of Calico's code is on [GitHub](https://github.com/projectcalico).  The following
 list contains the most commonly encountered repositories:
 
-Repository         | Description
--------------------|----------------------------
-[felix](https://github.com/projectcalico/felix) | The felix policy enforcement agent.
-[calicoctl](https://github.com/projectcalico/calicoctl) | Home of the calico/node and calicoctl components.
-[cni-plugin](https://github.com/projectcalico/cni-plugin) | The Calico CNI plugin.
-[libnetwork-plugin](https://github.com/projectcalico/libnetwork-plugin) | The Calico libnetwork plugin for Docker.
-[k8s-policy](https://github.com/projectcalico/k8s-policy) | Kubernetes policy controller.
-[libcalico](https://github.com/projectcalico/libcalico) | Python Calico library.
-[libcalico-go](https://github.com/projectcalico/libcalico-go) | Golang Calico library.
+Repository                                                              | Description
+------------------------------------------------------------------------|----------------------------
+[Calico](https://github.com/projectcalico/calico)                       | Calico release artifacts and documentation
+[calicoctl](https://github.com/projectcalico/calicoctl)                 | calico/node and calicoctl components
+[cni-plugin](https://github.com/projectcalico/cni-plugin)               | Calico CNI plugin
+[felix](https://github.com/projectcalico/felix)                         | felix policy enforcement agent
+[k8s-policy](https://github.com/projectcalico/k8s-policy)               | Kubernetes policy controller
+[libcalico](https://github.com/projectcalico/libcalico)                 | Python Calico library
+[libcalico-go](https://github.com/projectcalico/libcalico-go)           | Golang Calico library
+[libnetwork-plugin](https://github.com/projectcalico/libnetwork-plugin) | Calico libnetwork plugin for Docker
 
 ## Contributing
 
 Calico follows the "Fork & Pull" model of collaborative development,
-with changes being offered to the main Calico codebase via Pull
-Requests. So you can contribute a fix, change or enhancement by forking
+with changes being offered to the main Calico codebase via pull
+requests. So you can contribute a fix, change, or enhancement by forking
 one of our repositories and making a GitHub pull request. If you're
 interested in doing that:
 
 -   Thanks!
 -   See the [GitHub docs](https://help.github.com/articles/using-pull-requests) for how
-    to create a Pull Request.
--   Check our [contibution guide](contribute) for more information.
+    to create a pull request.
+-   Check the contribution guidelines at the root of each repo for more details.


### PR DESCRIPTION
## Description

- Updates, enhances, clarifies doc contribution process and other doc site details
- Creates matching MD file for code contribution guidelines at root of repo
- Moves code contribution guidelines from doc site into MD to be served by GitHub. This make this information more readily available to those navigating directly to repo (we cannot be sure code contributors will come to repo via doc site)

