### PR TITLE
Fix ALP tutorial ingress.

### DIFF
--- a/master/getting-started/kubernetes/tutorials/app-layer-policy/index.md
+++ b/master/getting-started/kubernetes/tutorials/app-layer-policy/index.md
@@ -76,23 +76,23 @@ traffic in the Istio service mesh, and the corresponding service account identit
 
 ### Determining Ingress IP & Port
 
-You will use the `istio-ingress` service to access the YAO Bank application.
+You will use the `istio-ingressgateway` service to access the YAO Bank application.
 
 1. If your Kubernetes cluster is running in an environment that supports external load balancers, the IP address of 
    ingress can be  obtained by the following command:
 
    ```bash
-   kubectl get ingress -o wide
+   kubectl get svc istio-ingressgateway -n istio-system
    ```
 
    whose output should be similar to
 
    ```bash
-   NAME      HOSTS     ADDRESS                 PORTS     AGE
-   gateway   *         130.211.10.121          80        1d
+   NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                                      AGE
+   istio-ingressgateway   LoadBalancer   172.21.109.129   130.211.10.121  80:31380/TCP,443:31390/TCP,31400:31400/TCP   17h
    ```
 
-   The address of the ingress service would then be
+   The address of the ingressgateway service is the external IP of the `istio-ingressgateway`, followed by port 80:
    
    ```bash
    export GATEWAY_URL=130.211.10.121:80
@@ -103,7 +103,7 @@ node, along with the NodePort, to access the ingress. The IP & port can be obtai
 of the following command:
    
    ```bash
-   export GATEWAY_URL=$(kubectl get po -n istio-system -l istio=ingress -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
+   export GATEWAY_URL=$(kubectl get po -n istio-system -l istio=ingressgateway -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
    ```
 
 Point your browser to `http://$GATEWAY_URL/` to confirm the YAO Bank application is functioning 

--- a/master/getting-started/kubernetes/tutorials/app-layer-policy/manifests/10-yaobank.yaml
+++ b/master/getting-started/kubernetes/tutorials/app-layer-policy/manifests/10-yaobank.yaml
@@ -140,18 +140,36 @@ spec:
         ports:
         - containerPort: 80
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
 metadata:
-  name: gateway
-  annotations:
-    kubernetes.io/ingress.class: "istio"
+  name: yaobank
 spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        backend:
-          serviceName: customer
-          servicePort: 80
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: yaobank
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - yaobank
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: customer
+        port:
+          number: 80

--- a/v3.2/getting-started/kubernetes/tutorials/app-layer-policy/index.md
+++ b/v3.2/getting-started/kubernetes/tutorials/app-layer-policy/index.md
@@ -76,23 +76,23 @@ traffic in the Istio service mesh, and the corresponding service account identit
 
 ### Determining Ingress IP & Port
 
-You will use the `istio-ingress` service to access the YAO Bank application.
+You will use the `istio-ingressgateway` service to access the YAO Bank application.
 
 1. If your Kubernetes cluster is running in an environment that supports external load balancers, the IP address of 
    ingress can be  obtained by the following command:
 
    ```bash
-   kubectl get ingress -o wide
+   kubectl get svc istio-ingressgateway -n istio-system
    ```
 
    whose output should be similar to
 
    ```bash
-   NAME      HOSTS     ADDRESS                 PORTS     AGE
-   gateway   *         130.211.10.121          80        1d
+   NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                                      AGE
+   istio-ingressgateway   LoadBalancer   172.21.109.129   130.211.10.121  80:31380/TCP,443:31390/TCP,31400:31400/TCP   17h
    ```
 
-   The address of the ingress service would then be
+   The address of the ingressgateway service is the external IP of the `istio-ingressgateway`, followed by port 80:
    
    ```bash
    export GATEWAY_URL=130.211.10.121:80
@@ -103,7 +103,7 @@ node, along with the NodePort, to access the ingress. The IP & port can be obtai
 of the following command:
    
    ```bash
-   export GATEWAY_URL=$(kubectl get po -n istio-system -l istio=ingress -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
+   export GATEWAY_URL=$(kubectl get po -n istio-system -l istio=ingressgateway -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
    ```
 
 Point your browser to `http://$GATEWAY_URL/` to confirm the YAO Bank application is functioning 

--- a/v3.2/getting-started/kubernetes/tutorials/app-layer-policy/manifests/10-yaobank.yaml
+++ b/v3.2/getting-started/kubernetes/tutorials/app-layer-policy/manifests/10-yaobank.yaml
@@ -140,18 +140,36 @@ spec:
         ports:
         - containerPort: 80
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
 metadata:
-  name: gateway
-  annotations:
-    kubernetes.io/ingress.class: "istio"
+  name: yaobank
 spec:
-  rules:
-  - http:
-      paths:
-      - path: /
-        backend:
-          serviceName: customer
-          servicePort: 80
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: yaobank
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - yaobank
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: customer
+        port:
+          number: 80


### PR DESCRIPTION
## Description

Cluster ingress changed from Istio 0.6 -> 1.0; this change updates our tutorial to use the new `istio-ingressgateway`.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
