### PR TITLE
Fix FelixConfiguration CRD manifest

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -195,15 +195,15 @@ apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigs.crd.projectcalico.org
+   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: FelixConfig
-    plural: felixconfigs
-    singular: felixconfig
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
 
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -201,15 +201,15 @@ apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigs.crd.projectcalico.org
+   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: FelixConfig
-    plural: felixconfigs
-    singular: felixconfig
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
 
 ---
 


### PR DESCRIPTION
## Description

Calico node fails to start with the following error:
```
Checking datastore connection
Datastore connection verified
ERROR: Unable to set global default configuration: resource does not exist: FelixConfiguration(default)
Terminating
time="2017-11-02T22:12:11Z" level=error msg="Error creating Felix global config" FelixConfig="&{{FelixConfiguration projectcalico.org/v2} {default      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] nil [] } {<nil>  <nil> <nil> <nil> <nil> <nil>  <nil> <nil> <nil> <nil> <nil>  <nil>         info  <nil> <nil> 0xc420301500 <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil>  <nil> <nil> <nil>}}" error="resource does not exist: FelixConfiguration(default)"
Calico node failed to start
```

Because policy-only manifest has a typo in the FelixConfiguration CRD name, so the created CRD name doesn't match with the one libcalico KDD code uses. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
