### PR TITLE
Include stat_prefix in TCP Ext Auth filter

### DIFF
--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-app-layer-policy.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-app-layer-policy.yaml
@@ -52,6 +52,7 @@ spec:
     filterType: NETWORK
     filterName: "envoy.ext_authz"
     filterConfig:
+      stat_prefix: "dikastes"
       grpc_service:
         envoy_grpc:
           cluster_name: "outbound|1||dikastes.calico.cluster.local"

--- a/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-app-layer-policy.yaml
+++ b/v3.2/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-app-layer-policy.yaml
@@ -52,6 +52,7 @@ spec:
     filterType: NETWORK
     filterName: "envoy.ext_authz"
     filterConfig:
+      stat_prefix: "dikastes"
       grpc_service:
         envoy_grpc:
           cluster_name: "outbound|1||dikastes.calico.cluster.local"

--- a/v3.3/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-app-layer-policy.yaml
+++ b/v3.3/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-app-layer-policy.yaml
@@ -52,6 +52,7 @@ spec:
     filterType: NETWORK
     filterName: "envoy.ext_authz"
     filterConfig:
+      stat_prefix: "dikastes"
       grpc_service:
         envoy_grpc:
           cluster_name: "outbound|1||dikastes.calico.cluster.local"


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

`stat_prefix` is a required field for the Envoy config: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/ext_authz/v2/ext_authz.proto#envoy-api-msg-config-filter-network-ext-authz-v2-extauthz

Reported via calico-users that this is causing problems with Istio v1.0.2 



## Todos

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
