### PR TITLE
Remove unused config options from kube-controllers

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -467,15 +467,6 @@ spec:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
               value: policy,profile,workloadendpoint,node
-            # The location of the Kubernetes API.  Use the default Kubernetes
-            # service for API access.
-            - name: K8S_API
-              value: "https://kubernetes.default:443"
-            # Since we're running in the host namespace and might not have KubeDNS
-            # access, configure the container's /etc/hosts to resolve
-            # kubernetes.default to the correct service clusterIP.
-            - name: CONFIGURE_ETC_HOSTS
-              value: "true"
           volumeMounts:
             # Mount in the etcd TLS secrets.
             - mountPath: /calico-secrets

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
@@ -178,7 +178,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
         - effect: NoExecute
-          operator: Exists  
+          operator: Exists
       serviceAccountName: calico-cni-plugin
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
@@ -350,18 +350,9 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            # The location of the Kubernetes API.  Use the default Kubernetes
-            # service for API access.
-            - name: K8S_API
-              value: "https://kubernetes.default:443"
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
               value: policy,profile,workloadendpoint,node
-            # Since we're running in the host namespace and might not have KubeDNS
-            # access, configure the container's /etc/hosts to resolve
-            # kubernetes.default to the correct service clusterIP.
-            - name: CONFIGURE_ETC_HOSTS
-              value: "true"
 
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -467,15 +467,6 @@ spec:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
               value: policy,profile,workloadendpoint,node
-            # The location of the Kubernetes API.  Use the default Kubernetes
-            # service for API access.
-            - name: K8S_API
-              value: "https://kubernetes.default:443"
-            # Since we're running in the host namespace and might not have KubeDNS
-            # access, configure the container's /etc/hosts to resolve
-            # kubernetes.default to the correct service clusterIP.
-            - name: CONFIGURE_ETC_HOSTS
-              value: "true"
           volumeMounts:
             # Mount in the etcd TLS secrets.
             - mountPath: /calico-secrets

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
@@ -358,18 +358,9 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            # The location of the Kubernetes API.  Use the default Kubernetes
-            # service for API access.
-            - name: K8S_API
-              value: "https://kubernetes.default:443"
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
               value: policy,profile,workloadendpoint,node
-            # Since we're running in the host namespace and might not have KubeDNS
-            # access, configure the container's /etc/hosts to resolve
-            # kubernetes.default to the correct service clusterIP.
-            - name: CONFIGURE_ETC_HOSTS
-              value: "true"
 
 ---
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

CONFIGURE_ETC_HOSTS and K8S_API are no longer used in kube-controllers - they're just left over from the old policy-controller config but aren't even respected any more.

This PR removes them from master and v3.0 manifests.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
