### PR TITLE
Remove extra env vars

### DIFF
--- a/calico_node/tests/st/utils/docker_host.py
+++ b/calico_node/tests/st/utils/docker_host.py
@@ -336,7 +336,6 @@ class DockerHost(object):
                 prefix +
                 (" -e CALICO_IPV4POOL_CIDR=%s " % DEFAULT_IPV4_POOL_CIDR) +
                 felix_logsetting + env_options +
-                " -e DISABLE_NODE_IP_CHECK=true -e FELIX_IPINIPENABLED=true " +
                 " -e " + suffix
             )
 


### PR DESCRIPTION
Empirically, all STs pass, with this change, when I run them locally
with `RELEASE_STREAM=master make st`.

It makes sense that we don't need `DISABLE_NODE_IP_CHECK` for the ST,
because it should only be used when starting (or restarting) a
calico/node in a very large cluster. Also, setting
`DISABLE_NODE_IP_CHECK=true` causes some calico/node startup.go code to
be skipped - so it is better for ST coverage if it is not set.

It also makes sense that setting `FELIX_IPINIPENABLED` is not needed,
because libcalico-go sets this whenever needed in a FelixConfiguration
resource, which feeds through to Felix and has the same effect as
FELIX_IPINIPENABLED.