### PR TITLE
Fix management-ui port of the stars policy demo

### DIFF
--- a/v2.6/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.6/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -32,7 +32,7 @@ kubectl get pods --all-namespaces --watch
 The management UI runs as a `NodePort` Service on Kubernetes, and shows the connectivity
 of the Services in this example.
 
-You can view the UI by visiting `http://<k8s-node-ip>:30002` in a browser.
+You can view the UI by visiting `http://<k8s-node-ip>:9001` in a browser.
 
 Once all the pods are started, they should have full connectivity. You can see this by visiting the UI.  Each service is
 represented by a single node in the graph.


### PR DESCRIPTION
The documented 30002 port is not used by the management-ui pod. 9001 is the good one.


```

$ kubectl describe --namespace management-ui po/management-ui-8bnpj

[...]

Containers:
  management-ui:
    Container ID:   docker://04efe0405218b06de4823a9294346357964b069c6368e1b477b6b97257eaa019
    Image:          calico/star-collect:v0.1.0
    Image ID:       docker-pullable://calico/star-collect@sha256:574ffc157e1c0c058d77cfee4c33d2373d815be105629d8159ae0ac5408209af
    Port:           9001/TCP
    State:          Running
      Started:      Mon, 18 Dec 2017 11:06:59 +0100
    Ready:          True
    Restart Count:  0
    Environment:    <none>

[...]
```