### PR TITLE
Set master download__urls to release

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1367,8 +1367,8 @@ master:
      calico/cni:
       version: master
       url: ""
-      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.0-alpha1-rc2/calico
-      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.0-alpha1-rc2/calico-ipam
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.0/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.0/calico-ipam
      calico-bird:
       version: v0.3.1
       url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1


### PR DESCRIPTION
I'm not sure if there was a need that the download_calico_url and download_calico_ipam_url were updated. This sets them to the last release so that hopefully the Semaphore tests pass.

## Release Note


```release-note
None required
```
