### PR TITLE
Moves Istio version req to req page and links to there

### DIFF
--- a/master/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/master/getting-started/kubernetes/installation/app-layer-policy.md
@@ -67,8 +67,7 @@ kubectl apply -f \
 
 ## Installing Istio
 
-Application layer policy requires you to use Istio in your cluster to function
-correctly. We support Istio version 1.0.0 or newer.
+Application layer policy [requires Istio](../requirements#application-layer-policy-requirements).
 
 Install Istio according to the [Istio project documentation](https://istio.io/docs/setup/kubernetes/), making sure to enable mutual TLS authentication. For example:
 
@@ -117,7 +116,7 @@ kubectl apply -f \
 
 > **Note**: You can also
 > [view the manifest in your browser](manifests/app-layer-policy/istio-app-layer-policy.yaml){:target="_blank"}.
-{: .alert .alert-info} 
+{: .alert .alert-info}
 
 ## Adding namespace labels
 

--- a/master/getting-started/kubernetes/requirements.md
+++ b/master/getting-started/kubernetes/requirements.md
@@ -51,8 +51,9 @@ Our manifests default to `192.168.0.0/16` for the pod IP range except [Canal/fla
 which defaults to `10.244.0.0/16`. Refer to [Configuring the pod IP range](./installation/config-options#configuring-the-pod-ip-range)
 for information on modifying the defaults.
 
-#### Mutating webhooks
+## Application layer policy requirements
 
-Application Layer Policy requires the [MutatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#mutatingadmissionwebhook) to be enabled.
+- [MutatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#mutatingadmissionwebhook) enabled
+- [Istio v1.0](https://istio.io/about/notes/1.0/)
 
 {% include {{page.version}}/reqs-kernel.md %}


### PR DESCRIPTION
## Description

- Makes app layer policy its own section in reqs
- Identifies version of Istio there and does not include third digit for point release flexibility
- Links to reqs page from install


## Todos

none

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
