### PR TITLE
Updates main and getting started splashes for v3.0

### DIFF
--- a/v3.0/getting-started/index.md
+++ b/v3.0/getting-started/index.md
@@ -12,3 +12,10 @@ a number of cloud services.
 
 - [Calico with Kubernetes](kubernetes)
 - [Host protection](bare-metal/bare-metal)
+
+> **Note**: For integrations with the OpenShift, OpenStack, 
+> Mesos, DC/OS, and Docker orchestrators, use
+> [Calico v2.6](/v2.6/introduction/). We plan 
+> to resume support for these orchestrators in a future 
+> v3.x release.
+{: .alert .alert-info}

--- a/v3.0/introduction/index.md
+++ b/v3.0/introduction/index.md
@@ -20,8 +20,14 @@ you can achieve fine-grained control over communications
 between containers, virtual machine workloads, and 
 bare metal host endpoints.
 
-Proven in production at scale, Calico features 
-integrations with Kubernetes, OpenShift, Docker, 
-Mesos, DC/OS, and OpenStack.
+Proven in production at scale, Calico v3.0 features 
+integration with Kubernetes.
+
+> **Note**: For integrations with the OpenShift, OpenStack, 
+> Mesos, DC/OS, and Docker orchestrators, use
+> [Calico v2.6](/v2.6/introduction/). We plan 
+> to resume support for these orchestrators in a future 
+> v3.x release.
+{: .alert .alert-info}
 
 <a href="/{{page.version}}/getting-started/" class="btn btn-primary btn-lg">Get started</a>


### PR DESCRIPTION
## Description

- Adjusts the main doc splash and the getting started splash to describe the dimensions of Calico v3.0 support.
- Adds a note to let people know to use v2.6 for the other orchestrators etc

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
