### PR TITLE
allocate-ipip-addr: retry loop around IPAM AutoAssign()

### DIFF
--- a/calico_node/allocateipip/allocate_ipip_addr.go
+++ b/calico_node/allocateipip/allocate_ipip_addr.go
@@ -122,12 +122,11 @@ func assignHostTunnelAddr(c *client.Client, nodename string, ipipCidrs []net.IPN
 
 	// Retry loop around AutoAssign to recover from a distributed race in case
 	// all nodes in a large cluster respond to a change in /pools simultaneously.
-	for a := 3; a > 0; a-- {
+	for a := 10; a > 0; a-- {
 		var err error
 		ipv4Addrs, _, err = c.IPAM().AutoAssign(args)
-
 		if err != nil {
-			log.WithError(err).Error("Unable to autoassign an address for IPIP:")
+			log.WithError(err).Error("Unable to autoassign an address for IPIP")
 			time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
 		}
 

--- a/calico_node/allocateipip/allocate_ipip_addr.go
+++ b/calico_node/allocateipip/allocate_ipip_addr.go
@@ -128,6 +128,8 @@ func assignHostTunnelAddr(c *client.Client, nodename string, ipipCidrs []net.IPN
 		if err != nil {
 			log.WithError(err).Error("Unable to autoassign an address for IPIP")
 			time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
+
+			continue
 		}
 
 		break


### PR DESCRIPTION
## Description

Follow-up PR to https://github.com/projectcalico/node/pull/18.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Internally retry address allocation from IP Pools with IPIP enabled (impacts pre-3.0 releases)
```

@caseydavenport 