### PR TITLE
Add network sets CRDs and docs

### DIFF
--- a/_data/master/navbars/reference.yml
+++ b/_data/master/navbars/reference.yml
@@ -59,6 +59,8 @@ toc:
         path: /reference/calicoctl/resources/bgpconfig
       - title: Felix Configuration
         path: /reference/calicoctl/resources/felixconfig
+      - title: Global Network Set
+        path: /reference/calicoctl/resources/globalnetworkset
       - title: Host Endpoint
         path: /reference/calicoctl/resources/hostendpoint
       - title: IP Pool

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -419,6 +419,22 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global Network Sets
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Network Policies
 kind: CustomResourceDefinition
 metadata:

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -63,6 +63,7 @@ rules:
       - clusterinformations
       - felixconfigurations
       - globalnetworkpolicies
+      - globalnetworksets
       - ippools
       - networkpolicies
     verbs:

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -397,6 +397,22 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Global Network Sets
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Network Policies
 kind: CustomResourceDefinition
 metadata:

--- a/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -68,6 +68,7 @@ rules:
       - bgpconfigurations
       - ippools
       - globalnetworkpolicies
+      - globalnetworksets
       - networkpolicies
       - clusterinformations
     verbs:

--- a/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -68,6 +68,7 @@ component needs access to in etcd to function successfully.
 | /calico/ipam/v2/\*                                              |   R    |
 | /calico/resources/v3/projectcalico.org/\*                       |   R    |
 | /calico/resources/v3/projectcalico.org/globalnetworkpolicies/\* |   RW   |
+| /calico/resources/v3/projectcalico.org/globalnetworksets/\*     |   RW   |
 | /calico/resources/v3/projectcalico.org/networkpolicies/\*       |   RW   |
 | /calico/resources/v3/projectcalico.org/profiles/\*              |   RW   |
 

--- a/master/reference/calicoctl/resources/globalnetworkset.md
+++ b/master/reference/calicoctl/resources/globalnetworkset.md
@@ -1,0 +1,52 @@
+---
+title: Global Network Set Resource (GlobalNetworkSet)
+---
+
+A global network set resource (GlobalNetworkSet) represents an arbitrary set of IP subnetworks/CIDRs, 
+allowing it to be matched by {{site.prodname}} policy.  Network sets are useful for applying policy to traffic
+coming from (or going to) external, non-{{site.prodname}}, networks.
+
+The metadata for each network set includes a set of labels.  When {{site.prodname}} is calculating the set of
+IPs that should match a source/destination selector within a
+[global network policy]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/globalnetworkpolicy) rule, it includes
+the CIDRs from any network sets that match the selector.
+
+> **Important**: Since {{site.prodname}} matches packets based on their source/destination IP addresses, 
+> {{site.prodname}} rules may not behave as expected if there is NAT between the {{site.prodname}}-enabled node and the
+> networks listed in a network set.  For example, in Kubernetes, incoming traffic via a service IP is
+> typically SNATed by the kube-proxy before reaching the destination host so {{site.prodname}}'s workload 
+> policy will see the kube-proxy's host's IP as the source instead of the real source.
+{: .alert .alert-danger}
+
+For `calicoctl` commands that specify a resource type on the CLI, the following
+aliases are supported (all case insensitive): `globalnetworkset`, `globalnetworksets`.
+
+### Sample YAML
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkSet
+metadata:
+  name: a-name-for-the-set
+  labels:
+    role: external-database
+spec:
+  nets:
+  - 198.51.100.0/28
+  - 203.0.113.0/24
+```
+
+### GlobalNetworkSet Definition
+
+#### Metadata
+
+| Field       | Description                                | Accepted Values   | Schema  |
+|-------------|--------------------------------------------|-------------------|---------|
+| name        | The name of this network set.              | Lower-case alphanumeric with optional `-`  | string  |
+| labels      | A set of labels to apply to this endpoint. |                   | map     |
+
+#### Spec
+
+| Field       | Description                                  | Accepted Values                                         | Schema | Default    |
+|-------------|----------------------------------------------|---------------------------------------------------------|--------|------------|
+| nets        | The IP networks/CIDRs to include in the set. | Valid IPv4 or IPv6 CIDRs, for example "192.0.2.128/25"  | list   |            |


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Update the KDD manifests to include the new CRD.
- Add docs for the new resource type.

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note
- [x] Check links after merge from 2.x

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico now supports a new resource type, GlobalNetworkSet.  A GlobalNetworkSet contains a set of CIDRs with associated labels, which can be matched by GlobalNetworkPolicies.  This allows for rules to refer to external networks, possibly consisting of thousands of CIDRs.
```
