### PR TITLE
wait for bgp to establish in node STs

### DIFF
--- a/calico_node/tests/st/bgp/test_bgp.py
+++ b/calico_node/tests/st/bgp/test_bgp.py
@@ -29,7 +29,7 @@ class TestReadiness(TestBase):
         """
         with DockerHost('host1',
                         additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host1:
-            retry_until_success(host1.execute, retries=10, command="docker exec calico-node /bin/readiness -bird -felix")
+            retry_until_success(host1.assert_is_ready, retries=10)
 
     def test_readiness_multihost(self):
         """
@@ -39,10 +39,8 @@ class TestReadiness(TestBase):
                         additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host1, \
                 DockerHost('host2',
                            additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host2:
-            retry_until_success(host1.execute, retries=10,
-                                command="docker exec calico-node /bin/readiness -bird -felix")
-            retry_until_success(host2.execute, retries=10,
-                                command="docker exec calico-node /bin/readiness -bird -felix")
+            retry_until_success(host1.assert_is_ready, retries=10)
+            retry_until_success(host2.assert_is_ready, retries=10)
 
     def test_not_ready_with_broken_felix(self):
         """
@@ -78,10 +76,8 @@ class TestReadiness(TestBase):
                         additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host1, \
                 DockerHost('host2',
                            additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS) as host2:
-            retry_until_success(host1.execute, retries=10,
-                                command="docker exec calico-node /bin/readiness -bird -felix")
-            retry_until_success(host2.execute, retries=10,
-                                command="docker exec calico-node /bin/readiness -bird -felix")
+            retry_until_success(host1.assert_is_ready, retries=10)
+            retry_until_success(host2.assert_is_ready, retries=10)
 
             # Create a network and a couple of workloads on each host.
             network1 = host1.create_network("subnet1")
@@ -114,9 +110,7 @@ class TestReadiness(TestBase):
             host2.execute("iptables -t raw -D PREROUTING -p tcp -m multiport --dports 179 -j DROP")
 
             _log.debug('check connected and retry until "Established"')
-            retry_until_success(host1.execute, retries=10,
-                                command="docker exec calico-node /bin/readiness -bird -felix")
-            retry_until_success(host2.execute, retries=10,
-                                command="docker exec calico-node /bin/readiness -bird -felix")
+            retry_until_success(host1.assert_is_ready, retries=10)
+            retry_until_success(host2.assert_is_ready, retries=10)
             check_bird_status(host1, [("node-to-node mesh", host2.ip, "Established")])
             check_bird_status(host2, [("node-to-node mesh", host1.ip, "Established")])

--- a/calico_node/tests/st/policy/test_namespace.py
+++ b/calico_node/tests/st/policy/test_namespace.py
@@ -79,7 +79,10 @@ class TestNamespace(TestBase):
 
         # Start calico node on hosts.
         for host in cls.hosts:
-            host.start_calico_node()
+            host.start_calico_node(env_options=" -e FELIX_HEALTHENABLED=true ")
+
+        retry_until_success(cls.host1.assert_is_ready, retries=10)
+        retry_until_success(cls.host2.assert_is_ready, retries=10)
 
         # Prepare namespace profile so that we can use namespaceSelector for non-k8s deployment.
         # CNI will use the existing profile which is setup here instead of creating its own.

--- a/calico_node/tests/st/utils/docker_host.py
+++ b/calico_node/tests/st/utils/docker_host.py
@@ -186,6 +186,15 @@ class DockerHost(object):
         if start_calico:
             self.start_calico_node(env_options=' -e FELIX_HEALTHENABLED=true ')
 
+    def assert_is_ready(self, bird=True, felix=True):
+        cmd = "docker exec calico-node /bin/readiness"
+        if bird:
+            cmd += " -bird"
+        if felix:
+            cmd += " -felix"
+
+        self.execute(cmd)
+
     def execute(self, command, raise_exception_on_failure=True, daemon_mode=False):
         """
         Pass a command into a host container.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Some of our tests are flaking (namely `test_can_access_without_policy` & `test_deny_default_with_two_policy`)  because they configure workloads after calico/node is running, but before bird has established BGP. This results in confd resetting bird multiple times before BGP is established. 

~This hotfix has the test rig sleep after creating calico/node to wait for BGP to establish.~

~We should not merge as is, since it will add too much time to the tests. Instead, we should look at how to detect when bird is ready, then commence creation of workloads.~

This test uses the bird readiness checks and does not start the test until bird is ready.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
