### PR TITLE
Surpress docker load output during STs

### DIFF
--- a/calico_node/tests/st/config/test_felix_config.py
+++ b/calico_node/tests/st/config/test_felix_config.py
@@ -26,7 +26,7 @@ _log = logging.getLogger(__name__)
 _log.setLevel(logging.DEBUG)
 
 POST_DOCKER_COMMANDS = [
-    "docker load -i /code/calico-node.tar",
+    "docker load -q -i /code/calico-node.tar",
 ]
 
 

--- a/calico_node/tests/st/ipam/test_ipam.py
+++ b/calico_node/tests/st/ipam/test_ipam.py
@@ -22,9 +22,9 @@ from nose_parameterized import parameterized
 from tests.st.test_base import TestBase
 from tests.st.utils.docker_host import DockerHost, CLUSTER_STORE_DOCKER_OPTIONS
 
-POST_DOCKER_COMMANDS = ["docker load -i /code/calico-node.tar",
-                        "docker load -i /code/busybox.tar",
-                        "docker load -i /code/workload.tar"]
+POST_DOCKER_COMMANDS = ["docker load -q -i /code/calico-node.tar",
+                        "docker load -q -i /code/busybox.tar",
+                        "docker load -q -i /code/workload.tar"]
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 logger = logging.getLogger(__name__)

--- a/calico_node/tests/st/libnetwork/test_labeling.py
+++ b/calico_node/tests/st/libnetwork/test_labeling.py
@@ -25,9 +25,9 @@ from tests.st.utils.utils import ETCD_CA, ETCD_CERT, \
     retry_until_success, wipe_etcd
 
 POST_DOCKER_COMMANDS = [
-    "docker load -i /code/calico-node.tar",
-    "docker load -i /code/busybox.tar",
-    "docker load -i /code/workload.tar",
+    "docker load -q -i /code/calico-node.tar",
+    "docker load -q -i /code/busybox.tar",
+    "docker load -q -i /code/workload.tar",
 ]
 
 if ETCD_SCHEME == "https":

--- a/calico_node/tests/st/policy/test_felix_gateway.py
+++ b/calico_node/tests/st/policy/test_felix_gateway.py
@@ -27,9 +27,9 @@ _log = logging.getLogger(__name__)
 _log.setLevel(logging.DEBUG)
 
 POST_DOCKER_COMMANDS = [
-    "docker load -i /code/calico-node.tar",
-    "docker load -i /code/busybox.tar",
-    "docker load -i /code/workload.tar",
+    "docker load -q -i /code/calico-node.tar",
+    "docker load -q -i /code/busybox.tar",
+    "docker load -q -i /code/workload.tar",
 ]
 
 

--- a/calico_node/tests/st/policy/test_namespace.py
+++ b/calico_node/tests/st/policy/test_namespace.py
@@ -27,8 +27,8 @@ _log = logging.getLogger(__name__)
 _log.setLevel(logging.DEBUG)
 
 POST_DOCKER_COMMANDS = [
-    "docker load -i /code/calico-node.tar",
-    "docker load -i /code/workload.tar",
+    "docker load -q -i /code/calico-node.tar",
+    "docker load -q -i /code/workload.tar",
 ]
 NAMESPACE_PREFIX = "pcns"
 

--- a/calico_node/tests/st/policy/test_profile.py
+++ b/calico_node/tests/st/policy/test_profile.py
@@ -23,9 +23,9 @@ from tests.st.utils.network import NETWORKING_CNI, NETWORKING_LIBNETWORK
 from tests.st.utils.utils import assert_profile, \
     assert_number_endpoints, get_profile_name
 
-POST_DOCKER_COMMANDS = ["docker load -i /code/calico-node.tar",
-                        "docker load -i /code/busybox.tar",
-                        "docker load -i /code/workload.tar"]
+POST_DOCKER_COMMANDS = ["docker load -q -i /code/calico-node.tar",
+                        "docker load -q -i /code/busybox.tar",
+                        "docker load -q -i /code/workload.tar"]
 
 
 _log = logging.getLogger(__name__)

--- a/calico_node/tests/st/utils/docker_host.py
+++ b/calico_node/tests/st/utils/docker_host.py
@@ -80,8 +80,8 @@ class DockerHost(object):
 
     def __init__(self, name, start_calico=True, dind=True,
                  additional_docker_options="",
-                 post_docker_commands=["docker load -i /code/calico-node.tar",
-                                       "docker load -i /code/busybox.tar"],
+                 post_docker_commands=["docker load -q -i /code/calico-node.tar",
+                                       "docker load -q -i /code/busybox.tar"],
                  calico_node_autodetect_ip=False,
                  simulate_gce_routing=False,
                  override_hostname=False,


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Minor tweak to STs - pass `-q` to `docker load` so that we don't see `Loading layer  4.403MB/4.403MB`  in the test output.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
