### PR TITLE
Add watch flag

### DIFF
--- a/v3.1/getting-started/kubernetes/index.md
+++ b/v3.1/getting-started/kubernetes/index.md
@@ -83,7 +83,7 @@ the host. Instead, continue directly to the
 1. Confirm that all of the pods are running with the following command.
 
    ```
-   watch kubectl get pods --all-namespaces
+   watch kubectl get pods --all-namespaces -w
    ```
    
    Wait until each pod has the `STATUS` of `Running`.


### PR DESCRIPTION
This PR fixes a kubectl command in the docs. We refer the command as watch but we don't pass the "watch" flag.