### PR TITLE
Add local AS configuration example in docs

### DIFF
--- a/v2.6/usage/configuration/bgp.md
+++ b/v2.6/usage/configuration/bgp.md
@@ -3,7 +3,7 @@ title: Configuring BGP Peers
 redirect_from: latest/usage/configuration/bgp
 ---
 
-This document describes the commands available in `calicoctl` for managing BGP.  It
+This document describes the commands available in `calicoctl` for managing BGP. It
 is intended primarily for users who are running on private cloud
 and would like to peer Calico with their underlying infrastructure.
 
@@ -93,6 +93,30 @@ number, the command will output the current value.
 	$ calicoctl config get asNumber
 	64513
 
+To get the node configuration:
+
+	$ calicoctl get node kube-node1 -o yaml
+	- apiVersion: v1
+	  kind: node
+	  metadata:
+	    name: kube-node1
+	  spec:
+	    bgp:
+	      ipv4Address: 172.31.3.11/32
+
+To set the local AS number to use for the node (just copy the retrieved 
+configuration and add `asNumber` key under `spec/bgp`:
+
+	$ calicoctl apply -f - <<EOF
+	- apiVersion: v1
+	  kind: node
+	  metadata:
+	    name: kube-node1
+	  spec:
+	    bgp:
+	      asNumber: 65011
+	      ipv4Address: 172.31.3.11/32
+	EOF
 
 ### Disabling the full node-to-node BGP mesh
 


### PR DESCRIPTION
From the BGP configuration document, it was not very clear how to configure local AS per node (it was mentioned in one sentence that is really easy to overlook). Let's add an example to demonstrate this, as this is a crucial feature for more complex topologies (AS-per-rack, AS-per-compute-server).