### PR TITLE
Add flannel to v2.6.7 versions

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -623,6 +623,8 @@ v2.6:
     calico/routereflector:
       version: v0.4.2
       url: ""
+    flannel:
+      version: v0.9.1
 
 - title: v2.6.6
   note: |
@@ -2229,6 +2231,8 @@ master:
      calico/routereflector:
       version: v0.5.0
       url: ""
+     flannel:
+      version: v0.9.1
 
 
 # Local directories to ignore when checking external links


### PR DESCRIPTION
## Description

It was missed that the v2.6.7 needed a flannel 'component' version, I'm guessing because I didn't add it to the 'master' section in _data/versions.yml.  If there is another place it should be added so it is not missed please let me know.

## Release Note

```release-note
None required
```
