### PR TITLE
Add Typhoon to Kubernetes GCE installation docs

### DIFF
--- a/master/getting-started/kubernetes/installation/gce.md
+++ b/master/getting-started/kubernetes/installation/gce.md
@@ -17,15 +17,18 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to GCE in 3 steps using a web-based interface.
 
+**[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for GCE and other platforms.
+
 #### More installation options
 
 If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
-on GCEusing one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
+on GCE using one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
 
 [ket]: https://apprenda.com/kismatic/
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [stackpoint]: https://stackpoint.io/#/
+[typhoon]: https://typhoon.psdn.io/
 
 [self-hosted]: hosted
 [integration-guide]: integration

--- a/v2.5/getting-started/kubernetes/installation/gce.md
+++ b/v2.5/getting-started/kubernetes/installation/gce.md
@@ -18,15 +18,18 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to GCE in 3 steps using a web-based interface.
 
+**[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for GCE and other platforms.
+
 #### More installation options
 
 If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
-on GCEusing one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
+on GCE using one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
 
 [ket]: https://apprenda.com/kismatic/
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [stackpoint]: https://stackpoint.io/#/
+[typhoon]: https://typhoon.psdn.io/
 
 [self-hosted]: hosted
 [integration-guide]: integration


### PR DESCRIPTION
## Description

Add [Typhoon](https://typhoon.psdn.io/) to Kubernetes GCE installation docs. Typhoon provides minimal and free Kubernetes clusters via Terraform module. It supports bare-metal, GCE, and Digital Ocean.

Clusters currently default to flannel for networking, but Calico v2.5.1 is an option on bare-metal, GCE, and Digital Ocean (DO w caveats) and runs in production. The default will be switched to "calico" soon.

## Reviewer

Should this change be made in the v2.5 folder or do those not get republished often?


