### PR TITLE
Move HtmlProofer local ignored dirs to versions.yml (Simplify Release Process)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 ###############################################################################
-# For local builds, YAML_CMD can be made faster by running
-# "go get github.com/mikefarah/yaml" and changing YAML_CMD to "yaml"
-YAML_CMD?=$(shell which yaml || echo docker run --rm -i $(CALICO_BUILD) yaml)
+# Determine whether there's a local yaml installed or use dockerized version.
+# Note, to install yaml: "go get github.com/mikefarah/yaml"
+GO_BUILD_VER?=v0.7
+CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
+YAML_CMD:=$(shell which yaml || echo docker run --rm -i $(CALICO_BUILD) yaml)
 
 ###############################################################################
 # Versions

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+###############################################################################
+# For local builds, YAML_CMD can be made faster by running
+# "go get github.com/mikefarah/yaml" and changing YAML_CMD to "yaml"
+YAML_CMD?=$(shell which yaml || echo docker run --rm -i $(CALICO_BUILD) yaml)
+
+###############################################################################
+# Versions
+CALICO_DIR=$(shell git rev-parse --show-toplevel)
+VERSIONS_FILE?=$(CALICO_DIR)/_data/versions.yml
+
+###############################################################################
+# HtmlProofer
+HP_IGNORE_LOCAL_DIRS?=$(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - "htmlProoferLocalDirIgnore")
+
 JEKYLL_VERSION=3.3.1
 DEV?=false
 
@@ -17,7 +31,7 @@ clean:
 	docker run --rm -ti -e JEKYLL_UID=`id -u` -v $$PWD:/srv/jekyll jekyll/jekyll:$(JEKYLL_VERSION) jekyll clean
 
 htmlproofer: clean _site
-	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --file-ignore /v1.5/,/v1.6/,/v2.0/ --assume-extension --check-html --empty-alt-ignore --url-ignore "/docs.openshift.org/,#,/github.com\/projectcalico\/calico\/releases\/download/"
+	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --file-ignore ${HP_IGNORE_LOCAL_DIRS} --assume-extension --check-html --empty-alt-ignore --url-ignore "/docs.openshift.org/,#,/github.com\/projectcalico\/calico\/releases\/download/"
 	-docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --assume-extension --check-html --empty-alt-ignore --url-ignore "#"
 	# Rerun htmlproofer across _all_ files, but ignore failure, allowing us to notice legacy docs issues without failing CI
 	

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -2,7 +2,7 @@
 currentReleaseStream: v2.5
 
 # Local directories to ignore when checking external links
-htmlProoferLocalDirIgnore: /v1.5/,/v1.6/,/v2.0/
+htmlProoferLocalDirIgnore: /v1.5/,/v1.6/,/v2.0/,/v2.1/,/v2.2/
 
 v2.5:
 - title: v2.5.1

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,6 +1,9 @@
 # vX.Y format: update during major release process
 currentReleaseStream: v2.5
 
+# Local directories to ignore when checking external links
+htmlProoferLocalDirIgnore: /v1.5/,/v1.6/,/v2.0/
+
 v2.5:
 - title: v2.5.1
   note: |


### PR DESCRIPTION
## Description
Now specify which local directories to ignore when running htmlproofer from calico/Makefile to _data/versions.yml.

The bigger picture is that versions.yml becomes more of the single stop for cutting a new release.

Note this PR also has a change to add v2.1 and v2.2 to the list of ignored directories when testing for missing external links via HtmlProofer.

Testing: ran UTs, htmlproofer, and built calico/node.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
