### PR TITLE
Fix link to RR release

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -154,7 +154,7 @@ v3.0:
       url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
     calico/routereflector:
       version: v0.5.0
-      url: ""
+      url: https://github.com/projectcalico/routereflector/releases/tag/v0.5.0
 
 - title: v3.0.0-beta1
   note: |


### PR DESCRIPTION
## Description
On releases page https://docs.projectcalico.org/v3.0/releases/ link to RR release 0.5.0 links back to the releases page instead of to the github RR repo.

## Release Note
```release-note
None required
```
