### PR TITLE
Update versions for Calico v3.0.7 release build

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1,4 +1,46 @@
 v3.0:
+- title: v3.0.7
+  note: ""
+  components:
+    felix:
+      version: 3.0.6
+      url: https://github.com/projectcalico/felix/releases/tag/3.0.6
+    typha:
+      version: v0.6.5
+      url: https://github.com/projectcalico/typha/releases/tag/v0.6.5
+    calicoctl:
+      version: v2.0.5
+      url: https://github.com/projectcalico/calicoctl/releases/tag/v2.0.5
+      download_url: https://github.com/projectcalico/calicoctl/releases/download/v2.0.5/calicoctl
+    calico/node:
+      version: v3.0.7
+      url: https://github.com/projectcalico/calico/releases/tag/v3.0.7
+    calico/cni:
+      version: v2.0.5
+      url: https://github.com/projectcalico/cni-plugin/releases/tag/v2.0.5
+      download_calico_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.5/calico
+      download_calico_ipam_url: https://github.com/projectcalico/cni-plugin/releases/download/v2.0.5/calico-ipam
+    calico/kube-controllers:
+      version: v2.0.4
+      url: https://github.com/projectcalico/k8s-policy/releases/tag/v2.0.4
+    confd:
+      version: v1.0.5
+      url: https://github.com/projectcalico/confd/releases/tag/v1.0.5
+    calico-bird:
+      version: v0.3.2
+      url: https://github.com/projectcalico/calico-bird/releases/tag/v0.3.2
+    calico/routereflector:
+      version: v0.5.0
+      url: https://github.com/projectcalico/routereflector/releases/tag/v0.5.0
+    calico-bgp-daemon:
+      version: v0.2.1
+      url: https://github.com/projectcalico/calico-bgp-daemon/releases/tag/v0.2.1
+    networking-calico:
+      version: 1.4.3
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=1.4.3
+    flannel:
+      version: v0.9.1
+
 - title: v3.0.6
   note: ""
   components:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Updates felix, typha, and calicoctl

Changes:

```
# Release notes for Calico v3.0.7
 - Fix invalid filter in "calicoctl node diags" command [calicoctl #1855](https://github.com/projectcalico/calicoctl/pull/1855) (@bcreane)
 - Felix supports watching a configurable interface prefix when using the Kubernetes API datastore [libcalico-go #864](https://github.com/projectcalico/libcalico-go/pull/864) (@caseydavenport)
```



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
