### PR TITLE
fix an error log about bgp_next_hop filter

### DIFF
--- a/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -15,7 +15,7 @@ filter calico_ipip {
 {{range ls "/v1/ipam/v4/pool"}}{{$data := json (getv (printf "/v1/ipam/v4/pool/%s" .))}}
   if ( net ~ {{$data.cidr}} ) then {
 {{if $data.ipip_mode}}{{if eq $data.ipip_mode "cross-subnet"}}
-    if ( bgp_next_hop ~ {{$network}} ) then
+    if defined(bgp_next_hop) && ( bgp_next_hop ~ {{$network}} ) then
       krt_tunnel = "";                     {{/* Destination in ipPool, mode is cross sub-net, route from-host on subnet, do not use IPIP */}}
     else
       krt_tunnel = "{{$data.ipip}}";       {{/* Destination in ipPool, mode is cross sub-net, route from-host off subnet, set the tunnel (if IPIP not enabled, value will be "") */}}


### PR DESCRIPTION
## Description

The bgp_next_hop isn't defined in some route rules, and the following
is log of the bird:

```
bird: filters, line 18: ~ applied on unknown type pair
```

So, before we use bgp_next_hop, we should check if the bgp_next_hop is defined or not:

```
filter calico_ipip {

  if ( net ~ 10.233.64.0/18 ) then {
    if defined(bgp_next_hop) && (bgp_next_hop ~ 192.168.137.0/24 ) then {
      krt_tunnel = "";
    } else {
      krt_tunnel = "tunl0";
    }
    accept;
  }

  accept;
}
```



## Todos

- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
