### PR TITLE
Remove refs to kismatic from docs

### DIFF
--- a/master/getting-started/kubernetes/installation/index.md
+++ b/master/getting-started/kubernetes/installation/index.md
@@ -34,7 +34,6 @@ environments.
 | [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
 | [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
 | [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
 | [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
 | [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
 | [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes with Ansible. |
@@ -45,7 +44,6 @@ environments.
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [ibmk]: https://www.ibm.com/cloud/container-service/
-[ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/

--- a/v2.0/getting-started/kubernetes/installation/index.md
+++ b/v2.0/getting-started/kubernetes/installation/index.md
@@ -34,7 +34,6 @@ to integrate Calico into your own installation or deployment scripts.
 A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
 Here are a few, listed alphabetically.
 
-- [Apprenda Kismatic Enterprise Toolkit](https://github.com/apprenda/kismatic)
 - [Container Linux by CoreOS](https://coreos.com/kubernetes/docs/latest/)
 - [GCE](http://kubernetes.io/docs/getting-started-guides/network-policy/calico/)
 - [Gravitational Telekube](http://gravitational.com/blog/gravitational-tigera-partnership/)

--- a/v2.1/getting-started/kubernetes/installation/index.md
+++ b/v2.1/getting-started/kubernetes/installation/index.md
@@ -36,7 +36,6 @@ to integrate Calico into your own installation or deployment scripts.
 A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
 Here are a few, listed alphabetically.
 
-- [Apprenda Kismatic Enterprise Toolkit](https://github.com/apprenda/kismatic)
 - [Container Linux by CoreOS](https://coreos.com/kubernetes/docs/latest/)
 - [GCE](http://kubernetes.io/docs/getting-started-guides/network-policy/calico/)
 - [Gravitational Telekube](http://gravitational.com/blog/gravitational-tigera-partnership/)

--- a/v2.2/getting-started/kubernetes/installation/index.md
+++ b/v2.2/getting-started/kubernetes/installation/index.md
@@ -37,7 +37,6 @@ to integrate Calico into your own installation or deployment scripts.
 A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
 Here are a few, listed alphabetically.
 
-- [Apprenda Kismatic Enterprise Toolkit](https://github.com/apprenda/kismatic)
 - [Container Linux by CoreOS](https://coreos.com/kubernetes/docs/latest/)
 - [GCE](http://kubernetes.io/docs/getting-started-guides/network-policy/calico/)
 - [Gravitational Telekube](http://gravitational.com/blog/gravitational-tigera-partnership/)

--- a/v2.3/getting-started/kubernetes/installation/index.md
+++ b/v2.3/getting-started/kubernetes/installation/index.md
@@ -37,7 +37,6 @@ to integrate Calico into your own installation or deployment scripts.
 A number of popular Kubernetes installers use Calico to provide networking and/or network policy.
 Here are a few, listed alphabetically.
 
-- [Apprenda Kismatic Enterprise Toolkit](https://github.com/apprenda/kismatic)
 - [Container Linux by CoreOS](https://coreos.com/kubernetes/docs/latest/)
 - [GCE](http://kubernetes.io/docs/getting-started-guides/network-policy/calico/)
 - [Gravitational Telekube](http://gravitational.com/blog/gravitational-tigera-partnership/)

--- a/v2.4/getting-started/kubernetes/installation/aws.md
+++ b/v2.4/getting-started/kubernetes/installation/aws.md
@@ -18,8 +18,6 @@ as well as other public and private cloud environments.
 
 **[CoreOS Kubernetes][coreos]** documentation to learn how to install, run and use Kubernetes on CoreOS Container Linux on AWS.
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on AWS and other clouds.
-
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to AWS in 3 steps using a web-based interface.
 
 
@@ -30,7 +28,6 @@ on AWS using one of our [self-hosted manifests][self-hosted], or by [integrating
 
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
-[ket]: https://apprenda.com/kismatic/
 [stackpoint]: https://stackpoint.io/#/
 [coreos]: https://coreos.com/kubernetes/docs/latest/
 

--- a/v2.4/getting-started/kubernetes/installation/gce.md
+++ b/v2.4/getting-started/kubernetes/installation/gce.md
@@ -10,7 +10,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 
 #### Popular guides and tools
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on GCE and other clouds.
 
 **[Kubernetes kube-up][kube-up]** deploys Calico on GCE using the same underlying open-source infrastructure as Google's GKE platform.
 
@@ -23,7 +22,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
 on GCEusing one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
 
-[ket]: https://apprenda.com/kismatic/
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [stackpoint]: https://stackpoint.io/#/

--- a/v2.5/getting-started/kubernetes/installation/aws.md
+++ b/v2.5/getting-started/kubernetes/installation/aws.md
@@ -18,8 +18,6 @@ as well as other public and private cloud environments.
 
 **[CoreOS Kubernetes][coreos]** documentation to learn how to install, run and use Kubernetes on CoreOS Container Linux on AWS.
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on AWS and other clouds.
-
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to AWS in 3 steps using a web-based interface.
 
 **[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for AWS and other platforms.
@@ -31,7 +29,6 @@ on AWS using one of our [self-hosted manifests][self-hosted], or by [integrating
 
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
-[ket]: https://apprenda.com/kismatic/
 [stackpoint]: https://stackpoint.io/#/
 [coreos]: https://coreos.com/kubernetes/docs/latest/
 [typhoon]: https://typhoon.psdn.io/

--- a/v2.5/getting-started/kubernetes/installation/gce.md
+++ b/v2.5/getting-started/kubernetes/installation/gce.md
@@ -10,8 +10,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 
 #### Popular guides and tools
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on GCE and other clouds.
-
 **[Kubernetes kube-up][kube-up]** deploys Calico on GCE using the same underlying open-source infrastructure as Google's GKE platform.
 
 **[Kubespray][kubespray]** is a Kubernetes incubator project for deploying Kubernetes on GCE.
@@ -25,7 +23,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
 on GCE using one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
 
-[ket]: https://apprenda.com/kismatic/
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [stackpoint]: https://stackpoint.io/#/

--- a/v2.6/getting-started/kubernetes/installation/aws.md
+++ b/v2.6/getting-started/kubernetes/installation/aws.md
@@ -18,8 +18,6 @@ as well as other public and private cloud environments.
 
 **[CoreOS Kubernetes][coreos]** documentation to learn how to install, run and use Kubernetes on CoreOS Container Linux on AWS.
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on AWS and other clouds.
-
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to AWS in 3 steps using a web-based interface.
 
 **[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for AWS and other platforms.
@@ -31,7 +29,6 @@ on AWS using one of our [self-hosted manifests][self-hosted], or by [integrating
 
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
-[ket]: https://apprenda.com/kismatic/
 [stackpoint]: https://stackpoint.io/#/
 [coreos]: https://coreos.com/kubernetes/docs/latest/
 [typhoon]: https://typhoon.psdn.io/

--- a/v2.6/getting-started/kubernetes/installation/gce.md
+++ b/v2.6/getting-started/kubernetes/installation/gce.md
@@ -10,8 +10,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 
 #### Popular guides and tools
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on GCE and other clouds.
-
 **[Kubernetes kube-up][kube-up]** deploys Calico on GCE using the same underlying open-source infrastructure as Google's GKE platform.
 
 **[Kubespray][kubespray]** is a Kubernetes incubator project for deploying Kubernetes on GCE.
@@ -25,7 +23,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
 on GCE using one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
 
-[ket]: https://apprenda.com/kismatic/
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [stackpoint]: https://stackpoint.io/#/

--- a/v2.6/getting-started/kubernetes/installation/index.md
+++ b/v2.6/getting-started/kubernetes/installation/index.md
@@ -44,7 +44,6 @@ environments.
 | [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
 | [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
 | [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
 | [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
 | [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
 | [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes on GCE. |
@@ -55,7 +54,6 @@ environments.
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [ibmk]: https://www.ibm.com/cloud/container-service/
-[ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/

--- a/v3.0/getting-started/kubernetes/installation/aws.md
+++ b/v3.0/getting-started/kubernetes/installation/aws.md
@@ -18,8 +18,6 @@ as well as other public and private cloud environments.
 
 **[CoreOS Kubernetes][coreos]** documentation to learn how to install, run and use Kubernetes on CoreOS Container Linux on AWS.
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on AWS and other clouds.
-
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with Calico to AWS in 3 steps using a web-based interface.
 
 **[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for AWS and other platforms.
@@ -31,7 +29,6 @@ on AWS using one of our [self-hosted manifests][self-hosted], or by [integrating
 
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
-[ket]: https://apprenda.com/kismatic/
 [stackpoint]: https://stackpoint.io/#/
 [coreos]: https://coreos.com/kubernetes/docs/latest/
 [typhoon]: https://typhoon.psdn.io/

--- a/v3.0/getting-started/kubernetes/installation/gce.md
+++ b/v3.0/getting-started/kubernetes/installation/gce.md
@@ -10,8 +10,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 
 #### Popular guides and tools
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on GCE and other clouds.
-
 **[Kubernetes kube-up][kube-up]** deploys Calico on GCE using the same underlying open-source infrastructure as Google's GKE platform.
 
 **[Kubespray][kubespray]** is a Kubernetes incubator project for deploying Kubernetes on GCE.
@@ -25,7 +23,6 @@ Make sure you've read the [Calico GCE reference guide][gce-reference] for detail
 If the out-of-the-box solutions listed above don't meet your requirements, you can install Calico for Kubernetes
 on GCE using one of our [self-hosted manifests][self-hosted], or by [integrating Calico with your own configuration management][integration-guide].
 
-[ket]: https://apprenda.com/kismatic/
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [stackpoint]: https://stackpoint.io/#/

--- a/v3.0/getting-started/kubernetes/installation/index.md
+++ b/v3.0/getting-started/kubernetes/installation/index.md
@@ -44,7 +44,6 @@ environments.
 | [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
 | [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
 | [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
 | [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
 | [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
 | [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes on GCE. |
@@ -55,7 +54,6 @@ environments.
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [ibmk]: https://www.ibm.com/cloud/container-service/
-[ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/

--- a/v3.1/getting-started/kubernetes/installation/aws.md
+++ b/v3.1/getting-started/kubernetes/installation/aws.md
@@ -17,8 +17,6 @@ as well as other public and private cloud environments.
 
 **[CoreOS Kubernetes][coreos]** documentation to learn how to install, run and use Kubernetes on CoreOS Container Linux on AWS.
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on AWS and other clouds.
-
 **[StackPointCloud][stackpoint]** lets you deploy a Kubernetes cluster with {{site.prodname}} to AWS in 3 steps using a web-based interface.
 
 **[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for AWS and other platforms.
@@ -26,7 +24,6 @@ as well as other public and private cloud environments.
 
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
-[ket]: https://apprenda.com/kismatic/
 [stackpoint]: https://stackpoint.io/#/
 [coreos]: https://coreos.com/kubernetes/docs/latest/
 [typhoon]: https://typhoon.psdn.io/

--- a/v3.1/getting-started/kubernetes/installation/gce.md
+++ b/v3.1/getting-started/kubernetes/installation/gce.md
@@ -10,8 +10,6 @@ Make sure you've read the [GCE configuration guide](../../../reference/public-cl
 
 #### Popular guides and tools
 
-**[Kismatic Enterprise Toolkit][ket]** Fully-automated, production-grade Kubernetes operations on GCE and other clouds.
-
 **[Kubernetes kube-up][kube-up]** deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform.
 
 **[Kubespray][kubespray]** is a Kubernetes incubator project for deploying Kubernetes on GCE.
@@ -20,7 +18,6 @@ Make sure you've read the [GCE configuration guide](../../../reference/public-cl
 
 **[Typhoon][typhoon]** deploys free and minimal Kubernetes clusters with Terraform, for GCE and other platforms.
 
-[ket]: https://apprenda.com/kismatic/
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [stackpoint]: https://stackpoint.io/#/

--- a/v3.1/getting-started/kubernetes/installation/index.md
+++ b/v3.1/getting-started/kubernetes/installation/index.md
@@ -30,7 +30,6 @@ environments.
 | [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
 | [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
 | [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
 | [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
 | [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
 | [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes on GCE. |
@@ -41,7 +40,6 @@ environments.
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [ibmk]: https://www.ibm.com/cloud/container-service/
-[ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/

--- a/v3.2/getting-started/kubernetes/installation/index.md
+++ b/v3.2/getting-started/kubernetes/installation/index.md
@@ -34,7 +34,6 @@ environments.
 | [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
 | [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
 | [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
 | [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
 | [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
 | [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes with Ansible |
@@ -45,7 +44,6 @@ environments.
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [ibmk]: https://www.ibm.com/cloud/container-service/
-[ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/

--- a/v3.3/getting-started/kubernetes/installation/index.md
+++ b/v3.3/getting-started/kubernetes/installation/index.md
@@ -34,7 +34,6 @@ environments.
 | [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
 | [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
 | [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
 | [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
 | [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
 | [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes with Ansible. |
@@ -45,7 +44,6 @@ environments.
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [ibmk]: https://www.ibm.com/cloud/container-service/
-[ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/

--- a/v3.4/getting-started/kubernetes/installation/index.md
+++ b/v3.4/getting-started/kubernetes/installation/index.md
@@ -35,7 +35,6 @@ environments.
 | [Google Container Engine][gke]       | A managed Kubernetes environment by Google using {{site.prodname}} for network policy. |
 | [Heptio AWS Quickstart][heptio]      | Uses kubeadm and CloudFormation to build Kubernetes clusters on AWS using {{site.prodname}} for networking and network policy enforcement. |
 | [IBM Cloud Kubernetes Service][ibmk] | A managed Kubernetes environment by IBM using {{site.prodname}} for networking and network policy enforcement. |
-| [Kismatic Enterprise Toolkit][ket]   | Fully-automated, production-grade Kubernetes operations on AWS and other clouds. |
 | [Kops][kops]                         | A popular Kubernetes project for launching production-ready clusters on AWS, as well as other public and private cloud environments. |
 | [Kubernetes kube-up][kube-up]        | Deploys {{site.prodname}} on GCE using the same underlying open-source infrastructure as Google's GKE platform. |
 | [Kubespray][kubespray]               | A Kubernetes project for deploying Kubernetes with Ansible. |
@@ -46,7 +45,6 @@ environments.
 [gke]: https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy
 [heptio]: https://s3.amazonaws.com/quickstart-reference/heptio/latest/doc/heptio-kubernetes-on-the-aws-cloud.pdf
 [ibmk]: https://www.ibm.com/cloud/container-service/
-[ket]: https://apprenda.com/kismatic/
 [kops]: https://github.com/kubernetes/kops/blob/master/docs/networking.md#calico-example-for-cni-and-network-policy
 [kubespray]: https://github.com/kubernetes-incubator/kubespray
 [kube-up]: http://kubernetes.io/docs/getting-started-guides/network-policy/calico/


### PR DESCRIPTION
## Description
Type of fix: Documentation
Reason for fix: Apprenda no longer exist, the link used throughout the docs (https://apprenda.com/kismatic/) now redirects to https://atos.net/en/ instead. Kismatic meanwhile appears to have been abandoned, with no new commits at https://github.com/apprenda/kismatic in the last 6 months and the twitter account now being suspended: https://twitter.com/kismatic
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
