### PR TITLE
Removes unnecessary Felix write permission as not required

### DIFF
--- a/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -19,12 +19,12 @@ component needs access to in etcd to function successfully.
 | /calico/ipam/v2/\*                        |   RW   |
 | /calico/resources/v3/projectcalico.org/\* |   RW   |
 
-## felix as a stand alone process
+## Felix as a stand alone process
 
 | Path                                      | Access |
 |-------------------------------------------|--------|
 | /calico/felix/v1/\*                       |   RW   |
-| /calico/resources/v3/projectcalico.org/\* |   RW   |
+| /calico/resources/v3/projectcalico.org/\* |   R    |
 
 ## CNI-plugin
 

--- a/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -19,12 +19,12 @@ component needs access to in etcd to function successfully.
 | /calico/ipam/v2/\*                        |   RW   |
 | /calico/resources/v3/projectcalico.org/\* |   RW   |
 
-## felix as a stand alone process
+## Felix as a stand alone process
 
 | Path                                      | Access |
 |-------------------------------------------|--------|
 | /calico/felix/v1/\*                       |   RW   |
-| /calico/resources/v3/projectcalico.org/\* |   RW   |
+| /calico/resources/v3/projectcalico.org/\* |   R    |
 
 ## CNI-plugin
 


### PR DESCRIPTION
## Description

- Removes unnecessary Felix write permission for some reason added to v3 and master docs but not present in v2.6 docs and not necessary. Raised by community, security implications.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
