### PR TITLE
Remove documentation for default etcd endpoints that do not exist

### DIFF
--- a/master/reference/calicoctl/setup/etcdv3.md
+++ b/master/reference/calicoctl/setup/etcdv3.md
@@ -41,17 +41,12 @@ will check a particular set of environment variables.
 
 See the table below for details on the etcdv3 specific environment variables.
 
-> **Note**: If neither file nor environment variables are set, calicoctl defaults to
-> using etcdv3 with a single endpoint of http://127.0.0.1:2379.
-{: .alert .alert-info}
-
-
 ## Complete list of etcdv3 connection configuration
 
 | Setting (Environment variable)     | Description                                                                            | Schema
 | ---------------------------------- | -------------------------------------------------------------------------------------- | ------
 | datastoreType (DATASTORE_TYPE)     | Indicates the datastore to use [Default: `etcdv3`] (optional)                          | kubernetes, etcdv3
-| etcdEndpoints (ETCD_ENDPOINTS)     | A comma separated list of etcd endpoints [Default: `http://127.0.0.1:2379`] (optional) | string
+| etcdEndpoints (ETCD_ENDPOINTS)     | A comma separated list of etcd endpoints, e.g. `http://127.0.0.1:2379`                 | string
 | etcdUsername (ETCD_USERNAME)       | Username for RBAC, e.g. `user` (optional)                                              | string
 | etcdPassword (ETCD_PASSWORD)       | Password for the given username, e.g. `password` (optional)                            | string
 | etcdKeyFile (ETCD_KEY_FILE)        | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)                       | string

--- a/v3.0/reference/calicoctl/setup/etcdv3.md
+++ b/v3.0/reference/calicoctl/setup/etcdv3.md
@@ -41,17 +41,12 @@ will check a particular set of environment variables.
 
 See the table below for details on the etcdv3 specific environment variables.
 
-> **Note**: If neither file nor environment variables are set, calicoctl defaults to
-> using etcdv3 with a single endpoint of http://127.0.0.1:2379.
-{: .alert .alert-info}
-
-
 ## Complete list of etcdv3 connection configuration
 
 | Setting (Environment variable)     | Description                                                                            | Schema
 | ---------------------------------- | -------------------------------------------------------------------------------------- | ------
 | datastoreType (DATASTORE_TYPE)     | Indicates the datastore to use [Default: `etcdv3`] (optional)                          | kubernetes, etcdv3
-| etcdEndpoints (ETCD_ENDPOINTS)     | A comma separated list of etcd endpoints [Default: `http://127.0.0.1:2379`] (optional) | string
+| etcdEndpoints (ETCD_ENDPOINTS)     | A comma separated list of etcd endpoints, e.g. `http://127.0.0.1:2379`                 | string
 | etcdUsername (ETCD_USERNAME)       | Username for RBAC, e.g. `user` (optional)                                              | string
 | etcdPassword (ETCD_PASSWORD)       | Password for the given username, e.g. `password` (optional)                            | string
 | etcdKeyFile (ETCD_KEY_FILE)        | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)                       | string


### PR DESCRIPTION
## Description
Remove faulty documentation about defaulted etcd endpoints when this is not supported for etcdv3.



## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
