### PR TITLE
Doc for service advertisement

### DIFF
--- a/_data/master/navbars/usage.yml
+++ b/_data/master/navbars/usage.yml
@@ -49,6 +49,8 @@ toc:
   path: /usage/decommissioning-a-node
 - title: Configuring Conntrack
   path: /usage/configuration/conntrack
+- title: Advertising Kubernetes service IPs
+  path: /usage/service-advertisement
 - title: Calico for OpenStack
   section:
   - title: Endpoint Labels

--- a/_data/master/navbars/usage.yml
+++ b/_data/master/navbars/usage.yml
@@ -49,7 +49,7 @@ toc:
   path: /usage/decommissioning-a-node
 - title: Configuring Conntrack
   path: /usage/configuration/conntrack
-- title: Advertising Kubernetes service IPs
+- title: Advertising Kubernetes services
   path: /usage/service-advertisement
 - title: Calico for OpenStack
   section:

--- a/master/getting-started/kubernetes/installation/config-options.md
+++ b/master/getting-started/kubernetes/installation/config-options.md
@@ -151,10 +151,10 @@ service accounts with the necessary permissions.
 
 ### Configuring service advertisement
 
-{{site.prodname}} supports [advertising Kubernetes service IPs over
+{{site.prodname}} supports [advertising Kubernetes services over
 BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement),
-so that those IPs are routable from outside the cluster.  To enable
-this, add an `ADVERTISE_CLUSTER_IPS` variable setting to the
+so that service cluster IPs are routable from outside the cluster.  To
+enable this, add an `ADVERTISE_CLUSTER_IPS` variable setting to the
 environment for {{site.nodecontainer}} in the `calico.yaml` manifest,
 with value equal to the cluster IP range for your Kubernetes cluster;
 for example:

--- a/master/getting-started/kubernetes/installation/config-options.md
+++ b/master/getting-started/kubernetes/installation/config-options.md
@@ -149,6 +149,26 @@ To use these manifests with a TLS-enabled etcd cluster you must do the following
 Depending on your cluster's authorization mode, you'll want to back these
 service accounts with the necessary permissions.
 
+### Configuring service advertisement
+
+{{site.prodname}} supports [advertising Kubernetes service IPs over
+BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement),
+so that those IPs are routable from outside the cluster.  To enable
+this, add an `ADVERTISE_CLUSTER_IPS` variable setting to the
+environment for {{site.nodecontainer}} in the `calico.yaml` manifest,
+with value equal to the cluster IP range for your Kubernetes cluster;
+for example:
+
+```yaml
+          env:
+            [...]
+            - name: ADVERTISE_CLUSTER_IPS
+              value: "10.96.0.0/12"
+```
+
+For more information, see [Configuring
+{{site.nodecontainer}}]({{site.baseurl}}/{{page.version}}/reference/node/configuration).
+
 ### Other configuration options
 
 The following table outlines the remaining supported `ConfigMap` options.

--- a/master/getting-started/kubernetes/installation/config-options.md
+++ b/master/getting-started/kubernetes/installation/config-options.md
@@ -154,15 +154,15 @@ service accounts with the necessary permissions.
 {{site.prodname}} supports [advertising Kubernetes services over
 BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement),
 so that service cluster IPs are routable from outside the cluster.  To
-enable this, add an `ADVERTISE_CLUSTER_IPS` variable setting to the
-environment for {{site.nodecontainer}} in the `calico.yaml` manifest,
-with value equal to the cluster IP range for your Kubernetes cluster;
-for example:
+enable this, add a `CALICO_ADVERTISE_CLUSTER_IPS` variable setting to
+the environment for {{site.nodecontainer}} in the `calico.yaml`
+manifest, with value equal to the cluster IP range for your Kubernetes
+cluster; for example:
 
 ```yaml
           env:
             [...]
-            - name: ADVERTISE_CLUSTER_IPS
+            - name: CALICO_ADVERTISE_CLUSTER_IPS
               value: "10.96.0.0/12"
 ```
 

--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -45,7 +45,7 @@ The `{{site.nodecontainer}}` container is primarily configured through environme
 | K8S_KEY_FILE | Location of a client key for accessing the Kubernetes API.                   | string |
 | K8S_CA_FILE | Location of a CA for accessing the Kubernetes API.                            | string |
 | K8S_TOKEN | Token to be used for accessing the Kubernetes API.                              | string |
-| ADVERTISE_CLUSTER_IPS | Enable [advertising Kubernetes service IPs over BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement), within the specified CIDR. [Default: disabled] | IPv4 CIDR |
+| ADVERTISE_CLUSTER_IPS | Enable [advertising Kubernetes service cluster IPs over BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement), within the specified CIDR. [Default: disabled] | IPv4 CIDR |
 
 In addition to the above, `{{site.nodecontainer}}` also supports [the standard Felix configuration environment variables](../felix/configuration).
 

--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -45,6 +45,7 @@ The `{{site.nodecontainer}}` container is primarily configured through environme
 | K8S_KEY_FILE | Location of a client key for accessing the Kubernetes API.                   | string |
 | K8S_CA_FILE | Location of a CA for accessing the Kubernetes API.                            | string |
 | K8S_TOKEN | Token to be used for accessing the Kubernetes API.                              | string |
+| ADVERTISE_CLUSTER_IPS | Enable [advertising Kubernetes service IPs over BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement), within the specified CIDR. [Default: disabled] | IPv4 CIDR |
 
 In addition to the above, `{{site.nodecontainer}}` also supports [the standard Felix configuration environment variables](../felix/configuration).
 

--- a/master/reference/node/configuration.md
+++ b/master/reference/node/configuration.md
@@ -45,7 +45,7 @@ The `{{site.nodecontainer}}` container is primarily configured through environme
 | K8S_KEY_FILE | Location of a client key for accessing the Kubernetes API.                   | string |
 | K8S_CA_FILE | Location of a CA for accessing the Kubernetes API.                            | string |
 | K8S_TOKEN | Token to be used for accessing the Kubernetes API.                              | string |
-| ADVERTISE_CLUSTER_IPS | Enable [advertising Kubernetes service cluster IPs over BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement), within the specified CIDR. [Default: disabled] | IPv4 CIDR |
+| CALICO_ADVERTISE_CLUSTER_IPS | Enable [advertising Kubernetes service cluster IPs over BGP]({{site.baseurl}}/{{page.version}}/usage/service-advertisement), within the specified CIDR. [Default: disabled] | IPv4 CIDR |
 
 In addition to the above, `{{site.nodecontainer}}` also supports [the standard Felix configuration environment variables](../felix/configuration).
 

--- a/master/usage/service-advertisement.md
+++ b/master/usage/service-advertisement.md
@@ -1,0 +1,33 @@
+---
+title: Advertising Kubernetes service IPs over BGP
+canonical_url: 'https://docs.projectcalico.org/master/usage/service-advertisement'
+---
+
+{{site.prodname}} supports advertising Kubernetes service cluster IPs
+over BGP, just as it advertises pod IPs.  This means that, if your
+{{site.prodname}} deployment is configured to peer with BGP routers
+outside the cluster, those routers - plus any further upstream places
+that those routers propagate to - will be able to send traffic to a
+Kubernetes service cluster IP, and that traffic will be routed to one
+of the available endpoints for that service.
+
+This feature is enabled for each {{site.prodname}} node by [setting
+the `ADVERTISE_CLUSTER_IPS` environment
+variable]({{site.baseurl}}/{{page.version}}/getting-started/kubernetes/installation/config-options#configuring-service-advertisement).
+
+When this feature is enabled:
+
+-  the cluster IP CIDR (for example, 10.96.0.0/12) is advertised from
+   every node in the cluster
+
+-  for each active service with `externalTrafficPolicy: Local`, the
+   cluster IP for that service is advertised as a /32 route from the
+   nodes that have endpoints for that service.
+
+Then, by normal BGP route processing and Linux ECMP routing,
+
+-  traffic to a service with `externalTrafficPolicy: Local` will be
+   load-balanced across the nodes with endpoints for that service
+
+-  traffic to a service with `externalTrafficPolicy: Cluster` will be
+   load-balanced across all the nodes in the cluster.

--- a/master/usage/service-advertisement.md
+++ b/master/usage/service-advertisement.md
@@ -1,5 +1,5 @@
 ---
-title: Advertising Kubernetes service IPs over BGP
+title: Advertising Kubernetes services over BGP
 canonical_url: 'https://docs.projectcalico.org/master/usage/service-advertisement'
 ---
 
@@ -26,8 +26,10 @@ When this feature is enabled:
 
 Then, by normal BGP route processing and Linux ECMP routing,
 
--  traffic to a service with `externalTrafficPolicy: Local` will be
-   load-balanced across the nodes with endpoints for that service
+-  traffic to the cluster IP for a service with
+   `externalTrafficPolicy: Local` will be load-balanced across the
+   nodes with endpoints for that service
 
--  traffic to a service with `externalTrafficPolicy: Cluster` will be
-   load-balanced across all the nodes in the cluster.
+-  traffic to the cluster IP for a service with
+   `externalTrafficPolicy: Cluster` will be load-balanced across all
+   the nodes in the cluster.


### PR DESCRIPTION
## Release Note
```release-note
Calico now supports advertising Kubernetes service cluster IPs over BGP.
```
