### PR TITLE
Updates doc contribution and style guide

### DIFF
--- a/DOC_STYLE_GUIDE.md
+++ b/DOC_STYLE_GUIDE.md
@@ -383,27 +383,28 @@ Use decimal points. Example, 2.5 pounds.
 
 ## Terminology
 
-| Correct               | Incorrect
-| --------------------- | ---------
-| agent                 | slave
-| API                   | api
-| API server            | api server, apiserver
-| DockerHub             | Dockerhub, dockerhub
-| GitHub                | Github, github
-| email                 | e-mail, Email, E-mail
-| etcd                  | Etcd, ETCD
-| flannel               | Flannel
-| internet              | Internet
-| kubeadm               | Kubeadmn
-| Mesos containerizer   | Unified containerizer, Universal containerizer
-| `NetworkPolicy`       | NetworkPolicy
-| network policy        | Network Policy, NetworkPolicy
-| quickstart            | quick start, quick-start   
-| systemd               | Systemd
-| to                    | in order to
-| tutorial or procedure | worked example
-| web interface         | GUI, UI
-| web server            | webserver
+| Correct                  | Incorrect
+| ------------------------ | ---------
+| agent                    | slave
+| API                      | api
+| API server               | api server, apiserver
+| DockerHub                | Dockerhub, dockerhub
+| GitHub                   | Github, github
+| email                    | e-mail, Email, E-mail
+| etcd                     | Etcd, ETCD
+| flannel                  | Flannel
+| internet                 | Internet
+| kubeadm                  | Kubeadmn
+| Kubernetes API datastore | Kubernetes datastore, kdd datastore
+| Mesos containerizer      | Unified containerizer, Universal containerizer
+| `NetworkPolicy`          | NetworkPolicy
+| network policy           | Network Policy, NetworkPolicy
+| quickstart               | quick start, quick-start   
+| systemd                  | Systemd
+| to                       | in order to
+| tutorial or procedure    | worked example
+| web interface            | GUI, UI
+| web server               | webserver
 
 
 ## Commonly confused


### PR DESCRIPTION
## Description

- Clarifies and updates some details around link syntax, the new `canonical_url` tag, and other updates. 
- Also adds "Kubernetes API datastore" to terms in style guide.



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
