### PR TITLE
Default for ipv6Support is true, not false

### DIFF
--- a/master/reference/calicoctl/resources/felixconfig.md
+++ b/master/reference/calicoctl/resources/felixconfig.md
@@ -38,7 +38,7 @@ spec:
 
 | Field       | Description                 | Accepted Values   | Schema | Default    |
 |-------------|-----------------------------|-------------------|--------|------------|
-| ipv6Support | IPv6 support for Felix | true, false | boolean | `false` |
+| ipv6Support | IPv6 support for Felix | true, false | boolean | `true` |
 | logFilePath | The full path to the Felix log. Set to `""` to disable file logging. | string | string | `/var/log/calico/felix.log` |
 | logSeveritySys | The log severity above which logs are sent to the syslog. Set to `""` for no logging to syslog. | Debug, Info, Warning, Error, Fatal | string | `Info` |
 | logSeverityFile| The log severity above which logs are sent to the log file. | Same as `logSeveritySys` | string | `Info` |

--- a/v3.0/reference/calicoctl/resources/felixconfig.md
+++ b/v3.0/reference/calicoctl/resources/felixconfig.md
@@ -38,7 +38,7 @@ spec:
 
 | Field       | Description                 | Accepted Values   | Schema | Default    |
 |-------------|-----------------------------|-------------------|--------|------------|
-| ipv6Support | IPv6 support for Felix | true, false | boolean | `false` |
+| ipv6Support | IPv6 support for Felix | true, false | boolean | `true` |
 | logFilePath | The full path to the Felix log. Set to `""` to disable file logging. | string | string | `/var/log/calico/felix.log` |
 | logSeveritySys | The log severity above which logs are sent to the syslog. Set to `""` for no logging to syslog. | Debug, Info, Warning, Error, Fatal | string | `Info` |
 | logSeverityFile| The log severity above which logs are sent to the log file. | Same as `logSeveritySys` | string | `Info` |


### PR DESCRIPTION
At least I think so, because of
https://github.com/projectcalico/felix/blob/master/config/config_params.go#L111:
```
	Ipv6Support    bool `config:"bool;true"`
```

Also wondering if this is still true in https://github.com/projectcalico/calico/blob/master/master/getting-started/bare-metal/bare-metal-install.md:

"Felix tries to detect whether IPv6 is available on your platform but the detection can fail on older (or more unusual) systems."

@fasaxc ?