### PR TITLE
Don't kubeval allow-istio-pilot.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ htmlproofer: clean _site
 	./htmlproofer.sh
 
 	# Run kubeval to check master manifests are valid Kubernetes resources.
-	docker run -v $$PWD:/calico --entrypoint /bin/sh -ti garethr/kubeval:0.1.1 -c 'find /calico/_site/master -name "*.yaml" |grep -v config.yaml | xargs /kubeval'
+	docker run -v $$PWD:/calico --entrypoint /bin/sh -ti garethr/kubeval:0.1.1 -c 'find /calico/_site/master -name "*.yaml" |grep -v "\(config\|allow-istio-pilot\).yaml" | xargs /kubeval'
 
 strip_redirects:
 	find \( -name '*.md' -o -name '*.html' \) -exec sed -i'' '/redirect_from:/d' '{}' \;


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

`kubeval` mistakes `allow-istio-pilot.yaml` as a Kubernetes NetworkPolicy, but really it is a valid Calico NetworkPolicy.  So, we exclude it from evaluation. 



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
