### PR TITLE
Variabilizes product name in manifest comments

### DIFF
--- a/master/getting-started/kubernetes/installation/calico-kube-controllers.yaml
+++ b/master/getting-started/kubernetes/installation/calico-kube-controllers.yaml
@@ -1,13 +1,13 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/kube-controllers:{{site.data.versions[page.version].first.components["calico/kube-controllers"].version}}
 
 # Create this manifest using kubectl to deploy
-# the Calico Kubernetes controllers.
+# the {{site.prodname}} Kubernetes controllers.
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -1,14 +1,14 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}
 #   calico/kube-controllers:{{site.data.versions[page.version].first.components["calico/kube-controllers"].version}}
 
-# This ConfigMap is used to configure a self-hosted Calico installation.
+# This ConfigMap is used to configure a self-hosted {{site.prodname}} installation.
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -18,7 +18,7 @@ data:
   # Configure this with the location of your etcd cluster.
   etcd_endpoints: "http://127.0.0.1:2379"
 
-  # Configure the Calico backend to use.
+  # Configure the {{site.prodname}} backend to use.
   calico_backend: "bird"
 
   # Configure the MTU to use
@@ -84,7 +84,7 @@ data:
 ---
 
 # This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
+# as the {{site.prodname}} CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -129,7 +129,7 @@ spec:
         - name: calico-node
           image: {{site.imageNames["node"]}}:{{site.data.versions[page.version].first.title}}
           env:
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
@@ -226,7 +226,7 @@ spec:
               readOnly: false
             - mountPath: /calico-secrets
               name: etcd-certs
-        # This container installs the Calico CNI binaries
+        # This container installs the {{site.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
           image: {{site.imageNames["cni"]}}:{{site.data.versions[page.version].first.components["calico/cni"].version}}
@@ -235,7 +235,7 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
@@ -287,7 +287,7 @@ spec:
 
 ---
 
-# This manifest deploys the Calico Kubernetes controllers.
+# This manifest deploys the {{site.prodname}} Kubernetes controllers.
 # See https://github.com/projectcalico/kube-controllers
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -324,7 +324,7 @@ spec:
         - name: calico-kube-controllers
           image: {{site.imageNames["kubeControllers"]}}:{{site.data.versions[page.version].first.components["calico/kube-controllers"].version}}
           env:
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:

--- a/master/getting-started/kubernetes/installation/hosted/calicoctl.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calicoctl.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -229,7 +229,7 @@ spec:
                 configMapKeyRef:
                   name: canal-config
                   key: etcd_cert
-            # Disable Calico BGP.  Calico is simply enforcing policy.
+            # Disable {{site.prodname}} BGP. {{site.prodname}} is simply enforcing policy.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
             # Cluster type to identify the deployment type
@@ -271,7 +271,7 @@ spec:
               readOnly: false
             - mountPath: /calico-secrets
               name: etcd-certs
-        # This container installs the Calico CNI binaries
+        # This container installs the {{site.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-calico-cni
           image: {{site.imageNames["cni"]}}:{{site.data.versions[page.version].first.components["calico/cni"].version}}
@@ -383,7 +383,7 @@ spec:
                 configMapKeyRef:
                   name: canal-config
                   key: etcd_endpoints
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCDCTL_CACERT
               valueFrom:
                 configMapKeyRef:
@@ -401,7 +401,7 @@ spec:
 
 ---
 
-# This manifest deploys the Calico policy controller on Kubernetes.
+# This manifest deploys the {{site.prodname}} policy controller on Kubernetes.
 # See https://github.com/projectcalico/k8s-policy
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -440,7 +440,7 @@ spec:
         - name: calico-kube-controllers
           image: {{site.imageNames["kubeControllers"]}}:{{site.data.versions[page.version].first.components["calico/kube-controllers"].version}}
           env:
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:

--- a/master/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/canal/canal.yaml
@@ -65,8 +65,8 @@ data:
 
 ---
 
-# This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
+# This manifest installs the {{site.nodecontainer}} container, as well
+# as the {{site.prodname}} CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -171,7 +171,7 @@ spec:
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
-        # This container installs the Calico CNI binaries
+        # This container installs the {{site.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
           image: {{site.imageNames["cni"]}}:{{site.data.versions[page.version].first.components["calico/cni"].version}}
@@ -250,7 +250,7 @@ spec:
 
 
 # Create all the CustomResourceDefinitions needed for
-# Calico policy-only mode.
+# {{site.prodname}} policy-only mode.
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/master/getting-started/kubernetes/installation/hosted/canal/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/canal/rbac.yaml
@@ -1,4 +1,4 @@
-# Calico Roles
+# {{site.prodname}} Roles
 # Reference {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -114,7 +114,7 @@ subjects:
 
 ---
 
-# Bind the calico ClusterRole to the canal ServiceAccount.
+# Bind the {{site.prodname}} ClusterRole to the canal ServiceAccount.
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
@@ -1,14 +1,14 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
-#   calico/node:{{site.data.versions[page.version].first.title}}
+#   {{site.nodecontainer}}:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}
 #   calico/kube-controllers:{{site.data.versions[page.version].first.components["calico/kube-controllers"].version}}
 
-# This ConfigMap is used to configure a self-hosted Calico installation.
+# This ConfigMap is used to configure a self-hosted {{site.prodname}} installation.
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -18,7 +18,7 @@ data:
   # The location of your etcd cluster.  This uses the Service clusterIP defined below.
   etcd_endpoints: "http://10.96.232.136:6666"
 
-  # Configure the Calico backend to use.
+  # Configure the {{site.prodname}} backend to use.
   calico_backend: "bird"
 
   # Configure the MTU to use
@@ -55,7 +55,7 @@ data:
 
 ---
 
-# This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
+# This manifest installs the {{site.prodname}} etcd on the kubeadm master.  This uses a DaemonSet
 # to force it to run on the master even when the master isn't schedulable, and uses
 # nodeSelector to ensure it only runs on the master.
 apiVersion: extensions/v1beta1
@@ -78,7 +78,7 @@ spec:
     spec:
       tolerations:
         # This taint is set by all kubelets running `--cloud-provider=external`
-        # so we should tolerate it to schedule the calico pods
+        # so we should tolerate it to schedule the {{site.prodname}} pods
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"
           effect: NoSchedule
@@ -120,7 +120,7 @@ spec:
 
 ---
 
-# This manifest installs the Service which gets traffic to the Calico
+# This manifest installs the Service which gets traffic to the {{site.prodname}}
 # etcd.
 apiVersion: v1
 kind: Service
@@ -141,8 +141,8 @@ spec:
 
 ---
 
-# This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
+# This manifest installs the {{site.nodecontainer}} container, as well
+# as the {{site.prodname}} CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -190,7 +190,7 @@ spec:
         - name: calico-node
           image: {{site.imageNames["node"]}}:{{site.data.versions[page.version].first.title}}
           env:
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
@@ -267,7 +267,7 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
-        # This container installs the Calico CNI binaries
+        # This container installs the {{site.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
           image: {{site.imageNames["cni"]}}:{{site.data.versions[page.version].first.components["calico/cni"].version}}
@@ -276,7 +276,7 @@ spec:
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-calico.conflist"
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:
@@ -320,7 +320,7 @@ spec:
 
 ---
 
-# This manifest deploys the Calico Kubernetes controllers.
+# This manifest deploys the {{site.prodname}} Kubernetes controllers.
 # See https://github.com/projectcalico/kube-controllers
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -361,7 +361,7 @@ spec:
         - name: calico-kube-controllers
           image: {{site.imageNames["kubeControllers"]}}:{{site.data.versions[page.version].first.components["calico/kube-controllers"].version}}
           env:
-            # The location of the Calico etcd cluster.
+            # The location of the {{site.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
               valueFrom:
                 configMapKeyRef:

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -1,13 +1,13 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}
 
-# This ConfigMap is used to configure a self-hosted Calico installation.
+# This ConfigMap is used to configure a self-hosted {{site.prodname}} installation.
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -55,8 +55,8 @@ data:
 
 ---
 
-# This manifest creates a Service, which will be backed by Calico's Typha daemon.
-# Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+# This manifest creates a Service, which will be backed by {{site.prodname}}'s Typha daemon.
+# Typha sits in between Felix and the API server, reducing {{site.prodname}}'s load on the API server.
 
 apiVersion: v1
 kind: Service
@@ -109,7 +109,7 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+      # Since {{site.prodname}} can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
@@ -157,7 +157,7 @@ spec:
 ---
 
 # This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
+# as the {{site.prodname}} CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -287,7 +287,7 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
-        # This container installs the Calico CNI binaries
+        # This container installs the {{site.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
           image: {{site.imageNames["cni"]}}:{{site.data.versions[page.version].first.components["calico/cni"].version}}
@@ -338,7 +338,7 @@ spec:
             path: /etc/cni/net.d
 
 # Create all the CustomResourceDefinitions needed for
-# Calico policy and networking mode.
+# {{site.prodname}} policy and networking mode.
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calicoctl.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/ctl:{{site.data.versions[page.version].first.components["calicoctl"].version}}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -1,13 +1,13 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
 #   calico/node:{{site.data.versions[page.version].first.title}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}
 
-# This ConfigMap is used to configure a self-hosted Calico installation.
+# This ConfigMap is used to configure a self-hosted {{site.prodname}} installation.
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -52,8 +52,8 @@ data:
 
 ---
 
-# This manifest creates a Service, which will be backed by Calico's Typha daemon.
-# Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+# This manifest creates a Service, which will be backed by {{site.prodname}}'s Typha daemon.
+# Typha sits in between Felix and the API server, reducing {{site.prodname}}'s load on the API server.
 
 apiVersion: v1
 kind: Service
@@ -106,7 +106,7 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+      # Since {{site.prodname}} can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
@@ -154,7 +154,7 @@ spec:
 ---
 
 # This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
+# as the {{site.prodname}} CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
 apiVersion: extensions/v1beta1
@@ -275,7 +275,7 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
-        # This container installs the Calico CNI binaries
+        # This container installs the {{site.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
           image: {{site.imageNames["cni"]}}:{{site.data.versions[page.version].first.components["calico/cni"].version}}
@@ -320,7 +320,7 @@ spec:
             path: /etc/cni/net.d
 
 # Create all the CustomResourceDefinitions needed for
-# Calico policy-only mode.
+# {{site.prodname}} policy-only mode.
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/master/getting-started/kubernetes/installation/rbac.yaml
+++ b/master/getting-started/kubernetes/installation/rbac.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-# Calico Version {{site.data.versions[page.version].first.title}}
+# {{site.prodname}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 
 ---


### PR DESCRIPTION
## Description

- Replaces hardcoded product name in manifest comments with variable
- Also replaces some instances of calico/node

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
