### PR TITLE
Pass the routereflector image name to system test.

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -106,6 +106,8 @@ LIBNETWORK_PLUGIN_REPO?=calico/libnetwork-plugin
 LIBNETWORK_PLUGIN_CONTAINER_NAME?=$(LIBNETWORK_PLUGIN_REPO)$(ARCHTAG):$(LIBNETWORK_PLUGIN_VER)
 CTL_CONTAINER_NAME?=calico/ctl$(ARCHTAG):$(CALICOCTL_VER)
 
+RR_CONTAINER_NAME?=calico/routereflector$(ARCHTAG)
+
 STARTUP_DIR=$(NODE_CONTAINER_DIR)/startup
 STARTUP_FILES=$(shell find $(STARTUP_DIR) -name '*.go')
 ALLOCATE_IPIP_DIR=$(NODE_CONTAINER_DIR)/allocateipip
@@ -424,7 +426,7 @@ st: dist/calicoctl dist/calicoctl-v1.0.2 busybox.tar routereflector.tar calico-n
 	           -e DEBUG_FAILURES=$(DEBUG_FAILURES) \
 	           -e MY_IP=$(LOCAL_IP_ENV) \
 	           -e NODE_CONTAINER_NAME=$(NODE_CONTAINER_NAME) \
-	           -e RR_VER=$(RR_VER) \
+		   -e RR_CONTAINER_NAME=$(RR_CONTAINER_NAME):$(RR_VER) \
 	           --rm -t \
 	           -v /var/run/docker.sock:/var/run/docker.sock \
 	           -v $(SOURCE_DIR):/code \
@@ -453,6 +455,7 @@ st-ssl: run-etcd-ssl dist/calicoctl busybox.tar calico-node.tar routereflector.t
 	           -e DEBUG_FAILURES=$(DEBUG_FAILURES) \
 	           -e MY_IP=$(LOCAL_IP_ENV) \
 	           -e NODE_CONTAINER_NAME=$(NODE_CONTAINER_NAME) \
+		   -e RR_CONTAINER_NAME=$(RR_CONTAINER_NAME):$(RR_VER) \
 	           -e ETCD_SCHEME=https \
 	           -e ETCD_CA_CERT_FILE=$(SOURCE_DIR)/certs/ca.pem \
 	           -e ETCD_CERT_FILE=$(SOURCE_DIR)/certs/client.pem \

--- a/calico_node/tests/st/utils/route_reflector.py
+++ b/calico_node/tests/st/utils/route_reflector.py
@@ -50,7 +50,7 @@ class RouteReflectorCluster(object):
                 #
                 # See https://github.com/projectcalico/calico-bird/tree/feature-ipinip/build_routereflector
                 # for details.
-                rr_ver = os.getenv("RR_VER", "latest")
+		rr_container_name = os.getenv("RR_CONTAINER_NAME", "calico/routereflector:latest")
                 if os.getenv("ETCD_SCHEME", None) == "https":
                     # Etcd is running with SSL/TLS, pass the key values
                     rr.execute("docker run --privileged --net=host -d "
@@ -60,9 +60,9 @@ class RouteReflectorCluster(object):
                                "-e ETCD_CERT_FILE=%s "
                                "-e ETCD_KEY_FILE=%s "
                                "-v %s/certs:%s/certs "
-                               "calico/routereflector:%s" %
+                               "%s" %
                                (ip_env, ETCD_HOSTNAME_SSL, ETCD_CA, ETCD_CERT,
-                                ETCD_KEY, CHECKOUT_DIR, CHECKOUT_DIR, rr_ver))
+                                ETCD_KEY, CHECKOUT_DIR, CHECKOUT_DIR, rr_container_name))
                     rr.execute(r'curl --cacert %s --cert %s --key %s '
                                r'-L https://%s:2379/v2/keys/calico/bgp/v1/rr_v4/%s '
                                r'-XPUT -d value="{'
@@ -76,7 +76,7 @@ class RouteReflectorCluster(object):
                     rr.execute("docker run --privileged --net=host -d "
                            "--name rr %s "
                            "-e ETCD_ENDPOINTS=http://%s:2379 "
-                           "calico/routereflector:%s" % (ip_env, get_ip(), rr_ver))
+                           "%s" % (ip_env, get_ip(), rr_container_name))
                     rr.execute(r'curl -L http://%s:2379/v2/keys/calico/bgp/v1/rr_v4/%s '
                                r'-XPUT -d value="{'
                                  r'\"ip\":\"%s\",'


### PR DESCRIPTION
Allows st to run on other architectures or for
the default rr container name to be specified.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Previously the of the routereflector image name was hard coded in calico_node/tests/st/utils/route_reflector.py.   This change adds the environment variable RR_CONTAINER_NAME to the Makefile setting to the architecture specific name of the image.  RR_CONTAINER_NAME is then passed to the system test container.

I tested on both amd64 and ppc64le with:
RELEASE_STREAM=master make st