### PR TITLE
Bugfix: startup fails with nil IPv6 conflict

### DIFF
--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -739,14 +739,14 @@ func checkConflictingNodes(ctx context.Context, client client.Interface, node *a
 		// an indication of multiple nodes using the same name.  This
 		// is not an error condition as the IPs could actually change.
 		if theirNode.Name == node.Name {
-			if theirIPv4 != nil && ourIPv4 != nil && !theirIPv4.IP.Equal(ourIPv4.IP) {
+			if theirIPv4.IP != nil && ourIPv4.IP != nil && !theirIPv4.IP.Equal(ourIPv4.IP) {
 				warning("Calico node '%s' IPv4 address has changed:",
 					theirNode.Name)
 				message(" -  This could happen if multiple nodes are configured with the same name")
 				message(" -  Original IP: %s", theirIPv4.String())
 				message(" -  Updated IP: %s", ourIPv4.String())
 			}
-			if theirIPv6 != nil && ourIPv6 != nil && !theirIPv6.IP.Equal(ourIPv6.IP) {
+			if theirIPv6.IP != nil && ourIPv6.IP != nil && !theirIPv6.IP.Equal(ourIPv6.IP) {
 				warning("Calico node '%s' IPv6 address has changed:",
 					theirNode.Name)
 				message(" -  This could happen if multiple nodes are configured with the same name")
@@ -758,13 +758,14 @@ func checkConflictingNodes(ctx context.Context, client client.Interface, node *a
 
 		// Check that other nodes aren't using the same IP addresses.
 		// This is an error condition.
-		if theirIPv4 != nil && ourIPv4 != nil && theirIPv4.IP.Equal(ourIPv4.IP) {
+		if theirIPv4.IP != nil && ourIPv4.IP != nil && theirIPv4.IP.Equal(ourIPv4.IP) {
 			message("Calico node '%s' is already using the IPv4 address %s:",
 				theirNode.Name, ourIPv4.String())
 			message(" -  Check the node configuration to remove the IP address conflict")
 			errored = true
 		}
-		if theirIPv6 != nil && ourIPv6 != nil && theirIPv6.IP.Equal(ourIPv6.IP) {
+
+		if theirIPv6.IP != nil && ourIPv6.IP != nil && theirIPv6.IP.Equal(ourIPv6.IP) {
 			message("Calico node '%s' is already using the IPv6 address %s:",
 				theirNode.Name, ourIPv6.String())
 			message(" -  Check the node configuration to remove the IP address conflict")


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes a bug where calico-node startup was failing with:
```
Calico node 'calico-01' is already using the IPv6 address <nil>:
 -  Check the node configuration to remove the IP address conflict
Terminating
```

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
