### PR TITLE
Highlight the importance (and utility) of expectedIPs on hostendpoints

### DIFF
--- a/master/reference/calicoctl/resources/hostendpoint.md
+++ b/master/reference/calicoctl/resources/hostendpoint.md
@@ -13,6 +13,11 @@ any policy.
 For `calicoctl` [commands]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/) that specify a resource type on the CLI, the following
 aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
 
+> **Important**: When rendering security rules on other hosts, {{site.prodname}} uses the
+> `expectedIPs` field to resolve label selectors to IP addresses. If the `expectedIPs` field
+> is omitted then security rules that use labels will fail to match this endpoint.
+{: .alert .alert-danger}
+
 ### Sample YAML
 
 ```yaml

--- a/v2.6/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.6/reference/calicoctl/resources/hostendpoint.md
@@ -13,6 +13,11 @@ any policy.
 For `calicoctl` commands that specify a resource type on the CLI, the following
 aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
 
+> **Important**: When rendering security rules on other hosts, Calico uses the
+> `expectedIPs` field to resolve label selectors to IP addresses. If the `expectedIPs` field
+> is omitted then security rules that use labels will fail to match this endpoint.
+{: .alert .alert-danger}
+
 ### Sample YAML
 
 ```yaml

--- a/v3.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.0/reference/calicoctl/resources/hostendpoint.md
@@ -14,6 +14,11 @@ any policy.
 For `calicoctl` [commands]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/) that specify a resource type on the CLI, the following
 aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
 
+> **Important**: When rendering security rules on other hosts, {{site.prodname}} uses the
+> `expectedIPs` field to resolve label selectors to IP addresses. If the `expectedIPs` field
+> is omitted then security rules that use labels will fail to match this endpoint.
+{: .alert .alert-danger}
+
 ### Sample YAML
 
 ```yaml


### PR DESCRIPTION
## Description

Small change to at least mention what `expectedIPs` is used for. This cost me too much time to figure out. The user is left guessing why the parameter is required and what its purpose is.

`hostEndpoint` documentation is spread out across multiple [blog](https://blog.tigera.io/securing-host-endpoints-with-project-calico-2591113ab99c) [posts](https://blog.tigera.io/securing-host-endpoints-with-project-calico-part-2-1e773e56c92d) and some sections in `getting-started/bare-metal`.

## Todos

- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added warning to the documentation of hostEndpoint to explain the purpose of the expectedIPs field.
```