### PR TITLE
Gather more docker diags on failure

### DIFF
--- a/calico_node/tests/st/utils/docker_host.py
+++ b/calico_node/tests/st/utils/docker_host.py
@@ -709,3 +709,7 @@ class DockerHost(object):
         self.execute("docker logs calico-node", raise_exception_on_failure=False)
         self.execute("docker exec calico-node ls -l /var/log/calico/felix", raise_exception_on_failure=False)
         self.execute("docker exec calico-node cat /var/log/calico/felix/*", raise_exception_on_failure=False)
+        self.execute("docker ps -a", raise_exception_on_failure=False)
+        for wl in self.workloads:
+            wl.host.execute("docker logs %s" % wl.name, raise_exception_on_failure=False)
+        log_and_run("docker logs %s" % self.name, raise_exception_on_failure=False)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In an effort to track down semaphore flakes which seem to possibly be hitting weird docker behavior, this PR adds the following logs on failure:

- docker daemon logs for each dind host
- output of `docker ps -a` for each dind host
- docker logs for each client in each dind host

<details>
  <summary>Here's some sample output: Click to expand</summary>

```
[2018-03-22 00:09:13.300863] docker exec -it cali-host2 sh -c 'docker ps -a'
  # CONTAINER ID        IMAGE               COMMAND                 CREATED             STATUS              PORTS               NAMES
  # 1e88a9eff33a        workload            "python responder.py"   7 seconds ago       Up 7 seconds                            default_h2_wl0
  # e3f63bfeff1c        workload            "python responder.py"   9 seconds ago       Up 8 seconds                            nsa_h2_wl0
  # 2c08b19f21a1        workload            "python responder.py"   10 seconds ago      Up 9 seconds                            nsb_h2_wl1
  # 3ada2028faf9        workload            "python responder.py"   11 seconds ago      Up 10 seconds                           nsb_h2_wl0
  # 52fb87fef7fe        calico/node         "start_runit"           20 seconds ago      Up 19 seconds                           calico-node
[2018-03-22 00:09:13.420273] docker exec -it cali-host2 sh -c 'docker logs nsb_h2_wl0'
  # __main__: waiting for tcp request
  # __main__: waiting for udp request
  # __main__: TCP Server on 0.0.0.0:80
  # __main__: UDP Server on 0.0.0.0:69
  # __main__: checking tcp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: waiting for response
  # __main__: handle
  # __main__: received (tcp) from ('127.0.0.1', 56974): "Hello world"
  # __main__: response from server: "Hello world"
  # __main__: checking udp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: handle
  # __main__: received (udp) from ('127.0.0.1', 33450): "Hello world"
  # __main__: waiting for response
  # __main__: response from server: "Hello world"
  # __main__: handle
  # __main__: received (tcp) from ('192.168.197.65', 43768): "hello
  # "
  # __main__: handle
  # __main__: received (tcp) from ('192.168.197.65', 43770): "hello
  # "
[2018-03-22 00:09:13.569517] docker exec -it cali-host2 sh -c 'docker logs default_h2_wl0'
  # __main__: waiting for tcp request
  # __main__: waiting for udp request
  # __main__: TCP Server on 0.0.0.0:80
  # __main__: UDP Server on 0.0.0.0:69
  # __main__: checking tcp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: waiting for response
  # __main__: handle
  # __main__: received (tcp) from ('127.0.0.1', 56992): "Hello world"
  # __main__: response from server: "Hello world"
  # __main__: checking udp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: handle
  # __main__: received (udp) from ('127.0.0.1', 47648): "Hello world"
  # __main__: waiting for response
  # __main__: response from server: "Hello world"
[2018-03-22 00:09:13.680272] docker exec -it cali-host2 sh -c 'docker logs nsb_h2_wl1'
  # __main__: waiting for tcp request
  # __main__: waiting for udp request
  # __main__: TCP Server on 0.0.0.0:80
  # __main__: UDP Server on 0.0.0.0:69
  # __main__: checking tcp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: handle
  # __main__: received (tcp) from ('127.0.0.1', 56980): "Hello world"
  # __main__: waiting for response
  # __main__: response from server: "Hello world"
  # __main__: checking udp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: handle
  # __main__: received (udp) from ('127.0.0.1', 37109): "Hello world"
  # __main__: waiting for response
  # __main__: response from server: "Hello world"
[2018-03-22 00:09:13.805750] docker exec -it cali-host2 sh -c 'docker logs nsa_h2_wl0'
  # __main__: waiting for tcp request
  # __main__: waiting for udp request
  # __main__: TCP Server on 0.0.0.0:80
  # __main__: UDP Server on 0.0.0.0:69
  # __main__: checking tcp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: waiting for response
  # __main__: handle
  # __main__: received (tcp) from ('127.0.0.1', 56986): "Hello world"
  # __main__: response from server: "Hello world"
  # __main__: checking udp server
  # __main__: connecting to server
  # __main__: sending data: "Hello world"
  # __main__: waiting for response
  # __main__: handle
  # __main__: received (udp) from ('127.0.0.1', 60906): "Hello world"
  # __main__: response from server: "Hello world"
[2018-03-22 00:09:13.915348] docker logs cali-host2
  # WARN[2018-03-22T00:08:39.811960268Z] could not change group /var/run/docker.sock to docker: group docker not found
  # WARN[2018-03-22T00:08:39.812321864Z] [!] DON'T BIND ON ANY IP ADDRESS WITHOUT setting --tlsverify IF YOU DON'T KNOW WHAT YOU'RE DOING [!]
  # INFO[2018-03-22T00:08:39.813046442Z] libcontainerd: started new docker-containerd process  pid=22
  # INFO[0000] starting containerd                           module=containerd revision=89623f28b87a6004d4b785663257362d1658a729 version=v1.0.0
  # INFO[0000] setting subreaper...                          module=containerd
  # INFO[0000] changing OOM score to -500                    module=containerd
  # INFO[0000] loading plugin "io.containerd.content.v1.content"...  module=containerd type=io.containerd.content.v1
  # INFO[0000] loading plugin "io.containerd.snapshotter.v1.btrfs"...  module=containerd type=io.containerd.snapshotter.v1
  # WARN[0000] failed to load plugin io.containerd.snapshotter.v1.btrfs  error="path /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter" module=containerd
  # INFO[0000] loading plugin "io.containerd.snapshotter.v1.overlayfs"...  module=containerd type=io.containerd.snapshotter.v1
  # INFO[0000] loading plugin "io.containerd.metadata.v1.bolt"...  module=containerd type=io.containerd.metadata.v1
  # WARN[0000] could not use snapshotter btrfs in metadata plugin  error="path /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.btrfs must be a btrfs filesystem to be used with the btrfs snapshotter" module="containerd/io.containerd.metadata.v1.bolt"
  # INFO[0000] loading plugin "io.containerd.differ.v1.walking"...  module=containerd type=io.containerd.differ.v1
  # INFO[0000] loading plugin "io.containerd.gc.v1.scheduler"...  module=containerd type=io.containerd.gc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.containers"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.content"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.diff"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.events"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.healthcheck"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.images"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.leases"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.namespaces"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.snapshots"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.monitor.v1.cgroups"...  module=containerd type=io.containerd.monitor.v1
  # INFO[0000] loading plugin "io.containerd.runtime.v1.linux"...  module=containerd type=io.containerd.runtime.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.tasks"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.version"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] loading plugin "io.containerd.grpc.v1.introspection"...  module=containerd type=io.containerd.grpc.v1
  # INFO[0000] serving...                                    address="/var/run/docker/containerd/docker-containerd-debug.sock" module="containerd/debug"
  # INFO[0000] serving...                                    address="/var/run/docker/containerd/docker-containerd.sock" module="containerd/grpc"
  # INFO[0000] containerd successfully booted in 0.035174s   module=containerd
  # INFO[2018-03-22T00:08:39.961421134Z] Graph migration to content-addressability took 0.00 seconds
  # WARN[2018-03-22T00:08:39.961669832Z] Your kernel does not support swap memory limit
  # WARN[2018-03-22T00:08:39.961722927Z] Your kernel does not support cgroup rt period
  # WARN[2018-03-22T00:08:39.961735321Z] Your kernel does not support cgroup rt runtime
  # INFO[2018-03-22T00:08:39.962286651Z] Loading containers: start.
  # INFO[2018-03-22T00:08:40.122539825Z] Default bridge (docker0) is assigned with an IP address 172.18.0.0/16. Daemon option --bip can be used to set a preferred IP address
  # INFO[2018-03-22T00:08:40.145640788Z] Loading containers: done.
  # INFO[2018-03-22T00:08:40.185321485Z] Docker daemon                                 commit=c97c6d6 graphdriver(s)=overlay2 version=17.12.0-ce
  # INFO[2018-03-22T00:08:40.185496948Z] Daemon has completed initialization
  # INFO[2018-03-22T00:08:40.198439587Z] API listen on /var/run/docker.sock
  # INFO[2018-03-22T00:08:40.198408912Z] API listen on [::]:2375
  # INFO[2018-03-22T00:08:53.981020327Z] ignoring event                                module=libcontainerd namespace=moby topic=/containers/create type="*events.ContainerCreate"
  # INFO[0014] shim docker-containerd-shim started           address="/containerd-shim/moby/52fb87fef7fe9a40d5e6fbf55ecfc4a598ab4e80d217ecb98c40d3bc8b2c6092/shim.sock" debug=false module="containerd/tasks" pid=277
  # WARN[2018-03-22T00:08:54.105497022Z] unknown container                             container=52fb87fef7fe9a40d5e6fbf55ecfc4a598ab4e80d217ecb98c40d3bc8b2c6092 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:08:54.127450485Z] unknown container                             container=52fb87fef7fe9a40d5e6fbf55ecfc4a598ab4e80d217ecb98c40d3bc8b2c6092 module=libcontainerd namespace=plugins.moby
  # INFO[2018-03-22T00:09:02.749257858Z] ignoring event                                module=libcontainerd namespace=moby topic=/containers/create type="*events.ContainerCreate"
  # INFO[0022] shim docker-containerd-shim started           address="/containerd-shim/moby/3ada2028faf97060c3e07ac2e8ee1d3353756b381d1d412813cf5c9543136ea8/shim.sock" debug=false module="containerd/tasks" pid=494
  # WARN[2018-03-22T00:09:03.010377203Z] unknown container                             container=3ada2028faf97060c3e07ac2e8ee1d3353756b381d1d412813cf5c9543136ea8 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:03.028805239Z] unknown container                             container=3ada2028faf97060c3e07ac2e8ee1d3353756b381d1d412813cf5c9543136ea8 module=libcontainerd namespace=plugins.moby
  # INFO[2018-03-22T00:09:03.902150238Z] ignoring event                                module=libcontainerd namespace=moby topic=/containers/create type="*events.ContainerCreate"
  # INFO[0024] shim docker-containerd-shim started           address="/containerd-shim/moby/2c08b19f21a1e27999da14203b5f56299fac84a27d2f8a20a625e2f7d1b2c682/shim.sock" debug=false module="containerd/tasks" pid=624
  # WARN[2018-03-22T00:09:04.119707915Z] unknown container                             container=2c08b19f21a1e27999da14203b5f56299fac84a27d2f8a20a625e2f7d1b2c682 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:04.154179222Z] unknown container                             container=2c08b19f21a1e27999da14203b5f56299fac84a27d2f8a20a625e2f7d1b2c682 module=libcontainerd namespace=plugins.moby
  # INFO[2018-03-22T00:09:05.047029704Z] ignoring event                                module=libcontainerd namespace=moby topic=/containers/create type="*events.ContainerCreate"
  # INFO[0025] shim docker-containerd-shim started           address="/containerd-shim/moby/e3f63bfeff1c7b6ce9de72be492e9738e54208ff1b8a37f57554bda8a2f276dc/shim.sock" debug=false module="containerd/tasks" pid=754
  # WARN[2018-03-22T00:09:05.310380633Z] unknown container                             container=e3f63bfeff1c7b6ce9de72be492e9738e54208ff1b8a37f57554bda8a2f276dc module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:05.325946511Z] unknown container                             container=e3f63bfeff1c7b6ce9de72be492e9738e54208ff1b8a37f57554bda8a2f276dc module=libcontainerd namespace=plugins.moby
  # INFO[2018-03-22T00:09:06.116636591Z] ignoring event                                module=libcontainerd namespace=moby topic=/containers/create type="*events.ContainerCreate"
  # INFO[0026] shim docker-containerd-shim started           address="/containerd-shim/moby/1e88a9eff33aff463bc1dbc432f0a2391e8012d87eb045ebd4fe51e7560f94d4/shim.sock" debug=false module="containerd/tasks" pid=869
  # WARN[2018-03-22T00:09:06.326198053Z] unknown container                             container=1e88a9eff33aff463bc1dbc432f0a2391e8012d87eb045ebd4fe51e7560f94d4 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:06.349925876Z] unknown container                             container=1e88a9eff33aff463bc1dbc432f0a2391e8012d87eb045ebd4fe51e7560f94d4 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:07.848041616Z] unknown container                             container=e3f63bfeff1c7b6ce9de72be492e9738e54208ff1b8a37f57554bda8a2f276dc module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:07.879299327Z] unknown container                             container=e3f63bfeff1c7b6ce9de72be492e9738e54208ff1b8a37f57554bda8a2f276dc module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:08.017449764Z] unknown container                             container=3ada2028faf97060c3e07ac2e8ee1d3353756b381d1d412813cf5c9543136ea8 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:08.028654972Z] unknown container                             container=3ada2028faf97060c3e07ac2e8ee1d3353756b381d1d412813cf5c9543136ea8 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:08.194189775Z] unknown container                             container=2c08b19f21a1e27999da14203b5f56299fac84a27d2f8a20a625e2f7d1b2c682 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:08.212294593Z] unknown container                             container=2c08b19f21a1e27999da14203b5f56299fac84a27d2f8a20a625e2f7d1b2c682 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:08.915010879Z] unknown container                             container=1e88a9eff33aff463bc1dbc432f0a2391e8012d87eb045ebd4fe51e7560f94d4 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:08.935701443Z] unknown container                             container=1e88a9eff33aff463bc1dbc432f0a2391e8012d87eb045ebd4fe51e7560f94d4 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:12.997829017Z] unknown container                             container=52fb87fef7fe9a40d5e6fbf55ecfc4a598ab4e80d217ecb98c40d3bc8b2c6092 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:13.013380562Z] unknown container                             container=52fb87fef7fe9a40d5e6fbf55ecfc4a598ab4e80d217ecb98c40d3bc8b2c6092 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:13.166941503Z] unknown container                             container=52fb87fef7fe9a40d5e6fbf55ecfc4a598ab4e80d217ecb98c40d3bc8b2c6092 module=libcontainerd namespace=plugins.moby
  # WARN[2018-03-22T00:09:13.186145235Z] unknown container                             container=52fb87fef7fe9a40d5e6fbf55ecfc4a598ab4e80d217ecb98c40d3bc8b2c6092 module=libcontainerd namespace=plugins.moby
> /usr/lib/python2.7/unittest/case.py(410)fail()
```

</details>

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
