### PR TITLE
Added in Canonical Link

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -41,7 +41,7 @@ The code is a little roundabout for a few reasons:
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- <link rel="canonical" href="https://www.projectcalico.org/docs{{page.url}}" /> -->
+    <link rel="canonical" href="https://docs.projectcalico.org/{{site.data.versions.first[0]}}{{page.url | remove_first: page.version | remove_first: '/' }}" />
     <link rel="shortcut icon" type="image/png" href="{{site.baseurl}}/images/favicon.png">
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">


### PR DESCRIPTION
## Description

Added in Canonical Link for Google Search Engine results to encourage Google to always return the latest version of that page in the search results.


## Todos

- [ ] Page Exists (old page where new page has been deleted)
- [ ] 404 gets a funky (also 404) url - shouldn't be an issue as Google shouldn't be indexing 404s