### PR TITLE
Adds redirect_from to new k8s quickstart

### DIFF
--- a/v2.6/getting-started/kubernetes/index.md
+++ b/v2.6/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart for Calico on Kubernetes
+redirect_from: latest/getting-started/kubernetes/
 ---
 
 


### PR DESCRIPTION
## Description

- This link was erroneously excluded previously
- Tested locally



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
