### PR TITLE
Fixes some broken doc links caused by changes in other repo

### DIFF
--- a/master/reference/calicoctl/commands/get.md
+++ b/master/reference/calicoctl/commands/get.md
@@ -180,8 +180,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 

--- a/v2.0/reference/calicoctl/commands/get.md
+++ b/v2.0/reference/calicoctl/commands/get.md
@@ -164,8 +164,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 

--- a/v2.1/reference/calicoctl/commands/get.md
+++ b/v2.1/reference/calicoctl/commands/get.md
@@ -164,8 +164,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 

--- a/v2.2/reference/calicoctl/commands/get.md
+++ b/v2.2/reference/calicoctl/commands/get.md
@@ -164,8 +164,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 

--- a/v2.3/reference/calicoctl/commands/get.md
+++ b/v2.3/reference/calicoctl/commands/get.md
@@ -172,8 +172,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 

--- a/v2.4/reference/calicoctl/commands/get.md
+++ b/v2.4/reference/calicoctl/commands/get.md
@@ -176,8 +176,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 

--- a/v2.5/reference/calicoctl/commands/get.md
+++ b/v2.5/reference/calicoctl/commands/get.md
@@ -176,8 +176,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 

--- a/v2.6/reference/calicoctl/commands/get.md
+++ b/v2.6/reference/calicoctl/commands/get.md
@@ -181,8 +181,7 @@ eth0
 #### `yaml / json`
 
 The `yaml` and `json` options display the output as a list of YAML documents or JSON dictionaries.  The fields for
-resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide, or alternatively view the structure
-definitions (implemented in golang) in the [libcalic API](https://github.com/projectcalico/libcalico-go/tree/master/lib/api).
+resource type are documented in the [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) guide.
 
 The output from either of these formats may be used as input for all of the resource management commands.
 


### PR DESCRIPTION
## Description

- This will unblock other PRs by fixing htmlproofer errors
- Caused by path change in libcalico-go repo



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
