### PR TITLE
Adding OrchRefs to startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,8 @@ _site build:
 clean:
 	docker run --rm -ti -e JEKYLL_UID=`id -u` -v $$PWD:/srv/jekyll jekyll/jekyll:$(JEKYLL_VERSION) jekyll clean
 
-htmlproofer: clean _site
-	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --file-ignore ${HP_IGNORE_LOCAL_DIRS} --assume-extension --check-html --empty-alt-ignore --url-ignore "/docs.openshift.org/,#,/github.com\/projectcalico\/calico\/releases\/download/,https://github.com/projectcalico/calico/tree/master/master/introduction/index.md,https://github.com/projectcalico/calico/tree/master/v2.6/introduction/index.md"
-	-docker run -ti -e JEKYLL_UID=`id -u` --rm -v $$PWD/_site:/_site/ quay.io/calico/htmlproofer /_site --assume-extension --check-html --empty-alt-ignore --url-ignore "#"
-	# Rerun htmlproofer across _all_ files, but ignore failure, allowing us to notice legacy docs issues without failing CI
-	
-	docker run -v $$PWD:/calico --entrypoint /bin/sh -ti garethr/kubeval:0.1.1 -c 'find /calico/_site/master -name "*.yaml" |grep -v config.yaml | xargs /kubeval'
+htmlproofer:
+	@echo "Do not make docs changes against this branch, please use master."
 
 strip_redirects:
 	find \( -name '*.md' -o -name '*.html' \) -exec sed -i'' '/redirect_from:/d' '{}' \;

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1355,20 +1355,20 @@ master:
   note: ""
   components:
      felix:
-      version: 2.6.0-8-gecbd512d
+      version: 2.x-series
       url: ""
      calicoctl:
-      version: master
+      version: v1.x-series
       url: "https://www.projectcalico.org/builds/calicoctl"
       download_url: "https://www.projectcalico.org/builds/calicoctl"
      calico/node:
-      version: master
+      version: v2.x-series
       url: ""
      calico/cni:
-      version: master
+      version: v1.11.0
       url: ""
-      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
-      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.0/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.0/calico-ipam
      calico-bird:
       version: v0.3.1
       url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
@@ -1379,7 +1379,7 @@ master:
       version: master
       url: ""
      calico/kube-controllers:
-      version: master
+      version: v1.x-series
       url: ""
      networking-calico:
       version: master

--- a/calico_node/glide.lock
+++ b/calico_node/glide.lock
@@ -1,5 +1,5 @@
-hash: 08ead48d6f41fcc525a57b287c1e4dbd6374b06b1ebfe2b2700cf9c637174a6f
-updated: 2017-09-24T18:48:42.14088973-07:00
+hash: 864a682d11c8615bd8d615a33d04b531e537cd3e2f55c071199df315df59f8e5
+updated: 2017-10-27T10:40:12.900547674-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -83,7 +83,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
+  version: 462fda1f11d8cad3660e52737b8beefd27acfb3f
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -91,7 +91,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/onsi/ginkgo
-  version: 9eda700730cba42af70d53180f9dcce9266bc2bc
+  version: 11459a886d9cd66b319dac7ef1e917ee221372c9
   subpackages:
   - config
   - extensions/table
@@ -120,7 +120,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 5cabf71a9999834727d83036e986836084e0a13a
+  version: 6410b9a3ddf7e3b2e33e1e9acd7984e00101ec8f
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -152,7 +152,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
@@ -187,7 +187,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: ebfc5b4631820b793c9010c87fd8fef0f39eb082
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -228,7 +228,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
+  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2
@@ -379,7 +379,7 @@ imports:
   - util/jsonpath
 testImports:
 - name: github.com/onsi/gomega
-  version: c893efa28eb45626cdaa76c9f653b62488858837
+  version: 283ed655c6b8238afecd5bea6434bc9b03129f2f
   subpackages:
   - format
   - internal/assertion

--- a/calico_node/glide.yaml
+++ b/calico_node/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: ^0.10.0
 - package: github.com/projectcalico/libcalico-go
-  version: v1.7.1
+  version: v1.x-series
   subpackages:
   - lib/api
   - lib/client

--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -102,6 +102,8 @@ func main() {
 		configureASNumber(node)
 	}
 
+	configureNodeRef(node)
+
 	// Check expected filesystem
 	ensureFilesystemAsExpected()
 
@@ -126,6 +128,20 @@ func main() {
 
 	// Tell the user what the name of the node is.
 	message("Using node name: %s", nodeName)
+}
+
+// configureNodeRef will attempt to discover the cluster type it is running on, check to ensure we
+// have not already set it on this Node, and set it if need be.
+func configureNodeRef(node *api.Node) {
+	orchestrator := "k8s"
+	nodeRef := ""
+
+	// Sort out what type of cluster we're running on.
+	if nodeRef = os.Getenv("CALICO_K8S_NODE_REF"); nodeRef == "" {
+		return
+	}
+
+	node.Spec.OrchRefs = []api.OrchRef{api.OrchRef{NodeName: nodeRef, Orchestrator: orchestrator}}
 }
 
 func configureLogging() {

--- a/calico_node/startup/startup_test.go
+++ b/calico_node/startup/startup_test.go
@@ -101,7 +101,7 @@ type EnvItem struct {
 }
 
 var _ = Describe("FV tests against a real etcd", func() {
-	changedEnvVars := []string{"CALICO_IPV4POOL_CIDR", "CALICO_IPV6POOL_CIDR", "NO_DEFAULT_POOLS", "CALICO_IPV4POOL_IPIP", "CALICO_IPV6POOL_NAT_OUTGOING", "CALICO_IPV4POOL_NAT_OUTGOING", "IP", "CLUSTER_TYPE"}
+	changedEnvVars := []string{"CALICO_IPV4POOL_CIDR", "CALICO_IPV6POOL_CIDR", "NO_DEFAULT_POOLS", "CALICO_IPV4POOL_IPIP", "CALICO_IPV6POOL_NAT_OUTGOING", "CALICO_IPV4POOL_NAT_OUTGOING", "IP", "CLUSTER_TYPE", "CALICO_K8S_NODE_REF", "CALICO_UNKNOWN_NODE_REF"}
 
 	BeforeEach(func() {
 		for _, envName := range changedEnvVars {
@@ -434,6 +434,46 @@ var _ = Describe("FV tests against a real etcd", func() {
 			It("should have only one instance of the expected value", func() {
 				Expect(strings.Count(val, "type2")).To(Equal(1), "Should only have one instance of type1, read '%s", val)
 			})
+		})
+	})
+
+	Describe("Test OrchRef configuration", func() {
+		DescribeTable("Should configure the OrchRef with the proper env var set", func(envs []EnvItem, expected api.OrchRef, isEqual bool) {
+			node := &api.Node{}
+
+			for _, env := range envs {
+				os.Setenv(env.key, env.value)
+			}
+
+			configureNodeRef(node)
+			// If we receieve an invalid env var then none will be set.
+			if len(node.Spec.OrchRefs) > 0 {
+				ref := node.Spec.OrchRefs[0]
+				Expect(ref == expected).To(Equal(isEqual))
+			} else {
+				Fail("OrchRefs slice was empty, expected at least one")
+			}
+		},
+
+			Entry("valid single k8s env var", []EnvItem{{"CALICO_K8S_NODE_REF", "node1"}}, api.OrchRef{"node1", "k8s"}, true),
+		)
+
+		It("Should not configure any OrchRefs when no valid env vars are passed", func() {
+			os.Setenv("CALICO_UNKNOWN_NODE_REF", "node1")
+
+			node := &api.Node{}
+			configureNodeRef(node)
+
+			Expect(node.Spec.OrchRefs).To(HaveLen(0))
+		})
+		It("Should not set an OrchRef if it is already set", func() {
+			os.Setenv("CALICO_K8S_NODE_REF", "node1")
+
+			node := &api.Node{}
+			node.Spec.OrchRefs = append(node.Spec.OrchRefs, api.OrchRef{"node1", "k8s"})
+			configureNodeRef(node)
+
+			Expect(node.Spec.OrchRefs).To(HaveLen(1))
 		})
 	})
 })

--- a/calico_node/tests/st/bgp/test_global_peers.py
+++ b/calico_node/tests/st/bgp/test_global_peers.py
@@ -70,10 +70,10 @@ class TestGlobalPeers(TestBase):
 
             # Check the BGP status on each host.  Connections from a node to
             # itself will be idle since this is invalid BGP configuration.
-            check_bird_status(host1, [("global", host1.ip, ["Idle", "Active"]),
+            check_bird_status(host1, [("global", host1.ip, ["Idle", "Connect", "OpenSent", "OpenConfirm", "Active"]),
                                        ("global", host2.ip, "Established")])
             check_bird_status(host2, [("global", host1.ip, "Established"),
-                                       ("global", host2.ip, ["Idle", "Active"])])
+                                       ("global", host2.ip, ["Idle", "Connect", "OpenSent", "OpenConfirm", "Active"])])
 
     @attr('slow')
     def test_bird_node_peers(self):


### PR DESCRIPTION
## Description

Adding in OrchRefs to startup.go, and revving libcalico-go to the required commit.

I've got k8s hardcoded as the "Orchestrator" right now, which feels wrong, seeking advice on how we should be setting it.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
