### PR TITLE
Add IPIP route scan test

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -2159,8 +2159,8 @@ master:
       download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.0/calico
       download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.0/calico-ipam
      calico-bird:
-      version: v0.3.1
-      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
+      version: v0.3.2
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.2
      confd:
       version: master
      calico-bgp-daemon:


### PR DESCRIPTION
## Description

This PR adds another IPIP test to check that bird correctly fixes up non-IPIP routes (that were previously over the tunnel) during bird startup. 

This PR includes a rev of bird to 0.3.2 (which includes the route scan fix).  Without the bird rev the ST fails.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes #1584 - this updates the bird revision to fix a route scan issue where upon startup bird did not spot that an tunneled route needed to be updated to be non-tunneled.
```