### PR TITLE
Modifies get started button link

### DIFF
--- a/master/introduction/index.md
+++ b/master/introduction/index.md
@@ -24,4 +24,4 @@ Proven in production at scale, Calico features
 integrations with Kubernetes, OpenShift, Docker, 
 Mesos, DC/OS, and OpenStack.
 
-<a href="/master/getting-started/" class="btn btn-primary btn-lg">Get started</a>
+<a href="/{{page.version}}/getting-started/" class="btn btn-primary btn-lg">Get started</a>

--- a/v2.6/introduction/index.md
+++ b/v2.6/introduction/index.md
@@ -25,4 +25,4 @@ Proven in production at scale, Calico features
 integrations with Kubernetes, OpenShift, Docker, 
 Mesos, DC/OS, and OpenStack.
 
-<a href="/v2.6/getting-started/" class="btn btn-primary btn-lg">Get started</a>
+<a href="/{{page.version}}/getting-started/" class="btn btn-primary btn-lg">Get started</a>


### PR DESCRIPTION
## Description

- Fixes link syntax of button to use a variable instead of hardcoding, allowing the page content to port more easily from version to version.
- Addresses https://github.com/projectcalico/calico/issues/1198

cc: @caseydavenport 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
