### PR TITLE
Make title of updated Advanced Policy tutorial more descriptive

### DIFF
--- a/master/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/master/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,5 @@
 ---
-title: Going Beyond NetworkPolicy with Calico
+title: Controlling ingress and egress traffic with network policy
 ---
 
 The Kubernetes `NetworkPolicy` API allows users to express ingress and egress policies (starting with Kubernetes 1.8.0) to Kubernetes pods

--- a/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,5 @@
 ---
-title: Going Beyond NetworkPolicy with Calico
+title: Controlling ingress and egress traffic with network policy
 redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 


### PR DESCRIPTION
## Description

Now that k8s network policy supports ingress and egress policy, the previous title no longer describes the content of this tutorial (no longer shows the policy features that Calico offers above and beyond k8s). This PR adjust the title to be more descriptive.



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
