### PR TITLE
update WEP yaml for errors

### DIFF
--- a/master/reference/calicoctl/resources/workloadendpoint.md
+++ b/master/reference/calicoctl/resources/workloadendpoint.md
@@ -33,7 +33,7 @@ insensitive): `workloadendpoint`, `workloadendpoints`, `wep`, `weps`.
 apiVersion: projectcalico.org/v3
 kind: WorkloadEndpoint
 metadata:
-  name: node1-k8s-frontend--5gs43-eth0
+  name: node1-k8s-my--nginx--b1337a-eth0
   namespace: default
   labels:
     app: frontend
@@ -49,16 +49,16 @@ spec:
   interfaceName: cali0ef24ba
   mac: ca:fe:1d:52:bb:e9
   ipNetworks:
-  - 192.168.0.0/16
+  - 192.168.0.0/32
   profiles:
   - profile1
   ports:
   - name: some-port
     port: 1234
-    protocol: tcp
+    protocol: TCP
   - name: another-port
     port: 5432
-    protocol: udp
+    protocol: UDP
 ```
 
 ### Definitions


### PR DESCRIPTION
## Description
When using the manifest found in the docs, I encountered some errors trying to create the WEP:

1. 
```bash
Failed to execute command: error with the following fields:                                    
-  EndpointPort.Protocol = 'tcp' (EndpointPort protocol must be 'TCP' or 'UDP'.)               
-  Protocol = 'udp' (protocol name invalid)                                                    
-  EndpointPort.Protocol = 'udp' (EndpointPort protocol must be 'TCP' or 'UDP'.)               
-  Protocol = 'tcp' (protocol name invalid)                                                                                                          
```
Solve by changing `tcp` and `udp` to all caps

2. 

```bash
Failed to execute command: error with field IPNetworks = '[192.168.0.0/16]' (IP network contains multiple addresses)
```
Seems like WEPs only support /32 addrs, changed to /32

3. 

```bash
Failed to create 'WorkloadEndpoint' resource: error with field Name = 'node1-k8s-frontend--5gs43-eth0' (the WorkloadEndpoint name does not match the primary identifiers assigned in the Spec: expected name node1-k8s-my--nginx--b1337a-eth0)                               
```
Changed name to `node1-k8s-my--nginx--b1337a-eth0`

With those changes was able to get:
```bash
Successfully created 1 'WorkloadEndpoint' resource(s)
```
## Release Note

```release-note
None required
```

Signed-off-by: derek mcquay <derek@tigera.io>
