### PR TITLE
'. startup.env' -> '. ./startup.env'

### DIFF
--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -15,7 +15,7 @@ startup || exit 1
 # Source any additional environment that was added by the startup script.  This
 # is done immediately after the startup script because the environments are
 # required by the remaining processing.
-. startup.env
+. ./startup.env
 
 # If possible pre-allocate the IP address on the IPIP tunnel.
 allocate-ipip-addr || exit 1

--- a/calico_node/filesystem/sbin/start_runit
+++ b/calico_node/filesystem/sbin/start_runit
@@ -11,6 +11,6 @@ then
 fi
 
 # Source any additional environment that was added by the startup script
-. startup.env
+. ./startup.env
 
 exec /sbin/runsvdir -P /etc/service/enabled


### PR DESCRIPTION
calico/node is using Busybox's sh, and there was a bump in Alpine:3.6
3 days ago, that could have brought in a increment to Busybox.

I couldn't find doc for Busybox sh, but Bash's doc for the 'source'
builtin says:

> 
>   source filename [arguments]
>          [...] If
>          filename does not contain a slash, filenames in PATH are used to  find  the
>          directory  containing  filename.  [...]
> 

So it's plausible that Busybox sh has been tightened to match this, and
that our '. startup.env' was always wrong and only worked by accident.
