### PR TITLE
add some suggestion to ipv6.

### DIFF
--- a/v3.2/usage/ipv6.md
+++ b/v3.2/usage/ipv6.md
@@ -112,7 +112,8 @@ steps below.
 If you wish to only use IPv6 (by disabling IPv4) or your hosts only have
 IPv6 addresses, you must disable autodetection of IPv4 by setting `IP`
 to `none`.  With that set you must also pass a `CALICO_ROUTER_ID` to each
-calico-node pod.
+calico-node pod. Also you must add an env `FELIX_HEALTHHOST` to `localhost6`
+because the calico-node's health check use IPv4 by default.
 
 ### Modifying your DNS for IPv6
 

--- a/v3.2/usage/ipv6.md
+++ b/v3.2/usage/ipv6.md
@@ -112,8 +112,8 @@ steps below.
 If you wish to only use IPv6 (by disabling IPv4) or your hosts only have
 IPv6 addresses, you must disable autodetection of IPv4 by setting `IP`
 to `none`.  With that set you must also pass a `CALICO_ROUTER_ID` to each
-calico-node pod. Also you must add an env `FELIX_HEALTHHOST` to `localhost6`
-because the calico-node's health check use IPv4 by default.
+calico-node pod. Also you must add an environment variable `FELIX_HEALTHHOST` to `localhost6`
+because the calico-node health check uses IPv4 by default.
 
 ### Modifying your DNS for IPv6
 


### PR DESCRIPTION
## Description
By default , the calico-node use IPv4 address to make health check ,if you want to deploy calico only use IPv6(by disabling IPv4), you should let calico-node using "localhost6" to make health check.  
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note


