### PR TITLE
Docs for label selector / IPPool changes in Calico v3.5

### DIFF
--- a/_data/master/navbars/reference.yml
+++ b/_data/master/navbars/reference.yml
@@ -26,6 +26,8 @@ toc:
       path: /reference/calicoctl/commands/delete
     - title: convert
       path: /reference/calicoctl/commands/convert
+    - title: label
+      path: /reference/calicoctl/commands/label
     - title: ipam
       section:
       - title: Overview

--- a/_data/master/navbars/usage.yml
+++ b/_data/master/navbars/usage.yml
@@ -51,6 +51,8 @@ toc:
   path: /usage/configuration/conntrack
 - title: Advertising Kubernetes services
   path: /usage/service-advertisement
+- title: Assigning IP addresses based on topology
+  path: /usage/assigning-ip-addresses-topology
 - title: Calico for OpenStack
   section:
   - title: Endpoint Labels

--- a/master/getting-started/kubernetes/troubleshooting.md
+++ b/master/getting-started/kubernetes/troubleshooting.md
@@ -43,7 +43,7 @@ key `log_level`.  See [the configuration guide]({{site.baseurl}}/{{page.version}
 When using {{site.prodname}} IPAM, IP addresses are assigned from [IP Pools]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/ippool).
 
 By default, all enabled IP Pool are used. However, you can specify which IP Pools to use for IP address management in the [CNI network config]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#ipam),
-or on a per-Pod basis using [Kubernetes annotations]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#ipam-manipulation-with-kubernetes-annotations).
+or on a per-Pod basis using [Kubernetes annotations]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#using-kubernetes-annotations).
 
 #### How do I assign a specific IP address to a pod?
 

--- a/master/reference/calicoctl/commands/index.md
+++ b/master/reference/calicoctl/commands/index.md
@@ -26,6 +26,7 @@ Usage:
               name.
     get       Get a resource identified by file, stdin or resource type and
               name.
+    label     Add or update labels of resources.
     convert   Convert config files between different API versions.
     ipam      IP address management.
     node      Calico node management.
@@ -55,6 +56,7 @@ organized by top level command.
 -  [calicoctl apply]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/apply)
 -  [calicoctl delete]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/delete)
 -  [calicoctl get]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/get)
+-  [calicoctl label]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/label)
 -  [calicoctl ipam]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/ipam)
 -  [calicoctl node]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node)
 -  [calicoctl convert]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/convert)

--- a/master/reference/calicoctl/commands/label.md
+++ b/master/reference/calicoctl/commands/label.md
@@ -1,0 +1,154 @@
+---
+title: calicoctl label
+canonical_url: 'https://docs.projectcalico.org/v3.5/reference/calicoctl/commands/label'
+---
+
+This section describes the `calicoctl label` command.
+
+Read the [calicoctl command line interface user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
+for a full list of calicoctl commands.
+
+> **Note**: The available actions for a specific resource type may be
+> limited based on the datastore used for {{site.prodname}} (etcdv3 / Kubernetes API).
+> Please refer to the
+> [Resources section]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/)
+> for details about each resource type.
+{: .alert .alert-info}
+
+
+## Displaying the help text for 'calicoctl label' command
+
+Run `calicoctl label --help` to display the following help menu for the
+command.
+
+```
+Usage:
+  calicoctl label (<KIND> <NAME>
+  	              ( <key>=<value> [--overwrite] |
+  	                <key> --remove )
+                  [--config=<CONFIG>] [--namespace=<NS>])
+
+Examples:
+  # Label a workload endpoint
+  calicoctl label workloadendpoints nginx --namespace=default app=web
+
+  # Label a node and overwrite the original value of key 'cluster'
+  calicoctl label nodes node1 cluster=frontend --overwrite
+
+  # Remove label with key 'cluster' of the node
+  calicoctl label nodes node1 cluster --remove
+
+Options:
+  -h --help                    Show this screen.
+  -c --config=<CONFIG>         Path to the file containing connection
+                               configuration in YAML or JSON format.
+                               [default: /etc/calico/calicoctl.cfg]
+  -n --namespace=<NS>          Namespace of the resource.
+                               Only applicable to NetworkPolicy and WorkloadEndpoint.
+                               Uses the default namespace if not specified.
+  --overwrite                  If true, overwrite the value when the key is already
+                               present in labels. Otherwise reports error when the
+                               labeled resource already have the key in its labels.
+                               Can not be used with --remove.
+  --remove                     If true, remove the specified key in labels of the
+                               resource. Reports error when specified key does not
+                               exist. Can not be used with --overwrite.
+
+Description:
+  The label command is used to add or update a label on a resource. Resource types
+  that can be labeled are:
+
+    * bgpConfiguration
+    * bgpPeer
+    * felixConfiguration
+    * globalNetworkPolicy
+    * globalNetworkSet
+    * hostEndpoint
+    * ipPool
+    * networkPolicy
+    * node
+    * profile
+    * workloadEndpoint
+
+  The resource type is case insensitive and may be pluralized.
+
+  Attempting to label resources that do not exist will get an error.
+
+  Attempting to remove a label that does not exist in the resource will get an error.
+
+  When labeling a resource on an existing key:
+  - gets an error if option --overwrite is not provided.
+  - value of the key updates to specified value if option --overwrite is provided.
+```
+{: .no-select-button}
+
+### Examples
+
+1. Label a node.
+
+   ```bash
+   calicoctl label nodes node1 cluster=backend
+   ```
+
+   Results indicate that label was successfully applied.
+
+   ```bash
+   Successfully set label cluster on nodes node1
+   ```
+   {: .no-select-button}
+
+1. Label a node and overwrite the original value of key `cluster`.
+   ```bash
+   calicoctl label nodes node1 cluster=frontend --overwrite
+   ```
+
+   Results indicate that label was successfully overwritten.
+
+   ```bash
+   Successfully updated label cluster on nodes node1
+   ```
+   {: .no-select-button}
+
+1. Remove label with key `cluster` from the node.
+   ```bash
+   calicoctl label nodes node1 cluster --remove
+   ```
+
+   Results indicate that the label was successfully removed.
+
+   ```bash
+   Successfully removed label cluster from nodes node1.
+   ```
+   {: .no-select-button}
+
+### Options
+
+```
+  -n --namespace=<NS>          Namespace of the resource.
+                               Only applicable to NetworkPolicy and WorkloadEndpoint.
+                               Uses the default namespace if not specified.
+  --overwrite                  If true, overwrite the value when the key is already
+                               present in labels. Otherwise reports error when the
+                               labeled resource already have the key in its labels.
+                               Can not be used with --remove.
+  --remove                     If true, remove the specified key in labels of the
+                               resource. Reports error when specified key does not
+                               exist. Can not be used with --overwrite.
+```
+{: .no-select-button}
+
+### General options
+
+```
+   -c --config=<CONFIG>      Path to the file containing connection
+                             configuration in YAML or JSON format.
+                             [default: /etc/calico/calicoctl.cfg]
+```
+{: .no-select-button}
+
+## See also
+
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
+   and schema
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup) for details on configuring `calicoctl` to access
+   the {{site.prodname}} datastore.

--- a/master/reference/calicoctl/resources/ippool.md
+++ b/master/reference/calicoctl/resources/ippool.md
@@ -21,6 +21,7 @@ spec:
   ipipMode: CrossSubnet
   natOutgoing: true
   disabled: false
+  nodeSelector: all()
 ```
 
 ### IP Pool Definition
@@ -40,10 +41,12 @@ spec:
 | ipipMode | The IPIP mode defining when IPIP will be used. | Always, CrossSubnet, Never | string| `Never` |
 | natOutgoing | When enabled, packets sent from {{site.prodname}} networked containers in this pool to destinations outside of this pool will be masqueraded. | true, false | boolean | `false` |
 | disabled | When set to true, {{site.prodname}} IPAM will not assign addresses from this pool. | true, false | boolean | `false` |
+| nodeSelector | Selects the nodes that {{site.prodname}} IPAM should assign addresses from this pool to. | | [selector](#node-selector) | all() |
 
-> **Important**: Do not use a custom `blockSize` until **all** Calico components have been updated to a version that 
-> supports it (at least v3.3.0).  Older versions of components do not understand the field so they may corrupt the 
-> IP pool by creating blocks of incorrect size.
+> **Important**: Do not use a custom `blockSize` until **all** Calico components
+> have been updated to a version that supports it. Older versions of components
+> do not understand the field so they may corrupt the IP pool by creating blocks
+> of incorrect size.
 {: .alert .alert-danger}
 
 #### IPIP
@@ -69,6 +72,18 @@ The default block sizes of `26` for IPv4 and `122` for IPv6 provide blocks of 64
 Increasing the block size from the default (e.g., using `24` for IPv4 to give 256 addresses per block) means fewer blocks per host, and potentially fewer routes. But try to ensure that there are at least as many blocks in the pool as there are hosts.
 
 Reducing the block size from the default (e.g., using `28` for IPv4 to give 16 addresses per block) means more blocks per host and therefore potentially more routes. This can be beneficial if it allows the blocks to be more fairly distributed amongst the hosts.
+
+#### Node Selector
+
+{% include {{page.version}}/selectors.md %}
+
+For details on configuring IP pool node selectors, please read the
+[Assigning IP addresses based on topology guide.]({{site.baseurl}}/{{page.version}}/usage/assigning-ip-addresses-topology).
+
+> **Note**: The pool's `disabled` field takes higher precedence than
+> `nodeSelector`. This means that {{site.prodname}} IPAM will not allocate any
+> IPs from a disabled pool even if it selects the node that it is on.
+{: .alert .alert-warning}
 
 ### Supported operations
 

--- a/master/reference/kube-controllers/configuration.md
+++ b/master/reference/kube-controllers/configuration.md
@@ -45,13 +45,12 @@ configure API access if needed.
 
 The following environment variables can be used to configure the {{site.prodname}} Kubernetes controllers.
 
-| Environment   | Description | Schema |
-| ------------- | ----------- | ------ |
-| `ENABLED_CONTROLLERS` | Which controllers to run | namespace, node, policy, serviceaccount, workloadendpoint |
-| `LOG_LEVEL`     | Minimum log level to be displayed. | debug, info, warning, error |
-| `KUBECONFIG`    | Path to a kubeconfig file for Kubernetes API access | path |
-
-If `ENABLED_CONTROLLERS` is not explicitly specified, the following controllers are run by default: policy, namespace, workloadendpoint, serviceaccount
+| Environment   | Description | Schema | Default |
+| ------------- | ----------- | ------ | -------
+| `ENABLED_CONTROLLERS` | Which controllers to run | namespace, node, policy, serviceaccount, workloadendpoint | policy,namespace,serviceaccount,workloadendpoint,node
+| `LOG_LEVEL`     | Minimum log level to be displayed. | debug, info, warning, error | info
+| `KUBECONFIG`    | Path to a kubeconfig file for Kubernetes API access | path | 
+| `SYNC_NODE_LABELS`    | When enabled, Kubernetes node labels will be copied to Calico node objects. | boolean | true
 
 [in-cluster-config]: https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
 [kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
@@ -79,6 +78,12 @@ To enable the node controller, perform the following two steps.
 ```
 
 This controller is only valid when using etcd as the {{site.prodname}} datastore.
+
+Set `SYNC_NODE_LABELS` to true (enabled by default) to ensure that labels on
+Kubernetes node resources remain in-sync with labels on the corresponding {{site.prodname}}
+node resource. If both node resources specify a label with different values,
+the Kubernetes node resource takes precedence. Labels on the {{site.prodname}}
+resource that don't exist in the Kubernetes node will remain as is.
 
 ### Policy controller
 

--- a/master/usage/assigning-ip-addresses-topology.md
+++ b/master/usage/assigning-ip-addresses-topology.md
@@ -1,0 +1,172 @@
+---
+title: Assigning IP addresses based on topology
+---
+
+## About IP address assignment
+
+{{site.prodname}} can be configured to use specific IP pools for different
+topological areas. For example, you may want workloads in a particular rack,
+zone, or region to receive addresses from the same IP pool. This may be
+desirable either to reduce the number of routes required in the network or to
+meet requirements imposed by an external firewall device or policy.
+
+There are three approaches to configuring IP address assignment behavior which
+the [IPAM section of the cni-plugin configuration reference
+document]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#ipam)
+explains in detail. For the purposes of topology, IP address
+assignment must be per-host (node) which disqualifies Kubernetes annotations
+as an option since it is only configurable on a per-namespace or per-pod level.
+Left between using CNI configuration and IP pool node selectors, the
+latter is preferred as it does not require making any changes within the
+host's file system which the former does.
+
+At a high level, node selection-based IP address assignment is exactly what it
+sounds like: node labels are set and then the appropriate node selectors
+on the desired IP pool resources are set. The remainder of this article goes
+into a detailed example of using this feature to configure IP address
+assignment based on a certain rack affinity.
+
+> **Important**: If Calico is unable to determine an IP pool for a workload
+> based on the above order, or if there are no IP addresses left in the
+> determined IP pools, then the workload will not be assigned an address and
+> will fail to start. To prevent this, we recommend ensuring that all nodes are
+> selected by at least one IP pool.
+{: .alert .alert-danger}
+
+## Prerequisites
+
+This feature requires {{site.prodname}} for networking in etcd mode.
+
+### Example: Kubernetes
+
+In this example, we created a cluster with four nodes across two racks
+(two nodes/rack). Consider the following:
+
+```
+       -------------------
+       |    router       |
+       -------------------
+       |                 |
+---------------   ---------------
+| rack-0      |   | rack-1      |
+---------------   ---------------
+| kube-node-0 |   | kube-node-2 |
+- - - - - - - -   - - - - - - - -
+| kube-node-1 |   | kube-node-3 |
+- - - - - - - -   - - - - - - - -
+```
+{: .no-select-button}
+
+Using the pod IP range `192.168.0.0/16`, we target the following setup: reserve
+the `192.168.0.0/24` and `192.168.1.0/24` pools for `rack-0`, `rack-1`. Let's
+get started.
+
+
+By installing {{ site.prodname }} without setting the default IP pool to match,
+running `calicoctl get ippool -o wide` shows that {{site.prodname}} created its
+default IP pool of `192.168.0.0/16`:
+
+```
+NAME                  CIDR             NAT    IPIPMODE   DISABLED   SELECTOR
+default-ipv4-ippool   192.168.0.0/16   true   Always     false      all()
+```
+{: .no-select-button}
+
+1. Delete the default IP pool.
+
+   Since the `default-ipv4-ippool` IP pool resource already exists and accounts
+   for the entire `/16` block, we will have to delete this first:
+
+   ```
+   calicoctl delete ippools default-ipv4-ippool
+   ```
+
+2. Label the nodes.
+
+   To assign IP pools to specific nodes, these nodes must be labelled
+   using [kubectl label](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#add-a-label-to-a-node).
+
+   ```
+   kubectl label nodes kube-node-0 rack=0
+   kubectl label nodes kube-node-1 rack=0
+   kubectl label nodes kube-node-2 rack=1
+   kubectl label nodes kube-node-3 rack=1
+   ```
+
+3. Create an IP pool for each rack.
+
+   ```
+   calicoctl create -f -<<EOF
+   apiVersion: projectcalico.org/v3
+   kind: IPPool
+   metadata:
+     name: rack-0-ippool
+   spec:
+     cidr: 192.168.0.0/24
+     ipipMode: Always
+     natOutgoing: true
+     nodeSelector: rack == "0"
+EOF
+   ```
+
+   ```
+   calicoctl create -f -<<EOF
+   apiVersion: projectcalico.org/v3
+   kind: IPPool
+   metadata:
+     name: rack-1-ippool
+   spec:
+     cidr: 192.168.1.0/24
+     ipipMode: Always
+     natOutgoing: true
+     nodeSelector: rack == "1"
+EOF
+   ```
+
+   We should now have two enabled IP pools, which we can see when running
+   `calicoctl get ippool -o wide`:
+
+   ```
+   NAME                  CIDR             NAT    IPIPMODE   DISABLED   SELECTOR
+   rack-1-ippool         192.168.0.0/24   true   Always     false      rack == "0"
+   rack-2-ippool         192.168.1.0/24   true   Always     false      rack == "1"
+   ```
+   {: .no-select-button}
+
+4. Verify that the IP pool node selectors are being respected.
+
+   We will create an nginx deployment with five replicas to get a workload
+   running on each node.
+
+   ```
+   kubectl run nginx --image nginx --replicas 5
+   ```
+
+   Check that the new workloads now have an address in the proper IP pool
+   allocated for the rack that the node is on with `kubectl get pods -owide`.
+
+   ```
+   NAME                   READY   STATUS    RESTARTS   AGE    IP             NODE          NOMINATED NODE   READINESS GATES
+   nginx-5c7588df-prx4z   1/1     Running   0          6m3s   192.168.0.64   kube-node-0   <none>           <none>
+   nginx-5c7588df-s7qw6   1/1     Running   0          6m7s   192.168.0.129  kube-node-1   <none>           <none>
+   nginx-5c7588df-w7r7g   1/1     Running   0          6m3s   192.168.1.65   kube-node-2   <none>           <none>
+   nginx-5c7588df-62lnf   1/1     Running   0          6m3s   192.168.1.1    kube-node-3   <none>           <none>
+   nginx-5c7588df-pnsvv   1/1     Running   0          6m3s   192.168.1.64   kube-node-2   <none>           <none>
+   ```
+   {: .no-select-button}
+
+   The grouping of IP addresses assigned to the workloads differ based on what
+   node that they were scheduled to. Additionally, the assigned address for
+   each workload falls within the respective IP pool that selects the rack that
+   they run on.
+
+> **Note**: {{site.prodname}} IPAM will not reassign IP addresses to workloads
+> that are already running. To update running workloads with IP addresses from
+> a newly configured IP pool, they must be recreated. We recommmend doing this
+> before going into production or during a maintenance window.
+{: .alert .alert-info}
+
+## Related links
+
+For more information on the structure of the IP pool resource, see
+[the IP pools reference]({{ site.baseurl }}/{{ page.version }}/reference/calicoctl/resources/ippool).

--- a/v3.5/getting-started/kubernetes/troubleshooting.md
+++ b/v3.5/getting-started/kubernetes/troubleshooting.md
@@ -43,7 +43,7 @@ key `log_level`.  See [the configuration guide]({{site.baseurl}}/{{page.version}
 When using {{site.prodname}} IPAM, IP addresses are assigned from [IP Pools]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/ippool).
 
 By default, all enabled IP Pool are used. However, you can specify which IP Pools to use for IP address management in the [CNI network config]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#ipam),
-or on a per-Pod basis using [Kubernetes annotations]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#ipam-manipulation-with-kubernetes-annotations).
+or on a per-Pod basis using [Kubernetes annotations]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#using-kubernetes-annotations).
 
 #### How do I assign a specific IP address to a pod?
 

--- a/v3.5/reference/calicoctl/commands/index.md
+++ b/v3.5/reference/calicoctl/commands/index.md
@@ -26,6 +26,7 @@ Usage:
               name.
     get       Get a resource identified by file, stdin or resource type and
               name.
+    label     Add or update labels of resources.
     convert   Convert config files between different API versions.
     ipam      IP address management.
     node      Calico node management.
@@ -55,6 +56,7 @@ organized by top level command.
 -  [calicoctl apply]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/apply)
 -  [calicoctl delete]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/delete)
 -  [calicoctl get]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/get)
+-  [calicoctl label]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/label)
 -  [calicoctl ipam]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/ipam)
 -  [calicoctl node]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/node)
 -  [calicoctl convert]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/convert)

--- a/v3.5/reference/calicoctl/commands/label.md
+++ b/v3.5/reference/calicoctl/commands/label.md
@@ -1,0 +1,154 @@
+---
+title: calicoctl label
+canonical_url: 'https://docs.projectcalico.org/v3.5/reference/calicoctl/commands/label'
+---
+
+This section describes the `calicoctl label` command.
+
+Read the [calicoctl command line interface user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/)
+for a full list of calicoctl commands.
+
+> **Note**: The available actions for a specific resource type may be
+> limited based on the datastore used for {{site.prodname}} (etcdv3 / Kubernetes API).
+> Please refer to the
+> [Resources section]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/)
+> for details about each resource type.
+{: .alert .alert-info}
+
+
+## Displaying the help text for 'calicoctl label' command
+
+Run `calicoctl label --help` to display the following help menu for the
+command.
+
+```
+Usage:
+  calicoctl label (<KIND> <NAME>
+  	              ( <key>=<value> [--overwrite] |
+  	                <key> --remove )
+                  [--config=<CONFIG>] [--namespace=<NS>])
+
+Examples:
+  # Label a workload endpoint
+  calicoctl label workloadendpoints nginx --namespace=default app=web
+
+  # Label a node and overwrite the original value of key 'cluster'
+  calicoctl label nodes node1 cluster=frontend --overwrite
+
+  # Remove label with key 'cluster' of the node
+  calicoctl label nodes node1 cluster --remove
+
+Options:
+  -h --help                    Show this screen.
+  -c --config=<CONFIG>         Path to the file containing connection
+                               configuration in YAML or JSON format.
+                               [default: /etc/calico/calicoctl.cfg]
+  -n --namespace=<NS>          Namespace of the resource.
+                               Only applicable to NetworkPolicy and WorkloadEndpoint.
+                               Uses the default namespace if not specified.
+  --overwrite                  If true, overwrite the value when the key is already
+                               present in labels. Otherwise reports error when the
+                               labeled resource already have the key in its labels.
+                               Can not be used with --remove.
+  --remove                     If true, remove the specified key in labels of the
+                               resource. Reports error when specified key does not
+                               exist. Can not be used with --overwrite.
+
+Description:
+  The label command is used to add or update a label on a resource. Resource types
+  that can be labeled are:
+
+    * bgpConfiguration
+    * bgpPeer
+    * felixConfiguration
+    * globalNetworkPolicy
+    * globalNetworkSet
+    * hostEndpoint
+    * ipPool
+    * networkPolicy
+    * node
+    * profile
+    * workloadEndpoint
+
+  The resource type is case insensitive and may be pluralized.
+
+  Attempting to label resources that do not exist will get an error.
+
+  Attempting to remove a label that does not exist in the resource will get an error.
+
+  When labeling a resource on an existing key:
+  - gets an error if option --overwrite is not provided.
+  - value of the key updates to specified value if option --overwrite is provided.
+```
+{: .no-select-button}
+
+### Examples
+
+1. Label a node.
+
+   ```bash
+   calicoctl label nodes node1 cluster=backend
+   ```
+
+   Results indicate that label was successfully applied.
+
+   ```bash
+   Successfully set label cluster on nodes node1
+   ```
+   {: .no-select-button}
+
+1. Label a node and overwrite the original value of key `cluster`.
+   ```bash
+   calicoctl label nodes node1 cluster=frontend --overwrite
+   ```
+
+   Results indicate that label was successfully overwritten.
+
+   ```bash
+   Successfully updated label cluster on nodes node1
+   ```
+   {: .no-select-button}
+
+1. Remove label with key `cluster` from the node.
+   ```bash
+   calicoctl label nodes node1 cluster --remove
+   ```
+
+   Results indicate that the label was successfully removed.
+
+   ```bash
+   Successfully removed label cluster from nodes node1.
+   ```
+   {: .no-select-button}
+
+### Options
+
+```
+  -n --namespace=<NS>          Namespace of the resource.
+                               Only applicable to NetworkPolicy and WorkloadEndpoint.
+                               Uses the default namespace if not specified.
+  --overwrite                  If true, overwrite the value when the key is already
+                               present in labels. Otherwise reports error when the
+                               labeled resource already have the key in its labels.
+                               Can not be used with --remove.
+  --remove                     If true, remove the specified key in labels of the
+                               resource. Reports error when specified key does not
+                               exist. Can not be used with --overwrite.
+```
+{: .no-select-button}
+
+### General options
+
+```
+   -c --config=<CONFIG>      Path to the file containing connection
+                             configuration in YAML or JSON format.
+                             [default: /etc/calico/calicoctl.cfg]
+```
+{: .no-select-button}
+
+## See also
+
+-  [Resources]({{site.baseurl}}/{{page.version}}/reference/calicoctl/resources/) for details on all valid resources, including file format
+   and schema
+-  [calicoctl configuration]({{site.baseurl}}/{{page.version}}/reference/calicoctl/setup) for details on configuring `calicoctl` to access
+   the {{site.prodname}} datastore.

--- a/v3.5/reference/calicoctl/resources/ippool.md
+++ b/v3.5/reference/calicoctl/resources/ippool.md
@@ -21,6 +21,7 @@ spec:
   ipipMode: CrossSubnet
   natOutgoing: true
   disabled: false
+  nodeSelector: all()
 ```
 
 ### IP Pool Definition
@@ -40,10 +41,12 @@ spec:
 | ipipMode | The IPIP mode defining when IPIP will be used. | Always, CrossSubnet, Never | string| `Never` |
 | natOutgoing | When enabled, packets sent from {{site.prodname}} networked containers in this pool to destinations outside of this pool will be masqueraded. | true, false | boolean | `false` |
 | disabled | When set to true, {{site.prodname}} IPAM will not assign addresses from this pool. | true, false | boolean | `false` |
+| nodeSelector | Selects the nodes that {{site.prodname}} IPAM should assign addresses from this pool to. | | [selector](#node-selector) | all() |
 
-> **Important**: Do not use a custom `blockSize` until **all** Calico components have been updated to a version that 
-> supports it (at least v3.3.0).  Older versions of components do not understand the field so they may corrupt the 
-> IP pool by creating blocks of incorrect size.
+> **Important**: Do not use a custom `blockSize` until **all** Calico components
+> have been updated to a version that supports it. Older versions of components
+> do not understand the field so they may corrupt the IP pool by creating blocks
+> of incorrect size.
 {: .alert .alert-danger}
 
 #### IPIP
@@ -69,6 +72,18 @@ The default block sizes of `26` for IPv4 and `122` for IPv6 provide blocks of 64
 Increasing the block size from the default (e.g., using `24` for IPv4 to give 256 addresses per block) means fewer blocks per host, and potentially fewer routes. But try to ensure that there are at least as many blocks in the pool as there are hosts.
 
 Reducing the block size from the default (e.g., using `28` for IPv4 to give 16 addresses per block) means more blocks per host and therefore potentially more routes. This can be beneficial if it allows the blocks to be more fairly distributed amongst the hosts.
+
+#### Node Selector
+
+{% include {{page.version}}/selectors.md %}
+
+For details on configuring IP pool node selectors, please read the
+[Assigning IP addresses based on topology guide.]({{site.baseurl}}/{{page.version}}/usage/assigning-ip-addresses-topology).
+
+> **Note**: The pool's `disabled` field takes higher precedence than
+> `nodeSelector`. This means that {{site.prodname}} IPAM will not allocate any
+> IPs from a disabled pool even if it selects the node that it is on.
+{: .alert .alert-warning}
 
 ### Supported operations
 

--- a/v3.5/reference/kube-controllers/configuration.md
+++ b/v3.5/reference/kube-controllers/configuration.md
@@ -45,13 +45,12 @@ configure API access if needed.
 
 The following environment variables can be used to configure the {{site.prodname}} Kubernetes controllers.
 
-| Environment   | Description | Schema |
-| ------------- | ----------- | ------ |
-| `ENABLED_CONTROLLERS` | Which controllers to run | namespace, node, policy, serviceaccount, workloadendpoint |
-| `LOG_LEVEL`     | Minimum log level to be displayed. | debug, info, warning, error |
-| `KUBECONFIG`    | Path to a kubeconfig file for Kubernetes API access | path |
-
-If `ENABLED_CONTROLLERS` is not explicitly specified, the following controllers are run by default: policy, namespace, workloadendpoint, serviceaccount
+| Environment   | Description | Schema | Default |
+| ------------- | ----------- | ------ | -------
+| `ENABLED_CONTROLLERS` | Which controllers to run | namespace, node, policy, serviceaccount, workloadendpoint | policy,namespace,serviceaccount,workloadendpoint,node
+| `LOG_LEVEL`     | Minimum log level to be displayed. | debug, info, warning, error | info
+| `KUBECONFIG`    | Path to a kubeconfig file for Kubernetes API access | path | 
+| `SYNC_NODE_LABELS`    | When enabled, Kubernetes node labels will be copied to Calico node objects. | boolean | true
 
 [in-cluster-config]: https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
 [kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
@@ -79,6 +78,12 @@ To enable the node controller, perform the following two steps.
 ```
 
 This controller is only valid when using etcd as the {{site.prodname}} datastore.
+
+Set `SYNC_NODE_LABELS` to true (enabled by default) to ensure that labels on
+Kubernetes node resources remain in-sync with labels on the corresponding {{site.prodname}}
+node resource. If both node resources specify a label with different values,
+the Kubernetes node resource takes precedence. Labels on the {{site.prodname}}
+resource that don't exist in the Kubernetes node will remain as is.
 
 ### Policy controller
 

--- a/v3.5/usage/assigning-ip-addresses-topology.md
+++ b/v3.5/usage/assigning-ip-addresses-topology.md
@@ -1,0 +1,172 @@
+---
+title: Assigning IP addresses based on topology
+---
+
+## About IP address assignment
+
+{{site.prodname}} can be configured to use specific IP pools for different
+topological areas. For example, you may want workloads in a particular rack,
+zone, or region to receive addresses from the same IP pool. This may be
+desirable either to reduce the number of routes required in the network or to
+meet requirements imposed by an external firewall device or policy.
+
+There are three approaches to configuring IP address assignment behavior which
+the [IPAM section of the cni-plugin configuration reference
+document]({{site.baseurl}}/{{page.version}}/reference/cni-plugin/configuration#ipam)
+explains in detail. For the purposes of topology, IP address
+assignment must be per-host (node) which disqualifies Kubernetes annotations
+as an option since it is only configurable on a per-namespace or per-pod level.
+Left between using CNI configuration and IP pool node selectors, the
+latter is preferred as it does not require making any changes within the
+host's file system which the former does.
+
+At a high level, node selection-based IP address assignment is exactly what it
+sounds like: node labels are set and then the appropriate node selectors
+on the desired IP pool resources are set. The remainder of this article goes
+into a detailed example of using this feature to configure IP address
+assignment based on a certain rack affinity.
+
+> **Important**: If Calico is unable to determine an IP pool for a workload
+> based on the above order, or if there are no IP addresses left in the
+> determined IP pools, then the workload will not be assigned an address and
+> will fail to start. To prevent this, we recommend ensuring that all nodes are
+> selected by at least one IP pool.
+{: .alert .alert-danger}
+
+## Prerequisites
+
+This feature requires {{site.prodname}} for networking in etcd mode.
+
+### Example: Kubernetes
+
+In this example, we created a cluster with four nodes across two racks
+(two nodes/rack). Consider the following:
+
+```
+       -------------------
+       |    router       |
+       -------------------
+       |                 |
+---------------   ---------------
+| rack-0      |   | rack-1      |
+---------------   ---------------
+| kube-node-0 |   | kube-node-2 |
+- - - - - - - -   - - - - - - - -
+| kube-node-1 |   | kube-node-3 |
+- - - - - - - -   - - - - - - - -
+```
+{: .no-select-button}
+
+Using the pod IP range `192.168.0.0/16`, we target the following setup: reserve
+the `192.168.0.0/24` and `192.168.1.0/24` pools for `rack-0`, `rack-1`. Let's
+get started.
+
+
+By installing {{ site.prodname }} without setting the default IP pool to match,
+running `calicoctl get ippool -o wide` shows that {{site.prodname}} created its
+default IP pool of `192.168.0.0/16`:
+
+```
+NAME                  CIDR             NAT    IPIPMODE   DISABLED   SELECTOR
+default-ipv4-ippool   192.168.0.0/16   true   Always     false      all()
+```
+{: .no-select-button}
+
+1. Delete the default IP pool.
+
+   Since the `default-ipv4-ippool` IP pool resource already exists and accounts
+   for the entire `/16` block, we will have to delete this first:
+
+   ```
+   calicoctl delete ippools default-ipv4-ippool
+   ```
+
+2. Label the nodes.
+
+   To assign IP pools to specific nodes, these nodes must be labelled
+   using [kubectl label](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#add-a-label-to-a-node).
+
+   ```
+   kubectl label nodes kube-node-0 rack=0
+   kubectl label nodes kube-node-1 rack=0
+   kubectl label nodes kube-node-2 rack=1
+   kubectl label nodes kube-node-3 rack=1
+   ```
+
+3. Create an IP pool for each rack.
+
+   ```
+   calicoctl create -f -<<EOF
+   apiVersion: projectcalico.org/v3
+   kind: IPPool
+   metadata:
+     name: rack-0-ippool
+   spec:
+     cidr: 192.168.0.0/24
+     ipipMode: Always
+     natOutgoing: true
+     nodeSelector: rack == "0"
+EOF
+   ```
+
+   ```
+   calicoctl create -f -<<EOF
+   apiVersion: projectcalico.org/v3
+   kind: IPPool
+   metadata:
+     name: rack-1-ippool
+   spec:
+     cidr: 192.168.1.0/24
+     ipipMode: Always
+     natOutgoing: true
+     nodeSelector: rack == "1"
+EOF
+   ```
+
+   We should now have two enabled IP pools, which we can see when running
+   `calicoctl get ippool -o wide`:
+
+   ```
+   NAME                  CIDR             NAT    IPIPMODE   DISABLED   SELECTOR
+   rack-1-ippool         192.168.0.0/24   true   Always     false      rack == "0"
+   rack-2-ippool         192.168.1.0/24   true   Always     false      rack == "1"
+   ```
+   {: .no-select-button}
+
+4. Verify that the IP pool node selectors are being respected.
+
+   We will create an nginx deployment with five replicas to get a workload
+   running on each node.
+
+   ```
+   kubectl run nginx --image nginx --replicas 5
+   ```
+
+   Check that the new workloads now have an address in the proper IP pool
+   allocated for the rack that the node is on with `kubectl get pods -owide`.
+
+   ```
+   NAME                   READY   STATUS    RESTARTS   AGE    IP             NODE          NOMINATED NODE   READINESS GATES
+   nginx-5c7588df-prx4z   1/1     Running   0          6m3s   192.168.0.64   kube-node-0   <none>           <none>
+   nginx-5c7588df-s7qw6   1/1     Running   0          6m7s   192.168.0.129  kube-node-1   <none>           <none>
+   nginx-5c7588df-w7r7g   1/1     Running   0          6m3s   192.168.1.65   kube-node-2   <none>           <none>
+   nginx-5c7588df-62lnf   1/1     Running   0          6m3s   192.168.1.1    kube-node-3   <none>           <none>
+   nginx-5c7588df-pnsvv   1/1     Running   0          6m3s   192.168.1.64   kube-node-2   <none>           <none>
+   ```
+   {: .no-select-button}
+
+   The grouping of IP addresses assigned to the workloads differ based on what
+   node that they were scheduled to. Additionally, the assigned address for
+   each workload falls within the respective IP pool that selects the rack that
+   they run on.
+
+> **Note**: {{site.prodname}} IPAM will not reassign IP addresses to workloads
+> that are already running. To update running workloads with IP addresses from
+> a newly configured IP pool, they must be recreated. We recommmend doing this
+> before going into production or during a maintenance window.
+{: .alert .alert-info}
+
+## Related links
+
+For more information on the structure of the IP pool resource, see
+[the IP pools reference]({{ site.baseurl }}/{{ page.version }}/reference/calicoctl/resources/ippool).


### PR DESCRIPTION
## Description
- adds `calicoctl label` command
- adds `nodeSelector` field to `IPPool` resource

## TODO
- [ ] full guide on IP pool node selection