### PR TITLE
Configure k8s node references in startup.go

### DIFF
--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -127,6 +127,8 @@ func main() {
 		configureASNumber(node)
 	}
 
+	configureNodeRef(node)
+
 	// Check expected filesystem
 	ensureFilesystemAsExpected()
 
@@ -151,6 +153,20 @@ func main() {
 
 	// Tell the user what the name of the node is.
 	log.Infof("Using node name: %s", nodeName)
+}
+
+// configureNodeRef will attempt to discover the cluster type it is running on, check to ensure we
+// have not already set it on this Node, and set it if need be.
+func configureNodeRef(node *api.Node) {
+	orchestrator := "k8s"
+	nodeRef := ""
+
+	// Sort out what type of cluster we're running on.
+	if nodeRef = os.Getenv("CALICO_K8S_NODE_REF"); nodeRef == "" {
+		return
+	}
+
+	node.Spec.OrchRefs = []api.OrchRef{api.OrchRef{NodeName: nodeRef, Orchestrator: orchestrator}}
 }
 
 // CreateOrUpdate creates the Node if ResourceVersion is not specified,


### PR DESCRIPTION
## Description

From https://github.com/projectcalico/calico/pull/1271/files

Updates startup.go to set node references when running in k8s.

Fixes #1592 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
