### PR TITLE
Replace extensions/v1beta1 with networking.k8s.io.

### DIFF
--- a/calico_node/glide.lock
+++ b/calico_node/glide.lock
@@ -1,5 +1,5 @@
-hash: 99087d67ed904c18d048172d8585ae1d442c2f5dc6b3cbdfca012bb70343baa1
-updated: 2017-12-19T18:52:53.532002242Z
+hash: 38ba04fd46d5bb51f94cae75b1dbff184dcf1dabe0f9201ce1d36e287d2c8694
+updated: 2018-01-17T15:45:59.894183024-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -142,7 +142,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: c893efa28eb45626cdaa76c9f653b62488858837
+  version: 003f63b7f4cff3fc95357005358af2de0f5fe152
   subpackages:
   - format
   - internal/assertion
@@ -168,7 +168,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 7c2de5ed8c029f222d87fc849b54c4075ef3173f
+  version: d725fa5db923e8abe1430a74ce4e38f6bee6573a
   subpackages:
   - lib/api
   - lib/apiconfig
@@ -236,7 +236,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
   version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/pflag
@@ -246,7 +246,7 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: 9419663f5a44be8b34ca85f08abc5fe1be11f8a3
+  version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -272,10 +272,9 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 314a259e304ff91bd6985da2a7149bbf91237993
+  version: e48874b42435b4347fc52bdee0424a52abc974d7
   subpackages:
   - unix
-  - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
@@ -334,7 +333,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 9b9dca205a15b6ce9ef10091f05d60a13fdcf418
+  version: 389dfa299845bcf399c16af89987e8775718ea48
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -361,7 +360,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 5134afd2c0c91158afac0d8a28bd2177185a3bcc
+  version: bc110fd540ab678abbf2bc71d9ce908eb9325ef6
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/calico_node/glide.yaml
+++ b/calico_node/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: ^1.0.3
 - package: github.com/projectcalico/libcalico-go
-  version: 7c2de5ed8c029f222d87fc849b54c4075ef3173f
+  version: d725fa5db923e8abe1430a74ce4e38f6bee6573a
   subpackages:
   - lib/api
   - lib/client

--- a/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -53,6 +53,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - globalfelixconfigs

--- a/master/getting-started/kubernetes/installation/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/rbac.yaml
@@ -22,6 +22,13 @@ rules:
     verbs:
       - watch
       - list
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/master/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/master/getting-started/kubernetes/tutorials/simple-policy.md
@@ -51,7 +51,7 @@ Running the following command creates a NetworkPolicy which implements a default
 ```
 kubectl create -f - <<EOF
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny
   namespace: policy-demo
@@ -89,7 +89,7 @@ Create a network policy `access-nginx` with the following contents:
 ```
 kubectl create -f - <<EOF
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: access-nginx
   namespace: policy-demo

--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui-client.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/allow-ui-client.yaml
@@ -1,5 +1,5 @@
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1 
+apiVersion: networking.k8s.io/v1
 metadata:
   namespace: client 
   name: allow-ui 

--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/backend-policy.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/backend-policy.yaml
@@ -1,5 +1,5 @@
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   namespace: stars
   name: backend-policy

--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/default-deny.yaml
@@ -1,5 +1,5 @@
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny
 spec:

--- a/master/getting-started/kubernetes/tutorials/stars-policy/policies/frontend-policy.yaml
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/policies/frontend-policy.yaml
@@ -1,5 +1,5 @@
 kind: NetworkPolicy
-apiVersion: extensions/v1beta1 
+apiVersion: networking.k8s.io/v1
 metadata:
   namespace: stars
   name: frontend-policy


### PR DESCRIPTION
## Description

Replace extensions/v1beta1 with networking.k8s.io.

See projectcalico/libcalico-go#704

## Todos

- [ ] Tests
- [ ] Documentation
- [ x] Release note

## Release Note

```release-note
Use networking.k8s.io api in place of deprecated extensions/v1beta1.
```
