### PR TITLE
Make calico/node STs run reliably regardless of batching

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -133,6 +133,7 @@ dist/calicoctl-v1.0.2:
 # variables.  These are used for the STs.
 dist/calicoctl:
 	-docker rm -f calicoctl
+	docker pull $(CTL_CONTAINER_NAME)
 	docker create --name calicoctl $(CTL_CONTAINER_NAME)
 	docker cp calicoctl:calicoctl dist/calicoctl && \
 	  test -e dist/calicoctl && \
@@ -140,6 +141,7 @@ dist/calicoctl:
 	-docker rm -f calicoctl
 dist/calico-cni-plugin dist/calico-ipam-plugin:
 	-docker rm -f calico-cni
+	docker pull calico/cni:$(CNI_VER)
 	docker create --name calico-cni calico/cni:$(CNI_VER)
 	docker cp calico-cni:/opt/cni/bin/calico dist/calico-cni-plugin && \
 	  test -e dist/calico-cni-plugin && \
@@ -192,6 +194,7 @@ $(NODE_CONTAINER_BIN_DIR)/calico-felix update-felix:
 	-docker rm -f calico-felix
 	# Latest felix binaries are stored in automated builds of calico/felix.
 	# To get them, we create (but don't start) a container from that image.
+	docker pull $(FELIX_CONTAINER_NAME)
 	docker create --name calico-felix $(FELIX_CONTAINER_NAME)
 	# Then we copy the files out of the container.  Since docker preserves
 	# mtimes on its copy, check the file really did appear, then touch it
@@ -206,6 +209,7 @@ $(NODE_CONTAINER_BIN_DIR)/libnetwork-plugin:
 	-docker rm -f calico-$(@F)
 	# Latest libnetwork-plugin binaries are stored in automated builds of calico/libnetwork-plugin.
 	# To get them, we pull that image, then copy the binaries out to our host
+	docker pull $(LIBNETWORK_PLUGIN_CONTAINER_NAME)
 	docker create --name calico-$(@F) $(LIBNETWORK_PLUGIN_CONTAINER_NAME)
 	docker cp calico-$(@F):/$(@F) $(@D)
 	-docker rm -f calico-$(@F)

--- a/calico_node/glide.lock
+++ b/calico_node/glide.lock
@@ -1,5 +1,5 @@
-hash: 395c008935d703953d44877159466a01a92b2404b9aaa35d82ffd55154449472
-updated: 2017-10-28T16:34:15.012157554-07:00
+hash: 152493f9a2a19d4b4de0640b858f3333ca42e36b94b6dbd954f8ee3d10afa3d0
+updated: 2017-11-07T12:45:27.55097665Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -139,6 +139,8 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/projectcalico/go-json
@@ -150,7 +152,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: dae320cd652b66d908eb5d59209717e3c3514c26
+  version: e8d93a6ef128b79fddc09e5f673386c46cab6d10
   subpackages:
   - lib/api
   - lib/apiconfig
@@ -171,6 +173,7 @@ imports:
   - lib/client
   - lib/clientv2
   - lib/errors
+  - lib/hash
   - lib/ipam
   - lib/ipip
   - lib/names
@@ -179,6 +182,8 @@ imports:
   - lib/numorstring
   - lib/options
   - lib/scope
+  - lib/selector/parser
+  - lib/selector/tokenizer
   - lib/testutils
   - lib/watch
 - name: github.com/PuerkitoBio/purell
@@ -278,7 +283,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
+  version: 6c6dac0277229b9e9578c5ca3f74a4345d35cdc2
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -340,6 +345,7 @@ imports:
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait

--- a/calico_node/glide.yaml
+++ b/calico_node/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: ^1.0.3
 - package: github.com/projectcalico/libcalico-go
-  version: v2.0.0-alpha1
+  version: e8d93a6ef128b79fddc09e5f673386c46cab6d10
   subpackages:
   - lib/api
   - lib/client

--- a/calico_node/tests/st/policy/test_felix_gateway.py
+++ b/calico_node/tests/st/policy/test_felix_gateway.py
@@ -874,7 +874,15 @@ class TestFelixOnGateway(TestBase):
 
     @staticmethod
     def _exec_calicoctl(action, data, host):
-        # use calicoctl with data
+        # Delete creationTimestamp fields from the data that we're going to
+        # write.
+        for obj in data.get('items', []):
+            if 'creationTimestamp' in obj['metadata']:
+                del obj['metadata']['creationTimestamp']
+        if 'metadata' in data and 'creationTimestamp' in data['metadata']:
+            del data['metadata']['creationTimestamp']
+
+        # Use calicoctl with the modified data.
         host.writefile("new_data",
                        yaml.dump(data, default_flow_style=False))
         host.calicoctl("%s -f new_data" % action)

--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -52,7 +52,7 @@ class MultiHostMainline(TestBase):
         super(MultiHostMainline, cls).tearDownClass()
 
     def setUp(self):
-        super(MultiHostMainline, self).setUp(wipe_etcd=False)
+        super(MultiHostMainline, self).setUp(clear_etcd=False)
         host1 = self.host1
         host2 = self.host2
 

--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -334,6 +334,8 @@ class MultiHostMainline(TestBase):
         # Set current resource versions in the profiles we are about to apply.
         for p in new_profiles:
             p['metadata']['resourceVersion'] = resource_version_map[p['metadata']['name']]
+            if 'creationTimestamp' in p['metadata']:
+                del p['metadata']['creationTimestamp']
 
         # Apply new profiles
         host.writefile("new_profiles",

--- a/calico_node/tests/st/test_base.py
+++ b/calico_node/tests/st/test_base.py
@@ -47,14 +47,14 @@ class TestBase(TestCase):
     def setUpClass(cls):
         wipe_etcd(HOST_IPV4)
 
-    def setUp(self, wipe_etcd=True):
+    def setUp(self, clear_etcd=True):
         """
         Clean up before every test.
         """
         self.ip = HOST_IPV4
 
-        if wipe_etcd:
-            self.wipe_etcd()
+        if clear_etcd:
+            wipe_etcd(self.ip)
 
         # Log a newline to ensure that the first log appears on its own line.
         logger.info("")
@@ -215,19 +215,6 @@ class TestBase(TestCase):
 
         assert False not in results, ("Connectivity check error!\r\n"
                                       "Results:\r\n %s\r\n" % diagstring)
-
-    def wipe_etcd(self):
-        wipe_etcd(self.ip)
-
-    def curl_etcd(self, path, options=None, recursive=True):
-        """
-        Perform a curl to etcd, returning JSON decoded response.
-        :param path:  The key path to query
-        :param options:  Additional options to include in the curl
-        :param recursive:  Whether we want recursive query or not
-        :return:  The JSON decoded response.
-        """
-        curl_etcd(path, options, recursive, self.ip)
 
     def check_data_in_datastore(self, host, data, resource, yaml_format=True):
         if yaml_format:

--- a/calico_node/tests/st/test_base.py
+++ b/calico_node/tests/st/test_base.py
@@ -24,7 +24,7 @@ from deepdiff import DeepDiff
 
 from tests.st.utils.utils import (get_ip, ETCD_SCHEME, ETCD_CA, ETCD_CERT,
                                   ETCD_KEY, debug_failures, ETCD_HOSTNAME_SSL,
-                                  wipe_etcd)
+                                  wipe_etcd, clear_on_failures)
 
 HOST_IPV6 = get_ip(v6=True)
 HOST_IPV4 = get_ip()
@@ -58,6 +58,8 @@ class TestBase(TestCase):
 
         # Log a newline to ensure that the first log appears on its own line.
         logger.info("")
+
+        clear_on_failures()
 
     @staticmethod
     def _conn_checker(args):

--- a/calico_node/tests/st/utils/utils.py
+++ b/calico_node/tests/st/utils/utils.py
@@ -456,3 +456,18 @@ def handle_failure(fn):
             raise
 
     return wrapped
+
+
+def dump_etcdv3():
+    etcd_container_name = "calico-etcd"
+    tls_vars = ""
+    if ETCD_SCHEME == "https":
+        # Etcd is running with SSL/TLS, require key/certificates
+        etcd_container_name = "calico-etcd-ssl"
+        tls_vars = ("ETCDCTL_CACERT=/etc/calico/certs/ca.pem " +
+                    "ETCDCTL_CERT=/etc/calico/certs/client.pem " +
+                    "ETCDCTL_KEY=/etc/calico/certs/client-key.pem ")
+
+    log_and_run("docker exec " + etcd_container_name + " sh -c '" + tls_vars +
+                 "ETCDCTL_API=3 etcdctl get --prefix /calico" +
+                 "'")


### PR DESCRIPTION
The key things here:
- test_felix_gateway's etcd wiping needs to wipe the etcd v3 data.
- Use docker pull to ensure that container images are up to date even if we already have a local image with the specified tag.  (Typically it's the 'master' tag that causes a problem here, as it isn't a fixed point.)

In addition,
- changes were needed to the handling of creationTimestamp fields, for corresponding libcalico-go changes
- print out lots of binary version information, to aid future debugging of scenarios where we accidentally pick up the wrong image
- add a mechanism for tests to show the problem immediately when they fail, and to collect diags.