### PR TITLE
Update CRDs that are used when operating in KDD Mode

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -192,18 +192,18 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Felix Configuration
+description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
-   name: globalfelixconfigs.crd.projectcalico.org
+   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalFelixConfig
-    plural: globalfelixconfigs
-    singular: globalfelixconfig
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
 
 ---
 
@@ -224,18 +224,18 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global BGP Configuration
+description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
-  name: globalbgpconfigs.crd.projectcalico.org
+  name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalBGPConfig
-    plural: globalbgpconfigs
-    singular: globalbgpconfig
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
 
 ---
 
@@ -255,6 +255,22 @@ spec:
 
 ---
 
+- apiVersion: apiextensions.k8s.io/v1beta1
+  description: Calico Cluster Information
+  kind: CustomResourceDefinition
+  metadata:
+    name: clusterinformations.crd.projectcalico.org
+  spec:
+    scope: Cluster
+    group: crd.projectcalico.org
+    version: v1
+    names:
+      kind: ClusterInformation
+      plural: clusterinformations
+      singular: clusterinformation
+
+---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Global Network Policies
 kind: CustomResourceDefinition
@@ -268,6 +284,22 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Network Policies
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespace
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
 
 ---
 

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -189,34 +189,34 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Felix Configuration
+description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
-   name: globalfelixconfigs.crd.projectcalico.org
+   name: felixconfigs.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalFelixConfig
-    plural: globalfelixconfigs
-    singular: globalfelixconfig
+    kind: FelixConfig
+    plural: felixconfigs
+    singular: felixconfig
 
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global BGP Configuration
+description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
-  name: globalbgpconfigs.crd.projectcalico.org
+  name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalBGPConfig
-    plural: globalbgpconfigs
-    singular: globalbgpconfig
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
 
 ---
 
@@ -236,6 +236,22 @@ spec:
 
 ---
 
+- apiVersion: apiextensions.k8s.io/v1beta1
+  description: Calico Cluster Information
+  kind: CustomResourceDefinition
+  metadata:
+    name: clusterinformations.crd.projectcalico.org
+  spec:
+    scope: Cluster
+    group: crd.projectcalico.org
+    version: v1
+    names:
+      kind: ClusterInformation
+      plural: clusterinformations
+      singular: clusterinformation
+
+---
+
 apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Global Network Policies
 kind: CustomResourceDefinition
@@ -249,6 +265,22 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Network Policies
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespace
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
 
 ---
 

--- a/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -44,11 +44,13 @@ rules:
       - watch
   - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - globalfelixconfigs
+      - felixconfigurations
       - bgppeers
-      - globalbgpconfigs
+      - bgpconfigurations
       - ippools
       - globalnetworkpolicies
+      - networkpolicies
+      - clusterinformations
     verbs:
       - create
       - get


### PR DESCRIPTION
## Description

Update the CRDs that Calico requires to exist in Kubernetes when operating in KDD Mode with the v2 data model.

CRDs that are renamed:
`GlobalBGPConfig` -> `BGPConfiguration`
`GlobalFelixConfig` -> `FelixConfiguration`

CRDs that stay the same:
`BGPPeers`
`GlobalNetworkPolicy`
`IPPool`

Newly created/supported CRDs:
`ClusterInformation`
`NetworkPolicy`




## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
