### PR TITLE
Move release notes to file

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -839,13 +839,6 @@ v3.0:
 
 v2.6:
 - title: v2.6.8
-  note: |
-    23 February 2018
-
-    - Ignore hidden files when checking for etcd certificates to copy over when installing CNI. [cni-plugin #474](https://github.com/projectcalico/cni-plugin/pull/474) (@tmjd)
-
-    - Sanitize Mesos labels by stripping preceding and succeeding special characters and converting the rest to periods. [cni-plugin #467](https://github.com/projectcalico/cni-plugin/pull/467) (@ozdanborne)
-
   components:
     felix:
       version: 2.6.6
@@ -890,13 +883,6 @@ v2.6:
       version: v0.9.1
 
 - title: v2.6.7
-  note: |
-    30 January 2018 
-
-    - Fixes a bug where Felix would crash when parsing a NetworkPolicy with a named port. [libcalico-go #774](https://github.com/projectcalico/libcalico-go/pull/774) (@caseydavenport)
-
-    - Fixes a route scan issue where upon startup BIRD did not spot that a tunneled route needed to be updated to be non-tunneled. [Calico #1625](https://github.com/projectcalico/calico/pull/1625) (@robbrockbank)
-
   components:
     felix:
       version: 2.6.6
@@ -941,16 +927,6 @@ v2.6:
       version: v0.9.1
 
 - title: v2.6.6
-  note: |
-    17 January 2018
-
-    - Updates the calico/node startup logging format to be consistent with other Calico logs. [calico #1594](https://github.com/projectcalico/calico/pull/1594) (@caseydavenport)
-
-    - Updates Typha and Felix to send logs to stdout instead of stderr. [typha #105](https://github.com/projectcalico/typha/pull/105) (@fasaxc)
-
-    - Resolves an issue when upgrading from old versions of Calico where the `k8s-policy-no-match` network
-      policy was not removed as expected. [kube-controllers #208](https://github.com/projectcalico/kube-controllers/pull/208) (@caseydavenport)
-
   components:
     felix:
       version: 2.6.5
@@ -995,24 +971,6 @@ v2.6:
       version: v0.9.1
 
 - title: v2.6.5
-  note: |
-    22 December 2017
-
-    - Resolves an issue which led to very brief loss of connectivity
-      after upgrading to v3.0.0 from v2.6.4 when using an etcd datastore.
-      [https://github.com/projectcalico/felix/pull/1676]
-
-    - Certain configuration changes no longer cause Felix to restart, allowing
-      upgrades to Calico v3.0.0. [felix #1631](https://github.com/projectcalico/felix/pull/1631) (@fasaxc)
-
-    - Calico now assigns the host side of veth pairs a MAC address of `ee:ee:ee:ee:ee:ee`.
-      If this fails, it uses a kernel-generated MAC address as before. For more information,
-      refer to the [Troubleshooting FAQ](https://docs.projectcalico.org/v2.6/usage/troubleshooting/). [cni-plugin #436](https://github.com/projectcalico/cni-plugin/pull/436) (@tmjd)
-
-    - `calicoctl` now includes a new environment variable called `CALICO_LIBNETWORK_VETH_MTU`
-      that allows you to configure the MTU of veth endpoints when using the Docker orchestrator.
-      [libnetwork-plugin #164](https://github.com/projectcalico/libnetwork-plugin/pull/164) (@ti-mo)
-
   components:
     felix:
       version: 2.6.4
@@ -1055,11 +1013,6 @@ v2.6:
       url: ""
 
 - title: v2.6.4
-  note: |
-    20 December 2017
-
-    - This release has an issue which causes rolling upgrades to not work properly. We
-      recommend that you use v2.6.5 instead.
   components:
     felix:
       version: 2.6.3
@@ -1102,15 +1055,6 @@ v2.6:
       url: ""
 
 - title: v2.6.3
-  note: |
-    28 November 2017
-
-    Calico v2.6.3 addresses several outstanding common vulnerabilities and exposures (CVE).
-
-    - A new node controller for Kubernetes deployments clears data associated with deleted nodes from the Calico datastore, preventing conflicts that can lead to crash loops.
-
-    <div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>
-
   components:
     felix:
       version: 2.6.2
@@ -1153,17 +1097,6 @@ v2.6:
       url: ""
 
 - title: v2.6.2
-  note: |
-    16 October 2017
-
-    Calico v2.6.2 adds fixes and enhancements for Calico/OpenStack deployments.  For Kubernetes and other integrations there is no change from v2.6.1.
-
-    - The dnsmasq packages that we provide have been upgraded so as to address various [security issues](https://github.com/projectcalico/calico/issues/1169).
-
-    - networking-calico master has been released, as 1.4.3, so as to provide support for OpenStack Ocata and later.
-
-    <div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>
-
   components:
     felix:
       version: 2.6.0
@@ -1204,13 +1137,6 @@ v2.6:
 
 
 - title: v2.6.1
-  note: |
-    29 September 2017
-
-    Calico v2.6.0 was released with the wrong version of Felix, which meant that egress network policy did not function as expected. Calico v2.6.1 includes the correct version.
-
-    <div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>
-
   components:
     felix:
       version: 2.6.0
@@ -1251,13 +1177,6 @@ v2.6:
 
 
 - title: v2.6.0
-  note: |
-    28 September 2017
-
-    <div class="alert alert-danger" role="alert"><b>Warning</b>: Incorrect release artifacts. Please use Calico v2.6.1 instead.</div>
-
-    Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
-
   components:
     felix:
       version: 2.6.0
@@ -1297,13 +1216,6 @@ v2.6:
       url: ""
 
 - title: v2.6.0-rc3
-  note: |
-    27 September 2017
-
-    Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
-
-    <div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>
-
   components:
     felix:
       version: 2.6.0-rc2
@@ -1343,13 +1255,6 @@ v2.6:
       url: ""
 
 - title: v2.6.0-rc2
-  note: |
-    24 September 2017
-
-    Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
-
-    <div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>
-
   components:
     felix:
       version: 2.6.0-rc2
@@ -1389,13 +1294,6 @@ v2.6:
       url: ""
 
 - title: v2.6.0-rc1
-  note: |
-    22 September 2017
-
-    Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
-
-    <div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>
-
   components:
     felix:
       version: 2.6.0-rc1

--- a/_includes/v2.6/release-notes/v2.6.0-rc1-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.0-rc1-release-notes.md
@@ -1,0 +1,5 @@
+22 September 2017
+
+Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
+
+<div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>

--- a/_includes/v2.6/release-notes/v2.6.0-rc2-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.0-rc2-release-notes.md
@@ -1,0 +1,5 @@
+24 September 2017
+
+Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
+
+<div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>

--- a/_includes/v2.6/release-notes/v2.6.0-rc3-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.0-rc3-release-notes.md
@@ -1,0 +1,3 @@
+27 September 2017
+Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).
+<div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>

--- a/_includes/v2.6/release-notes/v2.6.0-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.0-release-notes.md
@@ -1,0 +1,5 @@
+28 September 2017
+
+<div class="alert alert-danger" role="alert"><b>Warning</b>: Incorrect release artifacts. Please use Calico v2.6.1 instead.</div>
+
+Detailed release notes can be found on [GitHub](https://github.com/projectcalico/calico/releases).

--- a/_includes/v2.6/release-notes/v2.6.1-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.1-release-notes.md
@@ -1,0 +1,5 @@
+29 September 2017
+
+Calico v2.6.0 was released with the wrong version of Felix, which meant that egress network policy did not function as expected. Calico v2.6.1 includes the correct version.
+
+<div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>

--- a/_includes/v2.6/release-notes/v2.6.2-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.2-release-notes.md
@@ -1,0 +1,9 @@
+16 October 2017
+
+Calico v2.6.2 adds fixes and enhancements for Calico/OpenStack deployments.  For Kubernetes and other integrations there is no change from v2.6.1.
+
+- The dnsmasq packages that we provide have been upgraded so as to address various [security issues](https://github.com/projectcalico/calico/issues/1169).
+
+- networking-calico master has been released, as 1.4.3, so as to provide support for OpenStack Ocata and later.
+
+<div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>

--- a/_includes/v2.6/release-notes/v2.6.3-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.3-release-notes.md
@@ -1,0 +1,7 @@
+28 November 2017
+
+Calico v2.6.3 addresses several outstanding common vulnerabilities and exposures (CVE).
+
+- A new node controller for Kubernetes deployments clears data associated with deleted nodes from the Calico datastore, preventing conflicts that can lead to crash loops.
+
+<div class="alert alert-danger" role="alert"><b>Important</b>: If you are using the Kubernetes datastore and upgrading from Calico v2.4.x or earlier to Calico v2.5.x or later, you must <a href="https://github.com/projectcalico/calico/blob/master/upgrade/v2.5/README.md">migrate your Calico configuration data</a> before upgrading. Otherwise, your cluster may lose connectivity after the upgrade.</div>

--- a/_includes/v2.6/release-notes/v2.6.4-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.4-release-notes.md
@@ -1,0 +1,3 @@
+20 December 2017
+
+- This release has an issue which causes rolling upgrades to not work properly. We recommend that you use v2.6.5 instead.

--- a/_includes/v2.6/release-notes/v2.6.5-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.5-release-notes.md
@@ -1,0 +1,16 @@
+22 December 2017
+
+- Resolves an issue which led to very brief loss of connectivity
+    after upgrading to v3.0.0 from v2.6.4 when using an etcd datastore.
+    [https://github.com/projectcalico/felix/pull/1676]
+
+- Certain configuration changes no longer cause Felix to restart, allowing
+    upgrades to Calico v3.0.0. [felix #1631](https://github.com/projectcalico/felix/pull/1631) (@fasaxc)
+
+- Calico now assigns the host side of veth pairs a MAC address of `ee:ee:ee:ee:ee:ee`.
+    If this fails, it uses a kernel-generated MAC address as before. For more information,
+    refer to the [Troubleshooting FAQ](https://docs.projectcalico.org/v2.6/usage/troubleshooting/). [cni-plugin #436](https://github.com/projectcalico/cni-plugin/pull/436) (@tmjd)
+
+- `calicoctl` now includes a new environment variable called `CALICO_LIBNETWORK_VETH_MTU`
+    that allows you to configure the MTU of veth endpoints when using the Docker orchestrator.
+    [libnetwork-plugin #164](https://github.com/projectcalico/libnetwork-plugin/pull/164) (@ti-mo)

--- a/_includes/v2.6/release-notes/v2.6.6-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.6-release-notes.md
@@ -1,0 +1,8 @@
+17 January 2018
+
+- Updates the calico/node startup logging format to be consistent with other Calico logs. [calico #1594](https://github.com/projectcalico/calico/pull/1594) (@caseydavenport)
+
+- Updates Typha and Felix to send logs to stdout instead of stderr. [typha #105](https://github.com/projectcalico/typha/pull/105) (@fasaxc)
+
+- Resolves an issue when upgrading from old versions of Calico where the `k8s-policy-no-match` network
+    policy was not removed as expected. [kube-controllers #208](https://github.com/projectcalico/kube-controllers/pull/208) (@caseydavenport)

--- a/_includes/v2.6/release-notes/v2.6.7-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.7-release-notes.md
@@ -1,0 +1,5 @@
+30 January 2018
+
+- Fixes a bug where Felix would crash when parsing a NetworkPolicy with a named port. [libcalico-go #774](https://github.com/projectcalico/libcalico-go/pull/774) (@caseydavenport)
+
+- Fixes a route scan issue where upon startup BIRD did not spot that a tunneled route needed to be updated to be non-tunneled. [Calico #1625](https://github.com/projectcalico/calico/pull/1625) (@robbrockbank)

--- a/_includes/v2.6/release-notes/v2.6.8-release-notes.md
+++ b/_includes/v2.6/release-notes/v2.6.8-release-notes.md
@@ -1,0 +1,5 @@
+23 February 2018
+
+- Ignore hidden files when checking for etcd certificates to copy over when installing CNI. [cni-plugin #474](https://github.com/projectcalico/cni-plugin/pull/474) (@tmjd)
+
+- Sanitize Mesos labels by stripping preceding and succeeding special characters and converting the rest to periods. [cni-plugin #467](https://github.com/projectcalico/cni-plugin/pull/467) (@ozdanborne)

--- a/master/releases/index.md
+++ b/master/releases/index.md
@@ -1,5 +1,7 @@
 ---
 title: Releases
+canonical_url: https://docs.projectcalico.org/v3.0/releases/
+redirect_from: latest/releases/index
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.
@@ -12,7 +14,11 @@ Use the version selector at the top-right of this page to view a different relea
 [Release archive](https://github.com/projectcalico/calico/releases/download/{{ release.title }}/release-{{ release.title }}.tgz) with Kubernetes manifests, Docker images and binaries.
 {% endunless %}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}

--- a/v2.1/releases/index.md
+++ b/v2.1/releases/index.md
@@ -9,7 +9,11 @@ Use the version selector at the top-right of this page to view a different relea
 {% for release in site.data.versions[page.version] %}
 ## {{ release.title }}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}

--- a/v2.2/releases/index.md
+++ b/v2.2/releases/index.md
@@ -9,7 +9,11 @@ Use the version selector at the top-right of this page to view a different relea
 {% for release in site.data.versions[page.version] %}
 ## {{ release.title }}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}

--- a/v2.3/releases/index.md
+++ b/v2.3/releases/index.md
@@ -9,7 +9,11 @@ Use the version selector at the top-right of this page to view a different relea
 {% for release in site.data.versions[page.version] %}
 ## {{ release.title }}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}

--- a/v2.4/releases/index.md
+++ b/v2.4/releases/index.md
@@ -12,7 +12,11 @@ Use the version selector at the top-right of this page to view a different relea
 [Release archive](https://github.com/projectcalico/calico/releases/download/{{ release.title }}/release-{{ release.title }}.tgz) with Kubernetes manifests, Docker images and binaries.
 {% endunless %}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}

--- a/v2.5/releases/index.md
+++ b/v2.5/releases/index.md
@@ -12,7 +12,11 @@ Use the version selector at the top-right of this page to view a different relea
 [Release archive](https://github.com/projectcalico/calico/releases/download/{{ release.title }}/release-{{ release.title }}.tgz) with Kubernetes manifests, Docker images and binaries.
 {% endunless %}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}

--- a/v2.6/releases/index.md
+++ b/v2.6/releases/index.md
@@ -12,7 +12,11 @@ Use the version selector at the top-right of this page to view a different relea
 [Release archive](https://github.com/projectcalico/calico/releases/download/{{ release.title }}/release-{{ release.title }}.tgz) with Kubernetes manifests, Docker images and binaries.
 {% endunless %}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}

--- a/v3.0/releases/index.md
+++ b/v3.0/releases/index.md
@@ -14,7 +14,11 @@ Use the version selector at the top-right of this page to view a different relea
 [Release archive](https://github.com/projectcalico/calico/releases/download/{{ release.title }}/release-{{ release.title }}.tgz) with Kubernetes manifests, Docker images and binaries.
 {% endunless %}
 
+{% if release.note %}
 {{ release.note }}
+{% else %}
+{% include {{page.version}}/release-notes/{{release.title}}-release-notes.md %}
+{% endif %}
 
 | Component              | Version |
 |------------------------|---------|{% for component_name in release.components %}


### PR DESCRIPTION
Refresh of #1485.

First commit adds capability where if `release.note` is not defined, it checks on disk.

Second commit implements this for the entire v2.6 stream.

Bonus: If you don't do either, jekyll throws a fatal error on builds:

```
docker run --rm -ti -e JEKYLL_UID=`id -u` -v $PWD:/srv/jekyll jekyll/jekyll:3.5.2 jekyll build --incremental --config _config.yml,_config_dev.yml
Configuration file: _config.yml
Configuration file: _config_dev.yml
       Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
            Source: /srv/jekyll
       Destination: /srv/jekyll/_site
 Incremental build: enabled
      Generating... 
  Liquid Exception: Could not locate the included file 'master/master-release-notes.md' in any of ["/srv/jekyll/_includes"]. Ensure it exists in one of those directories and, if it is a symlink, does not point outside your site source. in master/releases/index.md
jekyll 3.5.2 | Error:  Could not locate the included file 'master/master-release-notes.md' in any of ["/srv/jekyll/_includes"]. Ensure it exists in one of those directories and, if it is a symlink, does not point outside your site source.
Makefile:30: recipe for target 'build' failed
make: *** [build] Error 1
```