### PR TITLE
Document Ingress/Egress Types field

### DIFF
--- a/master/reference/calicoctl/resources/policy.md
+++ b/master/reference/calicoctl/resources/policy.md
@@ -50,33 +50,33 @@ spec:
 
 #### Spec
 
-| Field      | Description                                                                                                                                           | Accepted Values | Schema                | Default  |
-|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------|----------|
-| order      | Controls the order of precedence. Calico applies the policy with the lowest value first.                                                              |                 | float             | Applied last* |
-| selector   | Specifies the endpoints that Calico should apply the policy to.                                                                                       |                 | [selector](#selector) | `all()`  |
-| types      | Applies the policy based on the direction of the traffic. To apply the policy to inbound traffic, set to `ingress`. To apply the policy to outbound traffic, set to `egress`. To apply the policy to both, set to `ingress, egress`. | | `ingress` `egress` `ingress, egress` | Depends on presence of ingress/egress rules** |
-| ingress    | Ordered list of ingress rules applied by policy.                                                                                                      |                 | List of [Rule](#rule) |          |
-| egress     | Ordered list of egress rules applied by this policy.                                                                                                  |                 | List of [Rule](#rule) |          |
-| doNotTrack*** | If `true`, Calico applies the policy before any data plane connection tracking and does not track allowed packets.                                 | `true` `false`  | boolean               | `false`  |
-| preDNAT***    | If `true`, Calico applies the policy before any destination network address translation (DNAT).                                                    | `true` `false`  | boolean               | `false`  |
+| Field      | Description                                                                                                                                           | Accepted Values | Schema                | Default |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
+| order      | (Optional) Indicates priority of this policy, with lower order taking precedence.  No value indicates highest order (lowest precedence)               |                 | float                 |         |
+| selector   | Selects the endpoints to which this policy applies.                                                                                                   |                 | [selector](#selector) | all()   |
+| types      | Applies the policy based on the direction of the traffic. To apply the policy to inbound traffic, set to `ingress`. To apply the policy to outbound traffic, set to `egress`. To apply the policy to both, set to `ingress, egress`. | `ingress`, `egress` | List of strings | Depends on presence of ingress/egress rules\* |
+| ingress    | Ordered list of ingress rules applied by policy.                                                                                                      |                 | List of [Rule](#rule) |         |
+| egress     | Ordered list of egress rules applied by this policy.                                                                                                  |                 | List of [Rule](#rule) |         |
+| doNotTrack | Indicates to apply the rules in this policy before any data plane connection tracking, and that packets allowed by these rules should not be tracked. | true, false     | boolean               | false   |
+| preDNAT    | Indicates to apply the rules in this policy before any DNAT.                                                                                          | true, false     | boolean               | false   |
 
-\* If more than one policy has no order, Calico applies these in lexicographic order according to their names.
-
-\*\* If `types` has no value, Calico defaults as follows.
-
->| Ingress Rules Present | Egress Rules Present | `Types` value       |
- |-----------------------|----------------------|---------------------|
- | No                    | No                   | `ingress`           |
- | Yes                   | No                   | `ingress`           |
- | No                    | Yes                  | `egress`            |
- | Yes                   | Yes                  | `ingress, egress`   |
-
-\*\*\* The `doNotTrack` and `preDNAT` fields are meaningful only when applying policy to a
+The `doNotTrack` and `preDNAT` fields are meaningful only when applying policy to a
 [host endpoint]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/hostendpoint).
-Only one of them may be set to `true` (in a given policy). If they are both `false`, or when applying the policy to a
+Only one of them may be set to `true` (in a given policy).  If they are both `false`, or when applying the policy to a
 [workload endpoint]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/workloadendpoint),
-the policy is enforced after connection tracking and any DNAT. See [Using Calico to Secure Host Interfaces]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal)
+the policy is enforced after connection tracking and any DNAT.
+
+See [Using Calico to Secure Host Interfaces]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal)
 for how `doNotTrack` and `preDNAT` can be useful for host endpoints.
+
+\* If `types` has no value, Calico defaults as follows.
+
+| Ingress Rules Present | Egress Rules Present | `Types` value       |
+|-----------------------|----------------------|---------------------|
+| No                    | No                   | `ingress`           |
+| Yes                   | No                   | `ingress`           |
+| No                    | Yes                  | `egress`            |
+| Yes                   | Yes                  | `ingress, egress`   |
 
 #### Rule
 

--- a/master/reference/calicoctl/resources/policy.md
+++ b/master/reference/calicoctl/resources/policy.md
@@ -23,6 +23,9 @@ metadata:
   name: allow-tcp-6379
 spec:
   selector: role == 'database'
+  types:
+  - ingress
+  - egress
   ingress:
   - action: allow
     protocol: tcp
@@ -47,22 +50,32 @@ spec:
 
 #### Spec
 
-| Field      | Description                                                                                                                                           | Accepted Values | Schema                | Default |
-|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
-| order      | (Optional) Indicates priority of this policy, with lower order taking precedence.  No value indicates highest order (lowest precedence)               |                 | float                 |         |
-| selector   | Selects the endpoints to which this policy applies.                                                                                                   |                 | [selector](#selector) | all()   |
-| ingress    | Ordered list of ingress rules applied by policy.                                                                                                      |                 | List of [Rule](#rule) |         |
-| egress     | Ordered list of egress rules applied by this policy.                                                                                                  |                 | List of [Rule](#rule) |         |
-| doNotTrack | Indicates to apply the rules in this policy before any data plane connection tracking, and that packets allowed by these rules should not be tracked. | true, false     | boolean               | false   |
-| preDNAT    | Indicates to apply the rules in this policy before any DNAT.                                                                                          | true, false     | boolean               | false   |
+| Field      | Description                                                                                                                                           | Accepted Values | Schema                | Default  |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------|----------|
+| order      | Controls the order of precedence. Calico applies the policy with the lowest value first.                                                              |                 | float             | Applied last* |
+| selector   | Specifies the endpoints that Calico should apply the policy to.                                                                                       |                 | [selector](#selector) | `all()`  |
+| types      | Applies the policy based on the direction of the traffic. To apply the policy to inbound traffic, set to `ingress`. To apply the policy to outbound traffic, set to `egress`. To apply the policy to both, set to `ingress, egress`. | | `ingress` `egress` `ingress, egress` | Depends on presence of ingress/egress rules** |
+| ingress    | Ordered list of ingress rules applied by policy.                                                                                                      |                 | List of [Rule](#rule) |          |
+| egress     | Ordered list of egress rules applied by this policy.                                                                                                  |                 | List of [Rule](#rule) |          |
+| doNotTrack*** | If `true`, Calico applies the policy before any data plane connection tracking and does not track allowed packets.                                 | `true` `false`  | boolean               | `false`  |
+| preDNAT***    | If `true`, Calico applies the policy before any destination network address translation (DNAT).                                                    | `true` `false`  | boolean               | `false`  |
 
-The `doNotTrack` and `preDNAT` fields are meaningful only when applying policy to a
+\* If more than one policy has no order, Calico applies these in lexicographic order according to their names.
+
+\*\* If `types` has no value, Calico defaults as follows.
+
+>| Ingress Rules Present | Egress Rules Present | `Types` value       |
+ |-----------------------|----------------------|---------------------|
+ | No                    | No                   | `ingress`           |
+ | Yes                   | No                   | `ingress`           |
+ | No                    | Yes                  | `egress`            |
+ | Yes                   | Yes                  | `ingress, egress`   |
+
+\*\*\* The `doNotTrack` and `preDNAT` fields are meaningful only when applying policy to a
 [host endpoint]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/hostendpoint).
-Only one of them may be set to `true` (in a given policy).  If they are both `false`, or when applying the policy to a
+Only one of them may be set to `true` (in a given policy). If they are both `false`, or when applying the policy to a
 [workload endpoint]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/workloadendpoint),
-the policy is enforced after connection tracking and any DNAT.
-
-See [Using Calico to Secure Host Interfaces]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal)
+the policy is enforced after connection tracking and any DNAT. See [Using Calico to Secure Host Interfaces]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/bare-metal)
 for how `doNotTrack` and `preDNAT` can be useful for host endpoints.
 
 #### Rule

--- a/master/reference/calicoctl/resources/policy.md
+++ b/master/reference/calicoctl/resources/policy.md
@@ -71,12 +71,12 @@ for how `doNotTrack` and `preDNAT` can be useful for host endpoints.
 
 \* If `types` has no value, Calico defaults as follows.
 
-| Ingress Rules Present | Egress Rules Present | `Types` value       |
-|-----------------------|----------------------|---------------------|
-| No                    | No                   | `ingress`           |
-| Yes                   | No                   | `ingress`           |
-| No                    | Yes                  | `egress`            |
-| Yes                   | Yes                  | `ingress, egress`   |
+>| Ingress Rules Present | Egress Rules Present | `Types` value       |
+ |-----------------------|----------------------|---------------------|
+ | No                    | No                   | `ingress`           |
+ | Yes                   | No                   | `ingress`           |
+ | No                    | Yes                  | `egress`            |
+ | Yes                   | Yes                  | `ingress, egress`   |
 
 #### Rule
 


### PR DESCRIPTION
## Description

Document the 'types' field introduced as part of the v2.6.0 ingress/egress feature:
- This PR supersedes https://github.com/projectcalico/calico/pull/1016
- Verified UTs pass (i.e. `make htmlproofer`).

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note
- Fix up all tables in reference section (will do this in a subsequent PR).

## Release Note

```release-note
A new Calico Policy `Types` field allows you to specify explicitly whether that Policy should apply to selected endpoints for ingress traffic, or for egress traffic, or for both; this makes it easy to apply ingress policy to certain endpoints without accidentally changing the default egress treatment for those endpoints, and vice versa.  For more information please see https://docs.projectcalico.org/v2.6/reference/calicoctl/resources/policy.
```
