### PR TITLE
Missing etcd binary in docker args

### DIFF
--- a/master/getting-started/mesos/installation/prerequisites.md
+++ b/master/getting-started/mesos/installation/prerequisites.md
@@ -18,7 +18,7 @@ or replaced `$ETCD_IP` and `$ETCD_PORT`:
 docker run --detach \
 	--net=host \
 	--name etcd quay.io/coreos/etcd:v3.1.10 \
-	--advertise-client-urls "http://$ETCD_IP:$ETCD_PORT" \
+	etcd --advertise-client-urls "http://$ETCD_IP:$ETCD_PORT" \
 	--listen-client-urls "http://$ETCD_IP:$ETCD_PORT,http://127.0.0.1:$ETCD_PORT"
 ```
 

--- a/v2.6/getting-started/mesos/installation/prerequisites.md
+++ b/v2.6/getting-started/mesos/installation/prerequisites.md
@@ -19,7 +19,7 @@ or replaced `$ETCD_IP` and `$ETCD_PORT`:
 docker run --detach \
 	--net=host \
 	--name etcd quay.io/coreos/etcd:v3.1.10 \
-	--advertise-client-urls "http://$ETCD_IP:$ETCD_PORT" \
+	etcd --advertise-client-urls "http://$ETCD_IP:$ETCD_PORT" \
 	--listen-client-urls "http://$ETCD_IP:$ETCD_PORT,http://127.0.0.1:$ETCD_PORT"
 ```
 


### PR DESCRIPTION
Executing the example which runs an ETCD server fails with the following error:

/run/torcx/bin/docker: Error response from daemon: oci runtime error: container_linux.go:262: starting container process caused "exec: \"--advertise-client-urls\": executable file not found in $PATH".

Adding "etcd" to the arguments fix the problem.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
