### PR TITLE
Updates supported version of k8s

### DIFF
--- a/master/getting-started/kubernetes/requirements.md
+++ b/master/getting-started/kubernetes/requirements.md
@@ -10,9 +10,9 @@ canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/r
 #### Supported versions
 
 We test {{site.prodname}} {{page.version}} against the following Kubernetes versions.
-- 1.7
 - 1.8
 - 1.9
+- 1.10
 
 Other versions are likely to work, but we do not actively test {{site.prodname}} 
 {{page.version}} against them.

--- a/v3.1/getting-started/kubernetes/requirements.md
+++ b/v3.1/getting-started/kubernetes/requirements.md
@@ -10,9 +10,9 @@ canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/r
 #### Supported versions
 
 We test {{site.prodname}} {{page.version}} against the following Kubernetes versions.
-- 1.7
 - 1.8
 - 1.9
+- 1.10
 
 Other versions are likely to work, but we do not actively test {{site.prodname}} 
 {{page.version}} against them.


### PR DESCRIPTION
## Description

- Removes k8s v1.7 and adds k8s v1.10 from master and v3.1



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
