### PR TITLE
update calicoctl get go-template example for v3

### DIFF
--- a/master/reference/calicoctl/commands/get.md
+++ b/master/reference/calicoctl/commands/get.md
@@ -219,7 +219,7 @@ within that list.
 Example
 {% raw %}
 ```
-$ bin/calicoctl get hostEndpoint --output=go-template="{{range .}}{{range .Items}}{{.Metadata.Name}},{{end}}{{end}}"
+$ bin/calicoctl get hostEndpoint --output=go-template="{{range .}}{{range .Items}}{{.ObjectMeta.Name}},{{end}}{{end}}"
 endpoint1,eth0,
 ```
 {% endraw %}

--- a/v3.0/reference/calicoctl/commands/get.md
+++ b/v3.0/reference/calicoctl/commands/get.md
@@ -219,7 +219,7 @@ within that list.
 Example
 {% raw %}
 ```
-$ bin/calicoctl get hostEndpoint --output=go-template="{{range .}}{{range .Items}}{{.Metadata.Name}},{{end}}{{end}}"
+$ bin/calicoctl get hostEndpoint --output=go-template="{{range .}}{{range .Items}}{{.ObjectMeta.Name}},{{end}}{{end}}"
 endpoint1,eth0,
 ```
 {% endraw %}


### PR DESCRIPTION
## Description
fix example calicoctl get go-template for v3
```release-note
None required
```
