### PR TITLE
Doc for OpenStack project name labels

### DIFF
--- a/_data/master/navbars/usage.yml
+++ b/_data/master/navbars/usage.yml
@@ -55,6 +55,8 @@ toc:
   path: /usage/configuration/conntrack
 - title: Calico for OpenStack
   section:
+  - title: Endpoint Labels
+    path: /usage/openstack/labels
   - title: Configuration
     path: /usage/openstack/configuration
   - title: Detailed Semantics

--- a/master/usage/openstack/labels.md
+++ b/master/usage/openstack/labels.md
@@ -3,24 +3,24 @@ title: Endpoint Labels
 canonical_url: 'https://docs.projectcalico.org/v3.2/usage/openstack/labels'
 ---
 
-When {{site.prodname}} represents an OpenStack VM as a Calico WorkloadEndpoint, it puts
-labels on the WorkloadEndpoint to identify the project and security groups that the VM
-belongs to.
+When {{site.prodname}} represents an OpenStack VM as a {{site.prodname}} WorkloadEndpoint,
+it puts labels on the WorkloadEndpoint to identify the project and security groups that
+the VM belongs to.
 
 For the VM's OpenStack project (previously known as 'tenant'), those labels are:
 
-| Label Name                               | Value                   |
-|------------------------------------------|-------------------------|
-| projectcalico.org/openstack-project-id   | <the VM's project ID>   |
-| projectcalico.org/openstack-project-name | <the VM's project name> |
-|------------------------------------------|-------------------------|
+| Label Name                                 | Value                     |
+|--------------------------------------------|---------------------------|
+| `projectcalico.org/openstack-project-id`   | `<the VM's project ID>`   |
+| `projectcalico.org/openstack-project-name` | `<the VM's project name>` |
+|--------------------------------------------|---------------------------|
 
 For each security group that the VM belongs to, those labels are:
 
 | Label Name                                                  | Value                   |
 |-------------------------------------------------------------|-------------------------|
-| sg.projectcalico.org/openstack-\<security group ID\>        | \<security group name\> |
-| sg-name.projectcalico.org/openstack-\<security group name\> | \<security group ID\>   |
+| `sg.projectcalico.org/openstack-<security group ID>`        | `<security group name>` |
+| `sg-name.projectcalico.org/openstack-<security group name>` | `<security group ID>`   |
 |-------------------------------------------------------------|-------------------------|
 
 > **Note**: Calico only allows certain characters in label names and values

--- a/master/usage/openstack/labels.md
+++ b/master/usage/openstack/labels.md
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Labels
-canonical_url: 'https://docs.projectcalico.org/v3.2/usage/openstack/labels'
+canonical_url: 'https://docs.projectcalico.org/master/usage/openstack/labels'
 ---
 
 When {{site.prodname}} represents an OpenStack VM as a {{site.prodname}} WorkloadEndpoint,

--- a/master/usage/openstack/labels.md
+++ b/master/usage/openstack/labels.md
@@ -1,0 +1,35 @@
+---
+title: Endpoint Labels
+canonical_url: 'https://docs.projectcalico.org/v3.2/usage/openstack/labels'
+---
+
+When {{site.prodname}} represents an OpenStack VM as a Calico WorkloadEndpoint, it puts
+labels on the WorkloadEndpoint to identify the project and security groups that the VM
+belongs to.
+
+For the VM's OpenStack project (previously known as 'tenant'), those labels are:
+
+| Label Name                               | Value                   |
+|------------------------------------------|-------------------------|
+| projectcalico.org/openstack-project-id   | <the VM's project ID>   |
+| projectcalico.org/openstack-project-name | <the VM's project name> |
+|------------------------------------------|-------------------------|
+
+For each security group that the VM belongs to, those labels are:
+
+| Label Name                                                  | Value                   |
+|-------------------------------------------------------------|-------------------------|
+| sg.projectcalico.org/openstack-\<security group ID\>        | \<security group name\> |
+| sg-name.projectcalico.org/openstack-\<security group name\> | \<security group ID\>   |
+|-------------------------------------------------------------|-------------------------|
+
+> **Note**: Calico only allows certain characters in label names and values
+> (alphanumerics, '-', '\_', '.' and '/'), so if a project or security group name normally
+> has other characters, those will be replaced here by '\_'.  Also there is a length
+> limit, so particularly long names may be truncated.
+
+> **Note**: Calico does not support changing project name or security group name for a
+> given ID associated with a VM after the VM has been created.  It is recommended that
+> operators avoid any possible confusion here by not changing project name for a
+> particular project ID or security group name for particular security group ID,
+> post-creation.


### PR DESCRIPTION
## Release Note

```release-note
Calico's OpenStack driver puts labels on each WorkloadEndpoint that it generates, to convey the OpenStack project and security groups that the corresponding VM belongs to.
```
