### PR TITLE
Add Typhoon to Kubernetes AWS installation docs

### DIFF
--- a/master/getting-started/kubernetes/installation/aws.md
+++ b/master/getting-started/kubernetes/installation/aws.md
@@ -21,6 +21,7 @@ as well as other public and private cloud environments.
 
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to AWS in 3 steps using a web-based interface.
 
+**[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for AWS and other platforms.
 
 #### More installation options
 
@@ -32,6 +33,7 @@ on AWS using one of our [self-hosted manifests][self-hosted], or by [integrating
 [ket]: https://apprenda.com/kismatic/
 [stackpoint]: https://stackpoint.io/#/
 [coreos]: https://coreos.com/kubernetes/docs/latest/
+[typhoon]: https://typhoon.psdn.io/
 
 [self-hosted]: hosted
 [integration-guide]: integration

--- a/v2.5/getting-started/kubernetes/installation/aws.md
+++ b/v2.5/getting-started/kubernetes/installation/aws.md
@@ -22,6 +22,7 @@ as well as other public and private cloud environments.
 
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to AWS in 3 steps using a web-based interface.
 
+**[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for AWS and other platforms.
 
 #### More installation options
 
@@ -33,6 +34,7 @@ on AWS using one of our [self-hosted manifests][self-hosted], or by [integrating
 [ket]: https://apprenda.com/kismatic/
 [stackpoint]: https://stackpoint.io/#/
 [coreos]: https://coreos.com/kubernetes/docs/latest/
+[typhoon]: https://typhoon.psdn.io/
 
 [self-hosted]: hosted
 [integration-guide]: integration


### PR DESCRIPTION
## Description

Add [Typhoon](https://typhoon.psdn.io/) to Kubernetes AWS installation docs. Typhoon provides minimal and free Kubernetes clusters via Terraform module. It supports AWS (new), bare-metal, GCE, and Digital Ocean with flannel or Calico. Calico is the default on AWS, bare-metal, and GCE.

Rough performance stats [for the curious](https://github.com/poseidon/typhoon/pull/18).

cc @emanic 
related: #1089 
