### PR TITLE
Don't advertise blocks with pending affinity

### DIFF
--- a/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
@@ -16,7 +16,19 @@ function calico_aggr ()
 {{range ls "/"}}
 {{$parts := split . "-"}}
 {{$cidr := join $parts "/"}}
-  if ( net = {{$cidr}} ) then { accept; }
-  if ( net ~ {{$cidr}} ) then { reject; }
+{{$affinity := json (getv (printf "/%s" .))}}
+
+  {{if $affinity.state}}
+      # Block {{$cidr}} is {{$affinity.state}}
+    {{if eq $affinity.state "confirmed"}}
+      if ( net = {{$cidr}} ) then { accept; }
+      if ( net ~ {{$cidr}} ) then { reject; }
+    {{end}}
+  {{ else }}
+      # Block {{$cidr}} is implicitly confirmed.
+      if ( net = {{$cidr}} ) then { accept; }
+      if ( net ~ {{$cidr}} ) then { reject; }
+  {{ end }}
+
 {{end}}
 }

--- a/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
@@ -13,11 +13,10 @@ protocol static {
 # Aggregation of routes on this host; export the block, nothing beneath it.
 function calico_aggr ()
 {
-{{range ls "/"}}
-{{$parts := split . "-"}}
+{{range gets "/"}}
+{{$parts := split .Key "-"}}
 {{$cidr := join $parts "/"}}
-{{$affinity := json (getv (printf "/%s" .))}}
-
+{{$affinity := json .Value}}
   {{if $affinity.state}}
       # Block {{$cidr}} is {{$affinity.state}}
     {{if eq $affinity.state "confirmed"}}
@@ -29,6 +28,5 @@ function calico_aggr ()
       if ( net = {{$cidr}} ) then { accept; }
       if ( net ~ {{$cidr}} ) then { reject; }
   {{ end }}
-
 {{end}}
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In conjunction with https://github.com/projectcalico/libcalico-go/pull/785, this change will make sure that any leaked block affinities won't get advertised by BIRD during the interim before they are cleaned up.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes a rare bug where a node could in some circumstances advertise /26 blocks that it didn't own
```
