### PR TITLE
get rid of extraneous 'calico' from the title (messes up build)

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,5 +1,5 @@
 v3.0:
-- title: Calico v3.0.0
+- title: v3.0.0
   note: |
     21 December 2017
 


### PR DESCRIPTION
## Description

Get rid of extra 'calico' from the version title since the make is a bit sensitive to any change whatsoever.

## Todos

## Release Note


```release-note
None required
```
