### PR TITLE
Updates casing of action and protocol in reference

### DIFF
--- a/_includes/master/endpointport.md
+++ b/_includes/master/endpointport.md
@@ -1,11 +1,11 @@
 An EndpointPort associates a name with a particular TCP/UDP port of the endpoint, allowing it to
 be referenced as a named port in [policy rules](./networkpolicy#entityrule).
 
-| Field       | Description                      | Accepted Values   | Schema | Default    |
-|-------------|----------------------------------|-------------------|--------|------------|
-| name        | The name to attach to this port, allowing it to be referred to in [policy rules](./networkpolicy#entityrule).  Names must be unique within an endpoint.  | | string |            |
-| protocol    | The protocol of this named port. | tcp, udp          | string |            |
-| port        | The workload port number.        | 1-65535           | int    |            |
+| Field    | Description                                                                                                                                            | Accepted Values | Schema | Default  |
+|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|--------|----------|
+| name     | The name to attach to this port, allowing it to be referred to in [policy rules](./networkpolicy#entityrule). Names must be unique within an endpoint. |                 | string |          |
+| protocol | The protocol of this named port.                                                                                                                       | `TCP`, `UDP`    | string |          |
+| port     | The workload port number.                                                                                                                              | `1`-`65535`     | int    |          |
 
 > **Note**: On their own, EndpointPort entries don't result in any change to the connectivity of the port.
 > They only have an effect if they are referred to in policy.

--- a/_includes/master/rule.md
+++ b/_includes/master/rule.md
@@ -1,14 +1,14 @@
-| Field       | Description                 | Accepted Values   | Schema | Default    |
-|-------------|-----------------------------|-------------------|--------|------------|
-| action      | Action to perform when matching this rule. | allow, deny, log, pass | string | |
-| protocol    | Positive protocol match.  | tcp, udp, icmp, icmpv6, sctp, udplite, integer 1-255. | string | |
-| notProtocol | Negative protocol match. | tcp, udp, icmp, icmpv6, sctp, udplite, integer 1-255. | string | |
-| icmp        | ICMP match criteria.     | | [ICMP](#icmp) | |
-| notICMP     | Negative match on ICMP. | | [ICMP](#icmp) | |
-| source      | Source match parameters. |  | [EntityRule](#entityrule) | |
-| destination | Destination match parameters. |  | [EntityRule](#entityrule) | |
+| Field       | Description                                | Accepted Values                                                   | Schema                    | Default    |
+|-------------|--------------------------------------------|-------------------------------------------------------------------|---------------------------|------------|
+| action      | Action to perform when matching this rule. | `Allow`, `Deny`, `Log`, `Pass`                                    | string                    |            |
+| protocol    | Positive protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
+| notProtocol | Negative protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
+| icmp        | ICMP match criteria.                       |                                                                   | [ICMP](#icmp)             |            |
+| notICMP     | Negative match on ICMP.                    |                                                                   | [ICMP](#icmp)             |            |
+| source      | Source match parameters.                   |                                                                   | [EntityRule](#entityrule) |            |
+| destination | Destination match parameters.              |                                                                   | [EntityRule](#entityrule) |            |
 
-An `action` of `pass` will skip over the remaining policies and jump to the
+An `action` of `Pass` will skip over the remaining policies and jump to the
 first [profile]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/profile) assigned to the endpoint, applying the policy configured in the
 profile; if there are no Profiles configured for the endpoint the default
-applied action is deny.
+applied action is `Deny`.

--- a/_includes/v3.0/endpointport.md
+++ b/_includes/v3.0/endpointport.md
@@ -1,11 +1,11 @@
 An EndpointPort associates a name with a particular TCP/UDP port of the endpoint, allowing it to
 be referenced as a named port in [policy rules](./networkpolicy#entityrule).
 
-| Field       | Description                      | Accepted Values   | Schema | Default    |
-|-------------|----------------------------------|-------------------|--------|------------|
-| name        | The name to attach to this port, allowing it to be referred to in [policy rules](./networkpolicy#entityrule).  Names must be unique within an endpoint.  | | string |            |
-| protocol    | The protocol of this named port. | tcp, udp          | string |            |
-| port        | The workload port number.        | 1-65535           | int    |            |
+| Field    | Description                                                                                                                                            | Accepted Values | Schema | Default  |
+|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|--------|----------|
+| name     | The name to attach to this port, allowing it to be referred to in [policy rules](./networkpolicy#entityrule). Names must be unique within an endpoint. |                 | string |          |
+| protocol | The protocol of this named port.                                                                                                                       | `TCP`, `UDP`    | string |          |
+| port     | The workload port number.                                                                                                                              | `1`-`65535`     | int    |          |
 
 > **Note**: On their own, EndpointPort entries don't result in any change to the connectivity of the port.
 > They only have an effect if they are referred to in policy.

--- a/_includes/v3.0/rule.md
+++ b/_includes/v3.0/rule.md
@@ -1,14 +1,14 @@
-| Field       | Description                 | Accepted Values   | Schema | Default    |
-|-------------|-----------------------------|-------------------|--------|------------|
-| action      | Action to perform when matching this rule. | allow, deny, log, pass | string | |
-| protocol    | Positive protocol match.  | tcp, udp, icmp, icmpv6, sctp, udplite, integer 1-255. | string | |
-| notProtocol | Negative protocol match. | tcp, udp, icmp, icmpv6, sctp, udplite, integer 1-255. | string | |
-| icmp        | ICMP match criteria.     | | [ICMP](#icmp) | |
-| notICMP     | Negative match on ICMP. | | [ICMP](#icmp) | |
-| source      | Source match parameters. |  | [EntityRule](#entityrule) | |
-| destination | Destination match parameters. |  | [EntityRule](#entityrule) | |
+| Field       | Description                                | Accepted Values                                                   | Schema                    | Default    |
+|-------------|--------------------------------------------|-------------------------------------------------------------------|---------------------------|------------|
+| action      | Action to perform when matching this rule. | `Allow`, `Deny`, `Log`, `Pass`                                    | string                    |            |
+| protocol    | Positive protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
+| notProtocol | Negative protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
+| icmp        | ICMP match criteria.                       |                                                                   | [ICMP](#icmp)             |            |
+| notICMP     | Negative match on ICMP.                    |                                                                   | [ICMP](#icmp)             |            |
+| source      | Source match parameters.                   |                                                                   | [EntityRule](#entityrule) |            |
+| destination | Destination match parameters.              |                                                                   | [EntityRule](#entityrule) |            |
 
-An `action` of `pass` will skip over the remaining policies and jump to the
+An `action` of `Pass` will skip over the remaining policies and jump to the
 first [profile]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/profile) assigned to the endpoint, applying the policy configured in the
 profile; if there are no Profiles configured for the endpoint the default
-applied action is deny.
+applied action is `Deny`.

--- a/master/reference/calicoctl/resources/globalnetworkpolicy.md
+++ b/master/reference/calicoctl/resources/globalnetworkpolicy.md
@@ -49,31 +49,31 @@ spec:
 
 #### Metadata
 
-| Field | Description  | Accepted Values   | Schema | Default |
-|-------|--------------|-------------------|--------|---------|
-| name | The name of the network policy. Required. | Alphanumeric string with optional `.`, `_`, or `-`. | string |         |
+| Field | Description                               | Accepted Values                                     | Schema | Default |
+|-------|-------------------------------------------|-----------------------------------------------------|--------|---------|
+| name  | The name of the network policy. Required. | Alphanumeric string with optional `.`, `_`, or `-`. | string |         |
 
 #### Spec
 
-| Field          | Description                                                                                                                                           | Accepted Values | Schema                | Default |
-|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
-| order          | Controls the order of precedence. {{site.prodname}} applies the policy with the lowest value first.                                                              |                 | float                 |         |
-| selector       | Selects the endpoints to which this policy applies.                                                                                                   |                 | [selector](#selector) | all()   |
-| types          | Applies the policy based on the direction of the traffic. To apply the policy to inbound traffic, set to `ingress`. To apply the policy to outbound traffic, set to `egress`. To apply the policy to both, set to `ingress, egress`. | `ingress`, `egress` | List of strings | Depends on presence of ingress/egress rules\* |
-| ingress        | Ordered list of ingress rules applied by policy.                                                                                                      |                 | List of [Rule](#rule) |         |
-| egress         | Ordered list of egress rules applied by this policy.                                                                                                  |                 | List of [Rule](#rule) |         |
-| doNotTrack\*\* | Indicates to apply the rules in this policy before any data plane connection tracking, and that packets allowed by these rules should not be tracked. | true, false     | boolean               | false   |
-| preDNAT\*\*    | Indicates to apply the rules in this policy before any DNAT.                                                                                          | true, false     | boolean               | false   |
-| applyOnForward\*\*  | Indicates to apply the rules in this policy on forwarded traffic as well as to locally terminated traffic.                                                                                          | true, false     | boolean               | false   |
+| Field              | Description                                                                                                                                           | Accepted Values | Schema                | Default |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
+| order              | Controls the order of precedence. {{site.prodname}} applies the policy with the lowest value first.                                                   |                 | float                 |         |
+| selector           | Selects the endpoints to which this policy applies.                                                                                                   |                 | [selector](#selector) | all()   |
+| types              | Applies the policy based on the direction of the traffic. To apply the policy to inbound traffic, set to `Ingress`. To apply the policy to outbound traffic, set to `Egress`. To apply the policy to both, set to `Ingress, Egress`. | `Ingress`, `Egress`  | List of strings | Depends on presence of ingress/egress rules\* |
+| ingress            | Ordered list of ingress rules applied by policy.                                                                                                      |                 | List of [Rule](#rule) |         |
+| egress             | Ordered list of egress rules applied by this policy.                                                                                                  |                 | List of [Rule](#rule) |         |
+| doNotTrack\*\*     | Indicates to apply the rules in this policy before any data plane connection tracking, and that packets allowed by these rules should not be tracked. | true, false     | boolean               | false   |
+| preDNAT\*\*        | Indicates to apply the rules in this policy before any DNAT.                                                                                          | true, false     | boolean               | false   |
+| applyOnForward\*\* | Indicates to apply the rules in this policy on forwarded traffic as well as to locally terminated traffic.                                            | true, false     | boolean               | false   |
 
 \* If `types` has no value, {{site.prodname}} defaults as follows.
 
 >| Ingress Rules Present | Egress Rules Present | `Types` value       |
  |-----------------------|----------------------|---------------------|
- | No                    | No                   | `ingress`           |
- | Yes                   | No                   | `ingress`           |
- | No                    | Yes                  | `egress`            |
- | Yes                   | Yes                  | `ingress, egress`   |
+ | No                    | No                   | `Ingress`           |
+ | Yes                   | No                   | `Ingress`           |
+ | No                    | Yes                  | `Egress`            |
+ | Yes                   | Yes                  | `Ingress, Egress`   |
 
 \*\* The `doNotTrack` and `preDNAT` and `applyOnForward` fields are meaningful 
 only when applying policy to a [host endpoint]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/hostendpoint).

--- a/master/reference/calicoctl/resources/hostendpoint.md
+++ b/master/reference/calicoctl/resources/hostendpoint.md
@@ -34,30 +34,30 @@ spec:
   ports:
   - name: some-port
     port: 1234
-    protocol: tcp
+    protocol: TCP
   - name: another-port
     port: 5432
-    protocol: udp
+    protocol: UDP
 ```
 
 ### HostEndpoint Definition
 
 #### Metadata
 
-| Field       | Description                 | Accepted Values   | Schema  |
-|-------------|-----------------------------|-------------------|---------|
-| name        | The name of this hostEndpoint. Required. |  Alphanumeric string with optional `.`, `_`, or `-`. | string |
-| labels      | A set of labels to apply to this endpoint. |      | map    |
+| Field   | Description                                | Accepted Values                                     | Schema |
+|---------|--------------------------------------------|-----------------------------------------------------|--------|
+| name    | The name of this hostEndpoint. Required.   | Alphanumeric string with optional `.`, `_`, or `-`. | string |
+| labels  | A set of labels to apply to this endpoint. |                                                     | map    |
 
 #### Spec
 
-| Field         | Description                 | Accepted Values   | Schema | Default    |
-|---------------|-----------------------------|-------------------|--------|------------|
-| node          | The name of the node where this HostEndpoint resides. |      | string |
-| interfaceName | The name of the interface on which to apply policy.      |                             | string          |
-| expectedIPs   | The expected IP addresses associated with the interface. | Valid IPv4 or IPv6 address  | list |
-| profiles      | The list of profiles to apply to the endpoint.           |                             | list |
-| ports         | List on named ports that this workload exposes. | | List of [EndpointPorts](#endpointport) |
+| Field         | Description                                              | Accepted Values             | Schema                                 | Default |
+|---------------|----------------------------------------------------------|-----------------------------|----------------------------------------|---------|
+| node          | The name of the node where this HostEndpoint resides.    |                             | string                                 |
+| interfaceName | The name of the interface on which to apply policy.      |                             | string                                 |
+| expectedIPs   | The expected IP addresses associated with the interface. | Valid IPv4 or IPv6 address  | list                                   |
+| profiles      | The list of profiles to apply to the endpoint.           |                             | list                                   |
+| ports         | List on named ports that this workload exposes.          |                             | List of [EndpointPorts](#endpointport) |
 
 #### EndpointPort
 

--- a/master/reference/calicoctl/resources/networkpolicy.md
+++ b/master/reference/calicoctl/resources/networkpolicy.md
@@ -50,30 +50,30 @@ spec:
 
 #### Metadata
 
-| Field | Description  | Accepted Values   | Schema | Default |
-|-------|--------------|-------------------|--------|---------|
-| name | The name of the network policy. Required. |     Alphanumeric string with optional `.`, `_`, or `-`.    | string |         |
-| namespace | Namespace provides an additional qualification to a resource name. | | map | "default" |
+| Field     | Description                                                        | Accepted Values                                     | Schema | Default   |
+|-----------|--------------------------------------------------------------------|-----------------------------------------------------|--------|-----------|
+| name      | The name of the network policy. Required.                          | Alphanumeric string with optional `.`, `_`, or `-`. | string |           |
+| namespace | Namespace provides an additional qualification to a resource name. |                                                     | map    | "default" |
 
 
 #### Spec
 
-| Field          | Description                                                                                                                                           | Accepted Values | Schema                | Default |
-|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
-| order          | Controls the order of precedence. {{site.prodname}} applies the policy with the lowest value first.                                                              |                 | float                 |         |
-| selector       | Selects the endpoints to which this policy applies.                                                                                                   |                 | [selector](#selector) | all()   |
-| types          | Applies the policy based on the direction of the traffic. To apply the policy to inbound traffic, set to `ingress`. To apply the policy to outbound traffic, set to `egress`. To apply the policy to both, set to `ingress, egress`. | `ingress`, `egress` | List of strings | Depends on presence of ingress/egress rules\* |
-| ingress        | Ordered list of ingress rules applied by policy.                                                                                                      |                 | List of [Rule](#rule) |         |
-| egress         | Ordered list of egress rules applied by this policy.                                                                                                  |                 | List of [Rule](#rule) |         |
+| Field    | Description                                                                                         | Accepted Values | Schema                | Default |
+|----------|-----------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
+| order    | Controls the order of precedence. {{site.prodname}} applies the policy with the lowest value first. |                 | float                 |         |
+| selector | Selects the endpoints to which this policy applies.                                                 |                 | [selector](#selector) | all()   |
+| types    | Applies the policy based on the direction of the traffic. To apply the policy to inbound traffic, set to `Ingress`. To apply the policy to outbound traffic, set to `Egress`. To apply the policy to both, set to `Ingress, Egress`. | `Ingress`, `Egress` | List of strings | Depends on presence of ingress/egress rules\* |
+| ingress  | Ordered list of ingress rules applied by policy.                                                    |                 | List of [Rule](#rule) |         |
+| egress   | Ordered list of egress rules applied by this policy.                                                |                 | List of [Rule](#rule) |         |
 
 \* If `types` has no value, {{site.prodname}} defaults as follows.
 
 >| Ingress Rules Present | Egress Rules Present | `Types` value       |
  |-----------------------|----------------------|---------------------|
- | No                    | No                   | `ingress`           |
- | Yes                   | No                   | `ingress`           |
- | No                    | Yes                  | `egress`            |
- | Yes                   | Yes                  | `ingress, egress`   |
+ | No                    | No                   | `Ingress`           |
+ | Yes                   | No                   | `Ingress`           |
+ | No                    | Yes                  | `Egress`            |
+ | Yes                   | Yes                  | `Ingress, Egress`   |
 
 
 #### Rule

--- a/v3.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.0/reference/calicoctl/resources/hostendpoint.md
@@ -2,12 +2,12 @@
 title: Host Endpoint Resource (HostEndpoint)
 ---
 
-A host endpoint resource (`HostEndpoint`) represents an interface attached to a host that is running Calico.
+A host endpoint resource (`HostEndpoint`) represents an interface attached to a host that is running {{site.prodname}}.
 
-Each host endpoint may include a set of labels and list of profiles that Calico
+Each host endpoint may include a set of labels and list of profiles that {{site.prodname}}
 will use to apply
 [policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/networkpolicy)
-to the interface.  If no profiles or labels are applied, Calico will not apply
+to the interface.  If no profiles or labels are applied, {{site.prodname}} will not apply
 any policy.
 
 For `calicoctl` [commands]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/) that specify a resource type on the CLI, the following
@@ -34,30 +34,30 @@ spec:
   ports:
   - name: some-port
     port: 1234
-    protocol: tcp
+    protocol: TCP
   - name: another-port
     port: 5432
-    protocol: udp
+    protocol: UDP
 ```
 
 ### HostEndpoint Definition
 
 #### Metadata
 
-| Field       | Description                 | Accepted Values   | Schema  |
-|-------------|-----------------------------|-------------------|---------|
-| name        | The name of this hostEndpoint. Required. |  Alphanumeric string with optional `.`, `_`, or `-`. | string |
-| labels      | A set of labels to apply to this endpoint. |      | map    |
+| Field   | Description                                | Accepted Values                                     | Schema |
+|---------|--------------------------------------------|-----------------------------------------------------|--------|
+| name    | The name of this hostEndpoint. Required.   | Alphanumeric string with optional `.`, `_`, or `-`. | string |
+| labels  | A set of labels to apply to this endpoint. |                                                     | map    |
 
 #### Spec
 
-| Field       | Description                 | Accepted Values   | Schema | Default    |
-|-------------|-----------------------------|-------------------|--------|------------|
-| node        | The name of the node where this HostEndpoint resides. |      | string |
-| interfaceName | The name of the interface on which to apply policy.      |                             | string          |
-| expectedIPs   | The expected IP addresses associated with the interface. | Valid IPv4 or IPv6 address  | list |
-| profiles      | The list of profiles to apply to the endpoint.           |                             | list |
-| ports         | List on named ports that this workload exposes. | | List of [EndpointPorts](#endpointport) |
+| Field         | Description                                              | Accepted Values             | Schema                                 | Default |
+|---------------|----------------------------------------------------------|-----------------------------|----------------------------------------|---------|
+| node          | The name of the node where this HostEndpoint resides.    |                             | string                                 |
+| interfaceName | The name of the interface on which to apply policy.      |                             | string                                 |
+| expectedIPs   | The expected IP addresses associated with the interface. | Valid IPv4 or IPv6 address  | list                                   |
+| profiles      | The list of profiles to apply to the endpoint.           |                             | list                                   |
+| ports         | List on named ports that this workload exposes.          |                             | List of [EndpointPorts](#endpointport) |
 
 #### EndpointPort
 


### PR DESCRIPTION
## Description

- Also corrects the casing of `action` and `protocol` in the reference content for v3.0 and master

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
