### PR TITLE
move to networkingv1 in place of extensions/v1beta1

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
@@ -441,6 +441,13 @@ rules:
     verbs:
       - watch
       - list
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
 
 ---
 


### PR DESCRIPTION
## Description
Move to networkingv1 in place of extensions/v1beta1. I missed updating the kubeadm/hosted manifest and we were getting permissions error on the new api. 

## Todos


## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
