### PR TITLE
Adds Azure public cloud reference doc

### DIFF
--- a/_data/master/navbars/reference.yml
+++ b/_data/master/navbars/reference.yml
@@ -91,6 +91,8 @@ toc:
   section:
     - title: AWS
       path: /reference/public-cloud/aws
+    - title: Azure
+      path: /reference/public-cloud/azure
     - title: GCE
       path: /reference/public-cloud/gce
 - title: Deploying on Private Cloud

--- a/_data/v3_0/navbars/reference.yml
+++ b/_data/v3_0/navbars/reference.yml
@@ -89,6 +89,8 @@ toc:
   section:
     - title: AWS
       path: /reference/public-cloud/aws
+    - title: Azure
+      path: /reference/public-cloud/azure
     - title: GCE
       path: /reference/public-cloud/gce
 - title: Deploying on Private Cloud

--- a/master/getting-started/kubernetes/installation/azure.md
+++ b/master/getting-started/kubernetes/installation/azure.md
@@ -5,6 +5,8 @@ title: Deploying Calico and Kubernetes on Azure
 There are a number of solutions for deploying {{site.prodname}} and Kubernetes on Azure.  We recommend taking
 a look at the following solutions and guides which install {{site.prodname}} for network policy on Azure.
 
+Make sure you've read the [{{site.prodname}} Azure reference guide][azure-reference] for details on how to configure {{site.prodname}} and Azure.
+
 #### Popular guides and tools
 
 **[ACS Engine][acs-engine]** configures and deploys Kubernetes clusters on Azure with an option to enable {{site.prodname}} policy.
@@ -15,5 +17,6 @@ If the out-of-the-box solutions listed above don't meet your requirements, you c
 on Azure using one of our [self-hosted manifests][self-hosted], or by [integrating {{site.prodname}} with your own configuration management][integration-guide].
 
 [acs-engine]: https://github.com/Azure/acs-engine/blob/master/docs/kubernetes.md
+[azure-reference]: {{site.baseurl}}/{{page.version}}/reference/public-cloud/azure
 [self-hosted]: hosted
 [integration-guide]: integration

--- a/master/reference/public-cloud/azure.md
+++ b/master/reference/public-cloud/azure.md
@@ -1,0 +1,38 @@
+---
+title: Deploying Calico on Azure
+no_canonical: true
+---
+
+{{site.prodname}} in [Microsoft Azure][Azure]{:target="_blank"} is supported in [policy-only][PolicyMode] mode. {{site.prodname}} IPAM needs to be configured in host-local mode and used in conjunction with Kubernetes pod CIDR assignments. Additional option would be to use [Canal][Canal] - {{site.prodname}} with flannel networking.
+
+#### Routing Traffic
+
+##### Azure user-defined routes (Azure UDR)
+
+[Azure user-defined routes][AzureUDR] is the only available option for traffic routing without overlay networking. To use Azure routing you must create [Azure route table][AzureUDRCreate]{:target="_blank"} and associatе it with VMs subnet.
+
+##### Flannel networking
+
+Refer to the following [Kubernetes self-hosted install guide][CanalGuide] in the Canal project for details on installing Calico with flannel.
+
+#### Enabling IP forwarding (only for Azure UDR)
+
+To allow pod traffic make sure VM network interfaces have [IP forwarding enabled][AzureIPForward]{:target="_blank"} in Azure.
+
+#### Enabling Kubernetes pod CIDR assignment (only for Azure UDR)
+
+To enable automatic pod CIDR assignment make sure Kubernetes controller manager has `allocate-node-cidrs` set to `true`
+and a proper subnet in the `cluster-cidr` parameter. Make sure that the selected pod's subnet is a part of your Azure virtual network IP range.
+You also must have Kubernetes Azure cloud provider configured with your routing table name in configuration file.
+
+#### Why doesn't Azure support {{site.prodname}} networking?
+
+Azure does not allow BGP, IPIP traffic, and traffic with unknown source IPs.
+
+[Azure]: https://azure.microsoft.com
+[AzureIPForward]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface#enable-or-disable-ip-forwarding
+[AzureUDR]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview#user-defined
+[AzureUDRCreate]: https://docs.microsoft.com/en-us/azure/virtual-network/create-user-defined-route-portal
+[Canal]: https://github.com/projectcalico/canal
+[CanalGuide]: https://github.com/projectcalico/canal/blob/master/k8s-install/README.md
+[PolicyMode]: {{site.baseurl}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubernetes-datastore/#2-calico-policy-only-with-user-supplied-networking

--- a/v3.0/getting-started/kubernetes/installation/azure.md
+++ b/v3.0/getting-started/kubernetes/installation/azure.md
@@ -5,6 +5,8 @@ title: Deploying Calico and Kubernetes on Azure
 There are a number of solutions for deploying Calico and Kubernetes on Azure.  We recommend taking
 a look at the following solutions and guides which install Calico for network policy on Azure.
 
+Make sure you've read the [{{site.prodname}} Azure reference guide][azure-reference] for details on how to configure {{site.prodname}} and Azure.
+
 #### Popular guides and tools
 
 **[ACS Engine][acs-engine]** configures and deploys Kubernetes clusters on Azure with an option to enable Calico policy.
@@ -15,6 +17,6 @@ If the out-of-the-box solutions listed above don't meet your requirements, you c
 on Azure using one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
 
 [acs-engine]: https://github.com/Azure/acs-engine/blob/master/docs/kubernetes.md
-
+[azure-reference]: {{site.baseurl}}/{{page.version}}/reference/public-cloud/azure
 [self-hosted]: hosted
 [integration-guide]: integration

--- a/v3.0/reference/public-cloud/azure.md
+++ b/v3.0/reference/public-cloud/azure.md
@@ -1,0 +1,38 @@
+---
+title: Deploying Calico on Azure
+no_canonical: true
+---
+
+{{site.prodname}} in [Microsoft Azure][Azure]{:target="_blank"} is supported in [policy-only][PolicyMode] mode. {{site.prodname}} IPAM needs to be configured in host-local mode and used in conjunction with Kubernetes pod CIDR assignments. Additional option would be to use [Canal][Canal] - {{site.prodname}} with flannel networking.
+
+#### Routing Traffic
+
+##### Azure user-defined routes (Azure UDR)
+
+[Azure user-defined routes][AzureUDR] is the only available option for traffic routing without overlay networking. To use Azure routing you must create [Azure route table][AzureUDRCreate]{:target="_blank"} and associatе it with VMs subnet.
+
+##### Flannel networking
+
+Refer to the following [Kubernetes self-hosted install guide][CanalGuide] in the Canal project for details on installing Calico with flannel.
+
+#### Enabling IP forwarding (only for Azure UDR)
+
+To allow pod traffic make sure VM network interfaces have [IP forwarding enabled][AzureIPForward]{:target="_blank"} in Azure.
+
+#### Enabling Kubernetes pod CIDR assignment (only for Azure UDR)
+
+To enable automatic pod CIDR assignment make sure Kubernetes controller manager has `allocate-node-cidrs` set to `true`
+and a proper subnet in the `cluster-cidr` parameter. Make sure that the selected pod's subnet is a part of your Azure virtual network IP range.
+You also must have Kubernetes Azure cloud provider configured with your routing table name in configuration file.
+
+#### Why doesn't Azure support {{site.prodname}} networking?
+
+Azure does not allow BGP, IPIP traffic, and traffic with unknown source IPs.
+
+[Azure]: https://azure.microsoft.com
+[AzureIPForward]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface#enable-or-disable-ip-forwarding
+[AzureUDR]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview#user-defined
+[AzureUDRCreate]: https://docs.microsoft.com/en-us/azure/virtual-network/create-user-defined-route-portal
+[Canal]: https://github.com/projectcalico/canal
+[CanalGuide]: https://github.com/projectcalico/canal/blob/master/k8s-install/README.md
+[PolicyMode]: {{site.baseurl}}/{{page.version}}/getting-started/kubernetes/installation/hosted/kubernetes-datastore/#2-calico-policy-only-with-user-supplied-networking


### PR DESCRIPTION
## Description

I've really struggled while trying to install k8s on Azure with Calico (own terraform), acs-engine reverse engineering took at least few days before i found proper Calico mode and Kubernetes configuration. So i thought that it can be useful for others to have explicit documentation on how Calico should be installed in Azure.

Describes only available installation option on Azure in policy-only
mode

Closes: https://github.com/projectcalico/calico/issues/220
Related-to: https://github.com/projectcalico/calicoctl/issues/949


## Todos

- [x] Documentation

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
