### PR TITLE
Fix regression caused by new keys above latest release stream

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,9 +1,3 @@
-# vX.Y format: update during major release process
-currentReleaseStream: v2.5
-
-# Local directories to ignore when checking external links
-htmlProoferLocalDirIgnore: /v1.5/,/v1.6/,/v2.0/,/v2.1/,/v2.2/
-
 v2.5:
 - title: v2.5.1
   note: |
@@ -1110,4 +1104,10 @@ master:
      calico/routereflector:
       version: v0.4.0
       url: ""
+
+# vX.Y format: update during major release process
+currentReleaseStream: v2.5
+
+# Local directories to ignore when checking external links
+htmlProoferLocalDirIgnore: /v1.5/,/v1.6/,/v2.0/,/v2.1/,/v2.2/
 


### PR DESCRIPTION
## Description

Fix regression caused by adding new keys above the latest release stream in `versions.yml`.

The issue is that determining the latest release requires that the release stream key (e.g. v2.5) be at the very top of the file. By moving the new keys to the bottom of the file, this issue is resolved and the new functionality is unaffected.

I'll look into making versions.yml less brittle and also adding validation for the redirect-to-latest functionality for a future PR.

## Testing
- verified redirects only happen for versions older than 2.5.
- ran htmlproofer w/o issues
- built calico/node and verified version

See issue https://github.com/projectcalico/calico/issues/1087

```release-note
None required
```
