### PR TITLE
Implements canonical tag with ability to define exceptions

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@ title: 404
 description: Uh Oh
 layout: docwithnav
 permalink: /404.html
+no_canonical: true
 ---
 <p>Sorry, this page doens't exist.</p>
 

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -41,7 +41,7 @@ The code is a little roundabout for a few reasons:
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- <link rel="canonical" href="https://www.projectcalico.org/docs{{page.url}}" /> -->
+    {% if page.no_canonical != true %}<link rel="canonical" href="{{site.url}}{{page.url | replace:page.version,'latest'}}" />{% endif %}
     <link rel="shortcut icon" type="image/png" href="{{site.baseurl}}/images/favicon.png">
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">

--- a/v2.3/getting-started/mesos/vagrant/index.md
+++ b/v2.3/getting-started/mesos/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+no_canonical: true
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster
 with Calico installed and ready to network Docker Containerizer tasks.

--- a/v2.3/reference/contribute.md
+++ b/v2.3/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+no_canonical: true
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.3/reference/policy-controller/configuration.md
+++ b/v2.3/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller 
+no_canonical: true
 ---
 
 The policy controller is primarily configured through environment variables.  When running

--- a/v2.4/reference/contribute.md
+++ b/v2.4/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+no_canonical: true
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.4/reference/policy-controller/configuration.md
+++ b/v2.4/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
-title: Configuring the Calico policy controller 
+title: Configuring the Calico policy controller
+no_canonical: true
 ---
 
 The policy controller is primarily configured through environment variables.  When running

--- a/v2.5/reference/contribute.md
+++ b/v2.5/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+no_canonical: true
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.5/reference/policy-controller/configuration.md
+++ b/v2.5/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
-title: Configuring the Calico policy controller 
+title: Configuring the Calico policy controller
+no_canonical: true
 ---
 
 The policy controller is primarily configured through environment variables.  When running

--- a/v2.6/reference/kube-controllers/configuration.md
+++ b/v2.6/reference/kube-controllers/configuration.md
@@ -1,6 +1,7 @@
 ---
 title: Configuring the Calico Kubernetes controllers
 redirect_from: latest/reference/kube-controllers/configuration
+no_canonical: true
 ---
 
 The Calico Kubernetes controllers are primarily configured through environment variables. When running


### PR DESCRIPTION
## Description

- Adds canonical tag to docwithnav.html that uses 'latest' directory
- Passes local htmlproofer
- Includes ability to define exceptions to the tag for deleted, renamed, and 404 pages
- Adds metadata to pages which are not present in 'latest'
- Incidentally adds validation for latest redirects

*Note*: Some of the no_canonicals can be removed when https://github.com/projectcalico/calico/pull/1202 is merged

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
