### PR TITLE
Pin spf13/pflag to get upgrade UTs building

### DIFF
--- a/calico_upgrade/glide.lock
+++ b/calico_upgrade/glide.lock
@@ -1,5 +1,5 @@
-hash: d9d21ccc49b6b2a5cc81276556d14f2b5c4f60eecc5efbf3f7d87924a610f7a9
-updated: 2017-12-05T08:21:16.5631332Z
+hash: 229993c6786263e49ba8651201e1953297386c4189cbbec3b8ed0a6fd2434bb4
+updated: 2017-12-05T14:37:16.178101019-06:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -233,15 +233,15 @@ imports:
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: 1351f936d976c60a0a48d728281922cf63eafb8d
+  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net

--- a/calico_upgrade/glide.yaml
+++ b/calico_upgrade/glide.yaml
@@ -6,4 +6,6 @@ import:
   version: master
 - package: github.com/coreos/etcd
   version: v3.2.7
+- package: github.com/spf13/pflag
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 


### PR DESCRIPTION
Getting UTs building and running in calico_upgrade

```release-note
None required
```
