### PR TITLE
Make cfssl an independent build target.

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -337,15 +337,17 @@ HOST_CHECKOUT_DIR?=$(shell pwd)
 
 # curl should failed on 404
 CURL=curl -sSf
-## Generate the keys and certificates for running etcd with SSL.
-ssl-certs: certs/.certificates.created    ## Generate self-signed SSL certificates
-certs/.certificates.created:
+
+certs/cfssl certs/cfssljson:
 	mkdir -p certs
 	$(CURL) -L "https://github.com/projectcalico/cfssl/releases/download/1.2.1/cfssl" -o certs/cfssl
 	$(CURL) -L "https://github.com/projectcalico/cfssl/releases/download/1.2.1/cfssljson" -o certs/cfssljson
 	chmod a+x certs/cfssl
 	chmod a+x certs/cfssljson
 
+## Generate the keys and certificates for running etcd with SSL.
+ssl-certs: certs/.certificates.created    ## Generate self-signed SSL certificates
+certs/.certificates.created: certs/cfssl certs/cfssljson
 	certs/cfssl gencert -initca tests/st/ssl-config/ca-csr.json | certs/cfssljson -bare certs/ca
 	certs/cfssl gencert \
 	  -ca certs/ca.pem \


### PR DESCRIPTION
Allowing cfssl and cfssljson to be pre-loaded
to override the default version or architecture.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Moved the downloading of certs/cfssl certs/cfssljson to their own targets.  This allows me to pre-load binaries matching the build architecture. 

Tested on both amd64 and ppc64le with:
ST_TO_RUN=tests/st/policy RELEASE_STREAM=master make st-ssl

