### PR TITLE
Removes custom install upgrade coming soon

### DIFF
--- a/master/getting-started/kubernetes/upgrade/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade/upgrade.md
@@ -14,8 +14,6 @@ and your datastore type.
 
 - [Upgrading a self-hosted installation that connects directly to an etcd datastore](#upgrading-a-self-hosted-installation-that-uses-the-etcd-datastore)
 
-- [Upgrading a custom installation](#upgrading-a-custom-installation)
-
 > **Important**: Do not use older versions of `calicoctl` after the upgrade.
 > This may result in unexpected behavior and data.
 {: .alert .alert-danger}
@@ -128,10 +126,4 @@ and your datastore type.
 1. Remove any existing `calicoctl` instances and install the new `calicoctl`.
 
 1. Congratulations! You have upgraded to {{site.prodname}} {{page.version}}.
-
-## Upgrading a custom installation
-
-_Docs for this coming soon!_
-
-
 

--- a/v3.0/getting-started/kubernetes/upgrade/upgrade.md
+++ b/v3.0/getting-started/kubernetes/upgrade/upgrade.md
@@ -15,8 +15,6 @@ and your datastore type.
 
 - [Upgrading a self-hosted installation that connects directly to an etcd datastore](#upgrading-a-self-hosted-installation-that-uses-the-etcd-datastore)
 
-- [Upgrading a custom installation](#upgrading-a-custom-installation)
-
 > **Important**: Do not use older versions of `calicoctl` after the upgrade.
 > This may result in unexpected behavior and data.
 {: .alert .alert-danger}
@@ -129,10 +127,6 @@ and your datastore type.
 1. Remove any existing `calicoctl` instances and install the new `calicoctl`.
 
 1. Congratulations! You have upgraded to {{site.prodname}} {{page.version}}.
-
-## Upgrading a custom installation
-
-_Docs for this coming soon!_
 
 
 

--- a/v3.1/getting-started/kubernetes/upgrade/upgrade.md
+++ b/v3.1/getting-started/kubernetes/upgrade/upgrade.md
@@ -14,8 +14,6 @@ and your datastore type.
 
 - [Upgrading a self-hosted installation that connects directly to an etcd datastore](#upgrading-a-self-hosted-installation-that-uses-the-etcd-datastore)
 
-- [Upgrading a custom installation](#upgrading-a-custom-installation)
-
 > **Important**: Do not use older versions of `calicoctl` after the upgrade.
 > This may result in unexpected behavior and data.
 {: .alert .alert-danger}
@@ -128,10 +126,4 @@ and your datastore type.
 1. Remove any existing `calicoctl` instances and install the new `calicoctl`.
 
 1. Congratulations! You have upgraded to {{site.prodname}} {{page.version}}.
-
-## Upgrading a custom installation
-
-_Docs for this coming soon!_
-
-
 


### PR DESCRIPTION
## Description

- Removes the section which claims that upgrade instructions for those who did a custom install are coming soon...unfortunately, they are not so it is misleading to have this in the page.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
