### PR TITLE
Removes unnecessary Felix write permission

### DIFF
--- a/calico_node/tests/st/utils/docker_host.py
+++ b/calico_node/tests/st/utils/docker_host.py
@@ -241,7 +241,7 @@ class DockerHost(object):
             raise Exception("Command %s returned non-zero exit code %s" %
                             (command, status))
 
-    def calicoctl(self, command, version=None):
+    def calicoctl(self, command, version=None, raise_exception_on_failure=True):
         """
         Convenience function for abstracting away calling the calicoctl
         command.
@@ -281,7 +281,7 @@ class DockerHost(object):
             calicoctl = "export HOSTNAME=%s; %s" % (
                 self.override_hostname, calicoctl)
 
-        return self.execute(calicoctl + " " + command)
+        return self.execute(calicoctl + " " + command, raise_exception_on_failure=raise_exception_on_failure)
 
     def start_calico_node(self, options="", with_ipv4pool_cidr_env_var=True, env_options=""):
         """

--- a/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -19,11 +19,11 @@ component needs access to in etcd to function successfully.
 | /calico/ipam/v2/\*                        |   RW   |
 | /calico/resources/v3/projectcalico.org/\* |   RW   |
 
-## felix as a stand alone process
+## Felix as a stand alone process
 
 | Path                                      | Access |
 |-------------------------------------------|--------|
-| /calico/felix/v1/\*                       |   RW   |
+| /calico/felix/v1/\*                       |   R    |
 | /calico/resources/v3/projectcalico.org/\* |   RW   |
 
 ## CNI-plugin

--- a/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -19,11 +19,11 @@ component needs access to in etcd to function successfully.
 | /calico/ipam/v2/\*                        |   RW   |
 | /calico/resources/v3/projectcalico.org/\* |   RW   |
 
-## felix as a stand alone process
+## Felix as a stand alone process
 
 | Path                                      | Access |
 |-------------------------------------------|--------|
-| /calico/felix/v1/\*                       |   RW   |
+| /calico/felix/v1/\*                       |   R    |
 | /calico/resources/v3/projectcalico.org/\* |   RW   |
 
 ## CNI-plugin


### PR DESCRIPTION
## Description

- Removes the `W` permission from `/calico/felix/v1/\* `...turns out to be unnecessary. Raised by community. Security implications.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
