### PR TITLE
Exclude auto detection of kube-ipvs0 dummy interface.

### DIFF
--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -47,7 +47,7 @@ const (
 var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
 	"docker.*", "cbr.*", "dummy.*",
 	"virbr.*", "lxcbr.*", "veth.*", "lo",
-	"cali.*", "tunl.*", "flannel.*",
+	"cali.*", "tunl.*", "flannel.*", "kube-ipvs.*",
 }
 
 // Version string, set during build.


### PR DESCRIPTION
## Description
kube-proxy creates kube-ipvs0 dummy interface if it is running in ipvs mode.  Exclude auto detection of this dummy interface from calico/node startup.