### PR TITLE
CentOS/RHEL 7 itself now provides a new enough version of dnsmasq

### DIFF
--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -264,7 +264,7 @@ On each control node, perform the following steps:
     > left around.
     {: .alert .alert-danger}
 
-3.  Edit the `/etc/neutron/neutron.conf` file. In the `\[DEFAULT\]`
+3.  Edit the `/etc/neutron/neutron.conf` file. In the `[DEFAULT]`
     section, find the line beginning with `core_plugin`, and change it to
     read `core_plugin = calico`.
 
@@ -327,7 +327,7 @@ On each compute node, perform the following steps:
     service libvirtd restart
     ```
 
-2.  Open `/etc/nova/nova.conf` and remove the line from the \[DEFAULT\]
+2.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 
     ```

--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -11,8 +11,6 @@ using OpenStack Liberty or later.
 >
 > - Using Newton or later (recommended), or
 >
-> - Using RHEL/CentOS 7.2, instead of 7.3, or
->
 > - Manually [patching](https://review.openstack.org/#/c/425637/) your Nova
 >   install on each compute node.
 {: .alert .alert-info}
@@ -97,7 +95,7 @@ through the process.
         cd etcd-v2.0.11-linux-amd64
         mv etcd* /usr/local/bin/
         ```
-        
+
         > **Important**: We've seen certificate errors downloading etcd—you may need
         > to add `--insecure` to the curl command to ignore this.
         >
@@ -256,7 +254,7 @@ On each control node, perform the following steps:
     routers, subnets and networks (in that order) created by the install
     process referenced above. You can do this using the web dashboard or
     at the command line.
-    
+
     > **Tip**: The Admin and Project sections of the web dashboard both
     > have subsections for networks and routers. Some networks may
     > need to be deleted from the Admin section.
@@ -265,8 +263,6 @@ On each control node, perform the following steps:
     > **Important**: The Calico install will fail if incompatible state is
     > left around.
     {: .alert .alert-danger}
-
-2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 3.  Edit the `/etc/neutron/neutron.conf` file. In the `\[DEFAULT\]`
     section, find the line beginning with `core_plugin`, and change it to
@@ -317,8 +313,8 @@ On each compute node, perform the following steps:
         "/dev/rtc", "/dev/hpet", "/dev/net/tun",
     ]
     ```
-    
-    
+
+
     > **Note**: The `cgroup_device_acl` entry is subtly different than the
     > default. It now contains `/dev/net/tun`.
     >
@@ -382,8 +378,6 @@ On each compute node, perform the following steps:
     ```
     neutron agent-delete <agent-id>
     ```
-
-4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/master/getting-started/openstack/installation/ubuntu.md
+++ b/master/getting-started/openstack/installation/ubuntu.md
@@ -195,13 +195,13 @@ perform the following steps:
         $ sudo apt-get install calico-control
     ```
 
-3.  Edit the `/etc/neutron/neutron.conf` file. In the [DEFAULT]
+3.  Edit the `/etc/neutron/neutron.conf` file. In the `[DEFAULT]`
     section:
     -   Find the line beginning with `core_plugin`, and change it to
         read `core_plugin = calico`.
 
 4.  With OpenStack releases earlier than Liberty, edit the
-    `/etc/neutron/neutron.conf` file. In the [DEFAULT] section:
+    `/etc/neutron/neutron.conf` file. In the `[DEFAULT]` section:
     -   Find the line for the `dhcp_agents_per_network` setting,
         uncomment it, and set its value to the number of compute nodes
         that you will have (or any number larger than that). This allows
@@ -251,7 +251,7 @@ perform the following steps:
         $ sudo service libvirt-bin restart
     ```
 
-2.  Open `/etc/nova/nova.conf` and remove the line from the \[DEFAULT\]
+2.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 
     ```shell
@@ -307,7 +307,7 @@ perform the following steps:
     will bring in Calico-specific updates to the OpenStack packages and
     to `dnsmasq`. For OpenStack Liberty, this step only upgrades
     `dnsmasq`.
-    
+
     > **Important**: Check the version of libvirt-bin that is installed using
     > `dpkg -s libvirt-bin`. For Kilo, the version of libvirt-bin
     > should be at least `1.2.12-0ubuntu13`. This will become part
@@ -319,7 +319,7 @@ perform the following steps:
     > `$ sudo apt-get update`
     >
     > `$ sudo apt-get upgrade`
-    >  
+    >
     {: .alert .alert-danger}
 
 

--- a/v1.5/getting-started/openstack/installation/redhat.md
+++ b/v1.5/getting-started/openstack/installation/redhat.md
@@ -282,9 +282,9 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. (OpenStack updates are not
-    needed for Liberty.)
+2.  Run `yum update`. For OpenStack Kilo and earlier, this will bring in
+    Calico-specific updates to the OpenStack packages. (OpenStack updates are
+    not needed for Liberty and later.)
 
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
@@ -411,9 +411,9 @@ On each compute node, perform the following steps:
         neutron agent-delete <agent-id>
     ```
 
-4.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. For OpenStack Liberty, this
-    step only upgrades `dnsmasq`.
+4.  Run `yum update`. For OpenStack Kilo and earlier, this will bring in
+    Calico-specific updates to the OpenStack packages. (OpenStack updates are
+    not needed for Liberty and later.)
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v1.6/getting-started/openstack/installation/redhat.md
+++ b/v1.6/getting-started/openstack/installation/redhat.md
@@ -282,9 +282,9 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. (OpenStack updates are not
-    needed for Liberty.)
+2.  Run `yum update`. For OpenStack Kilo and earlier, this will bring in
+    Calico-specific updates to the OpenStack packages. (OpenStack updates are
+    not needed for Liberty and later.)
 
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
@@ -411,9 +411,9 @@ On each compute node, perform the following steps:
         neutron agent-delete <agent-id>
     ```
 
-4.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. For OpenStack Liberty, this
-    step only upgrades `dnsmasq`.
+4.  Run `yum update`. For OpenStack Kilo and earlier, this will bring in
+    Calico-specific updates to the OpenStack packages. (OpenStack updates are
+    not needed for Liberty and later.)
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.0/getting-started/openstack/installation/redhat.md
+++ b/v2.0/getting-started/openstack/installation/redhat.md
@@ -279,9 +279,9 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. (OpenStack updates are not
-    needed for Liberty.)
+2.  Run `yum update`. For OpenStack Kilo and earlier, this will bring in
+    Calico-specific updates to the OpenStack packages. (OpenStack updates are
+    not needed for Liberty and later.)
 
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
@@ -408,9 +408,9 @@ On each compute node, perform the following steps:
         neutron agent-delete <agent-id>
     ```
 
-4.  Run `yum update`. This will bring in Calico-specific updates to the
-    OpenStack packages and to `dnsmasq`. For OpenStack Liberty, this
-    step only upgrades `dnsmasq`.
+4.  Run `yum update`. For OpenStack Kilo and earlier, this will bring in
+    Calico-specific updates to the OpenStack packages. (OpenStack updates are
+    not needed for Liberty and later.)
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.1/getting-started/openstack/installation/redhat.md
+++ b/v2.1/getting-started/openstack/installation/redhat.md
@@ -13,8 +13,6 @@ using OpenStack Liberty or later.
 >
 > - using Newton or later (recommended)
 >
-> - or using RHEL/CentOS 7.2, instead of 7.3
->
 > - or manually [patching](https://review.openstack.org/#/c/425637/) your Nova
 >   install on each compute node.
 
@@ -274,8 +272,6 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
-
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
     -   Find the line beginning with `core_plugin`, and change it to
@@ -391,8 +387,6 @@ On each compute node, perform the following steps:
     ```
         neutron agent-delete <agent-id>
     ```
-
-4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.2/getting-started/openstack/installation/redhat.md
+++ b/v2.2/getting-started/openstack/installation/redhat.md
@@ -13,8 +13,6 @@ using OpenStack Liberty or later.
 >
 > - using Newton or later (recommended)
 >
-> - or using RHEL/CentOS 7.2, instead of 7.3
->
 > - or manually [patching](https://review.openstack.org/#/c/425637/) your Nova
 >   install on each compute node.
 
@@ -274,8 +272,6 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
-
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
     -   Find the line beginning with `core_plugin`, and change it to
@@ -391,8 +387,6 @@ On each compute node, perform the following steps:
     ```
         neutron agent-delete <agent-id>
     ```
-
-4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.3/getting-started/openstack/installation/redhat.md
+++ b/v2.3/getting-started/openstack/installation/redhat.md
@@ -13,8 +13,6 @@ using OpenStack Liberty or later.
 >
 > - using Newton or later (recommended)
 >
-> - or using RHEL/CentOS 7.2, instead of 7.3
->
 > - or manually [patching](https://review.openstack.org/#/c/425637/) your Nova
 >   install on each compute node.
 
@@ -273,8 +271,6 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
-
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
     -   Find the line beginning with `core_plugin`, and change it to
@@ -390,8 +386,6 @@ On each compute node, perform the following steps:
     ```
         neutron agent-delete <agent-id>
     ```
-
-4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.4/getting-started/openstack/installation/redhat.md
+++ b/v2.4/getting-started/openstack/installation/redhat.md
@@ -13,8 +13,6 @@ using OpenStack Liberty or later.
 >
 > - using Newton or later (recommended)
 >
-> - or using RHEL/CentOS 7.2, instead of 7.3
->
 > - or manually [patching](https://review.openstack.org/#/c/425637/) your Nova
 >   install on each compute node.
 
@@ -273,8 +271,6 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
-
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
     -   Find the line beginning with `core_plugin`, and change it to
@@ -390,8 +386,6 @@ On each compute node, perform the following steps:
     ```
         neutron agent-delete <agent-id>
     ```
-
-4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.5/getting-started/openstack/installation/redhat.md
+++ b/v2.5/getting-started/openstack/installation/redhat.md
@@ -13,8 +13,6 @@ using OpenStack Liberty or later.
 >
 > - using Newton or later (recommended)
 >
-> - or using RHEL/CentOS 7.2, instead of 7.3
->
 > - or manually [patching](https://review.openstack.org/#/c/425637/) your Nova
 >   install on each compute node.
 
@@ -273,8 +271,6 @@ On each control node, perform the following steps:
     > left around.
     >
 
-2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
-
 3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
     section:
     -   Find the line beginning with `core_plugin`, and change it to
@@ -390,8 +386,6 @@ On each compute node, perform the following steps:
     ```
         neutron agent-delete <agent-id>
     ```
-
-4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.5/getting-started/openstack/installation/redhat.md
+++ b/v2.5/getting-started/openstack/installation/redhat.md
@@ -271,7 +271,7 @@ On each control node, perform the following steps:
     > left around.
     >
 
-3.  Edit the `/etc/neutron/neutron.conf` file. In the \[DEFAULT\]
+3.  Edit the `/etc/neutron/neutron.conf` file. In the `[DEFAULT]`
     section:
     -   Find the line beginning with `core_plugin`, and change it to
         read `core_plugin = calico`.
@@ -335,7 +335,7 @@ On each compute node, perform the following steps:
         service libvirtd restart
     ```
 
-2.  Open `/etc/nova/nova.conf` and remove the line from the \[DEFAULT\]
+2.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 
     ```

--- a/v2.5/getting-started/openstack/installation/ubuntu.md
+++ b/v2.5/getting-started/openstack/installation/ubuntu.md
@@ -195,13 +195,13 @@ perform the following steps:
         $ sudo apt-get install calico-control
     ```
 
-3.  Edit the `/etc/neutron/neutron.conf` file. In the [DEFAULT]
+3.  Edit the `/etc/neutron/neutron.conf` file. In the `[DEFAULT]`
     section:
     -   Find the line beginning with `core_plugin`, and change it to
         read `core_plugin = calico`.
 
 4.  With OpenStack releases earlier than Liberty, edit the
-    `/etc/neutron/neutron.conf` file. In the [DEFAULT] section:
+    `/etc/neutron/neutron.conf` file. In the `[DEFAULT]` section:
     -   Find the line for the `dhcp_agents_per_network` setting,
         uncomment it, and set its value to the number of compute nodes
         that you will have (or any number larger than that). This allows
@@ -251,7 +251,7 @@ perform the following steps:
         $ sudo service libvirt-bin restart
     ```
 
-2.  Open `/etc/nova/nova.conf` and remove the line from the \[DEFAULT\]
+2.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 
     ```shell

--- a/v2.6/getting-started/openstack/installation/redhat.md
+++ b/v2.6/getting-started/openstack/installation/redhat.md
@@ -12,8 +12,6 @@ using OpenStack Liberty or later.
 >
 > - Using Newton or later (recommended), or
 >
-> - Using RHEL/CentOS 7.2, instead of 7.3, or
->
 > - Manually [patching](https://review.openstack.org/#/c/425637/) your Nova
 >   install on each compute node.
 {: .alert .alert-info}
@@ -98,7 +96,7 @@ through the process.
         cd etcd-v2.0.11-linux-amd64
         mv etcd* /usr/local/bin/
         ```
-        
+
         > **Important**: We've seen certificate errors downloading etcd—you may need
         > to add `--insecure` to the curl command to ignore this.
         >
@@ -257,7 +255,7 @@ On each control node, perform the following steps:
     routers, subnets and networks (in that order) created by the install
     process referenced above. You can do this using the web dashboard or
     at the command line.
-    
+
     > **Tip**: The Admin and Project sections of the web dashboard both
     > have subsections for networks and routers. Some networks may
     > need to be deleted from the Admin section.
@@ -266,8 +264,6 @@ On each control node, perform the following steps:
     > **Important**: The Calico install will fail if incompatible state is
     > left around.
     {: .alert .alert-danger}
-
-2.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 3.  Edit the `/etc/neutron/neutron.conf` file. In the `\[DEFAULT\]`
     section, find the line beginning with `core_plugin`, and change it to
@@ -318,8 +314,8 @@ On each compute node, perform the following steps:
         "/dev/rtc", "/dev/hpet", "/dev/net/tun",
     ]
     ```
-    
-    
+
+
     > **Note**: The `cgroup_device_acl` entry is subtly different than the
     > default. It now contains `/dev/net/tun`.
     >
@@ -383,8 +379,6 @@ On each compute node, perform the following steps:
     ```
     neutron agent-delete <agent-id>
     ```
-
-4.  Run `yum update`. This will bring in Calico-specific updates to `dnsmasq`.
 
 5.  Install Neutron infrastructure code on the compute host:
 

--- a/v2.6/getting-started/openstack/installation/redhat.md
+++ b/v2.6/getting-started/openstack/installation/redhat.md
@@ -265,7 +265,7 @@ On each control node, perform the following steps:
     > left around.
     {: .alert .alert-danger}
 
-3.  Edit the `/etc/neutron/neutron.conf` file. In the `\[DEFAULT\]`
+3.  Edit the `/etc/neutron/neutron.conf` file. In the `[DEFAULT]`
     section, find the line beginning with `core_plugin`, and change it to
     read `core_plugin = calico`.
 
@@ -328,7 +328,7 @@ On each compute node, perform the following steps:
     service libvirtd restart
     ```
 
-2.  Open `/etc/nova/nova.conf` and remove the line from the \[DEFAULT\]
+2.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 
     ```

--- a/v2.6/getting-started/openstack/installation/ubuntu.md
+++ b/v2.6/getting-started/openstack/installation/ubuntu.md
@@ -196,13 +196,13 @@ perform the following steps:
         $ sudo apt-get install calico-control
     ```
 
-3.  Edit the `/etc/neutron/neutron.conf` file. In the [DEFAULT]
+3.  Edit the `/etc/neutron/neutron.conf` file. In the `[DEFAULT]`
     section:
     -   Find the line beginning with `core_plugin`, and change it to
         read `core_plugin = calico`.
 
 4.  With OpenStack releases earlier than Liberty, edit the
-    `/etc/neutron/neutron.conf` file. In the [DEFAULT] section:
+    `/etc/neutron/neutron.conf` file. In the `[DEFAULT]` section:
     -   Find the line for the `dhcp_agents_per_network` setting,
         uncomment it, and set its value to the number of compute nodes
         that you will have (or any number larger than that). This allows
@@ -252,7 +252,7 @@ perform the following steps:
         $ sudo service libvirt-bin restart
     ```
 
-2.  Open `/etc/nova/nova.conf` and remove the line from the \[DEFAULT\]
+2.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 
     ```shell
@@ -308,7 +308,7 @@ perform the following steps:
     will bring in Calico-specific updates to the OpenStack packages and
     to `dnsmasq`. For OpenStack Liberty, this step only upgrades
     `dnsmasq`.
-    
+
     > **Important**: Check the version of libvirt-bin that is installed using
     > `dpkg -s libvirt-bin`. For Kilo, the version of libvirt-bin
     > should be at least `1.2.12-0ubuntu13`. This will become part
@@ -320,7 +320,7 @@ perform the following steps:
     > `$ sudo apt-get update`
     >
     > `$ sudo apt-get upgrade`
-    >  
+    >
     {: .alert .alert-danger}
 
 


### PR DESCRIPTION
Therefore our instruction to run 'yum update', in order to upgrade
dnsmasq, is wrong.

However, this assumes using the latest available version of CentOS/RHEL
7 - currently 7.4 - so we should also remove the suggestion of
downgrading to 7.2 in order to work around the Nova bug in Mitaka and
earlier.  In practice, most new installers should be using Newton or
later, and there is still the manual patching option for earlier
OpenStack releases.  (And it is bad practice to suggest using a version
of CentOS/RHEL that is 2 minor versions behind what is now available.)
