### PR TITLE
Fix CI on v2.6 branch - don't use master

### DIFF
--- a/calico_node/Makefile
+++ b/calico_node/Makefile
@@ -1,7 +1,7 @@
 ###############################################################################
 # vX.Y format: update during major release process
 RELEASE_STREAM ?= v2.6
-CI_RELEASE_STREAM ?= master
+CI_RELEASE_STREAM ?= v2.6
 
 ###############################################################################
 GO_BUILD_VER?=v0.8


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Hopefully fixes these failures: https://semaphoreci.com/calico/calico-old-releases/branches/release-v2-6/builds/4

Looks like we were pulling in the master version of libnetwork plugin, which now uses etcdv3.


```
5409 docker exec -it host1 sh -c 'docker network create --driver calico --ipam-driver calico-ipam  subnet1'
5410   # 60ef753d7d77f76a903d441a0f58b1e6fb57894779bdc6f175b2240d66eb4af8
5411 docker exec -it host1 sh -c 'docker run -tid --name workload1 --net subnet1   busybox'
5412   # Return code: 125
5413   # 5f1da8d4e04e1fcee7f33b72ef1a437771ef86242cfa8f7feae0401b5f37af7a
5414   # docker: Error response from daemon: IpamDriver.RequestAddress: IP assignment error: no configured Calico pools.
5415   #
5416 docker exec -it host1 sh -c 'docker run -tid --name workload1 --net subnet1   busybox'
5417   # Return code: 125
5418   # docker: Error response from daemon: Conflict. The container name "/workload1" is already in use by container "5f1da8d4e04e1fcee7f33b72ef1a437771ef86242cfa8f7feae0401b5f37af7a". You have to remove (or rename) that container to be able to reuse that name.
5419   # See 'docker run --help'.
5420   #
```

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
