### PR TITLE
Clean up CNI config in k8s manifests

### DIFF
--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -28,24 +28,22 @@ data:
       "cniVersion": "0.3.0",
       "plugins": [
         {
-            "type": "calico",
-            "etcd_endpoints": "__ETCD_ENDPOINTS__",
-            "etcd_key_file": "__ETCD_KEY_FILE__",
-            "etcd_cert_file": "__ETCD_CERT_FILE__",
-            "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
-            "log_level": "info",
-            "mtu": 1500,
-            "ipam": {
-                "type": "calico-ipam"
-            },
-            "policy": {
-                "type": "k8s",
-                "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-                "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-            },
-            "kubernetes": {
-                "kubeconfig": "__KUBECONFIG_FILEPATH__"
-            }
+          "type": "calico",
+          "etcd_endpoints": "__ETCD_ENDPOINTS__",
+          "etcd_key_file": "__ETCD_KEY_FILE__",
+          "etcd_cert_file": "__ETCD_CERT_FILE__",
+          "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
+          "log_level": "info",
+          "mtu": 1500,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
         },
         {
           "type": "portmap",
@@ -116,7 +114,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
         - effect: NoExecute
-          operator: Exists  
+          operator: Exists
       serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.

--- a/master/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/canal/canal.yaml
@@ -27,33 +27,31 @@ data:
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
-        "name": "k8s-pod-network",
-        "cniVersion": "0.3.0",
-        "plugins": [
-            {
-                "type": "calico",
-                "log_level": "info",
-                "datastore_type": "kubernetes",
-                "nodename": "__KUBERNETES_NODE_NAME__",
-                "ipam": {
-                    "type": "host-local",
-                    "subnet": "usePodCidr"
-                },
-                "policy": {
-                    "type": "k8s",
-                    "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-                },
-                "kubernetes": {
-                    "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-                    "kubeconfig": "__KUBECONFIG_FILEPATH__"
-                }
-            },
-            {
-                "type": "portmap",
-                "capabilities": {"portMappings": true},
-                "snat": true
-            }
-        ]
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+          },
+          "policy": {
+            "type": "k8s"
+          },
+          "kubernetes": {
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
     }
 
   # Flannel network configuration. Mounted into the flannel container.

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
@@ -15,8 +15,7 @@ metadata:
   name: calico-config
   namespace: kube-system
 data:
-  # The location of your etcd cluster.  This uses the Service clusterIP
-  # defined below.
+  # The location of your etcd cluster.  This uses the Service clusterIP defined below.
   etcd_endpoints: "http://10.96.232.136:6666"
 
   # Configure the Calico backend to use.
@@ -37,12 +36,10 @@ data:
               "type": "calico-ipam"
           },
           "policy": {
-              "type": "k8s",
-               "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-               "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+              "type": "k8s"
           },
           "kubernetes": {
-              "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
           }
         },
         {
@@ -52,7 +49,6 @@ data:
         }
       ]
     }
-
 
 ---
 

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -18,6 +18,7 @@ data:
   # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
   # essential.
   typha_service_name: "none"
+
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
@@ -35,11 +36,9 @@ data:
             "subnet": "usePodCidr"
           },
           "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+            "type": "k8s"
           },
           "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
             "kubeconfig": "__KUBECONFIG_FILEPATH__"
           }
         },

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -18,6 +18,7 @@ data:
   # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
   # essential.
   typha_service_name: "none"
+
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
@@ -31,16 +32,14 @@ data:
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": 1500,
           "ipam": {
-              "type": "host-local",
-              "subnet": "usePodCidr"
+            "type": "host-local",
+            "subnet": "usePodCidr"
           },
           "policy": {
-              "type": "k8s",
-              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+            "type": "k8s"
           },
           "kubernetes": {
-              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
           }
         },
         {
@@ -192,7 +191,7 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
         - effect: NoExecute
-          operator: Exists 
+          operator: Exists
       serviceAccountName: calico-node
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Follow on from https://github.com/projectcalico/cni-plugin/pull/481

This PR updates the CNI config in each k8s manfiest to rely solely on the given kubeconfig file for k8s API connection details.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
