### PR TITLE
Clarifies several aspects of etcd that have caused confusion

### DIFF
--- a/_includes/master/reqs-sys.md
+++ b/_includes/master/reqs-sys.md
@@ -20,13 +20,26 @@
 ## Key/value store
 
 {{site.prodname}} {{page.version}} requires a key/value store accessible by all
-{{site.prodname}} components. {% if include.orch == "Kubernetes" %} On Kubernetes,
-you can configure {{site.prodname}} to access an etcdv3 cluster directly or to
-use the Kubernetes API datastore.{% endif %}{% if include.orch == "OpenShift" %} On
-OpenShift, {{site.prodname}} can share an etcdv3 cluster with OpenShift, or
-you can set up an etcdv3 cluster dedicated to {{site.prodname}}.{% endif %}
+{{site.prodname}} components. {% if include.orch == "Kubernetes" %} You can choose either
+of the following options.
+
+- Use the Kubernetes API datastore.
+
+- Configure {{site.prodname}} to access an etcdv3 cluster directly (required if you plan to protect
+  [bare metal hosts](../bare-metal/bare-metal)). If you don't already have an etcdv3 cluster set up,
+  refer to the [coreos](https://coreos.com/etcd/docs/latest/) documentation for instructions. Before
+  beginning our [production install](./installation/), you must have your etcdv3 cluster set up.
+  Otherwise, refer to our [Quickstart](.). The Quickstart sets up an etcd instance for you, but it won't
+  be suitable for production.
+{% endif %}{% if include.orch == "OpenShift" %}
+For testing and development purposes, you can configure {{site.prodname}} to share an etcdv3
+cluster with OpenShift. Production clusters require an etcdv3 cluster dedicated to {{site.prodname}}. Refer to the [coreos](https://coreos.com/etcd/docs/latest/)
+documentation for setup instructions.{% endif %}
 {% if include.orch == "OpenStack" %}If you don't already have an etcdv3 cluster
-to connect to, we provide instructions in the [installation documentation](./installation/).{% endif %}{% if include.orch == "host protection" %}The key/value store must be etcdv3.{% endif %}
+to connect to, we provide instructions in the [installation documentation](./installation/).{% endif %}
+{% if include.orch == "host protection" %}Bare metal hosts cannot connect to a datastore through the Kubernetes API.
+If you have a Kubernetes cluster and want to protect bare metal hosts, you must configure your Kubernetes cluster
+to connect directly to an etcdv3 cluster.{% endif %}
 
 ## Network requirements
 

--- a/master/getting-started/kubernetes/installation/calico.md
+++ b/master/getting-started/kubernetes/installation/calico.md
@@ -107,6 +107,10 @@ datastore type and number of nodes.
 
 ### Installing with the etcd datastore
 
+> **Note**: As discussed in the [system requirements](../requirements#keyvalue-store), ensure that you have an etcdv3 cluster
+> set up before beginning this procedure.
+{: .alert .alert-info}
+
 1. Download the {{site.prodname}} networking manifest for etcd.
 
    ```bash

--- a/master/getting-started/kubernetes/installation/flannel.md
+++ b/master/getting-started/kubernetes/installation/flannel.md
@@ -54,6 +54,10 @@ section that matches your type.
 We strongly recommend using the Kubernetes API datastore, but if you prefer to use
 etcd, complete the following steps.
 
+> **Note**: As discussed in the [system requirements](../requirements#keyvalue-store), ensure that you have an etcdv3 cluster
+> set up before beginning this procedure.
+{: .alert .alert-info}
+
 1. Download the {{site.prodname}} networking manifest.
 
    ```bash


### PR DESCRIPTION
## Description

- Clarifies that the production install for etcd requires an etcd data store set up in advance.
- Provides link to coreos docs for instructions.
- Also clarifies that the Quickstart is there as an alternative to the production install and does not require you to set up etcd in advance.
- Clarifies that if you want to protect bare metal hosts, you cannot use the Kubernetes API datastore.
- Also adds some notes in the install procedures in case people have missed this information which is there in the requirements and in the before you begin instructions: you need an etcd cluster to get through the procedure.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
