### PR TITLE
Removes outdated upgrade notes from install page in master dir

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -24,18 +24,6 @@ You must have a Kubernetes cluster, which meets the following requirements:
   - If using kubeadm, by passing `--pod-network-cidr=192.168.0.0/16` to `kubeadm`.
   - Otherwise, by passing `--cluster-cidr=192.168.0.0/16` directly to the controller manager.
 
-> **Note**: If you are upgrading from Calico v2.1, the cluster-cidr
-> selected for your controller manager should remain
-> unchanged from the v2.1 install (the v2.1 manifests default to
-> `10.244.0.0/16`).
-{: .alert .alert-info}
-
-> **Important**: If you are using the Kubernetes API datastore and upgrading
-> from Calico v2.4.x or earlier to Calico v2.5.x or later, you must
-> [migrate your Calico configuration data](https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md)
-> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.
-{: .alert .alert-danger}
-
 
 ## Installation
 

--- a/master/getting-started/kubernetes/upgrade/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade/upgrade.md
@@ -61,7 +61,7 @@ and your datastore type.
    > **Tip**: The {{site.noderunning}} pods will report `1/2` in the `READY` column, as shown.
    {: .alert .alert-success}
 
-1. 1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
+1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
 
    ```
    kubectl exec -n kube-system calico-node-hvvg8 versions


### PR DESCRIPTION
## Description

- Removes upgrade notes which are now irrelevant from K8s hosted install page
- Also corrects minor numbering error


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
