### PR TITLE
rev felix version to 2.5.1 for master branch

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1072,7 +1072,7 @@ master:
   note: ""
   components:
      felix:
-      version: 2.4.1
+      version: 2.5.1
       url: ""
      calicoctl:
       version: master


### PR DESCRIPTION
## Description
seeing some issues with syncer.go which led to checking the version of felix bundled in. Looks out of date. After I rev'd felix version to 2.5.1 the issue went away.

```
2017-08-31 20:34:07.575 [INFO][94] felix.go 137: Felix starting up GOMAXPROCS=4 buildDate="2017-08-10T08:01:00+0000" gitCommit="bc72231932710821cab866e81f0f3eefa276ef40" version="2.4.1"
...
2017-08-31 20:34:09.748 [WARNING][94] syncer.go 391: Failed to watch SystemNetworkPolicies, retrying: the server could not find the requested resource (get systemnetworkpolicies.alpha.projectcalico.org)
...
2017-08-31 20:34:10.748 [INFO][94] syncer.go 599: Needs resync: map[NetworkPolicy:true HostConfig:true CalicoReadyState:true Namespace:true Pod:true IPPool:true Node:true SystemNetworkPolicy:true GlobalConfig:true]
2017-08-31 20:34:10.748 [INFO][94] syncer.go 603: Syncing Namespaces
2017-08-31 20:34:10.752 [INFO][94] syncer.go 638: Syncing NetworkPolicy
2017-08-31 20:34:10.754 [INFO][94] syncer.go 661: Syncing SystemNetworkPolicy
2017-08-31 20:34:10.756 [INFO][94] syncer.go 683: Syncing Pods
2017-08-31 20:34:10.773 [INFO][94] syncer.go 717: Syncing GlobalConfig
2017-08-31 20:34:10.775 [INFO][94] syncer.go 739: Syncing HostConfig
2017-08-31 20:34:10.778 [INFO][94] syncer.go 760: Syncing IP Pools
2017-08-31 20:34:10.781 [INFO][94] syncer.go 782: Syncing Nodes
```

## Environment
Manifest: http://docs.projectcalico.org/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
OS: CoreOS
K8s: v1.7.4