### PR TITLE
Copy IBM cloud docs in master to v2.6, v3.0, and v3.1

### DIFF
--- a/_data/v2_6/navbars/reference.yml
+++ b/_data/v2_6/navbars/reference.yml
@@ -97,6 +97,8 @@ toc:
       path: /reference/public-cloud/aws
     - title: GCE
       path: /reference/public-cloud/gce
+    - title: IBM Cloud
+      path: /reference/public-cloud/ibm
 - title: Deploying on Private Cloud
   section:
     - title: Calico Over Ethernet Fabrics

--- a/_data/v3_0/navbars/reference.yml
+++ b/_data/v3_0/navbars/reference.yml
@@ -95,6 +95,8 @@ toc:
       path: /reference/public-cloud/azure
     - title: GCE
       path: /reference/public-cloud/gce
+    - title: IBM Cloud
+      path: /reference/public-cloud/ibm
 - title: Deploying on Private Cloud
   section:
     - title: Calico Over Ethernet Fabrics

--- a/_data/v3_1/navbars/reference.yml
+++ b/_data/v3_1/navbars/reference.yml
@@ -101,6 +101,8 @@ toc:
       path: /reference/public-cloud/azure
     - title: Google Compute Engine
       path: /reference/public-cloud/gce
+    - title: IBM Cloud
+      path: /reference/public-cloud/ibm
 - title: Network design
   section:
     - title: Calico Over Ethernet Fabrics

--- a/v2.6/getting-started/kubernetes/installation/index.md
+++ b/v2.6/getting-started/kubernetes/installation/index.md
@@ -33,12 +33,31 @@ own orchestration mechanisms (e.g ansible, chef, bash, etc)
 Follow the [integration guide](integration) if you're using a Kubernetes version < v1.4.0, or if you would like
 to integrate Calico into your own installation or deployment scripts.
 
-## Third Party Integrations
+## Third-party solutions
 
-A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
+Several third-party vendors also provide tools to install Kubernetes with {{site.prodname}} in a variety of
+environments.
 
-You can find some of them here, organized by cloud provider.
+| Name                                 | Description |
+|--------------------------------------|-------------|
+| [ACS Engine][acs-engine]             | Deploys Kubernetes clusters on Azure with an option to enable {{site.prodname}} policy. |
+| [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
+| [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
+| [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
+| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
+| [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
+| [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
+| [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes on GCE. |
+| [StackPointCloud][stackpoint]        | Deploys a Kubernetes cluster with {{site.prodname}} to AWS in 3 steps using a web-based interface. |
+| [Typhoon][typhoon]                   | Deploys free and minimal Kubernetes clusters with Terraform. |
 
-- [Amazon Web Services](aws)
-- [Google Compute Engine](gce)
-- [Microsoft Azure](azure)
+[acs-engine]: https://github.com/Azure/acs-engine/blob/master/docs/kubernetes.md
+[gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
+[heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
+[ibmk]: https://www.ibm.com/cloud/container-service/
+[ket]: https://apprenda.com/kismatic/
+[kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
+[kubespray]: https://github.com/kubernetes-incubator/kubespray
+[kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
+[stackpoint]: https://stackpoint.io/#/
+[typhoon]: https://typhoon.psdn.io/

--- a/v2.6/reference/public-cloud/ibm.md
+++ b/v2.6/reference/public-cloud/ibm.md
@@ -1,0 +1,17 @@
+---
+title: Calico Configured Automatically in IBM Cloud
+canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/ibm
+---
+
+{{site.prodname}} is installed and configured automatically in your [IBM Cloud Kubernetes Service][IBMKUBE].  Default policies are created to protect your Kubernetes cluster, with the option to create your own policies to protect specific services.
+
+## IP-in-IP encapsulation
+
+[IP-in-IP encapsulation][IPIP] is automatically configured to only encapsulate packets traveling across subnets, and uses NAT for outgoing connections from your containers.
+
+## Enabling Workload-to-WAN Traffic
+
+This is also handled automatically in the [IBM Cloud Kubernetes Service][IBMKUBE].  No additional configuration of Calico is necessary.
+
+[IPIP]: {{site.baseurl}}/{{page.version}}/usage/configuration/ip-in-ip
+[IBMKUBE]: https://www.ibm.com/cloud/container-service/

--- a/v3.0/getting-started/kubernetes/installation/index.md
+++ b/v3.0/getting-started/kubernetes/installation/index.md
@@ -33,12 +33,31 @@ own orchestration mechanisms (e.g ansible, chef, bash, etc)
 Follow the [integration guide](integration) if you're using a Kubernetes version < v1.4.0, or if you would like
 to integrate Calico into your own installation or deployment scripts.
 
-## Third Party Integrations
+## Third-party solutions
 
-A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
+Several third-party vendors also provide tools to install Kubernetes with {{site.prodname}} in a variety of
+environments.
 
-You can find some of them here, organized by cloud provider.
+| Name                                 | Description |
+|--------------------------------------|-------------|
+| [ACS Engine][acs-engine]             | Deploys Kubernetes clusters on Azure with an option to enable {{site.prodname}} policy. |
+| [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
+| [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
+| [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
+| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
+| [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
+| [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
+| [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes on GCE. |
+| [StackPointCloud][stackpoint]        | Deploys a Kubernetes cluster with {{site.prodname}} to AWS in 3 steps using a web-based interface. |
+| [Typhoon][typhoon]                   | Deploys free and minimal Kubernetes clusters with Terraform. |
 
-- [Amazon Web Services](aws)
-- [Google Compute Engine](gce)
-- [Microsoft Azure](azure)
+[acs-engine]: https://github.com/Azure/acs-engine/blob/master/docs/kubernetes.md
+[gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
+[heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
+[ibmk]: https://www.ibm.com/cloud/container-service/
+[ket]: https://apprenda.com/kismatic/
+[kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
+[kubespray]: https://github.com/kubernetes-incubator/kubespray
+[kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
+[stackpoint]: https://stackpoint.io/#/
+[typhoon]: https://typhoon.psdn.io/

--- a/v3.0/reference/public-cloud/ibm.md
+++ b/v3.0/reference/public-cloud/ibm.md
@@ -1,0 +1,17 @@
+---
+title: Calico Configured Automatically in IBM Cloud
+canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/ibm
+---
+
+{{site.prodname}} is installed and configured automatically in your [IBM Cloud Kubernetes Service][IBMKUBE].  Default policies are created to protect your Kubernetes cluster, with the option to create your own policies to protect specific services.
+
+## IP-in-IP encapsulation
+
+[IP-in-IP encapsulation][IPIP] is automatically configured to only encapsulate packets traveling across subnets, and uses NAT for outgoing connections from your containers.
+
+## Enabling Workload-to-WAN Traffic
+
+This is also handled automatically in the [IBM Cloud Kubernetes Service][IBMKUBE].  No additional configuration of Calico is necessary.
+
+[IPIP]: {{site.baseurl}}/{{page.version}}/usage/configuration/ip-in-ip
+[IBMKUBE]: https://www.ibm.com/cloud/container-service/

--- a/v3.1/getting-started/kubernetes/installation/index.md
+++ b/v3.1/getting-started/kubernetes/installation/index.md
@@ -20,12 +20,31 @@ Should you wish to modify the manifests before applying them, refer to
 If you prefer not to use Kubernetes to start the {{site.prodname}} services, refer to the
 [Integration guide](integration).
 
-Several third-party vendors also provide a variety of {{site.prodname}} installation
-methods for different public clouds. Refer to the section that corresponds to your provider
-for more details.
+## Third-party solutions
 
-- [Amazon Web Services (AWS)](aws)
+Several third-party vendors also provide tools to install Kubernetes with {{site.prodname}} in a variety of
+environments.
 
-- [Google Compute Engine (GCE)](gce)
+| Name                                 | Description |
+|--------------------------------------|-------------|
+| [ACS Engine][acs-engine]             | Deploys Kubernetes clusters on Azure with an option to enable {{site.prodname}} policy. |
+| [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
+| [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
+| [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
+| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
+| [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
+| [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
+| [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes on GCE. |
+| [StackPointCloud][stackpoint]        | Deploys a Kubernetes cluster with {{site.prodname}} to AWS in 3 steps using a web-based interface. |
+| [Typhoon][typhoon]                   | Deploys free and minimal Kubernetes clusters with Terraform. |
 
-- [Azure](azure)
+[acs-engine]: https://github.com/Azure/acs-engine/blob/master/docs/kubernetes.md
+[gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
+[heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
+[ibmk]: https://www.ibm.com/cloud/container-service/
+[ket]: https://apprenda.com/kismatic/
+[kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
+[kubespray]: https://github.com/kubernetes-incubator/kubespray
+[kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
+[stackpoint]: https://stackpoint.io/#/
+[typhoon]: https://typhoon.psdn.io/

--- a/v3.1/reference/public-cloud/ibm.md
+++ b/v3.1/reference/public-cloud/ibm.md
@@ -1,0 +1,18 @@
+---
+title: Calico Configured Automatically in IBM Cloud
+redirect_from: latest/reference/public-cloud/ibm
+canonical_url: https://docs.projectcalico.org/v3.1/reference/public-cloud/ibm
+---
+
+{{site.prodname}} is installed and configured automatically in your [IBM Cloud Kubernetes Service][IBMKUBE].  Default policies are created to protect your Kubernetes cluster, with the option to create your own policies to protect specific services.
+
+## IP-in-IP encapsulation
+
+[IP-in-IP encapsulation][IPIP] is automatically configured to only encapsulate packets traveling across subnets, and uses NAT for outgoing connections from your containers.
+
+## Enabling Workload-to-WAN Traffic
+
+This is also handled automatically in the [IBM Cloud Kubernetes Service][IBMKUBE].  No additional configuration of Calico is necessary.
+
+[IPIP]: {{site.baseurl}}/{{page.version}}/usage/configuration/ip-in-ip
+[IBMKUBE]: https://www.ibm.com/cloud/container-service/


### PR DESCRIPTION
Copy IBM cloud docs in master to v2.6, v3.0, and v3.1 since IBM Cloud
Kubernetes service supports those releases.

```
release-note: None required
```
