### PR TITLE
Variablize  remaining "calico-node" occurrences

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -88,14 +88,14 @@ data:
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system
   labels:
-    k8s-app: calico-node
+    k8s-app: {{site.noderunning}}
 spec:
   selector:
     matchLabels:
-      k8s-app: calico-node
+      k8s-app: {{site.noderunning}}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -103,7 +103,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: calico-node
+        k8s-app: {{site.noderunning}}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: |
@@ -111,15 +111,15 @@ spec:
            {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
-      serviceAccountName: calico-node
+      serviceAccountName: {{site.noderunning}}
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       containers:
-        # Runs calico/node container on each Kubernetes node.  This
+        # Runs {{site.nodecontainer}} container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
-        - name: calico-node
+        - name: {{site.noderunning}}
           image: {{site.imageNames["node"]}}:{{site.data.versions[page.version].first.title}}
           env:
             # The location of the Calico etcd cluster.
@@ -345,5 +345,5 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
@@ -147,14 +147,14 @@ spec:
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system
   labels:
-    k8s-app: calico-node
+    k8s-app: {{site.noderunning}}
 spec:
   selector:
     matchLabels:
-      k8s-app: calico-node
+      k8s-app: {{site.noderunning}}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -162,7 +162,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: calico-node
+        k8s-app: {{site.noderunning}}
       annotations:
         # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
         # reserves resources for critical add-on pods so that they can be rescheduled after
@@ -187,10 +187,10 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       containers:
-        # Runs calico/node container on each Kubernetes node.  This
+        # Runs {{site.nodecontainer}} container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
-        - name: calico-node
+        - name: {{site.noderunning}}
           image: {{site.imageNames["node"]}}:{{site.data.versions[page.version].first.title}}
           env:
             # The location of the Calico etcd cluster.

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -108,7 +108,7 @@ spec:
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       hostNetwork: true
-      serviceAccountName: calico-node
+      serviceAccountName: {{site.noderunning}}
       containers:
       - image: {{site.imageNames["typha"]}}:{{site.data.versions[page.version].first.components["typha"].version}}
         name: calico-typha
@@ -159,14 +159,14 @@ spec:
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system
   labels:
-    k8s-app: calico-node
+    k8s-app: {{site.noderunning}}
 spec:
   selector:
     matchLabels:
-      k8s-app: calico-node
+      k8s-app: {{site.noderunning}}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -174,7 +174,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: calico-node
+        k8s-app: {{site.noderunning}}
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets
@@ -183,7 +183,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
-      serviceAccountName: calico-node
+      serviceAccountName: {{site.noderunning}}
       tolerations:
         # Allow the pod to run on the master.  This is required for
         # the master to communicate with pods.
@@ -196,10 +196,10 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       containers:
-        # Runs calico/node container on each Kubernetes node.  This
+        # Runs {{site.nodecontainer}} container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
-        - name: calico-node
+        - name: {{site.noderunning}}
           image: {{site.imageNames["node"]}}:{{site.data.versions[page.version].first.title}}
           env:
             # Use Kubernetes API as the backing datastore.
@@ -435,5 +435,5 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -108,7 +108,7 @@ spec:
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       hostNetwork: true
-      serviceAccountName: calico-node
+      serviceAccountName: {{site.noderunning}}
       containers:
       - image: {{site.imageNames["typha"]}}:{{site.data.versions[page.version].first.components["typha"].version}}
         name: calico-typha
@@ -159,14 +159,14 @@ spec:
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system
   labels:
-    k8s-app: calico-node
+    k8s-app: {{site.noderunning}}
 spec:
   selector:
     matchLabels:
-      k8s-app: calico-node
+      k8s-app: {{site.noderunning}}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -174,7 +174,7 @@ spec:
   template:
     metadata:
       labels:
-        k8s-app: calico-node
+        k8s-app: {{site.noderunning}}
       annotations:
         # This, along with the CriticalAddonsOnly toleration below,
         # marks the pod as a critical add-on, ensuring it gets
@@ -183,7 +183,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       hostNetwork: true
-      serviceAccountName: calico-node
+      serviceAccountName: {{site.noderunning}}
       tolerations:
         # Allow the pod to run on the master.  This is required for
         # the master to communicate with pods.
@@ -199,7 +199,7 @@ spec:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
         # host.
-        - name: calico-node
+        - name: {{site.noderunning}}
           image: {{site.imageNames["node"]}}:{{site.data.versions[page.version].first.title}}
           env:
             # Use Kubernetes API as the backing datastore.
@@ -416,5 +416,5 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system

--- a/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -6,7 +6,7 @@ layout: null
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
 rules:
   - apiGroups: [""]
     resources:
@@ -76,12 +76,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico-node
+  name: {{site.noderunning}}
 subjects:
 - kind: ServiceAccount
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system

--- a/master/getting-started/kubernetes/installation/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/rbac.yaml
@@ -41,7 +41,7 @@ subjects:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
 rules:
   - apiGroups: [""]
     resources:
@@ -55,12 +55,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: calico-node
+  name: {{site.noderunning}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: calico-node
+  name: {{site.noderunning}}
 subjects:
 - kind: ServiceAccount
-  name: calico-node
+  name: {{site.noderunning}}
   namespace: kube-system

--- a/master/getting-started/kubernetes/upgrade/downgrade.md
+++ b/master/getting-started/kubernetes/upgrade/downgrade.md
@@ -54,7 +54,7 @@ follow the steps here to downgrade.
 1. Use the following commands to initiate a downgrade of the {{site.prodname}} components.
 
    ```
-   kubectl rollout undo ds/calico-node -n kube-system
+   kubectl rollout undo ds/{{site.noderunning}} -n kube-system
    kubectl rollout undo deployment/calico-kube-controllers -n kube-system
    ```
 
@@ -63,7 +63,7 @@ follow the steps here to downgrade.
 
    ```
    kubectl rollout status deployment/calico-kube-controllers -n kube-system
-   kubectl rollout status ds/calico-node -n kube-system
+   kubectl rollout status ds/{{site.noderunning}} -n kube-system
    ```
 
 ## Downgrading a self-hosted installation that uses the Kubernetes API datastore
@@ -71,14 +71,14 @@ follow the steps here to downgrade.
 1. Use the following commands to initiate a downgrade of the {{site.prodname}} components.
 
    ```
-   kubectl rollout undo ds/calico-node -n kube-system
+   kubectl rollout undo ds/{{site.noderunning}} -n kube-system
    ```
 
 1. Watch the status of the downgrade as follows. When it reports complete and
    a successful, {{site.prodname}} is downgraded to the previous version.
 
    ```
-   kubectl rollout status ds/calico-node -n kube-system
+   kubectl rollout status ds/{{site.noderunning}} -n kube-system
    ```
 
 ## Downgrading a custom installation

--- a/master/getting-started/kubernetes/upgrade/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade/upgrade.md
@@ -52,15 +52,15 @@ and your datastore type.
    Verify that the status of all {{site.prodname}} pods indicate `Running`.
 
    ```
-   calico-node-hvvg8                          2/2       Running   0          3m
-   calico-node-vm8kh                          2/2       Running   0          3m
-   calico-node-w92wk                          2/2       Running   0          3m
+   {{site.noderunning}}-hvvg8                          2/2       Running   0          3m
+   {{site.noderunning}}-vm8kh                          2/2       Running   0          3m
+   {{site.noderunning}}-w92wk                          2/2       Running   0          3m
    ```
 
 1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
 
    ```
-   kubectl exec -n kube-system calico-node-hvvg8 versions
+   kubectl exec -n kube-system {{site.noderunning}}-hvvg8 versions
    ```
    
    It should return `v3.0.x`.
@@ -96,9 +96,9 @@ and your datastore type.
 
    ```
    calico-kube-controllers-6d4b9d6b5b-wlkfj   1/1       Running   0          3m
-   calico-node-hvvg8                          1/2       Running   0          3m
-   calico-node-vm8kh                          1/2       Running   0          3m
-   calico-node-w92wk                          1/2       Running   0          3m
+   {{site.noderunning}}-hvvg8                          1/2       Running   0          3m
+   {{site.noderunning}}-vm8kh                          1/2       Running   0          3m
+   {{site.noderunning}}-w92wk                          1/2       Running   0          3m
    ```
 
    > **Tip**: The {{site.noderunning}} pods will report `1/2` in the `READY` column, as shown.
@@ -111,7 +111,7 @@ and your datastore type.
 1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
 
    ```
-   kubectl exec -n kube-system calico-node-hvvg8 versions
+   kubectl exec -n kube-system {{site.noderunning}}-hvvg8 versions
    ```
    
    It should return `v3.0.x`.


### PR DESCRIPTION
## Description
While "calico-node" was changed to use `{{site.noderunning}}` in most of the docs, it wasn't updated to be used in the manifest itself, leading to inaccurate docs if this site.noderunning variable was ever changed.

1. Is using `site.noderunning` okay as the Daemonset name or should I create a new variable for this. This could however create other inconsistencies if this new variable and noderunning got changed.
2. Same type of question for plugging a variable in place of the service account name across manifests.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
