### PR TITLE
Adds canonical urls to v3.0 docs

### DIFF
--- a/v3.0/getting-started/bare-metal/bare-metal-install.md
+++ b/v3.0/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/bare-metal/bare-metal-install
 redirect_from: latest/getting-started/bare-metal/bare-metal-install
 ---
 

--- a/v3.0/getting-started/bare-metal/bare-metal.md
+++ b/v3.0/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/bare-metal/bare-metal
 redirect_from: latest/getting-started/bare-metal/bare-metal
 ---
 

--- a/v3.0/getting-started/index.md
+++ b/v3.0/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/
 redirect_from: latest/getting-started/index
 ---
 

--- a/v3.0/getting-started/kubernetes/index.md
+++ b/v3.0/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart for Calico on Kubernetes
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/
 redirect_from: latest/getting-started/kubernetes/index
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/aws.md
+++ b/v3.0/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/aws
 redirect_from: latest/getting-started/kubernetes/installation/aws
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/azure.md
+++ b/v3.0/getting-started/kubernetes/installation/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/azure
 redirect_from: latest/getting-started/kubernetes/installation/azure
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/gce.md
+++ b/v3.0/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/gce
 redirect_from: latest/getting-started/kubernetes/installation/gce
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/hosted
 redirect_from: latest/getting-started/kubernetes/installation/hosted/hosted
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/
 redirect_from: latest/getting-started/kubernetes/installation/hosted/index
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: kubeadm Hosted Install
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/
 redirect_from: latest/getting-started/kubernetes/installation/hosted/kubeadm/index
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes API datastore
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/
 redirect_from: latest/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/index.md
+++ b/v3.0/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/
 redirect_from: latest/getting-started/kubernetes/installation/index
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/integration.md
+++ b/v3.0/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/integration
 redirect_from: latest/getting-started/kubernetes/installation/integration
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v3.0/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/vagrant/
 redirect_from: latest/getting-started/kubernetes/installation/vagrant/index
 ---
 

--- a/v3.0/getting-started/kubernetes/troubleshooting.md
+++ b/v3.0/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/troubleshooting
 redirect_from: latest/getting-started/kubernetes/troubleshooting
 ---
 

--- a/v3.0/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v3.0/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Controlling ingress and egress traffic with network policy
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/advanced-policy
 redirect_from: latest/getting-started/kubernetes/tutorials/advanced-policy
 ---
 

--- a/v3.0/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v3.0/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/simple-policy
 redirect_from: latest/getting-started/kubernetes/tutorials/simple-policy
 ---
 

--- a/v3.0/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v3.0/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/stars-policy/
 redirect_from: latest/getting-started/kubernetes/tutorials/stars-policy/index
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v3.0/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v3.0/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/tutorials/using-calicoctl
 redirect_from: latest/getting-started/kubernetes/tutorials/using-calicoctl
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/convert.md
+++ b/v3.0/getting-started/kubernetes/upgrade/convert.md
@@ -1,5 +1,6 @@
 ---
 title: Converting your calicoctl manifests
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/convert
 ---
 
  Use `calicoctl convert` to convert your Calico resource manifests from v1 API to v3 API.

--- a/v3.0/getting-started/kubernetes/upgrade/delete.md
+++ b/v3.0/getting-started/kubernetes/upgrade/delete.md
@@ -1,5 +1,6 @@
 ---
 title: Deleting old data
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/delete
 redirect_from: latest/getting-started/kubernetes/upgrade/delete
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/downgrade.md
+++ b/v3.0/getting-started/kubernetes/upgrade/downgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Downgrading Calico
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/downgrade
 redirect_from: latest/getting-started/kubernetes/upgrade/downgrade
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/index.md
+++ b/v3.0/getting-started/kubernetes/upgrade/index.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/
 redirect_from: latest/getting-started/kubernetes/upgrade/
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/migrate.md
+++ b/v3.0/getting-started/kubernetes/upgrade/migrate.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating Calico data
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/migrate
 redirect_from: latest/getting-started/kubernetes/upgrade/migrate
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/setup.md
+++ b/v3.0/getting-started/kubernetes/upgrade/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and configuring calico-upgrade
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/setup
 redirect_from: latest/getting-started/kubernetes/upgrade/setup
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/test.md
+++ b/v3.0/getting-started/kubernetes/upgrade/test.md
@@ -1,5 +1,6 @@
 ---
 title: Testing the data migration
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/test
 redirect_from: latest/getting-started/kubernetes/upgrade/test
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/upgrade.md
+++ b/v3.0/getting-started/kubernetes/upgrade/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico 
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/upgrade
 redirect_from: latest/getting-started/kubernetes/upgrade/upgrade
 ---
 

--- a/v3.0/getting-started/openshift/installation.md
+++ b/v3.0/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+canonical_url: https://docs.projectcalico.org/v3.0/getting-started/openshift/installation
 redirect_from: latest/getting-started/openshift/installation
 ---
 

--- a/v3.0/index.html
+++ b/v3.0/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+canonical_url: https://docs.projectcalico.org/v3.0/
 redirect_from: latest/index.html
 description: Home
 layout: docwithnav

--- a/v3.0/introduction/index.md
+++ b/v3.0/introduction/index.md
@@ -1,5 +1,6 @@
 ---
 title: About Calico
+canonical_url: https://docs.projectcalico.org/v3.0/introduction/
 redirect_from: latest/introduction/index
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
+canonical_url: https://docs.projectcalico.org/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths
 redirect_from: latest/reference/advanced/etcd-rbac/calico-etcdv3-paths
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/certificate-generation.md
+++ b/v3.0/reference/advanced/etcd-rbac/certificate-generation.md
@@ -1,5 +1,6 @@
 ---
 title: Generating Certificates for etcd RBAC
+canonical_url: https://docs.projectcalico.org/v3.0/reference/advanced/etcd-rbac/certificate-generation
 redirect_from: latest/reference/advanced/etcd-rbac/certificate-generation
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/index.md
+++ b/v3.0/reference/advanced/etcd-rbac/index.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up etcd certificates for RBAC
+canonical_url: https://docs.projectcalico.org/v3.0/reference/advanced/etcd-rbac/
 redirect_from: latest/reference/advanced/etcd-rbac/index
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/kubernetes-advanced.md
+++ b/v3.0/reference/advanced/etcd-rbac/kubernetes-advanced.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced etcd segmentation for Calico
+canonical_url: https://docs.projectcalico.org/v3.0/reference/advanced/etcd-rbac/kubernetes-advanced
 redirect_from: latest/reference/advanced/etcd-rbac/kubernetes-advanced
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/kubernetes.md
+++ b/v3.0/reference/advanced/etcd-rbac/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Using etcd RBAC to segment Kubernetes and Calico
+canonical_url: https://docs.projectcalico.org/v3.0/reference/advanced/etcd-rbac/kubernetes
 redirect_from: latest/reference/advanced/etcd-rbac/kubernetes
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/users-and-roles.md
+++ b/v3.0/reference/advanced/etcd-rbac/users-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Creating Users and Roles in etcd
+canonical_url: https://docs.projectcalico.org/v3.0/reference/advanced/etcd-rbac/users-and-roles
 redirect_from: latest/reference/advanced/etcd-rbac/users-and-roles
 ---
 

--- a/v3.0/reference/architecture/components.md
+++ b/v3.0/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+canonical_url: https://docs.projectcalico.org/v3.0/reference/architecture/components
 redirect_from: latest/reference/architecture/components
 ---
 

--- a/v3.0/reference/architecture/data-path.md
+++ b/v3.0/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+canonical_url: https://docs.projectcalico.org/v3.0/reference/architecture/data-path
 redirect_from: latest/reference/architecture/data-path
 ---
 

--- a/v3.0/reference/architecture/index.md
+++ b/v3.0/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+canonical_url: https://docs.projectcalico.org/v3.0/reference/architecture/
 redirect_from: latest/reference/architecture/index
 ---
 

--- a/v3.0/reference/calicoctl/commands/apply.md
+++ b/v3.0/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/apply
 redirect_from: latest/reference/calicoctl/commands/apply
 ---
 

--- a/v3.0/reference/calicoctl/commands/convert.md
+++ b/v3.0/reference/calicoctl/commands/convert.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl convert
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/convert
 redirect_from: latest/reference/calicoctl/commands/convert
 ---
 

--- a/v3.0/reference/calicoctl/commands/create.md
+++ b/v3.0/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/create
 redirect_from: latest/reference/calicoctl/commands/create
 ---
 

--- a/v3.0/reference/calicoctl/commands/delete.md
+++ b/v3.0/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/delete
 redirect_from: latest/reference/calicoctl/commands/delete
 ---
 

--- a/v3.0/reference/calicoctl/commands/get.md
+++ b/v3.0/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/get
 redirect_from: latest/reference/calicoctl/commands/get
 ---
 

--- a/v3.0/reference/calicoctl/commands/index.md
+++ b/v3.0/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/
 redirect_from: latest/reference/calicoctl/commands/index
 ---
 

--- a/v3.0/reference/calicoctl/commands/ipam/index.md
+++ b/v3.0/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/ipam/
 redirect_from: latest/reference/calicoctl/commands/ipam/index
 ---
 

--- a/v3.0/reference/calicoctl/commands/ipam/release.md
+++ b/v3.0/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/ipam/release
 redirect_from: latest/reference/calicoctl/commands/ipam/release
 ---
 

--- a/v3.0/reference/calicoctl/commands/ipam/show.md
+++ b/v3.0/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/ipam/show
 redirect_from: latest/reference/calicoctl/commands/ipam/show
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/checksystem.md
+++ b/v3.0/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/node/checksystem
 redirect_from: latest/reference/calicoctl/commands/node/checksystem
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/diags.md
+++ b/v3.0/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/node/diags
 redirect_from: latest/reference/calicoctl/commands/node/diags
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/index.md
+++ b/v3.0/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/node/
 redirect_from: latest/reference/calicoctl/commands/node/index
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/run.md
+++ b/v3.0/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/node/run
 redirect_from: latest/reference/calicoctl/commands/node/run
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/status.md
+++ b/v3.0/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/node/status
 redirect_from: latest/reference/calicoctl/commands/node/status
 ---
 

--- a/v3.0/reference/calicoctl/commands/replace.md
+++ b/v3.0/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/replace
 redirect_from: latest/reference/calicoctl/commands/replace
 ---
 

--- a/v3.0/reference/calicoctl/commands/version.md
+++ b/v3.0/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/commands/version
 redirect_from: latest/reference/calicoctl/commands/version
 ---
 

--- a/v3.0/reference/calicoctl/index.md
+++ b/v3.0/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/
 redirect_from: latest/reference/calicoctl/index
 ---
 

--- a/v3.0/reference/calicoctl/resources/bgpconfig.md
+++ b/v3.0/reference/calicoctl/resources/bgpconfig.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Configuration Resource (BGPConfiguration)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/bgpconfig
 redirect_from: latest/reference/calicoctl/resources/bgpconfig
 ---
 

--- a/v3.0/reference/calicoctl/resources/bgppeer.md
+++ b/v3.0/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (BGPPeer)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/bgppeer
 redirect_from: latest/reference/calicoctl/resources/bgppeer
 ---
 

--- a/v3.0/reference/calicoctl/resources/felixconfig.md
+++ b/v3.0/reference/calicoctl/resources/felixconfig.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Configuration Resource (FelixConfiguration)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/felixconfig
 redirect_from: latest/reference/calicoctl/resources/felixconfig
 ---
 

--- a/v3.0/reference/calicoctl/resources/globalnetworkpolicy.md
+++ b/v3.0/reference/calicoctl/resources/globalnetworkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Global Network Policy Resource (GlobalNetworkPolicy)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/globalnetworkpolicy
 redirect_from: latest/reference/calicoctl/resources/globalnetworkpolicy
 ---
 

--- a/v3.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.0/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (HostEndpoint)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/hostendpoint
 redirect_from: latest/reference/calicoctl/resources/hostendpoint
 ---
 

--- a/v3.0/reference/calicoctl/resources/index.md
+++ b/v3.0/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/
 redirect_from: latest/reference/calicoctl/resources/index
 ---
 

--- a/v3.0/reference/calicoctl/resources/ippool.md
+++ b/v3.0/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (IPPool)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/ippool
 redirect_from: latest/reference/calicoctl/resources/ippool
 ---
 

--- a/v3.0/reference/calicoctl/resources/networkpolicy.md
+++ b/v3.0/reference/calicoctl/resources/networkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy Resource (NetworkPolicy)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/networkpolicy
 redirect_from: latest/reference/calicoctl/resources/networkpolicy
 ---
 

--- a/v3.0/reference/calicoctl/resources/node.md
+++ b/v3.0/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (Node)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/node
 redirect_from: latest/reference/calicoctl/resources/node
 ---
 

--- a/v3.0/reference/calicoctl/resources/profile.md
+++ b/v3.0/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (Profile)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/profile
 redirect_from: latest/reference/calicoctl/resources/profile
 ---
 

--- a/v3.0/reference/calicoctl/resources/workloadendpoint.md
+++ b/v3.0/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (WorkloadEndpoint)
+canonical_url: https://docs.projectcalico.org/v3.0/reference/calicoctl/resources/workloadendpoint
 redirect_from: latest/reference/calicoctl/resources/workloadendpoint
 ---
 

--- a/v3.0/reference/cni-plugin/configuration.md
+++ b/v3.0/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+canonical_url: https://docs.projectcalico.org/v3.0/reference/cni-plugin/configuration
 redirect_from: latest/reference/cni-plugin/configuration
 ---
 

--- a/v3.0/reference/felix/configuration.md
+++ b/v3.0/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+canonical_url: https://docs.projectcalico.org/v3.0/reference/felix/configuration
 redirect_from: latest/reference/felix/configuration
 ---
 

--- a/v3.0/reference/felix/prometheus.md
+++ b/v3.0/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+canonical_url: https://docs.projectcalico.org/v3.0/reference/felix/prometheus
 redirect_from: latest/reference/felix/prometheus
 ---
 

--- a/v3.0/reference/index.md
+++ b/v3.0/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+canonical_url: https://docs.projectcalico.org/v3.0/reference/
 redirect_from: latest/reference/index
 noversion: yes
 ---

--- a/v3.0/reference/involved.md
+++ b/v3.0/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+canonical_url: https://docs.projectcalico.org/v3.0/reference/involved
 redirect_from: latest/reference/involved
 ---
 

--- a/v3.0/reference/kube-controllers/configuration.md
+++ b/v3.0/reference/kube-controllers/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico Kubernetes controllers
+canonical_url: https://docs.projectcalico.org/v3.0/reference/kube-controllers/configuration
 redirect_from: latest/reference/kube-controllers/configuration
 ---
 

--- a/v3.0/reference/license.md
+++ b/v3.0/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+canonical_url: https://docs.projectcalico.org/v3.0/reference/license
 redirect_from: latest/reference/license
 ---
 

--- a/v3.0/reference/node/configuration.md
+++ b/v3.0/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+canonical_url: https://docs.projectcalico.org/v3.0/reference/node/configuration
 redirect_from: latest/reference/node/configuration
 ---
 

--- a/v3.0/reference/previous-releases.md
+++ b/v3.0/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+canonical_url: https://docs.projectcalico.org/v3.0/reference/previous-releases
 redirect_from: latest/reference/previous-releases
 ---
 

--- a/v3.0/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v3.0/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+canonical_url: https://docs.projectcalico.org/v3.0/reference/private-cloud/l2-interconnect-fabric
 redirect_from: latest/reference/private-cloud/l2-interconnect-fabric
 ---
 

--- a/v3.0/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v3.0/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+canonical_url: https://docs.projectcalico.org/v3.0/reference/private-cloud/l3-interconnect-fabric
 redirect_from: latest/reference/private-cloud/l3-interconnect-fabric
 lead_text: 'Where large-scale IP networks and hardware collide'
 ---

--- a/v3.0/reference/public-cloud/aws.md
+++ b/v3.0/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+canonical_url: https://docs.projectcalico.org/v3.0/reference/public-cloud/aws
 redirect_from: latest/reference/public-cloud/aws
 ---
 

--- a/v3.0/reference/public-cloud/azure.md
+++ b/v3.0/reference/public-cloud/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on Azure
+canonical_url: https://docs.projectcalico.org/v3.0/reference/public-cloud/azure
 redirect_from: latest/reference/public-cloud/azure
 ---
 

--- a/v3.0/reference/public-cloud/gce.md
+++ b/v3.0/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+canonical_url: https://docs.projectcalico.org/v3.0/reference/public-cloud/gce
 redirect_from: latest/reference/public-cloud/gce
 ---
 

--- a/v3.0/reference/repo-structure.md
+++ b/v3.0/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+canonical_url: https://docs.projectcalico.org/v3.0/reference/repo-structure
 redirect_from: latest/reference/repo-structure
 ---
 

--- a/v3.0/reference/requirements.md
+++ b/v3.0/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+canonical_url: https://docs.projectcalico.org/v3.0/reference/requirements
 redirect_from: latest/reference/requirements
 ---
 

--- a/v3.0/releases/index.md
+++ b/v3.0/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+canonical_url: https://docs.projectcalico.org/v3.0/releases/
 redirect_from: latest/releases/index
 ---
 

--- a/v3.0/usage/calicoctl/configure/etcd.md
+++ b/v3.0/usage/calicoctl/configure/etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to an etcd datastore
+canonical_url: https://docs.projectcalico.org/v3.0/usage/calicoctl/configure/etcd
 redirect_from: latest/usage/calicoctl/configure/etcd
 ---
 

--- a/v3.0/usage/calicoctl/configure/index.md
+++ b/v3.0/usage/calicoctl/configure/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl
+canonical_url: https://docs.projectcalico.org/v3.0/usage/calicoctl/configure/
 redirect_from: latest/usage/calicoctl/configure/index
 ---
 

--- a/v3.0/usage/calicoctl/configure/kdd.md
+++ b/v3.0/usage/calicoctl/configure/kdd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to the Kubernetes API datastore
+canonical_url: https://docs.projectcalico.org/v3.0/usage/calicoctl/configure/kdd
 redirect_from: latest/usage/calicoctl/configure/kdd
 ---
 

--- a/v3.0/usage/calicoctl/install.md
+++ b/v3.0/usage/calicoctl/install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing calicoctl
+canonical_url: https://docs.projectcalico.org/v3.0/usage/calicoctl/install
 redirect_from: latest/usage/calicoctl/install
 ---
 

--- a/v3.0/usage/configuration/as-service.md
+++ b/v3.0/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running calico/node with an init system
+canonical_url: https://docs.projectcalico.org/v3.0/usage/configuration/as-service
 redirect_from: latest/usage/configuration/as-service
 ---
 

--- a/v3.0/usage/configuration/bgp.md
+++ b/v3.0/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+canonical_url: https://docs.projectcalico.org/v3.0/usage/configuration/bgp
 redirect_from: latest/usage/configuration/bgp
 ---
 

--- a/v3.0/usage/configuration/conntrack.md
+++ b/v3.0/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+canonical_url: https://docs.projectcalico.org/v3.0/usage/configuration/conntrack
 redirect_from: latest/usage/configuration/conntrack
 ---
 

--- a/v3.0/usage/configuration/ip-in-ip.md
+++ b/v3.0/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+canonical_url: https://docs.projectcalico.org/v3.0/usage/configuration/ip-in-ip
 redirect_from: latest/usage/configuration/ip-in-ip
 ---
 

--- a/v3.0/usage/configuration/mtu.md
+++ b/v3.0/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+canonical_url: https://docs.projectcalico.org/v3.0/usage/configuration/mtu
 redirect_from: latest/usage/configuration/mtu
 ---
 

--- a/v3.0/usage/configuration/node.md
+++ b/v3.0/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+canonical_url: https://docs.projectcalico.org/v3.0/usage/configuration/node
 redirect_from: latest/usage/configuration/node
 ---
 

--- a/v3.0/usage/decommissioning-a-node.md
+++ b/v3.0/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+canonical_url: https://docs.projectcalico.org/v3.0/usage/decommissioning-a-node
 redirect_from: latest/usage/decommissioning-a-node
 ---
 

--- a/v3.0/usage/external-connectivity.md
+++ b/v3.0/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+canonical_url: https://docs.projectcalico.org/v3.0/usage/external-connectivity
 redirect_from: latest/usage/external-connectivity
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v3.0/usage/index.md
+++ b/v3.0/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+canonical_url: https://docs.projectcalico.org/v3.0/usage/
 redirect_from: latest/usage/index
 ---
 

--- a/v3.0/usage/ipv6.md
+++ b/v3.0/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+canonical_url: https://docs.projectcalico.org/v3.0/usage/ipv6
 redirect_from: latest/usage/ipv6
 ---
 

--- a/v3.0/usage/routereflector/bird-rr-config.md
+++ b/v3.0/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+canonical_url: https://docs.projectcalico.org/v3.0/usage/routereflector/bird-rr-config
 redirect_from: latest/usage/routereflector/bird-rr-config
 ---
 

--- a/v3.0/usage/routereflector/calico-routereflector.md
+++ b/v3.0/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+canonical_url: https://docs.projectcalico.org/v3.0/usage/routereflector/calico-routereflector
 redirect_from: latest/usage/routereflector/calico-routereflector
 ---
 

--- a/v3.0/usage/troubleshooting/faq.md
+++ b/v3.0/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+canonical_url: https://docs.projectcalico.org/v3.0/usage/troubleshooting/faq
 redirect_from: latest/usage/troubleshooting/faq
 layout: docwithnav
 ---

--- a/v3.0/usage/troubleshooting/index.md
+++ b/v3.0/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+canonical_url: https://docs.projectcalico.org/v3.0/usage/troubleshooting/
 redirect_from: latest/usage/troubleshooting/index
 ---
 

--- a/v3.0/usage/troubleshooting/logging.md
+++ b/v3.0/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+canonical_url: https://docs.projectcalico.org/v3.0/usage/troubleshooting/logging
 redirect_from: latest/usage/troubleshooting/logging
 ---
 


### PR DESCRIPTION
## Description

- Adds canonical URL metadata to v3.0 docs. These links are added to the HTML by the jekyll-seo gem in any case but we need the metadata it turns out for the release process.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
