### PR TITLE
Replace rollout status check

### DIFF
--- a/master/getting-started/kubernetes/upgrade/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade/upgrade.md
@@ -27,13 +27,23 @@ Once you have upgraded {{site.prodname}}, you can [complete the upgrade](#comple
    ```
    kubectl apply -f <v3-manifest>
    ```
-1. Check the status of the upgrade as follows.
+1. Watch the status of the upgrade as follows.
 
    ```
-   kubectl rollout status ds/calico-node -n kube-system
+   watch kubectl get pods -n kube-system
    ```
    
-   For more information about this, refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#step-4-watching-the-rolling-update-status)
+   Verify that the status of all {{site.prodname}} pods indicate `Running`.
+
+   ```
+   calico-kube-controllers-6d4b9d6b5b-wlkfj   1/1       Running   0          3m
+   calico-node-hvvg8                          1/2       Running   0          3m
+   calico-node-vm8kh                          1/2       Running   0          3m
+   calico-node-w92wk                          1/2       Running   0          3m
+   ```
+
+   > **Note**: The {{site.noderunning}} pods will report `1/2` in the `READY` column, as shown.
+   {: .alert .alert-info}
    
 1. After waiting some time and ensuring that the upgrade succeeded and no problems ensued,
    continue to [Completing the upgrade](#completing-the-upgrade).


### PR DESCRIPTION
## Description
When running through upgrade and checking the rollout status after installing the new manifest it did not seem to function as the directions indicated it should.

You can see here that the calico-node pods are 'Running'  but the rollout shows that the rollout has not finished. I'm guessing this is because the pods are not reporting ready.
```
core@k8s-master ~ $ kgp
NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE       IP                NODE
default       iperf-client1-r9ntc                        1/1       Running   1          16m       192.168.154.195   172.18.18.102
default       iperf-srv1-pq6hh                           1/1       Running   0          16m       192.168.44.195    172.18.18.103
kube-system   calico-kube-controllers-6d4b9d6b5b-6zgjw   1/1       Running   0          9m        172.18.18.103     172.18.18.103
kube-system   calico-node-hbdvq                          1/2       Running   0          9m        172.18.18.101     172.18.18.101
kube-system   calico-node-kpl8h                          1/2       Running   0          9m        172.18.18.103     172.18.18.103
kube-system   calico-node-l7kms                          1/2       Running   0          9m        172.18.18.102     172.18.18.102
kube-system   kube-dns-57b6dbfd76-mkfx2                  3/3       Running   0          18m       192.168.154.193   172.18.18.102
policy-demo   nginx-7c87f569d-7ckjt                      1/1       Running   0          18m       192.168.154.194   172.18.18.102
policy-demo   nginx-7c87f569d-g6zbn                      1/1       Running   0          18m       192.168.44.193    172.18.18.103
core@k8s-master ~ $ kubectl rollout status ds/calico-node -n kube-system
Waiting for rollout to finish: 0 of 3 updated pods are available...
```

## Release Note

```release-note
None required
```
