### PR TITLE
rev coreos version constraint

### DIFF
--- a/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
+++ b/master/getting-started/kubernetes/installation/vagrant/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % update_channel
-  config.vm.box_version = ">= 1122.0.0"
+  config.vm.box_version = ">= 1576.4.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % update_channel
 
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
## Description

The installation process in the Vagrant/Virtual box Getting-starting guide can hang downloading kubectl on older versions of coreos. After updating to current-stable the issue was resolved.

```
vagrant git:(master) ✗ vagrant ssh k8s-master          
Last login: Fri Dec  8 16:23:42 UTC 2017 from 10.0.2.2 on ssh
Container Linux by CoreOS stable (1520.8.0)
core@k8s-master ~ $ ps auxwww |grep wget
root      1294  1.3  0.5  29436  5220 ?        Ss   16:24   0:00 /usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.7.5/bin/linux/amd64/kubectl
core      1345  0.0  0.0   6736   880 pts/0    S+   16:24   0:00 grep --colour=auto wget
```

shows old/outdated coreos
```
  vagrant box update 
==> k8s-node-02: Checking for updates to 'coreos-stable'
    k8s-node-02: Latest installed version: 1520.8.0
    k8s-node-02: Version constraints: >= 1122.0.0
    k8s-node-02: Provider: virtualbox
```
after updating...

```
 vagrant box update
==> k8s-node-02: Checking for updates to 'coreos-stable'
    k8s-node-02: Latest installed version: 1576.4.0
    k8s-node-02: Version constraints: >= 1576.4.0
    k8s-node-02: Provider: virtualbox
==> k8s-node-02: Box 'coreos-stable' (v1576.4.0) is running the latest version.
```

shows I can install Calico now...
```
 kubectl get pods --namespace=kube-system
NAME                                       READY     STATUS    RESTARTS   AGE
calico-kube-controllers-2686699925-8sqqg   1/1       Running   0          1m
calico-node-63mxk                          2/2       Running   0          1m
calico-node-hbll8                          2/2       Running   0          1m
calico-node-qsq4q                          2/2       Running   0          1m
```

## Release Note

Proposed release note:
```
The CoreOS version constraint for the Vagrant/VirtualBox: CoreOS Getting Started guide was updated to CoreOS stable, 1576.4.0
```