### PR TITLE
Update as-service.md

### DIFF
--- a/master/usage/configuration/as-service.md
+++ b/master/usage/configuration/as-service.md
@@ -97,6 +97,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v1.5/usage/configuration/as-service.md
+++ b/v1.5/usage/configuration/as-service.md
@@ -94,6 +94,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v1.6/usage/configuration/as-service.md
+++ b/v1.6/usage/configuration/as-service.md
@@ -94,6 +94,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v2.0/usage/configuration/as-service.md
+++ b/v2.0/usage/configuration/as-service.md
@@ -95,6 +95,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v2.1/usage/configuration/as-service.md
+++ b/v2.1/usage/configuration/as-service.md
@@ -95,6 +95,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v2.2/usage/configuration/as-service.md
+++ b/v2.2/usage/configuration/as-service.md
@@ -95,6 +95,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v2.3/usage/configuration/as-service.md
+++ b/v2.3/usage/configuration/as-service.md
@@ -95,6 +95,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v2.4/usage/configuration/as-service.md
+++ b/v2.4/usage/configuration/as-service.md
@@ -95,6 +95,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v2.5/usage/configuration/as-service.md
+++ b/v2.5/usage/configuration/as-service.md
@@ -95,6 +95,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```

--- a/v2.6/usage/configuration/as-service.md
+++ b/v2.6/usage/configuration/as-service.md
@@ -98,6 +98,10 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
 
 ExecStop=-/usr/bin/docker stop calico-node
 
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
 [Install]
 WantedBy=multi-user.target
 ```


### PR DESCRIPTION
Add systemd rule for restart `on-failure`.

Obviously we don't want our SDNs to die once and lose all connectivity, right?

## Description

Fixing Systemd unit docs

## Todos

- [X] Tests
- [X] Documentation
- [X] Release note

## Release Note


```release-note
Update as-service.md  …
Add systemd rule for restart `on-failure`.
```


@caseydavenport @ozdanborne @neiljerram