### PR TITLE
Simplify calico/node release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,7 +41,7 @@ release is announced.
          values:
            version: vX.Y
     ```
-1. Update the `RELEASE_STREAM` variable at the top of calico_node/Makefile to the new major/minor version.
+1. Update `currentReleaseStream` in `_data/versions.yml`. The correct format is v`Major`.`Minor`, e.g. `v2.5`.
 1. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
 1. Run `make -C calico-node release` - **do not push the git tag yet** - and follow the instructions to:
    1. Create release docker images (do not push the `latest` tag yet).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,7 +20,7 @@ that a release candidate will be created, published and tested before the final
 release is announced.
 
 1. Run `./release-scripts/do_release.py` to copy master directory to the new version directory
-1. Add the new version to `_data/versions.yaml` (add the date of the release in the description)
+1. Add the new version to `_data/versions.yml` (add the date of the release in the description)
    - Add new versions that are a release candidate to the end of the file.
      If a release is added to the top of the file it will become the 'Latest Release'.
    - Make sure new release candidate versions are added to the top of the new release section (otherwise
@@ -66,8 +66,8 @@ release is announced.
 ### Promoting a release candidate to a final release
 1. Add a new `<option>` entry to the `<span class="dropdown">` in `_layouts/docwithnav.html` file. This step should NOT be performed until testing of the release is complete.
 1. Modify the redirect in `/index.html` to point to your new release.
-1. Move the section for the release in `_data/versions.yaml` to the top of the file so that it will be the 'Latest Release'.
-1. Update the master release stream section in `_data/versions.yaml`.
+1. Move the section for the release in `_data/versions.yml` to the top of the file so that it will be the 'Latest Release'.
+1. Update the master release stream section in `_data/versions.yml`.
 1. Run `make add_redirects_for_latest VERSION=vX.Y` to update the redirects.
 1. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
 1. Create a git tag, docker images, and release file by running `make -C calico_node release`.
@@ -79,9 +79,9 @@ release is announced.
 
 ### Performing a "patch" release
 Patch releases shouldn't include any new functionality, just bug fixes (expect during pre-release testing).
-1. Add the new version to `_data/versions.yaml`:
+1. Add the new version to `_data/versions.yml`:
    - Add the date in the description.
-   - Add the new version to `_data/versions.yaml` (Remember to add the date in the description)
+   - Add the new version to `_data/versions.yml` (Remember to add the date in the description)
 1. Test the changes locally then open a pull request, make sure it passes CI and get it reviewed.
 1. Create a git tag, docker images, and release file by running `make -C calico_node release`. Follow the instructions to push the images but DO NOT PUSH THE TAG YET.
 1. Now merge the PR - this will cause the live docs site to be updated (after a few minutes).

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,3 +1,6 @@
+# vX.Y format: update during major release process
+currentReleaseStream: v2.5
+
 v2.5:
 - title: v2.5.1
   note: |

--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -1,12 +1,17 @@
 ###############################################################################
-# Versions:
-RELEASE_STREAM?=v2.5
 
 GO_BUILD_VER?=v0.7
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
 
 CALICO_NODE_DIR=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSIONS_FILE?=$(CALICO_NODE_DIR)/../_data/versions.yml
+
+# Read current stream version from _data/versions.yml
+RELEASE_STREAM?=$(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - "currentReleaseStream")
+
+.PHONY: print-version
+print-version:
+	$(info $$RELEASE_STREAM is ${RELEASE_STREAM})
 
 # For local builds this can be made faster by running "go get github.com/mikefarah/yaml" and changing YAML_CMD to "yaml"
 YAML_CMD?=$(shell which yaml || echo docker run --rm -i $(CALICO_BUILD) yaml)


### PR DESCRIPTION
## Description

Move the stream version (e.g. `v2.5`) from calico_node/Makefile into versions.yml. This simplifies the release process slightly since versions.yml becomes (mostly) the single source of truth for versions, and there's only one file to edit when managing calico/node versions (in this repo).
- testing: confirmed new version value is reflected in calico/node version; ran containerized fvs.

## Todos

- [x] Tests
- [x] Documentation

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
