### PR TITLE
Fix calico-node.yaml includes for ALP

### DIFF
--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="etcd" network="calico" calico_ipam="true" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="etcd" network="calico" calico_ipam="true" app_layer_policy="true" variant_name="Calico" %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="calico" ipip="true" typha="true" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="calico" ipip="true" typha="true" app_layer_policy="true" variant_name="Calico" %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="flannel" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="flannel" app_layer_policy="true" variant_name="Canal" %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" typha="true" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" typha="true" app_layer_policy="true" variant_name="Calico" %}

--- a/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
+++ b/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="etcd" network="calico" calico_ipam="true" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="etcd" network="calico" calico_ipam="true" app_layer_policy="true" variant_name="Calico" %}

--- a/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
+++ b/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="calico" ipip="true" typha="true" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="calico" ipip="true" typha="true" app_layer_policy="true" variant_name="Calico" %}

--- a/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/calico-node.yaml
+++ b/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="flannel" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="flannel" app_layer_policy="true" variant_name="Canal" %}

--- a/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
+++ b/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" typha="true" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" typha="true" app_layer_policy="true" variant_name="Calico" %}


### PR DESCRIPTION
## Description

Fixes ALP `calico-node.yaml` downloads which were rendering incorrectly because of a missing include.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
