### PR TITLE
Variabilizes version number on splash page

### DIFF
--- a/master/introduction/index.md
+++ b/master/introduction/index.md
@@ -21,7 +21,7 @@ you can achieve fine-grained control over communications
 between containers, virtual machine workloads, and 
 bare metal host endpoints.
 
-Proven in production at scale, {{site.prodname}} v3.0 features 
+Proven in production at scale, {{site.prodname}} {{page.version}} features 
 integrations with Kubernetes, OpenShift, and OpenStack.
 
 > **Note**: For integrations with the  Mesos, DC/OS, and Docker 


### PR DESCRIPTION
## Description

- changes hardcoded version number in intro page to variable for portability

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
