### PR TITLE
Remove docs to disable SELinux and modify QEMU config, on RHEL/CentOS

### DIFF
--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -163,48 +163,6 @@ On each control node, perform the following steps:
 
 On each compute node, perform the following steps:
 
-1.  Make changes to SELinux and QEMU config to allow VM interfaces with
-    `type='ethernet'` ([this libvirt Wiki
-    page](https://web.archive.org/web/20160226213437/http://wiki.libvirt.org/page/Guest_won't_start_-_warning:_could_not_open_/dev/net/tun_('generic_ethernet'_interface))
-    explains why these changes are required):
-
-    ```
-    setenforce permissive
-    ```
-
-    Edit `/etc/selinux/config` and change the `SELINUX=` line to the
-    following:
-
-    ```
-    SELINUX=permissive
-    ```
-
-    In `/etc/libvirt/qemu.conf`, add or edit the following four options:
-
-    ```
-    clear_emulator_capabilities = 0
-    user = "root"
-    group = "root"
-    cgroup_device_acl = [
-        "/dev/null", "/dev/full", "/dev/zero",
-        "/dev/random", "/dev/urandom",
-        "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
-        "/dev/rtc", "/dev/hpet", "/dev/net/tun",
-    ]
-    ```
-
-
-    > **Note**: The `cgroup_device_acl` entry is subtly different than the
-    > default. It now contains `/dev/net/tun`.
-    >
-    {: .alert .alert-info}
-
-    Then restart libvirt to pick up the changes:
-
-    ```
-    service libvirtd restart
-    ```
-
 1.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 

--- a/master/getting-started/openstack/installation/ubuntu.md
+++ b/master/getting-started/openstack/installation/ubuntu.md
@@ -128,43 +128,6 @@ perform the following steps.
 
 On each compute node, perform the following steps:
 
-1.  Make changes to SELinux and QEMU config to allow VM interfaces with
-    `type='ethernet'` ([this libvirt Wiki
-    page](https://web.archive.org/web/20160226213437/http://wiki.libvirt.org/page/Guest_won't_start_-_warning:_could_not_open_/dev/net/tun_('generic_ethernet'_interface))
-    explains why these changes are required):
-
-    Disable SELinux if it's running. SELinux isn't installed by default
-    on Ubuntu. You can check its status by running `sestatus`. If this
-    is installed and the current mode is `enforcing`, then disable it by
-    running `setenforce permissive` and setting `SELINUX=permissive` in
-    `/etc/selinux/config`.
-
-    In `/etc/libvirt/qemu.conf`, add or edit the following four options:
-
-    ```
-    clear_emulator_capabilities = 0
-    user = "root"
-    group = "root"
-    cgroup_device_acl = [
-        "/dev/null", "/dev/full", "/dev/zero",
-        "/dev/random", "/dev/urandom",
-        "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
-        "/dev/rtc", "/dev/hpet", "/dev/net/tun",
-    ]
-    ```
-
-
-    > **Note**: The `cgroup_device_acl` entry is subtly different than the
-    > default. It now contains `/dev/net/tun`.
-    >
-    {: .alert .alert-info}
-
-    Then restart libvirt to pick up the changes:
-
-    ```
-    service libvirt-bin restart
-    ```
-
 1.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 

--- a/v3.1/getting-started/openstack/installation/redhat.md
+++ b/v3.1/getting-started/openstack/installation/redhat.md
@@ -163,48 +163,6 @@ On each control node, perform the following steps:
 
 On each compute node, perform the following steps:
 
-1.  Make changes to SELinux and QEMU config to allow VM interfaces with
-    `type='ethernet'` ([this libvirt Wiki
-    page](https://web.archive.org/web/20160226213437/http://wiki.libvirt.org/page/Guest_won't_start_-_warning:_could_not_open_/dev/net/tun_('generic_ethernet'_interface))
-    explains why these changes are required):
-
-    ```
-    setenforce permissive
-    ```
-
-    Edit `/etc/selinux/config` and change the `SELINUX=` line to the
-    following:
-
-    ```
-    SELINUX=permissive
-    ```
-
-    In `/etc/libvirt/qemu.conf`, add or edit the following four options:
-
-    ```
-    clear_emulator_capabilities = 0
-    user = "root"
-    group = "root"
-    cgroup_device_acl = [
-        "/dev/null", "/dev/full", "/dev/zero",
-        "/dev/random", "/dev/urandom",
-        "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
-        "/dev/rtc", "/dev/hpet", "/dev/net/tun",
-    ]
-    ```
-
-
-    > **Note**: The `cgroup_device_acl` entry is subtly different than the
-    > default. It now contains `/dev/net/tun`.
-    >
-    {: .alert .alert-info}
-
-    Then restart libvirt to pick up the changes:
-
-    ```
-    service libvirtd restart
-    ```
-
 1.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 

--- a/v3.1/getting-started/openstack/installation/ubuntu.md
+++ b/v3.1/getting-started/openstack/installation/ubuntu.md
@@ -128,43 +128,6 @@ perform the following steps.
 
 On each compute node, perform the following steps:
 
-1.  Make changes to SELinux and QEMU config to allow VM interfaces with
-    `type='ethernet'` ([this libvirt Wiki
-    page](https://web.archive.org/web/20160226213437/http://wiki.libvirt.org/page/Guest_won't_start_-_warning:_could_not_open_/dev/net/tun_('generic_ethernet'_interface))
-    explains why these changes are required):
-
-    Disable SELinux if it's running. SELinux isn't installed by default
-    on Ubuntu. You can check its status by running `sestatus`. If this
-    is installed and the current mode is `enforcing`, then disable it by
-    running `setenforce permissive` and setting `SELINUX=permissive` in
-    `/etc/selinux/config`.
-
-    In `/etc/libvirt/qemu.conf`, add or edit the following four options:
-
-    ```
-    clear_emulator_capabilities = 0
-    user = "root"
-    group = "root"
-    cgroup_device_acl = [
-        "/dev/null", "/dev/full", "/dev/zero",
-        "/dev/random", "/dev/urandom",
-        "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
-        "/dev/rtc", "/dev/hpet", "/dev/net/tun",
-    ]
-    ```
-
-
-    > **Note**: The `cgroup_device_acl` entry is subtly different than the
-    > default. It now contains `/dev/net/tun`.
-    >
-    {: .alert .alert-info}
-
-    Then restart libvirt to pick up the changes:
-
-    ```
-    service libvirt-bin restart
-    ```
-
 1.  Open `/etc/nova/nova.conf` and remove the line from the `[DEFAULT]`
     section that reads:
 


### PR DESCRIPTION
It has been reported that the QEMU config modification is no longer
needed, and our own testing has now confirmed that.

It's possible that some SELinux configuration is still needed -
specifically to allow nova-compute and libvirt to access NFS shares
exported from another host - but this falls under general OpenStack
setup and is not specifically related to Calico; so we now delete that
from this doc too.
