### PR TITLE
Add IBM Cloud to cloud providers list

### DIFF
--- a/_data/master/navbars/reference.yml
+++ b/_data/master/navbars/reference.yml
@@ -105,6 +105,8 @@ toc:
       path: /reference/public-cloud/azure
     - title: Google Compute Engine
       path: /reference/public-cloud/gce
+    - title: IBM Cloud
+      path: /reference/public-cloud/ibm
 - title: Network design
   section:
     - title: Calico Over Ethernet Fabrics

--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -28,21 +28,23 @@ If you prefer not to use Kubernetes to start the {{site.prodname}} services, ref
 Several third-party vendors also provide tools to install Kubernetes with {{site.prodname}} in a variety of
 environments.
 
-| Name                               | Description |
-|------------------------------------|-------------|
-| [ACS Engine][acs-engine]           | Deploys Kubernetes clusters on Azure with an option to enable {{site.prodname}} policy. |
-| [Google Container Engine][gke]     | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
-| [Heptio AWS Quickstart][heptio]    | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket] | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
-| [Kops][kops]                       | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
-| [Kubernetes kube-up][kube-up]      | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
-| [Kubespray][kubespray]             | A Kubernetes project for deploying Kubernetes on GCE. |
-| [StackPointCloud][stackpoint]      | Deploys a Kubernetes cluster with {{site.prodname}} to AWS in 3 steps using a web-based interface. |
-| [Typhoon][typhoon]                 | Deploys free and minimal Kubernetes clusters with Terraform. |
+| Name                                 | Description |
+|--------------------------------------|-------------|
+| [ACS Engine][acs-engine]             | Deploys Kubernetes clusters on Azure with an option to enable {{site.prodname}} policy. |
+| [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
+| [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
+| [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
+| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
+| [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
+| [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
+| [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes on GCE. |
+| [StackPointCloud][stackpoint]        | Deploys a Kubernetes cluster with {{site.prodname}} to AWS in 3 steps using a web-based interface. |
+| [Typhoon][typhoon]                   | Deploys free and minimal Kubernetes clusters with Terraform. |
 
 [acs-engine]: https://github.com/Azure/acs-engine/blob/master/docs/kubernetes.md
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
+[ibmk]: https://www.ibm.com/cloud/container-service/
 [ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray

--- a/master/reference/public-cloud/ibm.md
+++ b/master/reference/public-cloud/ibm.md
@@ -1,0 +1,17 @@
+---
+title: Calico Configured Automatically in IBM Cloud
+canonical_url: https://docs.projectcalico.org/master/reference/public-cloud/ibm
+---
+
+{{site.prodname}} is installed and configured automatically in your [IBM Cloud Kubernetes Service][IBMKUBE].  Default policies are created to protect your Kubernetes cluster, with the option to create your own policies to protect specific services.
+
+## IP-in-IP encapsulation
+
+[IP-in-IP encapsulation][IPIP] is automatically configured to only encapsulate packets traveling across subnets, and uses NAT for outgoing connections from your containers.
+
+## Enabling Workload-to-WAN Traffic
+
+This is also handled automatically in the [IBM Cloud Kubernetes Service][IBMKUBE].  No additional configuration of Calico is necessary.
+
+[IPIP]: {{site.baseurl}}/{{page.version}}/usage/configuration/ip-in-ip
+[IBMKUBE]: https://www.ibm.com/cloud/container-service/


### PR DESCRIPTION
Add IBM Cloud to cloud providers list and to the list of third-party vendors

## Description

Adding information about IBM Cloud's support for calico.  I've built this locally and tested it, the only problem I hit was the `make htmlproofer` failed because it couldn't find the public link that was generated to the new ibm file (because it isn't out there yet).  I don't see a way to fix this until the PR merges.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
