### PR TITLE
Fixes uppercase letter that breaks redirect

### DIFF
--- a/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Going Beyond NetworkPolicy with Calico
-redirect_from: latest/getting-started/Kubernetes/tutorials/advanced-policy
+redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 
 The Kubernetes `NetworkPolicy` API allows users to express ingress and egress policies (starting with Kubernetes 1.8.0) to Kubernetes pods


### PR DESCRIPTION
## Description

- The uppercase kubernetes in the redirect path causes the redirect to not work
- Tested locally to verify
- Caused by a global find/replace operation



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
