### PR TITLE
Modify the image path of calico for supporting multi-arch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,11 +19,11 @@ noderunning: calico-node
 
 # Image names in case the host changes
 imageNames:
-  node: quay.io/calico/node
-  calicoctl: quay.io/calico/ctl
-  typha: quay.io/calico/typha
-  cni: quay.io/calico/cni
-  kubeControllers: quay.io/calico/kube-controllers
+  node: calico/node
+  calicoctl: calico/ctl
+  typha: calico/typha
+  cni: calico/cni
+  kubeControllers: calico/kube-controllers
   calico-upgrade: quay.io/calico/upgrade
   flannel: quay.io/coreos/flannel
   dikastes: quay.io/calico/dikastes


### PR DESCRIPTION
Modify the image path of _config.yml for auto generating
multi-arch yaml configuration files.

Signed-off-by: Jingzhao Ni <jingzhao.ni@arm.com>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
