### PR TITLE
Updating kubeadm docs with KDD info

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -2,70 +2,72 @@
 title: kubeadm Hosted Install
 ---
 
-This document outlines how to install Calico, as well as a as single node
-etcd cluster for use by Calico on a Kubernetes cluster created by kubeadm.
+This document outlines how to install Calico on a kubeadm cluster.
 If you have already built your cluster with kubeadm, please review the
 [Requirements / Limitations](#requirements--limitations) at the bottom of
 this page. It is likely you will need to recreate your cluster with the
 `--pod-network-cidr` and `--service-cidr` arguments to kubeadm.
 
+## Installation
+
+You can easily create a cluster compatible with these manifests by following [the official kubeadm guide](http://kubernetes.io/docs/getting-started-guides/kubeadm/).
+
+Calico installations require kubeadm initialized clusters to have set a `--pod-network-cidr`
+which should match the value set by `CALICO_IPV4POOL_CIDR` in the manifest:
+
+```yaml
+- name: CALICO_IPV4POOL_CIDR
+  value: "192.168.0.0/16"
+```
+
+This value can be changed to any CIDR that does not overlap the cluster's service CIDR.
+The manifests are currently setup to use the CIDR `192.168.0.0/16` so you would initialize
+the cluster with the following command:
+
+```shell
+kubeadm init --pod-network-cidr=192.168.0.0/16
+```
+
+### etcd datastore
+
 Users who have deployed their own etcd cluster outside of kubeadm should
 use the [Calico only manifest](../hosted) instead, as it does not deploy its
 own etcd.
 
-You can easily create a cluster compatible with this manifest by following [the official kubeadm guide](http://kubernetes.io/docs/getting-started-guides/kubeadm/).
+To install this Calico and a single node etcd on a run the following command:
 
+> **Note**: The following manifest requires Kubernetes 1.6.0 or later.
+{: .alert .alert-info}
 
-#### Installation
-
-To install this Calico and a single node etcd on a run the following command
-depending on your kubeadm / Kubernetes version:
-
-For kubeadm stable with Kubernetes version >= v1.6.0:
-
-```
+```shell
 kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
 ```
 
 >[Click here to view the above yaml directly.](1.6/calico.yaml)
 
-For kubeadm 1.5 with Kubernetes version v1.5.x:
+### Kubernetes datastore
 
+To install Calico configured to use the Kubernetes API as its sole data source, run the following commands:
+
+> **Note**: The following manifests require Kubernetes 1.7.0 or later.
+{: .alert .alert-info}
+
+```shell
+kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
 ```
-kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
-```
 
->[Click here to view the above yaml directly.](1.5/calico.yaml)
+>[Click here to view the above RBAC yaml directly.](../rbac-kdd.yaml)
+>
+>[Click here to view the above Calico yaml directly.](../kubernetes-datastore/calico-networking/1.7/calico.yaml)
 
-## Using calicoctl in a kubeadm Cluster
+## Using calicoctl in a kubeadm cluster
 
 The simplest way to use calicoctl in kubeadm is by running it as a pod.
 See [using calicoctl with Kubernetes](../../../tutorials/using-calicoctl#b-running-calicoctl-as-a-kubernetes-pod) for more information.
 
-## About
-
-This manifest deploys the standard Calico components described
-[here]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/installation/hosted)
-as well as a dedicated Calico etcd node on the Kubernetes master.  Note that in a production cluster, it is
-recommended you use a secure, replicated etcd cluster.
-
-This manifest uses a node label to select the master node on which Calico's etcd is run. This label is configured
-automatically on the master when using kubeadm.
-
-To check if the required label is applied, run the following command and
-inspect the output for the correct label:
-
-```shell
-$ kubectl get node <master_name> -o yaml
-```
-
 ### Requirements / Limitations
 
-* This install does not configure etcd TLS
-* This install expects that one Kubernetes master node has been labeled
-  (this is usually setup by kubeadm, but `kubectl get node --show-labels` will expose the labels) with:
-  * For kubeadm 1.5 `kubeadm.alpha.kubernetes.io/role: master`
-  * For kubeadm 1.6 `node-role.kubernetes.io/master: ""`
 * This install assumes no other pod network configurations have been installed
   in /etc/cni/net.d (or equivilent directory).
 * The CIDR(s) specified with the kubeadm flag `--cluster-cidr` (pre 1.6) or


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes #963 

I've pulled info from the KDD page and fit it in here, so we can represent how to bring up a kubeadm cluster with Calico using either etcd or KDD.

I also tried to make it fairly clear at the start that the cluster will need to have been initialized with `--pod-network-cidr=192.168.0.0/16`.

I did not pull over anything about policy only, or user supplied networking, but can if we feel it belongs here.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
