### PR TITLE
use release tag while building calico/node tarball

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -554,13 +554,13 @@ release: clean
 	# Build the calico/node images.
 	$(MAKE) $(NODE_CONTAINER_NAME)
 
-	# Create the release archive
-	$(MAKE) release-archive
-
 	# Retag images with corect version and quay
 	docker tag $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_NAME):$(CALICO_VER)
 	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):$(CALICO_VER)
 	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):latest
+
+	# Create the release archive
+	$(MAKE) release-archive
 
 	# Check that images were created recently and that the IDs of the versioned and latest images match
 	@docker images --format "{{.CreatedAt}}\tID:{{.ID}}\t{{.Repository}}:{{.Tag}}" $(NODE_CONTAINER_NAME)
@@ -635,7 +635,7 @@ $(RELEASE_DIR_K8S_MANIFESTS):
 
 $(RELEASE_DIR_IMAGES)/calico-node.tar:
 	mkdir -p $(RELEASE_DIR_IMAGES)
-	docker save --output $@ $(NODE_CONTAINER_NAME)
+	docker save --output $@ $(NODE_CONTAINER_NAME):$(CALICO_VER)
 
 $(RELEASE_DIR_IMAGES)/calico-typha.tar:
 	mkdir -p $(RELEASE_DIR_IMAGES)


### PR DESCRIPTION
## Description

Backport of same fix from master to v2.6.x-series.

Address the issue of the release calico/node tarball having the wrong/multiple container tags by:
* tag calico/node:$(RELEASE), then
* specify the release when building calico/node's output (tarball)

This addresses https://github.com/projectcalico/calico/issues/1451.

Prior to this fix, the release had the `latest` tag, and in some releases, it also had additional container tags in calico/node's tarball. After the fix, the container tag corresponds to the release, e.g. `calico/node:v3.0.0-beta1`. This should also prevent multiple tags from getting into the release tarball. 

## Release Note

```release-note
None required
```
