### PR TITLE
Rev bird to 0.3.2 and add IPIP test to check route scan processing works correctly

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1731,8 +1731,8 @@ master:
       download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.1/calico
       download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.1/calico-ipam
      calico-bird:
-      version: v0.3.1
-      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.1
+      version: v0.3.2
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.2
      confd:
       version: v2.6.x-dev
      calico-bgp-daemon:

--- a/calico_node/tests/st/bgp/test_ipip.py
+++ b/calico_node/tests/st/bgp/test_ipip.py
@@ -14,6 +14,7 @@
 import json
 import re
 import subprocess
+import logging
 
 from netaddr import IPAddress, IPNetwork
 from nose_parameterized import parameterized
@@ -25,6 +26,8 @@ from tests.st.utils.utils import check_bird_status, retry_until_success
 from time import sleep
 
 from .peer import create_bgp_peer
+
+logger = logging.getLogger(__name__)
 
 """
 Test calico IPIP behaviour.
@@ -166,6 +169,88 @@ class TestIPIP(TestBase):
             self.pool_action(host, "create", new_ipv4_pool, True)
             self.pool_action(host, "delete", ipv4_pool, True)
             self.assert_tunl_ip(host, new_ipv4_pool)
+
+    @parameterized.expand([
+        ('bird',),
+        #('gobgp',),  # See issue https://github.com/projectcalico/calico-bgp-daemon/issues/37
+    ])
+    def test_issue_1584(self, backend):
+        """
+        Test cold start of bgp daemon correctly fixes tunl/non-tunl routes.
+
+        This test modifies the working IPIP mode of the pool and monitors the
+        traffic flow to ensure it either is or is not going over the IPIP
+        tunnel as expected.
+        """
+        with DockerHost('host1',
+                        additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,
+                        start_calico=False) as host1, \
+             DockerHost('host2',
+                        additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,
+                        start_calico=False) as host2:
+
+            # Create an IP pool with IP-in-IP disabled.
+            self.pool_action(host1, "create", DEFAULT_IPV4_POOL_CIDR, False)
+
+            # Autodetect the IP addresses - this should ensure the subnet is
+            # correctly configured.
+            host1.start_calico_node("--ip=autodetect --backend={0}".format(backend))
+            host2.start_calico_node("--ip=autodetect --backend={0}".format(backend))
+
+            # Create a network and a workload on each host.
+            network1 = host1.create_network("subnet1")
+            workload_host1 = host1.create_workload("workload1",
+                                                   network=network1)
+            workload_host2 = host2.create_workload("workload2",
+                                                   network=network1)
+
+            # Allow network to converge.
+            self.assert_true(
+                workload_host1.check_can_ping(workload_host2.ip, retries=10))
+
+            # Check connectivity in both directions
+            self.assert_ip_connectivity(workload_list=[workload_host1,
+                                                       workload_host2],
+                                        ip_pass_list=[workload_host1.ip,
+                                                      workload_host2.ip])
+
+            # Turn on IPIP and check that IPIP tunnel is being used.
+            self.pool_action(host1, "replace", DEFAULT_IPV4_POOL_CIDR, True, ipip_mode="always")
+            self.assert_ipip_routing(host1, workload_host1, workload_host2,
+                                     True)
+
+            # Toggle the IPIP mode between being expecting IPIP and not.  Only the mode
+            # "Always" should result in IPIP tunnel being used in these tests.
+            modes = ["always"]
+            for mode in ["cross-subnet", "always", None, "always"]:
+                # At the start of this loop we should have connectivity.
+                logger.info("New mode setting: %s" % mode)
+                logger.info("Previous mode settings: %s" % modes)
+
+                # Shutdown the calico-node on host1, we should still have connectivity because
+                # the node was shut down without removing the routes.  Check tunnel usage based
+                # on the current IPIP mode (only a mode of Always will use the tunnel).
+                host1.execute("docker rm -f calico-node")
+                self.assert_ipip_routing(host1, workload_host1, workload_host2,
+                                         modes[-1] == "always")
+
+                # Update the IPIP mode.
+                self.pool_action(host1, "replace", DEFAULT_IPV4_POOL_CIDR, mode is not None, ipip_mode=mode)
+                modes.append(mode)
+
+                # At this point, since we are toggling between IPIP connectivity and no IPIP
+                # connectivity, there will be a mistmatch between the two nodes because host1
+                # does not have the BGP daemon running on it.
+                self.assert_ip_connectivity(workload_list=[workload_host1],
+                                            ip_pass_list=[],
+                                            ip_fail_list=[workload_host2.ip],
+                                            retries=10)
+
+                # Start the calico-node.  Connectivity should be restored once the BGP daemon
+                # on host1 fixes the route.
+                host1.start_calico_node("--ip=autodetect --backend={0}".format(backend))
+                self.assert_ipip_routing(host1, workload_host1, workload_host2,
+                                         modes[-1] == "always")
 
     def pool_action(self, host, action, cidr, ipip, disabled=False, ipip_mode="", calicoctl_version=None):
         """

--- a/calico_node/tests/st/test_base.py
+++ b/calico_node/tests/st/test_base.py
@@ -190,7 +190,7 @@ class TestBase(TestCase):
 
     @debug_failures
     def assert_ip_connectivity(self, workload_list, ip_pass_list,
-                               ip_fail_list=None, type_list=None):
+                               ip_fail_list=None, type_list=None, retries=0):
         """
         Assert partial connectivity graphs between workloads and given ips.
 
@@ -215,19 +215,19 @@ class TestBase(TestCase):
         for workload in workload_list:
             for ip in ip_pass_list:
                 if 'icmp' in type_list:
-                    conn_check_list.append((workload, ip, 'icmp', True, 0))
+                    conn_check_list.append((workload, ip, 'icmp', True, retries))
                 if 'tcp' in type_list:
-                    conn_check_list.append((workload, ip, 'tcp', True, 0))
+                    conn_check_list.append((workload, ip, 'tcp', True, retries))
                 if 'udp' in type_list:
-                    conn_check_list.append((workload, ip, 'udp', True, 0))
+                    conn_check_list.append((workload, ip, 'udp', True, retries))
 
             for ip in ip_fail_list:
                 if 'icmp' in type_list:
-                    conn_check_list.append((workload, ip, 'icmp', False, 0))
+                    conn_check_list.append((workload, ip, 'icmp', False, retries))
                 if 'tcp' in type_list:
-                    conn_check_list.append((workload, ip, 'tcp', False, 0))
+                    conn_check_list.append((workload, ip, 'tcp', False, retries))
                 if 'udp' in type_list:
-                    conn_check_list.append((workload, ip, 'udp', False, 0))
+                    conn_check_list.append((workload, ip, 'udp', False, retries))
 
         # Empirically, 18 threads works well on my machine!
         check_pool = ThreadPool(18)


### PR DESCRIPTION
## Description

v2.6.x cherrypick of #1624 

I have not included the go-bgp backend in the test because that also seems to be broken.  I've raised an issue for that against go bgp.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```