### PR TITLE
Automatic update of logrus to v1.0.4

### DIFF
--- a/calico_node/glide.lock
+++ b/calico_node/glide.lock
@@ -1,5 +1,5 @@
-hash: 466ec2a63ec277d2d0f23cba5b5c69bb4ee67b6afbe8b762747852f37127af87
-updated: 2018-03-02T18:54:50.793584618Z
+hash: 7da122c90265659121621d38b0bed0d04beeaae7cdcb0b41c2cb105ccce11304
+updated: 2018-03-19T15:02:56.058140843Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -273,7 +273,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 88d2dcc510266da9f7f8c7f34e1940716cab5f5c
+  version: ebfc5b4631820b793c9010c87fd8fef0f39eb082
   subpackages:
   - unix
   - windows
@@ -346,7 +346,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 389dfa299845bcf399c16af89987e8775718ea48
+  version: 3c2a58f9923aeb5d27fa4d91249e45a1460ca3bd
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -373,7 +373,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 4972c8e335e32ab65ba45bde0a99c6544c8a8e4c
+  version: ab7fc865fb0881d161f37adef3e5a67b89a18d05
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/calico_node/glide.yaml
+++ b/calico_node/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/projectcalico/calico/calico_node
 import:
 - package: github.com/sirupsen/logrus
-  version: ^1.0.3
+  version: v1.0.4
 - package: github.com/projectcalico/libcalico-go
   version: 16a16d0960511310db4772874de7650ab2967827
   subpackages:


### PR DESCRIPTION
Pin logrus to v1.0.4 due to a breaking bug in v1.0.5.