### PR TITLE
Fixes chicken egg link error blocking docs PRs

### DIFF
--- a/master/getting-started/kubernetes/upgrade/index.md
+++ b/master/getting-started/kubernetes/upgrade/index.md
@@ -8,9 +8,9 @@ no_canonical: true
 ## Prerequisites
 
 - {{site.prodname}} {{site.data.versions[page.version].first.title}} supports upgrades from 
-  {{site.prodname}} [v2.6.4](https://github.com/projectcalico/calico/releases/tag/v2.6.4) or 
+  {{site.prodname}} [v2.6.4](https://github.com/projectcalico/calico/releases) or 
   later. You must [upgrade](/v2.6/getting-started/kubernetes/upgrade) to a tagged release of 
-  {{site.prodname}} [v2.6.4](https://github.com/projectcalico/calico/releases/tag/v2.6.4) or 
+  {{site.prodname}} [v2.6.4](https://github.com/projectcalico/calico/releases) or 
   later before you can upgrade to {{site.prodname}} {{site.data.versions[page.version].first.title}}. 
 
 - An [etcdv3 cluster](https://coreos.com/etcd/docs/latest/). 


### PR DESCRIPTION
## Description

- Makes link to tagged release of 2.6.4 more general as 2.6.4 has not been released yet and this will cause many htmlproofer errors (this PR fixes that issue)


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
