### PR TITLE
Remove Felix IPIP enabling through environments

### DIFF
--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -6,7 +6,6 @@ calico-node.yaml acccepts the following include flags:
 | datastore        | kdd, etcd                |
 | typha            | true, false              |
 | network          | calico, flannel, <unset> |
-| ipip             | true, false              |
 | variant_name     | Calico, Canal            |
 | app_layer_policy | true, false              |
 
@@ -142,11 +141,6 @@ spec:
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "Always"
-  {%- if include.ipip == "true" %}
-            # Enable IP-in-IP within Felix.
-            - name: FELIX_IPINIPENABLED
-              value: "true"
-  {%- endif %}
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:

--- a/_includes/master/manifests/calico.yaml
+++ b/_includes/master/manifests/calico.yaml
@@ -7,7 +7,6 @@ calico.yaml acccepts the following include flags:
 | typha            | true, false              |
 | network          | calico, flannel, <unset> |
 | calico_ipam      | true, false              |
-| ipip             | true, false              |
 | variant_name     | Calico, Canal            |
 | app_layer_policy | true, false              |
 
@@ -36,7 +35,7 @@ calico.yaml acccepts the following include flags:
 ---
 {%- endif %}
 
-{% include {{page.version}}/manifests/calico-node.yaml datastore=include.datastore network=include.network ipip=include.ipip variant_name=variant_name typha=include.typha app_layer_policy=include.app_layer_policy %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore=include.datastore network=include.network variant_name=variant_name typha=include.typha app_layer_policy=include.app_layer_policy %}
 ---
 {%- if include.datastore == "etcd" and include.network == "flannel" %}
 

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico.yaml datastore="kdd" network="calico" ipip="true" typha="true" %}
+{% include {{page.version}}/manifests/calico.yaml datastore="kdd" network="calico" typha="true" %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="calico" ipip="true" typha="true" app_layer_policy="true" variant_name="Calico" %}
+{% include {{page.version}}/manifests/calico-node.yaml datastore="kdd" network="calico" typha="true" app_layer_policy="true" variant_name="Calico" %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico.yaml
@@ -1,4 +1,4 @@
 ---
 layout: null
 ---
-{% include {{page.version}}/manifests/calico.yaml datastore="kdd" network="calico" ipip="true" typha="true" app_layer_policy="true" %}
+{% include {{page.version}}/manifests/calico.yaml datastore="kdd" network="calico" typha="true" app_layer_policy="true" %}


### PR DESCRIPTION
## Description

Originally KDD did not support setting felix configuration through etcd, so in order to enable IPIP we needed to set the felix environments.

KDD now supports the FelixConfiguration resource.

The IPIP setting in Felix is enabled when an IPPool with IPIP is created (and the IPIP setting is not explicitly disabled already).  This is true for both KDD and etcdv3.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
