### PR TITLE
Corrects some OpenStack canonical URLs

### DIFF
--- a/v2.1/usage/openstack/configuration.md
+++ b/v2.1/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.1/usage/openstack/floating-ips.md
+++ b/v2.1/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.1/usage/openstack/host-routes.md
+++ b/v2.1/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.1/usage/openstack/kuryr.md
+++ b/v2.1/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.1/usage/openstack/semantics.md
+++ b/v2.1/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.1/usage/openstack/service-ips.md
+++ b/v2.1/usage/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.2/usage/openstack/configuration.md
+++ b/v2.2/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.2/usage/openstack/floating-ips.md
+++ b/v2.2/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.2/usage/openstack/host-routes.md
+++ b/v2.2/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.2/usage/openstack/kuryr.md
+++ b/v2.2/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.2/usage/openstack/semantics.md
+++ b/v2.2/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.2/usage/openstack/service-ips.md
+++ b/v2.2/usage/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.3/usage/openstack/configuration.md
+++ b/v2.3/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.3/usage/openstack/floating-ips.md
+++ b/v2.3/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.3/usage/openstack/host-routes.md
+++ b/v2.3/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.3/usage/openstack/kuryr.md
+++ b/v2.3/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.3/usage/openstack/semantics.md
+++ b/v2.3/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.3/usage/openstack/service-ips.md
+++ b/v2.3/usage/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.4/usage/openstack/configuration.md
+++ b/v2.4/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.4/usage/openstack/floating-ips.md
+++ b/v2.4/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.4/usage/openstack/host-routes.md
+++ b/v2.4/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.4/usage/openstack/kuryr.md
+++ b/v2.4/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.4/usage/openstack/semantics.md
+++ b/v2.4/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.4/usage/openstack/service-ips.md
+++ b/v2.4/usage/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.5/usage/openstack/configuration.md
+++ b/v2.5/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.5/usage/openstack/floating-ips.md
+++ b/v2.5/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.5/usage/openstack/host-routes.md
+++ b/v2.5/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v2.5/usage/openstack/kuryr.md
+++ b/v2.5/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.5/usage/openstack/semantics.md
+++ b/v2.5/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose

--- a/v2.5/usage/openstack/service-ips.md
+++ b/v2.5/usage/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v2.6/usage/openstack/configuration.md
+++ b/v2.6/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running Calico with OpenStack, you also need to configure various

--- a/v2.6/usage/openstack/floating-ips.md
+++ b/v2.6/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v2.6/usage/openstack/host-routes.md
+++ b/v2.6/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route
@@ -41,7 +41,7 @@ routed there.
 > according to its routing table, to wherever it needs to go. This also means
 > that the gateway IP address really is functioning as each instance's default
 > gateway, in the generally understood sense.
-> 
+>
 {: .alert .alert-info}
 
 

--- a/v2.6/usage/openstack/kuryr.md
+++ b/v2.6/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the Calico

--- a/v2.6/usage/openstack/semantics.md
+++ b/v2.6/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A 'Calico' network is a Neutron network (either provider or tenant) whose
@@ -47,8 +47,8 @@ Calico networks do not provide L2 adjacency, even though they report
 > and anycast IP. Anycast IP also requires support for allowed-address-pairs,
 > or some other way of assigning the same IP address to more than one instance;
 > work for allowed-address-pairs support is in progress at
-> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/). 
-> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP 
+> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/).
+> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP
 > is not possible because it depends on L2 adjacency.
 {: .alert .alert-info}
 

--- a/v2.6/usage/openstack/service-ips.md
+++ b/v2.6/usage/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 Calico supports two approaches for assigning a service IP to a Calico-networked

--- a/v3.1/usage/openstack/configuration.md
+++ b/v3.1/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running {{site.prodname}} with OpenStack, you also need to configure various

--- a/v3.1/usage/openstack/floating-ips.md
+++ b/v3.1/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v3.1/usage/openstack/host-routes.md
+++ b/v3.1/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route
@@ -41,7 +41,7 @@ routed there.
 > according to its routing table, to wherever it needs to go. This also means
 > that the gateway IP address really is functioning as each instance's default
 > gateway, in the generally understood sense.
-> 
+>
 {: .alert .alert-info}
 
 

--- a/v3.1/usage/openstack/kuryr.md
+++ b/v3.1/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the {{site.prodname}}

--- a/v3.1/usage/openstack/semantics.md
+++ b/v3.1/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A {{site.prodname}} network is a Neutron network (either provider or tenant) whose
@@ -47,8 +47,8 @@ False`, so at the moment - unfortunately - it *still* has to be understood that
 > and anycast IP. Anycast IP also requires support for allowed-address-pairs,
 > or some other way of assigning the same IP address to more than one instance;
 > work for allowed-address-pairs support is in progress at
-> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/). 
-> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP 
+> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/).
+> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP
 > is not possible because it depends on L2 adjacency.
 {: .alert .alert-info}
 

--- a/v3.1/usage/openstack/service-ips.md
+++ b/v3.1/usage/openstack/service-ips.md
@@ -1,9 +1,9 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
-{{site.prodname}} supports two approaches for assigning a service IP to a 
+{{site.prodname}} supports two approaches for assigning a service IP to a
 {{site.prodname}}-networked VM:
 
 - using a floating IP

--- a/v3.2/usage/openstack/configuration.md
+++ b/v3.2/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running {{site.prodname}} with OpenStack, you also need to configure various

--- a/v3.2/usage/openstack/floating-ips.md
+++ b/v3.2/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v3.2/usage/openstack/host-routes.md
+++ b/v3.2/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route
@@ -41,7 +41,7 @@ routed there.
 > according to its routing table, to wherever it needs to go. This also means
 > that the gateway IP address really is functioning as each instance's default
 > gateway, in the generally understood sense.
-> 
+>
 {: .alert .alert-info}
 
 

--- a/v3.2/usage/openstack/kuryr.md
+++ b/v3.2/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the {{site.prodname}}

--- a/v3.2/usage/openstack/labels.md
+++ b/v3.2/usage/openstack/labels.md
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Labels
-canonical_url: 'https://docs.projectcalico.org/master/usage/openstack/labels'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/labels'
 ---
 
 When {{site.prodname}} represents an OpenStack VM as a {{site.prodname}} WorkloadEndpoint,

--- a/v3.2/usage/openstack/semantics.md
+++ b/v3.2/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A {{site.prodname}} network is a Neutron network (either provider or tenant) whose
@@ -47,8 +47,8 @@ False`, so at the moment - unfortunately - it *still* has to be understood that
 > and anycast IP. Anycast IP also requires support for allowed-address-pairs,
 > or some other way of assigning the same IP address to more than one instance;
 > work for allowed-address-pairs support is in progress at
-> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/). 
-> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP 
+> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/).
+> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP
 > is not possible because it depends on L2 adjacency.
 {: .alert .alert-info}
 

--- a/v3.2/usage/openstack/service-ips.md
+++ b/v3.2/usage/openstack/service-ips.md
@@ -1,9 +1,9 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
-{{site.prodname}} supports two approaches for assigning a service IP to a 
+{{site.prodname}} supports two approaches for assigning a service IP to a
 {{site.prodname}}-networked VM:
 
 - using a floating IP

--- a/v3.3/usage/openstack/configuration.md
+++ b/v3.3/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running {{site.prodname}} with OpenStack, you also need to configure various

--- a/v3.3/usage/openstack/floating-ips.md
+++ b/v3.3/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this

--- a/v3.3/usage/openstack/host-routes.md
+++ b/v3.3/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route
@@ -41,7 +41,7 @@ routed there.
 > according to its routing table, to wherever it needs to go. This also means
 > that the gateway IP address really is functioning as each instance's default
 > gateway, in the generally understood sense.
-> 
+>
 {: .alert .alert-info}
 
 

--- a/v3.3/usage/openstack/kuryr.md
+++ b/v3.3/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the {{site.prodname}}

--- a/v3.3/usage/openstack/labels.md
+++ b/v3.3/usage/openstack/labels.md
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Labels
-canonical_url: 'https://docs.projectcalico.org/master/usage/openstack/labels'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/labels'
 ---
 
 When {{site.prodname}} represents an OpenStack VM as a {{site.prodname}} WorkloadEndpoint,

--- a/v3.3/usage/openstack/semantics.md
+++ b/v3.3/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A {{site.prodname}} network is a Neutron network (either provider or tenant) whose
@@ -47,8 +47,8 @@ False`, so at the moment - unfortunately - it *still* has to be understood that
 > and anycast IP. Anycast IP also requires support for allowed-address-pairs,
 > or some other way of assigning the same IP address to more than one instance;
 > work for allowed-address-pairs support is in progress at
-> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/). 
-> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP 
+> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/).
+> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP
 > is not possible because it depends on L2 adjacency.
 {: .alert .alert-info}
 

--- a/v3.3/usage/openstack/service-ips.md
+++ b/v3.3/usage/openstack/service-ips.md
@@ -1,9 +1,9 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
-{{site.prodname}} supports two approaches for assigning a service IP to a 
+{{site.prodname}} supports two approaches for assigning a service IP to a
 {{site.prodname}}-networked VM:
 
 - using a floating IP

--- a/v3.4/usage/openstack/configuration.md
+++ b/v3.4/usage/openstack/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring Systems for use with Calico
 redirect_from: latest/usage/openstack/configuration
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running {{site.prodname}} with OpenStack, you also need to configure various

--- a/v3.4/usage/openstack/floating-ips.md
+++ b/v3.4/usage/openstack/floating-ips.md
@@ -1,7 +1,7 @@
 ---
 title: Floating IPs
 redirect_from: latest/usage/openstack/floating-ips
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this
@@ -67,7 +67,7 @@ For example:
 1. Create a floating IP and associate it with the target VM.
 
    ```bash
-   neutron floatingip-create public 
+   neutron floatingip-create public
    neutron floatingip-associate <floatingip-id> <target-VM-port-id>
    ```
 

--- a/v3.4/usage/openstack/kuryr.md
+++ b/v3.4/usage/openstack/kuryr.md
@@ -1,7 +1,7 @@
 ---
 title: Kuryr
 redirect_from: latest/usage/openstack/kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the {{site.prodname}}

--- a/v3.4/usage/openstack/labels.md
+++ b/v3.4/usage/openstack/labels.md
@@ -1,7 +1,7 @@
 ---
 title: Endpoint Labels
 redirect_from: latest/usage/openstack/labels
-canonical_url: 'https://docs.projectcalico.org/master/usage/openstack/labels'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/labels'
 ---
 
 When {{site.prodname}} represents an OpenStack VM as a {{site.prodname}} WorkloadEndpoint,

--- a/v3.4/usage/openstack/semantics.md
+++ b/v3.4/usage/openstack/semantics.md
@@ -1,7 +1,7 @@
 ---
 title: Detailed Semantics
 redirect_from: latest/usage/openstack/semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A {{site.prodname}} network is a Neutron network (either provider or tenant) whose
@@ -48,8 +48,8 @@ False`, so at the moment - unfortunately - it *still* has to be understood that
 > and anycast IP. Anycast IP also requires support for allowed-address-pairs,
 > or some other way of assigning the same IP address to more than one instance;
 > work for allowed-address-pairs support is in progress at
-> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/). 
-> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP 
+> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/).
+> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP
 > is not possible because it depends on L2 adjacency.
 {: .alert .alert-info}
 

--- a/v3.4/usage/openstack/service-ips.md
+++ b/v3.4/usage/openstack/service-ips.md
@@ -1,7 +1,7 @@
 ---
 title: Service IPs
 redirect_from: latest/usage/openstack/service-ips
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 {{site.prodname}} supports two approaches for assigning a service IP to a

--- a/v3.5/usage/openstack/configuration.md
+++ b/v3.5/usage/openstack/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Systems for use with Calico
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/configuration'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/configuration'
 ---
 
 When running {{site.prodname}} with OpenStack, you also need to configure various

--- a/v3.5/usage/openstack/floating-ips.md
+++ b/v3.5/usage/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/floating-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/floating-ips'
 ---
 
 networking-calico includes beta support for floating IPs.  Currently this
@@ -66,7 +66,7 @@ For example:
 1. Create a floating IP and associate it with the target VM.
 
    ```bash
-   neutron floatingip-create public 
+   neutron floatingip-create public
    neutron floatingip-associate <floatingip-id> <target-VM-port-id>
    ```
 

--- a/v3.5/usage/openstack/host-routes.md
+++ b/v3.5/usage/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/host-routes'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/host-routes'
 ---
 
 Neutron allows "host routes" to be configured on a subnet, with each host route

--- a/v3.5/usage/openstack/kuryr.md
+++ b/v3.5/usage/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/kuryr'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/kuryr'
 ---
 
 networking-calico works with Kuryr; this means using Neutron, with the {{site.prodname}}

--- a/v3.5/usage/openstack/labels.md
+++ b/v3.5/usage/openstack/labels.md
@@ -1,6 +1,6 @@
 ---
 title: Endpoint Labels
-canonical_url: 'https://docs.projectcalico.org/master/usage/openstack/labels'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/labels'
 ---
 
 When {{site.prodname}} represents an OpenStack VM as a {{site.prodname}} WorkloadEndpoint,

--- a/v3.5/usage/openstack/semantics.md
+++ b/v3.5/usage/openstack/semantics.md
@@ -1,6 +1,6 @@
 ---
 title: Detailed Semantics
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/semantics'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/semantics'
 ---
 
 A {{site.prodname}} network is a Neutron network (either provider or tenant) whose
@@ -47,8 +47,8 @@ False`, so at the moment - unfortunately - it *still* has to be understood that
 > and anycast IP. Anycast IP also requires support for allowed-address-pairs,
 > or some other way of assigning the same IP address to more than one instance;
 > work for allowed-address-pairs support is in progress at
-> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/). 
-> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP 
+> [https://review.openstack.org/#/c/344008/](https://review.openstack.org/#/c/344008/).
+> Multicast IP support is on our roadmap but not yet implemented. Broadcast IP
 > is not possible because it depends on L2 adjacency.
 {: .alert .alert-info}
 

--- a/v3.5/usage/openstack/service-ips.md
+++ b/v3.5/usage/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-canonical_url: 'https://docs.projectcalico.org/v2.6/usage/openstack/service-ips'
+canonical_url: 'https://docs.projectcalico.org/v3.4/usage/openstack/service-ips'
 ---
 
 {{site.prodname}} supports two approaches for assigning a service IP to a


### PR DESCRIPTION
## Description

- Some canonical URLs in usage did not get updated when we added back the OpenStack support in v3.1. This PR corrects those strings.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
