### PR TITLE
Calico-typha pods - allow Cluster Autoscaler to evict

### DIFF
--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -103,3 +103,20 @@ spec:
             - check
             - readiness
           periodSeconds: 10
+
+  ---
+
+  # This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
+
+  apiVersion: policy/v1beta1
+  kind: PodDisruptionBudget
+  metadata:
+    name: calico-typha
+    namespace: kube-system
+    labels:
+      k8s-app: calico-typha
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        k8s-app: calico-typha

--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -46,6 +46,7 @@ spec:
         # add-on, ensuring it gets priority scheduling and that its resources are reserved
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
## Description
Type- bug fix/feature

On our GKE cluster I was looking into reasons why the CA wasn't taking effect against some nodes. It looks as though the calico-typha pods could be one reason. Once I deleted one of the typha pods from a node and let it run on a different node in the cluster, the node I was working on then became a valid candidate for scale down.

Unfortunately because we run on GKE I can't see the logs for the CA to 100% confirm this, but it does seem the most likely. As the pods have local node storage attached (at least they do in GKE) then I also added the safe-to-evict annotation as well as added a PDB.

This might not be right or useful as I'm mostly looking at what in GKE. GKE also runs pods for Typha autoscaling (calico-typha-vertical-autoscaler and calico-typha-horizontal-autoscaler) which also probably require the same settings to be applied.

Perhaps this is something I should feedback directly to GKE rather than via this PR?
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
