### PR TITLE
Cleaning namespaces out of ClusterRole

### DIFF
--- a/master/getting-started/kubernetes/installation/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/rbac.yaml
@@ -41,7 +41,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:

--- a/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+++ b/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
@@ -395,7 +395,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-cni-plugin
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:
@@ -433,7 +432,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-kube-controllers
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""

--- a/v2.6/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/v2.6/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -7,7 +7,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:

--- a/v2.6/getting-started/kubernetes/installation/rbac.yaml
+++ b/v2.6/getting-started/kubernetes/installation/rbac.yaml
@@ -10,7 +10,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-kube-controllers
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -42,7 +41,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:

--- a/v3.0/getting-started/kubernetes/installation/rbac.yaml
+++ b/v3.0/getting-started/kubernetes/installation/rbac.yaml
@@ -41,7 +41,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
behle in calicousers.slack.com noticed that the calico-node ClusterRole still had a namespace field, I believe these should be removed as I understand that ClusterRoles are not namespaced.

Thanks Brad