### PR TITLE
'. startup.env' -> '. ./startup.env'

### DIFF
--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -15,7 +15,7 @@ startup || exit 1
 # Source any additional environment that was added by the startup script.  This
 # is done immediately after the startup script because the environments are
 # required by the remaining processing.
-. startup.env
+. ./startup.env
 
 # If possible pre-allocate the IP address on the IPIP tunnel.
 allocate-ipip-addr || exit 1

--- a/calico_node/filesystem/sbin/start_runit
+++ b/calico_node/filesystem/sbin/start_runit
@@ -11,6 +11,6 @@ then
 fi
 
 # Source any additional environment that was added by the startup script
-. startup.env
+. ./startup.env
 
 exec /sbin/runsvdir -P /etc/service/enabled

--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -400,7 +400,7 @@ class MultiHostMainline(TestBase):
         # a workloads own hostname does not work).
         if types is None:
             types = ['icmp', 'tcp', 'udp']
-        self.assert_connectivity(retries=2,
+        self.assert_connectivity(retries=10,
                                  pass_list=n1_workloads,
                                  fail_list=n2_workloads,
                                  type_list=types)
@@ -409,4 +409,3 @@ class MultiHostMainline(TestBase):
         self.assert_connectivity(pass_list=n2_workloads,
                                  fail_list=n1_workloads,
                                  type_list=types)
-


### PR DESCRIPTION
calico/node is using Busybox's sh, and there was a bump in Alpine:3.6
3 days ago, that could have brought in a increment to Busybox.

I couldn't find doc for Busybox sh, but Bash's doc for the 'source'
builtin says:

  source filename [arguments]
         [...] If
         filename does not contain a slash, filenames in PATH are used to  find  the
         directory  containing  filename.  [...]

So it's plausible that Busybox sh has been tightened to match this, and
that our '. startup.env' was always wrong and only worked by accident.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
