### PR TITLE
Add Dockerfile for s390x builds

### DIFF
--- a/calico_node/Dockerfile-s390x
+++ b/calico_node/Dockerfile-s390x
@@ -1,0 +1,27 @@
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright IBM Corp. 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM s390x/alpine:3.7
+MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
+
+# Set the minimum Docker API version required for libnetwork.
+ENV DOCKER_API_VERSION 1.21
+
+# Install remaining runtime deps required for felix from the global repository
+RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools runit file
+
+# Copy in the filesystem - this contains felix, bird, gobgp etc...
+COPY filesystem /
+
+CMD ["start_runit"]


### PR DESCRIPTION
Signed-off-by: jose-bigio <jose.bigio@docker.com>

## Description

Would be nice to have the s390x file in the release branch, so you can build 390x Calico images for `3.0.x`. 

~I copied this file from what was in the release-v3.1 branch.~

Cherry picked this issue with: 

```
git cherry-pick -s -x  49ade154694d67f27981297241218ad9b92b0f4f
```

Cherry Pick went in clean

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->




## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
