### PR TITLE
Restructure migration code to have less UX integration

### DIFF
--- a/calico_upgrade/Makefile
+++ b/calico_upgrade/Makefile
@@ -1,6 +1,5 @@
 .PHONY: all binary test clean help
 default: help
-all: test                                            ## Run all the tests
 test: test-containerized                             ## Run all the tests
 all: dist/calico-upgrade dist/calico-upgrade-darwin-amd64 dist/calico-upgrade-windows-amd64.exe test-containerized
 
@@ -12,7 +11,7 @@ CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
 ###############################################################################
 # Version directory
 CALICO_UPGR_DIR=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
-VERSIONS_FILE?=$(CALICO_UPGR_DIR)/../_data/versions.yml
+VERSIONS_FILE?=$(CALICO_UPGR_DIR)../_data/versions.yml
 
 ###############################################################################
 # Determine whether there's a local yaml installed or use dockerized version.
@@ -210,14 +209,13 @@ st: dist/calico-upgrade dist/calicoctl dist/calicoctlv2 run-etcd
 ## contain calico-upgrade and a v2.x and current v3.x versions of calicoctl.
 .PHONY: st
 testenv: dist/calico-upgrade dist/calicoctl dist/calicoctlv2 run-etcd
-	docker run --net=host --privileged \
+	-docker run --net=host --privileged \
 	           -e MY_IP=$(LOCAL_IP_ENV) \
 	           --rm -ti \
 	           -v $(SOURCE_DIR):/code \
 	           --name=testenv \
 	           calico/test \
 	           sh
-	docker exec -it --name=testenv sh
 
 dist/calicoctl:
 	-docker rm -f calicoctl

--- a/calico_upgrade/pkg/clients/clients.go
+++ b/calico_upgrade/pkg/clients/clients.go
@@ -76,7 +76,7 @@ func LoadClients(v3Config, v1Config string) (clientv3.Interface, V1ClientInterfa
 		return nil, nil, fmt.Errorf("expecting apiconfigv1 datastore to be 'etcdv2', got '%s'", v1ApiConfig.Spec.DatastoreType)
 	}
 
-	// Create the backend etcdv2 client (v1 API).  We wrap this in the compat module to handle
+	// Create the backend etcdv2 client (v1 API). We wrap this in the compat module to handle
 	// multi-key backed resources.
 	ev1, err := etcdv2.NewEtcdClient(&v1ApiConfig.Spec.EtcdConfig)
 	if err != nil {
@@ -117,7 +117,7 @@ func loadClientConfigV1(filename string) (*apiv1.CalicoAPIConfig, error) {
 func loadClientConfigFromBytesV1(b []byte) (*apiv1.CalicoAPIConfig, error) {
 	var c apiv1.CalicoAPIConfig
 
-	// Default the backend type to be etcd v2.  This will be overridden if
+	// Default the backend type to be etcd v2. This will be overridden if
 	// explicitly specified in the file.
 	log.Info("Loading config from JSON or YAML data")
 	c = apiv1.CalicoAPIConfig{

--- a/calico_upgrade/pkg/commands/clihelper.go
+++ b/calico_upgrade/pkg/commands/clihelper.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	lineLength = 79
+	sepChar    = '-'
+	bullet     = "*  "
+)
+
+// cliHelper contains common methods for writing/reading from the CLI.
+// It also implements the StatusWriterInterface, so may be used directly by the
+// migration handler for writing status information.
+type cliHelper struct {
+}
+
+// Display a 79-char word wrapped status message.
+func (m *cliHelper) Msg(msg string) {
+	lines := wordWrap(msg, lineLength)
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+}
+
+// Display a 79-char word wrapped sub status (a bulleted message).
+func (m *cliHelper) Bullet(msg string) {
+	lines := wordWrap(msg, lineLength-len(bullet))
+	fmt.Println(bullet + lines[0])
+	for _, line := range lines[1:] {
+		fmt.Println("   " + line)
+	}
+}
+
+// Display a 79-char word wrapped error message.
+func (m *cliHelper) Error(msg string) {
+	lines := wordWrap("ERROR: "+msg, lineLength)
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+}
+
+// Display a 79-char word wrapped error message.
+func (m *cliHelper) NewLine() {
+	fmt.Println("")
+}
+
+// Display a 79-char word wrapped error message.
+func (m *cliHelper) Separator() {
+	sep := make([]byte, lineLength)
+	for i := 0; i < lineLength; i++ {
+		sep[i] = sepChar
+	}
+	m.NewLine()
+	fmt.Println(string(sep))
+	m.NewLine()
+}
+
+// Display a generic proceed? message and wait for a "yes" response.
+func (m *cliHelper) ConfirmProceed() {
+	fmt.Print("Type \"yes\" to proceed (any other input cancels): ")
+	var input string
+	fmt.Scanln(&input)
+	if strings.ToLower(strings.TrimSpace(input)) != "yes" {
+		fmt.Println("User cancelled. Exiting.")
+		os.Exit(1)
+	}
+}
+
+// wordWrap wraps a long string at the specified max length. The text may
+// contain newlines.
+func wordWrap(text string, length int) []string {
+	// First split by newlines. We want to honor existing newlines.
+	var lines []string
+	parts := strings.Split(text, "\n")
+	for _, part := range parts {
+		lines = append(lines, wordWrapPart(part, length)...)
+	}
+	return lines
+}
+
+// wordWrapPart wraps a long string at the specified max length. Newlines
+// are treated as whitespace.
+func wordWrapPart(text string, length int) []string {
+	// First split by newlines. We want to honor existing newlines.
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{}
+	}
+
+	var lines []string
+	line := words[0]
+	for _, word := range words[1:] {
+		if len(line)+1+len(word) > length {
+			lines = append(lines, line)
+			line = word
+		} else {
+			line += " " + word
+		}
+	}
+	lines = append(lines, line)
+
+	return lines
+}

--- a/calico_upgrade/pkg/commands/complete.go
+++ b/calico_upgrade/pkg/commands/complete.go
@@ -59,28 +59,41 @@ Description:
 	}
 	cfv3 := parsedArgs["--apiconfigv3"].(string)
 	cfv1 := parsedArgs["--apiconfigv1"].(string)
+	ch := &cliHelper{}
 
 	// Obtain the v1 and v3 clients.
 	clientv3, clientv1, err := clients.LoadClients(cfv3, cfv1)
 	if err != nil {
-		printFinalMessage("Failed to complete the upgrade.\n"+
-			"Error accessing the Calico API: %v", err)
+		ch.Separator()
+		ch.Msg("Failed to complete the upgrade.")
+		ch.Bullet(fmt.Sprintf("Error accessing the Calico API: %v", err))
+		ch.NewLine()
 		os.Exit(1)
 	}
 
-	// Ensure the migration code displays messages (this is basically indicating that it
-	// is being called from the calico-upgrade script).
-	migrate.DisplayStatusMessages(true)
-	migrate.Interactive(true)
+	m := migrate.New(clientv3, clientv1, ch)
 
-	// Perform the final stage of the upgrade.
-	res := migrate.Complete(clientv3, clientv1)
-	if res == migrate.ResultOK {
-		// We completed successfully.
-		printFinalMessage("Successfully completed the upgrade process.")
-	} else {
-		printFinalMessage("Failed to complete the upgrade - please retry the command.\n" +
-			"The previous messages may contain more details.")
-		os.Exit(1)
+	// The complete command is interactive to prevent accidentally kicking off the complete.
+	ch.NewLine()
+	ch.Msg("You are about to complete the upgrade process to Calico v3. " +
+		"At this point, the v1 format data should have been successfully converted " +
+		"to v3 format, and all calico/node instances and orchestrator plugins " +
+		"(e.g. CNI) should be running Calico v3.x.")
+	ch.NewLine()
+	ch.ConfirmProceed()
+
+	// Perform the data migration.
+	err = m.Complete()
+	if err == nil {
+		ch.Separator()
+		ch.Msg("Successfully completed the upgrade process.")
+		ch.NewLine()
+		return
 	}
+
+	ch.Separator()
+	ch.Msg("Failed to complete the upgrade process.")
+	ch.Bullet(err.Error())
+	ch.NewLine()
+	os.Exit(1)
 }

--- a/calico_upgrade/pkg/commands/report.go
+++ b/calico_upgrade/pkg/commands/report.go
@@ -56,17 +56,9 @@ func ensureDirectory(output string) {
 	}
 }
 
-// printFinalMessage displays the final message for a command. It adds a large
-// banner to make it stand out.
-func printFinalMessage(reportFormat string, parms ...interface{}) {
-	fmt.Println("\n*******************************************************************************\n")
-	fmt.Printf(reportFormat, parms...)
-	fmt.Println("\n")
-}
-
 // printAndOutputReport writes out a set of report files and outputs the
 // files to screen.
-func printAndOutputReport(output string, data *migrate.ConvertedData) {
+func printAndOutputReport(output string, data *migrate.MigrationData) {
 	fmt.Println("Reports:")
 	if len(data.NameConversions) != 0 {
 		fp := filepath.Join(output, constants.FileConvertedNames)


### PR DESCRIPTION
## Description

Remove as many traces of UX from the migration code (before we move it to libcalico-go).  In particular:
-  No mention of UX specific commands should be in the migration code.  Text should be generic.  Especially no switches etc.
-  No user interaction in the UX
-  No printing to stdout in the migration code (now handled by an optional status interface)

Also improves the error handling by tracing the last error in the final report message.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
