### PR TITLE
Updates v3.0 dir to be the latest and greatest

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -11,7 +11,7 @@ v3.0:
     
     ##### Migration and upgrade from v2.6.4
     
-    - This version of Calico supports [migration and upgrade](/{{page.version}}/getting-started/kubernetes/upgrade/) from Calico v2.6.4. 
+    - This version of Calico supports [migration and upgrade](/v3.0/getting-started/kubernetes/upgrade/) from Calico v2.6.4. 
     
     ##### calicoctl enhancements
 
@@ -417,8 +417,8 @@ master:
      calico/cni:
       version: master
       url: ""
-      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.0/calico
-      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.0/calico-ipam
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.0/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.0/calico-ipam
      calico-bird:
       version: v0.3.1
       url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -155,7 +155,8 @@ The code is a little roundabout for a few reasons:
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Version ({% if page.version == 'master' %}nightly{% else %}{{page.version}}{% endif %})<span class="caret"></span></a>
                 <ul class="dropdown-menu">
-                   <li><a href="{{site.baseurl}}/v2.6/introduction">v2.6 (latest)</a></li>
+                   <li><a href="{{site.baseurl}}/v3.0/introduction">v3.0 (latest)</a></li>
+                   <li><a href="{{site.baseurl}}/v2.6/introduction">v2.6</a></li>
                    <li><a href="{{site.baseurl}}/v2.5/introduction">v2.5</a></li>
                    <li><a href="{{site.baseurl}}/v2.4/introduction">v2.4</a></li>
                    <li><a href="{{site.baseurl}}/v2.3/introduction">v2.3</a></li>
@@ -165,7 +166,6 @@ The code is a little roundabout for a few reasons:
                    <li><a href="{{site.baseurl}}/v1.6/introduction">v1.6</a></li>
                    <li><a href="{{site.baseurl}}/v1.5/introduction">v1.5</a></li>
                   <li role="separator" class="divider"></li>
-                  <li><a href="{{site.baseurl}}/v3.0/introduction">v3.0 (beta)</a></li>
                   <li><a href="{{site.baseurl}}/master/introduction">nightly</a></li>
                 </ul>
               </li>

--- a/index.html
+++ b/index.html
@@ -5,5 +5,5 @@ layout: docwithnav
 ---
 <p>You are being redirected to the latest release of Calico Docs.</p>
 <script type="text/javascript">
-window.location = "v2.6/introduction"
+window.location = "v3.0/introduction"
 </script>

--- a/master/getting-started/kubernetes/upgrade/index.md
+++ b/master/getting-started/kubernetes/upgrade/index.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrading Calico for Kubernetes
-redirect_from: latest/getting-started/kubernetes/upgrade
 no_canonical: true
 ---
 

--- a/v2.6/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.6/getting-started/bare-metal/bare-metal-install.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Felix as a static binary
-redirect_from: latest/getting-started/bare-metal/bare-metal-install
 ---
 
 These instructions will take you through a first-time install of

--- a/v2.6/getting-started/bare-metal/bare-metal.md
+++ b/v2.6/getting-started/bare-metal/bare-metal.md
@@ -1,6 +1,5 @@
 ---
 title: Using Calico to Secure Host Interfaces
-redirect_from: latest/getting-started/bare-metal/bare-metal
 ---
 
 This guide describes how to use Calico to secure the network interfaces

--- a/v2.6/getting-started/docker/index.md
+++ b/v2.6/getting-started/docker/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico with Docker
-redirect_from: latest/getting-started/docker/index
 ---
 
 Calico implements a Docker network plugin that can be used to provide routing and advanced network policy for Docker containers.

--- a/v2.6/getting-started/docker/installation/manual.md
+++ b/v2.6/getting-started/docker/installation/manual.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Calico for Docker
-redirect_from: latest/getting-started/docker/installation/manual
 ---
 
 Calico runs as a Docker container on each host. The `calicoctl` command line tool can be used to launch the `calico/node` container.

--- a/v2.6/getting-started/docker/installation/requirements.md
+++ b/v2.6/getting-started/docker/installation/requirements.md
@@ -1,6 +1,5 @@
 ---
 title:  Requirements
-redirect_from: latest/getting-started/docker/installation/requirements
 ---
 
 The following information details basic prerequisites that must be met

--- a/v2.6/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.6/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,6 +1,5 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
-redirect_from: latest/getting-started/docker/installation/vagrant-coreos/index
 ---
 
 These instructions allow you to set up a CoreOS Container Linux cluster ready to network Docker containers with

--- a/v2.6/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.6/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,6 +1,5 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
-redirect_from: latest/getting-started/docker/installation/vagrant-ubuntu/index
 ---
 
 These instructions allow you to set up an Ubuntu cluster ready to network Docker containers with

--- a/v2.6/getting-started/docker/troubleshooting.md
+++ b/v2.6/getting-started/docker/troubleshooting.md
@@ -1,5 +1,4 @@
 ---
 title: Troubleshooting Calico for Docker
-redirect_from: latest/getting-started/docker/troubleshooting
 ---
 Information coming soon!

--- a/v2.6/getting-started/docker/tutorials/ipam.md
+++ b/v2.6/getting-started/docker/tutorials/ipam.md
@@ -1,6 +1,5 @@
 ---
 title: IPAM
-redirect_from: latest/getting-started/docker/tutorials/ipam
 ---
 
 With the release of Docker 1.10, support has been added to allow users to

--- a/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Security using Calico Profiles and Policy
-redirect_from: latest/getting-started/docker/tutorials/security-using-calico-profiles-and-policy
 ---
 
 ## Background

--- a/v2.6/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.6/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,6 +1,5 @@
 ---
 title: Security using Calico Profiles
-redirect_from: latest/getting-started/docker/tutorials/security-using-calico-profiles
 ---
 
 ## Background

--- a/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Security using Docker Labels and Calico Policy
-redirect_from: latest/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy
 ---
 
 ## Background

--- a/v2.6/getting-started/docker/upgrade.md
+++ b/v2.6/getting-started/docker/upgrade.md
@@ -1,5 +1,4 @@
 ---
 title: Upgrading Calico for Docker
-redirect_from: latest/getting-started/docker/upgrade
 ---
 Information coming soon!

--- a/v2.6/getting-started/index.md
+++ b/v2.6/getting-started/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Integrations
-redirect_from: latest/getting-started/index
 ---
 
 To get started using Calico, we recommend running through one or more of the

--- a/v2.6/getting-started/kubernetes/index.md
+++ b/v2.6/getting-started/kubernetes/index.md
@@ -1,6 +1,5 @@
 ---
 title: Quickstart for Calico on Kubernetes
-redirect_from: latest/getting-started/kubernetes/
 ---
 
 

--- a/v2.6/getting-started/kubernetes/installation/aws.md
+++ b/v2.6/getting-started/kubernetes/installation/aws.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
-redirect_from: latest/getting-started/kubernetes/installation/aws
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on AWS.  We recommend taking

--- a/v2.6/getting-started/kubernetes/installation/azure.md
+++ b/v2.6/getting-started/kubernetes/installation/azure.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
-redirect_from: latest/getting-started/kubernetes/installation/azure
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on Azure.  We recommend taking

--- a/v2.6/getting-started/kubernetes/installation/gce.md
+++ b/v2.6/getting-started/kubernetes/installation/gce.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
-redirect_from: latest/getting-started/kubernetes/installation/gce
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on GCE.  We recommend taking

--- a/v2.6/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,6 +1,5 @@
 ---
 title: Standard Hosted Install
-redirect_from: latest/getting-started/kubernetes/installation/hosted/hosted
 ---
 
 The following steps install Calico as a Kubernetes add-on using your own etcd cluster.

--- a/v2.6/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Kubernetes Hosted Install
-redirect_from: latest/getting-started/kubernetes/installation/hosted/index
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,6 +1,5 @@
 ---
 title: kubeadm Hosted Install
-redirect_from: latest/getting-started/kubernetes/installation/hosted/kubeadm/index
 ---
 
 This document outlines how to install Calico, as well as a as single node

--- a/v2.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,6 +1,5 @@
 ---
 title: Kubernetes Datastore
-redirect_from: latest/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.

--- a/v2.6/getting-started/kubernetes/installation/index.md
+++ b/v2.6/getting-started/kubernetes/installation/index.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Calico on Kubernetes
-redirect_from: latest/getting-started/kubernetes/installation/index
 ---
 
 Calico can be installed on a Kubernetes cluster in a number of configurations.  This document

--- a/v2.6/getting-started/kubernetes/installation/integration.md
+++ b/v2.6/getting-started/kubernetes/installation/integration.md
@@ -1,6 +1,5 @@
 ---
 title: Integration Guide
-redirect_from: latest/getting-started/kubernetes/installation/integration
 ---
 
 

--- a/v2.6/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.6/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
-redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 
 These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not set up TLS between Kubernetes components.

--- a/v2.6/getting-started/kubernetes/troubleshooting.md
+++ b/v2.6/getting-started/kubernetes/troubleshooting.md
@@ -1,6 +1,5 @@
 ---
 title: Troubleshooting Calico for Kubernetes
-redirect_from: latest/getting-started/kubernetes/troubleshooting
 ---
 
 This article contains Kubernetes specific troubleshooting advice for Calico and

--- a/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Controlling ingress and egress traffic with network policy
-redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 
 The Kubernetes `NetworkPolicy` API allows users to express ingress and egress policies (starting with Kubernetes 1.8.0) to Kubernetes pods

--- a/v2.6/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,6 +1,5 @@
 ---
 title: Simple Policy Demo
-redirect_from: latest/getting-started/kubernetes/tutorials/simple-policy
 ---
 
 This guide provides a simple way to try out Kubernetes NetworkPolicy with Calico.  It requires a Kubernetes cluster configured with Calico networking, and expects that you have `kubectl` configured to interact with the cluster.

--- a/v2.6/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.6/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,6 +1,5 @@
 ---
 title: Stars Policy Demo
-redirect_from: latest/getting-started/kubernetes/tutorials/stars-policy/index
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all
 running on Kubernetes.  It then configures network policy on each service.

--- a/v2.6/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.6/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,6 +1,5 @@
 ---
 title: Using calicoctl in Kubernetes
-redirect_from: latest/getting-started/kubernetes/tutorials/using-calicoctl
 ---
 
 There are two ways to run `calicoctl` in Kubernetes:

--- a/v2.6/getting-started/kubernetes/upgrade.md
+++ b/v2.6/getting-started/kubernetes/upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrading Calico for Kubernetes
-redirect_from: latest/getting-started/kubernetes/upgrade
 ---
 
 This document covers upgrading the Calico components in a Kubernetes deployment.  This

--- a/v2.6/getting-started/mesos/index.md
+++ b/v2.6/getting-started/mesos/index.md
@@ -1,6 +1,5 @@
 ---
 title: Integration Guide
-redirect_from: latest/getting-started/mesos/index
 ---
 
 Calico introduces IP-per-container & fine-grained security policies to Mesos, while

--- a/v2.6/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.6/getting-started/mesos/installation/dc-os/custom.md
@@ -1,6 +1,5 @@
 ---
 title: Customizing the Calico Universe Framework
-redirect_from: latest/getting-started/mesos/installation/dc-os/custom
 ---
 
 The the Calico Universe Framework includes customization options which support

--- a/v2.6/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.6/getting-started/mesos/installation/dc-os/framework.md
@@ -1,6 +1,5 @@
 ---
 title: Calico DC/OS Installation Guide
-redirect_from: latest/getting-started/mesos/installation/dc-os/framework
 ---
 
 The following guide walks through installing Calico for DC/OS using the Universe

--- a/v2.6/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.6/getting-started/mesos/installation/dc-os/index.md
@@ -1,6 +1,5 @@
 ---
 title: Overview of Calico for DC/OS
-redirect_from: latest/getting-started/mesos/installation/dc-os/index
 ---
 
 The following information details Calico's installation and runtime dependencies

--- a/v2.6/getting-started/mesos/installation/integration.md
+++ b/v2.6/getting-started/mesos/installation/integration.md
@@ -1,6 +1,5 @@
 ---
 title: Integration Guide
-redirect_from: latest/getting-started/mesos/installation/integration
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing

--- a/v2.6/getting-started/mesos/installation/prerequisites.md
+++ b/v2.6/getting-started/mesos/installation/prerequisites.md
@@ -1,6 +1,5 @@
 ---
 title: Requirements for Calico with Mesos
-redirect_from: latest/getting-started/mesos/installation/prerequisites
 ---
 
 #### 1. etcd

--- a/v2.6/getting-started/mesos/installation/vagrant-centos/index.md
+++ b/v2.6/getting-started/mesos/installation/vagrant-centos/index.md
@@ -1,6 +1,5 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
-redirect_from: latest/getting-started/mesos/installation/vagrant-centos/index
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster
 with Calico installed and ready to network Docker Containerizer tasks.

--- a/v2.6/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.6/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,6 +1,5 @@
 ---
 title: Connecting to Tasks
-redirect_from: latest/getting-started/mesos/tutorials/connecting-tasks
 ---
 
 When Calico is used to network Mesos tasks,

--- a/v2.6/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.6/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,6 +1,5 @@
 ---
 title: Launching Tasks
-redirect_from: latest/getting-started/mesos/tutorials/launching-tasks
 ---
 
 The following information describes how to launch Calico networked tasks in Mesos

--- a/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,6 +1,5 @@
 ---
 title: Network Policy (Docker Containerizer)
-redirect_from: latest/getting-started/mesos/tutorials/policy/docker-containerizer
 ---
 
 The Docker Containerizer uses Docker directly to launch tasks.

--- a/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,6 +1,5 @@
 ---
 title: Network Policy (Universal Containerizer)
-redirect_from: latest/getting-started/mesos/tutorials/policy/universal-containerizer
 ---
 
 This document will demonstrate how to manipulate policy for Calico using

--- a/v2.6/getting-started/openshift/installation.md
+++ b/v2.6/getting-started/openshift/installation.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Calico on OpenShift
-redirect_from: latest/getting-started/openshift/installation
 ---
 
 Installation of Calico in OpenShift is integrated in openshift-ansible v3.6.

--- a/v2.6/getting-started/openstack/connectivity.md
+++ b/v2.6/getting-started/openstack/connectivity.md
@@ -1,6 +1,5 @@
 ---
 title: Connectivity in OpenStack
-redirect_from: latest/getting-started/openstack/connectivity
 ---
 
 An OpenStack deployment is of limited use if its VMs cannot reach and be

--- a/v2.6/getting-started/openstack/index.md
+++ b/v2.6/getting-started/openstack/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico for OpenStack
-redirect_from: latest/getting-started/openstack/index
 ---
 
 Calico's integration with OpenStack consists of the following pieces.

--- a/v2.6/getting-started/openstack/installation/chef.md
+++ b/v2.6/getting-started/openstack/installation/chef.md
@@ -1,6 +1,5 @@
 ---
 title: Chef Trial Install
-redirect_from: latest/getting-started/openstack/installation/chef
 ---
 
 > **Important**: The chef install only supports OpenStack Icehouse and we've heard

--- a/v2.6/getting-started/openstack/installation/devstack.md
+++ b/v2.6/getting-started/openstack/installation/devstack.md
@@ -1,6 +1,5 @@
 ---
 title: DevStack plugin for Calico
-redirect_from: latest/getting-started/openstack/installation/devstack
 ---
 
 The networking-calico project provides a DevStack plugin.  The following

--- a/v2.6/getting-started/openstack/installation/fuel.md
+++ b/v2.6/getting-started/openstack/installation/fuel.md
@@ -1,6 +1,5 @@
 ---
 title: Integration with Fuel
-redirect_from: latest/getting-started/openstack/installation/fuel
 ---
 
 Calico plugins are available for Fuel 6.1 and 7.0, and work is in progress for

--- a/v2.6/getting-started/openstack/installation/index.md
+++ b/v2.6/getting-started/openstack/installation/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico with OpenStack
-redirect_from: latest/getting-started/openstack/installation/index
 ---
 
 There are many ways to try out Calico with OpenStack, because OpenStack

--- a/v2.6/getting-started/openstack/installation/juju.md
+++ b/v2.6/getting-started/openstack/installation/juju.md
@@ -1,6 +1,5 @@
 ---
 title: Juju Install
-redirect_from: latest/getting-started/openstack/installation/juju
 ---
 
 You can use Ubuntu's [Juju Charms](https://jujucharms.com/) to quickly deploy a

--- a/v2.6/getting-started/openstack/installation/redhat.md
+++ b/v2.6/getting-started/openstack/installation/redhat.md
@@ -1,6 +1,5 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
-redirect_from: latest/getting-started/openstack/installation/redhat
 ---
 
 For this version of Calico, with OpenStack on RHEL 7 or CentOS 7, we recommend

--- a/v2.6/getting-started/openstack/installation/ubuntu.md
+++ b/v2.6/getting-started/openstack/installation/ubuntu.md
@@ -1,6 +1,5 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
-redirect_from: latest/getting-started/openstack/installation/ubuntu
 ---
 
 For this version of Calico, with OpenStack on Ubuntu Trusty or Xenial, we

--- a/v2.6/getting-started/openstack/neutron-api.md
+++ b/v2.6/getting-started/openstack/neutron-api.md
@@ -1,6 +1,5 @@
 ---
 title: How Calico Interprets Neutron API Calls
-redirect_from: latest/getting-started/openstack/neutron-api
 ---
 
 When running in an OpenStack deployment, Calico receives and interprets

--- a/v2.6/getting-started/openstack/tutorials.md
+++ b/v2.6/getting-started/openstack/tutorials.md
@@ -1,6 +1,5 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
-redirect_from: latest/getting-started/openstack/tutorials
 ---
 
 Here are a few worked examples for common Calico on OpenStack deployment

--- a/v2.6/getting-started/openstack/upgrade.md
+++ b/v2.6/getting-started/openstack/upgrade.md
@@ -1,6 +1,5 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
-redirect_from: latest/getting-started/openstack/upgrade
 ---
 
 This document details the procedure for upgrading a Calico-based

--- a/v2.6/getting-started/openstack/verification.md
+++ b/v2.6/getting-started/openstack/verification.md
@@ -1,6 +1,5 @@
 ---
 title: Verifying your Calico on OpenStack deployment
-redirect_from: latest/getting-started/openstack/verification
 ---
 
 This document takes you through the steps you can perform to verify that

--- a/v2.6/getting-started/rkt/index.md
+++ b/v2.6/getting-started/rkt/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico with rkt
-redirect_from: latest/getting-started/rkt/index
 no-canonical: true
 ---
 

--- a/v2.6/getting-started/rkt/installation/manual.md
+++ b/v2.6/getting-started/rkt/installation/manual.md
@@ -1,6 +1,5 @@
 ---
 title:  Manual Installation of Calico with rkt
-redirect_from: latest/getting-started/rkt/installation/manual
 no-canonical: true
 ---
 

--- a/v2.6/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.6/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,6 +1,5 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
-redirect_from: latest/getting-started/rkt/installation/vagrant-coreos/index
 no-canonical: true
 ---
 

--- a/v2.6/getting-started/rkt/troubleshooting.md
+++ b/v2.6/getting-started/rkt/troubleshooting.md
@@ -1,6 +1,5 @@
 ---
 title: Troubleshooting Calico for rkt
-redirect_from: latest/getting-started/rkt/troubleshooting
 no-canonical: true
 ---
 

--- a/v2.6/getting-started/rkt/tutorials/basic.md
+++ b/v2.6/getting-started/rkt/tutorials/basic.md
@@ -1,6 +1,5 @@
 ---
 title: Basic Network Isolation
-redirect_from: latest/getting-started/rkt/tutorials/basic
 no-canonical: true
 ---
 

--- a/v2.6/index.html
+++ b/v2.6/index.html
@@ -1,6 +1,5 @@
 ---
 title: Project Calico Documentation
-redirect_from: latest/index.html
 description: Home
 layout: docwithnav
 ---

--- a/v2.6/introduction/index.md
+++ b/v2.6/introduction/index.md
@@ -1,6 +1,5 @@
 ---
 title: About Calico
-redirect_from: latest/introduction/index.html
 ---
 
 Calico provides secure network connectivity for 

--- a/v2.6/reference/advanced/etcd-rbac/calico-etcdv2-paths.md
+++ b/v2.6/reference/advanced/etcd-rbac/calico-etcdv2-paths.md
@@ -1,6 +1,5 @@
 ---
 title: Calico key and path prefixes in etcd v2
-redirect_from: latest/reference/advanced/etcd-rbac/calico-etcdv2-paths
 ---
 
 The Paths listed here are the key or path prefixes that a particular calico

--- a/v2.6/reference/advanced/etcd-rbac/certificate-generation.md
+++ b/v2.6/reference/advanced/etcd-rbac/certificate-generation.md
@@ -1,6 +1,5 @@
 ---
 title: Generating Certificates for etcd RBAC
-redirect_from: latest/reference/advanced/etcd-rbac/certificate-generation
 ---
 
 The etcd datastore has the concept of users that are linked to roles, where

--- a/v2.6/reference/advanced/etcd-rbac/index.md
+++ b/v2.6/reference/advanced/etcd-rbac/index.md
@@ -1,6 +1,5 @@
 ---
 title: Setting up etcd certificates for RBAC
-redirect_from: latest/reference/advanced/etcd-rbac/index
 ---
 
 When using etcd it is a good idea to protect the data stored there.  This is

--- a/v2.6/reference/advanced/etcd-rbac/kubernetes-advanced.md
+++ b/v2.6/reference/advanced/etcd-rbac/kubernetes-advanced.md
@@ -1,6 +1,5 @@
 ---
 title: Advanced etcd segmentation for Calico
-redirect_from: latest/reference/advanced/etcd-rbac/kubernetes-advanced
 ---
 
 This document describes advanced segmentation of the etcd roles to limit

--- a/v2.6/reference/advanced/etcd-rbac/kubernetes.md
+++ b/v2.6/reference/advanced/etcd-rbac/kubernetes.md
@@ -1,6 +1,5 @@
 ---
 title: Using etcd RBAC to segment Kubernetes and Calico
-redirect_from: latest/reference/advanced/etcd-rbac/kubernetes
 ---
 
 When using etcd with RBAC, all components that access etcd must be configured

--- a/v2.6/reference/advanced/etcd-rbac/users-and-roles.md
+++ b/v2.6/reference/advanced/etcd-rbac/users-and-roles.md
@@ -1,6 +1,5 @@
 ---
 title: Creating Users and Roles in etcd
-redirect_from: latest/reference/advanced/etcd-rbac/users-and-roles
 ---
 
 Providing role based access control within etcd requires the following:

--- a/v2.6/reference/architecture/components.md
+++ b/v2.6/reference/architecture/components.md
@@ -1,6 +1,5 @@
 ---
 title: Anatomy of a calico-node container
-redirect_from: latest/reference/architecture/components
 ---
 
 `calico/node` can be regarded as a helper container that bundles together the

--- a/v2.6/reference/architecture/data-path.md
+++ b/v2.6/reference/architecture/data-path.md
@@ -1,6 +1,5 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
-redirect_from: latest/reference/architecture/data-path
 ---
 
 

--- a/v2.6/reference/architecture/index.md
+++ b/v2.6/reference/architecture/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Architecture
-redirect_from: latest/reference/architecture/index
 ---
 
 This document discusses the various pieces of the Calico's architecture, 

--- a/v2.6/reference/calicoctl/commands/apply.md
+++ b/v2.6/reference/calicoctl/commands/apply.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl apply
-redirect_from: latest/reference/calicoctl/commands/apply
 ---
 
 This sections describes the `calicoctl apply` command.

--- a/v2.6/reference/calicoctl/commands/config.md
+++ b/v2.6/reference/calicoctl/commands/config.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl config
-redirect_from: latest/reference/calicoctl/commands/config
 ---
 
 This sections describes the `calicoctl config` commands.

--- a/v2.6/reference/calicoctl/commands/create.md
+++ b/v2.6/reference/calicoctl/commands/create.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl create
-redirect_from: latest/reference/calicoctl/commands/create
 ---
 
 This sections describes the `calicoctl create` command.

--- a/v2.6/reference/calicoctl/commands/delete.md
+++ b/v2.6/reference/calicoctl/commands/delete.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl delete
-redirect_from: latest/reference/calicoctl/commands/delete
 ---
 
 This sections describes the `calicoctl delete` command.

--- a/v2.6/reference/calicoctl/commands/get.md
+++ b/v2.6/reference/calicoctl/commands/get.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl get
-redirect_from: latest/reference/calicoctl/commands/get
 ---
 
 This sections describes the `calicoctl get` command.

--- a/v2.6/reference/calicoctl/commands/index.md
+++ b/v2.6/reference/calicoctl/commands/index.md
@@ -1,6 +1,5 @@
 ---
 title: Command Reference
-redirect_from: latest/reference/calicoctl/commands/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage Calico network

--- a/v2.6/reference/calicoctl/commands/ipam/index.md
+++ b/v2.6/reference/calicoctl/commands/ipam/index.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl ipam
-redirect_from: latest/reference/calicoctl/commands/ipam/index
 ---
 
 This section describes the `calicoctl ipam` commands.

--- a/v2.6/reference/calicoctl/commands/ipam/release.md
+++ b/v2.6/reference/calicoctl/commands/ipam/release.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl ipam
-redirect_from: latest/reference/calicoctl/commands/ipam/release
 ---
 
 This section describes the `calicoctl ipam release` command.

--- a/v2.6/reference/calicoctl/commands/ipam/show.md
+++ b/v2.6/reference/calicoctl/commands/ipam/show.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl ipam
-redirect_from: latest/reference/calicoctl/commands/ipam/show
 ---
 
 This section describes the `calicoctl ipam show` command.

--- a/v2.6/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.6/reference/calicoctl/commands/node/checksystem.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node checksystem
-redirect_from: latest/reference/calicoctl/commands/node/checksystem
 ---
 
 This section describes the `calicoctl node checksystem` command.

--- a/v2.6/reference/calicoctl/commands/node/diags.md
+++ b/v2.6/reference/calicoctl/commands/node/diags.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node diags
-redirect_from: latest/reference/calicoctl/commands/node/diags
 ---
 
 This section describes the `calicoctl node diags` command.

--- a/v2.6/reference/calicoctl/commands/node/index.md
+++ b/v2.6/reference/calicoctl/commands/node/index.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node
-redirect_from: latest/reference/calicoctl/commands/node/index
 ---
 
 This section describes the `calicoctl node` commands.

--- a/v2.6/reference/calicoctl/commands/node/run.md
+++ b/v2.6/reference/calicoctl/commands/node/run.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node run
-redirect_from: latest/reference/calicoctl/commands/node/run
 ---
 
 This sections describes the `calicoctl node run` command.

--- a/v2.6/reference/calicoctl/commands/node/status.md
+++ b/v2.6/reference/calicoctl/commands/node/status.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl node status
-redirect_from: latest/reference/calicoctl/commands/node/status
 ---
 
 This sections describes the `calicoctl node status` command.

--- a/v2.6/reference/calicoctl/commands/replace.md
+++ b/v2.6/reference/calicoctl/commands/replace.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl replace
-redirect_from: latest/reference/calicoctl/commands/replace
 ---
 
 This sections describes the `calicoctl replace` command.

--- a/v2.6/reference/calicoctl/commands/version.md
+++ b/v2.6/reference/calicoctl/commands/version.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl version
-redirect_from: latest/reference/calicoctl/commands/version
 ---
 
 This sections describes the `calicoctl version` command.

--- a/v2.6/reference/calicoctl/index.md
+++ b/v2.6/reference/calicoctl/index.md
@@ -1,6 +1,5 @@
 ---
 title: calicoctl user reference
-redirect_from: latest/reference/calicoctl/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage Calico network

--- a/v2.6/reference/calicoctl/resources/bgppeer.md
+++ b/v2.6/reference/calicoctl/resources/bgppeer.md
@@ -1,6 +1,5 @@
 ---
 title: BGP Peer Resource (bgpPeer)
-redirect_from: latest/reference/calicoctl/resources/bgppeer
 ---
 
 A BGP Peer resource (bgpPeer) represents a remote BGP peer with which the node(s) in a Calico 

--- a/v2.6/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.6/reference/calicoctl/resources/hostendpoint.md
@@ -1,6 +1,5 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
-redirect_from: latest/reference/calicoctl/resources/hostendpoint
 ---
 
 A Host Endpoint resource (hostEndpoint) represents an interface attached to a host that is running Calico.

--- a/v2.6/reference/calicoctl/resources/index.md
+++ b/v2.6/reference/calicoctl/resources/index.md
@@ -1,6 +1,5 @@
 ---
 title: Resource Definitions
-redirect_from: latest/reference/calicoctl/resources/index
 ---
 
 This section describes the set of valid resource types that can be managed

--- a/v2.6/reference/calicoctl/resources/ippool.md
+++ b/v2.6/reference/calicoctl/resources/ippool.md
@@ -1,6 +1,5 @@
 ---
 title: IP Pool Resource (ipPool)
-redirect_from: latest/reference/calicoctl/resources/ippool
 ---
 
 An IP pool resource (ipPool) represents a collection of IP addresses from which Calico expects

--- a/v2.6/reference/calicoctl/resources/node.md
+++ b/v2.6/reference/calicoctl/resources/node.md
@@ -1,6 +1,5 @@
 ---
 title: Node Resource (node)
-redirect_from: latest/reference/calicoctl/resources/node
 ---
 
 An Node resource (node) represents a node running Calico.  When adding a host

--- a/v2.6/reference/calicoctl/resources/policy.md
+++ b/v2.6/reference/calicoctl/resources/policy.md
@@ -1,6 +1,5 @@
 ---
 title: Policy Resource (policy)
-redirect_from: latest/reference/calicoctl/resources/policy
 ---
 
 A Policy resource (policy) represents an ordered set of rules which are applied

--- a/v2.6/reference/calicoctl/resources/profile.md
+++ b/v2.6/reference/calicoctl/resources/profile.md
@@ -1,6 +1,5 @@
 ---
 title: Profile Resource (profile)
-redirect_from: latest/reference/calicoctl/resources/profile
 ---
 
 A Profile resource (profile) represents a set of rules which are applied 

--- a/v2.6/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.6/reference/calicoctl/resources/workloadendpoint.md
@@ -1,6 +1,5 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
-redirect_from: latest/reference/calicoctl/resources/workloadendpoint
 ---
 
 A Workload Endpoint resource (workloadEndpoint) represents an interface

--- a/v2.6/reference/calicoctl/setup/etcdv2.md
+++ b/v2.6/reference/calicoctl/setup/etcdv2.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
-redirect_from: latest/reference/calicoctl/setup/etcdv2
 ---
 
 This document covers the configuration options for calicoctl when using an etcdv2 datastore.

--- a/v2.6/reference/calicoctl/setup/index.md
+++ b/v2.6/reference/calicoctl/setup/index.md
@@ -1,6 +1,5 @@
 ---
 title: Calicoctl Configuration Overview 
-redirect_from: latest/reference/calicoctl/setup/index
 ---
 
 The `calicoctl` command line tool needs to be configured with details of

--- a/v2.6/reference/calicoctl/setup/kubernetes.md
+++ b/v2.6/reference/calicoctl/setup/kubernetes.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore
-redirect_from: latest/reference/calicoctl/setup/kubernetes
 layout: docwithnav
 ---
 

--- a/v2.6/reference/cni-plugin/configuration.md
+++ b/v2.6/reference/cni-plugin/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring the Calico CNI plugins
-redirect_from: latest/reference/cni-plugin/configuration
 ---
 
 The Calico CNI plugin is configured through the standard CNI [configuration mechanism](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration)

--- a/v2.6/reference/felix/configuration.md
+++ b/v2.6/reference/felix/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Felix
-redirect_from: latest/reference/felix/configuration
 ---
 
 Configuration for Felix is read from one of four possible locations, in

--- a/v2.6/reference/felix/prometheus.md
+++ b/v2.6/reference/felix/prometheus.md
@@ -1,6 +1,5 @@
 ---
 title: Felix Prometheus Statistics
-redirect_from: latest/reference/felix/prometheus
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the

--- a/v2.6/reference/index.md
+++ b/v2.6/reference/index.md
@@ -1,6 +1,5 @@
 ---
 title: Reference
-redirect_from: latest/reference/index
 noversion: yes
 ---
 

--- a/v2.6/reference/involved.md
+++ b/v2.6/reference/involved.md
@@ -1,6 +1,5 @@
 ---
 title: Getting Involved
-redirect_from: latest/reference/involved
 ---
 
 Calico is an open source project, and we'd love you to get involved.

--- a/v2.6/reference/kube-controllers/configuration.md
+++ b/v2.6/reference/kube-controllers/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring the Calico Kubernetes controllers
-redirect_from: latest/reference/kube-controllers/configuration
 no_canonical: true
 ---
 

--- a/v2.6/reference/license.md
+++ b/v2.6/reference/license.md
@@ -1,6 +1,5 @@
 ---
 title: Third Party Software Attributions
-redirect_from: latest/reference/license
 ---
 
 

--- a/v2.6/reference/node/configuration.md
+++ b/v2.6/reference/node/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring calico/node
-redirect_from: latest/reference/node/configuration
 ---
 
 The `calico/node` container is primarily configured through environment variables.

--- a/v2.6/reference/previous-releases.md
+++ b/v2.6/reference/previous-releases.md
@@ -1,6 +1,5 @@
 ---
 title: Previous releases
-redirect_from: latest/reference/previous-releases
 ---
 
 

--- a/v2.6/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.6/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,7 +1,6 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
-redirect_from: latest/reference/private-cloud/l2-interconnect-fabric
 ---
 
 

--- a/v2.6/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.6/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,6 +1,5 @@
 ---
 title: IP Interconnect Fabrics in Calico
-redirect_from: latest/reference/private-cloud/l3-interconnect-fabric
 lead_text: 'Where large-scale IP networks and hardware collide'
 ---
 

--- a/v2.6/reference/public-cloud/aws.md
+++ b/v2.6/reference/public-cloud/aws.md
@@ -1,6 +1,5 @@
 ---
 title: AWS
-redirect_from: latest/reference/public-cloud/aws
 ---
 
 Calico provides the following advantages when running in AWS:

--- a/v2.6/reference/public-cloud/gce.md
+++ b/v2.6/reference/public-cloud/gce.md
@@ -1,6 +1,5 @@
 ---
 title: Deploying Calico on GCE
-redirect_from: latest/reference/public-cloud/gce
 ---
 
 To deploy Calico in [Google Compute Engine][GCE], you must ensure that the

--- a/v2.6/reference/repo-structure.md
+++ b/v2.6/reference/repo-structure.md
@@ -1,6 +1,5 @@
 ---
 title: Calico Repositories
-redirect_from: latest/reference/repo-structure
 ---
 
 The following information details which artifacts are built from which

--- a/v2.6/reference/requirements.md
+++ b/v2.6/reference/requirements.md
@@ -1,6 +1,5 @@
 ---
 title: Calico System Requirements
-redirect_from: latest/reference/requirements
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v2.6/reference/supported-platforms.md
+++ b/v2.6/reference/supported-platforms.md
@@ -1,6 +1,5 @@
 ---
 title: Supported Platforms
-redirect_from: latest/reference/supported-platforms
 ---
 
 Calico version {{ page.version }} has supported integration with the following platforms.

--- a/v2.6/releases/index.md
+++ b/v2.6/releases/index.md
@@ -1,6 +1,5 @@
 ---
 title: Releases
-redirect_from: latest/releases/index
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.6/usage/calicoctl/container.md
+++ b/v2.6/usage/calicoctl/container.md
@@ -1,6 +1,5 @@
 ---
 title: calico/ctl container
-redirect_from: latest/usage/calicoctl/container
 ---
 
 With each release of calicoctl the docker container `calico/ctl` is released to

--- a/v2.6/usage/calicoctl/install-and-configuration.md
+++ b/v2.6/usage/calicoctl/install-and-configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Installing and Configuring calicoctl
-redirect_from: latest/usage/calicoctl/install-and-configuration
 ---
 
 This document outlines how to install and configure calicoctl which is the

--- a/v2.6/usage/configuration/as-service.md
+++ b/v2.6/usage/configuration/as-service.md
@@ -1,6 +1,5 @@
 ---
 title: Running Calico Node Container as a Service
-redirect_from: latest/usage/configuration/as-service
 ---
 
 This guide explains how to run Calico as a system process or service,

--- a/v2.6/usage/configuration/bgp.md
+++ b/v2.6/usage/configuration/bgp.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring BGP Peers
-redirect_from: latest/usage/configuration/bgp
 ---
 
 This document describes the commands available in `calicoctl` for managing BGP.  It

--- a/v2.6/usage/configuration/conntrack.md
+++ b/v2.6/usage/configuration/conntrack.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Conntrack
-redirect_from: latest/usage/configuration/conntrack
 ---
 
 A common problem on Linux systems is running out of space in the

--- a/v2.6/usage/configuration/ip-in-ip.md
+++ b/v2.6/usage/configuration/ip-in-ip.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring IP-in-IP
-redirect_from: latest/usage/configuration/ip-in-ip
 ---
 
 If your network fabric performs source/destination address checks

--- a/v2.6/usage/configuration/mtu.md
+++ b/v2.6/usage/configuration/mtu.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring MTU
-redirect_from: latest/usage/configuration/mtu
 ---
 
 Depending on the environment Calico is being deployed into it may be

--- a/v2.6/usage/configuration/node.md
+++ b/v2.6/usage/configuration/node.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring a Node IP Address and Subnet
-redirect_from: latest/usage/configuration/node
 ---
 
 By default, Calico automatically detects each Node's IP address and subnet.  In most cases,

--- a/v2.6/usage/decommissioning-a-node.md
+++ b/v2.6/usage/decommissioning-a-node.md
@@ -1,6 +1,5 @@
 ---
 title: Decommissioning a Node
-redirect_from: latest/usage/decommissioning-a-node
 ---
 
 ### About decommissioning nodes

--- a/v2.6/usage/external-connectivity.md
+++ b/v2.6/usage/external-connectivity.md
@@ -1,6 +1,5 @@
 ---
 title: External Connectivity
-redirect_from: latest/usage/external-connectivity
 ---
 Calico creates a routed network on which your containers look like normal IP
 speakers. You can connect to them from a host in your cluster (assuming the

--- a/v2.6/usage/index.md
+++ b/v2.6/usage/index.md
@@ -1,6 +1,5 @@
 ---
 title: Using Calico
-redirect_from: latest/usage/index
 ---
 
 This section contains information on using Calico.

--- a/v2.6/usage/ipv6.md
+++ b/v2.6/usage/ipv6.md
@@ -1,6 +1,5 @@
 ---
 title: IPv6 Support
-redirect_from: latest/usage/ipv6
 ---
 
 Calico supports connectivity over IPv6, between compute hosts, and

--- a/v2.6/usage/openstack/configuration.md
+++ b/v2.6/usage/openstack/configuration.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Systems for use with Calico
-redirect_from: latest/usage/openstack/configuration
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.6/usage/openstack/floating-ips.md
+++ b/v2.6/usage/openstack/floating-ips.md
@@ -1,6 +1,5 @@
 ---
 title: Floating IPs
-redirect_from: latest/usage/openstack/floating-ips
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.6/usage/openstack/host-routes.md
+++ b/v2.6/usage/openstack/host-routes.md
@@ -1,6 +1,5 @@
 ---
 title: Host routes
-redirect_from: latest/usage/openstack/host-routes
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.6/usage/openstack/kuryr.md
+++ b/v2.6/usage/openstack/kuryr.md
@@ -1,6 +1,5 @@
 ---
 title: Kuryr
-redirect_from: latest/usage/openstack/kuryr
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.6/usage/openstack/semantics.md
+++ b/v2.6/usage/openstack/semantics.md
@@ -1,6 +1,5 @@
 ---
 title: Detailed Semantics
-redirect_from: latest/usage/openstack/semantics
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.6/usage/openstack/service-ips.md
+++ b/v2.6/usage/openstack/service-ips.md
@@ -1,6 +1,5 @@
 ---
 title: Service IPs
-redirect_from: latest/usage/openstack/service-ips
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.6/usage/routereflector/bird-rr-config.md
+++ b/v2.6/usage/routereflector/bird-rr-config.md
@@ -1,6 +1,5 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
-redirect_from: latest/usage/routereflector/bird-rr-config
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required. 

--- a/v2.6/usage/routereflector/calico-routereflector.md
+++ b/v2.6/usage/routereflector/calico-routereflector.md
@@ -1,6 +1,5 @@
 ---
 title: 'Calico BIRD Route Reflector container'
-redirect_from: latest/usage/routereflector/calico-routereflector
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required.

--- a/v2.6/usage/troubleshooting/faq.md
+++ b/v2.6/usage/troubleshooting/faq.md
@@ -1,6 +1,5 @@
 ---
 title: Frequently Asked Questions
-redirect_from: latest/usage/troubleshooting/faq
 layout: docwithnav
 ---
 

--- a/v2.6/usage/troubleshooting/index.md
+++ b/v2.6/usage/troubleshooting/index.md
@@ -1,6 +1,5 @@
 ---
 title: Troubleshooting
-redirect_from: latest/usage/troubleshooting/index
 ---
 
 ## Running `sudo calicoctl ...` with Environment Variables

--- a/v2.6/usage/troubleshooting/logging.md
+++ b/v2.6/usage/troubleshooting/logging.md
@@ -1,6 +1,5 @@
 ---
 title: Logging
-redirect_from: latest/usage/troubleshooting/logging
 ---
 
 ## The calico-node container

--- a/v3.0/getting-started/bare-metal/bare-metal-install.md
+++ b/v3.0/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+redirect_from: latest/getting-started/bare-metal/bare-metal-install
 ---
 
 These instructions will take you through a first-time install of

--- a/v3.0/getting-started/bare-metal/bare-metal.md
+++ b/v3.0/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+redirect_from: latest/getting-started/bare-metal/bare-metal
 ---
 
 This guide describes how to use {{site.prodname}} to secure the network interfaces

--- a/v3.0/getting-started/index.md
+++ b/v3.0/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+redirect_from: latest/getting-started/index
 ---
 
 To get started using Calico, we recommend running through one or more of the

--- a/v3.0/getting-started/kubernetes/index.md
+++ b/v3.0/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart for Calico on Kubernetes
+redirect_from: latest/getting-started/kubernetes/index
 ---
 
 

--- a/v3.0/getting-started/kubernetes/installation/aws.md
+++ b/v3.0/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+redirect_from: latest/getting-started/kubernetes/installation/aws
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on AWS.  We recommend taking

--- a/v3.0/getting-started/kubernetes/installation/azure.md
+++ b/v3.0/getting-started/kubernetes/installation/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
+redirect_from: latest/getting-started/kubernetes/installation/azure
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on Azure.  We recommend taking

--- a/v3.0/getting-started/kubernetes/installation/gce.md
+++ b/v3.0/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+redirect_from: latest/getting-started/kubernetes/installation/gce
 ---
 
 There are a number of solutions for deploying Calico and Kubernetes on GCE.  We recommend taking

--- a/v3.0/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+redirect_from: latest/getting-started/kubernetes/installation/hosted/hosted
 ---
 
 The following steps install Calico as a Kubernetes add-on using your own etcd cluster.

--- a/v3.0/getting-started/kubernetes/installation/hosted/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+redirect_from: latest/getting-started/kubernetes/installation/hosted/index
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: kubeadm Hosted Install
+redirect_from: latest/getting-started/kubernetes/installation/hosted/kubeadm/index
 ---
 
 This document outlines how to install {{site.prodname}} on a cluster initialized with 

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes API datastore
+redirect_from: latest/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index
 ---
 
 This document describes how to install {{site.prodname}} on Kubernetes without a separate etcd cluster.

--- a/v3.0/getting-started/kubernetes/installation/index.md
+++ b/v3.0/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+redirect_from: latest/getting-started/kubernetes/installation/index
 ---
 
 Calico can be installed on a Kubernetes cluster in a number of configurations.  This document

--- a/v3.0/getting-started/kubernetes/installation/integration.md
+++ b/v3.0/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+redirect_from: latest/getting-started/kubernetes/installation/integration
 ---
 
 

--- a/v3.0/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v3.0/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 
 These instructions allow you to set up a Kubernetes cluster with Calico networking using Vagrant and the [Calico CNI plugin][cni-plugin]. This guide does not set up TLS between Kubernetes components.

--- a/v3.0/getting-started/kubernetes/troubleshooting.md
+++ b/v3.0/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+redirect_from: latest/getting-started/kubernetes/troubleshooting
 ---
 
 This article contains Kubernetes specific troubleshooting advice for Calico and

--- a/v3.0/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v3.0/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Controlling ingress and egress traffic with network policy
+redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 
 The Kubernetes `NetworkPolicy` API allows users to express ingress and egress policies (starting with Kubernetes 1.8.0) to Kubernetes pods

--- a/v3.0/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v3.0/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+redirect_from: latest/getting-started/kubernetes/tutorials/simple-policy
 ---
 
 This guide provides a simple way to try out Kubernetes NetworkPolicy with Calico.  It requires a Kubernetes cluster configured with Calico networking, and expects that you have `kubectl` configured to interact with the cluster.

--- a/v3.0/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v3.0/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+redirect_from: latest/getting-started/kubernetes/tutorials/stars-policy/index
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all
 running on Kubernetes.  It then configures network policy on each service.

--- a/v3.0/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v3.0/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+redirect_from: latest/getting-started/kubernetes/tutorials/using-calicoctl
 ---
 
 `calicoctl` allows you to create, read, update, and delete {{site.prodname}} objects

--- a/v3.0/getting-started/kubernetes/upgrade/convert.md
+++ b/v3.0/getting-started/kubernetes/upgrade/convert.md
@@ -1,5 +1,6 @@
 ---
 title: Converting your calicoctl manifests
+redirect_from: latest/getting-started/kubernetes/upgrade/convert
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/delete.md
+++ b/v3.0/getting-started/kubernetes/upgrade/delete.md
@@ -1,5 +1,6 @@
 ---
 title: Deleting old data
+redirect_from: latest/getting-started/kubernetes/upgrade/delete
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/downgrade.md
+++ b/v3.0/getting-started/kubernetes/upgrade/downgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Downgrading Calico
+redirect_from: latest/getting-started/kubernetes/upgrade/downgrade
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/index.md
+++ b/v3.0/getting-started/kubernetes/upgrade/index.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
-redirect_from: latest/getting-started/kubernetes/upgrade
+redirect_from: latest/getting-started/kubernetes/upgrade/index
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/migrate.md
+++ b/v3.0/getting-started/kubernetes/upgrade/migrate.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating Calico data
+redirect_from: latest/getting-started/kubernetes/upgrade/migrate
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/setup.md
+++ b/v3.0/getting-started/kubernetes/upgrade/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and configuring calico-upgrade
+redirect_from: latest/getting-started/kubernetes/upgrade/setup
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/test.md
+++ b/v3.0/getting-started/kubernetes/upgrade/test.md
@@ -1,5 +1,6 @@
 ---
 title: Testing the data migration
+redirect_from: latest/getting-started/kubernetes/upgrade/test
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/upgrade.md
+++ b/v3.0/getting-started/kubernetes/upgrade/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico 
+redirect_from: latest/getting-started/kubernetes/upgrade/upgrade
 no_canonical: true
 ---
 

--- a/v3.0/getting-started/openshift/installation.md
+++ b/v3.0/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+redirect_from: latest/getting-started/openshift/installation
 ---
 
 Installation of {{site.prodname}} in OpenShift is integrated in openshift-ansible v3.6.

--- a/v3.0/index.html
+++ b/v3.0/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+redirect_from: latest/index.html
 description: Home
 layout: docwithnav
 ---

--- a/v3.0/introduction/index.md
+++ b/v3.0/introduction/index.md
@@ -1,5 +1,6 @@
 ---
 title: About Calico
+redirect_from: latest/introduction/index
 ---
 
 {{site.prodname}} provides secure network connectivity for 

--- a/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
+redirect_from: latest/reference/advanced/etcd-rbac/calico-etcdv3-paths
 no_canonical: true
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/certificate-generation.md
+++ b/v3.0/reference/advanced/etcd-rbac/certificate-generation.md
@@ -1,5 +1,6 @@
 ---
 title: Generating Certificates for etcd RBAC
+redirect_from: latest/reference/advanced/etcd-rbac/certificate-generation
 ---
 
 The etcd datastore has the concept of users that are linked to roles, where

--- a/v3.0/reference/advanced/etcd-rbac/index.md
+++ b/v3.0/reference/advanced/etcd-rbac/index.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up etcd certificates for RBAC
+redirect_from: latest/reference/advanced/etcd-rbac/index
 ---
 
 When using etcd it is a good idea to protect the data stored there. This is

--- a/v3.0/reference/advanced/etcd-rbac/kubernetes-advanced.md
+++ b/v3.0/reference/advanced/etcd-rbac/kubernetes-advanced.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced etcd segmentation for Calico
+redirect_from: latest/reference/advanced/etcd-rbac/kubernetes-advanced
 ---
 
 This document describes advanced segmentation of the etcd roles to limit

--- a/v3.0/reference/advanced/etcd-rbac/kubernetes.md
+++ b/v3.0/reference/advanced/etcd-rbac/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Using etcd RBAC to segment Kubernetes and Calico
+redirect_from: latest/reference/advanced/etcd-rbac/kubernetes
 ---
 
 When using etcd with RBAC, all components that access etcd must be configured

--- a/v3.0/reference/advanced/etcd-rbac/users-and-roles.md
+++ b/v3.0/reference/advanced/etcd-rbac/users-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Creating Users and Roles in etcd
+redirect_from: latest/reference/advanced/etcd-rbac/users-and-roles
 ---
 
 Providing role based access control within etcd requires the following:

--- a/v3.0/reference/architecture/components.md
+++ b/v3.0/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+redirect_from: latest/reference/architecture/components
 ---
 
 `calico/node` can be regarded as a helper container that bundles together the

--- a/v3.0/reference/architecture/data-path.md
+++ b/v3.0/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+redirect_from: latest/reference/architecture/data-path
 ---
 
 

--- a/v3.0/reference/architecture/index.md
+++ b/v3.0/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+redirect_from: latest/reference/architecture/index
 ---
 
 This document discusses the various pieces of the Calico's architecture, 

--- a/v3.0/reference/calicoctl/commands/apply.md
+++ b/v3.0/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+redirect_from: latest/reference/calicoctl/commands/apply
 ---
 
 This sections describes the `calicoctl apply` command.

--- a/v3.0/reference/calicoctl/commands/create.md
+++ b/v3.0/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+redirect_from: latest/reference/calicoctl/commands/create
 ---
 
 This sections describes the `calicoctl create` command.

--- a/v3.0/reference/calicoctl/commands/delete.md
+++ b/v3.0/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+redirect_from: latest/reference/calicoctl/commands/delete
 ---
 
 This sections describes the `calicoctl delete` command.

--- a/v3.0/reference/calicoctl/commands/get.md
+++ b/v3.0/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+redirect_from: latest/reference/calicoctl/commands/get
 ---
 
 This sections describes the `calicoctl get` command.

--- a/v3.0/reference/calicoctl/commands/index.md
+++ b/v3.0/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+redirect_from: latest/reference/calicoctl/commands/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage Calico network

--- a/v3.0/reference/calicoctl/commands/ipam/index.md
+++ b/v3.0/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+redirect_from: latest/reference/calicoctl/commands/ipam/index
 ---
 
 This section describes the `calicoctl ipam` commands.

--- a/v3.0/reference/calicoctl/commands/ipam/release.md
+++ b/v3.0/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+redirect_from: latest/reference/calicoctl/commands/ipam/release
 ---
 
 This section describes the `calicoctl ipam release` command.

--- a/v3.0/reference/calicoctl/commands/ipam/show.md
+++ b/v3.0/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+redirect_from: latest/reference/calicoctl/commands/ipam/show
 ---
 
 This section describes the `calicoctl ipam show` command.

--- a/v3.0/reference/calicoctl/commands/node/checksystem.md
+++ b/v3.0/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+redirect_from: latest/reference/calicoctl/commands/node/checksystem
 ---
 
 This section describes the `calicoctl node checksystem` command.

--- a/v3.0/reference/calicoctl/commands/node/diags.md
+++ b/v3.0/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+redirect_from: latest/reference/calicoctl/commands/node/diags
 ---
 
 This section describes the `calicoctl node diags` command.

--- a/v3.0/reference/calicoctl/commands/node/index.md
+++ b/v3.0/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+redirect_from: latest/reference/calicoctl/commands/node/index
 ---
 
 This section describes the `calicoctl node` commands.

--- a/v3.0/reference/calicoctl/commands/node/run.md
+++ b/v3.0/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+redirect_from: latest/reference/calicoctl/commands/node/run
 ---
 
 This sections describes the `calicoctl node run` command.

--- a/v3.0/reference/calicoctl/commands/node/status.md
+++ b/v3.0/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+redirect_from: latest/reference/calicoctl/commands/node/status
 ---
 
 This sections describes the `calicoctl node status` command.

--- a/v3.0/reference/calicoctl/commands/replace.md
+++ b/v3.0/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+redirect_from: latest/reference/calicoctl/commands/replace
 ---
 
 This sections describes the `calicoctl replace` command.

--- a/v3.0/reference/calicoctl/commands/version.md
+++ b/v3.0/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+redirect_from: latest/reference/calicoctl/commands/version
 ---
 
 This sections describes the `calicoctl version` command.

--- a/v3.0/reference/calicoctl/index.md
+++ b/v3.0/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+redirect_from: latest/reference/calicoctl/index
 ---
 
 The command line tool, `calicoctl`, makes it easy to manage {{site.prodname}} network and security policy, as well as other

--- a/v3.0/reference/calicoctl/resources/bgpconfig.md
+++ b/v3.0/reference/calicoctl/resources/bgpconfig.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Configuration Resource (BGPConfiguration)
+redirect_from: latest/reference/calicoctl/resources/bgpconfig
 no_canonical: true
 ---
 

--- a/v3.0/reference/calicoctl/resources/bgppeer.md
+++ b/v3.0/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (BGPPeer)
+redirect_from: latest/reference/calicoctl/resources/bgppeer
 ---
 
 A BGP peer resource (`BGPPeer`) represents a remote BGP peer with which the node(s) in a Calico 

--- a/v3.0/reference/calicoctl/resources/felixconfig.md
+++ b/v3.0/reference/calicoctl/resources/felixconfig.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Configuration Resource (FelixConfiguration)
+redirect_from: latest/reference/calicoctl/resources/felixconfig
 no_canonical: true
 ---
 

--- a/v3.0/reference/calicoctl/resources/globalnetworkpolicy.md
+++ b/v3.0/reference/calicoctl/resources/globalnetworkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Global Network Policy Resource (GlobalNetworkPolicy)
+redirect_from: latest/reference/calicoctl/resources/globalnetworkpolicy
 no_canonical: true
 ---
 

--- a/v3.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.0/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (HostEndpoint)
+redirect_from: latest/reference/calicoctl/resources/hostendpoint
 ---
 
 A host endpoint resource (`HostEndpoint`) represents an interface attached to a host that is running {{site.prodname}}.

--- a/v3.0/reference/calicoctl/resources/index.md
+++ b/v3.0/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+redirect_from: latest/reference/calicoctl/resources/index
 ---
 
 This section describes the set of valid resource types that can be managed

--- a/v3.0/reference/calicoctl/resources/ippool.md
+++ b/v3.0/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (IPPool)
+redirect_from: latest/reference/calicoctl/resources/ippool
 ---
 
 An IP pool resource (`IPPool`) represents a collection of IP addresses from which Calico expects

--- a/v3.0/reference/calicoctl/resources/networkpolicy.md
+++ b/v3.0/reference/calicoctl/resources/networkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy Resource (NetworkPolicy)
+redirect_from: latest/reference/calicoctl/resources/networkpolicy
 no_canonical: true
 ---
 

--- a/v3.0/reference/calicoctl/resources/node.md
+++ b/v3.0/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (Node)
+redirect_from: latest/reference/calicoctl/resources/node
 ---
 
 A node resource (`Node`) represents a node running Calico.  When adding a host

--- a/v3.0/reference/calicoctl/resources/profile.md
+++ b/v3.0/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (Profile)
+redirect_from: latest/reference/calicoctl/resources/profile
 ---
 
 A profile resource (`Profile`) represents a set of rules which are applied 

--- a/v3.0/reference/calicoctl/resources/workloadendpoint.md
+++ b/v3.0/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (WorkloadEndpoint)
+redirect_from: latest/reference/calicoctl/resources/workloadendpoint
 ---
 
 A workload endpoint resource (`WorkloadEndpoint`) represents an interface

--- a/v3.0/reference/cni-plugin/configuration.md
+++ b/v3.0/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+redirect_from: latest/reference/cni-plugin/configuration
 ---
 
 The Calico CNI plugin is configured through the standard CNI [configuration mechanism](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration)

--- a/v3.0/reference/felix/configuration.md
+++ b/v3.0/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+redirect_from: latest/reference/felix/configuration
 ---
 
 Configuration for Felix is read from one of four possible locations, in

--- a/v3.0/reference/felix/prometheus.md
+++ b/v3.0/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+redirect_from: latest/reference/felix/prometheus
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the

--- a/v3.0/reference/index.md
+++ b/v3.0/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+redirect_from: latest/reference/index
 noversion: yes
 ---
 

--- a/v3.0/reference/involved.md
+++ b/v3.0/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+redirect_from: latest/reference/involved
 ---
 
 Calico is an open source project, and we'd love you to get involved.

--- a/v3.0/reference/kube-controllers/configuration.md
+++ b/v3.0/reference/kube-controllers/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico Kubernetes controllers
+redirect_from: latest/reference/kube-controllers/configuration
 ---
 
 The Calico Kubernetes controllers are primarily configured through environment variables. When running

--- a/v3.0/reference/license.md
+++ b/v3.0/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+redirect_from: latest/reference/license
 ---
 
 

--- a/v3.0/reference/node/configuration.md
+++ b/v3.0/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+redirect_from: latest/reference/node/configuration
 ---
 
 The `calico/node` container is primarily configured through environment variables.

--- a/v3.0/reference/previous-releases.md
+++ b/v3.0/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+redirect_from: latest/reference/previous-releases
 ---
 
 

--- a/v3.0/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v3.0/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+redirect_from: latest/reference/private-cloud/l2-interconnect-fabric
 ---
 
 

--- a/v3.0/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v3.0/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+redirect_from: latest/reference/private-cloud/l3-interconnect-fabric
 lead_text: 'Where large-scale IP networks and hardware collide'
 ---
 

--- a/v3.0/reference/public-cloud/aws.md
+++ b/v3.0/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+redirect_from: latest/reference/public-cloud/aws
 ---
 
 Calico provides the following advantages when running in AWS:

--- a/v3.0/reference/public-cloud/azure.md
+++ b/v3.0/reference/public-cloud/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on Azure
+redirect_from: latest/reference/public-cloud/azure
 no_canonical: true
 ---
 

--- a/v3.0/reference/public-cloud/gce.md
+++ b/v3.0/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+redirect_from: latest/reference/public-cloud/gce
 ---
 
 To deploy Calico in [Google Compute Engine][GCE], you must ensure that the

--- a/v3.0/reference/repo-structure.md
+++ b/v3.0/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+redirect_from: latest/reference/repo-structure
 ---
 
 The following information details which artifacts are built from which

--- a/v3.0/reference/requirements.md
+++ b/v3.0/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+redirect_from: latest/reference/requirements
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v3.0/releases/index.md
+++ b/v3.0/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+redirect_from: latest/releases/index
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v3.0/usage/calicoctl/configure/etcd.md
+++ b/v3.0/usage/calicoctl/configure/etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to an etcd datastore
+redirect_from: latest/usage/calicoctl/configure/etcd
 no_canonical: true
 ---
 

--- a/v3.0/usage/calicoctl/configure/index.md
+++ b/v3.0/usage/calicoctl/configure/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl
+redirect_from: latest/usage/calicoctl/configure/index
 no_canonical: true
 ---
 

--- a/v3.0/usage/calicoctl/configure/kdd.md
+++ b/v3.0/usage/calicoctl/configure/kdd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to the Kubernetes API datastore
+redirect_from: latest/usage/calicoctl/configure/kdd
 no_canonical: true
 ---
 

--- a/v3.0/usage/calicoctl/install.md
+++ b/v3.0/usage/calicoctl/install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing calicoctl
+redirect_from: latest/usage/calicoctl/install
 no_canonical: true
 ---
 

--- a/v3.0/usage/configuration/as-service.md
+++ b/v3.0/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running calico/node with an init system
+redirect_from: latest/usage/configuration/as-service
 ---
 
 This guide explains how to run `calico/node` with an init system like

--- a/v3.0/usage/configuration/bgp.md
+++ b/v3.0/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+redirect_from: latest/usage/configuration/bgp
 ---
 
 This document describes the commands available in `calicoctl` for managing BGP.  It

--- a/v3.0/usage/configuration/conntrack.md
+++ b/v3.0/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+redirect_from: latest/usage/configuration/conntrack
 ---
 
 A common problem on Linux systems is running out of space in the

--- a/v3.0/usage/configuration/ip-in-ip.md
+++ b/v3.0/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+redirect_from: latest/usage/configuration/ip-in-ip
 ---
 
 If your network fabric performs source/destination address checks

--- a/v3.0/usage/configuration/mtu.md
+++ b/v3.0/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+redirect_from: latest/usage/configuration/mtu
 ---
 
 Depending on the environment Calico is being deployed into it may be

--- a/v3.0/usage/configuration/node.md
+++ b/v3.0/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+redirect_from: latest/usage/configuration/node
 ---
 
 By default, Calico automatically detects each Node's IP address and subnet.  In most cases,

--- a/v3.0/usage/decommissioning-a-node.md
+++ b/v3.0/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+redirect_from: latest/usage/decommissioning-a-node
 ---
 
 ### About decommissioning nodes

--- a/v3.0/usage/external-connectivity.md
+++ b/v3.0/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+redirect_from: latest/usage/external-connectivity
 ---
 Calico creates a routed network on which your containers look like normal IP
 speakers. You can connect to them from a host in your cluster (assuming the

--- a/v3.0/usage/index.md
+++ b/v3.0/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+redirect_from: latest/usage/index
 ---
 
 This section contains information on using Calico.

--- a/v3.0/usage/ipv6.md
+++ b/v3.0/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+redirect_from: latest/usage/ipv6
 ---
 
 Calico supports connectivity over IPv6, between compute hosts, and

--- a/v3.0/usage/routereflector/bird-rr-config.md
+++ b/v3.0/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+redirect_from: latest/usage/routereflector/bird-rr-config
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required. 

--- a/v3.0/usage/routereflector/calico-routereflector.md
+++ b/v3.0/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+redirect_from: latest/usage/routereflector/calico-routereflector
 ---
 
 For many Calico deployments, the use of a Route Reflector is not required.

--- a/v3.0/usage/troubleshooting/faq.md
+++ b/v3.0/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+redirect_from: latest/usage/troubleshooting/faq
 layout: docwithnav
 ---
 

--- a/v3.0/usage/troubleshooting/index.md
+++ b/v3.0/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+redirect_from: latest/usage/troubleshooting/index
 ---
 
 ## Running `sudo calicoctl ...` with Environment Variables

--- a/v3.0/usage/troubleshooting/logging.md
+++ b/v3.0/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+redirect_from: latest/usage/troubleshooting/logging
 ---
 
 ## The calico-node container


### PR DESCRIPTION
## Description

- Modifies version drop down to put v3.0 at the top and it also becomes latest
- Adds redirect_from latest tags to the v3.0 docs
- Removes redirect_from latest tags from the v2.6 docs
- Updates and corrects component version numbers in "master release stream" in versions.yml

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
