### PR TITLE
Separate semaphore target into a clean target for use on other CI systems

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -588,13 +588,8 @@ node-test-at:
 	chmod +rx /tmp/goss && \
 	/tmp/goss --gossfile /tmp/goss.yaml validate'
 
-# This depends on clean to ensure that dependent images get untagged and repulled
-# THIS JOB DELETES LOTS OF THINGS - DO NOT RUN IT ON YOUR LOCAL DEV MACHINE.
-.PHONY: semaphore
-semaphore:
-	# Clean up unwanted files to free disk space.
-	bash -c 'rm -rf /usr/local/golang /opt /var/lib/mongodb /usr/lib/jvm /home/runner/{.npm,.phpbrew,.phpunit,.kerl,.kiex,.lein,.nvm,.npm,.phpbrew,.rbenv}'
-
+.PHONY: ci 
+ci:
 	# Run the containerized UTs first.
 	$(MAKE) node-test-containerized
 
@@ -603,6 +598,14 @@ semaphore:
 	# using "latest" tagged images.
 	$(MAKE) RELEASE_STREAM=master $(NODE_CONTAINER_NAME) st
 	ST_TO_RUN=tests/st/policy $(MAKE) RELEASE_STREAM=master st-ssl
+
+# This depends on clean to ensure that dependent images get untagged and repulled
+# THIS JOB DELETES LOTS OF THINGS - DO NOT RUN IT ON YOUR LOCAL DEV MACHINE.
+.PHONY: semaphore
+semaphore:
+	# Clean up unwanted files to free disk space.
+	bash -c 'rm -rf /usr/local/golang /opt /var/lib/mongodb /usr/lib/jvm /home/runner/{.npm,.phpbrew,.phpunit,.kerl,.kiex,.lein,.nvm,.npm,.phpbrew,.rbenv}'
+	$(MAKE) ci
 
 release: clean
 	@echo ""


### PR DESCRIPTION
Signed-off-by: jose-bigio <jose.bigio@docker.com>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- **Fix type**: Continuous Integration

The CI system utilizes the `semaphore` target to build. This target first cleans the Semaphore machine with: 
```
bash -c 'rm -rf /usr/local/golang /opt /var/lib/mongodb /usr/lib/jvm /home/runner/{.npm,.phpbrew,.phpunit,.kerl,.kiex,.lein,.nvm,.npm,.phpbrew,.rbenv}'
```

It would be desirable to utilize this target on other CI systems. For instance, I want to set up a different CI on a fork, but running the clean target would be destructive to the CI.

This change would require a change to the  semaphore CI, because the bash commands would need to be updated to call `make clean-semaphore` and `make semaphore` as opposed to only `make semaphore`. 

On a related note I wanted to know if the CI commands such as 
```
if [ -e calico_node/Makefile ]; then if [ -z $PULL_REQUEST_NUMBER ] || git diff --name-only HEAD^ | grep '^calico_node/' || git diff --name-only HEAD^ | grep '^_data/versions.yml'; then if grep batchnumber calico_node/tests/st/test_base.py; then sudo -E ST_OPTIONS="-A batchnumber==0" make -C calico_node semaphore; else sudo -E make -C calico_node semaphore; fi; fi; fi
```
are stored in source control anywhere? 


## Todos

- [ ] ~Update Semaphore CI to call make clean-semaphore && make semaphore~
- [ ] Documentation (If the CI system is documented anywhere possibly update the process there)

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
