### PR TITLE
Bare-metal: Fix NodePort example destination

### DIFF
--- a/master/getting-started/bare-metal/policy/tutorial.md
+++ b/master/getting-started/bare-metal/policy/tutorial.md
@@ -164,6 +164,7 @@ calicoctl apply -f - <<EOF
       - action: Allow
         protocol: TCP
         destination:
+          selector: has(host-endpoint)
           ports: [31852]
     selector: has(host-endpoint)
 EOF

--- a/v3.3/getting-started/bare-metal/policy/tutorial.md
+++ b/v3.3/getting-started/bare-metal/policy/tutorial.md
@@ -165,6 +165,7 @@ calicoctl apply -f - <<EOF
       - action: Allow
         protocol: TCP
         destination:
+          selector: has(host-endpoint)
           ports: [31852]
     selector: has(host-endpoint)
 EOF

--- a/v3.4/getting-started/bare-metal/policy/tutorial.md
+++ b/v3.4/getting-started/bare-metal/policy/tutorial.md
@@ -164,6 +164,7 @@ calicoctl apply -f - <<EOF
       - action: Allow
         protocol: TCP
         destination:
+          selector: has(host-endpoint)
           ports: [31852]
     selector: has(host-endpoint)
 EOF


### PR DESCRIPTION
## Description

Without restricting the destination, this policy allows access to all
endpoints, including all Kubernetes pods on the specified port (31852) instead of just the NodePort service on this port.

The point of the example is to show how to make a NodePort accessible,
not how to open the port in general.

Related: I'm not sure why this policy has `applyOnForward: true` either (and accessing the node port seems to work without it) - from what I understand, Kubernetes NodePort services are accessible on the host network interface, even if only virtually when using kube-proxy in iptables mode.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```