### PR TITLE
Docs: Redirect to correct version

### DIFF
--- a/v2.6/introduction/index.md
+++ b/v2.6/introduction/index.md
@@ -25,4 +25,4 @@ Proven in production at scale, Calico features
 integrations with Kubernetes, OpenShift, Docker, 
 Mesos, DC/OS, and OpenStack.
 
-<a href="/master/getting-started/" class="btn btn-primary btn-lg">Get started</a>
+<a href="/v2.6/getting-started/" class="btn btn-primary btn-lg">Get started</a>


### PR DESCRIPTION
## Description
I noticed that the getting-started link in `v2.6` was incorrectly linked to `master`. Sending out a quick fix for it.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
