### PR TITLE
Doc for TLS for Felix-Typha communication

### DIFF
--- a/_includes/master/felix-typha-tls-howto.md
+++ b/_includes/master/felix-typha-tls-howto.md
@@ -1,0 +1,55 @@
+
+Here is an example of how you can secure the Felix-Typha communications in your
+cluster:
+
+1.  Choose a Certificate Authority, or set up your own.
+
+1.  Obtain or generate the following leaf certificates, signed by that
+    authority, and corresponding keys:
+
+    -  A certificate for each Felix with Common Name 'typha-client' and
+       extended key usage 'ClientAuth'.
+
+    -  A certificate for each Typha with Common Name 'typha-server' and
+       extended key usage 'ServerAuth'.
+
+1.  Configure each Typha with:
+
+    -  `CAFile` pointing to the Certificate Authority certificate
+
+    -  `ServerCertFile` pointing to that Typha's certificate
+
+    -  `ServerKeyFile` pointing to that Typha's key
+
+    -  `ClientCN` set to 'typha-client'
+
+    -  `ClientURISAN` unset.
+
+1.  Configure each Felix with:
+
+    -  `TyphaCAFile` pointing to the Certificate Authority certificate
+
+    -  `TyphaCertFile` pointing to that Felix's certificate
+
+    -  `TyphaKeyFile` pointing to that Felix's key
+
+    -  `TyphaCN` set to 'typha-server'
+
+    -  `TyphaURISAN` unset.
+
+For a [SPIFFE](https://github.com/spiffe/spiffe)-compliant deployment you can
+follow the same procedure as above, except:
+
+1.  Choose [SPIFFE
+    Identities](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#2-spiffe-identity)
+    to represent Felix and Typha.
+
+1.  When generating leaf certificates for Felix and Typha, put the relevant
+    SPIFFE Identity in the certificate as a URI SAN.
+
+1.  Leave `ClientCN` and `TyphaCN` unset.
+
+1.  Set Typha's `ClientURISAN` parameter to the SPIFFE Identity for Felix that
+    you use in each Felix certificate.
+
+1.  Set Felix's `TyphaURISAN` parameter to the SPIFFE Identity for Typha.

--- a/_includes/master/felix-typha-tls-intro.md
+++ b/_includes/master/felix-typha-tls-intro.md
@@ -1,0 +1,12 @@
+
+The communication between Felix and Typha instances can be secured with TLS.
+This protects against:
+
+-  a rogue or impostor Typha sending incorrect endpoint or policy information
+   to the Felix instances that connect to it
+
+-  a rogue or impostor Felix wrongly receiving privileged information about the
+   overall cluster from the Typha that it connects to
+
+-  any other process discovering privileged information about the overall
+   cluster by eavesdropping on the communication channel.

--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -115,6 +115,40 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | ----------------------- | ----------------------- | ----------- | ------ |
 | `InterfacePrefix`       | `FELIX_INTERFACEPREFIX` | The interface name prefix that identifies workload endpoints and so distinguishes them from host endpoint interfaces. Accepts more than one interface name prefix in comma-delimited format, e.g., `tap,cali`. Note: in environments other than bare metal, the orchestrators configure this appropriately.  For example our Kubernetes and Docker integrations set the `cali` value, and our OpenStack integration sets the `tap` value. [Default: `cali`] | string |
 
+#### Felix-Typha TLS configuration
+
+{% include {{page.version}}/felix-typha-tls-intro.md %}
+
+To use TLS, each Felix instance must have a certificate and key pair signed by
+a trusted CA.  Felix then uses TLS when connecting to Typha, and requires Typha
+to present a certificate that is signed by a trusted CA and
+has an expected identity in its Common Name or URI SAN field.  Either
+`TyphaCN` or `TyphaURISAN` must be configured, and Felix will check the
+presented certificate accordingly.
+
+-  For a [SPIFFE](https://github.com/spiffe/spiffe)-compliant deployment you
+   should configure `TyphaURISAN` with a [SPIFFE
+   Identity](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#2-spiffe-identity)
+   and provision Typha certificates with the same identity in their URI SAN
+   field.
+
+-  Alternatively you can configure `TyphaCN` and provision Typha certificates
+   with that `TyphaCN` value in their Common Name field.
+
+If both those parameters are set, a Typha certificate only has to match one of
+them; this is intended for when a deployment is migrating from using Common
+Name to using a URI SAN, to express identity.
+
+| Configuration parameter | Environment variable   | Description | Schema |
+| ----------------------- | ---------------------- | ----------- | ------ |
+| `TyphaCAFile`           | `FELIX_TYPHACAFILE`    | The full path to the certificate file for the Certificate Authorities that Felix trusts for Felix-Typha communications. | string |
+| `TyphaCertFile`         | `FELIX_TYPHACERTFILE`  | The full path to the certificate file for this Felix instance to use to connect to Typha. | string |
+| `TyphaCN`               | `FELIX_TYPHACN`        | If set, the Common Name that Typha's certificate must have. [Default: not set] | string |
+| `TyphaKeyFile`          | `FELIX_TYPHAKEYFILE`   | The full path to the private key file for this Felix instance to use to connect to Typha. | string |
+| `TyphaURISAN`           | `FELIX_TYPHAURISAN`    | If set, a URI SAN that Typha's certificate must have. [Default: not set] | string |
+
+{% include {{page.version}}/felix-typha-tls-howto.md %}
+
 Environment variables
 ---------------------
 

--- a/master/reference/typha/configuration.md
+++ b/master/reference/typha/configuration.md
@@ -48,3 +48,37 @@ The full list of parameters which can be set is as follows.
 #### Kubernetes API datastore configuration
 
 The Kubernetes API datastore driver reads its configuration from Kubernetes-provided environment variables.
+
+#### Felix-Typha TLS configuration
+
+{% include {{page.version}}/felix-typha-tls-intro.md %}
+
+To use TLS, each Typha instance must have a certificate and key pair signed by
+a trusted CA.  Typha then only accepts TLS connections, and requires each
+connecting client to present a certificate that is signed by a trusted CA and
+has an expected identity in its Common Name or URI SAN field.  Either
+`ClientCN` or `ClientURISAN` must be configured, and Typha will check the
+presented certificate accordingly.
+
+-  For a [SPIFFE](https://github.com/spiffe/spiffe)-compliant deployment you
+   should configure `ClientURISAN` with a [SPIFFE
+   Identity](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#2-spiffe-identity)
+   and provision client certificates with the same identity in their URI SAN
+   field.
+
+-  Alternatively you can configure `ClientCN` and provision client certificates
+   with that `ClientCN` value in their Common Name field.
+
+If both those parameters are set, a client certificate only has to match one of
+them; this is intended for when a deployment is migrating from using Common
+Name to using a URI SAN, to express identity.
+
+| Configuration parameter | Environment variable   | Description | Schema |
+| ----------------------- | ---------------------- | ----------- | ------ |
+| `CAFile`                | `TYPHA_CAFILE`         | The full path to the certificate file for the Certificate Authorities that Typha trusts for Felix-Typha communications. | string |
+| `ClientCN`              | `TYPHA_CLIENTCN`       | If set, the Common Name that each connecting client certificate must have. [Default: not set] | string |
+| `ClientURISAN`          | `TYPHA_CLIENTURISAN`   | If set, a URI SAN that each connecting client certificate must have. [Default: not set] | string |
+| `ServerCertFile`        | `TYPHA_SERVERCERTFILE` | The full path to the certificate file for this Typha instance. | string |
+| `ServerKeyFile`         | `TYPHA_SERVERKEYFILE`  | The full path to the private key file for this Typha instance. | string |
+
+{% include {{page.version}}/felix-typha-tls-howto.md %}


### PR DESCRIPTION
## Todos

- [x] Release note

## Release Note

```release-note
Felix-Typha communications can now be secured with TLS.  Please see https://docs.projectcalico.org/master/reference/felix/configuration and https://docs.projectcalico.org/master/reference/typha/configuration for the details.
```
