### PR TITLE
Fix missing typha from the master release stream

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1491,6 +1491,9 @@ master:
      felix:
       version: master
       url: ""
+     typha:
+      version: master
+      url: ""
      calicoctl:
       version: master
       url: "https://www.projectcalico.org/builds/calicoctl"


### PR DESCRIPTION
## Description

We're missing typha from the master release stream.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
