### PR TITLE
Fixing calicoctl manifest for KDD RBAC installs

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -7,12 +7,21 @@ layout: null
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calicoctl
+  namespace: kube-system
+
+---
+
+apiVersion: v1
 kind: Pod
 metadata:
   name: calicoctl
   namespace: kube-system
 spec:
   hostNetwork: true
+  serviceAccountName: calicoctl
   containers:
   - name: calicoctl
     image: quay.io/calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
@@ -20,3 +29,61 @@ spec:
     env:
     - name: DATASTORE_TYPE
       value: kubernetes
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calicoctl
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgppeers
+      - bgpconfigurations
+      - clusterinformations
+      - felixconfigurations
+      - globalnetworkpolicies
+      - ippools
+      - networkpolicies
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calicoctl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calicoctl
+subjects:
+- kind: ServiceAccount
+  name: calicoctl
+  namespace: kube-system
+

--- a/v2.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/v2.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -7,12 +7,21 @@ layout: null
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calicoctl
+  namespace: kube-system
+
+---
+
+apiVersion: v1
 kind: Pod
 metadata:
   name: calicoctl
   namespace: kube-system
 spec:
   hostNetwork: true
+  serviceAccountName: calicoctl
   containers:
   - name: calicoctl
     image: quay.io/calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
@@ -20,3 +29,61 @@ spec:
     env:
     - name: DATASTORE_TYPE
       value: kubernetes
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calicoctl
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgppeers
+      - bgpconfigurations
+      - clusterinformations
+      - felixconfigurations
+      - globalnetworkpolicies
+      - ippools
+      - networkpolicies
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calicoctl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calicoctl
+subjects:
+- kind: ServiceAccount
+  name: calicoctl
+  namespace: kube-system
+

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -7,12 +7,21 @@ layout: null
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
 
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calicoctl
+  namespace: kube-system
+
+---
+
+apiVersion: v1
 kind: Pod
 metadata:
   name: calicoctl
   namespace: kube-system
 spec:
   hostNetwork: true
+  serviceAccountName: calicoctl
   containers:
   - name: calicoctl
     image: quay.io/calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}
@@ -20,3 +29,61 @@ spec:
     env:
     - name: DATASTORE_TYPE
       value: kubernetes
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calicoctl
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgppeers
+      - bgpconfigurations
+      - clusterinformations
+      - felixconfigurations
+      - globalnetworkpolicies
+      - ippools
+      - networkpolicies
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calicoctl
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calicoctl
+subjects:
+- kind: ServiceAccount
+  name: calicoctl
+  namespace: kube-system
+


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes #1276 
We need to use our service account for the calicoctl manifests to work with RBAC enabled.

I've backported this to v3.0 and v2.6, but it looks to be missing further back as well, if we feel it is beneficial I can add it as far back as we supported RBAC.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
