### PR TITLE
Increase retries for _check_original_connectivity (test_profile)

### DIFF
--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -423,7 +423,7 @@ class MultiHostMainline(TestBase):
         # a workloads own hostname does not work).
         if types is None:
             types = ['icmp', 'tcp', 'udp']
-        self.assert_connectivity(retries=2,
+        self.assert_connectivity(retries=10,
                                  pass_list=n1_workloads,
                                  fail_list=n2_workloads,
                                  type_list=types)
@@ -432,4 +432,3 @@ class MultiHostMainline(TestBase):
         self.assert_connectivity(pass_list=n2_workloads,
                                  fail_list=n1_workloads,
                                  type_list=types)
-


### PR DESCRIPTION
We have been seeing flakes here on semaphore,
e.g. https://semaphoreci.com/calico/calico/branches/master/builds/1206.
Problems are apparently always in _check_original_connectivity, not in
the connectivity checks that a test makes later on after applying
various profiles, and always between workloads on different hosts.  So
our hypothesis is that _check_original_connectivity can fail because we
aren't allowing enough time for routes to propagate over BGP; and if
that's the case, increasing retries here should help.  (Bearing in mind
that there is a hardcoded 1s sleep between retries.)