### PR TITLE
Introduce netlify.toml file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,10 +29,6 @@ imageNames:
   pilot-webhook: quay.io/calico/pilot-webhook
   flexvol: quay.io/calico/pod2daemon-flexvol
 
-# List of files to explicitly include. Jekyll ignore some files by default (such as those starting with . or _)  
-include:
-  - _headers
-
 # List of files to exclude. These files won't get included in the deployed site.
 exclude:
   - release-scripts

--- a/_headers
+++ b/_headers
@@ -1,4 +1,0 @@
-/*.yaml
-  content-type: text/yaml
-/*.yml
-  content-type: text/yaml

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,19 @@
+# Settings in the [build] context are global and are applied to all contexts unless otherwise overridden by more specific contexts.
+# The cp, bundle install and bundle exec parts are only required to work around not being able to put the Gemfile int he root directory. It can't go in the root because that breaks the jekyll/jekyll container.
+[build]
+  command = 'cp netlify/Gemfile Gemfile; bundle install && bundle exec jekyll build'
+
+# Deploy Preview context: All Deploy Previews will inherit these settings.
+# Override the build command to include the Preview URL
+[context.deploy-preview]
+  command = 'cp netlify/Gemfile Gemfile; echo "url: $DEPLOY_PRIME_URL" >_config_url.yml; bundle install && bundle exec jekyll build --config _config.yml,_config_url.yml'
+
+[[headers]]
+  for = "/*.yaml"
+  [headers.values]
+    content-type = "text/yaml"
+
+[[headers]]
+  for = "/*.yml"
+  [headers.values]
+    content-type = "text/yaml"


### PR DESCRIPTION
Introduce netlify.toml file

- Get rid of _headers file since logic is moved into netlify.toml
- Build the site differently for deploy-previews