### PR TITLE
no need to create GNP CRD now that we create it in the manifests

### DIFF
--- a/hack/remove-calico-policy/global-network-policy-override.yaml
+++ b/hack/remove-calico-policy/global-network-policy-override.yaml
@@ -1,20 +1,3 @@
-# Create the GlobalNetworkPolicy CustomResourceDefinition.
-apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Network Policies
-kind: CustomResourceDefinition
-metadata:
-  name: globalnetworkpolicies.crd.projectcalico.org
-spec:
-  scope: Cluster
-  group: crd.projectcalico.org
-  version: v1
-  names:
-    kind: GlobalNetworkPolicy
-    plural: globalnetworkpolicies
-    singular: globalnetworkpolicy
-
----
-
 # Create a custom resource instance of the GlobalNetworkPolicy
 # which allows all ingress and egress traffic.
 apiVersion: "crd.projectcalico.org/v1"


### PR DESCRIPTION
## Description

Now that we create GNP as part of the manifest if you follow the instructions for LRB, you get the following warning:

```
kubectl create -f=https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/global-network-policy-override.yaml
globalnetworkpolicy "allow-all-calico-policy" created
Error from server (AlreadyExists): error when creating "https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/global-network-policy-override.yaml": customresourcedefinitions.apiextensions.k8s.io "globalnetworkpolicies.crd.projectcalico.org" already exists
```

it doesn't break anything, but we don't need to create something that's already there.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
