### PR TITLE
Update docs to use v2.6.8

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -658,6 +658,55 @@ v3.0:
       url: ""
 
 v2.6:
+- title: v2.6.8
+  note: |
+    23 February 2018
+
+    - Ignore hidden files when checking for etcd certificates to copy over when installing CNI. [cni-plugin #474](https://github.com/projectcalico/cni-plugin/pull/474) (@tmjd)
+
+    - Sanitize Mesos labels by stripping preceding and succeeding special characters and converting the rest to periods. [cni-plugin #467](https://github.com/projectcalico/cni-plugin/pull/467) (@ozdanborne)
+
+  components:
+    felix:
+      version: 2.6.6
+      url: https://github.com/projectcalico/felix/releases/tag/2.6.6
+    typha:
+      version: v0.5.6
+      url: https://github.com/projectcalico/typha/releases/tag/v0.5.6
+    calicoctl:
+      version: v1.6.3
+      url: https://github.com/projectcalico/calicoctl/releases/tag/v1.6.3
+      download_url: https://github.com/projectcalico/calicoctl/releases/download/v1.6.3/calicoctl
+    calico/node:
+      version: v2.6.8
+      url: https://github.com/projectcalico/calico/releases/tag/v2.6.8
+    calico/cni:
+      version: v1.11.4
+      url: https://github.com/projectcalico/cni-plugin/releases/tag/v1.11.4
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.4/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v1.11.4/calico-ipam
+    confd:
+      version: v0.12.1-calico-0.4.3
+      url: https://github.com/projectcalico/confd/releases/tag/v0.12.1-calico-0.4.3
+    libnetwork-plugin:
+      version: v1.1.2
+      url: https://github.com/projectcalico/libnetwork-plugin/releases/tag/v1.1.2
+    calico/kube-controllers:
+      version: v1.0.3
+      url: https://github.com/projectcalico/k8s-policy/releases/tag/v1.0.3
+    calico-bird:
+      version: v0.3.2
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.2
+    calico-bgp-daemon:
+      version: v0.2.2
+      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.2
+    networking-calico:
+      version: 1.4.3
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.3
+    calico/routereflector:
+      version: v0.4.2
+      url: ""
+
 - title: v2.6.7
   note: |
     30 January 2018 


### PR DESCRIPTION
## Description

updates the latest v2.6 release to be Calico v2.6.8