### PR TITLE
Updates a few ETCD_ENDPOINT references

### DIFF
--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -32,7 +32,7 @@ The `calico/node` container is primarily configured through environment variable
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. [Default: `false`] | boolean |
 | CALICO_STARTUP_LOGLEVEL      | The log severity above which startup calico/node logs are sent to the stdout. [Default: `ERROR`] | DEBUG, INFO, WARNING, ERROR, CRITICAL, or NONE (case-insensitive) |
 | CLUSTER_TYPE | Contains comma delimited list of indicators about this cluster.  e.g. k8s, mesos, kubeadm, canal, bgp | string |
-| ETCD_ENDPOINTS    | A comma separated list of etcd endpoints [Default: `http://127.0.0.1:2379`] (optional) | string |
+| ETCD_ENDPOINTS    | A comma separated list of etcd endpoints [Example: `http://127.0.0.1:2379,http://127.0.0.2:2379`] (required) | string |
 | ETCD_KEY_FILE     | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)        | string |
 | ETCD_CERT_FILE    | Path to the etcd client cert, e.g. `/etc/calico/cert.pem` (optional)    | string |
 | ETCD_CA_CERT_FILE | Path to the etcd CA file, e.g. `/etc/calico/ca.pem` (optional)          | string |

--- a/master/usage/configuration/as-service.md
+++ b/master/usage/configuration/as-service.md
@@ -149,8 +149,6 @@ sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
 
 > **Note**: Replace `<ETCD_IP>:<ETCD_PORT>` with your etcd configuration. The `ETCD_ENDPOINTS`
 > environment may contain a comma separated list of endpoints of your etcd cluster.
-> If the environment is omitted, {{site.prodname}} defaults to a single etcd
-> endpoint at http://127.0.0.1:2379.
 {: .alert .alert-info}
 
 You can check that it's running using `sudo rkt list`.

--- a/v3.0/reference/node/configuration.md
+++ b/v3.0/reference/node/configuration.md
@@ -32,7 +32,7 @@ The `calico/node` container is primarily configured through environment variable
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. [Default: `false`] | boolean |
 | CALICO_STARTUP_LOGLEVEL      | The log severity above which startup calico/node logs are sent to the stdout. [Default: `ERROR`] | DEBUG, INFO, WARNING, ERROR, CRITICAL, or NONE (case-insensitive) |
 | CLUSTER_TYPE | Contains comma delimited list of indicators about this cluster.  e.g. k8s, mesos, kubeadm, canal, bgp | string |
-| ETCD_ENDPOINTS    | A comma separated list of etcd endpoints [Default: `http://127.0.0.1:2379`] (optional) | string |
+| ETCD_ENDPOINTS    | A comma separated list of etcd endpoints [Example: `http://127.0.0.1:2379,http://127.0.0.2:2379`] (required) | string |
 | ETCD_KEY_FILE     | Path to the etcd key file, e.g. `/etc/calico/key.pem` (optional)        | string |
 | ETCD_CERT_FILE    | Path to the etcd client cert, e.g. `/etc/calico/cert.pem` (optional)    | string |
 | ETCD_CA_CERT_FILE | Path to the etcd CA file, e.g. `/etc/calico/ca.pem` (optional)          | string |

--- a/v3.0/usage/configuration/as-service.md
+++ b/v3.0/usage/configuration/as-service.md
@@ -149,8 +149,6 @@ sudo rkt run --stage1-path=/usr/share/rkt/stage1-fly.aci \
 
 > **Note**: Replace `<ETCD_IP>:<ETCD_PORT>` with your etcd configuration. The `ETCD_ENDPOINTS`
 > environment may contain a comma separated list of endpoints of your etcd cluster.
-> If the environment is omitted, Calico defaults to a single etcd
-> endpoint at http://127.0.0.1:2379.
 {: .alert .alert-info}
 
 You can check that it's running using `sudo rkt list`.


### PR DESCRIPTION
## Description

- Corrects info in as-service as per the change in ETCD_ENDPOINT
- Corrects info in calico/node configuration reference page to indicate ETCD_ENDPOINT now required (no default value)



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
