### PR TITLE
Fix tests for changes regarding reading node names from file

### DIFF
--- a/calico_node/tests/st/utils/workload.py
+++ b/calico_node/tests/st/utils/workload.py
@@ -125,7 +125,8 @@ class Workload(object):
                    '"type":"calico-cni-plugin",' +
                    etcd_json +
                    labels_json +
-                   '"ipam":{"type":"calico-ipam-plugin"%s}' % ip_json +
+                   '"ipam":{"type":"calico-ipam-plugin"%s},' % ip_json +
+                   '"nodename_file_optional":true' +
                    '}\' | ' +
                    'CNI_COMMAND=%s ' % add_or_del +
                    'CNI_CONTAINERID=%s ' % container_id +


### PR DESCRIPTION
## Description

Fixes some tests by running the CNI plugin with a corrected config so that it does not require the nodename file to be found at `/var/lib/calico/nodename`.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
