### PR TITLE
release v2.6.5

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,7 +1,11 @@
 v2.6:
-- title: v2.6.4
+- title: v2.6.5
   note: |
-    20 December 2017
+    22 December 2017
+
+    - Resolves an issue which led to very brief loss of connectivity
+      after upgrading to v3.0.0 from v2.6.4 when using an etcd datastore.
+      [https://github.com/projectcalico/felix/pull/1676]
 
     - Certain configuration changes no longer cause Felix to restart, allowing
       upgrades to Calico v3.0.0. [felix #1631](https://github.com/projectcalico/felix/pull/1631) (@fasaxc)
@@ -18,6 +22,53 @@ v2.6:
       that allows you to configure the MTU of veth endpoints when using the Docker orchestrator.
       [libnetwork-plugin #164](https://github.com/projectcalico/libnetwork-plugin/pull/164) (@ti-mo)
 
+  components:
+    felix:
+      version: 2.6.4
+      url: https://github.com/projectcalico/felix/releases/tag/2.6.4
+    typha:
+      version: v0.5.4
+      url: https://github.com/projectcalico/typha/releases/tag/v0.5.4
+    calicoctl:
+      version: v1.6.3
+      url: https://github.com/projectcalico/calicoctl/releases/tag/v1.6.3
+      download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.6.3/calicoctl
+    calico/node:
+      version: v2.6.5
+      url: https://github.com/projectcalico/calico/releases/tag/v2.6.5
+    calico/cni:
+      version: v1.11.2
+      url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.11.2
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.2/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.2/calico-ipam
+    confd:
+      version: v0.12.1-calico-0.4.3
+      url: https://github.com/projectcalico/confd/releases/tag/v0.12.1-calico-0.4.3
+    libnetwork-plugin:
+      version: v1.1.2
+      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.2
+    calico/kube-controllers:
+      version: v1.0.2
+      url: https://github.com/projectcalico/k8s-policy/releases/tag/v1.0.2
+    calico-bird:
+      version: v0.3.1
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
+    calico-bgp-daemon:
+      version: v0.2.1
+      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
+    networking-calico:
+      version: 1.4.3
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.3
+    calico/routereflector:
+      version: v0.4.2
+      url: ""
+
+- title: v2.6.4
+  note: |
+    20 December 2017
+
+    - This release has an issue which causes rolling upgrades to not work properly. We
+      recommend that you use v2.6.5 instead.
   components:
     felix:
       version: 2.6.3


### PR DESCRIPTION
## Description

release v2.6.5 - bumps felix to 2.6.4 and RR to v0.4.2. Also mentions the rolling upgrade fix we're shipping and disavows v2.6.4.


## Todos

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
