### PR TITLE
Really fix number of replicas when Typha is wanted

### DIFF
--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -35,11 +35,7 @@ spec:
   # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
   # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
-{%- if include.typha == "true" %}
   replicas: 1
-{%- else %}
-  replicas: 0
-{%- endif %}
   revisionHistoryLimit: 2
   template:
     metadata:


### PR DESCRIPTION
https://github.com/projectcalico/calico/pull/2340 didn't work because
include variables (like include.typha) are not automatically propagated
from one include to its sub-includes.

In any case, in master, calico-typha.yaml is _only_ included now when
include.typha is true, so we can change it unconditionally to "replicas:
1", and we don't need the include variable here.
