### PR TITLE
Swapping permissions for calico-node, node Update->UpdateStatus

### DIFF
--- a/_includes/master/manifests/rbac.yaml
+++ b/_includes/master/manifests/rbac.yaml
@@ -73,8 +73,11 @@ rules:
     resources:
       - nodes/status
     verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
       - patch
 {%- if include.datastore == "kdd" %}
+      # Calico stores some configuration information in node annotations.
+      - update
   # Watch for changes to Kubernetes NetworkPolicies.
   - apiGroups: ["networking.k8s.io"]
     resources:
@@ -131,7 +134,6 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
   # Used to discover Typhas.
   - apiGroups: [""]


### PR DESCRIPTION
## Description

A recent PR (https://github.com/projectcalico/libcalico-go/pull/971) changed the needed permissions for ClusterRole calico-node from Update for nodes, to UpdateStatus for nodes/status.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
None