### PR TITLE
Redirect to the latest version of this doc if it exists

### DIFF
--- a/_includes/version_warning.html
+++ b/_includes/version_warning.html
@@ -1,5 +1,18 @@
+{% capture canonical_path %}
+{{- page.canonical_url | remove: "https://docs.projectcalico.org/" -}}
+{% endcapture %}
+
+{% capture canonical_version %}
+{{- canonical_path | split: "/" | first -}}
+{% endcapture %}
+
 {% if page.version != site.data.versions.first[0] %}
   <div class="alert alert-warning" role="alert">
-    <strong>Warning:</strong> You are viewing the {{ page.version }} docs. <a href="{{site.baseurl}}/latest">Click here to view the docs for the latest release.</a>
+    <strong>Warning:</strong> You are viewing the {{ page.version }} docs.
+    {% if canonical_version == site.data.versions.first[0] %}
+      <a href="{{site.baseurl}}/{{canonical_path}}">Click here to view this doc on the latest release.</a>
+    {% else %}
+      <a href="{{site.baseurl}}/latest">Click here to view the docs for the latest release.</a>
+    {% endif %}
   </div>
 {% endif %}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

fixes #1036 

This PR makes it so that when you are viewing a doc from an older release, and it still exists in the latest release, the link at the top will take you to it.

It does this by checking `canonical_url`, which points to the latest version of any doc. If that doc is in the latest release, it links to it. Otherwise, it links to the latest introduction (current default).

Implements 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
