### PR TITLE
Adds no canonical true to new etcdv3 rbac pages

### DIFF
--- a/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
+no-canonical: true
 ---
 
 The paths listed here are the key or path prefixes that a particular {{site.prodname}}

--- a/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
+no-canonical: true
 ---
 
 The paths listed here are the key or path prefixes that a particular {{site.prodname}}


### PR DESCRIPTION
## Description

- Adds a `no-canonical: true` to the metadata of the new etcdv3 pages.
- This unblocks other doc PRs which will fail because of this.
- We need this because this page was renamed and therefore is "new" and v3.0 has not GA'ed yet, so `latest` does not redirect here yet.
- Plan to update CONTRIBUTING_DOCS.md to clarify this but we are still wrapping up this PR here https://github.com/projectcalico/calico/pull/1211

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
