### PR TITLE
Versioning: Retrieve correct versions from versions.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ RELEASE_STREAM?=
 
 # Use := so that these V_ variables are computed only once per make run.
 CALICO_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].title')
-NODE_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].title')
+NODE_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico/node.version')
 CTL_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calicoctl.version')
 CNI_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico/cni.version')
 KUBE_CONTROLLERS_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '"$(RELEASE_STREAM)".[0].components.calico/kube-controllers.version')

--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -56,7 +56,7 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:master
+      - image: quay.io/calico/typha:{{site.nodecontainer}}:{{site.data.versions[page.version].first.components["calico/typha"].version}}
         name: calico-typha
         ports:
         - containerPort: 5473

--- a/_includes/master/manifests/calico.yaml
+++ b/_includes/master/manifests/calico.yaml
@@ -16,7 +16,7 @@ calico.yaml acccepts the following include flags:
 # {{variant_name}} Version {{site.data.versions[page.version].first.title}}
 # {{site.url}}/{{page.version}}/releases#{{site.data.versions[page.version].first.title}}
 # This manifest includes the following component versions:
-#   {{site.nodecontainer}}:{{site.data.versions[page.version].first.title}}
+#   {{site.nodecontainer}}:{{site.data.versions[page.version].first.components["calico/node"].version}}
 #   calico/cni:{{site.data.versions[page.version].first.components["calico/cni"].version}}
 {%- if include.datastore == "etcd" %}
 #   calico/kube-controllers:{{site.data.versions[page.version].first.components["calico/kube-controllers"].version}}


### PR DESCRIPTION
## Description
The templating changes introduced a regressions where the incorrect
versions were being used for node and typha.

This PR ensures that the versions are fetched from versions.yml