### PR TITLE
fix simple-policy demo isolation policy for k8s-v1.8.0-rc.1

### DIFF
--- a/master/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/master/getting-started/kubernetes/tutorials/simple-policy.md
@@ -57,6 +57,7 @@ metadata:
   namespace: policy-demo
 spec:
   podSelector:
+    matchLabels: {}
 EOF
 ```
 

--- a/v2.6/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/simple-policy.md
@@ -57,6 +57,7 @@ metadata:
   namespace: policy-demo
 spec:
   podSelector:
+    matchLabels: {}
 EOF
 ```
 


### PR DESCRIPTION
## Description
Running the simple-policy-demo on a k8s-1.8.0-rc.1 cluster kicked a validation error.

```
kubectl create -f - <<EOF
> kind: NetworkPolicy
> apiVersion: extensions/v1beta1
> metadata:
>   name: default-deny
>   namespace: policy-demo
> spec:
>   podSelector:
> EOF
error: error validating "STDIN": error validating data: ValidationError(NetworkPolicy.spec): missing required field "podSelector" in io.k8s.api.extensions.v1beta1.NetworkPolicySpec; if you choose to ignore these errors, turn validation off with --validate=false
```

# Proposed fix
Add `matchLabels: {}`

```
 kubectl create -f - <<EOF
> kind: NetworkPolicy
> apiVersion: extensions/v1beta1
> metadata:
>   name: default-deny
>   namespace: policy-demo
> spec:
>   podSelector:
>     matchLabels: {}
> EOF
networkpolicy "default-deny" created
```

# release-note
None required
