### PR TITLE
Adjusts calicoctl install when running as a pod

### DIFF
--- a/_includes/master/ctl-container-install.md
+++ b/_includes/master/ctl-container-install.md
@@ -48,3 +48,9 @@ NAME                 TAGS
 kns.default          kns.default
 kns.kube-system      kns.kube-system
 ```
+
+We recommend setting an alias as follows.
+
+```
+alias calicoctl="kubectl exec -i -n kube-system calicoctl /calicoctl -- "
+```

--- a/master/usage/calicoctl/install.md
+++ b/master/usage/calicoctl/install.md
@@ -6,7 +6,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.2/usage/calicoctl/install'
 ## About installing calicoctl
 
 `calicoctl` allows you to create, read, update, and delete {{site.prodname}} objects
-from the command line. 
+from the command line.
 
 You can run `calicoctl` on any host with network access to the
 {{site.prodname}} datastore as either a binary or a container.
@@ -29,7 +29,3 @@ corresponds to your desired deployment.
 [Configure `calicoctl` to connect to your datastore](/{{page.version}}/usage/calicoctl/configure/).
 
 {% include {{page.version}}/ctl-container-install.md %}
-
-**Next step**:
-
-[Configure `calicoctl` to connect to your datastore](/{{page.version}}/usage/calicoctl/configure/).


### PR DESCRIPTION
## Description

- For pod install, they should not need to manually configure the datastore, the YAML we provide should set that up for them.
- Recommends adding an alias. This is not only more convenient, but also makes the rest of the commands in the documentation easier to follow.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
