### PR TITLE
Use CNI to network workloads in ST

### DIFF
--- a/calico_node/tests/st/libnetwork/test_labeling.py
+++ b/calico_node/tests/st/libnetwork/test_labeling.py
@@ -19,6 +19,7 @@ from unittest import skip
 
 from tests.st.test_base import TestBase
 from tests.st.utils.docker_host import DockerHost
+from tests.st.utils.network import NETWORKING_LIBNETWORK
 from tests.st.utils.utils import ETCD_CA, ETCD_CERT, \
     ETCD_KEY, ETCD_HOSTNAME_SSL, ETCD_SCHEME, get_ip, \
     retry_until_success, wipe_etcd
@@ -69,14 +70,16 @@ class TestLibnetworkLabeling(TestBase):
                 "host1",
                 additional_docker_options=ADDITIONAL_DOCKER_OPTIONS,
                 post_docker_commands=POST_DOCKER_COMMANDS,
-                start_calico=False)
+                start_calico=False,
+                networking=NETWORKING_LIBNETWORK)
         cls.host1_hostname = cls.host1.execute("hostname")
         cls.hosts.append(cls.host1)
         cls.host2 = DockerHost(
                 "host2",
                 additional_docker_options=ADDITIONAL_DOCKER_OPTIONS,
                 post_docker_commands=POST_DOCKER_COMMANDS,
-                start_calico=False)
+                start_calico=False,
+                networking=NETWORKING_LIBNETWORK)
         cls.host2_hostname = cls.host1.execute("hostname")
         cls.hosts.append(cls.host2)
 

--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -19,6 +19,7 @@ import yaml
 from tests.st.test_base import TestBase
 from tests.st.utils.docker_host import DockerHost, CLUSTER_STORE_DOCKER_OPTIONS
 from tests.st.utils.exceptions import CommandExecError
+from tests.st.utils.network import NETWORKING_CNI, NETWORKING_LIBNETWORK
 from tests.st.utils.utils import assert_network, assert_profile, \
     assert_number_endpoints, get_profile_name
 
@@ -376,8 +377,10 @@ class MultiHostMainline(TestBase):
 
         # Test deleting the network. It will fail if there are any
         # endpoints connected still.
-        self.assertRaises(CommandExecError, network1.delete)
-        self.assertRaises(CommandExecError, network2.delete)
+        if (host1.networking == NETWORKING_LIBNETWORK or
+            host2.networking == NETWORKING_LIBNETWORK):
+            self.assertRaises(CommandExecError, network1.delete)
+            self.assertRaises(CommandExecError, network2.delete)
 
         return n1_workloads, n2_workloads, networks
 

--- a/calico_node/tests/st/utils/network.py
+++ b/calico_node/tests/st/utils/network.py
@@ -12,11 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
 from functools import partial
 from tests.st.utils.exceptions import CommandExecError
 from tests.st.utils.utils import retry_until_success
 
 logger = logging.getLogger(__name__)
+
+global_networking = None
+NETWORKING_CNI = "cni"
+NETWORKING_LIBNETWORK = "libnetwork"
+
+
+def global_setting():
+    global global_networking
+    if global_networking is None:
+        global_networking = os.getenv("ST_NETWORKING")
+        if global_networking:
+            assert global_networking in [NETWORKING_CNI, NETWORKING_LIBNETWORK]
+        else:
+            global_networking = NETWORKING_CNI
+    return global_networking
+
 
 class DockerNetwork(object):
     """

--- a/calico_node/tests/st/utils/workload.py
+++ b/calico_node/tests/st/utils/workload.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import json
 from functools import partial
 
 from netaddr import IPAddress
 
 from exceptions import CommandExecError
-from utils import retry_until_success, debug_failures
+from utils import retry_until_success, debug_failures, get_ip
+from utils import ETCD_SCHEME, ETCD_CA, ETCD_CERT, ETCD_KEY, ETCD_HOSTNAME_SSL
+from network import NETWORKING_CNI, NETWORKING_LIBNETWORK
+
 
 NET_NONE = "none"
 
@@ -44,27 +48,87 @@ class Workload(object):
         :param image: The docker image to be used to instantiate this
         container. busybox used by default because it is extremely small and
         has ping.
-        :param network: The DockerNetwork to connect to.  Set to None to use
-        default Docker networking.
+        :param network: The name of the network to connect to.
         :param ip: The ip address to assign to the container.
         :param labels: List of labels '<var>=<value>' to add to workload.
         """
         self.host = host
         self.name = name
+        self.network = network
+        assert self.network is not None
 
         lbl_args = ""
         for label in labels:
             lbl_args += " --label %s" % (label)
 
-        ip_option = ("--ip %s" % ip) if ip else ""
-        command = "docker run -tid --name %s --net %s %s %s %s" % \
-                  (name, network, lbl_args, ip_option, image)
+        net_options = "--net=none"
+        if self.host.networking == NETWORKING_LIBNETWORK:
+            ip_option = (" --ip %s" % ip) if ip else ""
+            net_options = "--net %s%s" % (network, ip_option)
+
+        command = "docker run -tid --name %s %s %s %s" % (name,
+                                                          net_options,
+                                                          lbl_args,
+                                                          image)
         docker_run_wl = partial(host.execute, command)
         retry_until_success(docker_run_wl)
-        self.ip = host.execute(
-            "docker inspect --format "
-            "'{{.NetworkSettings.Networks.%s.IPAddress}}' %s"
-            % (network, name))
+
+        if self.host.networking == NETWORKING_LIBNETWORK:
+            self.ip = host.execute(
+                "docker inspect --format "
+                "'{{.NetworkSettings.Networks.%s.IPAddress}}' %s"
+                % (network, name))
+        else:
+            self.run_cni("ADD", ip=ip)
+
+    def run_cni(self, add_or_del, ip=None):
+        adding = (add_or_del == "ADD")
+        workload_pid = self.host.execute(
+            "docker inspect --format '{{.State.Pid}}' %s" % self.name)
+        container_id = self.host.execute(
+            "docker inspect --format '{{.Id}}' %s" % self.name)
+        ip_json = (',"args":{"ip":"%s"}' % ip) if (ip and adding) else ''
+        ip_args = ('CNI_ARGS=IP=%s ' % ip) if (ip and adding) else ''
+        etcd_json = '"etcd_endpoints":"http://%s:2379",' % get_ip()
+        if ETCD_SCHEME == "https":
+            etcd_json = ('"etcd_endpoints":"https://%s:2379",' % ETCD_HOSTNAME_SSL +
+                         '"etcd_ca_cert_file":"%s",' % ETCD_CA +
+                         '"etcd_cert_file":"%s",' % ETCD_CERT +
+                         '"etcd_key_file":"%s",' % ETCD_KEY)
+        command = ('echo \'{' +
+                   '"name":"%s",' % self.network +
+                   '"type":"calico-cni-plugin",' +
+                   etcd_json +
+                   '"ipam":{"type":"calico-ipam-plugin"%s}' % ip_json +
+                   '}\' | ' +
+                   'CNI_COMMAND=%s ' % add_or_del +
+                   'CNI_CONTAINERID=%s ' % container_id +
+                   'CNI_NETNS=/proc/%s/ns/net ' % workload_pid +
+                   'CNI_IFNAME=eth0 ' +
+                   'CNI_PATH=/code/dist ' +
+                   ip_args +
+                   '/code/dist/calico-cni-plugin')
+        output = self.host.execute(command)
+
+        if adding:
+            # The CNI plugin writes its logging to stderr and its JSON output -
+            # including the IP address that we need - to stdout, but
+            # unfortunately 'docker exec' combines these into its own stdout,
+            # and that is what 'output' contains here.  So we need heuristics
+            # to ignore the logging lines and pick up the JSON.  Writing out
+            # the JSON is the last thing that the CNI plugin does, so it should
+            # be robust to ignore everything before a line that begins with a
+            # curly bracket.
+            json_text = ""
+            json_started = False
+            for line in output.split('\n'):
+                if not json_started and line.strip() == "{":
+                    json_started = True
+                if json_started:
+                    json_text = json_text + line
+            logger.debug("JSON text from Calico CNI = %s", json_text)
+            result = json.loads(json_text)
+            self.ip = result["ip4"]["ip"].split('/')[0]
 
     def execute(self, command):
         """


### PR DESCRIPTION
## Description
Enhancing the calico_node STs so that they can use the Calico CNI plugin to set up networking for their workloads, with `docker run ... --net=none`, instead of using the Calico libnetwork plugin with ``docker run ... --net=<docker network name`.

## Todo
- [x] Squash commits.
- [x] Make it conditional: a test run as a whole should either use libnetwork or CNI, with individual tests within the run being able to override this.