### PR TITLE
Adds info about using calicotcl with kdd to edit policy & ETCD_AUTHORITY to Release Notes

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1359,6 +1359,8 @@ v3.0:
 
     - Two new `calicoctl` resources: [BGP Configuration](https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/bgpconfig) and [Felix Configuration](https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/felixconfig).
 
+    - Those using the Kubernetes API datastore can now use `calicoctl` to create, update, and delete Calico policies. 
+    
     - The `calicoctl` Policy resource has been split into [Network Policy](https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/networkpolicy) and [Global Network Policy](https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/globalnetworkpolicy).
     
     - The `get`, `apply`, `create`, `delete`, and `replace` commands of `calicoctl` now include an optional `--namespace=<NS>` flag. Refer to the `calicoctl` [Command reference](https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/) section for more details.
@@ -1374,6 +1376,8 @@ v3.0:
     - The new `ApplyOnForward` flag allows you to specify if a host endpoint policy should apply to forwarded traffic or not. Forwarded traffic includes traffic forwarded between host endpoints and traffic forwarded between a host endpoint and a workload endpoint on the same host. Refer to [Using Calico to secure host interfaces](https://docs.projectcalico.org/v3.0/getting-started/bare-metal/bare-metal) for more details.
 
     - Calico now works with Kubernetes network services proxy with IPVS/LVS. Calico enforces network policies with kube-proxy running in ipvs mode for Kubernetes clusters. Currently only workload ingress policy is supported.
+    
+    - After a period of deprecation, this release removes support for the `ETCD_AUTHORITY` and `ETCD_SCHEME` environment variables. Calico no longer reads these values. If you have not transitioned to `ETCD_ENDPOINTS`, you must do so as of v3.0. Refer to [Configuring `calicoctl` - etcdv3 datastore](https://docs.projectcalico.org/v3.0/reference/calicoctl/setup/etcdv3) for more information.
     
 
 


### PR DESCRIPTION
## Description

- Adds info about new capability to edit Calico policy with calicoctl and kdd
- Adds info about ETCD_AUTHORITY and ETCD_SCHEME no longer supported after period of deprecation



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
