### PR TITLE
[DO NOT MERGE] Add upgrade note for policy controller

### DIFF
--- a/master/getting-started/kubernetes/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade.md
@@ -32,6 +32,14 @@ impact on Calico.
 > before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.
 {: .alert .alert-danger}
 
+> **Important**: If you are using the Calico policy controller and upgrading
+> from Calico v2.5.x or earlier to Calico v2.6.x or later, you must ensure that
+> the [Calico Daemonset](#upgrading-the-calico-daemonset)
+> \([calico-node](#upgrading-the-caliconode-container)\) is upgraded
+> prior to upgrading the
+> [policy controller](#upgrading-the-calico-policy-controller).
+{: .alert .alert-danger}
+
 
 ## Upgrading a Hosted Installation of Calico
 


### PR DESCRIPTION
## Description

This PR adds a note to the K8s upgrade page about the need to upgrade calico-node before updating the policy controller.


## Todos

- [X] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
If using the policy controller and upgrading from v2.5.x Calico or earlier it is necessary to upgrade calico-node before upgrading the policy controller.
```
