### PR TITLE
Escapes pipe in rule table

### DIFF
--- a/_includes/master/rule.md
+++ b/_includes/master/rule.md
@@ -1,8 +1,8 @@
 | Field       | Description                                | Accepted Values                                                   | Schema                    | Default    |
 |-------------|--------------------------------------------|-------------------------------------------------------------------|---------------------------|------------|
 | action      | Action to perform when matching this rule. | `Allow`, `Deny`, `Log`, `Pass`                                    | string                    |            |
-| protocol    | Positive protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
-| notProtocol | Negative protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
+| protocol    | Positive protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string \| integer         |            |
+| notProtocol | Negative protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string \| integer         |            |
 | icmp        | ICMP match criteria.                       |                                                                   | [ICMP](#icmp)             |            |
 | notICMP     | Negative match on ICMP.                    |                                                                   | [ICMP](#icmp)             |            |
 | source      | Source match parameters.                   |                                                                   | [EntityRule](#entityrule) |            |

--- a/_includes/v3.0/rule.md
+++ b/_includes/v3.0/rule.md
@@ -1,8 +1,8 @@
 | Field       | Description                                | Accepted Values                                                   | Schema                    | Default    |
 |-------------|--------------------------------------------|-------------------------------------------------------------------|---------------------------|------------|
 | action      | Action to perform when matching this rule. | `Allow`, `Deny`, `Log`, `Pass`                                    | string                    |            |
-| protocol    | Positive protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
-| notProtocol | Negative protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string|integer            |            |
+| protocol    | Positive protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string \| integer         |            |
+| notProtocol | Negative protocol match.                   | `TCP`, `UDP`, `ICMP`, `ICMPv6`, `SCTP`, `UDPLite`, `1`-`255`      | string \| integer         |            |
 | icmp        | ICMP match criteria.                       |                                                                   | [ICMP](#icmp)             |            |
 | notICMP     | Negative match on ICMP.                    |                                                                   | [ICMP](#icmp)             |            |
 | source      | Source match parameters.                   |                                                                   | [EntityRule](#entityrule) |            |


### PR DESCRIPTION
## Description

- Escapes a couple of pipes in the rule table which caused a rendering error where the unescaped pipe was resulting in a new table column.



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
