### PR TITLE
Adds a sitemap to improve search results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,14 @@ endif
 	find $(VERSION) \( -name '*.md' -o -name '*.html' \) -exec sed -i 's#^\(redirect_from:.*\)\.md#\1#' '{}' \;
 
 update_canonical_urls:
-	# You must pass two version numbers into this command, e.g., make update_canonical_urls OLD=v3.0 NEW=v3.1
+	# You must pass two version numbers into this command, e.g., make update_canonical_urls OLD=v3.1 NEW=v3.2
 	# Looks through all directories and replaces previous latest release version numbers in canonical URLs with new
 	find . \( -name '*.md' -o -name '*.html' \) -exec sed -i '/canonical_url:/s/$(OLD)/$(NEW)/g' {} \;
+
+update_sitemap:
+	# You must pass the previous latest version number into this command, e.g., make update_sitemap PREVIOUS=v3.1
+	# Adds metadata to pages in previous release to exclude them from the sitemap.xml
+	find $(PREVIOUS) \( -name '*.md' -o -name '*.html' \) -exec sed -i 's#^title:.*#&\nsitemap: false #' '{}' \;
 
 ###############################################################################
 # Release targets

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -190,6 +190,21 @@ release in the documentation. Perform these steps on a branch off of master.
    >       page was deleted, adjust the version number of the canonical URLs to the final copy of the page.
    >       If the page was renamed, update the canonical URLs to the new path.
 
+### Updating sitemap metadata
+
+   1. Pull the latest master and check out a _new_ branch.
+
+   1. Update the files in the previous latest release to include the `sitemap: false` metadata that excludes them from
+      the sitemap.xml.
+
+      ```
+      make update_sitemap PREVIOUS=vX.Y
+      ```
+
+      Example: `make update_sitemap PREVIOUS=v3.1`, where `3.1` was the previous latest release.
+
+   1. Submit a PR with the sitemap changes.
+
 ## <a name="patch"></a> Performing a "patch" release
 
 ### Creating the release

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ permalink:     /:title.html
 plugins:
   - jekyll-redirect-from
   - jekyll-seo-tag
+  - jekyll-sitemap
 
 url: https://docs.projectcalico.org
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 title: Project Calico Documentation
 description: Home
 layout: docwithnav
+sitemap: false
 ---
 <p>You are being redirected to the latest release of Calico Docs.</p>
 <script type="text/javascript">

--- a/master/getting-started/bare-metal/bare-metal.md
+++ b/master/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/master/getting-started/bare-metal/installation/binary-mgr.md
+++ b/master/getting-started/bare-metal/installation/binary-mgr.md
@@ -1,5 +1,6 @@
 ---
 title: Binary install with package manager
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/installation/binary-mgr'
 ---
 

--- a/master/getting-started/bare-metal/installation/binary.md
+++ b/master/getting-started/bare-metal/installation/binary.md
@@ -1,5 +1,6 @@
 ---
 title: Binary install without package manager
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/installation/binary'
 ---
 

--- a/master/getting-started/bare-metal/installation/container.md
+++ b/master/getting-started/bare-metal/installation/container.md
@@ -1,5 +1,6 @@
 ---
 title: Container install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/installation/container'
 ---
 

--- a/master/getting-started/bare-metal/installation/index.md
+++ b/master/getting-started/bare-metal/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on host endpoints
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/installation/'
 ---
 

--- a/master/getting-started/bare-metal/policy/conntrack.md
+++ b/master/getting-started/bare-metal/policy/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/conntrack'
 ---
 

--- a/master/getting-started/bare-metal/policy/donottrack.md
+++ b/master/getting-started/bare-metal/policy/donottrack.md
@@ -1,5 +1,6 @@
 ---
 title: Untracked policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/donottrack'
 ---
 

--- a/master/getting-started/bare-metal/policy/failsafe.md
+++ b/master/getting-started/bare-metal/policy/failsafe.md
@@ -1,5 +1,6 @@
 ---
 title: Failsafe rules
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/failsafe'
 ---
 

--- a/master/getting-started/bare-metal/policy/forwarded.md
+++ b/master/getting-started/bare-metal/policy/forwarded.md
@@ -1,5 +1,6 @@
 ---
 title: Apply on forwarded traffic
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/forwarded'
 ---
 

--- a/master/getting-started/bare-metal/policy/index.md
+++ b/master/getting-started/bare-metal/policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Creating policy for basic connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/'
 ---
 

--- a/master/getting-started/bare-metal/policy/objects.md
+++ b/master/getting-started/bare-metal/policy/objects.md
@@ -1,5 +1,6 @@
 ---
 title: Creating host endpoint objects
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/objects'
 ---
 

--- a/master/getting-started/bare-metal/policy/pre-dnat.md
+++ b/master/getting-started/bare-metal/policy/pre-dnat.md
@@ -1,5 +1,6 @@
 ---
 title: Pre-DNAT policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/pre-dnat'
 ---
 

--- a/master/getting-started/bare-metal/policy/selector.md
+++ b/master/getting-started/bare-metal/policy/selector.md
@@ -1,5 +1,6 @@
 ---
 title: Selector-based policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/selector'
 ---
 

--- a/master/getting-started/bare-metal/policy/summary.md
+++ b/master/getting-started/bare-metal/policy/summary.md
@@ -1,5 +1,6 @@
 ---
 title: Summary
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/summary'
 ---
 

--- a/master/getting-started/bare-metal/policy/tutorial.md
+++ b/master/getting-started/bare-metal/policy/tutorial.md
@@ -1,5 +1,6 @@
 ---
 title: Tutorial
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/policy/tutorial'
 ---
 

--- a/master/getting-started/bare-metal/requirements.md
+++ b/master/getting-started/bare-metal/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/requirements'
 ---
 

--- a/master/getting-started/docker/index.md
+++ b/master/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 

--- a/master/getting-started/docker/installation/manual.md
+++ b/master/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/master/getting-started/docker/installation/requirements.md
+++ b/master/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/requirements'
 ---
 

--- a/master/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/master/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/master/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/master/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/master/getting-started/docker/tutorials/ipam.md
+++ b/master/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/master/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/master/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles and Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy'
 ---
 

--- a/master/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/master/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles'
 ---
 

--- a/master/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/master/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Docker Labels and Calico Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy'
 ---
 

--- a/master/getting-started/index.md
+++ b/master/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/master/getting-started/kubernetes/index.md
+++ b/master/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart for Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/master/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/master/getting-started/kubernetes/installation/app-layer-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Enabling application layer policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/master/getting-started/kubernetes/installation/app-layer-policy'
 ---
 

--- a/master/getting-started/kubernetes/installation/calico.md
+++ b/master/getting-started/kubernetes/installation/calico.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for policy and networking (recommended)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/calico'
 ---
 

--- a/master/getting-started/kubernetes/installation/config-options.md
+++ b/master/getting-started/kubernetes/installation/config-options.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the manifests
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/config-options'
 ---
 

--- a/master/getting-started/kubernetes/installation/flannel.md
+++ b/master/getting-started/kubernetes/installation/flannel.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for policy and flannel for networking
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/flannel'
 ---
 

--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/master/getting-started/kubernetes/installation/other.md
+++ b/master/getting-started/kubernetes/installation/other.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for policy (advanced)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/other'
 ---
 

--- a/master/getting-started/kubernetes/requirements.md
+++ b/master/getting-started/kubernetes/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/requirements'
 ---
 

--- a/master/getting-started/kubernetes/troubleshooting.md
+++ b/master/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/master/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/master/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Controlling ingress and egress traffic with network policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/master/getting-started/kubernetes/tutorials/app-layer-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/app-layer-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Application layer policy tutorial
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/master/getting-started/kubernetes/tutorials/app-layer-policy/'
 ---
 

--- a/master/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/master/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/master/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all
 running on Kubernetes.  It then configures network policy on each service.

--- a/master/getting-started/kubernetes/upgrade/convert.md
+++ b/master/getting-started/kubernetes/upgrade/convert.md
@@ -1,5 +1,6 @@
 ---
 title: Converting your calicoctl manifests
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/convert'
 ---
 

--- a/master/getting-started/kubernetes/upgrade/delete.md
+++ b/master/getting-started/kubernetes/upgrade/delete.md
@@ -1,5 +1,6 @@
 ---
 title: Deleting old data
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/delete'
 ---
 

--- a/master/getting-started/kubernetes/upgrade/downgrade.md
+++ b/master/getting-started/kubernetes/upgrade/downgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Downgrading Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/downgrade'
 ---
 

--- a/master/getting-started/kubernetes/upgrade/index.md
+++ b/master/getting-started/kubernetes/upgrade/index.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/master/getting-started/kubernetes/upgrade/migrate.md
+++ b/master/getting-started/kubernetes/upgrade/migrate.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating Calico data
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/migrate'
 ---
 

--- a/master/getting-started/kubernetes/upgrade/setup.md
+++ b/master/getting-started/kubernetes/upgrade/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and configuring calico-upgrade
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/setup'
 ---
 

--- a/master/getting-started/kubernetes/upgrade/test.md
+++ b/master/getting-started/kubernetes/upgrade/test.md
@@ -1,5 +1,6 @@
 ---
 title: Testing the data migration
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/test'
 ---
 

--- a/master/getting-started/kubernetes/upgrade/upgrade.md
+++ b/master/getting-started/kubernetes/upgrade/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade'
 ---
 

--- a/master/getting-started/mesos/index.md
+++ b/master/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/master/getting-started/mesos/installation/dc-os/custom.md
+++ b/master/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/custom'
 ---
 

--- a/master/getting-started/mesos/installation/dc-os/framework.md
+++ b/master/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/framework'
 ---
 

--- a/master/getting-started/mesos/installation/dc-os/index.md
+++ b/master/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/master/getting-started/mesos/installation/integration.md
+++ b/master/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/integration'
 ---
 

--- a/master/getting-started/mesos/installation/prerequisites.md
+++ b/master/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/prerequisites'
 ---
 

--- a/master/getting-started/mesos/installation/reqs/system.md
+++ b/master/getting-started/mesos/installation/reqs/system.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/prerequisites'
 ---
 

--- a/master/getting-started/mesos/installation/requirements.md
+++ b/master/getting-started/mesos/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/prerequisites'
 ---
 

--- a/master/getting-started/mesos/installation/vagrant-centos/index.md
+++ b/master/getting-started/mesos/installation/vagrant-centos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/master/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/master/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting to Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/connecting-tasks'
 ---
 

--- a/master/getting-started/mesos/tutorials/launching-tasks.md
+++ b/master/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Launching Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/launching-tasks'
 ---
 

--- a/master/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/master/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Docker Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/master/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/master/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Universal Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/master/getting-started/openshift/dedicated-etcd.md
+++ b/master/getting-started/openshift/dedicated-etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift with a dedicated etcd cluster
+sitemap: false 
 ---
 
 {{site.prodname}}'s OpenShift-ansible integration supports connection to a custom etcd which

--- a/master/getting-started/openshift/installation.md
+++ b/master/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openshift/installation'
 ---
 

--- a/master/getting-started/openshift/requirements.md
+++ b/master/getting-started/openshift/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openshift/requirements'
 ---
 

--- a/master/getting-started/openstack/connectivity.md
+++ b/master/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/master/getting-started/openstack/index.md
+++ b/master/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/master/getting-started/openstack/installation/devstack.md
+++ b/master/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/devstack'
 ---
 

--- a/master/getting-started/openstack/installation/index.md
+++ b/master/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico on OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux packaged install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/master/getting-started/openstack/installation/ubuntu.md
+++ b/master/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: Ubuntu packaged install instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/master/getting-started/openstack/neutron-api.md
+++ b/master/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/master/getting-started/openstack/requirements.md
+++ b/master/getting-started/openstack/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/requirements'
 ---
 

--- a/master/getting-started/openstack/tutorials.md
+++ b/master/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: Worked Examples Using Calico-based OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/master/getting-started/openstack/upgrade/convert.md
+++ b/master/getting-started/openstack/upgrade/convert.md
@@ -1,5 +1,6 @@
 ---
 title: Converting your calicoctl manifests
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/convert'
 ---
 

--- a/master/getting-started/openstack/upgrade/delete.md
+++ b/master/getting-started/openstack/upgrade/delete.md
@@ -1,5 +1,6 @@
 ---
 title: Deleting old data
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/delete'
 ---
 

--- a/master/getting-started/openstack/upgrade/downgrade.md
+++ b/master/getting-started/openstack/upgrade/downgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Downgrading Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/downgrade'
 ---
 

--- a/master/getting-started/openstack/upgrade/index.md
+++ b/master/getting-started/openstack/upgrade/index.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 ## Upgrade procedure

--- a/master/getting-started/openstack/upgrade/migrate.md
+++ b/master/getting-started/openstack/upgrade/migrate.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating Calico data
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/migrate'
 ---
 

--- a/master/getting-started/openstack/upgrade/setup.md
+++ b/master/getting-started/openstack/upgrade/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and configuring calico-upgrade
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/setup'
 ---
 

--- a/master/getting-started/openstack/upgrade/test.md
+++ b/master/getting-started/openstack/upgrade/test.md
@@ -1,5 +1,6 @@
 ---
 title: Testing the data migration
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/test'
 ---
 

--- a/master/getting-started/openstack/upgrade/upgrade.md
+++ b/master/getting-started/openstack/upgrade/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/upgrade'
 ---
 

--- a/master/getting-started/openstack/verification.md
+++ b/master/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/master/index.html
+++ b/master/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/master/introduction/deployments.md
+++ b/master/introduction/deployments.md
@@ -1,5 +1,6 @@
 ---
 title: Sample deployments
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/deployments'
 ---
 

--- a/master/introduction/index.md
+++ b/master/introduction/index.md
@@ -1,5 +1,6 @@
 ---
 title: About Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'
 ---
 

--- a/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/calico-etcdv3-paths'
 ---
 

--- a/master/reference/advanced/etcd-rbac/certificate-generation.md
+++ b/master/reference/advanced/etcd-rbac/certificate-generation.md
@@ -1,5 +1,6 @@
 ---
 title: Generating Certificates for etcd RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/certificate-generation'
 ---
 

--- a/master/reference/advanced/etcd-rbac/index.md
+++ b/master/reference/advanced/etcd-rbac/index.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up etcd certificates for RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/'
 ---
 

--- a/master/reference/advanced/etcd-rbac/kubernetes-advanced.md
+++ b/master/reference/advanced/etcd-rbac/kubernetes-advanced.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced etcd segmentation for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/kubernetes-advanced'
 ---
 

--- a/master/reference/advanced/etcd-rbac/kubernetes.md
+++ b/master/reference/advanced/etcd-rbac/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Using etcd RBAC to segment Kubernetes and Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/kubernetes'
 ---
 

--- a/master/reference/advanced/etcd-rbac/users-and-roles.md
+++ b/master/reference/advanced/etcd-rbac/users-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Creating Users and Roles in etcd
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/users-and-roles'
 ---
 

--- a/master/reference/architecture/components.md
+++ b/master/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico/node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/master/reference/architecture/data-path.md
+++ b/master/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/master/reference/architecture/index.md
+++ b/master/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/master/reference/calicoctl/commands/apply.md
+++ b/master/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/master/reference/calicoctl/commands/convert.md
+++ b/master/reference/calicoctl/commands/convert.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl convert
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/convert'
 ---
 

--- a/master/reference/calicoctl/commands/create.md
+++ b/master/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/master/reference/calicoctl/commands/delete.md
+++ b/master/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/master/reference/calicoctl/commands/get.md
+++ b/master/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/master/reference/calicoctl/commands/index.md
+++ b/master/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/master/reference/calicoctl/commands/ipam/index.md
+++ b/master/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/master/reference/calicoctl/commands/ipam/release.md
+++ b/master/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/master/reference/calicoctl/commands/ipam/show.md
+++ b/master/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/master/reference/calicoctl/commands/node/checksystem.md
+++ b/master/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/master/reference/calicoctl/commands/node/diags.md
+++ b/master/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/master/reference/calicoctl/commands/node/index.md
+++ b/master/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/master/reference/calicoctl/commands/node/run.md
+++ b/master/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/master/reference/calicoctl/commands/node/status.md
+++ b/master/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/master/reference/calicoctl/commands/replace.md
+++ b/master/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/master/reference/calicoctl/commands/version.md
+++ b/master/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/master/reference/calicoctl/index.md
+++ b/master/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/master/reference/calicoctl/resources/bgpconfig.md
+++ b/master/reference/calicoctl/resources/bgpconfig.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Configuration Resource (BGPConfiguration)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgpconfig'
 ---
 

--- a/master/reference/calicoctl/resources/bgppeer.md
+++ b/master/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (BGPPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/master/reference/calicoctl/resources/felixconfig.md
+++ b/master/reference/calicoctl/resources/felixconfig.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Configuration Resource (FelixConfiguration)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/felixconfig'
 ---
 

--- a/master/reference/calicoctl/resources/globalnetworkpolicy.md
+++ b/master/reference/calicoctl/resources/globalnetworkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Global Network Policy Resource (GlobalNetworkPolicy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/master/reference/calicoctl/resources/globalnetworkset.md
+++ b/master/reference/calicoctl/resources/globalnetworkset.md
@@ -1,5 +1,6 @@
 ---
 title: Global Network Set Resource (GlobalNetworkSet)
+sitemap: false 
 ---
 
 A global network set resource (GlobalNetworkSet) represents an arbitrary set of IP subnetworks/CIDRs, 

--- a/master/reference/calicoctl/resources/hostendpoint.md
+++ b/master/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (HostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/master/reference/calicoctl/resources/index.md
+++ b/master/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/master/reference/calicoctl/resources/ippool.md
+++ b/master/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (IPPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/master/reference/calicoctl/resources/networkpolicy.md
+++ b/master/reference/calicoctl/resources/networkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy Resource (NetworkPolicy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/networkpolicy'
 ---
 

--- a/master/reference/calicoctl/resources/node.md
+++ b/master/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (Node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/master/reference/calicoctl/resources/profile.md
+++ b/master/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (Profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/master/reference/calicoctl/resources/workloadendpoint.md
+++ b/master/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (WorkloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/master/reference/cni-plugin/configuration.md
+++ b/master/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/master/reference/dikastes/configuration.md
+++ b/master/reference/dikastes/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Dikastes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/master/reference/dikastes/configuration'
 ---
 

--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/configuration'
 ---
 

--- a/master/reference/felix/prometheus.md
+++ b/master/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/prometheus'
 ---
 

--- a/master/reference/index.md
+++ b/master/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/master/reference/involved.md
+++ b/master/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/master/reference/kube-controllers/configuration.md
+++ b/master/reference/kube-controllers/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico Kubernetes controllers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/master/reference/license.md
+++ b/master/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/master/reference/previous-releases.md
+++ b/master/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/master/reference/private-cloud/l2-interconnect-fabric.md
+++ b/master/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/master/reference/private-cloud/l3-interconnect-fabric.md
+++ b/master/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/master/reference/public-cloud/aws.md
+++ b/master/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/aws
 ---
 

--- a/master/reference/public-cloud/azure.md
+++ b/master/reference/public-cloud/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on Azure
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/azure
 ---
 

--- a/master/reference/public-cloud/gce.md
+++ b/master/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/gce
 ---
 

--- a/master/reference/public-cloud/ibm.md
+++ b/master/reference/public-cloud/ibm.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Configured Automatically in IBM Cloud
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/master/reference/public-cloud/ibm
 ---
 

--- a/master/reference/repo-structure.md
+++ b/master/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/master/reference/requirements.md
+++ b/master/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/requirements'
 ---
 

--- a/master/reference/typha/configuration.md
+++ b/master/reference/typha/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Typha
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/typha/configuration'
 ---
 

--- a/master/releases/index.md
+++ b/master/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/releases/
 ---
 

--- a/master/usage/calicoctl/configure/etcd.md
+++ b/master/usage/calicoctl/configure/etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to an etcd datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/master/usage/calicoctl/configure/index.md
+++ b/master/usage/calicoctl/configure/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/master/usage/calicoctl/configure/kdd.md
+++ b/master/usage/calicoctl/configure/kdd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to the Kubernetes API datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/master/usage/calicoctl/install.md
+++ b/master/usage/calicoctl/install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing calicoctl
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/master/usage/changing-ip-pools.md
+++ b/master/usage/changing-ip-pools.md
@@ -1,5 +1,6 @@
 ---
 title: Changing IP pools
+sitemap: false 
 ---
 
 ## About changing IP pools

--- a/master/usage/configuration/as-service.md
+++ b/master/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running calico/node with an init system
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/master/usage/configuration/bgp.md
+++ b/master/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/master/usage/configuration/conntrack.md
+++ b/master/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/conntrack'
 ---
 

--- a/master/usage/configuration/ip-in-ip.md
+++ b/master/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip'
 ---
 

--- a/master/usage/configuration/mtu.md
+++ b/master/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/mtu'
 ---
 

--- a/master/usage/configuration/node.md
+++ b/master/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/node'
 ---
 

--- a/master/usage/decommissioning-a-node.md
+++ b/master/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/decommissioning-a-node'
 ---
 

--- a/master/usage/enabling-ipvs.md
+++ b/master/usage/enabling-ipvs.md
@@ -1,5 +1,6 @@
 ---
 title: Enabling IPVS in Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/enabling-ipvs'
 ---
 

--- a/master/usage/encrypt-comms.md
+++ b/master/usage/encrypt-comms.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring encryption and authentication
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/master/usage/encrypt-comms'
 ---
 

--- a/master/usage/external-connectivity.md
+++ b/master/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 

--- a/master/usage/index.md
+++ b/master/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using {{site.prodname}}.

--- a/master/usage/ipv6.md
+++ b/master/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: Enabling IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/master/usage/openstack/configuration.md
+++ b/master/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
 ---
 

--- a/master/usage/openstack/floating-ips.md
+++ b/master/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
 ---
 

--- a/master/usage/openstack/host-routes.md
+++ b/master/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
 ---
 

--- a/master/usage/openstack/kuryr.md
+++ b/master/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
 ---
 

--- a/master/usage/openstack/semantics.md
+++ b/master/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
 ---
 

--- a/master/usage/openstack/service-ips.md
+++ b/master/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
 ---
 

--- a/master/usage/policy/secure-metrics.md
+++ b/master/usage/policy/secure-metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Securing Calico's Prometheus endpoints
+sitemap: false 
 ---
 
 ## About securing access to {{site.prodname}}'s metrics endpoints

--- a/master/usage/reduce-nodes.md
+++ b/master/usage/reduce-nodes.md
@@ -1,5 +1,6 @@
 ---
 title: Scheduling to well-known nodes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/master/usage/reduce-nodes'
 ---
 

--- a/master/usage/routereflector/bird-rr-config.md
+++ b/master/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BIRD as a BGP Route Reflector
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/master/usage/routereflector/calico-routereflector.md
+++ b/master/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: Calico BIRD Route Reflector container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/calico-routereflector'
 ---
 

--- a/master/usage/troubleshooting/faq.md
+++ b/master/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/master/usage/troubleshooting/index.md
+++ b/master/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/master/usage/troubleshooting/logging.md
+++ b/master/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v1.5/getting-started/bare-metal/bare-metal.md
+++ b/v1.5/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v1.5/getting-started/bare-metal/pyi-bare-metal-install.md
+++ b/v1.5/getting-started/bare-metal/pyi-bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Alternative Felix Install with PyInstaller Bundle
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v1.5/getting-started/bare-metal/troubleshooting.md
+++ b/v1.5/getting-started/bare-metal/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Hosts
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/bare-metal/tutorials.md
+++ b/v1.5/getting-started/bare-metal/tutorials.md
@@ -1,4 +1,5 @@
 ---
 title: Tutorials for Calico Host Protection
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/bare-metal/upgrade.md
+++ b/v1.5/getting-started/bare-metal/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Hosts
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/docker/index.md
+++ b/v1.5/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 More information coming soon!

--- a/v1.5/getting-started/docker/installation/aws.md
+++ b/v1.5/getting-started/docker/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/getting-started/docker/installation/aws'
 ---
 

--- a/v1.5/getting-started/docker/installation/digital-ocean.md
+++ b/v1.5/getting-started/docker/installation/digital-ocean.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on DigitalOcean
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/getting-started/docker/installation/digital-ocean'
 ---
 

--- a/v1.5/getting-started/docker/installation/gce.md
+++ b/v1.5/getting-started/docker/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/getting-started/docker/installation/gce'
 ---
 

--- a/v1.5/getting-started/docker/installation/manual.md
+++ b/v1.5/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Preparing the environment for Calico as a Docker network plugin
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v1.5/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v1.5/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v1.5/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v1.5/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v1.5/getting-started/docker/troubleshooting.md
+++ b/v1.5/getting-started/docker/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/docker/tutorials/advanced-policy.md
+++ b/v1.5/getting-started/docker/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Accessing Calico policy with Calico as a network plugin
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.0/getting-started/docker/tutorials/advanced-policy'
 ---
 

--- a/v1.5/getting-started/docker/tutorials/basic.md
+++ b/v1.5/getting-started/docker/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Calico as a Docker network plugin
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v1.5/getting-started/docker/tutorials/docker-swarm.md
+++ b/v1.5/getting-started/docker/tutorials/docker-swarm.md
@@ -14,7 +14,7 @@ tutorial, we will do the following:
 
 This tutorial assumes that your client and each node in your cluster
 have `calicoctl`, etcd, and Docker 1.9 or greater installed in your `$PATH`.
-See our [Prerequisite tutorial]({{site.baseurl}}/{{page.version}}/getting-started/docker/installation/manual) 
+See our [Prerequisite tutorial]({{site.baseurl}}/{{page.version}}/getting-started/docker/installation/manual)
 for instructions on getting this properly set up.
 
 To make things simpler, let's store some commonly used values as environment

--- a/v1.5/getting-started/docker/tutorials/index.md
+++ b/v1.5/getting-started/docker/tutorials/index.md
@@ -1,4 +1,5 @@
 ---
 title: Basic Walkthrough
+sitemap: false 
 ---
 More info coming soon!

--- a/v1.5/getting-started/docker/tutorials/ipv6.md
+++ b/v1.5/getting-started/docker/tutorials/ipv6.md
@@ -1,5 +1,6 @@
 ---
-Title: Calico IPv6 networking as a Docker network plugin (Optional)
+title: Calico IPv6 networking as a Docker network plugin (Optional)
+sitemap: false
 canonical_url: 'https://docs.projectcalico.org/v1.6/getting-started/docker/tutorials/ipv6'
 ---
 

--- a/v1.5/getting-started/docker/upgrade.md
+++ b/v1.5/getting-started/docker/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/index.md
+++ b/v1.5/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v1.5/getting-started/kubernetes/index.md
+++ b/v1.5/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 Calico can be used as a network plugin for Kubernetes to provide connectivity and network policy in a Kubernetes cluster.

--- a/v1.5/getting-started/kubernetes/installation/aws.md
+++ b/v1.5/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v1.5/getting-started/kubernetes/installation/gce.md
+++ b/v1.5/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v1.5/getting-started/kubernetes/installation/hosted/index.md
+++ b/v1.5/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v1.5/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v1.5/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Install for Kubeadm
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v1.5/getting-started/kubernetes/installation/index.md
+++ b/v1.5/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Adding Calico to an Existing Kubernetes Cluster
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v1.5/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v1.5/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v1.5/getting-started/kubernetes/troubleshooting.md
+++ b/v1.5/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v1.5/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v1.5/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v1.5/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v1.5/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v1.5/getting-started/kubernetes/upgrade.md
+++ b/v1.5/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 Information coming soon!

--- a/v1.5/getting-started/mesos/demos/cni/index.md
+++ b/v1.5/getting-started/mesos/demos/cni/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart with Docker-Compose - Calico for Mesos CNI
+sitemap: false 
 ---
 This directory includes files for running a docker-compose demo of Calico for Mesos CNI.
 

--- a/v1.5/getting-started/mesos/demos/docker/index.md
+++ b/v1.5/getting-started/mesos/demos/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars demo with the Mesos Docker Containerizer
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/getting-started/mesos/demos/docker/'
 ---
 

--- a/v1.5/getting-started/mesos/index.md
+++ b/v1.5/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Networking for Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v1.5/getting-started/mesos/installation/dc-os.md
+++ b/v1.5/getting-started/mesos/installation/dc-os.md
@@ -1,6 +1,7 @@
 ---
-tile: Installing Calico in DC/OS
+title: Installing Calico in DC/OS
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
+sitemap: false
 ---
 
 

--- a/v1.5/getting-started/mesos/installation/docker.md
+++ b/v1.5/getting-started/mesos/installation/docker.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for the Docker Containerizer
+sitemap: false 
 ---
 
 This document provides the commands to download and run Calico

--- a/v1.5/getting-started/mesos/installation/prerequisites.md
+++ b/v1.5/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Prerequisites for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v1.5/getting-started/mesos/installation/unified.md
+++ b/v1.5/getting-started/mesos/installation/unified.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico-CNI for the Unified Containerizer
+sitemap: false 
 ---
 
 This guide details how to add Calico networking to a Mesos Agent with CNI enabled.

--- a/v1.5/getting-started/mesos/troubleshooting.md
+++ b/v1.5/getting-started/mesos/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Mesos
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/mesos/tutorials/docker.md
+++ b/v1.5/getting-started/mesos/tutorials/docker.md
@@ -1,5 +1,6 @@
 ---
 title: Calico-Mesos Usage Guide with the Docker Containerizer
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v1.5/getting-started/mesos/tutorials/unified.md
+++ b/v1.5/getting-started/mesos/tutorials/unified.md
@@ -1,5 +1,6 @@
 ---
 title: Networking Mesos Tasks with Calico-CNI
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v1.5/getting-started/mesos/upgrade.md
+++ b/v1.5/getting-started/mesos/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Mesos
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/mesos/vagrant/index.md
+++ b/v1.5/getting-started/mesos/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v1.5/getting-started/openstack/connectivity.md
+++ b/v1.5/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v1.5/getting-started/openstack/index.md
+++ b/v1.5/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v1.5/getting-started/openstack/installation/chef.md
+++ b/v1.5/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ...
 

--- a/v1.5/getting-started/openstack/installation/fuel.md
+++ b/v1.5/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v1.5/getting-started/openstack/installation/index.md
+++ b/v1.5/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v1.5/getting-started/openstack/installation/juju.md
+++ b/v1.5/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v1.5/getting-started/openstack/installation/redhat.md
+++ b/v1.5/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v1.5/getting-started/openstack/installation/ubuntu.md
+++ b/v1.5/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v1.5/getting-started/openstack/tutorials.md
+++ b/v1.5/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v1.5/getting-started/openstack/upgrade.md
+++ b/v1.5/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v1.5/getting-started/openstack/verification.md
+++ b/v1.5/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v1.5/getting-started/rkt/index.md
+++ b/v1.5/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 Information coming soon!

--- a/v1.5/getting-started/rkt/installation.md
+++ b/v1.5/getting-started/rkt/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Manage `calico/node` using systemd
+sitemap: false 
 ---
 
 It is recommended to use systemd to run the `calico/node` container in production.  Use the following [sample `systemd` unit file]({{site.baseurl}}/{{page.version}}/getting-started/rkt/vagrant/systemd/calico-node.service) to manage the `calico/node` container using rkt.

--- a/v1.5/getting-started/rkt/troubleshooting.md
+++ b/v1.5/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 Information coming soon!

--- a/v1.5/getting-started/rkt/tutorials.md
+++ b/v1.5/getting-started/rkt/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Tutorials for Rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 Information coming soon!

--- a/v1.5/getting-started/rkt/upgrade.md
+++ b/v1.5/getting-started/rkt/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for rkt
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/getting-started/rkt/vagrant/index.md
+++ b/v1.5/getting-started/rkt/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Networking with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v1.5/index.html
+++ b/v1.5/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v1.5/introduction/index.html
+++ b/v1.5/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v1.5/reference/addressing.md
+++ b/v1.5/reference/addressing.md
@@ -1,5 +1,6 @@
 ---
 title: Addressing and Connectivity Overview
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/reference/addressing'
 ---
 

--- a/v1.5/reference/advanced/calico-cni.md
+++ b/v1.5/reference/advanced/calico-cni.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for CNI
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/reference/advanced/calico-cni'
 ---
 Calico provides a CNI plugin for integration with orchestrators which use the [containernetworking/cni][containernetworking-repo] interface.

--- a/v1.5/reference/advanced/calico-neutron-api.md
+++ b/v1.5/reference/advanced/calico-neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/reference/advanced/calico-neutron-api'
 ---
 

--- a/v1.5/reference/advanced/etcd-secure.md
+++ b/v1.5/reference/advanced/etcd-secure.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico with a secure etcd cluster
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/reference/advanced/etcd-secure'
 ---
 

--- a/v1.5/reference/advanced/overlap-ips.md
+++ b/v1.5/reference/advanced/overlap-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Overlapping IPv4 address ranges
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/reference/advanced/overlap-ips'
 ---
 This document describes how we can use 464XLAT to allow multiple tenants within the same data center to use the same IPv4 address ranges (including actually using the same IPv4 addresses). This is known as “overlapping” IPv4 addresses, and also as “address space isolation”, because it means that an IP address such as 10.10.0.2 (for example) for one tenant has nothing to do with the same IP address being used by a different tenant.

--- a/v1.5/reference/architecture/components.md
+++ b/v1.5/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v1.5/reference/architecture/data-path.md
+++ b/v1.5/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v1.5/reference/architecture/index.md
+++ b/v1.5/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v1.5/reference/calicoctl/bgp.md
+++ b/v1.5/reference/calicoctl/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl bgp
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v1.5/reference/calicoctl/checksystem.md
+++ b/v1.5/reference/calicoctl/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 This section describes the `calicoctl checksystem` commands.

--- a/v1.5/reference/calicoctl/config.md
+++ b/v1.5/reference/calicoctl/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v1.5/reference/calicoctl/container.md
+++ b/v1.5/reference/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl container
+sitemap: false 
 ---
 
 > NOTE: The `calicoctl container` configuration commands are used specifically

--- a/v1.5/reference/calicoctl/diags.md
+++ b/v1.5/reference/calicoctl/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v1.5/reference/calicoctl/endpoint.md
+++ b/v1.5/reference/calicoctl/endpoint.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl endpoint
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v1.5/reference/calicoctl/index.md
+++ b/v1.5/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl CLI user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v1.5/reference/calicoctl/ipam.md
+++ b/v1.5/reference/calicoctl/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v1.5/reference/calicoctl/node.md
+++ b/v1.5/reference/calicoctl/node.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v1.5/reference/calicoctl/pool.md
+++ b/v1.5/reference/calicoctl/pool.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl pool
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v1.5/reference/calicoctl/profile.md
+++ b/v1.5/reference/calicoctl/profile.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl profile
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v1.5/reference/calicoctl/status.md
+++ b/v1.5/reference/calicoctl/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v1.5/reference/calicoctl/version.md
+++ b/v1.5/reference/calicoctl/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v1.5/reference/contribute.md
+++ b/v1.5/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v1.5/reference/index.md
+++ b/v1.5/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v1.5/reference/involved.md
+++ b/v1.5/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v1.5/reference/license.md
+++ b/v1.5/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v1.5/reference/previous-releases.md
+++ b/v1.5/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v1.5/reference/private-cloud/index.md
+++ b/v1.5/reference/private-cloud/index.md
@@ -1,4 +1,5 @@
 ---
 title: Deploying Calico On-prem
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v1.5/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v1.5/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v1.5/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v1.5/reference/private-cloud/troubleshooting.md
+++ b/v1.5/reference/private-cloud/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico On-Prem
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/reference/public-cloud/overview.md
+++ b/v1.5/reference/public-cloud/overview.md
@@ -1,4 +1,5 @@
 ---
 title: Deploying Calico in Public Cloud
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/reference/repo-structure.md
+++ b/v1.5/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v1.5/reference/security-model.md
+++ b/v1.5/reference/security-model.md
@@ -1,5 +1,6 @@
 ---
 title: Security Policy Model
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v1.6/reference/security-model'
 ---
 

--- a/v1.5/reference/supported-platforms.md
+++ b/v1.5/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v1.5/reference/without-docker-networking/docker-container-lifecycle.md
+++ b/v1.5/reference/without-docker-networking/docker-container-lifecycle.md
@@ -1,5 +1,6 @@
 ---
 title: Lifecycle of a container (Calico without Docker networking)
+sitemap: false 
 ---
 
 

--- a/v1.5/reference/without-docker-networking/environment-setup/aws.md
+++ b/v1.5/reference/without-docker-networking/environment-setup/aws.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on AWS
+sitemap: false 
 ---
 
 Calico is designed to provide high performance massively scalable virtual

--- a/v1.5/reference/without-docker-networking/environment-setup/digital-ocean.md
+++ b/v1.5/reference/without-docker-networking/environment-setup/digital-ocean.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on DigitalOcean
+sitemap: false 
 ---
 
 

--- a/v1.5/reference/without-docker-networking/environment-setup/gce.md
+++ b/v1.5/reference/without-docker-networking/environment-setup/gce.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on GCE
+sitemap: false 
 ---
 
 Calico is designed to provide high performance massively scalable virtual networking for private data centers. But you

--- a/v1.5/reference/without-docker-networking/environment-setup/vagrant-coreos/index.md
+++ b/v1.5/reference/without-docker-networking/environment-setup/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS using Vagrant and VirtualBox
+sitemap: false 
 ---
 
 These instructions allow you to set up a CoreOS cluster ready to network Docker containers with

--- a/v1.5/reference/without-docker-networking/environment-setup/vagrant-ubuntu/index.md
+++ b/v1.5/reference/without-docker-networking/environment-setup/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 ---
 
 These instructions allow you to set up an Ubuntu cluster ready to network Docker containers with

--- a/v1.5/reference/without-docker-networking/installation.md
+++ b/v1.5/reference/without-docker-networking/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Calico without Docker networking (i.e. `--net=none`)
+sitemap: false 
 ---
 
 

--- a/v1.5/reference/without-docker-networking/ipv6.md
+++ b/v1.5/reference/without-docker-networking/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: Calico IPv6 networking without Docker networking (Optional)
+sitemap: false 
 ---
 
 This tutorial is a continuation of the main

--- a/v1.5/reference/without-docker-networking/prerequisites.md
+++ b/v1.5/reference/without-docker-networking/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Preparing the environment for Calico without Docker networking
+sitemap: false 
 ---
 
 The worked example in the _Calico without Docker networking tutorial_ is run on

--- a/v1.5/releases/index.md
+++ b/v1.5/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v1.5/usage/bird-rr-config.md
+++ b/v1.5/usage/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v1.5/usage/configuration/advanced-network-policy.md
+++ b/v1.5/usage/configuration/advanced-network-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Network Policy
+sitemap: false 
 ---
 
 Calico endpoints are assigned their network policy by configuring them with a

--- a/v1.5/usage/configuration/as-service.md
+++ b/v1.5/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v1.5/usage/configuration/bgp.md
+++ b/v1.5/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Configuration
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v1.5/usage/configuration/index.md
+++ b/v1.5/usage/configuration/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Calico
+sitemap: false 
 ---
 
 This page describes how to configure Calico. We first describe the

--- a/v1.5/usage/configuration/securing-calico.md
+++ b/v1.5/usage/configuration/securing-calico.md
@@ -1,5 +1,6 @@
 ---
 title: Securing Calico
+sitemap: false 
 ---
 
 What Calico does and does not provide

--- a/v1.5/usage/dockerless-calico.md
+++ b/v1.5/usage/dockerless-calico.md
@@ -1,5 +1,6 @@
 ---
 title: Dockerless Calico - Manual Installation
+sitemap: false 
 ---
 Project Calico releases are primarily distributed as docker containers for quick, easy, and consistant deployment. However, it is possible to run the core Calico components directly on the host, removing the dependency on docker.
 

--- a/v1.5/usage/exposing-ports.md
+++ b/v1.5/usage/exposing-ports.md
@@ -1,4 +1,5 @@
 ---
 title: Expose Ports
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.5/usage/external-connectivity.md
+++ b/v1.5/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v1.5/usage/index.md
+++ b/v1.5/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contans information on using Calico.

--- a/v1.5/usage/ipv6.md
+++ b/v1.5/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v1.5/usage/troubleshooting/faq-2.md
+++ b/v1.5/usage/troubleshooting/faq-2.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v1.5/usage/troubleshooting/faq.md
+++ b/v1.5/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v1.5/usage/troubleshooting/index.md
+++ b/v1.5/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v1.5/usage/troubleshooting/logging.md
+++ b/v1.5/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v1.6/getting-started/bare-metal/bare-metal.md
+++ b/v1.6/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v1.6/getting-started/bare-metal/pyi-bare-metal-install.md
+++ b/v1.6/getting-started/bare-metal/pyi-bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Alternative Felix Install with PyInstaller Bundle
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v1.6/getting-started/bare-metal/troubleshooting.md
+++ b/v1.6/getting-started/bare-metal/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Hosts
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/bare-metal/tutorials.md
+++ b/v1.6/getting-started/bare-metal/tutorials.md
@@ -1,4 +1,5 @@
 ---
 title: Tutorials for Calico Host Protection
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/bare-metal/upgrade.md
+++ b/v1.6/getting-started/bare-metal/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Hosts
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/docker/index.md
+++ b/v1.6/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 More information coming soon!

--- a/v1.6/getting-started/docker/installation/aws.md
+++ b/v1.6/getting-started/docker/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on AWS
+sitemap: false 
 ---
 
 Calico is designed to provide high performance massively scalable virtual

--- a/v1.6/getting-started/docker/installation/digital-ocean.md
+++ b/v1.6/getting-started/docker/installation/digital-ocean.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on DigitalOcean
+sitemap: false 
 ---
 
 

--- a/v1.6/getting-started/docker/installation/gce.md
+++ b/v1.6/getting-started/docker/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on GCE
+sitemap: false 
 ---
 
 Calico is designed to provide high performance massively scalable virtual networking for private data centers. But you

--- a/v1.6/getting-started/docker/installation/manual.md
+++ b/v1.6/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Preparing the environment for Calico as a Docker network plugin
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v1.6/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v1.6/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v1.6/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v1.6/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v1.6/getting-started/docker/troubleshooting.md
+++ b/v1.6/getting-started/docker/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/docker/tutorials/advanced-policy.md
+++ b/v1.6/getting-started/docker/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Accessing Calico policy with Calico as a network plugin
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.0/getting-started/docker/tutorials/advanced-policy'
 ---
 

--- a/v1.6/getting-started/docker/tutorials/basic.md
+++ b/v1.6/getting-started/docker/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Calico as a Docker network plugin
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v1.6/getting-started/docker/tutorials/docker-swarm.md
+++ b/v1.6/getting-started/docker/tutorials/docker-swarm.md
@@ -1,5 +1,6 @@
 ---
-Title: Runing Calico on a Docker Swarm
+title: Runing Calico on a Docker Swarm
+sitemap: false
 ---
 
 The following tutorial provides instructions for configuring a Docker Swarm
@@ -13,7 +14,7 @@ tutorial, we will do the following:
 
 This tutorial assumes that your client and each node in your cluster
 have `calicoctl`, etcd, and Docker 1.9 or greater installed in your `$PATH`.
-See our [Prerequisite tutorial]({{site.baseurl}}/{{page.version}}/getting-started/docker/installation/manual) 
+See our [Prerequisite tutorial]({{site.baseurl}}/{{page.version}}/getting-started/docker/installation/manual)
 for instructions on getting this properly set up.
 
 To make things simpler, let's store some commonly used values as environment

--- a/v1.6/getting-started/docker/tutorials/index.md
+++ b/v1.6/getting-started/docker/tutorials/index.md
@@ -1,4 +1,5 @@
 ---
 title: Basic Walkthrough
+sitemap: false 
 ---
 More info coming soon!

--- a/v1.6/getting-started/docker/tutorials/ipv6.md
+++ b/v1.6/getting-started/docker/tutorials/ipv6.md
@@ -1,5 +1,6 @@
 ---
-Title: Calico IPv6 networking as a Docker network plugin (Optional)
+title: Calico IPv6 networking as a Docker network plugin (Optional)
+sitemap: false
 ---
 
 This tutorial is a continuation of the main

--- a/v1.6/getting-started/docker/upgrade.md
+++ b/v1.6/getting-started/docker/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/index.md
+++ b/v1.6/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v1.6/getting-started/kubernetes/index.md
+++ b/v1.6/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 Calico can be used as a network plugin for Kubernetes to provide connectivity and network policy in a Kubernetes cluster.

--- a/v1.6/getting-started/kubernetes/installation/aws.md
+++ b/v1.6/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v1.6/getting-started/kubernetes/installation/gce.md
+++ b/v1.6/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v1.6/getting-started/kubernetes/installation/hosted/index.md
+++ b/v1.6/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v1.6/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v1.6/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Install for Kubeadm
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v1.6/getting-started/kubernetes/installation/index.md
+++ b/v1.6/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Adding Calico to an Existing Kubernetes Cluster
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v1.6/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v1.6/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v1.6/getting-started/kubernetes/troubleshooting.md
+++ b/v1.6/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v1.6/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v1.6/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 This guide provides a simple way to try out Kubernetes NetworkPolicy with Calico.  It requires a Kubernetes cluster configured with Calico networking, and expects that you have `kubectl` configured to interact with the cluster.

--- a/v1.6/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v1.6/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v1.6/getting-started/kubernetes/upgrade.md
+++ b/v1.6/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 Information coming soon!

--- a/v1.6/getting-started/mesos/demos/cni/index.md
+++ b/v1.6/getting-started/mesos/demos/cni/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart with Docker-Compose - Calico for Mesos CNI
+sitemap: false 
 ---
 This directory includes files for running a docker-compose demo of Calico for Mesos CNI.
 

--- a/v1.6/getting-started/mesos/demos/docker/index.md
+++ b/v1.6/getting-started/mesos/demos/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars demo with the Mesos Docker Containerizer
+sitemap: false 
 ---
 
 

--- a/v1.6/getting-started/mesos/index.md
+++ b/v1.6/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Networking for Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v1.6/getting-started/mesos/installation/dc-os/framework.md
+++ b/v1.6/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Framework Install Walkthrough
+sitemap: false 
 ---
 
 Calico maintains a Framework for DC/OS for simple installation and use.

--- a/v1.6/getting-started/mesos/installation/dc-os/index.md
+++ b/v1.6/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico in DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v1.6/getting-started/mesos/installation/docker.md
+++ b/v1.6/getting-started/mesos/installation/docker.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for the Docker Containerizer
+sitemap: false 
 ---
 
 This document provides the commands to download and run Calico

--- a/v1.6/getting-started/mesos/installation/prerequisites.md
+++ b/v1.6/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Prerequisites for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v1.6/getting-started/mesos/installation/unified.md
+++ b/v1.6/getting-started/mesos/installation/unified.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico CNI for the Unified Containerizer
+sitemap: false 
 ---
 
 This guide details how to add Calico networking to a Mesos Agent with CNI enabled.

--- a/v1.6/getting-started/mesos/troubleshooting.md
+++ b/v1.6/getting-started/mesos/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Mesos
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/mesos/tutorials/docker.md
+++ b/v1.6/getting-started/mesos/tutorials/docker.md
@@ -1,5 +1,6 @@
 ---
 title: Calico-Mesos Usage Guide with the Docker Containerizer
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v1.6/getting-started/mesos/tutorials/unified.md
+++ b/v1.6/getting-started/mesos/tutorials/unified.md
@@ -1,5 +1,6 @@
 ---
 title: Networking Mesos Tasks with Calico-CNI
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v1.6/getting-started/mesos/upgrade.md
+++ b/v1.6/getting-started/mesos/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Mesos
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/mesos/vagrant/index.md
+++ b/v1.6/getting-started/mesos/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v1.6/getting-started/openstack/connectivity.md
+++ b/v1.6/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v1.6/getting-started/openstack/index.md
+++ b/v1.6/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v1.6/getting-started/openstack/installation/chef.md
+++ b/v1.6/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ...
 

--- a/v1.6/getting-started/openstack/installation/fuel.md
+++ b/v1.6/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v1.6/getting-started/openstack/installation/index.md
+++ b/v1.6/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v1.6/getting-started/openstack/installation/juju.md
+++ b/v1.6/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v1.6/getting-started/openstack/installation/redhat.md
+++ b/v1.6/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v1.6/getting-started/openstack/installation/ubuntu.md
+++ b/v1.6/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v1.6/getting-started/openstack/tutorials.md
+++ b/v1.6/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v1.6/getting-started/openstack/upgrade.md
+++ b/v1.6/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v1.6/getting-started/openstack/verification.md
+++ b/v1.6/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v1.6/getting-started/rkt/index.md
+++ b/v1.6/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 Information coming soon!

--- a/v1.6/getting-started/rkt/installation.md
+++ b/v1.6/getting-started/rkt/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Manage `calico/node` using systemd
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v1.6/getting-started/rkt/troubleshooting.md
+++ b/v1.6/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 Information coming soon!

--- a/v1.6/getting-started/rkt/tutorials.md
+++ b/v1.6/getting-started/rkt/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Tutorials for Rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 Information coming soon!

--- a/v1.6/getting-started/rkt/upgrade.md
+++ b/v1.6/getting-started/rkt/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for rkt
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/getting-started/rkt/vagrant/index.md
+++ b/v1.6/getting-started/rkt/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Networking with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v1.6/index.html
+++ b/v1.6/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v1.6/introduction/index.html
+++ b/v1.6/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v1.6/reference/addressing.md
+++ b/v1.6/reference/addressing.md
@@ -1,5 +1,6 @@
 ---
 title: Addressing and Connectivity Overview
+sitemap: false 
 ---
 
 

--- a/v1.6/reference/advanced/calico-cni.md
+++ b/v1.6/reference/advanced/calico-cni.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for CNI
+sitemap: false 
 ---
 Calico provides a CNI plugin for integration with orchestrators which use the [containernetworking/cni][containernetworking-repo] interface.
 

--- a/v1.6/reference/advanced/calico-neutron-api.md
+++ b/v1.6/reference/advanced/calico-neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 ---
 
 When running in an OpenStack deployment, Calico receives and interprets

--- a/v1.6/reference/advanced/etcd-secure.md
+++ b/v1.6/reference/advanced/etcd-secure.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico with a secure etcd cluster
+sitemap: false 
 ---
 
 

--- a/v1.6/reference/advanced/overlap-ips.md
+++ b/v1.6/reference/advanced/overlap-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Overlapping IPv4 address ranges
+sitemap: false 
 ---
 This document describes how we can use 464XLAT to allow multiple tenants within the same data center to use the same IPv4 address ranges (including actually using the same IPv4 addresses). This is known as “overlapping” IPv4 addresses, and also as “address space isolation”, because it means that an IP address such as 10.10.0.2 (for example) for one tenant has nothing to do with the same IP address being used by a different tenant.
 

--- a/v1.6/reference/architecture/components.md
+++ b/v1.6/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v1.6/reference/architecture/data-path.md
+++ b/v1.6/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v1.6/reference/architecture/index.md
+++ b/v1.6/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v1.6/reference/calicoctl/bgp.md
+++ b/v1.6/reference/calicoctl/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl bgp
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v1.6/reference/calicoctl/checksystem.md
+++ b/v1.6/reference/calicoctl/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 This section describes the `calicoctl checksystem` commands.

--- a/v1.6/reference/calicoctl/config.md
+++ b/v1.6/reference/calicoctl/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v1.6/reference/calicoctl/container.md
+++ b/v1.6/reference/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl container
+sitemap: false 
 ---
 
 > NOTE: The `calicoctl container` configuration commands are used specifically

--- a/v1.6/reference/calicoctl/diags.md
+++ b/v1.6/reference/calicoctl/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v1.6/reference/calicoctl/endpoint.md
+++ b/v1.6/reference/calicoctl/endpoint.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl endpoint
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v1.6/reference/calicoctl/index.md
+++ b/v1.6/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl CLI user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v1.6/reference/calicoctl/ipam.md
+++ b/v1.6/reference/calicoctl/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v1.6/reference/calicoctl/node.md
+++ b/v1.6/reference/calicoctl/node.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v1.6/reference/calicoctl/pool.md
+++ b/v1.6/reference/calicoctl/pool.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl pool
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v1.6/reference/calicoctl/profile.md
+++ b/v1.6/reference/calicoctl/profile.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl profile
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v1.6/reference/calicoctl/status.md
+++ b/v1.6/reference/calicoctl/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v1.6/reference/calicoctl/version.md
+++ b/v1.6/reference/calicoctl/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v1.6/reference/contribute.md
+++ b/v1.6/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v1.6/reference/index.md
+++ b/v1.6/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v1.6/reference/involved.md
+++ b/v1.6/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v1.6/reference/license.md
+++ b/v1.6/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v1.6/reference/previous-releases.md
+++ b/v1.6/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v1.6/reference/private-cloud/index.md
+++ b/v1.6/reference/private-cloud/index.md
@@ -1,4 +1,5 @@
 ---
 title: Deploying Calico On-prem
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v1.6/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v1.6/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v1.6/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v1.6/reference/private-cloud/troubleshooting.md
+++ b/v1.6/reference/private-cloud/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico On-Prem
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/reference/public-cloud/overview.md
+++ b/v1.6/reference/public-cloud/overview.md
@@ -1,4 +1,5 @@
 ---
 title: Deploying Calico in Public Cloud
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/reference/repo-structure.md
+++ b/v1.6/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v1.6/reference/security-model.md
+++ b/v1.6/reference/security-model.md
@@ -1,5 +1,6 @@
 ---
 title: Security Policy Model
+sitemap: false 
 ---
 
 Calico applies security policy to **endpoints**. Calico policy is

--- a/v1.6/reference/supported-platforms.md
+++ b/v1.6/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v1.6/reference/without-docker-networking/docker-container-lifecycle.md
+++ b/v1.6/reference/without-docker-networking/docker-container-lifecycle.md
@@ -1,5 +1,6 @@
 ---
 title: Lifecycle of a container (Calico without Docker networking)
+sitemap: false 
 ---
 
 

--- a/v1.6/reference/without-docker-networking/environment-setup/aws.md
+++ b/v1.6/reference/without-docker-networking/environment-setup/aws.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on AWS
+sitemap: false 
 ---
 
 Calico is designed to provide high performance massively scalable virtual

--- a/v1.6/reference/without-docker-networking/environment-setup/digital-ocean.md
+++ b/v1.6/reference/without-docker-networking/environment-setup/digital-ocean.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on DigitalOcean
+sitemap: false 
 ---
 
 

--- a/v1.6/reference/without-docker-networking/environment-setup/gce.md
+++ b/v1.6/reference/without-docker-networking/environment-setup/gce.md
@@ -1,5 +1,6 @@
 ---
 title: # Running the Calico tutorials on GCE
+sitemap: false 
 ---
 
 Calico is designed to provide high performance massively scalable virtual networking for private data centers. But you

--- a/v1.6/reference/without-docker-networking/environment-setup/vagrant-coreos/index.md
+++ b/v1.6/reference/without-docker-networking/environment-setup/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS using Vagrant and VirtualBox
+sitemap: false 
 ---
 
 These instructions allow you to set up a CoreOS cluster ready to network Docker containers with

--- a/v1.6/reference/without-docker-networking/environment-setup/vagrant-ubuntu/index.md
+++ b/v1.6/reference/without-docker-networking/environment-setup/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 ---
 
 These instructions allow you to set up an Ubuntu cluster ready to network Docker containers with

--- a/v1.6/reference/without-docker-networking/installation.md
+++ b/v1.6/reference/without-docker-networking/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Calico without Docker networking (i.e. `--net=none`)
+sitemap: false 
 ---
 
 

--- a/v1.6/reference/without-docker-networking/ipv6.md
+++ b/v1.6/reference/without-docker-networking/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: Calico IPv6 networking without Docker networking (Optional)
+sitemap: false 
 ---
 
 This tutorial is a continuation of the main

--- a/v1.6/reference/without-docker-networking/prerequisites.md
+++ b/v1.6/reference/without-docker-networking/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Preparing the environment for Calico without Docker networking
+sitemap: false 
 ---
 
 The worked example in the _Calico without Docker networking tutorial_ is run on

--- a/v1.6/releases/index.md
+++ b/v1.6/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v1.6/usage/bird-rr-config.md
+++ b/v1.6/usage/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v1.6/usage/configuration/advanced-network-policy.md
+++ b/v1.6/usage/configuration/advanced-network-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Network Policy
+sitemap: false 
 ---
 
 Calico endpoints are assigned their network policy by configuring them with a

--- a/v1.6/usage/configuration/as-service.md
+++ b/v1.6/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v1.6/usage/configuration/bgp.md
+++ b/v1.6/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Configuration
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v1.6/usage/configuration/index.md
+++ b/v1.6/usage/configuration/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Calico
+sitemap: false 
 ---
 
 This page describes how to configure Calico. We first describe the

--- a/v1.6/usage/configuration/securing-calico.md
+++ b/v1.6/usage/configuration/securing-calico.md
@@ -1,5 +1,6 @@
 ---
 title: Securing Calico
+sitemap: false 
 ---
 
 What Calico does and does not provide

--- a/v1.6/usage/dockerless-calico.md
+++ b/v1.6/usage/dockerless-calico.md
@@ -1,5 +1,6 @@
 ---
 title: Dockerless Calico - Manual Installation
+sitemap: false 
 ---
 Project Calico releases are primarily distributed as docker containers for quick, easy, and consistant deployment. However, it is possible to run the core Calico components directly on the host, removing the dependency on docker.
 

--- a/v1.6/usage/exposing-ports.md
+++ b/v1.6/usage/exposing-ports.md
@@ -1,4 +1,5 @@
 ---
 title: Expose Ports
+sitemap: false 
 ---
 Information coming soon!

--- a/v1.6/usage/external-connectivity.md
+++ b/v1.6/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v1.6/usage/index.md
+++ b/v1.6/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contans information on using Calico.

--- a/v1.6/usage/ipv6.md
+++ b/v1.6/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v1.6/usage/troubleshooting/faq-2.md
+++ b/v1.6/usage/troubleshooting/faq-2.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v1.6/usage/troubleshooting/faq.md
+++ b/v1.6/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v1.6/usage/troubleshooting/index.md
+++ b/v1.6/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v1.6/usage/troubleshooting/logging.md
+++ b/v1.6/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v2.0/getting-started/bare-metal/bare-metal.md
+++ b/v2.0/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v2.0/getting-started/bare-metal/pyi-bare-metal-install.md
+++ b/v2.0/getting-started/bare-metal/pyi-bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Alternative Felix Install with PyInstaller Bundle
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v2.0/getting-started/docker/index.md
+++ b/v2.0/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 

--- a/v2.0/getting-started/docker/installation/manual.md
+++ b/v2.0/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v2.0/getting-started/docker/installation/requirements.md
+++ b/v2.0/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/requirements'
 ---
 

--- a/v2.0/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.0/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v2.0/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.0/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v2.0/getting-started/docker/troubleshooting.md
+++ b/v2.0/getting-started/docker/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.0/getting-started/docker/tutorials/advanced-policy.md
+++ b/v2.0/getting-started/docker/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.0/getting-started/docker/tutorials/advanced-policy'
 ---
 

--- a/v2.0/getting-started/docker/tutorials/ipam.md
+++ b/v2.0/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v2.0/getting-started/docker/tutorials/simple-policy.md
+++ b/v2.0/getting-started/docker/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy
+sitemap: false 
 ---
 
 The following guide walks through a simple policy demo.

--- a/v2.0/getting-started/docker/upgrade.md
+++ b/v2.0/getting-started/docker/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.0/getting-started/index.md
+++ b/v2.0/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v2.0/getting-started/kubernetes/index.md
+++ b/v2.0/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/v2.0/getting-started/kubernetes/installation/aws.md
+++ b/v2.0/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v2.0/getting-started/kubernetes/installation/gce.md
+++ b/v2.0/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v2.0/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v2.0/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.  

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/index.md
@@ -1,5 +1,6 @@
 ---
 title: Etcdless Hosted Install using Kube Addon Manager
+sitemap: false 
 ---
 
 See [Etcdless Hosted Install](../k8s-backend)

--- a/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -1,5 +1,6 @@
 ---
 title: Etcdless Hosted Install
+sitemap: false 
 ---
 
 This document describes installing Calico on Kubernetes in a mode that does not require access to an etcd cluster.  Note that this feature is

--- a/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubeadm Hosted Install 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v2.0/getting-started/kubernetes/installation/index.md
+++ b/v2.0/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v2.0/getting-started/kubernetes/installation/integration.md
+++ b/v2.0/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/v2.0/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.0/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v2.0/getting-started/kubernetes/troubleshooting.md
+++ b/v2.0/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v2.0/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.0/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/v2.0/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.0/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v2.0/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.0/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v2.0/getting-started/kubernetes/upgrade.md
+++ b/v2.0/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/v2.0/getting-started/mesos/index.md
+++ b/v2.0/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v2.0/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.0/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+sitemap: false 
 ---
 
 The the Calico Universe Framework includes customization options which support

--- a/v2.0/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.0/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+sitemap: false 
 ---
 
 The following guide walks through installing Calico for DC/OS using the Universe

--- a/v2.0/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.0/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.0/getting-started/mesos/installation/integration.md
+++ b/v2.0/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 ---
 
 This guide explains the components necessary to install Calico on Mesos for integrating with custom configuration management. To install Calico in Mesos, no changes are needed on any Mesos Master.

--- a/v2.0/getting-started/mesos/installation/prerequisites.md
+++ b/v2.0/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.0/getting-started/mesos/tutorials/docker.md
+++ b/v2.0/getting-started/mesos/tutorials/docker.md
@@ -1,5 +1,6 @@
 ---
 title: Calico-Mesos Usage Guide for the Docker Containerizer
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v2.0/getting-started/mesos/tutorials/unified.md
+++ b/v2.0/getting-started/mesos/tutorials/unified.md
@@ -1,5 +1,6 @@
 ---
 title: Networking Mesos Tasks with Calico-CNI
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v2.0/getting-started/mesos/vagrant/index.md
+++ b/v2.0/getting-started/mesos/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v2.0/getting-started/openstack/connectivity.md
+++ b/v2.0/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v2.0/getting-started/openstack/index.md
+++ b/v2.0/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v2.0/getting-started/openstack/installation/chef.md
+++ b/v2.0/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ...
 

--- a/v2.0/getting-started/openstack/installation/fuel.md
+++ b/v2.0/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v2.0/getting-started/openstack/installation/index.md
+++ b/v2.0/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v2.0/getting-started/openstack/installation/juju.md
+++ b/v2.0/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v2.0/getting-started/openstack/installation/redhat.md
+++ b/v2.0/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v2.0/getting-started/openstack/installation/ubuntu.md
+++ b/v2.0/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v2.0/getting-started/openstack/neutron-api.md
+++ b/v2.0/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/v2.0/getting-started/openstack/tutorials.md
+++ b/v2.0/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v2.0/getting-started/openstack/upgrade.md
+++ b/v2.0/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v2.0/getting-started/openstack/verification.md
+++ b/v2.0/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v2.0/getting-started/rkt/index.md
+++ b/v2.0/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 

--- a/v2.0/getting-started/rkt/installation/manual.md
+++ b/v2.0/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/manual'
 ---
 

--- a/v2.0/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.0/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v2.0/getting-started/rkt/troubleshooting.md
+++ b/v2.0/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 

--- a/v2.0/getting-started/rkt/tutorials/basic.md
+++ b/v2.0/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 

--- a/v2.0/index.html
+++ b/v2.0/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v2.0/introduction/index.html
+++ b/v2.0/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v2.0/reference/advanced/etcd-rbac.md
+++ b/v2.0/reference/advanced/etcd-rbac.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Calico Role for etcdv2 RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/'
 ---
 

--- a/v2.0/reference/architecture/components.md
+++ b/v2.0/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v2.0/reference/architecture/data-path.md
+++ b/v2.0/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v2.0/reference/architecture/index.md
+++ b/v2.0/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v2.0/reference/calicoctl/commands/apply.md
+++ b/v2.0/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/v2.0/reference/calicoctl/commands/config.md
+++ b/v2.0/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v2.0/reference/calicoctl/commands/create.md
+++ b/v2.0/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/v2.0/reference/calicoctl/commands/delete.md
+++ b/v2.0/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/v2.0/reference/calicoctl/commands/get.md
+++ b/v2.0/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/v2.0/reference/calicoctl/commands/index.md
+++ b/v2.0/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/v2.0/reference/calicoctl/commands/ipam/index.md
+++ b/v2.0/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v2.0/reference/calicoctl/commands/ipam/release.md
+++ b/v2.0/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/v2.0/reference/calicoctl/commands/ipam/show.md
+++ b/v2.0/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/v2.0/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.0/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/v2.0/reference/calicoctl/commands/node/diags.md
+++ b/v2.0/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v2.0/reference/calicoctl/commands/node/index.md
+++ b/v2.0/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v2.0/reference/calicoctl/commands/node/run.md
+++ b/v2.0/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/v2.0/reference/calicoctl/commands/node/status.md
+++ b/v2.0/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v2.0/reference/calicoctl/commands/replace.md
+++ b/v2.0/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/v2.0/reference/calicoctl/commands/version.md
+++ b/v2.0/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v2.0/reference/calicoctl/index.md
+++ b/v2.0/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v2.0/reference/calicoctl/resources/bgppeer.md
+++ b/v2.0/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v2.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.0/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v2.0/reference/calicoctl/resources/index.md
+++ b/v2.0/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/v2.0/reference/calicoctl/resources/ippool.md
+++ b/v2.0/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v2.0/reference/calicoctl/resources/node.md
+++ b/v2.0/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/v2.0/reference/calicoctl/resources/policy.md
+++ b/v2.0/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/v2.0/reference/calicoctl/resources/profile.md
+++ b/v2.0/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v2.0/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.0/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/v2.0/reference/calicoctl/setup/etcdv2.md
+++ b/v2.0/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/v2.0/reference/calicoctl/setup/index.md
+++ b/v2.0/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/v2.0/reference/calicoctl/setup/kubernetes.md
+++ b/v2.0/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/v2.0/reference/cni-plugin/configuration.md
+++ b/v2.0/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/v2.0/reference/contribute.md
+++ b/v2.0/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.0/reference/index.md
+++ b/v2.0/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v2.0/reference/involved.md
+++ b/v2.0/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v2.0/reference/license.md
+++ b/v2.0/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v2.0/reference/node/configuration.md
+++ b/v2.0/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/v2.0/reference/policy-controller/configuration.md
+++ b/v2.0/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/v2.0/reference/previous-releases.md
+++ b/v2.0/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v2.0/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.0/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v2.0/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.0/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v2.0/reference/public-cloud/aws.md
+++ b/v2.0/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/aws'
 ---
 

--- a/v2.0/reference/repo-structure.md
+++ b/v2.0/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v2.0/reference/supported-platforms.md
+++ b/v2.0/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v2.0/releases/index.md
+++ b/v2.0/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.0/usage/bird-rr-config.md
+++ b/v2.0/usage/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v2.0/usage/configuration/as-service.md
+++ b/v2.0/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v2.0/usage/configuration/bgp.md
+++ b/v2.0/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v2.0/usage/configuration/index.md
+++ b/v2.0/usage/configuration/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Calico
+sitemap: false 
 ---
 
 This page describes the configuration options for Calico's per-host agent,

--- a/v2.0/usage/external-connectivity.md
+++ b/v2.0/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v2.0/usage/index.md
+++ b/v2.0/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using Calico.

--- a/v2.0/usage/ipv6.md
+++ b/v2.0/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v2.0/usage/troubleshooting/faq.md
+++ b/v2.0/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v2.0/usage/troubleshooting/index.md
+++ b/v2.0/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v2.0/usage/troubleshooting/logging.md
+++ b/v2.0/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v2.1/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.1/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v2.1/getting-started/bare-metal/bare-metal.md
+++ b/v2.1/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v2.1/getting-started/docker/index.md
+++ b/v2.1/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 

--- a/v2.1/getting-started/docker/installation/manual.md
+++ b/v2.1/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v2.1/getting-started/docker/installation/requirements.md
+++ b/v2.1/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/requirements'
 ---
 

--- a/v2.1/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.1/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v2.1/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.1/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v2.1/getting-started/docker/troubleshooting.md
+++ b/v2.1/getting-started/docker/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.1/getting-started/docker/tutorials/ipam.md
+++ b/v2.1/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v2.1/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.1/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles and Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy'
 ---
 

--- a/v2.1/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.1/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles'
 ---
 

--- a/v2.1/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.1/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Docker Labels and Calico Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy'
 ---
 

--- a/v2.1/getting-started/docker/upgrade.md
+++ b/v2.1/getting-started/docker/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.1/getting-started/index.md
+++ b/v2.1/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v2.1/getting-started/kubernetes/index.md
+++ b/v2.1/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/v2.1/getting-started/kubernetes/installation/aws.md
+++ b/v2.1/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v2.1/getting-started/kubernetes/installation/gce.md
+++ b/v2.1/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v2.1/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v2.1/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/k8s-backend/index.md
@@ -1,5 +1,6 @@
 ---
 title: Etcdless Hosted Install
+sitemap: false 
 ---
 
 This document describes installing Calico on Kubernetes in a mode that does not require access to an etcd cluster.  

--- a/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubeadm Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v2.1/getting-started/kubernetes/installation/index.md
+++ b/v2.1/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v2.1/getting-started/kubernetes/installation/integration.md
+++ b/v2.1/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/v2.1/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.1/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v2.1/getting-started/kubernetes/troubleshooting.md
+++ b/v2.1/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v2.1/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.1/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/v2.1/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.1/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.1/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v2.1/getting-started/kubernetes/upgrade.md
+++ b/v2.1/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/v2.1/getting-started/mesos/index.md
+++ b/v2.1/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v2.1/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.1/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+sitemap: false 
 ---
 
 The the Calico Universe Framework includes customization options which support

--- a/v2.1/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.1/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+sitemap: false 
 ---
 
 The following guide walks through installing Calico for DC/OS using the Universe

--- a/v2.1/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.1/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.1/getting-started/mesos/installation/integration.md
+++ b/v2.1/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 ---
 
 This guide explains the components necessary to install Calico on Mesos for integrating with custom configuration management. To install Calico in Mesos, no changes are needed on any Mesos Master.

--- a/v2.1/getting-started/mesos/installation/prerequisites.md
+++ b/v2.1/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.1/getting-started/mesos/tutorials/docker.md
+++ b/v2.1/getting-started/mesos/tutorials/docker.md
@@ -1,5 +1,6 @@
 ---
 title: Calico-Mesos Usage Guide for the Docker Containerizer
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v2.1/getting-started/mesos/tutorials/unified.md
+++ b/v2.1/getting-started/mesos/tutorials/unified.md
@@ -1,5 +1,6 @@
 ---
 title: Networking Mesos Tasks with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v2.1/getting-started/mesos/vagrant/index.md
+++ b/v2.1/getting-started/mesos/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v2.1/getting-started/openstack/connectivity.md
+++ b/v2.1/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v2.1/getting-started/openstack/index.md
+++ b/v2.1/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v2.1/getting-started/openstack/installation/chef.md
+++ b/v2.1/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ...
 

--- a/v2.1/getting-started/openstack/installation/devstack.md
+++ b/v2.1/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/devstack'
 ---
 

--- a/v2.1/getting-started/openstack/installation/fuel.md
+++ b/v2.1/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v2.1/getting-started/openstack/installation/index.md
+++ b/v2.1/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v2.1/getting-started/openstack/installation/juju.md
+++ b/v2.1/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v2.1/getting-started/openstack/installation/redhat.md
+++ b/v2.1/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v2.1/getting-started/openstack/installation/ubuntu.md
+++ b/v2.1/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v2.1/getting-started/openstack/neutron-api.md
+++ b/v2.1/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/v2.1/getting-started/openstack/tutorials.md
+++ b/v2.1/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v2.1/getting-started/openstack/upgrade.md
+++ b/v2.1/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v2.1/getting-started/openstack/verification.md
+++ b/v2.1/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v2.1/getting-started/rkt/index.md
+++ b/v2.1/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 

--- a/v2.1/getting-started/rkt/installation/manual.md
+++ b/v2.1/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/manual'
 ---
 

--- a/v2.1/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.1/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v2.1/getting-started/rkt/troubleshooting.md
+++ b/v2.1/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 

--- a/v2.1/getting-started/rkt/tutorials/basic.md
+++ b/v2.1/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 

--- a/v2.1/index.html
+++ b/v2.1/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v2.1/introduction/index.html
+++ b/v2.1/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v2.1/reference/advanced/etcd-rbac.md
+++ b/v2.1/reference/advanced/etcd-rbac.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Calico Role for etcdv2 RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/'
 ---
 

--- a/v2.1/reference/architecture/components.md
+++ b/v2.1/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v2.1/reference/architecture/data-path.md
+++ b/v2.1/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v2.1/reference/architecture/index.md
+++ b/v2.1/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v2.1/reference/calicoctl/commands/apply.md
+++ b/v2.1/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/v2.1/reference/calicoctl/commands/config.md
+++ b/v2.1/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v2.1/reference/calicoctl/commands/create.md
+++ b/v2.1/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/v2.1/reference/calicoctl/commands/delete.md
+++ b/v2.1/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/v2.1/reference/calicoctl/commands/get.md
+++ b/v2.1/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/v2.1/reference/calicoctl/commands/index.md
+++ b/v2.1/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/v2.1/reference/calicoctl/commands/ipam/index.md
+++ b/v2.1/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v2.1/reference/calicoctl/commands/ipam/release.md
+++ b/v2.1/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/v2.1/reference/calicoctl/commands/ipam/show.md
+++ b/v2.1/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/v2.1/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.1/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/v2.1/reference/calicoctl/commands/node/diags.md
+++ b/v2.1/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v2.1/reference/calicoctl/commands/node/index.md
+++ b/v2.1/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v2.1/reference/calicoctl/commands/node/run.md
+++ b/v2.1/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/v2.1/reference/calicoctl/commands/node/status.md
+++ b/v2.1/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v2.1/reference/calicoctl/commands/replace.md
+++ b/v2.1/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/v2.1/reference/calicoctl/commands/version.md
+++ b/v2.1/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v2.1/reference/calicoctl/index.md
+++ b/v2.1/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v2.1/reference/calicoctl/resources/bgppeer.md
+++ b/v2.1/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v2.1/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.1/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v2.1/reference/calicoctl/resources/index.md
+++ b/v2.1/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/v2.1/reference/calicoctl/resources/ippool.md
+++ b/v2.1/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v2.1/reference/calicoctl/resources/node.md
+++ b/v2.1/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/v2.1/reference/calicoctl/resources/policy.md
+++ b/v2.1/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/v2.1/reference/calicoctl/resources/profile.md
+++ b/v2.1/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v2.1/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.1/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/v2.1/reference/calicoctl/setup/etcdv2.md
+++ b/v2.1/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/v2.1/reference/calicoctl/setup/index.md
+++ b/v2.1/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/v2.1/reference/calicoctl/setup/kubernetes.md
+++ b/v2.1/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/v2.1/reference/cni-plugin/configuration.md
+++ b/v2.1/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/v2.1/reference/contribute.md
+++ b/v2.1/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.1/reference/felix/configuration.md
+++ b/v2.1/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/configuration'
 ---
 

--- a/v2.1/reference/felix/prometheus.md
+++ b/v2.1/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/prometheus'
 ---
 

--- a/v2.1/reference/index.md
+++ b/v2.1/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v2.1/reference/involved.md
+++ b/v2.1/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v2.1/reference/license.md
+++ b/v2.1/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v2.1/reference/node/configuration.md
+++ b/v2.1/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/v2.1/reference/policy-controller/configuration.md
+++ b/v2.1/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/v2.1/reference/previous-releases.md
+++ b/v2.1/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v2.1/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.1/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v2.1/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.1/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v2.1/reference/public-cloud/aws.md
+++ b/v2.1/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/aws'
 ---
 

--- a/v2.1/reference/repo-structure.md
+++ b/v2.1/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v2.1/reference/supported-platforms.md
+++ b/v2.1/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v2.1/releases/index.md
+++ b/v2.1/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.1/usage/bird-rr-config.md
+++ b/v2.1/usage/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v2.1/usage/configuration/as-service.md
+++ b/v2.1/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v2.1/usage/configuration/bgp.md
+++ b/v2.1/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v2.1/usage/configuration/conntrack.md
+++ b/v2.1/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/conntrack'
 ---
 

--- a/v2.1/usage/configuration/ip-in-ip.md
+++ b/v2.1/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip'
 ---
 

--- a/v2.1/usage/configuration/mtu.md
+++ b/v2.1/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/mtu'
 ---
 

--- a/v2.1/usage/configuration/node.md
+++ b/v2.1/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/node'
 ---
 

--- a/v2.1/usage/external-connectivity.md
+++ b/v2.1/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v2.1/usage/index.md
+++ b/v2.1/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using Calico.

--- a/v2.1/usage/ipv6.md
+++ b/v2.1/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v2.1/usage/openstack/configuration.md
+++ b/v2.1/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
 ---
 

--- a/v2.1/usage/openstack/floating-ips.md
+++ b/v2.1/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
 ---
 

--- a/v2.1/usage/openstack/host-routes.md
+++ b/v2.1/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
 ---
 

--- a/v2.1/usage/openstack/kuryr.md
+++ b/v2.1/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
 ---
 

--- a/v2.1/usage/openstack/semantics.md
+++ b/v2.1/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
 ---
 

--- a/v2.1/usage/openstack/service-ips.md
+++ b/v2.1/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
 ---
 

--- a/v2.1/usage/troubleshooting/faq.md
+++ b/v2.1/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v2.1/usage/troubleshooting/index.md
+++ b/v2.1/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v2.1/usage/troubleshooting/logging.md
+++ b/v2.1/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v2.2/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.2/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v2.2/getting-started/bare-metal/bare-metal.md
+++ b/v2.2/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v2.2/getting-started/docker/index.md
+++ b/v2.2/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 

--- a/v2.2/getting-started/docker/installation/manual.md
+++ b/v2.2/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v2.2/getting-started/docker/installation/requirements.md
+++ b/v2.2/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/requirements'
 ---
 

--- a/v2.2/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.2/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v2.2/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.2/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v2.2/getting-started/docker/troubleshooting.md
+++ b/v2.2/getting-started/docker/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.2/getting-started/docker/tutorials/ipam.md
+++ b/v2.2/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v2.2/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.2/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles and Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy'
 ---
 

--- a/v2.2/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.2/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles'
 ---
 

--- a/v2.2/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.2/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Docker Labels and Calico Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy'
 ---
 

--- a/v2.2/getting-started/docker/upgrade.md
+++ b/v2.2/getting-started/docker/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.2/getting-started/index.md
+++ b/v2.2/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v2.2/getting-started/kubernetes/index.md
+++ b/v2.2/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/v2.2/getting-started/kubernetes/installation/aws.md
+++ b/v2.2/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v2.2/getting-started/kubernetes/installation/gce.md
+++ b/v2.2/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v2.2/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.2/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v2.2/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.2/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubeadm Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Datastore
+sitemap: false 
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.  

--- a/v2.2/getting-started/kubernetes/installation/index.md
+++ b/v2.2/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v2.2/getting-started/kubernetes/installation/integration.md
+++ b/v2.2/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/v2.2/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.2/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v2.2/getting-started/kubernetes/troubleshooting.md
+++ b/v2.2/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v2.2/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.2/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/v2.2/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.2/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v2.2/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.2/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v2.2/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.2/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/using-calicoctl'
 ---
 

--- a/v2.2/getting-started/kubernetes/upgrade.md
+++ b/v2.2/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/v2.2/getting-started/mesos/index.md
+++ b/v2.2/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v2.2/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.2/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+sitemap: false 
 ---
 
 The the Calico Universe Framework includes customization options which support

--- a/v2.2/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.2/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+sitemap: false 
 ---
 
 The following guide walks through installing Calico for DC/OS using the Universe

--- a/v2.2/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.2/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.2/getting-started/mesos/installation/integration.md
+++ b/v2.2/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing

--- a/v2.2/getting-started/mesos/installation/prerequisites.md
+++ b/v2.2/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.2/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.2/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting to Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/connecting-tasks'
 ---
 

--- a/v2.2/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.2/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Launching Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/launching-tasks'
 ---
 

--- a/v2.2/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/v2.2/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Docker Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v2.2/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.2/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Universal Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v2.2/getting-started/mesos/vagrant/index.md
+++ b/v2.2/getting-started/mesos/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v2.2/getting-started/openstack/connectivity.md
+++ b/v2.2/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v2.2/getting-started/openstack/index.md
+++ b/v2.2/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v2.2/getting-started/openstack/installation/chef.md
+++ b/v2.2/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ...
 

--- a/v2.2/getting-started/openstack/installation/devstack.md
+++ b/v2.2/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/devstack'
 ---
 

--- a/v2.2/getting-started/openstack/installation/fuel.md
+++ b/v2.2/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v2.2/getting-started/openstack/installation/index.md
+++ b/v2.2/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v2.2/getting-started/openstack/installation/juju.md
+++ b/v2.2/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v2.2/getting-started/openstack/installation/redhat.md
+++ b/v2.2/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v2.2/getting-started/openstack/installation/ubuntu.md
+++ b/v2.2/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v2.2/getting-started/openstack/neutron-api.md
+++ b/v2.2/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/v2.2/getting-started/openstack/tutorials.md
+++ b/v2.2/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v2.2/getting-started/openstack/upgrade.md
+++ b/v2.2/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v2.2/getting-started/openstack/verification.md
+++ b/v2.2/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v2.2/getting-started/rkt/index.md
+++ b/v2.2/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 

--- a/v2.2/getting-started/rkt/installation/manual.md
+++ b/v2.2/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/manual'
 ---
 

--- a/v2.2/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.2/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v2.2/getting-started/rkt/troubleshooting.md
+++ b/v2.2/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 

--- a/v2.2/getting-started/rkt/tutorials/basic.md
+++ b/v2.2/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 

--- a/v2.2/index.html
+++ b/v2.2/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v2.2/introduction/index.html
+++ b/v2.2/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v2.2/reference/advanced/etcd-rbac.md
+++ b/v2.2/reference/advanced/etcd-rbac.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Calico Role for etcdv2 RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/'
 ---
 

--- a/v2.2/reference/architecture/components.md
+++ b/v2.2/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v2.2/reference/architecture/data-path.md
+++ b/v2.2/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v2.2/reference/architecture/index.md
+++ b/v2.2/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v2.2/reference/calicoctl/commands/apply.md
+++ b/v2.2/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/v2.2/reference/calicoctl/commands/config.md
+++ b/v2.2/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v2.2/reference/calicoctl/commands/create.md
+++ b/v2.2/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/v2.2/reference/calicoctl/commands/delete.md
+++ b/v2.2/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/v2.2/reference/calicoctl/commands/get.md
+++ b/v2.2/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/v2.2/reference/calicoctl/commands/index.md
+++ b/v2.2/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/v2.2/reference/calicoctl/commands/ipam/index.md
+++ b/v2.2/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v2.2/reference/calicoctl/commands/ipam/release.md
+++ b/v2.2/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/v2.2/reference/calicoctl/commands/ipam/show.md
+++ b/v2.2/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/v2.2/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.2/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/v2.2/reference/calicoctl/commands/node/diags.md
+++ b/v2.2/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v2.2/reference/calicoctl/commands/node/index.md
+++ b/v2.2/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v2.2/reference/calicoctl/commands/node/run.md
+++ b/v2.2/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/v2.2/reference/calicoctl/commands/node/status.md
+++ b/v2.2/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v2.2/reference/calicoctl/commands/replace.md
+++ b/v2.2/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/v2.2/reference/calicoctl/commands/version.md
+++ b/v2.2/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v2.2/reference/calicoctl/index.md
+++ b/v2.2/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v2.2/reference/calicoctl/resources/bgppeer.md
+++ b/v2.2/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v2.2/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.2/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v2.2/reference/calicoctl/resources/index.md
+++ b/v2.2/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/v2.2/reference/calicoctl/resources/ippool.md
+++ b/v2.2/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v2.2/reference/calicoctl/resources/node.md
+++ b/v2.2/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/v2.2/reference/calicoctl/resources/policy.md
+++ b/v2.2/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/v2.2/reference/calicoctl/resources/profile.md
+++ b/v2.2/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v2.2/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.2/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/v2.2/reference/calicoctl/setup/etcdv2.md
+++ b/v2.2/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/v2.2/reference/calicoctl/setup/index.md
+++ b/v2.2/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/v2.2/reference/calicoctl/setup/kubernetes.md
+++ b/v2.2/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/v2.2/reference/cni-plugin/configuration.md
+++ b/v2.2/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/v2.2/reference/contribute.md
+++ b/v2.2/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 ---
 
 Features or any changes to the codebase should be done as follows:

--- a/v2.2/reference/felix/configuration.md
+++ b/v2.2/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/configuration'
 ---
 

--- a/v2.2/reference/felix/prometheus.md
+++ b/v2.2/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/prometheus'
 ---
 

--- a/v2.2/reference/index.md
+++ b/v2.2/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v2.2/reference/involved.md
+++ b/v2.2/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v2.2/reference/license.md
+++ b/v2.2/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v2.2/reference/node/configuration.md
+++ b/v2.2/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/v2.2/reference/policy-controller/configuration.md
+++ b/v2.2/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/v2.2/reference/previous-releases.md
+++ b/v2.2/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v2.2/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.2/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v2.2/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.2/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v2.2/reference/public-cloud/aws.md
+++ b/v2.2/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/aws'
 ---
 

--- a/v2.2/reference/public-cloud/gce.md
+++ b/v2.2/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/gce'
 ---
 

--- a/v2.2/reference/repo-structure.md
+++ b/v2.2/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v2.2/reference/supported-platforms.md
+++ b/v2.2/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v2.2/releases/index.md
+++ b/v2.2/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.2/usage/calicoctl/container.md
+++ b/v2.2/usage/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calico/ctl container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.2/usage/calicoctl/install-and-configuration.md
+++ b/v2.2/usage/calicoctl/install-and-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and Configuring calicoctl
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.2/usage/configuration/as-service.md
+++ b/v2.2/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v2.2/usage/configuration/bgp.md
+++ b/v2.2/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v2.2/usage/configuration/conntrack.md
+++ b/v2.2/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/conntrack'
 ---
 

--- a/v2.2/usage/configuration/ip-in-ip.md
+++ b/v2.2/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip'
 ---
 

--- a/v2.2/usage/configuration/mtu.md
+++ b/v2.2/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/mtu'
 ---
 

--- a/v2.2/usage/configuration/node.md
+++ b/v2.2/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/node'
 ---
 

--- a/v2.2/usage/decommissioning-a-node.md
+++ b/v2.2/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/decommissioning-a-node'
 ---
 

--- a/v2.2/usage/external-connectivity.md
+++ b/v2.2/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v2.2/usage/index.md
+++ b/v2.2/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using Calico.

--- a/v2.2/usage/ipv6.md
+++ b/v2.2/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v2.2/usage/openstack/configuration.md
+++ b/v2.2/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
 ---
 

--- a/v2.2/usage/openstack/floating-ips.md
+++ b/v2.2/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
 ---
 

--- a/v2.2/usage/openstack/host-routes.md
+++ b/v2.2/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
 ---
 

--- a/v2.2/usage/openstack/kuryr.md
+++ b/v2.2/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
 ---
 

--- a/v2.2/usage/openstack/semantics.md
+++ b/v2.2/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
 ---
 

--- a/v2.2/usage/openstack/service-ips.md
+++ b/v2.2/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
 ---
 

--- a/v2.2/usage/routereflector/bird-rr-config.md
+++ b/v2.2/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v2.2/usage/routereflector/calico-routereflector.md
+++ b/v2.2/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/calico-routereflector'
 ---
 

--- a/v2.2/usage/troubleshooting/faq.md
+++ b/v2.2/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v2.2/usage/troubleshooting/index.md
+++ b/v2.2/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v2.2/usage/troubleshooting/logging.md
+++ b/v2.2/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v2.3/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.3/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v2.3/getting-started/bare-metal/bare-metal.md
+++ b/v2.3/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v2.3/getting-started/docker/index.md
+++ b/v2.3/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 

--- a/v2.3/getting-started/docker/installation/manual.md
+++ b/v2.3/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v2.3/getting-started/docker/installation/requirements.md
+++ b/v2.3/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/requirements'
 ---
 

--- a/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.3/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v2.3/getting-started/docker/troubleshooting.md
+++ b/v2.3/getting-started/docker/troubleshooting.md
@@ -1,4 +1,5 @@
 ---
 title: Troubleshooting Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.3/getting-started/docker/tutorials/ipam.md
+++ b/v2.3/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v2.3/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.3/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles and Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy'
 ---
 

--- a/v2.3/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.3/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles'
 ---
 

--- a/v2.3/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.3/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Docker Labels and Calico Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy'
 ---
 

--- a/v2.3/getting-started/docker/upgrade.md
+++ b/v2.3/getting-started/docker/upgrade.md
@@ -1,4 +1,5 @@
 ---
 title: Upgrading Calico for Docker
+sitemap: false 
 ---
 Information coming soon!

--- a/v2.3/getting-started/index.md
+++ b/v2.3/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v2.3/getting-started/kubernetes/index.md
+++ b/v2.3/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/v2.3/getting-started/kubernetes/installation/aws.md
+++ b/v2.3/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v2.3/getting-started/kubernetes/installation/gce.md
+++ b/v2.3/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v2.3/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v2.3/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubeadm Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Datastore
+sitemap: false 
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.  

--- a/v2.3/getting-started/kubernetes/installation/index.md
+++ b/v2.3/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v2.3/getting-started/kubernetes/installation/integration.md
+++ b/v2.3/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/v2.3/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.3/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v2.3/getting-started/kubernetes/troubleshooting.md
+++ b/v2.3/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v2.3/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.3/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/v2.3/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.3/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v2.3/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.3/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v2.3/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.3/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/using-calicoctl'
 ---
 

--- a/v2.3/getting-started/kubernetes/upgrade.md
+++ b/v2.3/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/v2.3/getting-started/mesos/index.md
+++ b/v2.3/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v2.3/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.3/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+sitemap: false 
 ---
 
 The the Calico Universe Framework includes customization options which support

--- a/v2.3/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.3/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+sitemap: false 
 ---
 
 The following guide walks through installing Calico for DC/OS using the Universe

--- a/v2.3/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.3/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.3/getting-started/mesos/installation/integration.md
+++ b/v2.3/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 ---
 
 This guide explains how to integrate Calico networking and policy on an existing

--- a/v2.3/getting-started/mesos/installation/prerequisites.md
+++ b/v2.3/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.3/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.3/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting to Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/connecting-tasks'
 ---
 

--- a/v2.3/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.3/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Launching Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/launching-tasks'
 ---
 

--- a/v2.3/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/v2.3/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Docker Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v2.3/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.3/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Universal Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v2.3/getting-started/mesos/vagrant/index.md
+++ b/v2.3/getting-started/mesos/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v2.3/getting-started/openstack/connectivity.md
+++ b/v2.3/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v2.3/getting-started/openstack/index.md
+++ b/v2.3/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v2.3/getting-started/openstack/installation/chef.md
+++ b/v2.3/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ...
 

--- a/v2.3/getting-started/openstack/installation/devstack.md
+++ b/v2.3/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/devstack'
 ---
 

--- a/v2.3/getting-started/openstack/installation/fuel.md
+++ b/v2.3/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v2.3/getting-started/openstack/installation/index.md
+++ b/v2.3/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v2.3/getting-started/openstack/installation/juju.md
+++ b/v2.3/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v2.3/getting-started/openstack/installation/redhat.md
+++ b/v2.3/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v2.3/getting-started/openstack/installation/ubuntu.md
+++ b/v2.3/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v2.3/getting-started/openstack/neutron-api.md
+++ b/v2.3/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/v2.3/getting-started/openstack/tutorials.md
+++ b/v2.3/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v2.3/getting-started/openstack/upgrade.md
+++ b/v2.3/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v2.3/getting-started/openstack/verification.md
+++ b/v2.3/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v2.3/getting-started/rkt/index.md
+++ b/v2.3/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 

--- a/v2.3/getting-started/rkt/installation/manual.md
+++ b/v2.3/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/manual'
 ---
 

--- a/v2.3/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.3/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v2.3/getting-started/rkt/troubleshooting.md
+++ b/v2.3/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 

--- a/v2.3/getting-started/rkt/tutorials/basic.md
+++ b/v2.3/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 

--- a/v2.3/index.html
+++ b/v2.3/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v2.3/introduction/index.html
+++ b/v2.3/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v2.3/reference/advanced/etcd-rbac.md
+++ b/v2.3/reference/advanced/etcd-rbac.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Calico Role for etcdv2 RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/'
 ---
 

--- a/v2.3/reference/architecture/components.md
+++ b/v2.3/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v2.3/reference/architecture/data-path.md
+++ b/v2.3/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v2.3/reference/architecture/index.md
+++ b/v2.3/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v2.3/reference/calicoctl/commands/apply.md
+++ b/v2.3/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/v2.3/reference/calicoctl/commands/config.md
+++ b/v2.3/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v2.3/reference/calicoctl/commands/create.md
+++ b/v2.3/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/v2.3/reference/calicoctl/commands/delete.md
+++ b/v2.3/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/v2.3/reference/calicoctl/commands/get.md
+++ b/v2.3/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/v2.3/reference/calicoctl/commands/index.md
+++ b/v2.3/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/v2.3/reference/calicoctl/commands/ipam/index.md
+++ b/v2.3/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v2.3/reference/calicoctl/commands/ipam/release.md
+++ b/v2.3/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/v2.3/reference/calicoctl/commands/ipam/show.md
+++ b/v2.3/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/v2.3/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.3/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/v2.3/reference/calicoctl/commands/node/diags.md
+++ b/v2.3/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v2.3/reference/calicoctl/commands/node/index.md
+++ b/v2.3/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v2.3/reference/calicoctl/commands/node/run.md
+++ b/v2.3/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/v2.3/reference/calicoctl/commands/node/status.md
+++ b/v2.3/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v2.3/reference/calicoctl/commands/replace.md
+++ b/v2.3/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/v2.3/reference/calicoctl/commands/version.md
+++ b/v2.3/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v2.3/reference/calicoctl/index.md
+++ b/v2.3/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v2.3/reference/calicoctl/resources/bgppeer.md
+++ b/v2.3/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v2.3/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.3/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v2.3/reference/calicoctl/resources/index.md
+++ b/v2.3/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/v2.3/reference/calicoctl/resources/ippool.md
+++ b/v2.3/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v2.3/reference/calicoctl/resources/node.md
+++ b/v2.3/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/v2.3/reference/calicoctl/resources/policy.md
+++ b/v2.3/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/v2.3/reference/calicoctl/resources/profile.md
+++ b/v2.3/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v2.3/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.3/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/v2.3/reference/calicoctl/setup/etcdv2.md
+++ b/v2.3/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/v2.3/reference/calicoctl/setup/index.md
+++ b/v2.3/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/v2.3/reference/calicoctl/setup/kubernetes.md
+++ b/v2.3/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/v2.3/reference/cni-plugin/configuration.md
+++ b/v2.3/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/v2.3/reference/contribute.md
+++ b/v2.3/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.5/reference/contribute'
 ---
 

--- a/v2.3/reference/felix/configuration.md
+++ b/v2.3/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/configuration'
 ---
 

--- a/v2.3/reference/felix/prometheus.md
+++ b/v2.3/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/prometheus'
 ---
 

--- a/v2.3/reference/index.md
+++ b/v2.3/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v2.3/reference/involved.md
+++ b/v2.3/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v2.3/reference/license.md
+++ b/v2.3/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v2.3/reference/node/configuration.md
+++ b/v2.3/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/v2.3/reference/policy-controller/configuration.md
+++ b/v2.3/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/v2.3/reference/previous-releases.md
+++ b/v2.3/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v2.3/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.3/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v2.3/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.3/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v2.3/reference/public-cloud/aws.md
+++ b/v2.3/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/aws'
 ---
 

--- a/v2.3/reference/public-cloud/gce.md
+++ b/v2.3/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/gce'
 ---
 

--- a/v2.3/reference/repo-structure.md
+++ b/v2.3/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v2.3/reference/requirements.md
+++ b/v2.3/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+sitemap: false 
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v2.3/reference/supported-platforms.md
+++ b/v2.3/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v2.3/releases/index.md
+++ b/v2.3/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.3/usage/calicoctl/container.md
+++ b/v2.3/usage/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calico/ctl container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.3/usage/calicoctl/install-and-configuration.md
+++ b/v2.3/usage/calicoctl/install-and-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and Configuring calicoctl
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.3/usage/configuration/as-service.md
+++ b/v2.3/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v2.3/usage/configuration/bgp.md
+++ b/v2.3/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v2.3/usage/configuration/conntrack.md
+++ b/v2.3/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/conntrack'
 ---
 

--- a/v2.3/usage/configuration/ip-in-ip.md
+++ b/v2.3/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip'
 ---
 

--- a/v2.3/usage/configuration/mtu.md
+++ b/v2.3/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/mtu'
 ---
 

--- a/v2.3/usage/configuration/node.md
+++ b/v2.3/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/node'
 ---
 

--- a/v2.3/usage/decommissioning-a-node.md
+++ b/v2.3/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/decommissioning-a-node'
 ---
 

--- a/v2.3/usage/external-connectivity.md
+++ b/v2.3/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v2.3/usage/index.md
+++ b/v2.3/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using Calico.

--- a/v2.3/usage/ipv6.md
+++ b/v2.3/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v2.3/usage/openstack/configuration.md
+++ b/v2.3/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
 ---
 

--- a/v2.3/usage/openstack/floating-ips.md
+++ b/v2.3/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
 ---
 

--- a/v2.3/usage/openstack/host-routes.md
+++ b/v2.3/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
 ---
 

--- a/v2.3/usage/openstack/kuryr.md
+++ b/v2.3/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
 ---
 

--- a/v2.3/usage/openstack/semantics.md
+++ b/v2.3/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
 ---
 

--- a/v2.3/usage/openstack/service-ips.md
+++ b/v2.3/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
 ---
 

--- a/v2.3/usage/routereflector/bird-rr-config.md
+++ b/v2.3/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v2.3/usage/routereflector/calico-routereflector.md
+++ b/v2.3/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/calico-routereflector'
 ---
 

--- a/v2.3/usage/troubleshooting/faq.md
+++ b/v2.3/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v2.3/usage/troubleshooting/index.md
+++ b/v2.3/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v2.3/usage/troubleshooting/logging.md
+++ b/v2.3/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v2.4/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.4/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v2.4/getting-started/bare-metal/bare-metal.md
+++ b/v2.4/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v2.4/getting-started/docker/index.md
+++ b/v2.4/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 

--- a/v2.4/getting-started/docker/installation/manual.md
+++ b/v2.4/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v2.4/getting-started/docker/installation/requirements.md
+++ b/v2.4/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/requirements'
 ---
 

--- a/v2.4/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.4/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v2.4/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.4/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v2.4/getting-started/docker/tutorials/ipam.md
+++ b/v2.4/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v2.4/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.4/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles and Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy'
 ---
 

--- a/v2.4/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.4/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles'
 ---
 

--- a/v2.4/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.4/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Docker Labels and Calico Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy'
 ---
 

--- a/v2.4/getting-started/index.md
+++ b/v2.4/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v2.4/getting-started/kubernetes/index.md
+++ b/v2.4/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/aws.md
+++ b/v2.4/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/azure.md
+++ b/v2.4/getting-started/kubernetes/installation/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/azure'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/gce.md
+++ b/v2.4/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubeadm Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Datastore
+sitemap: false 
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.

--- a/v2.4/getting-started/kubernetes/installation/index.md
+++ b/v2.4/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/integration.md
+++ b/v2.4/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/v2.4/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.4/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v2.4/getting-started/kubernetes/troubleshooting.md
+++ b/v2.4/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v2.4/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.4/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/v2.4/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.4/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v2.4/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.4/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v2.4/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.4/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/using-calicoctl'
 ---
 

--- a/v2.4/getting-started/kubernetes/upgrade.md
+++ b/v2.4/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/v2.4/getting-started/mesos/index.md
+++ b/v2.4/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v2.4/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.4/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/custom'
 ---
 

--- a/v2.4/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.4/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/framework'
 ---
 

--- a/v2.4/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.4/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.4/getting-started/mesos/installation/integration.md
+++ b/v2.4/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/integration'
 ---
 

--- a/v2.4/getting-started/mesos/installation/prerequisites.md
+++ b/v2.4/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.4/getting-started/mesos/installation/vagrant-centos/index.md
+++ b/v2.4/getting-started/mesos/installation/vagrant-centos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v2.4/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.4/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting to Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/connecting-tasks'
 ---
 

--- a/v2.4/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.4/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Launching Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/launching-tasks'
 ---
 

--- a/v2.4/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/v2.4/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Docker Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v2.4/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.4/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Universal Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v2.4/getting-started/openshift/installation.md
+++ b/v2.4/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openshift/installation'
 ---
 

--- a/v2.4/getting-started/openstack/connectivity.md
+++ b/v2.4/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v2.4/getting-started/openstack/index.md
+++ b/v2.4/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v2.4/getting-started/openstack/installation/chef.md
+++ b/v2.4/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ---
 

--- a/v2.4/getting-started/openstack/installation/devstack.md
+++ b/v2.4/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/devstack'
 ---
 

--- a/v2.4/getting-started/openstack/installation/fuel.md
+++ b/v2.4/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v2.4/getting-started/openstack/installation/index.md
+++ b/v2.4/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v2.4/getting-started/openstack/installation/juju.md
+++ b/v2.4/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v2.4/getting-started/openstack/installation/redhat.md
+++ b/v2.4/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v2.4/getting-started/openstack/installation/ubuntu.md
+++ b/v2.4/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v2.4/getting-started/openstack/neutron-api.md
+++ b/v2.4/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/v2.4/getting-started/openstack/tutorials.md
+++ b/v2.4/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v2.4/getting-started/openstack/upgrade.md
+++ b/v2.4/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v2.4/getting-started/openstack/verification.md
+++ b/v2.4/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v2.4/getting-started/rkt/index.md
+++ b/v2.4/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 

--- a/v2.4/getting-started/rkt/installation/manual.md
+++ b/v2.4/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/manual'
 ---
 

--- a/v2.4/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.4/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v2.4/getting-started/rkt/troubleshooting.md
+++ b/v2.4/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 

--- a/v2.4/getting-started/rkt/tutorials/basic.md
+++ b/v2.4/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 

--- a/v2.4/index.html
+++ b/v2.4/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v2.4/introduction/index.html
+++ b/v2.4/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v2.4/reference/advanced/etcd-rbac.md
+++ b/v2.4/reference/advanced/etcd-rbac.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Calico Role for etcdv2 RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/'
 ---
 

--- a/v2.4/reference/architecture/components.md
+++ b/v2.4/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v2.4/reference/architecture/data-path.md
+++ b/v2.4/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v2.4/reference/architecture/index.md
+++ b/v2.4/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v2.4/reference/calicoctl/commands/apply.md
+++ b/v2.4/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/v2.4/reference/calicoctl/commands/config.md
+++ b/v2.4/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v2.4/reference/calicoctl/commands/create.md
+++ b/v2.4/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/v2.4/reference/calicoctl/commands/delete.md
+++ b/v2.4/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/v2.4/reference/calicoctl/commands/get.md
+++ b/v2.4/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/v2.4/reference/calicoctl/commands/index.md
+++ b/v2.4/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/v2.4/reference/calicoctl/commands/ipam/index.md
+++ b/v2.4/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v2.4/reference/calicoctl/commands/ipam/release.md
+++ b/v2.4/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/v2.4/reference/calicoctl/commands/ipam/show.md
+++ b/v2.4/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/v2.4/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.4/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/v2.4/reference/calicoctl/commands/node/diags.md
+++ b/v2.4/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v2.4/reference/calicoctl/commands/node/index.md
+++ b/v2.4/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v2.4/reference/calicoctl/commands/node/run.md
+++ b/v2.4/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/v2.4/reference/calicoctl/commands/node/status.md
+++ b/v2.4/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v2.4/reference/calicoctl/commands/replace.md
+++ b/v2.4/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/v2.4/reference/calicoctl/commands/version.md
+++ b/v2.4/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v2.4/reference/calicoctl/index.md
+++ b/v2.4/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v2.4/reference/calicoctl/resources/bgppeer.md
+++ b/v2.4/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v2.4/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.4/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v2.4/reference/calicoctl/resources/index.md
+++ b/v2.4/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/v2.4/reference/calicoctl/resources/ippool.md
+++ b/v2.4/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v2.4/reference/calicoctl/resources/node.md
+++ b/v2.4/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/v2.4/reference/calicoctl/resources/policy.md
+++ b/v2.4/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/v2.4/reference/calicoctl/resources/profile.md
+++ b/v2.4/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v2.4/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.4/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/v2.4/reference/calicoctl/setup/etcdv2.md
+++ b/v2.4/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/v2.4/reference/calicoctl/setup/index.md
+++ b/v2.4/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/v2.4/reference/calicoctl/setup/kubernetes.md
+++ b/v2.4/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/v2.4/reference/cni-plugin/configuration.md
+++ b/v2.4/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/v2.4/reference/contribute.md
+++ b/v2.4/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.5/reference/contribute'
 ---
 

--- a/v2.4/reference/felix/configuration.md
+++ b/v2.4/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/configuration'
 ---
 

--- a/v2.4/reference/felix/prometheus.md
+++ b/v2.4/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/prometheus'
 ---
 

--- a/v2.4/reference/index.md
+++ b/v2.4/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v2.4/reference/involved.md
+++ b/v2.4/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v2.4/reference/license.md
+++ b/v2.4/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v2.4/reference/node/configuration.md
+++ b/v2.4/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/v2.4/reference/policy-controller/configuration.md
+++ b/v2.4/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/v2.4/reference/previous-releases.md
+++ b/v2.4/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v2.4/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.4/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v2.4/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.4/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v2.4/reference/public-cloud/aws.md
+++ b/v2.4/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/aws'
 ---
 

--- a/v2.4/reference/public-cloud/gce.md
+++ b/v2.4/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/gce'
 ---
 

--- a/v2.4/reference/repo-structure.md
+++ b/v2.4/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v2.4/reference/requirements.md
+++ b/v2.4/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+sitemap: false 
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v2.4/reference/supported-platforms.md
+++ b/v2.4/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v2.4/releases/index.md
+++ b/v2.4/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.4/usage/calicoctl/container.md
+++ b/v2.4/usage/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calico/ctl container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.4/usage/calicoctl/install-and-configuration.md
+++ b/v2.4/usage/calicoctl/install-and-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and Configuring calicoctl
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.4/usage/configuration/as-service.md
+++ b/v2.4/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v2.4/usage/configuration/bgp.md
+++ b/v2.4/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v2.4/usage/configuration/conntrack.md
+++ b/v2.4/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/conntrack'
 ---
 

--- a/v2.4/usage/configuration/ip-in-ip.md
+++ b/v2.4/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip'
 ---
 

--- a/v2.4/usage/configuration/mtu.md
+++ b/v2.4/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/mtu'
 ---
 

--- a/v2.4/usage/configuration/node.md
+++ b/v2.4/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/node'
 ---
 

--- a/v2.4/usage/decommissioning-a-node.md
+++ b/v2.4/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/decommissioning-a-node'
 ---
 

--- a/v2.4/usage/external-connectivity.md
+++ b/v2.4/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v2.4/usage/index.md
+++ b/v2.4/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using Calico.

--- a/v2.4/usage/ipv6.md
+++ b/v2.4/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v2.4/usage/openstack/configuration.md
+++ b/v2.4/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
 ---
 

--- a/v2.4/usage/openstack/floating-ips.md
+++ b/v2.4/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
 ---
 

--- a/v2.4/usage/openstack/host-routes.md
+++ b/v2.4/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
 ---
 

--- a/v2.4/usage/openstack/kuryr.md
+++ b/v2.4/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
 ---
 

--- a/v2.4/usage/openstack/semantics.md
+++ b/v2.4/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
 ---
 

--- a/v2.4/usage/openstack/service-ips.md
+++ b/v2.4/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
 ---
 

--- a/v2.4/usage/routereflector/bird-rr-config.md
+++ b/v2.4/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v2.4/usage/routereflector/calico-routereflector.md
+++ b/v2.4/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/calico-routereflector'
 ---
 

--- a/v2.4/usage/troubleshooting/faq.md
+++ b/v2.4/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v2.4/usage/troubleshooting/index.md
+++ b/v2.4/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v2.4/usage/troubleshooting/logging.md
+++ b/v2.4/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v2.5/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.5/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal-install'
 ---
 

--- a/v2.5/getting-started/bare-metal/bare-metal.md
+++ b/v2.5/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v2.5/getting-started/docker/index.md
+++ b/v2.5/getting-started/docker/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/'
 ---
 

--- a/v2.5/getting-started/docker/installation/manual.md
+++ b/v2.5/getting-started/docker/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for Docker
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/manual'
 ---
 

--- a/v2.5/getting-started/docker/installation/requirements.md
+++ b/v2.5/getting-started/docker/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title:  Requirements
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/requirements'
 ---
 

--- a/v2.5/getting-started/docker/installation/vagrant-coreos/index.md
+++ b/v2.5/getting-started/docker/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-coreos/'
 ---
 

--- a/v2.5/getting-started/docker/installation/vagrant-ubuntu/index.md
+++ b/v2.5/getting-started/docker/installation/vagrant-ubuntu/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/installation/vagrant-ubuntu/'
 ---
 

--- a/v2.5/getting-started/docker/tutorials/ipam.md
+++ b/v2.5/getting-started/docker/tutorials/ipam.md
@@ -1,5 +1,6 @@
 ---
 title: IPAM
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/ipam'
 ---
 

--- a/v2.5/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
+++ b/v2.5/getting-started/docker/tutorials/security-using-calico-profiles-and-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles and Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles-and-policy'
 ---
 

--- a/v2.5/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.5/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Calico Profiles
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-calico-profiles'
 ---
 

--- a/v2.5/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.5/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Security using Docker Labels and Calico Policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy'
 ---
 

--- a/v2.5/getting-started/index.md
+++ b/v2.5/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v2.5/getting-started/kubernetes/index.md
+++ b/v2.5/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/aws.md
+++ b/v2.5/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/azure.md
+++ b/v2.5/getting-started/kubernetes/installation/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/azure'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/gce.md
+++ b/v2.5/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.5/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/hosted'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.5/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.5/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.5/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubeadm Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubeadm/'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.5/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Datastore
+sitemap: false 
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.

--- a/v2.5/getting-started/kubernetes/installation/index.md
+++ b/v2.5/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/integration.md
+++ b/v2.5/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/v2.5/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.5/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/vagrant/'
 ---
 

--- a/v2.5/getting-started/kubernetes/troubleshooting.md
+++ b/v2.5/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v2.5/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.5/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Going Beyond `NetworkPolicy` with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/v2.5/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.5/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v2.5/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.5/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v2.5/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.5/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/using-calicoctl'
 ---
 

--- a/v2.5/getting-started/kubernetes/upgrade.md
+++ b/v2.5/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/v2.5/getting-started/mesos/index.md
+++ b/v2.5/getting-started/mesos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/'
 ---
 

--- a/v2.5/getting-started/mesos/installation/dc-os/custom.md
+++ b/v2.5/getting-started/mesos/installation/dc-os/custom.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the Calico Universe Framework
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/custom'
 ---
 

--- a/v2.5/getting-started/mesos/installation/dc-os/framework.md
+++ b/v2.5/getting-started/mesos/installation/dc-os/framework.md
@@ -1,5 +1,6 @@
 ---
 title: Calico DC/OS Installation Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/framework'
 ---
 

--- a/v2.5/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.5/getting-started/mesos/installation/dc-os/index.md
@@ -1,5 +1,6 @@
 ---
 title: Overview of Calico for DC/OS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.5/getting-started/mesos/installation/integration.md
+++ b/v2.5/getting-started/mesos/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/integration'
 ---
 

--- a/v2.5/getting-started/mesos/installation/prerequisites.md
+++ b/v2.5/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for Calico with Mesos
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 

--- a/v2.5/getting-started/mesos/installation/vagrant-centos/index.md
+++ b/v2.5/getting-started/mesos/installation/vagrant-centos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Vagrant Deployed Mesos Cluster with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/vagrant-centos/'
 ---
 This guide will show you how to use Vagrant to launch a Mesos Cluster

--- a/v2.5/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.5/getting-started/mesos/tutorials/connecting-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting to Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/connecting-tasks'
 ---
 

--- a/v2.5/getting-started/mesos/tutorials/launching-tasks.md
+++ b/v2.5/getting-started/mesos/tutorials/launching-tasks.md
@@ -1,5 +1,6 @@
 ---
 title: Launching Tasks
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/launching-tasks'
 ---
 

--- a/v2.5/getting-started/mesos/tutorials/policy/docker-containerizer.md
+++ b/v2.5/getting-started/mesos/tutorials/policy/docker-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Docker Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/docker-containerizer'
 ---
 

--- a/v2.5/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.5/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy (Universal Containerizer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer'
 ---
 

--- a/v2.5/getting-started/openshift/installation.md
+++ b/v2.5/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openshift/installation'
 ---
 

--- a/v2.5/getting-started/openstack/connectivity.md
+++ b/v2.5/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v2.5/getting-started/openstack/index.md
+++ b/v2.5/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v2.5/getting-started/openstack/installation/chef.md
+++ b/v2.5/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ---
 

--- a/v2.5/getting-started/openstack/installation/devstack.md
+++ b/v2.5/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/devstack'
 ---
 

--- a/v2.5/getting-started/openstack/installation/fuel.md
+++ b/v2.5/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v2.5/getting-started/openstack/installation/index.md
+++ b/v2.5/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v2.5/getting-started/openstack/installation/juju.md
+++ b/v2.5/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v2.5/getting-started/openstack/installation/redhat.md
+++ b/v2.5/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux 7 Packaged Install Instructions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v2.5/getting-started/openstack/installation/ubuntu.md
+++ b/v2.5/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v2.5/getting-started/openstack/neutron-api.md
+++ b/v2.5/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/v2.5/getting-started/openstack/tutorials.md
+++ b/v2.5/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v2.5/getting-started/openstack/upgrade.md
+++ b/v2.5/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v2.5/getting-started/openstack/verification.md
+++ b/v2.5/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v2.5/getting-started/rkt/index.md
+++ b/v2.5/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 

--- a/v2.5/getting-started/rkt/installation/manual.md
+++ b/v2.5/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/manual'
 ---
 

--- a/v2.5/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.5/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/installation/vagrant-coreos/'
 ---
 

--- a/v2.5/getting-started/rkt/troubleshooting.md
+++ b/v2.5/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/troubleshooting'
 ---
 

--- a/v2.5/getting-started/rkt/tutorials/basic.md
+++ b/v2.5/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/tutorials/basic'
 ---
 

--- a/v2.5/index.html
+++ b/v2.5/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v2.5/introduction/index.html
+++ b/v2.5/introduction/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'

--- a/v2.5/reference/advanced/etcd-rbac/calico-etcdv2-paths.md
+++ b/v2.5/reference/advanced/etcd-rbac/calico-etcdv2-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v2
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/calico-etcdv3-paths'
 ---
 

--- a/v2.5/reference/advanced/etcd-rbac/certificate-generation.md
+++ b/v2.5/reference/advanced/etcd-rbac/certificate-generation.md
@@ -1,5 +1,6 @@
 ---
 title: Generating Certificates for etcd RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/certificate-generation'
 ---
 

--- a/v2.5/reference/advanced/etcd-rbac/index.md
+++ b/v2.5/reference/advanced/etcd-rbac/index.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up etcd certificates for RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/'
 ---
 

--- a/v2.5/reference/advanced/etcd-rbac/kubernetes-advanced.md
+++ b/v2.5/reference/advanced/etcd-rbac/kubernetes-advanced.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced etcd segmentation for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/kubernetes-advanced'
 ---
 

--- a/v2.5/reference/advanced/etcd-rbac/kubernetes.md
+++ b/v2.5/reference/advanced/etcd-rbac/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Using etcd RBAC to segment Kubernetes and Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/kubernetes'
 ---
 

--- a/v2.5/reference/advanced/etcd-rbac/users-and-roles.md
+++ b/v2.5/reference/advanced/etcd-rbac/users-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Creating Users and Roles in etcd
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/users-and-roles'
 ---
 

--- a/v2.5/reference/architecture/components.md
+++ b/v2.5/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v2.5/reference/architecture/data-path.md
+++ b/v2.5/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v2.5/reference/architecture/index.md
+++ b/v2.5/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v2.5/reference/calicoctl/commands/apply.md
+++ b/v2.5/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/v2.5/reference/calicoctl/commands/config.md
+++ b/v2.5/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/calicoctl/commands/config'
 ---
 

--- a/v2.5/reference/calicoctl/commands/create.md
+++ b/v2.5/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/v2.5/reference/calicoctl/commands/delete.md
+++ b/v2.5/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/v2.5/reference/calicoctl/commands/get.md
+++ b/v2.5/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/v2.5/reference/calicoctl/commands/index.md
+++ b/v2.5/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/v2.5/reference/calicoctl/commands/ipam/index.md
+++ b/v2.5/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v2.5/reference/calicoctl/commands/ipam/release.md
+++ b/v2.5/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/v2.5/reference/calicoctl/commands/ipam/show.md
+++ b/v2.5/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/v2.5/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.5/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/v2.5/reference/calicoctl/commands/node/diags.md
+++ b/v2.5/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v2.5/reference/calicoctl/commands/node/index.md
+++ b/v2.5/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v2.5/reference/calicoctl/commands/node/run.md
+++ b/v2.5/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/v2.5/reference/calicoctl/commands/node/status.md
+++ b/v2.5/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v2.5/reference/calicoctl/commands/replace.md
+++ b/v2.5/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/v2.5/reference/calicoctl/commands/version.md
+++ b/v2.5/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v2.5/reference/calicoctl/index.md
+++ b/v2.5/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v2.5/reference/calicoctl/resources/bgppeer.md
+++ b/v2.5/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v2.5/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.5/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v2.5/reference/calicoctl/resources/index.md
+++ b/v2.5/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/v2.5/reference/calicoctl/resources/ippool.md
+++ b/v2.5/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v2.5/reference/calicoctl/resources/node.md
+++ b/v2.5/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/v2.5/reference/calicoctl/resources/policy.md
+++ b/v2.5/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/v2.5/reference/calicoctl/resources/profile.md
+++ b/v2.5/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v2.5/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.5/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/v2.5/reference/calicoctl/setup/etcdv2.md
+++ b/v2.5/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/v2.5/reference/calicoctl/setup/index.md
+++ b/v2.5/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/v2.5/reference/calicoctl/setup/kubernetes.md
+++ b/v2.5/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/v2.5/reference/cni-plugin/configuration.md
+++ b/v2.5/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/v2.5/reference/contribute.md
+++ b/v2.5/reference/contribute.md
@@ -1,5 +1,6 @@
 ---
 title: Contribution Guidelines
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.5/reference/contribute'
 ---
 

--- a/v2.5/reference/felix/configuration.md
+++ b/v2.5/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/configuration'
 ---
 

--- a/v2.5/reference/felix/prometheus.md
+++ b/v2.5/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/prometheus'
 ---
 

--- a/v2.5/reference/index.md
+++ b/v2.5/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v2.5/reference/involved.md
+++ b/v2.5/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v2.5/reference/license.md
+++ b/v2.5/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v2.5/reference/node/configuration.md
+++ b/v2.5/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/v2.5/reference/policy-controller/configuration.md
+++ b/v2.5/reference/policy-controller/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico policy controller
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/v2.5/reference/previous-releases.md
+++ b/v2.5/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v2.5/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.5/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v2.5/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.5/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v2.5/reference/public-cloud/aws.md
+++ b/v2.5/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/aws'
 ---
 

--- a/v2.5/reference/public-cloud/gce.md
+++ b/v2.5/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/gce'
 ---
 

--- a/v2.5/reference/repo-structure.md
+++ b/v2.5/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v2.5/reference/requirements.md
+++ b/v2.5/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+sitemap: false 
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v2.5/reference/supported-platforms.md
+++ b/v2.5/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/reference/supported-platforms'
 ---
 

--- a/v2.5/releases/index.md
+++ b/v2.5/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.5/usage/calicoctl/container.md
+++ b/v2.5/usage/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calico/ctl container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.5/usage/calicoctl/install-and-configuration.md
+++ b/v2.5/usage/calicoctl/install-and-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and Configuring calicoctl
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.5/usage/configuration/as-service.md
+++ b/v2.5/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v2.5/usage/configuration/bgp.md
+++ b/v2.5/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v2.5/usage/configuration/conntrack.md
+++ b/v2.5/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/conntrack'
 ---
 

--- a/v2.5/usage/configuration/ip-in-ip.md
+++ b/v2.5/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip'
 ---
 

--- a/v2.5/usage/configuration/mtu.md
+++ b/v2.5/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/mtu'
 ---
 

--- a/v2.5/usage/configuration/node.md
+++ b/v2.5/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/node'
 ---
 

--- a/v2.5/usage/decommissioning-a-node.md
+++ b/v2.5/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/decommissioning-a-node'
 ---
 

--- a/v2.5/usage/external-connectivity.md
+++ b/v2.5/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v2.5/usage/index.md
+++ b/v2.5/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using Calico.

--- a/v2.5/usage/ipv6.md
+++ b/v2.5/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v2.5/usage/openstack/configuration.md
+++ b/v2.5/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
 ---
 

--- a/v2.5/usage/openstack/floating-ips.md
+++ b/v2.5/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
 ---
 

--- a/v2.5/usage/openstack/host-routes.md
+++ b/v2.5/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
 ---
 

--- a/v2.5/usage/openstack/kuryr.md
+++ b/v2.5/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
 ---
 

--- a/v2.5/usage/openstack/semantics.md
+++ b/v2.5/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
 ---
 

--- a/v2.5/usage/openstack/service-ips.md
+++ b/v2.5/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
 ---
 

--- a/v2.5/usage/routereflector/bird-rr-config.md
+++ b/v2.5/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v2.5/usage/routereflector/calico-routereflector.md
+++ b/v2.5/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/calico-routereflector'
 ---
 

--- a/v2.5/usage/troubleshooting/faq.md
+++ b/v2.5/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v2.5/usage/troubleshooting/index.md
+++ b/v2.5/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v2.5/usage/troubleshooting/logging.md
+++ b/v2.5/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v2.6/getting-started/bare-metal/bare-metal-install.md
+++ b/v2.6/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/installation'
 ---
 

--- a/v2.6/getting-started/bare-metal/bare-metal.md
+++ b/v2.6/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal'
 ---
 

--- a/v2.6/getting-started/docker/installation/requirements.md
+++ b/v2.6/getting-started/docker/installation/requirements.md
@@ -30,7 +30,7 @@ also [configure the Docker daemon][daemon-cert-config] with the correct
 certificates to allow access.
 
 > **Note**: For Docker 1.10+, you can use the [daemon configuration file][daemon-config-file],
-> or for 1.9 see the appropriate 'Configuring Docker' section in 
+> or for 1.9 see the appropriate 'Configuring Docker' section in
 > [configuring docker][configuring-docker-1.9].
 {: .alert .alert-info}
 

--- a/v2.6/getting-started/docker/tutorials/security-using-calico-profiles.md
+++ b/v2.6/getting-started/docker/tutorials/security-using-calico-profiles.md
@@ -38,8 +38,8 @@ To create the networks, run the following commands on one of the hosts:
     docker network create --driver calico --ipam-driver calico-ipam net2
     docker network create --driver calico --ipam-driver calico-ipam net3
 
-> **Note**: To allocate from a specific Calico IP Pool, the 
-> `--subnet a.b.c.d/xx` command can be passed to `docker network create`. 
+> **Note**: To allocate from a specific Calico IP Pool, the
+> `--subnet a.b.c.d/xx` command can be passed to `docker network create`.
 > For more details see below.
 {: .alert .alert-info}
 

--- a/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
+++ b/v2.6/getting-started/docker/tutorials/security-using-docker-labels-and-calico-policy.md
@@ -16,7 +16,7 @@ powerful way to group together all of your network Policy, makes it easy to
 reuse policy in different networks, and makes it easier to define policy that
 extends across different orchestration systems that use Calico.
 
-When Calico is configured to use container labels, profiles are not created and 
+When Calico is configured to use container labels, profiles are not created and
 have no impact on any container traffic.
 
 ## Enabling Docker Networking Container Labels Policy
@@ -170,7 +170,7 @@ One approach for doing this is as follows:
 -  Define global policy "backupnetwork" that allows full access between all
    components with the  `backup = true` label.
 
-For your database containers that also need to be able to access the backup 
+For your database containers that also need to be able to access the backup
 endpoints, launch them assigning both the `role = database` and `backup = true`
 labels.
 

--- a/v2.6/getting-started/index.md
+++ b/v2.6/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/'
 ---
 

--- a/v2.6/getting-started/kubernetes/index.md
+++ b/v2.6/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart for Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/'
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/aws.md
+++ b/v2.6/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws'
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/azure.md
+++ b/v2.6/getting-started/kubernetes/installation/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/azure'
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/gce.md
+++ b/v2.6/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce'
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/hosted/canal/index.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/canal/index.md
@@ -1,5 +1,6 @@
 ---
 title: Canal/flannel Hosted Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/canal/'
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/hosted/index.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 ---
 
 Calico can be installed on a Kubernetes cluster with a single command.

--- a/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: kubeadm Hosted Install
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v2.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Datastore
+sitemap: false 
 ---
 
 This document describes how to install Calico on Kubernetes in a mode that does not require access to an etcd cluster.

--- a/v2.6/getting-started/kubernetes/installation/index.md
+++ b/v2.6/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/'
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/integration.md
+++ b/v2.6/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration'
 ---
 

--- a/v2.6/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v2.6/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/vagrant/
 ---
 

--- a/v2.6/getting-started/kubernetes/troubleshooting.md
+++ b/v2.6/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting'
 ---
 

--- a/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Controlling ingress and egress traffic with network policy
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy'
 ---
 

--- a/v2.6/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v2.6/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy'
 ---
 

--- a/v2.6/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v2.6/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v2.6/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v2.6/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/using-calicoctl'
 ---
 

--- a/v2.6/getting-started/kubernetes/upgrade.md
+++ b/v2.6/getting-started/kubernetes/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/'
 ---
 

--- a/v2.6/getting-started/mesos/installation/dc-os/index.md
+++ b/v2.6/getting-started/mesos/installation/dc-os/index.md
@@ -109,7 +109,7 @@ be restarted to pick up the change. The Framework then performs the following st
        }
    }
    ```
-   
+
    > **Note**: If not running etcd in proxy mode, be sure to change `etcd_endpoints`
    to your correct etcd endpoint address.
    {: .alert .alert-info}

--- a/v2.6/getting-started/mesos/installation/prerequisites.md
+++ b/v2.6/getting-started/mesos/installation/prerequisites.md
@@ -1,5 +1,5 @@
 ---
-title: Requirements for Calico with Mesos
+title: Requirements for Calico with Mesos 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/mesos/installation/dc-os/'
 ---
 
@@ -44,7 +44,7 @@ as Calico by setting the following flag when starting the docker daemon:
 --cluster-store=etcd://$ETCD_IP:$ETCD_PORT
 ```
 
-> **Note**: Set or replace `$ETCD_IP` and `$ETCD_PORT` with the appropriate 
+> **Note**: Set or replace `$ETCD_IP` and `$ETCD_PORT` with the appropriate
 > address of your etcd cluster.
 {: .alert .alert-info}
 
@@ -61,7 +61,7 @@ Cluster Store: etcd://10.0.0.1:2379
 By default, Mesos only enables the "Mesos" Containerizer. Ensure
 the Docker Containerizer is also enabled on each Agent.
 
-> **Note**: You may skip this step if you do not plan on using the Docker 
+> **Note**: You may skip this step if you do not plan on using the Docker
 > Containerizer.
 {: .alert .alert-info}
 
@@ -79,7 +79,7 @@ $ systemctl restart mesos-slave.service
 If you are planning to use Calico with the Unified containerizer,
 [enable the CNI Isolator on each agent](http://mesos.apache.org/documentation/latest/cni/#usage)
 
-> **Note**: You may skip this step if you do not plan on using the 
+> **Note**: You may skip this step if you do not plan on using the
 > Unified Containerizer.
 {: .alert .alert-info}
 

--- a/v2.6/getting-started/mesos/tutorials/connecting-tasks.md
+++ b/v2.6/getting-started/mesos/tutorials/connecting-tasks.md
@@ -12,8 +12,8 @@ service discovery solutions available for Mesos.
 
 ### Mesos-DNS
 
-> **Important**: Modifying Mesos-DNS **in DC/OS** may break components 
-> which rely on Mesos-DNS resolving to Agent IPs. It is instead 
+> **Important**: Modifying Mesos-DNS **in DC/OS** may break components
+> which rely on Mesos-DNS resolving to Agent IPs. It is instead
 > recommended to use Navstar DNS entries.
 > Skip ahead for information on how to use this alternative DNS service.
 {: .alert .alert-danger}

--- a/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer.md
+++ b/v2.6/getting-started/mesos/tutorials/policy/universal-containerizer.md
@@ -12,10 +12,10 @@ This document will demonstrate how to manipulate policy for Calico using
 To demonstrate this, we will use Marathon to launch an nginx webserver using the Universal Containerizer.
 Then, we will launch basic curl task which will repeatedly curl the webserver.
 
-> **Note**: This example assumes you are running in a DC/OS environment 
-> since it uses the DC/OS DNS to access the web server. It is easy enough 
+> **Note**: This example assumes you are running in a DC/OS environment
+> since it uses the DC/OS DNS to access the web server. It is easy enough
 > to adjust this demo for non-DC/OS environments by replacing the
-> `webserver.marathon.containerip.dcos.thisdcos.directory` DNS name with 
+> `webserver.marathon.containerip.dcos.thisdcos.directory` DNS name with
 > the IP address of the web server container.
 {: .alert .alert-info}
 
@@ -96,7 +96,7 @@ calicoctl apply -f - <<EOF
 EOF
 ```
 
-> **Note**: You'll need `calicoctl` configured to access your central etcd datastore. 
+> **Note**: You'll need `calicoctl` configured to access your central etcd datastore.
 > See [help]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup/etcdv2).
 {: .alert .alert-info}
 

--- a/v2.6/getting-started/openshift/installation.md
+++ b/v2.6/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openshift/installation'
 ---
 

--- a/v2.6/getting-started/openstack/connectivity.md
+++ b/v2.6/getting-started/openstack/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Connectivity in OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/connectivity'
 ---
 

--- a/v2.6/getting-started/openstack/index.md
+++ b/v2.6/getting-started/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico for OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/'
 ---
 

--- a/v2.6/getting-started/openstack/installation/chef.md
+++ b/v2.6/getting-started/openstack/installation/chef.md
@@ -1,5 +1,6 @@
 ---
 title: Chef Trial Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/chef'
 ---
 

--- a/v2.6/getting-started/openstack/installation/devstack.md
+++ b/v2.6/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack plugin for Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/devstack'
 ---
 

--- a/v2.6/getting-started/openstack/installation/fuel.md
+++ b/v2.6/getting-started/openstack/installation/fuel.md
@@ -1,5 +1,6 @@
 ---
 title: Integration with Fuel
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/fuel'
 ---
 

--- a/v2.6/getting-started/openstack/installation/index.md
+++ b/v2.6/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with OpenStack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/'
 ---
 

--- a/v2.6/getting-started/openstack/installation/juju.md
+++ b/v2.6/getting-started/openstack/installation/juju.md
@@ -1,5 +1,6 @@
 ---
 title: Juju Install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/openstack/installation/juju'
 ---
 

--- a/v2.6/getting-started/openstack/installation/redhat.md
+++ b/v2.6/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux packaged install
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/redhat'
 ---
 

--- a/v2.6/getting-started/openstack/installation/ubuntu.md
+++ b/v2.6/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Packaged Install Instructions'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/v2.6/getting-started/openstack/neutron-api.md
+++ b/v2.6/getting-started/openstack/neutron-api.md
@@ -1,5 +1,6 @@
 ---
 title: How Calico Interprets Neutron API Calls
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/neutron-api'
 ---
 

--- a/v2.6/getting-started/openstack/tutorials.md
+++ b/v2.6/getting-started/openstack/tutorials.md
@@ -1,5 +1,6 @@
 ---
 title: 'Worked Examples: Using Calico-based OpenStack'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/tutorials'
 ---
 

--- a/v2.6/getting-started/openstack/upgrade.md
+++ b/v2.6/getting-started/openstack/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: 'Upgrade Procedure (OpenStack)'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/upgrade/'
 ---
 

--- a/v2.6/getting-started/openstack/verification.md
+++ b/v2.6/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your Calico on OpenStack deployment
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/openstack/verification'
 ---
 

--- a/v2.6/getting-started/rkt/index.md
+++ b/v2.6/getting-started/rkt/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico with rkt
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/getting-started/rkt/'
 ---
 

--- a/v2.6/getting-started/rkt/installation/manual.md
+++ b/v2.6/getting-started/rkt/installation/manual.md
@@ -1,5 +1,6 @@
 ---
 title:  Manual Installation of Calico with rkt
+sitemap: false 
 ---
 
 This tutorial describes how to manually configure a working environment for

--- a/v2.6/getting-started/rkt/installation/vagrant-coreos/index.md
+++ b/v2.6/getting-started/rkt/installation/vagrant-coreos/index.md
@@ -1,5 +1,6 @@
 ---
 title: Running the Calico rkt tutorials on CoreOS Container Linux using Vagrant and VirtualBox
+sitemap: false 
 ---
 
 This is a Quick Start guide that uses Vagrant and VirtualBox to create a two-node

--- a/v2.6/getting-started/rkt/troubleshooting.md
+++ b/v2.6/getting-started/rkt/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for rkt
+sitemap: false 
 ---
 
 This article contains rkt specific troubleshooting advice for Calico and 

--- a/v2.6/getting-started/rkt/tutorials/basic.md
+++ b/v2.6/getting-started/rkt/tutorials/basic.md
@@ -1,5 +1,6 @@
 ---
 title: Basic Network Isolation
+sitemap: false 
 ---
 
 This guide provides a simple way to try out rkt network isolation with Calico.

--- a/v2.6/index.html
+++ b/v2.6/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 description: Home
 layout: docwithnav
 ---

--- a/v2.6/introduction/index.md
+++ b/v2.6/introduction/index.md
@@ -1,5 +1,6 @@
 ---
 title: About Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/introduction/'
 ---
 

--- a/v2.6/reference/advanced/etcd-rbac/calico-etcdv2-paths.md
+++ b/v2.6/reference/advanced/etcd-rbac/calico-etcdv2-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v2
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/calico-etcdv3-paths'
 ---
 

--- a/v2.6/reference/advanced/etcd-rbac/certificate-generation.md
+++ b/v2.6/reference/advanced/etcd-rbac/certificate-generation.md
@@ -1,5 +1,6 @@
 ---
 title: Generating Certificates for etcd RBAC
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/certificate-generation'
 ---
 

--- a/v2.6/reference/advanced/etcd-rbac/index.md
+++ b/v2.6/reference/advanced/etcd-rbac/index.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up etcd certificates for RBAC
+sitemap: false 
 ---
 
 When using etcd it is a good idea to protect the data stored there.  This is

--- a/v2.6/reference/advanced/etcd-rbac/kubernetes-advanced.md
+++ b/v2.6/reference/advanced/etcd-rbac/kubernetes-advanced.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced etcd segmentation for Calico
+sitemap: false 
 ---
 
 This document describes advanced segmentation of the etcd roles to limit

--- a/v2.6/reference/advanced/etcd-rbac/kubernetes.md
+++ b/v2.6/reference/advanced/etcd-rbac/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Using etcd RBAC to segment Kubernetes and Calico
+sitemap: false 
 ---
 
 When using etcd with RBAC, all components that access etcd must be configured

--- a/v2.6/reference/advanced/etcd-rbac/users-and-roles.md
+++ b/v2.6/reference/advanced/etcd-rbac/users-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Creating Users and Roles in etcd
+sitemap: false 
 ---
 
 Providing role based access control within etcd requires the following:

--- a/v2.6/reference/architecture/components.md
+++ b/v2.6/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/components'
 ---
 

--- a/v2.6/reference/architecture/data-path.md
+++ b/v2.6/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/data-path'
 ---
 

--- a/v2.6/reference/architecture/index.md
+++ b/v2.6/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/architecture/'
 ---
 

--- a/v2.6/reference/calicoctl/commands/apply.md
+++ b/v2.6/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply'
 ---
 

--- a/v2.6/reference/calicoctl/commands/config.md
+++ b/v2.6/reference/calicoctl/commands/config.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl config
+sitemap: false 
 ---
 
 This sections describes the `calicoctl config` commands.

--- a/v2.6/reference/calicoctl/commands/create.md
+++ b/v2.6/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create'
 ---
 

--- a/v2.6/reference/calicoctl/commands/delete.md
+++ b/v2.6/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete'
 ---
 

--- a/v2.6/reference/calicoctl/commands/get.md
+++ b/v2.6/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get'
 ---
 

--- a/v2.6/reference/calicoctl/commands/index.md
+++ b/v2.6/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/'
 ---
 

--- a/v2.6/reference/calicoctl/commands/ipam/index.md
+++ b/v2.6/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/'
 ---
 

--- a/v2.6/reference/calicoctl/commands/ipam/release.md
+++ b/v2.6/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release'
 ---
 

--- a/v2.6/reference/calicoctl/commands/ipam/show.md
+++ b/v2.6/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show'
 ---
 

--- a/v2.6/reference/calicoctl/commands/node/checksystem.md
+++ b/v2.6/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem'
 ---
 

--- a/v2.6/reference/calicoctl/commands/node/diags.md
+++ b/v2.6/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags'
 ---
 

--- a/v2.6/reference/calicoctl/commands/node/index.md
+++ b/v2.6/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/'
 ---
 

--- a/v2.6/reference/calicoctl/commands/node/run.md
+++ b/v2.6/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run'
 ---
 

--- a/v2.6/reference/calicoctl/commands/node/status.md
+++ b/v2.6/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status'
 ---
 

--- a/v2.6/reference/calicoctl/commands/replace.md
+++ b/v2.6/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace'
 ---
 

--- a/v2.6/reference/calicoctl/commands/version.md
+++ b/v2.6/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version'
 ---
 

--- a/v2.6/reference/calicoctl/index.md
+++ b/v2.6/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/'
 ---
 

--- a/v2.6/reference/calicoctl/resources/bgppeer.md
+++ b/v2.6/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (bgpPeer)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer'
 ---
 

--- a/v2.6/reference/calicoctl/resources/hostendpoint.md
+++ b/v2.6/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (hostEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint'
 ---
 

--- a/v2.6/reference/calicoctl/resources/index.md
+++ b/v2.6/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/'
 ---
 

--- a/v2.6/reference/calicoctl/resources/ippool.md
+++ b/v2.6/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (ipPool)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool'
 ---
 

--- a/v2.6/reference/calicoctl/resources/node.md
+++ b/v2.6/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (node)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node'
 ---
 

--- a/v2.6/reference/calicoctl/resources/policy.md
+++ b/v2.6/reference/calicoctl/resources/policy.md
@@ -1,5 +1,6 @@
 ---
 title: Policy Resource (policy)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy'
 ---
 

--- a/v2.6/reference/calicoctl/resources/profile.md
+++ b/v2.6/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (profile)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile'
 ---
 

--- a/v2.6/reference/calicoctl/resources/workloadendpoint.md
+++ b/v2.6/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (workloadEndpoint)
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint'
 ---
 

--- a/v2.6/reference/calicoctl/setup/etcdv2.md
+++ b/v2.6/reference/calicoctl/setup/etcdv2.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - etcdv2 datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd'
 ---
 

--- a/v2.6/reference/calicoctl/setup/index.md
+++ b/v2.6/reference/calicoctl/setup/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calicoctl Configuration Overview 
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/'
 ---
 

--- a/v2.6/reference/calicoctl/setup/kubernetes.md
+++ b/v2.6/reference/calicoctl/setup/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl - Kubernetes datastore
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd'
 ---
 

--- a/v2.6/reference/cni-plugin/configuration.md
+++ b/v2.6/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration'
 ---
 

--- a/v2.6/reference/felix/configuration.md
+++ b/v2.6/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/configuration'
 ---
 

--- a/v2.6/reference/felix/prometheus.md
+++ b/v2.6/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/felix/prometheus'
 ---
 

--- a/v2.6/reference/index.md
+++ b/v2.6/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 noversion: yes
 ---
 

--- a/v2.6/reference/involved.md
+++ b/v2.6/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/involved'
 ---
 

--- a/v2.6/reference/kube-controllers/configuration.md
+++ b/v2.6/reference/kube-controllers/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico Kubernetes controllers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration'
 ---
 

--- a/v2.6/reference/license.md
+++ b/v2.6/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/license'
 ---
 

--- a/v2.6/reference/node/configuration.md
+++ b/v2.6/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/node/configuration'
 ---
 

--- a/v2.6/reference/previous-releases.md
+++ b/v2.6/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 ---
 
 

--- a/v2.6/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v2.6/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric'
 ---
 

--- a/v2.6/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v2.6/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 lead_text: 'Where large-scale IP networks and hardware collide'
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric'
 ---

--- a/v2.6/reference/public-cloud/aws.md
+++ b/v2.6/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/aws'
 ---
 

--- a/v2.6/reference/public-cloud/gce.md
+++ b/v2.6/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/public-cloud/gce'
 ---
 

--- a/v2.6/reference/repo-structure.md
+++ b/v2.6/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/reference/repo-structure'
 ---
 

--- a/v2.6/reference/requirements.md
+++ b/v2.6/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+sitemap: false 
 ---
 
 Depending on the Calico functionality you are using, there are some requirements your system needs to meet in order for Calico to work properly.

--- a/v2.6/reference/supported-platforms.md
+++ b/v2.6/reference/supported-platforms.md
@@ -1,5 +1,6 @@
 ---
 title: Supported Platforms
+sitemap: false 
 ---
 
 Calico version {{ page.version }} has supported integration with the following platforms.

--- a/v2.6/releases/index.md
+++ b/v2.6/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 ---
 
 The following table shows component versioning for Calico  **{{ page.version }}**.

--- a/v2.6/usage/calicoctl/container.md
+++ b/v2.6/usage/calicoctl/container.md
@@ -1,5 +1,6 @@
 ---
 title: calico/ctl container
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.6/usage/calicoctl/install-and-configuration.md
+++ b/v2.6/usage/calicoctl/install-and-configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and Configuring calicoctl
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/calicoctl/install'
 ---
 

--- a/v2.6/usage/configuration/as-service.md
+++ b/v2.6/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running Calico Node Container as a Service
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/as-service'
 ---
 

--- a/v2.6/usage/configuration/bgp.md
+++ b/v2.6/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/bgp'
 ---
 

--- a/v2.6/usage/configuration/conntrack.md
+++ b/v2.6/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/conntrack'
 ---
 

--- a/v2.6/usage/configuration/ip-in-ip.md
+++ b/v2.6/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip'
 ---
 

--- a/v2.6/usage/configuration/mtu.md
+++ b/v2.6/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/mtu'
 ---
 

--- a/v2.6/usage/configuration/node.md
+++ b/v2.6/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/configuration/node'
 ---
 

--- a/v2.6/usage/decommissioning-a-node.md
+++ b/v2.6/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/decommissioning-a-node'
 ---
 

--- a/v2.6/usage/external-connectivity.md
+++ b/v2.6/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/external-connectivity'
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v2.6/usage/index.md
+++ b/v2.6/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 ---
 
 This section contains information on using Calico.

--- a/v2.6/usage/ipv6.md
+++ b/v2.6/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/ipv6'
 ---
 

--- a/v2.6/usage/openstack/configuration.md
+++ b/v2.6/usage/openstack/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
 ---
 

--- a/v2.6/usage/openstack/floating-ips.md
+++ b/v2.6/usage/openstack/floating-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Floating IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
 ---
 

--- a/v2.6/usage/openstack/host-routes.md
+++ b/v2.6/usage/openstack/host-routes.md
@@ -1,5 +1,6 @@
 ---
 title: Host routes
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
 ---
 

--- a/v2.6/usage/openstack/kuryr.md
+++ b/v2.6/usage/openstack/kuryr.md
@@ -1,5 +1,6 @@
 ---
 title: Kuryr
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
 ---
 

--- a/v2.6/usage/openstack/semantics.md
+++ b/v2.6/usage/openstack/semantics.md
@@ -1,5 +1,6 @@
 ---
 title: Detailed Semantics
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
 ---
 

--- a/v2.6/usage/openstack/service-ips.md
+++ b/v2.6/usage/openstack/service-ips.md
@@ -1,5 +1,6 @@
 ---
 title: Service IPs
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
 ---
 

--- a/v2.6/usage/routereflector/bird-rr-config.md
+++ b/v2.6/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: 'Configuring BIRD as a BGP Route Reflector'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config'
 ---
 

--- a/v2.6/usage/routereflector/calico-routereflector.md
+++ b/v2.6/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/routereflector/calico-routereflector'
 ---
 

--- a/v2.6/usage/troubleshooting/faq.md
+++ b/v2.6/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq'
 ---
 

--- a/v2.6/usage/troubleshooting/index.md
+++ b/v2.6/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/'
 ---
 

--- a/v2.6/usage/troubleshooting/logging.md
+++ b/v2.6/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: 'https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging'
 ---
 

--- a/v3.0/getting-started/bare-metal/bare-metal-install.md
+++ b/v3.0/getting-started/bare-metal/bare-metal-install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Felix as a static binary
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/bare-metal/installation/
 ---
 

--- a/v3.0/getting-started/bare-metal/bare-metal.md
+++ b/v3.0/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico to Secure Host Interfaces
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/bare-metal/bare-metal
 ---
 

--- a/v3.0/getting-started/index.md
+++ b/v3.0/getting-started/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Integrations
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/
 ---
 

--- a/v3.0/getting-started/kubernetes/index.md
+++ b/v3.0/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quickstart for Calico on Kubernetes
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/aws.md
+++ b/v3.0/getting-started/kubernetes/installation/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on AWS
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/aws
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/azure.md
+++ b/v3.0/getting-started/kubernetes/installation/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Azure
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/azure
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/gce.md
+++ b/v3.0/getting-started/kubernetes/installation/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on GCE
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/gce
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/canal/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/canal/index.md
@@ -1,5 +1,6 @@
 ---
 title: Canal/flannel Hosted Install
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/flannel
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/hosted.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/hosted.md
@@ -1,5 +1,6 @@
 ---
 title: Standard Hosted Install
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Kubernetes Hosted Install
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/index.md
@@ -1,5 +1,6 @@
 ---
 title: kubeadm Hosted Install
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
+++ b/v3.0/getting-started/kubernetes/installation/hosted/kubernetes-datastore/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes API datastore
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/index.md
+++ b/v3.0/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/integration.md
+++ b/v3.0/getting-started/kubernetes/installation/integration.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/integration
 ---
 

--- a/v3.0/getting-started/kubernetes/installation/vagrant/index.md
+++ b/v3.0/getting-started/kubernetes/installation/vagrant/index.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico and Kubernetes on Container Linux by CoreOS using Vagrant and VirtualBox
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/vagrant/
 ---
 

--- a/v3.0/getting-started/kubernetes/troubleshooting.md
+++ b/v3.0/getting-started/kubernetes/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Calico for Kubernetes
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/troubleshooting
 ---
 

--- a/v3.0/getting-started/kubernetes/tutorials/advanced-policy.md
+++ b/v3.0/getting-started/kubernetes/tutorials/advanced-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Controlling ingress and egress traffic with network policy
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/advanced-policy
 ---
 

--- a/v3.0/getting-started/kubernetes/tutorials/simple-policy.md
+++ b/v3.0/getting-started/kubernetes/tutorials/simple-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Simple Policy Demo
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/simple-policy
 ---
 

--- a/v3.0/getting-started/kubernetes/tutorials/stars-policy/index.md
+++ b/v3.0/getting-started/kubernetes/tutorials/stars-policy/index.md
@@ -1,5 +1,6 @@
 ---
 title: Stars Policy Demo
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/stars-policy/
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all

--- a/v3.0/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v3.0/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: Using calicoctl in Kubernetes
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/using-calicoctl
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/convert.md
+++ b/v3.0/getting-started/kubernetes/upgrade/convert.md
@@ -1,5 +1,6 @@
 ---
 title: Converting your calicoctl manifests
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/convert
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/delete.md
+++ b/v3.0/getting-started/kubernetes/upgrade/delete.md
@@ -1,5 +1,6 @@
 ---
 title: Deleting old data
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/delete
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/downgrade.md
+++ b/v3.0/getting-started/kubernetes/upgrade/downgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Downgrading Calico
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/downgrade
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/index.md
+++ b/v3.0/getting-started/kubernetes/upgrade/index.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico for Kubernetes
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/migrate.md
+++ b/v3.0/getting-started/kubernetes/upgrade/migrate.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating Calico data
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/migrate
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/setup.md
+++ b/v3.0/getting-started/kubernetes/upgrade/setup.md
@@ -1,5 +1,6 @@
 ---
 title: Installing and configuring calico-upgrade
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/setup
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/test.md
+++ b/v3.0/getting-started/kubernetes/upgrade/test.md
@@ -1,5 +1,6 @@
 ---
 title: Testing the data migration
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/test
 ---
 

--- a/v3.0/getting-started/kubernetes/upgrade/upgrade.md
+++ b/v3.0/getting-started/kubernetes/upgrade/upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico 
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/kubernetes/upgrade/upgrade
 ---
 

--- a/v3.0/getting-started/openshift/installation.md
+++ b/v3.0/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico on OpenShift
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/getting-started/openshift/installation
 ---
 

--- a/v3.0/index.html
+++ b/v3.0/index.html
@@ -1,5 +1,6 @@
 ---
 title: Project Calico Documentation
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/
 description: Home
 layout: docwithnav

--- a/v3.0/introduction/index.md
+++ b/v3.0/introduction/index.md
@@ -1,5 +1,6 @@
 ---
 title: About Calico
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/introduction/
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.0/reference/advanced/etcd-rbac/calico-etcdv3-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes in etcd v3
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/calico-etcdv3-paths
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/certificate-generation.md
+++ b/v3.0/reference/advanced/etcd-rbac/certificate-generation.md
@@ -1,5 +1,6 @@
 ---
 title: Generating Certificates for etcd RBAC
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/certificate-generation
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/index.md
+++ b/v3.0/reference/advanced/etcd-rbac/index.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up etcd certificates for RBAC
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/kubernetes-advanced.md
+++ b/v3.0/reference/advanced/etcd-rbac/kubernetes-advanced.md
@@ -1,5 +1,6 @@
 ---
 title: Advanced etcd segmentation for Calico
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/kubernetes-advanced
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/kubernetes.md
+++ b/v3.0/reference/advanced/etcd-rbac/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Using etcd RBAC to segment Kubernetes and Calico
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/kubernetes
 ---
 

--- a/v3.0/reference/advanced/etcd-rbac/users-and-roles.md
+++ b/v3.0/reference/advanced/etcd-rbac/users-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Creating Users and Roles in etcd
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/advanced/etcd-rbac/users-and-roles
 ---
 

--- a/v3.0/reference/architecture/components.md
+++ b/v3.0/reference/architecture/components.md
@@ -1,5 +1,6 @@
 ---
 title: Anatomy of a calico-node container
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/architecture/components
 ---
 

--- a/v3.0/reference/architecture/data-path.md
+++ b/v3.0/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
 title: 'The Calico Data Path: IP Routing and iptables'
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/architecture/data-path
 ---
 

--- a/v3.0/reference/architecture/index.md
+++ b/v3.0/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Architecture
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/architecture/
 ---
 

--- a/v3.0/reference/calicoctl/commands/apply.md
+++ b/v3.0/reference/calicoctl/commands/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/apply
 ---
 

--- a/v3.0/reference/calicoctl/commands/convert.md
+++ b/v3.0/reference/calicoctl/commands/convert.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl convert
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/convert
 ---
 

--- a/v3.0/reference/calicoctl/commands/create.md
+++ b/v3.0/reference/calicoctl/commands/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/create
 ---
 

--- a/v3.0/reference/calicoctl/commands/delete.md
+++ b/v3.0/reference/calicoctl/commands/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/delete
 ---
 

--- a/v3.0/reference/calicoctl/commands/get.md
+++ b/v3.0/reference/calicoctl/commands/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/get
 ---
 

--- a/v3.0/reference/calicoctl/commands/index.md
+++ b/v3.0/reference/calicoctl/commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: Command Reference
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/
 ---
 

--- a/v3.0/reference/calicoctl/commands/ipam/index.md
+++ b/v3.0/reference/calicoctl/commands/ipam/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/
 ---
 

--- a/v3.0/reference/calicoctl/commands/ipam/release.md
+++ b/v3.0/reference/calicoctl/commands/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/release
 ---
 

--- a/v3.0/reference/calicoctl/commands/ipam/show.md
+++ b/v3.0/reference/calicoctl/commands/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/ipam/show
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/checksystem.md
+++ b/v3.0/reference/calicoctl/commands/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/checksystem
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/diags.md
+++ b/v3.0/reference/calicoctl/commands/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/diags
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/index.md
+++ b/v3.0/reference/calicoctl/commands/node/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/run.md
+++ b/v3.0/reference/calicoctl/commands/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/run
 ---
 

--- a/v3.0/reference/calicoctl/commands/node/status.md
+++ b/v3.0/reference/calicoctl/commands/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/node/status
 ---
 

--- a/v3.0/reference/calicoctl/commands/replace.md
+++ b/v3.0/reference/calicoctl/commands/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/replace
 ---
 

--- a/v3.0/reference/calicoctl/commands/version.md
+++ b/v3.0/reference/calicoctl/commands/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/commands/version
 ---
 

--- a/v3.0/reference/calicoctl/index.md
+++ b/v3.0/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl user reference
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/
 ---
 

--- a/v3.0/reference/calicoctl/resources/bgpconfig.md
+++ b/v3.0/reference/calicoctl/resources/bgpconfig.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Configuration Resource (BGPConfiguration)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgpconfig
 ---
 

--- a/v3.0/reference/calicoctl/resources/bgppeer.md
+++ b/v3.0/reference/calicoctl/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP Peer Resource (BGPPeer)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/bgppeer
 ---
 

--- a/v3.0/reference/calicoctl/resources/felixconfig.md
+++ b/v3.0/reference/calicoctl/resources/felixconfig.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Configuration Resource (FelixConfiguration)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/felixconfig
 ---
 

--- a/v3.0/reference/calicoctl/resources/globalnetworkpolicy.md
+++ b/v3.0/reference/calicoctl/resources/globalnetworkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Global Network Policy Resource (GlobalNetworkPolicy)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/globalnetworkpolicy
 ---
 

--- a/v3.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.0/reference/calicoctl/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host Endpoint Resource (HostEndpoint)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/hostendpoint
 ---
 

--- a/v3.0/reference/calicoctl/resources/index.md
+++ b/v3.0/reference/calicoctl/resources/index.md
@@ -1,5 +1,6 @@
 ---
 title: Resource Definitions
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/
 ---
 

--- a/v3.0/reference/calicoctl/resources/ippool.md
+++ b/v3.0/reference/calicoctl/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP Pool Resource (IPPool)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/ippool
 ---
 

--- a/v3.0/reference/calicoctl/resources/networkpolicy.md
+++ b/v3.0/reference/calicoctl/resources/networkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Network Policy Resource (NetworkPolicy)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/networkpolicy
 ---
 

--- a/v3.0/reference/calicoctl/resources/node.md
+++ b/v3.0/reference/calicoctl/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node Resource (Node)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/node
 ---
 

--- a/v3.0/reference/calicoctl/resources/profile.md
+++ b/v3.0/reference/calicoctl/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile Resource (Profile)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/profile
 ---
 

--- a/v3.0/reference/calicoctl/resources/workloadendpoint.md
+++ b/v3.0/reference/calicoctl/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload Endpoint Resource (WorkloadEndpoint)
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/calicoctl/resources/workloadendpoint
 ---
 

--- a/v3.0/reference/cni-plugin/configuration.md
+++ b/v3.0/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/cni-plugin/configuration
 ---
 

--- a/v3.0/reference/felix/configuration.md
+++ b/v3.0/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/felix/configuration
 ---
 

--- a/v3.0/reference/felix/prometheus.md
+++ b/v3.0/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Felix Prometheus Statistics
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/felix/prometheus
 ---
 

--- a/v3.0/reference/index.md
+++ b/v3.0/reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/
 noversion: yes
 ---

--- a/v3.0/reference/involved.md
+++ b/v3.0/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting Involved
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/involved
 ---
 

--- a/v3.0/reference/kube-controllers/configuration.md
+++ b/v3.0/reference/kube-controllers/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico Kubernetes controllers
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/kube-controllers/configuration
 ---
 

--- a/v3.0/reference/license.md
+++ b/v3.0/reference/license.md
@@ -1,5 +1,6 @@
 ---
 title: Third Party Software Attributions
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/license
 ---
 

--- a/v3.0/reference/node/configuration.md
+++ b/v3.0/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/node/configuration
 ---
 

--- a/v3.0/reference/previous-releases.md
+++ b/v3.0/reference/previous-releases.md
@@ -1,5 +1,6 @@
 ---
 title: Previous releases
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/previous-releases
 ---
 

--- a/v3.0/reference/private-cloud/l2-interconnect-fabric.md
+++ b/v3.0/reference/private-cloud/l2-interconnect-fabric.md
@@ -1,6 +1,7 @@
 ---
 subtitle: 'At scale, and no, we''re not joking'
 title: Calico over an Ethernet interconnect fabric
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/private-cloud/l2-interconnect-fabric
 ---
 

--- a/v3.0/reference/private-cloud/l3-interconnect-fabric.md
+++ b/v3.0/reference/private-cloud/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: IP Interconnect Fabrics in Calico
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/private-cloud/l3-interconnect-fabric
 lead_text: 'Where large-scale IP networks and hardware collide'
 ---

--- a/v3.0/reference/public-cloud/aws.md
+++ b/v3.0/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: AWS
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/aws
 ---
 

--- a/v3.0/reference/public-cloud/azure.md
+++ b/v3.0/reference/public-cloud/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on Azure
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/azure
 ---
 

--- a/v3.0/reference/public-cloud/gce.md
+++ b/v3.0/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Deploying Calico on GCE
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/gce
 ---
 

--- a/v3.0/reference/repo-structure.md
+++ b/v3.0/reference/repo-structure.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Repositories
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/repo-structure
 ---
 

--- a/v3.0/reference/requirements.md
+++ b/v3.0/reference/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Calico System Requirements
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/reference/requirements
 ---
 

--- a/v3.0/releases/index.md
+++ b/v3.0/releases/index.md
@@ -1,5 +1,6 @@
 ---
 title: Releases
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/releases/
 ---
 

--- a/v3.0/usage/calicoctl/configure/etcd.md
+++ b/v3.0/usage/calicoctl/configure/etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to an etcd datastore
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/etcd
 ---
 

--- a/v3.0/usage/calicoctl/configure/index.md
+++ b/v3.0/usage/calicoctl/configure/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/
 ---
 

--- a/v3.0/usage/calicoctl/configure/kdd.md
+++ b/v3.0/usage/calicoctl/configure/kdd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to the Kubernetes API datastore
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/calicoctl/configure/kdd
 ---
 

--- a/v3.0/usage/calicoctl/install.md
+++ b/v3.0/usage/calicoctl/install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing calicoctl
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/calicoctl/install
 ---
 

--- a/v3.0/usage/configuration/as-service.md
+++ b/v3.0/usage/configuration/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running calico/node with an init system
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/configuration/as-service
 ---
 

--- a/v3.0/usage/configuration/bgp.md
+++ b/v3.0/usage/configuration/bgp.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BGP Peers
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/configuration/bgp
 ---
 

--- a/v3.0/usage/configuration/conntrack.md
+++ b/v3.0/usage/configuration/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Conntrack
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/configuration/conntrack
 ---
 

--- a/v3.0/usage/configuration/ip-in-ip.md
+++ b/v3.0/usage/configuration/ip-in-ip.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring IP-in-IP
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/configuration/ip-in-ip
 ---
 

--- a/v3.0/usage/configuration/mtu.md
+++ b/v3.0/usage/configuration/mtu.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring MTU
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/configuration/mtu
 ---
 

--- a/v3.0/usage/configuration/node.md
+++ b/v3.0/usage/configuration/node.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring a Node IP Address and Subnet
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/configuration/node
 ---
 

--- a/v3.0/usage/decommissioning-a-node.md
+++ b/v3.0/usage/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a Node
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/decommissioning-a-node
 ---
 

--- a/v3.0/usage/external-connectivity.md
+++ b/v3.0/usage/external-connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: External Connectivity
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/external-connectivity
 ---
 Calico creates a routed network on which your containers look like normal IP

--- a/v3.0/usage/index.md
+++ b/v3.0/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: Using Calico
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/
 ---
 

--- a/v3.0/usage/ipv6.md
+++ b/v3.0/usage/ipv6.md
@@ -1,5 +1,6 @@
 ---
 title: IPv6 Support
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/ipv6
 ---
 

--- a/v3.0/usage/routereflector/bird-rr-config.md
+++ b/v3.0/usage/routereflector/bird-rr-config.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring BIRD as a BGP route reflector
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/routereflector/bird-rr-config
 ---
 

--- a/v3.0/usage/routereflector/calico-routereflector.md
+++ b/v3.0/usage/routereflector/calico-routereflector.md
@@ -1,5 +1,6 @@
 ---
 title: 'Calico BIRD Route Reflector container'
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/routereflector/calico-routereflector
 ---
 

--- a/v3.0/usage/troubleshooting/faq.md
+++ b/v3.0/usage/troubleshooting/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently Asked Questions
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/troubleshooting/faq
 layout: docwithnav
 ---

--- a/v3.0/usage/troubleshooting/index.md
+++ b/v3.0/usage/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/troubleshooting/
 ---
 

--- a/v3.0/usage/troubleshooting/logging.md
+++ b/v3.0/usage/troubleshooting/logging.md
@@ -1,5 +1,6 @@
 ---
 title: Logging
+sitemap: false 
 canonical_url: https://docs.projectcalico.org/v3.1/usage/troubleshooting/logging
 ---
 

--- a/v3.1/index.html
+++ b/v3.1/index.html
@@ -3,6 +3,7 @@ title: Project Calico Documentation
 redirect_from: latest/index.html
 description: Home
 layout: docwithnav
+sitemap: false
 ---
 <p>You are being redirected to the latest release of Calico Docs.</p>
 <script type="text/javascript">

--- a/v3.1/reference/index.md
+++ b/v3.1/reference/index.md
@@ -2,6 +2,7 @@
 title: Reference
 redirect_from: latest/reference/index
 noversion: yes
+sitemap: false
 ---
 
 This section contains reference information.

--- a/v3.1/usage/index.md
+++ b/v3.1/usage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using Calico
 redirect_from: latest/usage/index
+sitemap: false
 ---
 
 This section contains information on using {{site.prodname}}.


### PR DESCRIPTION
## Description

- Adds jekyll-sitemap plugin to autogenerate a sitemap.xml file in _site dir
- Adds metadata to non-canonical pages so that they get excluded from the sitemap
- Also corrects some incorrect casing in title metadata which complicates sed commands
- Sorry GitHub does not show the diff of the commit that modifies the metadata in the older files to ensure that they get excluded. It is apparently too many...hoping you can pull this down and take a look locally.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
