### PR TITLE
Update etcdv3 calicoctl.cfg example with CalicoAPIConfig

### DIFF
--- a/master/reference/calicoctl/setup/etcdv3.md
+++ b/master/reference/calicoctl/setup/etcdv3.md
@@ -20,7 +20,7 @@ The config file is a yaml or json document in the following format:
 
 ```
 apiVersion: projectcalico.org/v2
-kind: CalicoApiConfig
+kind: CalicoAPIConfig
 metadata:
 spec:
   datastoreType: "etcdv3"

--- a/v3.0/reference/calicoctl/setup/etcdv3.md
+++ b/v3.0/reference/calicoctl/setup/etcdv3.md
@@ -20,7 +20,7 @@ The config file is a yaml or json document in the following format:
 
 ```
 apiVersion: projectcalico.org/v2
-kind: CalicoApiConfig
+kind: CalicoAPIConfig
 metadata:
 spec:
   datastoreType: "etcdv3"


### PR DESCRIPTION
## Description
Update etcdv3 calicoctl.cfg example with CalicoAPIConfig. This change is required for `calicoctl` to correctly parse `calicoctl.cfg` example.

## Todos

- [X] Tests

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
