### PR TITLE
Fixing v1beta1 network policy link

### DIFF
--- a/v2.0/usage/troubleshooting/faq.md
+++ b/v2.0/usage/troubleshooting/faq.md
@@ -51,7 +51,7 @@ to the interface.
 
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
-The Kubernetes [NetworkPolicy](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
+The Kubernetes [NetworkPolicy](https://v1-8.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
 API doesn't currently support this.  However,
 Calico does!  You can use `calicoctl` to configure egress policy to prevent
 Kubernetes pods from initiating outgoing connections based on the full set of

--- a/v2.1/usage/troubleshooting/faq.md
+++ b/v2.1/usage/troubleshooting/faq.md
@@ -51,7 +51,7 @@ to the interface.
 
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
-The Kubernetes [NetworkPolicy](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
+The Kubernetes [NetworkPolicy](https://v1-8.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
 API doesn't currently support this.  However,
 Calico does!  You can use `calicoctl` to configure egress policy to prevent
 Kubernetes pods from initiating outgoing connections based on the full set of

--- a/v2.2/usage/troubleshooting/faq.md
+++ b/v2.2/usage/troubleshooting/faq.md
@@ -51,7 +51,7 @@ to the interface.
 
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
-The Kubernetes [NetworkPolicy](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
+The Kubernetes [NetworkPolicy](https://v1-8.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
 API doesn't currently support this.  However,
 Calico does!  You can use `calicoctl` to configure egress policy to prevent
 Kubernetes pods from initiating outgoing connections based on the full set of

--- a/v2.3/usage/troubleshooting/faq.md
+++ b/v2.3/usage/troubleshooting/faq.md
@@ -51,7 +51,7 @@ to the interface.
 
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
-The Kubernetes [NetworkPolicy](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
+The Kubernetes [NetworkPolicy](https://v1-8.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
 API doesn't currently support this.  However,
 Calico does!  You can use `calicoctl` to configure egress policy to prevent
 Kubernetes pods from initiating outgoing connections based on the full set of

--- a/v2.4/usage/troubleshooting/faq.md
+++ b/v2.4/usage/troubleshooting/faq.md
@@ -51,7 +51,7 @@ to the interface.
 
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
-The Kubernetes [NetworkPolicy](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
+The Kubernetes [NetworkPolicy](https://v1-8.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
 API doesn't currently support this.  However,
 Calico does!  You can use `calicoctl` to configure egress policy to prevent
 Kubernetes pods from initiating outgoing connections based on the full set of

--- a/v2.5/usage/troubleshooting/faq.md
+++ b/v2.5/usage/troubleshooting/faq.md
@@ -51,7 +51,7 @@ to the interface.
 
 ## Can I prevent my Kubernetes pods from initiating outgoing connections?
 
-The Kubernetes [NetworkPolicy](http://kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
+The Kubernetes [NetworkPolicy](https://v1-8.docs.kubernetes.io/docs/api-reference/extensions/v1beta1/definitions/#_v1beta1_networkpolicy)
 API doesn't currently support this.  However,
 Calico does!  You can use `calicoctl` to configure egress policy to prevent
 Kubernetes pods from initiating outgoing connections based on the full set of


### PR DESCRIPTION
## Description

Seems like the v1beta1 link has been removed from latest K8s docs so this switches to point to the specific K8s v1.8 docs.

## Release Note

```release-note
None required
```
