### PR TITLE
Fixes chicken-egg problem with htmlproofer

### DIFF
--- a/htmlproofer.sh
+++ b/htmlproofer.sh
@@ -15,13 +15,13 @@ HP_IGNORE_URLS="/docs.openshift.org/,#,/github.com\/projectcalico\/calico\/relea
 echo "Running a hard URL check against recent releases"
 for i in `seq 1 3`; do
 	echo "htmlproofer attempt #${i}"
-	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $(pwd)/_site:/_site/ quay.io/calico/htmlproofer:${HP_VERSION} /_site --file-ignore ${HP_IGNORE_LOCAL_DIRS} --assume-extension --check-html --empty-alt-ignore --url-ignore ${HP_IGNORE_URLS}
+	docker run -ti -e JEKYLL_UID=`id -u` --rm -v $(pwd)/_site:/_site/ quay.io/calico/htmlproofer:${HP_VERSION} /_site --file-ignore ${HP_IGNORE_LOCAL_DIRS} --assume-extension --check-html --empty-alt-ignore --url-ignore ${HP_IGNORE_URLS} --internal_domains "docs.projectcalico.org"
 
 	# Store the RC for future use.
 	rc=$?
 	echo "htmlproofer rc: $rc"
 
-	# If the command executed successfully, break out. Otherwise, retry. 
+	# If the command executed successfully, break out. Otherwise, retry.
 	if [[ $rc == 0 ]]; then break; fi
 
 	# Otherwise, sleep a short period and then retry.


### PR DESCRIPTION
## Description

- Fixes issue where htmlproofer complains about absolute paths to new pages created via the PR itself and therefore do not yet exist in the live doc site.
- Credit to @matthewdupre for discovering this option


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
