### PR TITLE
Add note for using calico on Fedora Atomic

### DIFF
--- a/master/usage/troubleshooting/index.md
+++ b/master/usage/troubleshooting/index.md
@@ -99,6 +99,16 @@ NetworkManager removes your host's interfaces. See the Debian
 [NetworkConfiguration](https://wiki.debian.org/NetworkConfiguration)
 guide for more information.
 
+The same thing is happening on Fedora Atomic. And instead of totally disable
+NetworkManager, you can add below snippet into /etc/NetworkManager/NetworkManager.conf
+As above mentioned, NetworkManager will periodically delete the interface by Calico
+then Calico has to recreate them, as a result, pods will lose connection periodically.
+
+```
+[keyfile]
+unmanaged-devices=interface-name:cali*;interface-name:tunl*
+```
+
 ## Running sudo calicoctl ... with Environment Variables
 
 If you use `sudo` for commands like `calicoctl node run`, remember that your environment


### PR DESCRIPTION
When using Calico on Fedora Atomic, pods will periodically lose
connection to k8s API server because the calico pod interface on
node are deleted by NetworkManager. This patch just add a note
in troubleshooting page about this.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
