### PR TITLE
Fix incorrect calico/node version for v2.6.1

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -19,7 +19,7 @@ v2.6:
       url: https://github.com/projectcalico/calicoctl/releases/tag/v1.6.1
       download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.6.1/calicoctl
     calico/node:
-      version: v2.6.0
+      version: v2.6.1
       url: https://github.com/projectcalico/calico/releases/tag/v2.6.0
     calico/cni:
       version: v1.11.0


### PR DESCRIPTION
## Description

Just a cosmetic error - forgot to update versions.yml to reference calico/node:v2.6.1

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
