### PR TITLE
Adds OpenShift to v3.0 dir as beta resumes support

### DIFF
--- a/_data/v3_0/navbars/getting-started.yml
+++ b/_data/v3_0/navbars/getting-started.yml
@@ -45,6 +45,11 @@ toc:
       path: /getting-started/kubernetes/tutorials/advanced-policy
   - title: Troubleshooting / FAQ
     path: /getting-started/kubernetes/troubleshooting
+    
+- title: OpenShift
+  section:
+    - title: Installation
+      path: /getting-started/openshift/installation
 
 - title: Host Protection
   section:

--- a/v3.0/getting-started/index.md
+++ b/v3.0/getting-started/index.md
@@ -11,11 +11,10 @@ your own servers, a quick set-up in a virtualized environment using Vagrant and
 a number of cloud services.
 
 - [Calico with Kubernetes](kubernetes)
+- [Calico with OpenShift](openshift/installation)
 - [Host protection](bare-metal/bare-metal)
 
-> **Note**: For integrations with the OpenShift, OpenStack, 
-> Mesos, DC/OS, and Docker orchestrators, use
-> [Calico v2.6](/v2.6/introduction/). We plan 
-> to resume support for these orchestrators in a future 
-> v3.x release.
+> **Note**: For integrations with the OpenStack, Mesos, DC/OS, and Docker 
+> orchestrators, use [Calico v2.6](/v2.6/introduction/). We plan to resume 
+> support for these orchestrators in a future v3.x release.
 {: .alert .alert-info}

--- a/v3.0/getting-started/openshift/installation.md
+++ b/v3.0/getting-started/openshift/installation.md
@@ -1,0 +1,91 @@
+---
+title: Installing Calico on OpenShift
+---
+
+Installation of {{site.prodname}} in OpenShift is integrated in openshift-ansible v3.6.
+The information below explains the variables which must be set during
+during the standard [Advanced Installation](https://docs.openshift.org/latest/install_config/install/advanced_install.html#configuring-cluster-variables).
+
+## Shared etcd
+
+To enable an installation of {{site.prodname}} that shares the etcd
+instance used by the apiserver, set the following `OSEv3:vars` in your
+inventory file:
+
+  - `os_sdn_network_plugin_name=cni`
+  - `openshift_use_calico=true`
+  - `openshift_use_openshift_sdn=false`
+
+Also ensure that you have an explicitly defined host in the `[etcd]` group.
+
+**Sample Inventory File:**
+
+```
+[OSEv3:children]
+masters
+nodes
+etcd
+
+[OSEv3:vars]
+os_sdn_network_plugin_name=cni
+openshift_use_calico=true
+openshift_use_openshift_sdn=false
+
+[masters]
+master1
+
+[nodes]
+node1
+
+[etcd]
+etcd1
+```
+
+## Bring-your-own etcd
+
+{{site.prodname}}'s OpenShift-ansible integration supports connection to a custom etcd which
+a user has already set up.
+
+**Requirements:**
+
+  - The etcd instance must have SSL authentication enabled.
+  - Certs must be present at the specified filepath on all nodes.
+  - All cert files must be in the same directory specified by `calico_etcd_cert_dir`.
+
+**Inventory Parameters:**
+
+| Key                        | Value                                                     |
+| :------------------------- | :-------------------------------------------------------- |
+| `calico_etcd_endpoints`    | Address of etcd, e.g. `https://calico-etcd:2379`          |
+| `calico_etcd_ca_cert_file` | Absolute filepath of the etcd CA file.                    |
+| `calico_etcd_cert_file`    | Absolute filepath of the etcd client cert.                |
+| `calico_etcd_key_file`     | Absolute filepath of the etcd key file.                   |
+| `calico_etcd_cert_dir`     | Absolute path to the directory containing the etcd certs. |
+
+**Sample Inventory File:**
+
+```
+[OSEv3:children]
+masters
+nodes
+etcd
+
+[OSEv3:vars]
+os_sdn_network_plugin_name=cni
+openshift_use_calico=true
+openshift_use_openshift_sdn=false
+calico_etcd_endpoints=http://calico-etcd:2379
+calico_etcd_ca_cert_file=/etc/calico/etcd-ca.crt
+calico_etcd_cert_file=/etc/calico/etcd-client.crt
+calico_etcd_key_file=/etc/calico/etcd-client.key
+calico_etcd_cert_dir=/etc/calico/
+
+[masters]
+master1
+
+[nodes]
+node1
+
+[etcd]
+etcd1
+```

--- a/v3.0/introduction/index.md
+++ b/v3.0/introduction/index.md
@@ -2,28 +2,28 @@
 title: About Calico
 ---
 
-Calico provides secure network connectivity for 
+{{site.prodname}} provides secure network connectivity for 
 containers and virtual machine workloads.
 
-Calico creates and manages a flat layer 3 network, 
+{{site.prodname}} creates and manages a flat layer 3 network, 
 assigning each workload a fully routable IP address. 
 Workloads can communicate without IP encapsulation 
 or network address translation for bare metal 
 performance, easier troubleshooting, and better 
 interoperability. In environments that require an 
-overlay, Calico uses IP-in-IP tunneling or can work 
+overlay, {{site.prodname}} uses IP-in-IP tunneling or can work 
 with other overlay networking such as flannel.
 
-Calico also provides dynamic enforcement of network 
-security rules. Using Calico's simple policy language, 
+{{site.prodname}} also provides dynamic enforcement of network 
+security rules. Using {{site.prodname}}'s simple policy language, 
 you can achieve fine-grained control over communications 
 between containers, virtual machine workloads, and 
 bare metal host endpoints.
 
-Proven in production at scale, Calico v3.0 features 
-integration with Kubernetes.
+Proven in production at scale, {{site.prodname}} v3.0 features 
+integrations with Kubernetes and OpenShift.
 
-> **Note**: For integrations with the OpenShift, OpenStack, 
+> **Note**: For integrations with the OpenStack, 
 > Mesos, DC/OS, and Docker orchestrators, use
 > [Calico v2.6](/v2.6/introduction/). We plan 
 > to resume support for these orchestrators in a future 


### PR DESCRIPTION
## Description

- Adds OpenShift install docs back into the v3.0 directory as we have established that it works.
- Also adjusts notes and intro pages accordingly.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
