### PR TITLE
Turn off debug logging in Dikastes

### DIFF
--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-inject-configmap.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-inject-configmap.yaml
@@ -147,7 +147,7 @@ data:
           name: dikastes-sock
       - name: dikastes
         image: {{site.imageNames["dikastes"]}}:{{site.data.versions[page.version].first.components["calico/dikastes"].version}}
-        args: ["/dikastes", "server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket", "--debug"]
+        args: ["/dikastes", "server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         volumeMounts:
         - mountPath: /var/run/dikastes
           name: dikastes-sock


### PR DESCRIPTION
## Description

Disable debug logging in Dikastes by default.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
