### PR TITLE
Fixes #1036 . Corrects routing from old version

### DIFF
--- a/_includes/version_warning.html
+++ b/_includes/version_warning.html
@@ -1,5 +1,5 @@
 {% if page.version != site.data.versions.first[0] %}
   <div class="alert alert-warning" role="alert">
-    <strong>Warning:</strong> You are viewing the {{ page.version }} docs. <a href="{{site.baseurl}}/latest">Click here to view the docs for the latest release.</a>
+	  <strong>Warning:</strong> You are viewing the {{ page.version }} docs. <a href="{{site.baseurl}}/{{site.data.versions.first[0]}}/{{page.url | remove:page.version }}">Click here to view the docs for the latest release.</a>
   </div>
 {% endif %}


### PR DESCRIPTION
## Description
This is a bug fix - fixing issue #1036 .
This bug fixes routing related issues from old version of doc to latest version.
Tested on dev machine using make serve and make htmlproofer targets
Documentation gets fixed with this PR.

