### PR TITLE
Canal: fixing and adding felix log level

### DIFF
--- a/v2.6/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/v2.6/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -228,6 +228,9 @@ spec:
             # Disable Calico BGP.  Calico is simply enforcing policy.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
+            # Enable felix logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,canal"

--- a/v2.6/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+++ b/v2.6/getting-started/kubernetes/installation/hosted/canal/canal.yaml
@@ -113,7 +113,7 @@ spec:
             - name: DATASTORE_TYPE
               value: "kubernetes"
             # Enable felix logging.
-            - name: FELIX_LOGSEVERITYSYS
+            - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND

--- a/v3.0/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -232,6 +232,9 @@ spec:
             # Disable Calico BGP.  Calico is simply enforcing policy.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
+            # Enable felix logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,canal"

--- a/v3.0/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+++ b/v3.0/getting-started/kubernetes/installation/hosted/canal/canal.yaml
@@ -117,7 +117,7 @@ spec:
             - name: DATASTORE_TYPE
               value: "kubernetes"
             # Enable felix logging.
-            - name: FELIX_LOGSEVERITYSYS
+            - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND

--- a/v3.1/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/v3.1/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -232,6 +232,9 @@ spec:
             # Disable Calico BGP.  Calico is simply enforcing policy.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
+            # Enable felix logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s,canal"

--- a/v3.1/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+++ b/v3.1/getting-started/kubernetes/installation/hosted/canal/canal.yaml
@@ -115,7 +115,7 @@ spec:
             - name: DATASTORE_TYPE
               value: "kubernetes"
             # Enable felix logging.
-            - name: FELIX_LOGSEVERITYSYS
+            - name: FELIX_LOGSEVERITYSCREEN
               value: "info"
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND


### PR DESCRIPTION
## Description

I was helping someone with setting the log level and noticed the wrong env var name in the v2.6 and v3.0 canal manifests https://github.com/projectcalico/canal/issues/131.  It was also missing from the etcd version of those manifests too.


## Todos

## Release Note

```release-note
None required
```
