### PR TITLE
add healthcheck to kube-controller manifest

### DIFF
--- a/_includes/master/manifests/calico-kube-controllers.yaml
+++ b/_includes/master/manifests/calico-kube-controllers.yaml
@@ -74,6 +74,11 @@ spec:
             # Mount in the etcd TLS secrets.
             - mountPath: /calico-secrets
               name: etcd-certs
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
       volumes:
         # Mount in the etcd TLS secrets with mode 400.
         # See https://kubernetes.io/docs/concepts/configuration/secret/


### PR DESCRIPTION
Signed-off-by: derek mcquay <derek@tigera.io>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

With the addition of healthchecks to kube-controllers (see https://github.com/projectcalico/kube-controllers/pull/273), this PR includes an update of the kube-controller manifest to add in the readiness check.  

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add healthcheck to kube-controllers manifest
```
