### PR TITLE
Trivial: Backticks do not work in page title

### DIFF
--- a/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,5 @@
 ---
-title: Going Beyond `NetworkPolicy` with Calico
+title: Going Beyond NetworkPolicy with Calico
 redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 


### PR DESCRIPTION
The backticks around NetworkPolicy in the title display as backticks on https://docs.projectcalico.org/v2.6/getting-started/kubernetes/tutorials/advanced-policy and do not format the text as intended.

## Description

This is a trivial, and tiny change.
Documentation only.
Just a typo.

Two screenshots from Safari 11.0 attached.

![calico 2](https://user-images.githubusercontent.com/59195/31086305-68cff03c-a791-11e7-81a3-faae19185b1e.png)
![calico 1](https://user-images.githubusercontent.com/59195/31086306-68e78e9a-a791-11e7-987a-d5ee1e27a5a0.png)
