### PR TITLE
changed subtitle from BGP Peer Definition to BGP Configuration Defini…

### DIFF
--- a/master/reference/calicoctl/resources/bgpconfig.md
+++ b/master/reference/calicoctl/resources/bgpconfig.md
@@ -21,7 +21,7 @@ spec:
   asNumber: 63400
 ```
 
-### BGP Peer Definition
+### BGP Configuration Definition
 
 #### Metadata
 

--- a/v3.0/reference/calicoctl/resources/bgpconfig.md
+++ b/v3.0/reference/calicoctl/resources/bgpconfig.md
@@ -21,7 +21,7 @@ spec:
   asNumber: 63400
 ```
 
-### BGP Peer Definition
+### BGP Configuration Definition
 
 #### Metadata
 


### PR DESCRIPTION
…tion

## Description

The `BGPConfiguration` resource reference documentation contained a copy-and-paste mistake in the resource definition subtitle which erroneously read `BGP Peer Definition`.

This has been corrected to read `BGP Configuration Definition` in both the `master` and `v3.0` directories.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
