### PR TITLE
Changes hyphen to underscore in no canonical tag

### DIFF
--- a/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,6 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
-no-canonical: true
+no_canonical: true
 ---
 
 The paths listed here are the key or path prefixes that a particular {{site.prodname}}

--- a/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,6 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
-no-canonical: true
+no_canonical: true
 ---
 
 The paths listed here are the key or path prefixes that a particular {{site.prodname}}


### PR DESCRIPTION
## Description

- Resolves an error in the no canonical tag, in which a hyphen was used instead of an underscore.



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
