### PR TITLE
Updates upgrade content for v3.1

### DIFF
--- a/_includes/master/calicoctl-convert.md
+++ b/_includes/master/calicoctl-convert.md
@@ -1,10 +1,11 @@
 
  Use `calicoctl convert` to convert your Calico resource manifests from v1 API to v3 API.
  
-   > **Note**: Make sure to use the latest version of `calicoctl`
+ > **Important**: Make sure to use the latest version of `calicoctl`.
+ {: .alert .alert-danger}
    
  `calicoctl convert` command allows you to convert multiple resources from v1 API to v3 at the same time.
- You can convert your v1 yaml or json manifests v3 yaml or json manifests.
+ You can convert your v1 YAML or JSON manifests to v3 YAML or JSON manifests.
  
  **Example**
  ```

--- a/_includes/v3.1/calicoctl-convert.md
+++ b/_includes/v3.1/calicoctl-convert.md
@@ -1,10 +1,11 @@
 
  Use `calicoctl convert` to convert your Calico resource manifests from v1 API to v3 API.
  
-   > **Note**: Make sure to use the latest version of `calicoctl`
+ > **Important**: Make sure to use the latest version of `calicoctl`.
+ {: .alert .alert-danger}
    
  `calicoctl convert` command allows you to convert multiple resources from v1 API to v3 at the same time.
- You can convert your v1 yaml or json manifests v3 yaml or json manifests.
+ You can convert your v1 YAML or JSON manifests to v3 YAML or JSON manifests.
  
  **Example**
  ```

--- a/master/getting-started/kubernetes/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade.md
@@ -1,7 +1,0 @@
----
-redirect_to: /master/getting-started/kubernetes/upgrade/
----
-
-<!--- Page was deleted, now it just performs a redirect
-to its replacement so as to prevent a 404. Site does not support
-server-side redirects right now. -->

--- a/master/getting-started/kubernetes/upgrade/delete.md
+++ b/master/getting-started/kubernetes/upgrade/delete.md
@@ -8,7 +8,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.0/getting-started/kubernetes/u
 You may need or wish to manually delete Calico data from your etcd datastore under the
 following conditions.
   
-- [**etcd**: You succeeded in migrating your data and upgrading to Calico v3.0. After
+- [**etcd**: You succeeded in migrating your data and upgrading to Calico v3.x. After
   running Calico for some time and experiencing no errors, you want to delete
   the old Calico data from the etcdv2 datastore](#deleting-calico-data-from-etcdv2-after-a-successful-migration-and-upgrade).
   
@@ -16,9 +16,9 @@ following conditions.
   with some, but not all of your etcvd2 data](#deleting-calico-data-from-etcdv3-after-a-partial-migration).
 
 - [**Kubernetes API datastore**: You are using the Kubernetes API datastore and upgraded 
-  to Calico v3.0 but then downgraded to v2.6.5. You want to clean the Calico v3.0 data out of
+  to Calico v3.x but then downgraded to v2.6.x. You want to clean the Calico v3.x data out of
   the Kubernetes API datastore. If you plan to attempt another upgrade to
-  Calico v3.0, this is required.](#deleting-calico-data-from-the-kubernetes-api-datastore-after-a-downgrade).
+  Calico v3.x, this is required.](#deleting-calico-data-from-the-kubernetes-api-datastore-after-a-downgrade).
 
 {% include {{page.version}}/deleting-etcd-v2-v3-data.md %}
 
@@ -27,7 +27,7 @@ following conditions.
 ### Prerequisites
 
 - This procedure requires kubectl.
-- This procedure should only be done if you have upgraded to v3.0+ and then
+- This procedure should only be done if you have upgraded to v3.x and then
   downgraded to your previous version.
 
 ### Deleting Calico data from the Kubernetes API datastore

--- a/master/getting-started/kubernetes/upgrade/downgrade.md
+++ b/master/getting-started/kubernetes/upgrade/downgrade.md
@@ -9,7 +9,7 @@ Under some circumstances, you may need to perform a downgrade and return your
 cluster to the previous version of {{site.prodname}}. If you need to downgrade
 you should do so as soon as possible to avoid an outage.
 
-> **Important**: After downgrading or aborting the migration it is necessary
+> **Note**: After downgrading or aborting the migration it is necessary
 > to delete the previously migrated
 > [etcd](delete#deleting-calico-data-from-etcdv2-after-a-successful-migration-and-upgrade)
 > or [Kubernetes API](delete#deleting-calico-data-from-the-kubernetes-api-datastore-after-a-downgrade)
@@ -31,9 +31,6 @@ The downgrade procedure varies according to how you originally installed
   Kubernetes API datastore](#downgrading-a-self-hosted-installation-that-uses-the-kubernetes-api-datastore)
   follow these steps.
 
-
-- [Downgrading a custom installation](#downgrading-a-custom-installation)
-
 ## Downgrading a self-hosted installation that uses the etcd datastore
 
 If you have upgraded {{site.prodname}} by deploying the latest manifest,
@@ -47,7 +44,7 @@ follow the steps here to downgrade.
    calico-upgrade abort
    ```
    
-   > **Important**: Do not use versions of `calicoctl` v3.0+ after aborting the upgrade.
+   > **Important**: Do not use versions of `calicoctl` v3.x after aborting the upgrade.
    > Doing so may result in unexpected behavior and data.
    {: .alert .alert-danger}
 
@@ -80,8 +77,3 @@ follow the steps here to downgrade.
    ```
    kubectl rollout status ds/calico-node -n kube-system
    ```
-
-## Downgrading a custom installation
-
-_Docs for this coming soon!_
-

--- a/master/getting-started/kubernetes/upgrade/index.md
+++ b/master/getting-started/kubernetes/upgrade/index.md
@@ -3,42 +3,35 @@ title: Upgrading Calico for Kubernetes
 canonical_url: 'https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/'
 ---
 
-Upgrading to this release of {{site.prodname}} from a pre-v3.0 release may require some manual steps, depending on
-your choice of datastore.
-
 ## Before you begin
 
-- You must first [upgrade](/v2.6/getting-started/kubernetes/upgrade) 
-  to {{site.prodname}} [v2.6.5](https://github.com/projectcalico/calico/releases) 
-  (or a later v2.6.x release) before you can upgrade to {{site.prodname}} 
-  {{site.data.versions[page.version].first.title}}. 
+- You must first upgrade to at least {{site.prodname}} [v2.6.5](https://github.com/projectcalico/calico/releases) 
+  before you can upgrade to {{site.prodname}} {{site.data.versions[page.version].first.title}}. 
   
-  > **Important**: {{site.prodname}} v2.6.5 was a special transitional release that included changes to enable 
-  > upgrade to v3.0.1+; do not skip this step!
+  > **Important**: {{site.prodname}} v2.6.5 was a special transitional release that 
+  > included changes to enable upgrade to {{site.prodname}} v3.x. Do not skip this step!
   {: .alert .alert-danger}
 
-- If you are using the etcd datastore, you should upgrade etcd to the latest stable 
+- If you are using the etcd datastore, upgrade etcd to the latest stable 
   [v3 release](https://coreos.com/etcd/docs/latest/).  
+
+## About upgrading to {{site.prodname}} {{site.data.versions[page.version].first.title}}
+
+The steps to upgrade differ according to your current version and datastore type.
+
+- **Kubernetes API datastore, {{site.prodname}} v2.6.5 or later**: Complete the steps in 
+  [Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade#upgrading-a-self-hosted-installation-that-uses-the-kubernetes-api-datastore).
   
-  > **Tip**: etcd v3.x still supports the etcd v2 API, as used by {{site.prodname}} v2.6.x.
-  > However, {{site.prodname}} v3.0.0+ does not support the etcd v2 API.  The upgrade steps below
-  > move the data from the etcd v2 API to the etcd v3 API.  This requires an etcd v3.x server.
-  {: .alert .alert-success}
+- **etcd datastore, {{site.prodname}} v3.x**: Complete the steps in 
+  [Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade#upgrading-a-self-hosted-installation-that-uses-the-etcd-datastore).
+  
+- **etcd datastore, {{site.prodname}} v2.6.x**: You must migrate your data before
+  you can upgrade. Complete the steps in each of the following sections.
+  
+  1. **[Install and configure calico-upgrade](/{{page.version}}/getting-started/kubernetes/upgrade/setup)** 
 
-## Kubernetes API datastore upgrade steps
+  1. **[Test the data migration and check for errors](/{{page.version}}/getting-started/kubernetes/upgrade/test)**
 
-If you are using the Kubernetes API datastore, complete the steps in 
-[Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade).
+  1. **[Migrate {{site.prodname}} data](/{{page.version}}/getting-started/kubernetes/upgrade/migrate)** 
 
-## etcd datastore upgrade steps
-
-If you are using the etcd datastore then a manual migration step is required, using the 
-`calico-upgrade` tool.  To complete the upgrade follow these steps in sequence:
-
-1. **[Install and configure calico-upgrade](/{{page.version}}/getting-started/kubernetes/upgrade/setup)** 
-
-1. **[Test the data migration and check for errors](/{{page.version}}/getting-started/kubernetes/upgrade/test)**
-
-1. **[Migrate {{site.prodname}} data](/{{page.version}}/getting-started/kubernetes/upgrade/migrate)** 
-
-1. **[Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade)** 
+  1. **[Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade#upgrading-a-self-hosted-installation-that-uses-the-etcd-datastore)** 

--- a/master/getting-started/kubernetes/upgrade/setup.md
+++ b/master/getting-started/kubernetes/upgrade/setup.md
@@ -23,7 +23,7 @@ following:
 
 - [The existing etcdv2 datastore used by Calico v2.6.5](#configuring-calico-upgrade-to-connect-to-the-etcdv2-datastore)
 
-- [The etcdv3 cluster you plan to use for Calico v3.0](#configuring-calico-upgrade-to-connect-to-the-etcdv3-cluster)
+- [The etcdv3 cluster you plan to use for Calico v3.x](#configuring-calico-upgrade-to-connect-to-the-etcdv3-cluster)
 
 {% include {{page.version}}/config-calico-upgrade-etcd.md %}
 

--- a/master/getting-started/kubernetes/upgrade/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade/upgrade.md
@@ -28,10 +28,10 @@ and your datastore type.
    kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
    ```
    > **Note**: You can also 
-   > [view the YAML in your browser]({{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml){:target="_blank"}.
+   > [view the manifest in your browser]({{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml){:target="_blank"}.
    {: .alert .alert-info}
 
-1. [Refer to the Kubernetes datastore hosted installation documentation and 
+1. [Refer to the Kubernetes API datastore hosted installation documentation and 
    obtain the manifest needed for your configuration.](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/)
 
 1. Use the following command to initiate a rolling update, after replacing 
@@ -55,16 +55,16 @@ and your datastore type.
    calico-node-w92wk                          2/2       Running   0          3m
    ```
 
-1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
+1. Use the following command to confirm that {{site.noderunning}} has upgraded to {{page.version}}.x.
 
    ```
    kubectl exec -n kube-system calico-node-hvvg8 versions
    ```
    
-   It should return `v3.0.x`.
+   It should return `{{page.version}}.x`.
    
-   > **Note**: If an error occurs during the upgrade, refer to 
-   > [Downgrading Calico](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
+   > **Note**: If upgrading from {{site.prodname}} 2.6.x and an error occurs during 
+   > the upgrade, refer to [Downgrading Calico](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
    {: .alert .alert-info}
    
 1. Remove any existing `calicoctl` instances and install the new `calicoctl`.
@@ -74,7 +74,7 @@ and your datastore type.
 
 ## Upgrading a self-hosted installation that uses the etcd datastore
 
-1. [Refer to the v3.0 documentation and obtain the manifest that matches your installation
+1. [Refer to the installation documentation and obtain the manifest that matches your installation
    method.](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/)
 
 1. Use the following command to initiate a rolling update, after replacing 
@@ -102,25 +102,27 @@ and your datastore type.
    > **Tip**: The {{site.noderunning}} pods will report `1/2` in the `READY` column, as shown.
    {: .alert .alert-success}
 
-   > **Note**: If an error occurs during the upgrade, refer to 
-   > [Downgrading Calico](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
+   > **Note**: If upgrading from {{site.prodname}} 2.6.x and an error occurs during 
+   > the upgrade, refer to an error occurs during the upgrade, refer to 
+   > [Downgrading {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
    {: .alert .alert-info}
    
-1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
+1. Use the following command to confirm that {{site.noderunning}} has upgraded to {{page.version}}.x.
 
    ```
    kubectl exec -n kube-system calico-node-hvvg8 versions
    ```
    
-   It should return `v3.0.x`.
+   It should return `{{page.version}}.x`.
    
-1. We recommend waiting for some time and really ensuring that the upgrade succeeded 
-   and no problems ensued before completing the upgrade by running 
-   `calico-upgrade complete`. After this, you can once again schedule pods and 
-   make changes to configuration and policy. 
+1. If you are upgrading from {{site.prodname}} 3.x, skip to the next step. Otherwise, 
+   for those upgrading from {{site.prodname}} 2.6.x, wait for some time to really 
+   ensure that the upgrade succeeded and no problems ensued. Then complete the 
+   upgrade by running `calico-upgrade complete`. After this, you can once again schedule 
+   pods and make changes to configuration and policy. 
 
    > **Important**: If you experience errors after running `calico-upgrade complete`, 
-   > such as an inability to schedule pods, [downgrade Calico as soon as possible](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
+   > such as an inability to schedule pods, [downgrade {{site.prodname}} as soon as possible](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
    {: .alert .alert-danger}
    
 1. Remove any existing `calicoctl` instances and install the new `calicoctl`.

--- a/v3.1/getting-started/kubernetes/upgrade.md
+++ b/v3.1/getting-started/kubernetes/upgrade.md
@@ -1,7 +1,0 @@
----
-redirect_to: /master/getting-started/kubernetes/upgrade/
----
-
-<!--- Page was deleted, now it just performs a redirect
-to its replacement so as to prevent a 404. Site does not support
-server-side redirects right now. -->

--- a/v3.1/getting-started/kubernetes/upgrade/delete.md
+++ b/v3.1/getting-started/kubernetes/upgrade/delete.md
@@ -8,7 +8,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.0/getting-started/kubernetes/u
 You may need or wish to manually delete Calico data from your etcd datastore under the
 following conditions.
   
-- [**etcd**: You succeeded in migrating your data and upgrading to Calico v3.0. After
+- [**etcd**: You succeeded in migrating your data and upgrading to Calico v3.x. After
   running Calico for some time and experiencing no errors, you want to delete
   the old Calico data from the etcdv2 datastore](#deleting-calico-data-from-etcdv2-after-a-successful-migration-and-upgrade).
   
@@ -16,9 +16,9 @@ following conditions.
   with some, but not all of your etcvd2 data](#deleting-calico-data-from-etcdv3-after-a-partial-migration).
 
 - [**Kubernetes API datastore**: You are using the Kubernetes API datastore and upgraded 
-  to Calico v3.0 but then downgraded to v2.6.5. You want to clean the Calico v3.0 data out of
+  to Calico v3.x but then downgraded to v2.6.x. You want to clean the Calico v3.x data out of
   the Kubernetes API datastore. If you plan to attempt another upgrade to
-  Calico v3.0, this is required.](#deleting-calico-data-from-the-kubernetes-api-datastore-after-a-downgrade).
+  Calico v3.x, this is required.](#deleting-calico-data-from-the-kubernetes-api-datastore-after-a-downgrade).
 
 {% include {{page.version}}/deleting-etcd-v2-v3-data.md %}
 
@@ -27,7 +27,7 @@ following conditions.
 ### Prerequisites
 
 - This procedure requires kubectl.
-- This procedure should only be done if you have upgraded to v3.0+ and then
+- This procedure should only be done if you have upgraded to v3.x and then
   downgraded to your previous version.
 
 ### Deleting Calico data from the Kubernetes API datastore

--- a/v3.1/getting-started/kubernetes/upgrade/downgrade.md
+++ b/v3.1/getting-started/kubernetes/upgrade/downgrade.md
@@ -9,7 +9,7 @@ Under some circumstances, you may need to perform a downgrade and return your
 cluster to the previous version of {{site.prodname}}. If you need to downgrade
 you should do so as soon as possible to avoid an outage.
 
-> **Important**: After downgrading or aborting the migration it is necessary
+> **Note**: After downgrading or aborting the migration it is necessary
 > to delete the previously migrated
 > [etcd](delete#deleting-calico-data-from-etcdv2-after-a-successful-migration-and-upgrade)
 > or [Kubernetes API](delete#deleting-calico-data-from-the-kubernetes-api-datastore-after-a-downgrade)
@@ -31,9 +31,6 @@ The downgrade procedure varies according to how you originally installed
   Kubernetes API datastore](#downgrading-a-self-hosted-installation-that-uses-the-kubernetes-api-datastore)
   follow these steps.
 
-
-- [Downgrading a custom installation](#downgrading-a-custom-installation)
-
 ## Downgrading a self-hosted installation that uses the etcd datastore
 
 If you have upgraded {{site.prodname}} by deploying the latest manifest,
@@ -47,7 +44,7 @@ follow the steps here to downgrade.
    calico-upgrade abort
    ```
    
-   > **Important**: Do not use versions of `calicoctl` v3.0+ after aborting the upgrade.
+   > **Important**: Do not use versions of `calicoctl` v3.x after aborting the upgrade.
    > Doing so may result in unexpected behavior and data.
    {: .alert .alert-danger}
 
@@ -80,8 +77,3 @@ follow the steps here to downgrade.
    ```
    kubectl rollout status ds/calico-node -n kube-system
    ```
-
-## Downgrading a custom installation
-
-_Docs for this coming soon!_
-

--- a/v3.1/getting-started/kubernetes/upgrade/index.md
+++ b/v3.1/getting-started/kubernetes/upgrade/index.md
@@ -3,42 +3,35 @@ title: Upgrading Calico for Kubernetes
 canonical_url: 'https://docs.projectcalico.org/v3.0/getting-started/kubernetes/upgrade/'
 ---
 
-Upgrading to this release of {{site.prodname}} from a pre-v3.0 release may require some manual steps, depending on
-your choice of datastore.
-
 ## Before you begin
 
-- You must first [upgrade](/v2.6/getting-started/kubernetes/upgrade) 
-  to {{site.prodname}} [v2.6.5](https://github.com/projectcalico/calico/releases) 
-  (or a later v2.6.x release) before you can upgrade to {{site.prodname}} 
-  {{site.data.versions[page.version].first.title}}. 
+- You must first upgrade to at least {{site.prodname}} [v2.6.5](https://github.com/projectcalico/calico/releases) 
+  before you can upgrade to {{site.prodname}} {{site.data.versions[page.version].first.title}}. 
   
-  > **Important**: {{site.prodname}} v2.6.5 was a special transitional release that included changes to enable 
-  > upgrade to v3.0.1+; do not skip this step!
+  > **Important**: {{site.prodname}} v2.6.5 was a special transitional release that 
+  > included changes to enable upgrade to {{site.prodname}} v3.x. Do not skip this step!
   {: .alert .alert-danger}
 
-- If you are using the etcd datastore, you should upgrade etcd to the latest stable 
+- If you are using the etcd datastore, upgrade etcd to the latest stable 
   [v3 release](https://coreos.com/etcd/docs/latest/).  
+
+## About upgrading to {{site.prodname}} {{site.data.versions[page.version].first.title}}
+
+The steps to upgrade differ according to your current version and datastore type.
+
+- **Kubernetes API datastore, {{site.prodname}} v2.6.5 or later**: Complete the steps in 
+  [Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade#upgrading-a-self-hosted-installation-that-uses-the-kubernetes-api-datastore).
   
-  > **Tip**: etcd v3.x still supports the etcd v2 API, as used by {{site.prodname}} v2.6.x.
-  > However, {{site.prodname}} v3.0.0+ does not support the etcd v2 API.  The upgrade steps below
-  > move the data from the etcd v2 API to the etcd v3 API.  This requires an etcd v3.x server.
-  {: .alert .alert-success}
+- **etcd datastore, {{site.prodname}} v3.x**: Complete the steps in 
+  [Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade#upgrading-a-self-hosted-installation-that-uses-the-etcd-datastore).
+  
+- **etcd datastore, {{site.prodname}} v2.6.x**: You must migrate your data before
+  you can upgrade. Complete the steps in each of the following sections.
+  
+  1. **[Install and configure calico-upgrade](/{{page.version}}/getting-started/kubernetes/upgrade/setup)** 
 
-## Kubernetes API datastore upgrade steps
+  1. **[Test the data migration and check for errors](/{{page.version}}/getting-started/kubernetes/upgrade/test)**
 
-If you are using the Kubernetes API datastore, complete the steps in 
-[Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade).
+  1. **[Migrate {{site.prodname}} data](/{{page.version}}/getting-started/kubernetes/upgrade/migrate)** 
 
-## etcd datastore upgrade steps
-
-If you are using the etcd datastore then a manual migration step is required, using the 
-`calico-upgrade` tool.  To complete the upgrade follow these steps in sequence:
-
-1. **[Install and configure calico-upgrade](/{{page.version}}/getting-started/kubernetes/upgrade/setup)** 
-
-1. **[Test the data migration and check for errors](/{{page.version}}/getting-started/kubernetes/upgrade/test)**
-
-1. **[Migrate {{site.prodname}} data](/{{page.version}}/getting-started/kubernetes/upgrade/migrate)** 
-
-1. **[Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade)** 
+  1. **[Upgrade {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/upgrade#upgrading-a-self-hosted-installation-that-uses-the-etcd-datastore)** 

--- a/v3.1/getting-started/kubernetes/upgrade/setup.md
+++ b/v3.1/getting-started/kubernetes/upgrade/setup.md
@@ -23,7 +23,7 @@ following:
 
 - [The existing etcdv2 datastore used by Calico v2.6.5](#configuring-calico-upgrade-to-connect-to-the-etcdv2-datastore)
 
-- [The etcdv3 cluster you plan to use for Calico v3.0](#configuring-calico-upgrade-to-connect-to-the-etcdv3-cluster)
+- [The etcdv3 cluster you plan to use for Calico v3.x](#configuring-calico-upgrade-to-connect-to-the-etcdv3-cluster)
 
 {% include {{page.version}}/config-calico-upgrade-etcd.md %}
 

--- a/v3.1/getting-started/kubernetes/upgrade/upgrade.md
+++ b/v3.1/getting-started/kubernetes/upgrade/upgrade.md
@@ -28,10 +28,10 @@ and your datastore type.
    kubectl apply -f {{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
    ```
    > **Note**: You can also 
-   > [view the YAML in your browser]({{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml){:target="_blank"}.
+   > [view the manifest in your browser]({{site.url}}/{{page.version}}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml){:target="_blank"}.
    {: .alert .alert-info}
 
-1. [Refer to the Kubernetes datastore hosted installation documentation and 
+1. [Refer to the Kubernetes API datastore hosted installation documentation and 
    obtain the manifest needed for your configuration.](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/)
 
 1. Use the following command to initiate a rolling update, after replacing 
@@ -55,16 +55,16 @@ and your datastore type.
    calico-node-w92wk                          2/2       Running   0          3m
    ```
 
-1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
+1. Use the following command to confirm that {{site.noderunning}} has upgraded to {{page.version}}.x.
 
    ```
    kubectl exec -n kube-system calico-node-hvvg8 versions
    ```
    
-   It should return `v3.0.x`.
+   It should return `{{page.version}}.x`.
    
-   > **Note**: If an error occurs during the upgrade, refer to 
-   > [Downgrading Calico](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
+   > **Note**: If upgrading from {{site.prodname}} 2.6.x and an error occurs during 
+   > the upgrade, refer to [Downgrading Calico](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
    {: .alert .alert-info}
    
 1. Remove any existing `calicoctl` instances and install the new `calicoctl`.
@@ -74,7 +74,7 @@ and your datastore type.
 
 ## Upgrading a self-hosted installation that uses the etcd datastore
 
-1. [Refer to the v3.0 documentation and obtain the manifest that matches your installation
+1. [Refer to the installation documentation and obtain the manifest that matches your installation
    method.](https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/)
 
 1. Use the following command to initiate a rolling update, after replacing 
@@ -102,25 +102,27 @@ and your datastore type.
    > **Tip**: The {{site.noderunning}} pods will report `1/2` in the `READY` column, as shown.
    {: .alert .alert-success}
 
-   > **Note**: If an error occurs during the upgrade, refer to 
-   > [Downgrading Calico](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
+   > **Note**: If upgrading from {{site.prodname}} 2.6.x and an error occurs during 
+   > the upgrade, refer to an error occurs during the upgrade, refer to 
+   > [Downgrading {{site.prodname}}](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
    {: .alert .alert-info}
    
-1. Use the following command to confirm that {{site.noderunning}} has upgraded to v3.0.x.
+1. Use the following command to confirm that {{site.noderunning}} has upgraded to {{page.version}}.x.
 
    ```
    kubectl exec -n kube-system calico-node-hvvg8 versions
    ```
    
-   It should return `v3.0.x`.
+   It should return `{{page.version}}.x`.
    
-1. We recommend waiting for some time and really ensuring that the upgrade succeeded 
-   and no problems ensued before completing the upgrade by running 
-   `calico-upgrade complete`. After this, you can once again schedule pods and 
-   make changes to configuration and policy. 
+1. If you are upgrading from {{site.prodname}} 3.x, skip to the next step. Otherwise, 
+   for those upgrading from {{site.prodname}} 2.6.x, wait for some time to really 
+   ensure that the upgrade succeeded and no problems ensued. Then complete the 
+   upgrade by running `calico-upgrade complete`. After this, you can once again schedule 
+   pods and make changes to configuration and policy. 
 
    > **Important**: If you experience errors after running `calico-upgrade complete`, 
-   > such as an inability to schedule pods, [downgrade Calico as soon as possible](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
+   > such as an inability to schedule pods, [downgrade {{site.prodname}} as soon as possible](/{{page.version}}/getting-started/kubernetes/upgrade/downgrade).
    {: .alert .alert-danger}
    
 1. Remove any existing `calicoctl` instances and install the new `calicoctl`.


### PR DESCRIPTION
## Description

- Reduces brittle characteristics of upgrade content so that it can port from release dir to release with less errors.
- Updates intro to address needs of people wanting to upgrade from one v3.x release to another.
- Removes redirect files which were causing infinite loops in local doc builds.
- Removes coming soon for custom install downgrade instructions.
- Other minor stylistic/editorial corrections.

 NOTE: will update links in upgrade page when we merge other PR for install instruction improvements

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
