### PR TITLE
Adds doc style guide to list of excludes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ exclude:
   - BUILDING_CALICO.md
   - CONTRIBUTING_DOCS.md
   - CONTRIBUTING_CODE.md
+  - DOC_STYLE_GUIDE.md
   - hack
   - calico_node
 


### PR DESCRIPTION
## Description

- Fixes issue where doc style guide file was not added to list of excludes and as a result, is built by Jekyll and placed in the _site directory, which is incorrect



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
