### PR TITLE
copy missing changes from master/calico.yaml manifests to v3.0

### DIFF
--- a/v3.0/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -133,20 +133,14 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,bgp"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
             # Set noderef for node controller.
             - name: CALICO_K8S_NODE_REF
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Enable Felix IPInIPEnabled, pending code changes
-            - name: FELIX_IPINIPENABLED
-              value: "true"
-            # Disable node ip check, pending code changes
-            - name: DISABLE_NODE_IP_CHECK
-              value: "true"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
@@ -53,6 +53,7 @@ data:
       ]
     }
 
+
 ---
 
 # This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
@@ -203,20 +204,14 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "kubeadm,bgp"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
             # Set noderef for node controller.
             - name: CALICO_K8S_NODE_REF
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            # Enable Felix IPInIPEnabled, pending code changes
-            - name: FELIX_IPINIPENABLED
-              value: "true"
-            # Disable node ip check, pending code changes
-            - name: DISABLE_NODE_IP_CHECK
-              value: "true"
-            # Disable file logging so `kubectl logs` works.
-            - name: CALICO_DISABLE_FILE_LOGGING
-              value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -97,12 +97,6 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
-            # Enable Felix IPInIPEnabled, pending code changes
-            - name: FELIX_IPINIPENABLED
-              value: "true"
-            # Disable node ip check, pending code changes
-            - name: DISABLE_NODE_IP_CHECK
-              value: "true"
             # Enable felix info logging.
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -27,16 +27,16 @@ data:
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": 1500,
           "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
+              "type": "host-local",
+              "subnet": "usePodCidr"
           },
           "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+              "type": "k8s",
+              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
           },
           "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
           }
         },
         {
@@ -97,12 +97,6 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
-            # Enable Felix IPInIPEnabled, pending code changes
-            - name: FELIX_IPINIPENABLED
-              value: "true"
-            # Disable node ip check, pending code changes
-            - name: DISABLE_NODE_IP_CHECK
-              value: "true"
             # Enable felix info logging.
             - name: FELIX_LOGSEVERITYSCREEN
               value: "info"


### PR DESCRIPTION
## Description

Copy a couple of fixes that went into `master's` calico.yaml manifests back to the v3.0 versions. One of the misses was mine (we backed out a hack, but the master->v3.0 copy happened after the hack, but before the revert of the hack): https://github.com/projectcalico/calico/commit/594fe0e8ad6f83e586ff48b5c19baf4e7627fd3f#diff-4ceb7a31688dfeb74a67f586f66e01be.

I haven't tracked down where the other discrepancy came from, but from code inspection it looks like the right fix (its just indenting the `ipam` attributes).

After this PR, all the yaml files are identical between master and v3.0.

```release-note
None required
```
