### PR TITLE
Add FAQ about cali interface MAC

### DIFF
--- a/master/usage/troubleshooting/faq.md
+++ b/master/usage/troubleshooting/faq.md
@@ -49,6 +49,14 @@ interface.  This makes the host behave like a gateway, responding to
 ARPs for 169.254.1.1 without having to actually allocate the IP address
 to the interface.
 
+## Why do all cali\* interfaces have the MAC address ee:ee:ee:ee:ee:ee?
+
+In some setups the kernel is unable to generate a persistent MAC address and so
+{{site.prodname}} assigns a MAC address itself. Since {{site.prodname}} uses
+point-to-point routed interfaces, traffic does not reach the data link layer
+so the MAC Address is never used and can therefore be the same for all the
+cali\* interfaces.
+
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
 Yes! The Kubernetes [`NetworkPolicy`](https://kubernetes.io/docs/concepts/services-networking/network-policies/)

--- a/v2.6/usage/troubleshooting/faq.md
+++ b/v2.6/usage/troubleshooting/faq.md
@@ -50,6 +50,14 @@ interface.  This makes the host behave like a gateway, responding to
 ARPs for 169.254.1.1 without having to actually allocate the IP address
 to the interface.
 
+## Why do all cali\* interfaces have the MAC address ee:ee:ee:ee:ee:ee?
+
+In some setups the kernel is unable to generate a persistent MAC address and so
+{{site.prodname}} assigns a MAC address itself. Since {{site.prodname}} uses
+point-to-point routed interfaces, traffic does not reach the data link layer
+so the MAC Address is never used and can therefore be the same for all the
+cali\* interfaces.
+
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
 Yes! The Kubernetes [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)

--- a/v3.0/usage/troubleshooting/faq.md
+++ b/v3.0/usage/troubleshooting/faq.md
@@ -49,6 +49,14 @@ interface.  This makes the host behave like a gateway, responding to
 ARPs for 169.254.1.1 without having to actually allocate the IP address
 to the interface.
 
+## Why do all cali\* interfaces have the MAC address ee:ee:ee:ee:ee:ee?
+
+In some setups the kernel is unable to generate a persistent MAC address and so
+{{site.prodname}} assigns a MAC address itself. Since {{site.prodname}} uses
+point-to-point routed interfaces, traffic does not reach the data link layer
+so the MAC Address is never used and can therefore be the same for all the
+cali\* interfaces.
+
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
 Yes! The Kubernetes [`NetworkPolicy`](https://kubernetes.io/docs/concepts/services-networking/network-policies/)


### PR DESCRIPTION
With https://github.com/projectcalico/cni-plugin/pull/432 it is expected that there will be questions about why the cali interfaces have the specific MAC address so this will hopefully cut down on those questions.