### PR TITLE
remove unused components from release notes for v3.0.1

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -171,15 +171,15 @@ v3.0:
     calico/routereflector:
       version: v0.5.0
       url: https://github.com/projectcalico/routereflector/releases/tag/v0.5.0
-    calico-bgp-daemon:
-      version: v0.2.1
-      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
-    libnetwork-plugin:
-      version: v1.1.0
-      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
-    networking-calico:
-      version: 1.4.3
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.3
+    #calico-bgp-daemon:
+    #  version: v0.2.1
+    #  url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
+    #libnetwork-plugin:
+    #  version: v1.1.0
+    #  url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.0
+    #networking-calico:
+    #  version: 1.4.3
+    #  url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.3
       
 - title: v3.0.0
   note: |


### PR DESCRIPTION
## Description

Remove unused components from release notes for v3.0.1

## Todos

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
