### PR TITLE
Revert "Use gets instead of ls"

### DIFF
--- a/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
@@ -17,7 +17,6 @@ function calico_aggr ()
 {{$parts := split . "-"}}
 {{$cidr := join $parts "/"}}
 {{$affinity := json (getv (printf "/%s" .))}}
-
   {{if $affinity.state}}
       # Block {{$cidr}} is {{$affinity.state}}
     {{if eq $affinity.state "confirmed"}}
@@ -29,6 +28,5 @@ function calico_aggr ()
       if ( net = {{$cidr}} ) then { accept; }
       if ( net ~ {{$cidr}} ) then { reject; }
   {{ end }}
-
 {{end}}
 }

--- a/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.cfg.template
@@ -13,10 +13,11 @@ protocol static {
 # Aggregation of routes on this host; export the block, nothing beneath it.
 function calico_aggr ()
 {
-{{range gets "/"}}
-{{$parts := split .Key "-"}}
+{{range ls "/"}}
+{{$parts := split . "-"}}
 {{$cidr := join $parts "/"}}
-{{$affinity := json .Value}}
+{{$affinity := json (getv (printf "/%s" .))}}
+
   {{if $affinity.state}}
       # Block {{$cidr}} is {{$affinity.state}}
     {{if eq $affinity.state "confirmed"}}
@@ -28,5 +29,6 @@ function calico_aggr ()
       if ( net = {{$cidr}} ) then { accept; }
       if ( net ~ {{$cidr}} ) then { reject; }
   {{ end }}
+
 {{end}}
 }


### PR DESCRIPTION
This reverts commit 9e3f8831c16ae52a1c69f3047771628c75d9a4e3.

Reverting from this PR: https://github.com/projectcalico/calico/pull/1712

Change to use get doesn't seem to work with our modified confd code.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
