### PR TITLE
Change the bgpPeer yaml SPEC

### DIFF
--- a/master/usage/routereflector/calico-routereflector.md
+++ b/master/usage/routereflector/calico-routereflector.md
@@ -197,6 +197,7 @@ apiVersion: projectcalico.org/v3
 kind: BGPPeer
 metadata:
   name: bgppeer-global
+spec:
   peerIP: <IP_RR>
   asNumber: <AS_NUM>
 EOF

--- a/v3.0/usage/routereflector/calico-routereflector.md
+++ b/v3.0/usage/routereflector/calico-routereflector.md
@@ -196,6 +196,7 @@ apiVersion: projectcalico.org/v3
 kind: BGPPeer
 metadata:
   name: bgppeer-global
+spec:
   peerIP: <IP_RR>
   asNumber: <AS_NUM>
 EOF


### PR DESCRIPTION
Change bgpPeer yaml spec to reflect the right configuration.

## Description

This PR is just a Documentation ajustment.

The YAML specified does not have the 'spec' field, failing to be created.

I've tested this in my environment (k8s 1.8 and Calico 3) and works fine.

## Todos

- [x] Tests
- [x] Documentation
- [ ] Release note

