### PR TITLE
Remove networking-calico, calico-bgp-daemon, libnetwork-plugin v3.0

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -152,15 +152,6 @@ v3.0:
     calico-bird:
       version: v0.3.1
       url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
-    calico-bgp-daemon:
-      version: v0.2.1
-      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
-    libnetwork-plugin:
-      version: v1.1.0
-      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
-    networking-calico:
-      version: 1.4.3
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.3
     calico/routereflector:
       version: v0.5.0
       url: ""


### PR DESCRIPTION
## Description
Remove networking-calico, calico-bgp-daemon, libnetwork-plugin from v3.0 release

## Release Note


```release-note
None required
```
