### PR TITLE
Update docs to include IPVS support.

### DIFF
--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -12,13 +12,20 @@ information.
 {{site.prodname}} can run on any Kubernetes cluster which meets the following criteria.
 
 - The kubelet must be configured to use CNI network plugins (e.g `--network-plugin=cni`).
-- The kube-proxy must be started in `iptables` proxy mode.  This is the default as of Kubernetes v1.2.0.
+- kube-proxy must be started in one of the following modes:
+
+   - `iptables` the default as of Kubernetes v1.2.0
+   - `ipvs` {{site.prodname}} supports this at the beta level with
+     [some limitations](#kube-proxy-ipvs-mode). Requires Kubernetes v1.9.3 or later due to
+     critical bugs in earlier releases.
+
+- For kube-proxy `ipvs` mode, Kubernetes v1.9.3 or above is required due to
+  critical bugs in earlier releases.
 - The kube-proxy must be started without the `--masquerade-all` flag, which conflicts with {{site.prodname}} policy.
 - The Kubernetes `NetworkPolicy` API requires at least Kubernetes version v1.3.0.
 - When RBAC is enabled, the proper accounts, roles, and bindings must be defined
   and utilized by the {{site.prodname}} components.  Examples exist for both the [etcd](rbac.yaml) and
   [kubernetes api](hosted/rbac-kdd.yaml) datastores.
-
 
 ## [{{site.prodname}} Hosted Install](hosted)
 
@@ -42,3 +49,32 @@ You can find some of them here, organized by cloud provider.
 - [Amazon Web Services](aws)
 - [Google Compute Engine](gce)
 - [Microsoft Azure](azure)
+
+## kube-proxy IPVS mode
+
+{{site.prodname}} has beta-level support for `kube-proxy`'s `ipvs` proxy mode.
+{{site.prodname}} `ipvs` support is activated automatically if {{site.prodname}}
+detects that `kube-proxy` is running in that mode.
+
+`ipvs` mode promises greater scale and performance vs `iptables` mode.
+However, it comes with some limitations.  In IPVS mode:
+
+- `kube-proxy` has a [known issue](https://github.com/kubernetes/kubernetes/issues/58202)
+  affecting hosts with host interfaces that that are **not** named using the
+  pattern `ethN`.
+- {{site.prodname}} requires [additional `iptables` packet mark bits](../../../reference/felix/configuration#ipvs-bits)
+  in order to track packets as they pass through IPVS.
+- {{site.prodname}} needs to be [configured](../../../reference/felix/configuration#ipvs-portranges)
+  with the port range that is assigned to Kubernetes NodePorts.  If services
+  do use NodePorts outside {{site.prodname}}'s expected range,
+  {{site.prodname}} will treat traffic to those ports as host traffic instead
+  of pod traffic.
+- {{site.prodname}} does not yet support Kubernetes services that make use of a
+  locally-assigned ExternalIP.  {{site.prodname}} does support ExternalIPs that
+  are implemented via an external load balancer.
+- {{site.prodname}} has not yet been scale tested with `ipvs`.
+
+ {{site.prodname}} will detect if you change `kube-proxy`'s proxy mode after 
+ {{site.prodname}} has been deployed. Any Kubernetes `ipvs`-specific configuration 
+ needs to be [configured](../../../reference/felix/configuration#ipvs-portranges) 
+ before changing the `kube-proxy` proxy mode to `ipvs`.

--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -234,16 +234,18 @@ for more details.
 
 ### Configuring the kube-proxy
 
-In order to use {{site.prodname}} policy with Kubernetes, the `kube-proxy` component must
-be configured to leave the source address of service bound traffic intact.
-This feature is first officially supported in Kubernetes v1.1.0 and is the default mode starting
-in Kubernetes v1.2.0.
+In order to use {{site.prodname}} policy with Kubernetes, the `kube-proxy` component must be
+configured
 
-We highly recommend using the latest stable Kubernetes release, but if you're using an older release
-there are two ways to enable this behavior.
+- in either `iptables` or (beta) `ipvs` proxy mode
+- to disable its "masquerade-all" feature
+- with a "cluster CIDR" that is equal to (or contains) the {{site.prodname}} IP pool.
 
-- Option 1: Start the `kube-proxy` with the `--proxy-mode=iptables` option.
-- Option 2: Annotate the Kubernetes Node API object with `net.experimental.kubernetes.io/proxy-mode` set to `iptables`.
+This ensures that the source address of service-bound packets is preserved.  `iptables` 
+mode is the default as of Kubernetes v1.2.0.  {{site.prodname}}'s `ipvs` mode support requires at 
+least Kubernetes v1.9.3 and it has [some limitations](../installation/#kube-proxy-ipvs-mode).
 
-See the [kube-proxy reference documentation](http://kubernetes.io/docs/admin/kube-proxy/)
-for more details.
+The Kubernetes team is in the process of migrating kube-proxy from command-line argument
+configuration to a configuration file.  At the time of writing, the required options are
+controlled by command line arguments `--proxy-mode`, `--masquerade-all`, and `--cluster-cidr`,
+as detailed in the [kube-proxy reference documentation](http://kubernetes.io/docs/admin/kube-proxy/).

--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.0/reference/felix/configuratio
 ---
 
 Configuration for Felix is read from one of four possible locations, in
-order, as follows. 
+order, as follows.
 
 1.  Environment variables.
 2.  The Felix configuration file.
@@ -12,16 +12,16 @@ order, as follows.
 4.  The global `FelixConfiguration` resource (`default`).
 
 The value of any configuration parameter is the value read from the
-*first* location containing a value. For example, if an environment variable 
+*first* location containing a value. For example, if an environment variable
 contains a value, it takes top precedence.
 
-If not set in any of these locations, most configuration parameters have 
+If not set in any of these locations, most configuration parameters have
 defaults, and it should be rare to have to explicitly set them.
 
 The full list of parameters which can be set is as follows.
 
-> **Note**: The following tables detail the configuration file and 
-> environment variable parameters. For `FelixConfiguration` resource settings, 
+> **Note**: The following tables detail the configuration file and
+> environment variable parameters. For `FelixConfiguration` resource settings,
 > refer to [Felix Configuration Resource](../calicoctl/resources/felixconfig).
 {: .alert .alert-info}
 
@@ -61,7 +61,7 @@ The full list of parameters which can be set is as follows.
 
 #### Kubernetes datastore configuration
 
-The Kubernetes datastore driver reads its configuration from Kubernetes-provided environment variables. 
+The Kubernetes datastore driver reads its configuration from Kubernetes-provided environment variables.
 
 #### iptables dataplane configuration
 
@@ -78,13 +78,26 @@ The Kubernetes datastore driver reads its configuration from Kubernetes-provided
 | `IptablesLockProbeIntervalMillis`    | `FELIX_IPTABLESLOCKPROBEINTERVALMILLIS`    | Time, in milliseconds, that Felix will wait between attempts to acquire the iptables lock if it is not available.  Lower values make Felix more responsive when the lock is contended, but use more CPU. [Default: `50`]  | int |
 | `IptablesLockTimeoutSecs`            | `FELIX_IPTABLESLOCKTIMEOUTSECS`            | Time, in seconds, that Felix will wait for the iptables lock, or 0, to disable. To use this feature, Felix must share the iptables lock file with all other processes that also take the lock.  When running Felix inside a container, this requires the /run directory of the host to be mounted into the `{{site.nodecontainer}}` or `calico/felix` container. [Default: `0` disabled] | int |
 | `IptablesMangleAllowAction`          | `FELIX_IPTABLESALLOWACTION`                | This parameter controls what happens to traffic that is allowed by a Felix policy chain in the iptables mangle table (i.e., a pre-DNAT policy chain). The default will immediately `Accept` the traffic. Use `Return` to send the traffic back up to the system chains for further processing. [Default: `Accept`]  | `Accept`, `Return` |
-| `IptablesMarkMask`                   | `FELIX_IPTABLESMARKMASK`                                     | Mask that Felix selects its IPTables Mark bits from. Should be a 32 bit hexadecimal number with at least 8 bits set, none of which clash with any other mark bits in use on the system. [Default: `0xff000000`] | netmask |
+| `IptablesMarkMask`                   | `FELIX_IPTABLESMARKMASK`                   | Mask that Felix selects its IPTables Mark bits from. Should be a 32 bit hexadecimal number with at least 8 bits set, none of which clash with any other mark bits in use on the system.  When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, [we recommend allowing at least 16 bits](#ipvs-bits). [Default: `0xffff0000`] | netmask |
 | `IptablesPostWriteCheckIntervalSecs` | `FELIX_IPTABLESPOSTWRITECHECKINTERVALSECS` | Period, in seconds, after Felix has done a write to the dataplane that it schedules an extra read back in order to check the write was not clobbered by another process.  This should only occur if another application on the system doesn't respect the iptables lock. [Default: `1`] | int |
 | `IptablesRefreshInterval`            | `FELIX_IPTABLESREFRESHINTERVAL`            | Period, in seconds, at which Felix re-checks all iptables state to ensure that no other process has accidentally broken {{site.prodname}}'s rules. Set to 0 to disable iptables refresh. [Default: `90`] | int |
 | `LogPrefix`                          | `FELIX_LOGPREFIX`                          | The log prefix that Felix uses when rendering LOG rules. [Default: `calico-packet`] | string |
 | `MaxIpsetSize`                       | `FELIX_MAXIPSETSIZE`                       | Maximum size for the ipsets used by Felix to implement tags. Should be set to a number that is greater than the maximum number of IP addresses that are ever expected in a tag. [Default: `1048576`] | int |
 | `NetlinkTimeoutSecs`                 | `FELIX_NETLINKTIMEOUTSECS`                 | Time, in seconds, that Felix will wait for netlink (i.e. routing table list/update) operations to complete before giving up and retrying. [Default: `10`] | float |
 | `RouteRefreshIntervalSecs`           | `FELIX_ROUTEREFRESHINTERVAL`               | Period, in seconds, at which Felix re-checks the routes in the dataplane to ensure that no other process has accidentally broken {{site.prodname}}'s rules. Set to 0 to disable route refresh. [Default: `90`] | int |
+
+#### Kubernetes-specific configuration
+
+| Configuration parameter | Environment variable       | Description  | Schema |
+| ------------------------|----------------------------| ------------ | ------ |
+| `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
+
+
+> **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.
+> For example, the default `IptablesMarkMask` value, `0xffff0000` gives {{site.prodname}} 16 bits, up to 6 of which are used for internal purposes, leaving 10 bits for endpoint IDs.
+> 10 bits is enough for 1024 different values and {{site.prodname}} uses 2 of those for internal purposes, leaving enough for 1022 endpoints on the host.
+{: .alert .alert-info}
+
 
 #### OpenStack-specific configuration
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico now has beta support for kube-proxy's IPVS proxy mode, including ingress, egress and host endpoint policy.
```
