### PR TITLE
[WIP] Update peer tests to use V2 API

### DIFF
--- a/calico_node/tests/st/bgp/peer.py
+++ b/calico_node/tests/st/bgp/peer.py
@@ -12,20 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def create_bgp_peer(host, scope, ip, asNum):
+
+def create_bgp_peer(host, scope, ip, asNum, metadata=None):
     assert scope in ('node', 'global')
-    node = host.get_hostname() if scope == 'node' else ""
     testdata = {
-        'apiVersion': 'v1',
-        'kind': 'bgpPeer',
-        'metadata': {
-            'scope': scope,
-            'node': node,
-            'peerIP': ip,
-        },
+        'apiVersion': 'projectcalico.org/v2',
+        'kind': 'BGPPeer',
         'spec': {
-            'asNumber': asNum
+            'peerIP': ip,
+            'asNumber': asNum,
         }
     }
+    # Add optional params
+    # If node is not specified, scope is global.
+    if scope == "node":
+        testdata['spec']['node'] = host.get_hostname()
+    if metadata is not None:
+        testdata['metadata'] = metadata
+
     host.writefile("testfile.yaml", testdata)
     host.calicoctl("create -f testfile.yaml")

--- a/calico_node/tests/st/bgp/test_ipip.py
+++ b/calico_node/tests/st/bgp/test_ipip.py
@@ -58,8 +58,9 @@ class TestIPIP(TestBase):
             # v1.0.2 calicoctl.  For calicoctl v1.1.0+, a new IPIP mode field
             # is introduced - by testing with an older pool version validates
             # the IPAM BIRD templates function correctly without the mode field.
-            self.pool_action(host1, "create", DEFAULT_IPV4_POOL_CIDR, ipip_mode="Never",
-                             calicoctl_version="v1.0.2")
+            self.pool_action(host1, "create", DEFAULT_IPV4_POOL_CIDR, ipip_mode="Never",)
+                             # comment this out for now because we don't support upgrading data yet
+                             # calicoctl_version="v1.0.2")
 
             # Autodetect the IP addresses - this should ensure the subnet is
             # correctly configured.
@@ -91,8 +92,9 @@ class TestIPIP(TestBase):
 
             # Turn on IPIP with a v1.0.2 calicoctl and check that the
             # IPIP tunnel is being used.
-            self.pool_action(host1, "replace", DEFAULT_IPV4_POOL_CIDR, ipip_mode="Always",
-                             calicoctl_version="v1.0.2")
+            self.pool_action(host1, "replace", DEFAULT_IPV4_POOL_CIDR, ipip_mode="Always",)
+                             # comment this out for now because we don't support upgrading data yet
+                             # calicoctl_version="v1.0.2")
             self.assert_ipip_routing(host1, workload_host1, workload_host2,
                                      True)
 


### PR DESCRIPTION
## Description

Update BGP peer tests to use V2 API

## Todos

- [ ] Test these tests against a V2 supporting calico-node

## Release Note

```release-note
None required
```
