### PR TITLE
fix default-deny.yaml with podSelector reqs in k8s-v1.8.0-rc.1

### DIFF
--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui-client.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui-client.yaml
@@ -5,6 +5,7 @@ metadata:
   name: allow-ui 
 spec:
   podSelector:
+    matchLabels: {}
   ingress:
     - from:
         - namespaceSelector:

--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui.yaml
@@ -5,6 +5,7 @@ metadata:
   name: allow-ui 
 spec:
   podSelector:
+    matchLabels: {}
   ingress:
     - from:
         - namespaceSelector:

--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
@@ -4,3 +4,4 @@ metadata:
   name: default-deny
 spec:
   podSelector:
+    matchLabels: {}

--- a/v2.6/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui-client.yaml
+++ b/v2.6/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui-client.yaml
@@ -5,6 +5,7 @@ metadata:
   name: allow-ui 
 spec:
   podSelector:
+    matchLabels: {}
   ingress:
     - from:
         - namespaceSelector:

--- a/v2.6/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui.yaml
+++ b/v2.6/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui.yaml
@@ -5,6 +5,7 @@ metadata:
   name: allow-ui 
 spec:
   podSelector:
+    matchLabels: {}
   ingress:
     - from:
         - namespaceSelector:

--- a/v2.6/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+++ b/v2.6/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
@@ -4,3 +4,4 @@ metadata:
   name: default-deny
 spec:
   podSelector:
+    matchLabels: {}


### PR DESCRIPTION
Is compatible with k8s-v1.7.6

## Description
fixes https://github.com/projectcalico/calico/issues/1135

```release-note
None required
```
