### PR TITLE
Adding support for ppc64le.

### DIFF
--- a/calico_node/Dockerfile-ppc64le
+++ b/calico_node/Dockerfile-ppc64le
@@ -1,0 +1,27 @@
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright IBM Corp. 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM ppc64le/alpine
+MAINTAINER David Wilder <wilder@us.ibm.com>
+
+# Set the minimum Docker API version required for libnetwork.
+ENV DOCKER_API_VERSION 1.21
+
+# Install remaining runtime deps required for felix from the global repository
+RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools runit file
+
+# Copy in the filesystem - this contains felix, bird, gobgp etc...
+COPY filesystem /
+
+CMD ["start_runit"]

--- a/calico_node/calico_test/Dockerfile-ppc64le.calico_test
+++ b/calico_node/calico_test/Dockerfile-ppc64le.calico_test
@@ -1,0 +1,60 @@
+# Copyright (c) 2015 Tigera, Inc. All rights reserved.
+# Copyright IBM Corp. 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+### calico/test
+# This image is used by various calico repositories and components to run UTs
+# and STs. It has libcalico, nose, and other common python libraries
+# already installed
+#
+# For UTs:
+#  - volume mount in python code that uses libcalico
+#  - volume mount in your unit tests for this code
+#  - run 'nosetests'
+#
+# This container can also be used for running STs written in python. This
+# eliminates all dependencies besides docker on the host system to enable
+# running of the ST frameworks.
+# To run:
+# - volume mount the docker socket, allowing the STs to launch docker
+#   containers alongside itself.
+# - eliminate most isolation, (--uts=host --pid=host --net=host --privileged)
+# - volume mount your ST source code
+# - run 'nosetests'
+FROM ppc64le/alpine:3.6
+MAINTAINER David Wilder <wilder@us.ibm.com>
+
+# Running STs in this container requires that it has all dependencies installed
+# for executing the tests. Install these dependencies:
+RUN apk add --update python python-dev py2-pip py-setuptools openssl-dev libffi-dev tshark \
+         netcat-openbsd iptables ip6tables iproute2 iputils ipset curl docker && \
+         echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
+         rm -rf /var/cache/apk/*
+
+COPY requirements.txt /requirements.txt
+RUN pip install -r /requirements.txt
+
+RUN   apk update \
+&&   apk add ca-certificates wget \
+&&   update-ca-certificates
+
+# Install etcdctl
+RUN wget https://github.com/coreos/etcd/releases/download/v3.2.4/etcd-v3.2.4-linux-ppc64le.tar.gz && \
+	tar -xzf etcd-v3.2.4-linux-ppc64le.tar.gz && \
+	cd etcd-v3.2.4-linux-ppc64le && \
+	ln -s etcdctl /usr/local/bin/
+
+# The container is used by mounting the code-under-test to /code
+WORKDIR /code/

--- a/calico_node/workload/Dockerfile-ppc64le
+++ b/calico_node/workload/Dockerfile-ppc64le
@@ -1,0 +1,11 @@
+# Copyright IBM Corp. 2017
+FROM ppc64le/alpine:3.6
+MAINTAINER David Wilder <wilder@us.ibm.com>
+
+RUN apk add --no-cache \
+    python \
+    netcat-openbsd
+COPY udpping.sh tcpping.sh responder.py /code/
+WORKDIR /code/
+RUN chmod +x udpping.sh && chmod +x tcpping.sh
+CMD ["python", "responder.py"]


### PR DESCRIPTION
Adding support for ppc64le build.

Updating the calico/node Makefile and adding Dockerfiles for ppc64le.

The build architecture is select by setting the ARCH environment variable.
For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
When ARCH is undefined builds defaults to amd64.
