### PR TITLE
Fix app layer policy include

### DIFF
--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -495,7 +495,7 @@ spec:
             secretName: calico-etcd-secrets
             defaultMode: 0400
 {%- endif %}
-{%- if include.app_layer_policy %}
+{%- if include.app_layer_policy == "true" %}
         # Used to create per-pod Unix Domain Sockets
         - name: policysync
           hostPath:

--- a/_includes/v3.3/manifests/calico-node.yaml
+++ b/_includes/v3.3/manifests/calico-node.yaml
@@ -463,7 +463,7 @@ spec:
             secretName: calico-etcd-secrets
             defaultMode: 0400
 {%- endif %}
-{%- if include.app_layer_policy %}
+{%- if include.app_layer_policy == "true" %}
         # Used to create per-pod Unix Domain Sockets
         - name: policysync
           hostPath:


### PR DESCRIPTION
## Description

Fix a "bug" where some ALP settings are included when you set `app_layer_policy` to `false`.

There is no impact to our docs from this bug or fix. Our docs just don't pass that key at all when they don't want ALP, so our current manifests are rendering just fine. 

But the comment at the top states: ` app_layer_policy | true, false`

Best to be consistent. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
