### PR TITLE
Delete UDP conntrack state before rechecking connectivity

### DIFF
--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -70,6 +70,12 @@ class MultiHostMainline(TestBase):
         self.host1.calicoctl("delete globalnetworkset netset-1", raise_exception_on_failure=False)
         self.host1.calicoctl("delete globalnetworkset netset-2", raise_exception_on_failure=False)
 
+        # Delete conntrack state for UDP connections to the workloads.
+        # Otherwise a new UDP connection may be allowed where it should be
+        # denied.
+        self.host1.delete_conntrack_state_to_workloads("udp")
+        self.host2.delete_conntrack_state_to_workloads("udp")
+
         # Now restore the original profile and check it all works as before
         self._apply_new_profile(self.original_profiles, self.host1)
         self.host1.calicoctl("get profile -o yaml")

--- a/calico_node/tests/st/utils/docker_host.py
+++ b/calico_node/tests/st/utils/docker_host.py
@@ -718,3 +718,11 @@ class DockerHost(object):
         for wl in self.workloads:
             wl.host.execute("docker logs %s" % wl.name, raise_exception_on_failure=False)
         log_and_run("docker logs %s" % self.name, raise_exception_on_failure=False)
+
+    def delete_conntrack_state_to_ip(self, protocol, dst_ip):
+        self.execute("docker exec calico-node conntrack -D -p %s --orig-dst %s" % (protocol, dst_ip),
+                     raise_exception_on_failure=False)
+
+    def delete_conntrack_state_to_workloads(self, protocol):
+        for workload in self.workloads:
+            self.delete_conntrack_state_to_ip(protocol, workload.ip)


### PR DESCRIPTION
This is an attempt to address calico/node ST flakes like the one here:
https://semaphoreci.com/calico/calico/branches/master/builds/1238

I guess this is caused by leftover conntrack state.  The overall flow in
the test that failed is:

1. Create 6 workloads in 2 disjoint groups, and check
connectivity.  (Workloads can connect to others in same group, but not
in the other group.)

2. Modify profile rules so that there is connectivity between the
groups, and check that.

3. Restore normal profile rules, and check normal (=> disjoint)
connectivity again.

The failure is seen in part (3), specifically because a UDP
connection (echo hello | nc -u -w1 $1 69 | grep hello) succeeds when the
test expects it to fail.

Adding the nc -r option might help, although it sounds like it would not
theoretically eliminate all possibility of source port reuse:

     -r      Specifies that source and/or destination ports should be
      chosen randomly instead of sequentially within a range or in the
      order that the system assigns them.

Alternatively we can flush the conntrack state before step 3, and that's
what this PR does.