### PR TITLE
Pull the route reflector version indicated in versions.yml

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -26,6 +26,7 @@ V_GOBGPD := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM
 V_KUBE_CONTROLLERS := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico/kube-controllers.version')
 V_LIBNETWORK_PLUGIN := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.libnetwork-plugin.version')
 V_TYPHA := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.typha.version')
+V_RR := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico/routereflector.version')
 
 # Now use ?= to allow the versions derived from versions.yml to be
 # overriden (by the environment).
@@ -40,6 +41,7 @@ GOBGPD_VER ?= $(V_GOBGPD)
 KUBE_CONTROLLERS_VER ?= $(V_KUBE_CONTROLLERS)
 LIBNETWORK_PLUGIN_VER ?= $(V_LIBNETWORK_PLUGIN)
 TYPHA_VER ?= $(V_TYPHA)
+RR_VER ?= $(V_RR)
 
 $(info $(shell printf "%-21s = %-10s\n" "RELEASE_STREAM" $(RELEASE_STREAM)))
 $(info $(shell printf "%-21s = %-10s\n" "CALICO_VER" $(CALICO_VER)))
@@ -53,6 +55,7 @@ $(info $(shell printf "%-21s = %-10s\n" "GOBGPD_VER" $(GOBGPD_VER)))
 $(info $(shell printf "%-21s = %-10s\n" "KUBE_CONTROLLERS_VER" $(KUBE_CONTROLLERS_VER)))
 $(info $(shell printf "%-21s = %-10s\n" "LIBNETWORK_PLUGIN_VER" $(LIBNETWORK_PLUGIN_VER)))
 $(info $(shell printf "%-21s = %-10s\n" "TYPHA_VER" $(TYPHA_VER)))
+$(info $(shell printf "%-21s = %-10s\n" "RR_VER" $(RR_VER)))
 
 SYSTEMTEST_CONTAINER_VER ?= latest
 # we can use "custom" build image and test image name
@@ -309,8 +312,8 @@ busybox.tar:
 	docker save --output busybox.tar busybox:latest
 
 routereflector.tar:
-	docker pull calico/routereflector:latest
-	docker save --output routereflector.tar calico/routereflector:latest
+	docker pull calico/routereflector:$(RR_VER)
+	docker save --output routereflector.tar calico/routereflector:$(RR_VER)
 
 workload.tar:
 	cd workload && docker build -t workload .
@@ -363,6 +366,7 @@ st: dist/calicoctl dist/calicoctl-v1.0.2 busybox.tar routereflector.tar calico-n
 	           -e DEBUG_FAILURES=$(DEBUG_FAILURES) \
 	           -e MY_IP=$(LOCAL_IP_ENV) \
 	           -e NODE_CONTAINER_NAME=$(NODE_CONTAINER_NAME) \
+	           -e RR_VER=$(RR_VER) \
 	           --rm -ti \
 	           -v /var/run/docker.sock:/var/run/docker.sock \
 	           -v $(SOURCE_DIR):/code \

--- a/calico_node/tests/st/utils/route_reflector.py
+++ b/calico_node/tests/st/utils/route_reflector.py
@@ -50,6 +50,7 @@ class RouteReflectorCluster(object):
                 #
                 # See https://github.com/projectcalico/calico-bird/tree/feature-ipinip/build_routereflector
                 # for details.
+                rr_ver = os.getenv("RR_VER", "latest")
                 if os.getenv("ETCD_SCHEME", None) == "https":
                     # Etcd is running with SSL/TLS, pass the key values
                     rr.execute("docker run --privileged --net=host -d "
@@ -59,9 +60,9 @@ class RouteReflectorCluster(object):
                                "-e ETCD_CERT_FILE=%s "
                                "-e ETCD_KEY_FILE=%s "
                                "-v %s/certs:%s/certs "
-                               "calico/routereflector" %
+                               "calico/routereflector:%s" %
                                (ip_env, ETCD_HOSTNAME_SSL, ETCD_CA, ETCD_CERT,
-                                ETCD_KEY, CHECKOUT_DIR,CHECKOUT_DIR))
+                                ETCD_KEY, CHECKOUT_DIR, CHECKOUT_DIR, rr_ver))
                     rr.execute(r'curl --cacert %s --cert %s --key %s '
                                r'-L https://%s:2379/v2/keys/calico/bgp/v1/rr_v4/%s '
                                r'-XPUT -d value="{'
@@ -75,7 +76,7 @@ class RouteReflectorCluster(object):
                     rr.execute("docker run --privileged --net=host -d "
                            "--name rr %s "
                            "-e ETCD_ENDPOINTS=http://%s:2379 "
-                           "calico/routereflector" % (ip_env, get_ip()))
+                           "calico/routereflector:%s" % (ip_env, get_ip(), rr_ver))
                     rr.execute(r'curl -L http://%s:2379/v2/keys/calico/bgp/v1/rr_v4/%s '
                                r'-XPUT -d value="{'
                                  r'\"ip\":\"%s\",'


### PR DESCRIPTION
## Description
Now that master's route reflector is only compatible with v3.0+, pull the route reflector version indicated in versions.yml.

Let's see how the STs do with this change.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
