### PR TITLE
[3.0.x] Backport glibc Bump to 2.27 -r0

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -14,15 +14,18 @@
 FROM alpine
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
+# Set glibc version
+ENV GLIBC_VERSION 2.27-r0
+
 # Download and install glibc for use by non-static binaries that require it.
 RUN apk --no-cache add wget ca-certificates libgcc && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-bin-2.23-r3.apk && \
-    apk add glibc-2.23-r3.apk glibc-bin-2.23-r3.apk && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk && \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-bin-$GLIBC_VERSION.apk && \
+    apk add glibc-$GLIBC_VERSION.apk glibc-bin-$GLIBC_VERSION.apk && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc/usr/lib && \
     apk del wget && \
-    rm -f glibc-2.23-r3.apk glibc-bin-2.23-r3.apk
+    rm -f glibc-$GLIBC_VERSION.apk glibc-bin-$GLIBC_VERSION.apk
 
 # Install runit from the community repository, as its not yet available in global
 RUN apk add --no-cache --repository "http://alpine.gliderlabs.com/alpine/edge/community" runit


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

    Update glibc to 2.27-r0
    Conflicts:
            calico_node/Dockerfile
            resolved conflict by removing ENV DOCKER_API_VERSION 1.21

Cherry picked from: 
* https://github.com/projectcalico/calico/pull/1713

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->


