### PR TITLE
Tweak IPIP wording for OpenStack requirements

### DIFF
--- a/_includes/master/reqs-sys.md
+++ b/_includes/master/reqs-sys.md
@@ -2,8 +2,8 @@
 
 - AMD64 processor
 
-- Linux kernel 3.10 or later with [required dependencies](#kernel-dependencies). 
-  The following distributions have the required kernel, its dependencies, and are 
+- Linux kernel 3.10 or later with [required dependencies](#kernel-dependencies).
+  The following distributions have the required kernel, its dependencies, and are
   known to work well with {{site.prodname}} and {{include.orch}}.
   - RedHat Linux 7{% if include.orch == "Kubernetes" or include.orch == "host protection" %}
   - CentOS 7
@@ -19,7 +19,7 @@
 
 ## Key/value store
 
-{{site.prodname}} {{page.version}} requires a key/value store accessible by all 
+{{site.prodname}} {{page.version}} requires a key/value store accessible by all
 {{site.prodname}} components. {% if include.orch == "Kubernetes" %} On Kubernetes,
 you can configure {{site.prodname}} to access an etcdv3 cluster directly or to
 use the Kubernetes API datastore.{% endif %}{% if include.orch == "OpenShift" %} On
@@ -37,9 +37,12 @@ to connect to, we provide instructions in the [installation documentation](./ins
 | BGP     | TCP      | 179  |
 | IPIP\*  | 4        | n/a  |
 
-\* Our manifests enable IPIP by default. If you disable IPIP, you won't need to
-   allow IPIP traffic. Refer to [Configuring IP-in-IP](../../usage/configuration/ip-in-ip) for more information.
+\* {% if include.orch == "OpenStack" %} If your compute hosts connect directly
+   and don't use IPIP, you don't need to allow IPIP traffic. {% else %} Our
+   manifests enable IPIP by default.  If you disable IPIP, you won't need to
+   allow IPIP traffic. {% endif %} Refer to [Configuring
+   IP-in-IP](../../usage/configuration/ip-in-ip) for more information.
 
-> **Tip**: On GCE, you can allow this traffic using firewall rules. In AWS, use 
+> **Tip**: On GCE, you can allow this traffic using firewall rules. In AWS, use
 > EC2 security group rules.
 {: .alert .alert-success}

--- a/_includes/v3.1/reqs-sys.md
+++ b/_includes/v3.1/reqs-sys.md
@@ -2,8 +2,8 @@
 
 - AMD64 processor
 
-- Linux kernel 3.10 or later with [required dependencies](#kernel-dependencies). 
-  The following distributions have the required kernel, its dependencies, and are 
+- Linux kernel 3.10 or later with [required dependencies](#kernel-dependencies).
+  The following distributions have the required kernel, its dependencies, and are
   known to work well with {{site.prodname}} and {{include.orch}}.
   - RedHat Linux 7{% if include.orch == "Kubernetes" or include.orch == "host protection" %}
   - CentOS 7
@@ -19,7 +19,7 @@
 
 ## Key/value store
 
-{{site.prodname}} {{page.version}} requires a key/value store accessible by all 
+{{site.prodname}} {{page.version}} requires a key/value store accessible by all
 {{site.prodname}} components. {% if include.orch == "Kubernetes" %} On Kubernetes,
 you can configure {{site.prodname}} to access an etcdv3 cluster directly or to
 use the Kubernetes API datastore.{% endif %}{% if include.orch == "OpenShift" %} On
@@ -37,9 +37,12 @@ to connect to, we provide instructions in the [installation documentation](./ins
 | BGP     | TCP      | 179  |
 | IPIP\*  | 4        | n/a  |
 
-\* Our manifests enable IPIP by default. If you disable IPIP, you won't need to
-   allow IPIP traffic. Refer to [Configuring IP-in-IP](../../usage/configuration/ip-in-ip) for more information.
+\* {% if include.orch == "OpenStack" %} If your compute hosts connect directly
+   and don't use IPIP, you don't need to allow IPIP traffic. {% else %} Our
+   manifests enable IPIP by default.  If you disable IPIP, you won't need to
+   allow IPIP traffic. {% endif %} Refer to [Configuring
+   IP-in-IP](../../usage/configuration/ip-in-ip) for more information.
 
-> **Tip**: On GCE, you can allow this traffic using firewall rules. In AWS, use 
+> **Tip**: On GCE, you can allow this traffic using firewall rules. In AWS, use
 > EC2 security group rules.
 {: .alert .alert-success}


### PR DESCRIPTION
Since we don't use manifests for OpenStack.

Note: broken out from #1809, for easier reviewing.