### PR TITLE
Clarifies bare metal key value store req

### DIFF
--- a/_includes/master/reqs-sys.md
+++ b/_includes/master/reqs-sys.md
@@ -26,7 +26,8 @@ use the Kubernetes API datastore.{% endif %}{% if include.orch == "OpenShift" %}
 OpenShift, {{site.prodname}} can share an etcdv3 cluster with OpenShift, or
 you can set up an etcdv3 cluster dedicated to {{site.prodname}}.{% endif %}
 {% if include.orch == "OpenStack" %}If you don't already have an etcdv3 cluster
-to connect to, we provide instructions in the [installation documentation](./installation/).{% endif %}
+to connect to, we provide instructions in the [installation documentation](./installation/).{% endif %}{% if include.orch == "host protection" %}The key/value store must be etcdv3.{% endif %}
+
 
 ## Network requirements
 

--- a/_includes/v3.1/reqs-sys.md
+++ b/_includes/v3.1/reqs-sys.md
@@ -26,7 +26,7 @@ use the Kubernetes API datastore.{% endif %}{% if include.orch == "OpenShift" %}
 OpenShift, {{site.prodname}} can share an etcdv3 cluster with OpenShift, or
 you can set up an etcdv3 cluster dedicated to {{site.prodname}}.{% endif %}
 {% if include.orch == "OpenStack" %}If you don't already have an etcdv3 cluster
-to connect to, we provide instructions in the [installation documentation](./installation/).{% endif %}
+to connect to, we provide instructions in the [installation documentation](./installation/).{% endif %}{% if include.orch == "host protection" %}The key/value store must be etcdv3.{% endif %}
 
 ## Network requirements
 


### PR DESCRIPTION
## Description

- Clarifies that for bare metal aka legacy hosts, you need etcdv3


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
