### PR TITLE
Add nodeSelectors to ensure components only run on Linux

### DIFF
--- a/_includes/master/manifests/calico-kube-controllers.yaml
+++ b/_includes/master/manifests/calico-kube-controllers.yaml
@@ -29,6 +29,8 @@ spec:
       labels:
         k8s-app: calico-kube-controllers
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true

--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -41,6 +41,8 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure {{objname}} gets scheduled on all nodes.

--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -47,6 +47,8 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.

--- a/_includes/master/manifests/configure-canal.yaml
+++ b/_includes/master/manifests/configure-canal.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       name: configure-canal
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       restartPolicy: OnFailure
       containers:

--- a/_includes/v3.2/manifests/calico-kube-controllers.yaml
+++ b/_includes/v3.2/manifests/calico-kube-controllers.yaml
@@ -29,6 +29,8 @@ spec:
       labels:
         k8s-app: calico-kube-controllers
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true

--- a/_includes/v3.2/manifests/calico-node.yaml
+++ b/_includes/v3.2/manifests/calico-node.yaml
@@ -41,6 +41,8 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure {{objname}} gets scheduled on all nodes.

--- a/_includes/v3.2/manifests/calico-typha.yaml
+++ b/_includes/v3.2/manifests/calico-typha.yaml
@@ -47,6 +47,8 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.

--- a/_includes/v3.2/manifests/configure-canal.yaml
+++ b/_includes/v3.2/manifests/configure-canal.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       name: configure-canal
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       restartPolicy: OnFailure
       containers:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Allows for Calico to be installed to only the linux nodes in a hybrid Linux + Windows cluster.  Without this change, Kubernetes tries to schedule our daemonsets on all nodes.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
