### PR TITLE
Release networking-calico v3.3.0

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -14,8 +14,8 @@ v3.3:
       version: v3.3.0
       url: https://github.com/projectcalico/k8s-policy/releases/tag/v3.3.0
     networking-calico:
-      version: 3.2.0
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=3.2.0
+      version: v3.3.0
+      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=3.3.0
     typha:
       version: v3.3.0
       url: https://github.com/projectcalico/typha/releases/tag/v3.3.0

--- a/master/getting-started/openstack/installation/redhat.md
+++ b/master/getting-started/openstack/installation/redhat.md
@@ -51,23 +51,6 @@ These steps are detailed in this section.
     EOF
     ```
 
-1.  Install the `etcd3gw` Python package, if it is not already installed on
-    your system.  `etcd3gw` is needed by {{site.prodname}}'s OpenStack driver
-    and DHCP agent, but is not yet RPM-packaged, so you should install it with
-    `pip`.  First check in case it has already been pulled in by your OpenStack
-    installation.
-
-    ```
-    find /usr/lib/python2.7/ -name etcd3gw
-    ```
-
-    If you see no output there, install `etcd3gw` with pip.
-
-    ```
-    yum install -y python-pip
-    pip install etcd3gw
-    ```
-
 ## etcd install
 
 {{site.prodname}} operation requires an etcd v3 key/value store—this may be

--- a/v3.3/getting-started/openstack/installation/redhat.md
+++ b/v3.3/getting-started/openstack/installation/redhat.md
@@ -52,23 +52,6 @@ These steps are detailed in this section.
     EOF
     ```
 
-1.  Install the `etcd3gw` Python package, if it is not already installed on
-    your system.  `etcd3gw` is needed by {{site.prodname}}'s OpenStack driver
-    and DHCP agent, but is not yet RPM-packaged, so you should install it with
-    `pip`.  First check in case it has already been pulled in by your OpenStack
-    installation.
-
-    ```
-    find /usr/lib/python2.7/ -name etcd3gw
-    ```
-
-    If you see no output there, install `etcd3gw` with pip.
-
-    ```
-    yum install -y python-pip
-    pip install etcd3gw
-    ```
-
 ## etcd install
 
 {{site.prodname}} operation requires an etcd v3 key/value store—this may be


### PR DESCRIPTION
This dependency is now RPM-packaged, and is pulled in automatically when
installing the rest of Calico for OpenStack.
