### PR TITLE
Updates vanilla BIRD install instructions to not use EPEL

### DIFF
--- a/_data/master/navbars/getting-started.yml
+++ b/_data/master/navbars/getting-started.yml
@@ -139,7 +139,7 @@ toc:
       path: /getting-started/openstack/installation/
     - title: Ubuntu
       path: /getting-started/openstack/installation/ubuntu
-    - title: Red Hat Enterprise Linux 7
+    - title: Red Hat Enterprise Linux 
       path: /getting-started/openstack/installation/redhat
     - title: Juju Charms
       path: /getting-started/openstack/installation/juju

--- a/_data/v2_6/navbars/getting-started.yml
+++ b/_data/v2_6/navbars/getting-started.yml
@@ -123,7 +123,7 @@ toc:
       path: /getting-started/openstack/installation/
     - title: Ubuntu
       path: /getting-started/openstack/installation/ubuntu
-    - title: Red Hat Enterprise Linux 7
+    - title: Red Hat Enterprise Linux
       path: /getting-started/openstack/installation/redhat
     - title: Juju Charms
       path: /getting-started/openstack/installation/juju

--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -1,13 +1,13 @@
 ---
-title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+title: Red Hat Enterprise Linux packaged install
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/redhat'
 ---
 
-For this version of {{site.prodname}}, with OpenStack on RHEL 7 or CentOS 7, we recommend
+For this version of {{site.prodname}}, with OpenStack on RHEL or CentOS, we recommend
 using OpenStack Liberty or later.
 
 > **Note**: On RHEL/CentOS 7.3, with Mitaka or earlier, there is a Nova
-> [bug](https://bugs.launchpad.net/nova/+bug/1649527) that breaks Calico
+> [bug](https://bugs.launchpad.net/nova/+bug/1649527) that breaks {{site.prodname}}
 > operation. You can avoid this bug by:
 >
 > - Using Newton or later (recommended), or
@@ -40,7 +40,7 @@ sections.
 
 Before starting this you will need the following:
 
--   One or more machines running RHEL 7, with OpenStack installed.
+-   One or more machines running RHEL, with OpenStack installed.
 -   SSH access to these machines.
 -   Working DNS between these machines (use `/etc/hosts` if you don't
     have DNS on your network).
@@ -77,9 +77,9 @@ Configure the {{site.prodname}} repository:
     EOF
 ```
 
-## Etcd Install
+## etcd install
 
-{{site.prodname}} requires an etcd database to operate - this may be installed on a
+{{site.prodname}} requires an etcd database to operate—this may be installed on a
 single machine or as a cluster.
 
 These instructions cover installing a single node etcd database. You may
@@ -182,7 +182,7 @@ through the process.
     systemctl enable etcd
     ```
 
-## Etcd Proxy Install
+## etcd proxy install
 
 Install an etcd proxy on every node running OpenStack services that
 isn't running the etcd database itself (both control and compute nodes).
@@ -247,7 +247,7 @@ isn't running the etcd database itself (both control and compute nodes).
     systemctl enable etcd
     ```
 
-## Control Node Install
+## Control node install
 
 On each control node, perform the following steps:
 
@@ -281,7 +281,7 @@ On each control node, perform the following steps:
     service neutron-server restart
     ```
 
-## Compute Node Install
+## Compute node install
 
 On each compute node, perform the following steps:
 
@@ -346,20 +346,20 @@ On each compute node, perform the following steps:
     service openstack-nova-compute restart
     ```
 
-    If this node is also a controller, additionally restart nova-api:
+    If this node is also a controller, additionally restart nova-api.
 
     ```
     service openstack-nova-api restart
     ```
 
-3.  If they're running, stop the Open vSwitch services:
+3.  If they're running, stop the Open vSwitch services.
 
     ```
     service neutron-openvswitch-agent stop
     service openvswitch stop
     ```
 
-    Then, prevent the services running if you reboot:
+    Then, prevent the services running if you reboot.
 
     ```
     chkconfig openvswitch off
@@ -367,27 +367,27 @@ On each compute node, perform the following steps:
     ```
 
     Then, on your control node, run the following command to find the
-    agents that you just stopped:
+    agents that you just stopped.
 
     ```
     neutron agent-list
     ```
 
     For each agent, delete them with the following command on your
-    control node, replacing `<agent-id>` with the ID of the agent:
+    control node, replacing `<agent-id>` with the ID of the agent.
 
     ```
     neutron agent-delete <agent-id>
     ```
 
-5.  Install Neutron infrastructure code on the compute host:
+5.  Install Neutron infrastructure code on the compute host.
 
     ```
     yum install openstack-neutron
     ```
 
 6.  Modify `/etc/neutron/neutron.conf`.  In the `[oslo_concurrency]` section,
-    ensure that the `lock_path` variable is uncommented and set as follows:
+    ensure that the `lock_path` variable is uncommented and set as follows.
 
     ```
     # Directory to use for lock files. For security, the specified directory should
@@ -399,7 +399,7 @@ On each compute node, perform the following steps:
 
     Then, stop and disable the Neutron DHCP agent, and install the
     {{site.prodname}} DHCP agent (which uses etcd, allowing it to scale to higher
-    numbers of hosts):
+    numbers of hosts).
 
     ```
     service neutron-dhcp-agent stop
@@ -427,13 +427,13 @@ On each compute node, perform the following steps:
     chkconfig openstack-nova-metadata-api on
     ```
 
-9.  Install the BIRD BGP client from EPEL:
+9.  Install the BIRD BGP client.
 
     ```
     yum install -y bird bird6
     ```
 
-10. Install the `calico-compute` package:
+10. Install the `calico-compute` package.
 
     ```
     yum install calico-compute
@@ -461,14 +461,14 @@ On each compute node, perform the following steps:
     Note that you'll also need to configure your route reflector to
     allow connections from the compute node as a route reflector client.
     If you are using BIRD as a route reflector, follow the instructions
-    in [this document]({{site.baseurl}}/{{page.version}}/usage/routereflector/bird-rr-config). If you are using another route reflector, refer
+    in [Configuring BIRD as a BGP route reflector]({{site.baseurl}}/{{page.version}}/usage/routereflector/bird-rr-config). If you are using another route reflector, refer
     to the appropriate instructions to configure a client connection.
 
     If you *are* configuring a full BGP mesh you'll need to handle the
     BGP configuration appropriately on each compute host. The scripts
     above can be used to generate a sample configuration for BIRD, by
     replacing the `<route_reflector_ip>` with the IP of one other
-    compute host -- this will generate the configuration for a single
+    compute host—this will generate the configuration for a single
     peer connection, which you can duplicate and update for each compute
     host in your mesh.
 
@@ -480,7 +480,7 @@ On each compute node, perform the following steps:
     -   Add KillSignal=SIGKILL as a new line in the \[Service\] section.
 
     Ensure BIRD (and/or BIRD 6 for IPv6) is running and starts on
-    reboot:
+    reboot.
 
     ```
     service bird restart
@@ -493,7 +493,7 @@ On each compute node, perform the following steps:
     `/etc/calico/felix.cfg.example`. Ordinarily the default values
     should be used, but see [Configuration]({{site.baseurl}}/{{page.version}}/getting-started/openstack/) for more details.
 
-13. Restart the Felix service:
+13. Restart the Felix service.
 
     ```
     systemctl restart calico-felix

--- a/master/usage/routereflector/bird-rr-config.md
+++ b/master/usage/routereflector/bird-rr-config.md
@@ -3,24 +3,24 @@ title: Configuring BIRD as a BGP Route Reflector
 canonical_url: 'https://docs.projectcalico.org/v3.0/usage/routereflector/bird-rr-config'
 ---
 
-For many {{site.prodname}} deployments, the use of a Route Reflector is not required. 
+For many {{site.prodname}} deployments, the use of a route reflector is not required. 
 However, for large scale deployments a full mesh of BGP peerings between each
 of your {{site.prodname}} nodes may become untenable.  In this case, route reflectors
 allow you to remove the full mesh and scale up the size of the cluster.
 
 These instructions will take you through installing BIRD as a BGP route
 reflector, and updating your other BIRD instances to speak to your new
-route reflector.  The instructions that are are valid for both Ubuntu 14.04 and 
-RHEL 7.  
+route reflector.  The instructions are valid for both Ubuntu and Red Hat 
+Enterprise Linux (RHEL).  
 
 For a container-based deployment, using the `{{site.nodecontainer}}` container, check 
-out the [{{site.prodname}} BIRD Route Reflector container](calico-routereflector).
+out the [{{site.prodname}} BIRD route reflector container](calico-routereflector).
 
 ## Prerequisites
 
 Before starting this you will need the following:
 
--   A machine running either Ubuntu 14.04 or RHEL 7 that is not already
+-   A machine running either Ubuntu or RHEL that is not already
     being used as a compute host.
 -   SSH access to the machine.
 
@@ -28,10 +28,10 @@ Before starting this you will need the following:
 
 ### Step 1: Install BIRD
 
-#### Ubuntu 14.04
+#### Ubuntu
 
 Add the official [BIRD](http://bird.network.cz/) PPA. This PPA contains
-fixes to BIRD that are not yet available in Ubuntu 14.04. To add the
+fixes to BIRD that are not yet available in Ubuntu. To add the
 PPA, run:
 
     sudo add-apt-repository ppa:cz.nic-labs/bird
@@ -42,20 +42,60 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
     sudo apt-get update
     sudo apt-get install bird
 
-#### RHEL 7
+#### RHEL
 
-First, install EPEL. Depending on your system, the following command may
-be sufficient:
+> **Note**: The following commands require root privileges. You can either open a root shell
+> or prefix them with `sudo`.
+{: .alert .alert-info}
 
-    sudo yum install epel-release
+1. From a terminal prompt, create a new file called bird.repo in the 
+   `/etc/yum.repos.d/` directory.
 
-If that fails, try the following instead:
+   ```bash 
+   vi /etc/yum.repos.d/bird.repo
+   ```
 
-    sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+1. Add the following lines to the file.
 
-With that complete, you can now install BIRD:
+   ```
+   [bird]
+   name=Network.CZ Repository
+   baseurl=ftp://repo.network.cz/pub/redhat/
+   enabled=1
+   gpgcheck=0
+   gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
+   ```
 
-    yum install -y bird{,6}
+1. Save and close the file.
+
+1. If you don't already have the `/pki/rpm-gpg/` directory, use the following command
+   to create it.
+   
+   ```bash
+   mkdir /etc/pki/ /etc/pki/rpm-gpg/
+   ```
+   
+1. Download the public key of the BIRD repository into the `/etc/pki/rpm-gpg/` directory.
+   
+   ```bash
+   curl ftp://bird.network.cz/pub/bird/redhat/RPM-GPG-KEY-network.cz -o /etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
+   ```
+   
+   > **Tip**: If you don't have curl, try replacing `curl` with `wget` in the command.
+   {: .alert .alert-success}
+   
+1. Use the following command to install BIRD.
+
+   ```bash
+   yum install -y bird
+   ```
+   
+> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL). 
+> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains 
+> other packages. Installing EPEL may cause existing packages on your system to
+> be overwritten with unsupported packages. To avoid issues of this kind, we recommend 
+> using the method described above.
+{: .alert .alert-info}
 
 ### Step 2: Set your BIRD IPv4 configuration
 
@@ -121,7 +161,7 @@ IPv4 address: you cannot use an IPv6 address in that field.
 
 ### Step 4: Restart BIRD
 
-#### Ubuntu 14.04
+#### Ubuntu
 
 Restart BIRD:
 
@@ -131,7 +171,7 @@ Optionally, if you configured IPv6 in step 3, also restart BIRD6:
 
     sudo service bird6 restart
 
-#### RHEL 7
+#### RHEL
 
 Restart BIRD:
 

--- a/master/usage/routereflector/bird-rr-config.md
+++ b/master/usage/routereflector/bird-rr-config.md
@@ -3,17 +3,17 @@ title: Configuring BIRD as a BGP Route Reflector
 canonical_url: 'https://docs.projectcalico.org/v3.0/usage/routereflector/bird-rr-config'
 ---
 
-For many {{site.prodname}} deployments, the use of a route reflector is not required. 
+For many {{site.prodname}} deployments, the use of a route reflector is not required.
 However, for large scale deployments a full mesh of BGP peerings between each
 of your {{site.prodname}} nodes may become untenable.  In this case, route reflectors
 allow you to remove the full mesh and scale up the size of the cluster.
 
 These instructions will take you through installing BIRD as a BGP route
 reflector, and updating your other BIRD instances to speak to your new
-route reflector.  The instructions are valid for both Ubuntu and Red Hat 
-Enterprise Linux (RHEL).  
+route reflector.  The instructions are valid for both Ubuntu and Red Hat
+Enterprise Linux (RHEL).
 
-For a container-based deployment, using the `{{site.nodecontainer}}` container, check 
+For a container-based deployment, using the `{{site.nodecontainer}}` container, check
 out the [{{site.prodname}} BIRD route reflector container](calico-routereflector).
 
 ## Prerequisites
@@ -48,10 +48,10 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
 > or prefix them with `sudo`.
 {: .alert .alert-info}
 
-1. From a terminal prompt, create a new file called bird.repo in the 
+1. From a terminal prompt, create a new file called bird.repo in the
    `/etc/yum.repos.d/` directory.
 
-   ```bash 
+   ```bash
    vi /etc/yum.repos.d/bird.repo
    ```
 
@@ -68,32 +68,32 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
 
 1. Save and close the file.
 
-1. If you don't already have the `/pki/rpm-gpg/` directory, use the following command
+1. If you don't already have the `/etc/pki/rpm-gpg/` directory, use the following command
    to create it.
-   
+
    ```bash
-   mkdir /etc/pki/ /etc/pki/rpm-gpg/
+   mkdir -p /etc/pki/rpm-gpg/
    ```
-   
+
 1. Download the public key of the BIRD repository into the `/etc/pki/rpm-gpg/` directory.
-   
+
    ```bash
    curl ftp://bird.network.cz/pub/bird/redhat/RPM-GPG-KEY-network.cz -o /etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
    ```
-   
+
    > **Tip**: If you don't have curl, try replacing `curl` with `wget` in the command.
    {: .alert .alert-success}
-   
+
 1. Use the following command to install BIRD.
 
    ```bash
    yum install -y bird
    ```
-   
-> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL). 
-> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains 
+
+> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL).
+> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains
 > other packages. Installing EPEL may cause existing packages on your system to
-> be overwritten with unsupported packages. To avoid issues of this kind, we recommend 
+> be overwritten with unsupported packages. To avoid issues of this kind, we recommend
 > using the method described above.
 {: .alert .alert-info}
 
@@ -183,7 +183,7 @@ Optionally, if you configured IPv6 in step 3, also restart BIRD6:
     systemctl restart bird6
     systemctl enable bird6
 
-### Step 5: Reconfigure compute nodes 
+### Step 5: Reconfigure compute nodes
 
 #### Openstack deployments
 
@@ -200,7 +200,7 @@ instances as detailed in step 4.
 
 #### Container-based deployments
 
-For container-based deployments using the `{{site.nodecontainer}}` container, use 
+For container-based deployments using the `{{site.nodecontainer}}` container, use
 `calicoctl` to disable the full mesh between each node and configure the
 route reflector as a global peer.
 

--- a/v2.6/getting-started/openstack/installation/redhat.md
+++ b/v2.6/getting-started/openstack/installation/redhat.md
@@ -1,13 +1,13 @@
 ---
-title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+title: Red Hat Enterprise Linux packaged install
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/redhat'
 ---
 
-For this version of Calico, with OpenStack on RHEL 7 or CentOS 7, we recommend
+For this version of {{site.prodname}}, with OpenStack on RHEL or CentOS, we recommend
 using OpenStack Liberty or later.
 
 > **Note**: On RHEL/CentOS 7.3, with Mitaka or earlier, there is a Nova
-> [bug](https://bugs.launchpad.net/nova/+bug/1649527) that breaks Calico
+> [bug](https://bugs.launchpad.net/nova/+bug/1649527) that breaks {{site.prodname}}
 > operation. You can avoid this bug by:
 >
 > - Using Newton or later (recommended), or
@@ -16,19 +16,19 @@ using OpenStack Liberty or later.
 >   install on each compute node.
 {: .alert .alert-info}
 
-These instructions will take you through a first-time install of Calico.  If
-you are upgrading an existing system, please see the [Calico on OpenStack
+These instructions will take you through a first-time install of {{site.prodname}}.  If
+you are upgrading an existing system, please see the [{{site.prodname}} on OpenStack
 upgrade]({{site.baseurl}}/{{page.version}}/getting-started/openstack/upgrade)
 document instead for upgrade instructions.
 
 There are three sections to the install: installing etcd, upgrading
-control nodes to use Calico, and upgrading compute nodes to use Calico.
-Follow the **Common Steps** on each node before moving on to the
+control nodes to use {{site.prodname}}, and upgrading compute nodes to use {{site.prodname}}.
+Follow the [Common Steps](#common-steps) on each node before moving on to the
 specific instructions in the control and compute sections. If you want
 to create a combined control and compute node, work through all three
 sections.
 
-> **Important**: Following the upgrade to use etcd as a data store, Calico
+> **Important**: Following the upgrade to use etcd as a data store, {{site.prodname}}
 > currently only supports RHEL 7 and above. If support on RHEL 6.x
 > or other versions of Linux is important to you, then please [let
 > us know](https://www.projectcalico.org/contact/).
@@ -40,14 +40,14 @@ sections.
 
 Before starting this you will need the following:
 
--   One or more machines running RHEL 7, with OpenStack installed.
+-   One or more machines running RHEL, with OpenStack installed.
 -   SSH access to these machines.
 -   Working DNS between these machines (use `/etc/hosts` if you don't
     have DNS on your network).
 
 ## Common Steps
 
-Some steps need to be taken on all machines being installed with Calico.
+Some steps need to be taken on all machines being installed with {{site.prodname}}.
 These steps are detailed in this section.
 
 ### Install OpenStack
@@ -62,7 +62,7 @@ networking.
 Add the EPEL repository -- see <https://fedoraproject.org/wiki/EPEL>.
 You may have already added this to install OpenStack.
 
-Configure the Calico repository:
+Configure the {{site.prodname}} repository:
 
 ```
     cat > /etc/yum.repos.d/calico.repo <<EOF
@@ -77,9 +77,9 @@ Configure the Calico repository:
     EOF
 ```
 
-## Etcd Install
+## etcd install
 
-Calico requires an etcd database to operate - this may be installed on a
+{{site.prodname}} requires an etcd database to operate—this may be installed on a
 single machine or as a cluster.
 
 These instructions cover installing a single node etcd database. You may
@@ -182,7 +182,7 @@ through the process.
     systemctl enable etcd
     ```
 
-## Etcd Proxy Install
+## etcd proxy install
 
 Install an etcd proxy on every node running OpenStack services that
 isn't running the etcd database itself (both control and compute nodes).
@@ -247,7 +247,7 @@ isn't running the etcd database itself (both control and compute nodes).
     systemctl enable etcd
     ```
 
-## Control Node Install
+## Control node install
 
 On each control node, perform the following steps:
 
@@ -261,7 +261,7 @@ On each control node, perform the following steps:
     > need to be deleted from the Admin section.
     {: .alert .alert-success}
 
-    > **Important**: The Calico install will fail if incompatible state is
+    > **Important**: The {{site.prodname}} install will fail if incompatible state is
     > left around.
     {: .alert .alert-danger}
 
@@ -281,7 +281,7 @@ On each control node, perform the following steps:
     service neutron-server restart
     ```
 
-## Compute Node Install
+## Compute node install
 
 On each compute node, perform the following steps:
 
@@ -346,20 +346,20 @@ On each compute node, perform the following steps:
     service openstack-nova-compute restart
     ```
 
-    If this node is also a controller, additionally restart nova-api:
+    If this node is also a controller, additionally restart nova-api.
 
     ```
     service openstack-nova-api restart
     ```
 
-3.  If they're running, stop the Open vSwitch services:
+3.  If they're running, stop the Open vSwitch services.
 
     ```
     service neutron-openvswitch-agent stop
     service openvswitch stop
     ```
 
-    Then, prevent the services running if you reboot:
+    Then, prevent the services running if you reboot.
 
     ```
     chkconfig openvswitch off
@@ -367,27 +367,27 @@ On each compute node, perform the following steps:
     ```
 
     Then, on your control node, run the following command to find the
-    agents that you just stopped:
+    agents that you just stopped.
 
     ```
     neutron agent-list
     ```
 
     For each agent, delete them with the following command on your
-    control node, replacing `<agent-id>` with the ID of the agent:
+    control node, replacing `<agent-id>` with the ID of the agent.
 
     ```
     neutron agent-delete <agent-id>
     ```
 
-5.  Install Neutron infrastructure code on the compute host:
+5.  Install Neutron infrastructure code on the compute host.
 
     ```
     yum install openstack-neutron
     ```
 
 6.  Modify `/etc/neutron/neutron.conf`.  In the `[oslo_concurrency]` section,
-    ensure that the `lock_path` variable is uncommented and set as follows:
+    ensure that the `lock_path` variable is uncommented and set as follows.
 
     ```
     # Directory to use for lock files. For security, the specified directory should
@@ -398,8 +398,8 @@ On each compute node, perform the following steps:
     ```
 
     Then, stop and disable the Neutron DHCP agent, and install the
-    Calico DHCP agent (which uses etcd, allowing it to scale to higher
-    numbers of hosts):
+    {{site.prodname}} DHCP agent (which uses etcd, allowing it to scale to higher
+    numbers of hosts).
 
     ```
     service neutron-dhcp-agent stop
@@ -409,7 +409,7 @@ On each compute node, perform the following steps:
 
 7.  Stop and disable any other routing/bridging agents such as the L3
     routing agent or the Linux bridging agent. These conflict
-    with Calico.
+    with {{site.prodname}}.
 
     ```
     service neutron-l3-agent stop
@@ -427,19 +427,19 @@ On each compute node, perform the following steps:
     chkconfig openstack-nova-metadata-api on
     ```
 
-9.  Install the BIRD BGP client from EPEL:
+9.  Install the BIRD BGP client.
 
     ```
     yum install -y bird bird6
     ```
 
-10. Install the `calico-compute` package:
+10. Install the `calico-compute` package.
 
     ```
     yum install calico-compute
     ```
 
-11. Configure BIRD. By default Calico assumes that you'll be deploying a
+11. Configure BIRD. By default {{site.prodname}} assumes that you'll be deploying a
     route reflector to avoid the need for a full BGP mesh. To this end,
     it includes useful configuration scripts that will prepare a BIRD
     config file with a single peering to the route reflector. If that's
@@ -461,14 +461,14 @@ On each compute node, perform the following steps:
     Note that you'll also need to configure your route reflector to
     allow connections from the compute node as a route reflector client.
     If you are using BIRD as a route reflector, follow the instructions
-    in [this document]({{site.baseurl}}/{{page.version}}/usage/routereflector/bird-rr-config). If you are using another route reflector, refer
+    in [Configuring BIRD as a BGP route reflector]({{site.baseurl}}/{{page.version}}/usage/routereflector/bird-rr-config). If you are using another route reflector, refer
     to the appropriate instructions to configure a client connection.
 
     If you *are* configuring a full BGP mesh you'll need to handle the
     BGP configuration appropriately on each compute host. The scripts
     above can be used to generate a sample configuration for BIRD, by
     replacing the `<route_reflector_ip>` with the IP of one other
-    compute host -- this will generate the configuration for a single
+    compute host—this will generate the configuration for a single
     peer connection, which you can duplicate and update for each compute
     host in your mesh.
 
@@ -480,7 +480,7 @@ On each compute node, perform the following steps:
     -   Add KillSignal=SIGKILL as a new line in the \[Service\] section.
 
     Ensure BIRD (and/or BIRD 6 for IPv6) is running and starts on
-    reboot:
+    reboot.
 
     ```
     service bird restart
@@ -493,7 +493,7 @@ On each compute node, perform the following steps:
     `/etc/calico/felix.cfg.example`. Ordinarily the default values
     should be used, but see [Configuration]({{site.baseurl}}/{{page.version}}/getting-started/openstack/) for more details.
 
-13. Restart the Felix service:
+13. Restart the Felix service.
 
     ```
     systemctl restart calico-felix

--- a/v2.6/usage/routereflector/bird-rr-config.md
+++ b/v2.6/usage/routereflector/bird-rr-config.md
@@ -3,17 +3,17 @@ title: 'Configuring BIRD as a BGP Route Reflector'
 canonical_url: 'https://docs.projectcalico.org/v3.0/usage/routereflector/bird-rr-config'
 ---
 
-For many Calico deployments, the use of a route reflector is not required. 
+For many Calico deployments, the use of a route reflector is not required.
 However, for large scale deployments a full mesh of BGP peerings between each
 of your Calico nodes may become untenable.  In this case, route reflectors
 allow you to remove the full mesh and scale up the size of the cluster.
 
 These instructions will take you through installing BIRD as a BGP route
 reflector, and updating your other BIRD instances to speak to your new
-route reflector.  The instructions are valid for both Ubuntu and Red Hat 
-Enterprise Linux (RHEL).  
+route reflector.  The instructions are valid for both Ubuntu and Red Hat
+Enterprise Linux (RHEL).
 
-For a container-based deployment, using the `{{site.nodecontainer}}` container, check 
+For a container-based deployment, using the `{{site.nodecontainer}}` container, check
 out the [{{site.prodname}} BIRD route reflector container](calico-routereflector).
 
 ## Prerequisites
@@ -48,10 +48,10 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
 > or prefix them with `sudo`.
 {: .alert .alert-info}
 
-1. From a terminal prompt, create a new file called bird.repo in the 
+1. From a terminal prompt, create a new file called bird.repo in the
    `/etc/yum.repos.d/` directory.
 
-   ```bash 
+   ```bash
    vi /etc/yum.repos.d/bird.repo
    ```
 
@@ -68,32 +68,32 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
 
 1. Save and close the file.
 
-1. If you don't already have the `/pki/rpm-gpg/` directory, use the following command
+1. If you don't already have the `/etc/pki/rpm-gpg/` directory, use the following command
    to create it.
-   
+
    ```bash
-   mkdir /etc/pki/ /etc/pki/rpm-gpg/
+   mkdir -p /etc/pki/rpm-gpg/
    ```
-   
+
 1. Download the public key of the BIRD repository into the `/etc/pki/rpm-gpg/` directory.
-   
+
    ```bash
    curl ftp://bird.network.cz/pub/bird/redhat/RPM-GPG-KEY-network.cz -o /etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
    ```
-   
+
    > **Tip**: If you don't have curl, try replacing `curl` with `wget` in the command.
    {: .alert .alert-success}
-   
+
 1. Use the following command to install BIRD.
 
    ```bash
    yum install -y bird
    ```
-   
-> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL). 
-> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains 
+
+> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL).
+> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains
 > other packages. Installing EPEL may cause existing packages on your system to
-> be overwritten with unsupported packages. To avoid issues of this kind, we recommend 
+> be overwritten with unsupported packages. To avoid issues of this kind, we recommend
 > using the method described above.
 {: .alert .alert-info}
 
@@ -183,7 +183,7 @@ Optionally, if you configured IPv6 in step 3, also restart BIRD6:
     systemctl restart bird6
     systemctl enable bird6
 
-### Step 5: Reconfigure compute nodes 
+### Step 5: Reconfigure compute nodes
 
 #### Openstack deployments
 
@@ -200,7 +200,7 @@ instances as detailed in step 4.
 
 #### Container-based deployments
 
-For container-based deployments using the `{{site.nodecontainer}}` container, use 
+For container-based deployments using the `{{site.nodecontainer}}` container, use
 `calicoctl` to disable the full mesh between each node and configure the
 route reflector as a global peer.
 

--- a/v2.6/usage/routereflector/bird-rr-config.md
+++ b/v2.6/usage/routereflector/bird-rr-config.md
@@ -3,24 +3,24 @@ title: 'Configuring BIRD as a BGP Route Reflector'
 canonical_url: 'https://docs.projectcalico.org/v3.0/usage/routereflector/bird-rr-config'
 ---
 
-For many Calico deployments, the use of a Route Reflector is not required. 
+For many Calico deployments, the use of a route reflector is not required. 
 However, for large scale deployments a full mesh of BGP peerings between each
 of your Calico nodes may become untenable.  In this case, route reflectors
 allow you to remove the full mesh and scale up the size of the cluster.
 
 These instructions will take you through installing BIRD as a BGP route
 reflector, and updating your other BIRD instances to speak to your new
-route reflector.  The instructions that are are valid for both Ubuntu 14.04 and 
-RHEL 7.  
+route reflector.  The instructions are valid for both Ubuntu and Red Hat 
+Enterprise Linux (RHEL).  
 
-For a container-based deployment, using the calico/node container, check 
-out the [Calico BIRD Route Reflector container](calico-routereflector).
+For a container-based deployment, using the `{{site.nodecontainer}}` container, check 
+out the [{{site.prodname}} BIRD route reflector container](calico-routereflector).
 
 ## Prerequisites
 
 Before starting this you will need the following:
 
--   A machine running either Ubuntu 14.04 or RHEL 7 that is not already
+-   A machine running either Ubuntu or RHEL that is not already
     being used as a compute host.
 -   SSH access to the machine.
 
@@ -28,10 +28,10 @@ Before starting this you will need the following:
 
 ### Step 1: Install BIRD
 
-#### Ubuntu 14.04
+#### Ubuntu
 
 Add the official [BIRD](http://bird.network.cz/) PPA. This PPA contains
-fixes to BIRD that are not yet available in Ubuntu 14.04. To add the
+fixes to BIRD that are not yet available in Ubuntu. To add the
 PPA, run:
 
     sudo add-apt-repository ppa:cz.nic-labs/bird
@@ -42,20 +42,60 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
     sudo apt-get update
     sudo apt-get install bird
 
-#### RHEL 7
+#### RHEL
 
-First, install EPEL. Depending on your system, the following command may
-be sufficient:
+> **Note**: The following commands require root privileges. You can either open a root shell
+> or prefix them with `sudo`.
+{: .alert .alert-info}
 
-    sudo yum install epel-release
+1. From a terminal prompt, create a new file called bird.repo in the 
+   `/etc/yum.repos.d/` directory.
 
-If that fails, try the following instead:
+   ```bash 
+   vi /etc/yum.repos.d/bird.repo
+   ```
 
-    sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+1. Add the following lines to the file.
 
-With that complete, you can now install BIRD:
+   ```
+   [bird]
+   name=Network.CZ Repository
+   baseurl=ftp://repo.network.cz/pub/redhat/
+   enabled=1
+   gpgcheck=0
+   gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
+   ```
 
-    yum install -y bird{,6}
+1. Save and close the file.
+
+1. If you don't already have the `/pki/rpm-gpg/` directory, use the following command
+   to create it.
+   
+   ```bash
+   mkdir /etc/pki/ /etc/pki/rpm-gpg/
+   ```
+   
+1. Download the public key of the BIRD repository into the `/etc/pki/rpm-gpg/` directory.
+   
+   ```bash
+   curl ftp://bird.network.cz/pub/bird/redhat/RPM-GPG-KEY-network.cz -o /etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
+   ```
+   
+   > **Tip**: If you don't have curl, try replacing `curl` with `wget` in the command.
+   {: .alert .alert-success}
+   
+1. Use the following command to install BIRD.
+
+   ```bash
+   yum install -y bird
+   ```
+   
+> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL). 
+> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains 
+> other packages. Installing EPEL may cause existing packages on your system to
+> be overwritten with unsupported packages. To avoid issues of this kind, we recommend 
+> using the method described above.
+{: .alert .alert-info}
 
 ### Step 2: Set your BIRD IPv4 configuration
 
@@ -121,7 +161,7 @@ IPv4 address: you cannot use an IPv6 address in that field.
 
 ### Step 4: Restart BIRD
 
-#### Ubuntu 14.04
+#### Ubuntu
 
 Restart BIRD:
 
@@ -131,7 +171,7 @@ Optionally, if you configured IPv6 in step 3, also restart BIRD6:
 
     sudo service bird6 restart
 
-#### RHEL 7
+#### RHEL
 
 Restart BIRD:
 
@@ -160,7 +200,7 @@ instances as detailed in step 4.
 
 #### Container-based deployments
 
-For container-based deployments using the `calico/node` container, use 
+For container-based deployments using the `{{site.nodecontainer}}` container, use 
 `calicoctl` to disable the full mesh between each node and configure the
 route reflector as a global peer.
 

--- a/v3.0/usage/routereflector/bird-rr-config.md
+++ b/v3.0/usage/routereflector/bird-rr-config.md
@@ -4,17 +4,17 @@ canonical_url: https://docs.projectcalico.org/v3.0/usage/routereflector/bird-rr-
 redirect_from: latest/usage/routereflector/bird-rr-config
 ---
 
-For many Calico deployments, the use of a route reflector is not required. 
+For many Calico deployments, the use of a route reflector is not required.
 However, for large scale deployments a full mesh of BGP peerings between each
 of your Calico nodes may become untenable.  In this case, route reflectors
 allow you to remove the full mesh and scale up the size of the cluster.
 
 These instructions will take you through installing BIRD as a BGP route
 reflector, and updating your other BIRD instances to speak to your new
-route reflector.  The instructions are valid for both Ubuntu and Red Hat 
-Enterprise Linux (RHEL).  
+route reflector.  The instructions are valid for both Ubuntu and Red Hat
+Enterprise Linux (RHEL).
 
-For a container-based deployment, using the `{{site.nodecontainer}}` container, check 
+For a container-based deployment, using the `{{site.nodecontainer}}` container, check
 out the [{{site.prodname}} BIRD route reflector container](calico-routereflector).
 
 ## Prerequisites
@@ -49,10 +49,10 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
 > or prefix them with `sudo`.
 {: .alert .alert-info}
 
-1. From a terminal prompt, create a new file called bird.repo in the 
+1. From a terminal prompt, create a new file called bird.repo in the
    `/etc/yum.repos.d/` directory.
 
-   ```bash 
+   ```bash
    vi /etc/yum.repos.d/bird.repo
    ```
 
@@ -69,32 +69,32 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
 
 1. Save and close the file.
 
-1. If you don't already have the `/pki/rpm-gpg/` directory, use the following command
+1. If you don't already have the `/etc/pki/rpm-gpg/` directory, use the following command
    to create it.
-   
+
    ```bash
-   mkdir /etc/pki/ /etc/pki/rpm-gpg/
+   mkdir -p /etc/pki/rpm-gpg/
    ```
-   
+
 1. Download the public key of the BIRD repository into the `/etc/pki/rpm-gpg/` directory.
-   
+
    ```bash
    curl ftp://bird.network.cz/pub/bird/redhat/RPM-GPG-KEY-network.cz -o /etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
    ```
-   
+
    > **Tip**: If you don't have curl, try replacing `curl` with `wget` in the command.
    {: .alert .alert-success}
-   
+
 1. Use the following command to install BIRD.
 
    ```bash
    yum install -y bird
    ```
-   
-> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL). 
-> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains 
+
+> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL).
+> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains
 > other packages. Installing EPEL may cause existing packages on your system to
-> be overwritten with unsupported packages. To avoid issues of this kind, we recommend 
+> be overwritten with unsupported packages. To avoid issues of this kind, we recommend
 > using the method described above.
 {: .alert .alert-info}
 
@@ -184,12 +184,12 @@ Optionally, if you configured IPv6 in step 3, also restart BIRD6:
     systemctl restart bird6
     systemctl enable bird6
 
-### Step 5: Reconfigure compute nodes 
+### Step 5: Reconfigure compute nodes
 
 
 #### Container-based deployments
 
-For container-based deployments using the `{{site.nodecontainer}}` container, use 
+For container-based deployments using the `{{site.nodecontainer}}` container, use
 `calicoctl` to disable the full mesh between each node and configure the
 route reflector as a global peer.
 

--- a/v3.0/usage/routereflector/bird-rr-config.md
+++ b/v3.0/usage/routereflector/bird-rr-config.md
@@ -1,27 +1,27 @@
 ---
-title: 'Configuring BIRD as a BGP Route Reflector'
+title: Configuring BIRD as a BGP route reflector
 canonical_url: https://docs.projectcalico.org/v3.0/usage/routereflector/bird-rr-config
 redirect_from: latest/usage/routereflector/bird-rr-config
 ---
 
-For many Calico deployments, the use of a Route Reflector is not required. 
+For many Calico deployments, the use of a route reflector is not required. 
 However, for large scale deployments a full mesh of BGP peerings between each
 of your Calico nodes may become untenable.  In this case, route reflectors
 allow you to remove the full mesh and scale up the size of the cluster.
 
 These instructions will take you through installing BIRD as a BGP route
 reflector, and updating your other BIRD instances to speak to your new
-route reflector.  The instructions that are are valid for both Ubuntu 14.04 and 
-RHEL 7.  
+route reflector.  The instructions are valid for both Ubuntu and Red Hat 
+Enterprise Linux (RHEL).  
 
-For a container-based deployment, using the calico/node container, check 
-out the [Calico BIRD Route Reflector container](calico-routereflector).
+For a container-based deployment, using the `{{site.nodecontainer}}` container, check 
+out the [{{site.prodname}} BIRD route reflector container](calico-routereflector).
 
 ## Prerequisites
 
 Before starting this you will need the following:
 
--   A machine running either Ubuntu 14.04 or RHEL 7 that is not already
+-   A machine running either Ubuntu or RHEL that is not already
     being used as a compute host.
 -   SSH access to the machine.
 
@@ -29,10 +29,10 @@ Before starting this you will need the following:
 
 ### Step 1: Install BIRD
 
-#### Ubuntu 14.04
+#### Ubuntu
 
 Add the official [BIRD](http://bird.network.cz/) PPA. This PPA contains
-fixes to BIRD that are not yet available in Ubuntu 14.04. To add the
+fixes to BIRD that are not yet available in Ubuntu. To add the
 PPA, run:
 
     sudo add-apt-repository ppa:cz.nic-labs/bird
@@ -43,20 +43,60 @@ single `bird` package installs both IPv4 and IPv6 BIRD):
     sudo apt-get update
     sudo apt-get install bird
 
-#### RHEL 7
+#### RHEL
 
-First, install EPEL. Depending on your system, the following command may
-be sufficient:
+> **Note**: The following commands require root privileges. You can either open a root shell
+> or prefix them with `sudo`.
+{: .alert .alert-info}
 
-    sudo yum install epel-release
+1. From a terminal prompt, create a new file called bird.repo in the 
+   `/etc/yum.repos.d/` directory.
 
-If that fails, try the following instead:
+   ```bash 
+   vi /etc/yum.repos.d/bird.repo
+   ```
 
-    sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+1. Add the following lines to the file.
 
-With that complete, you can now install BIRD:
+   ```
+   [bird]
+   name=Network.CZ Repository
+   baseurl=ftp://repo.network.cz/pub/redhat/
+   enabled=1
+   gpgcheck=0
+   gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
+   ```
 
-    yum install -y bird{,6}
+1. Save and close the file.
+
+1. If you don't already have the `/pki/rpm-gpg/` directory, use the following command
+   to create it.
+   
+   ```bash
+   mkdir /etc/pki/ /etc/pki/rpm-gpg/
+   ```
+   
+1. Download the public key of the BIRD repository into the `/etc/pki/rpm-gpg/` directory.
+   
+   ```bash
+   curl ftp://bird.network.cz/pub/bird/redhat/RPM-GPG-KEY-network.cz -o /etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
+   ```
+   
+   > **Tip**: If you don't have curl, try replacing `curl` with `wget` in the command.
+   {: .alert .alert-success}
+   
+1. Use the following command to install BIRD.
+
+   ```bash
+   yum install -y bird
+   ```
+   
+> **Note**: We do not recommend installing [Extra Packages for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL). 
+> EPEL lacks official Red Hat support. It contains the BIRD package, but it also contains 
+> other packages. Installing EPEL may cause existing packages on your system to
+> be overwritten with unsupported packages. To avoid issues of this kind, we recommend 
+> using the method described above.
+{: .alert .alert-info}
 
 ### Step 2: Set your BIRD IPv4 configuration
 
@@ -122,7 +162,7 @@ IPv4 address: you cannot use an IPv6 address in that field.
 
 ### Step 4: Restart BIRD
 
-#### Ubuntu 14.04
+#### Ubuntu
 
 Restart BIRD:
 
@@ -132,7 +172,7 @@ Optionally, if you configured IPv6 in step 3, also restart BIRD6:
 
     sudo service bird6 restart
 
-#### RHEL 7
+#### RHEL
 
 Restart BIRD:
 
@@ -149,7 +189,7 @@ Optionally, if you configured IPv6 in step 3, also restart BIRD6:
 
 #### Container-based deployments
 
-For container-based deployments using the `calico/node` container, use 
+For container-based deployments using the `{{site.nodecontainer}}` container, use 
 `calicoctl` to disable the full mesh between each node and configure the
 route reflector as a global peer.
 


### PR DESCRIPTION
## Description

- Updates the vanilla BIRD install instructions to remove the recommendation to use EPEL, which creates problems due to its lack of official support. Instead, recommends using http://bird.network.cz/?download&tdir=redhat/. Continues https://github.com/projectcalico/calico/pull/1639
- Removes RHEL version number from text for reasons of maintainability.
- Other edits for conformance to style guide.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
