### PR TITLE
Add RBAC permissions required for upgrade from Calico v2.6

### DIFF
--- a/_includes/master/manifests/rbac.yaml
+++ b/_includes/master/manifests/rbac.yaml
@@ -147,6 +147,15 @@ rules:
       - get
       - list
       - watch
+  # These permissions are only requried for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
 {%- endif %}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/_includes/v3.4/manifests/rbac.yaml
+++ b/_includes/v3.4/manifests/rbac.yaml
@@ -147,6 +147,15 @@ rules:
       - get
       - list
       - watch
+  # These permissions are only requried for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
 {%- endif %}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

As part of this PR (https://github.com/projectcalico/calico/pull/2234/files#diff-711384064eb4903b1c831d52b7ff0fbfR102) we did some permissions consolidation to reduce which permissions we were giving Calico.

In the process, a few permissions which are required for upgrade from v2.6 got lost. This PR adds them back in, but in a separate section so it is easy to tell which permissions can be removed post-upgrade. 


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
