### PR TITLE
Update calico_node url reference in document

### DIFF
--- a/master/reference/architecture/components.md
+++ b/master/reference/architecture/components.md
@@ -12,7 +12,7 @@ components are:
 
 In addition, we use runit for logging (`svlogd`) and init (`runsv`) services.
 
-The [calicoctl repostiory](https://github.com/projectcalico/calicoctl) contains the Dockerfile for `calico/node` along with various
+The [calico repostiory](https://github.com/projectcalico/calico) contains the Dockerfile for `calico/node` along with various
 configuration files that are used to configure and "glue" these components
 together.
 


### PR DESCRIPTION
`calico/node` moved from `projectcalico/calicoctl` to
`projectcalico/calico` since v2.4.0[1]. Updating doc reference
accordingly.

[1] commit id: b4e4c1aa12b41f44b84d455ecb486e4e54ee31d3

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
