### PR TITLE
Propagates red note about k8s CRDs and 2.5

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -33,6 +33,12 @@ You must have a cluster which meets the following requirements:
 > `10.244.0.0/16`).
 {: .alert .alert-info}
 
+> **Important**: If you are using the Kubernetes datastore and upgrading 
+> from Calico v2.4.x or earlier to Calico v2.5.x or later, you must 
+> [migrate your Calico configuration data](https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md) 
+> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.
+{: .alert .alert-danger}
+
 
 ## Installation
 

--- a/master/getting-started/kubernetes/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade.md
@@ -26,6 +26,12 @@ impact on Calico.
 > [upgrading to v1 NetworkPolicy semantics](#upgrading-to-v1-networkpolicy-semantics)
 {: .alert .alert-info}
 
+> **Important**: If you are using the Kubernetes datastore and upgrading from 
+> Calico v2.4.x or earlier to Calico v2.5.x or later, you must 
+> [migrate your Calico configuration data](https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md) 
+> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.
+{: .alert .alert-danger}
+
 
 ## Upgrading a Hosted Installation of Calico
 

--- a/v2.5/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.5/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -30,6 +30,12 @@ You must have a cluster which meets the following requirements:
 > Note:  If you are upgrading from Calico v2.1, the cluster-cidr selected for your controller manager should remain
 > unchanged from the v2.1 install (the v2.1 manifests default to `10.244.0.0/16`).
 
+> **Important**: If you are using the Kubernetes datastore and upgrading 
+> from Calico v2.4.x or earlier to Calico v2.5.x or later, you must 
+> [migrate your Calico configuration data](https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md) 
+> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.
+{: .alert .alert-danger}
+
 ## Installation
 
 This document describes three installation options for Calico using Kubernetes API as the datastore:

--- a/v2.5/getting-started/kubernetes/upgrade.md
+++ b/v2.5/getting-started/kubernetes/upgrade.md
@@ -28,6 +28,13 @@ impact on Calico.
 > to a version >= v2.3.0, or when upgrading Calico using the etcd datastore from a version < v2.4.0
 > to a version >= v2.4.0, you should follow the steps for [upgrading to v1 NetworkPolicy semantics](#upgrading-to-v1-networkpolicy-semantics)
 
+> **Important**: If you are using the Kubernetes datastore and upgrading from 
+> Calico v2.4.x or earlier to Calico v2.5.x or later, you must 
+> [migrate your Calico configuration data](https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md) 
+> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.
+{: .alert .alert-danger}
+
+
 ## Upgrading a Hosted Installation of Calico
 
 This section covers upgrading a [self-hosted]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/installation/hosted) Calico installation.


### PR DESCRIPTION
## Description

- Adds red note from Releases page to the k8s upgrade and hosted kdd pages for 2.5 and master


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
