### PR TITLE
Clarifies the use of master in canonical URLs

### DIFF
--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -141,7 +141,7 @@ Examples:
 
 - [Add the new page to the side navigation bar](#linking-content).
 
-- Within the copies of the page in the `master` and previous release directories, add a `canonical_url` line below the `title` line in the metadata of the page. This should contain the absolute path to the page in the current latest directory. Example: `canonical_url: 'https://docs.projectcalico.org/v3.0/getting-started/kubernetes/'`. For more discussion of canonical URLs, refer to the [Canonical URLs](#canonical-urls) section.
+- Within all copies of the page (in the `master` as well as relevant release directories), add a `canonical_url` line below the `title` line in the metadata of the page. This should contain the absolute path to the page in the current latest directory. If you are creating a new page that does not exist in any directory except `master` (for example, because the release directory has not yet been cut), use the `master` path in the `canonical_url`. Example: `canonical_url: 'https://docs.projectcalico.org/v3.0/getting-started/kubernetes/'`. If the For more discussion of canonical URLs, refer to the [Canonical URLs](#canonical-urls) section.
 
 
 ### Deleting or renaming pages

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -229,6 +229,15 @@ release in the documentation. Perform these steps on a branch off of master.
 
    Example: `make update_canonical_urls OLD=v3.0 NEW=v3.1`, where `3.0` was the previous latest and `3.1` is the new latest release.
 
+   Then run the following command to switch any canonical URLs pointing to the `master` directory to
+   the latest release. This can occur when people create new pages before the release directory gets cut.
+
+   ```
+   make update_canonical_urls OLD=master NEW=vX.Y
+   ```
+
+   Example: `make update_canonical_urls OLD=master NEW=v3.1`, where `3.1` is the new latest release.
+
 1. Submit a PR with the canonical link changes, make sure it passes CI, and get it reviewed.
 
    ```


### PR DESCRIPTION
## Description

- Clarifies what to use for a canonical URL when the page exists only in master.
- Updates RELEASING.md to handle for this case.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
