### PR TITLE
calculate release page urls instead of specifying for each release

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -1860,22 +1860,16 @@ master:
   components:
      typha:
       version: master
-      url: ""
      calicoctl:
       version: master
-      url: "https://www.projectcalico.org/builds/calicoctl"
      calico/node:
       version: master
-      url: ""
      calico/cni:
       version: master
-      url: ""
      calico/kube-controllers:
       version: master
-      url: ""
      networking-calico:
       version: master
-      url: ""
      flannel:
       version: v0.9.1
      calico/dikastes:

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -10,7 +10,7 @@ v3.5:
     calico/kube-controllers:
       version: v3.5.0
     networking-calico:
-      version: v3.4.0
+      version: 3.4.0
     typha:
       version: v3.5.0
     flannel:

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -3,30 +3,22 @@ v3.5:
   components:
     calico/node:
       version: v3.5.0
-      url: https://github.com/projectcalico/node/releases/tag/v3.5.0
     calicoctl:
       version: v3.5.0
-      url: https://github.com/projectcalico/calicoctl/releases/tag/v3.5.0
     calico/cni:
       version: v3.5.0
-      url: https://github.com/projectcalico/cni-plugin/releases/tag/v3.5.0
     calico/kube-controllers:
       version: v3.5.0
-      url: https://github.com/projectcalico/k8s-policy/releases/tag/v3.5.0
     networking-calico:
       version: v3.4.0
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=3.4.0
     typha:
       version: v3.5.0
-      url: https://github.com/projectcalico/typha/releases/tag/v3.5.0
     flannel:
       version: v0.9.1
     calico/dikastes:
       version: v3.5.0
-      url: https://github.com/projectcalico/app-policy/releases/tag/v3.5.0
     flexvol:
       version: v3.5.0
-      url: https://github.com/projectcalico/pod2daemon/releases/tag/v3.5.0
 
 v3.4:
 - title: v3.4.0

--- a/_includes/component_url
+++ b/_includes/component_url
@@ -1,0 +1,42 @@
+{%- if release.title != "master" -%}
+{%- case include.component -%}
+
+{%- when 'calico/node' -%}
+https://github.com/projectcalico/node/releases/tag/{{ release.components[include.component].version }}
+
+{%- when 'calicoctl' -%}
+https://github.com/projectcalico/calicoctl/releases/tag/{{ release.components[include.component].version }}
+
+{%- when 'calico/cni' -%}
+https://github.com/projectcalico/cni-plugin/releases/tag/{{ release.components[include.component].version }}
+
+{%- when 'calico/kube-controllers' -%}
+https://github.com/projectcalico/k8s-policy/releases/tag/{{ release.components[include.component].version }}
+
+{%- when 'networking-calico' -%}
+http://git.openstack.org/cgit/openstack/networking-calico/commit/?h={{ release.components[include.component].version }}
+
+{%- when 'typha' -%}
+https://github.com/projectcalico/typha/releases/tag/{{ release.components[include.component].version }}
+
+{%- when 'flannel' -%}
+https://github.com/coreos/flannel/releases/tag/{{ release.components[include.component].version }}
+
+{%- when 'calico/dikastes' -%}
+https://github.com/projectcalico/app-policy/releases/tag/{{ release.components[include.component].version }}
+
+{%- when 'flexvol' -%}
+https://github.com/projectcalico/pod2daemon/releases/tag/{{ release.components[include.component].version }}
+
+{%- endcase -%}
+
+{%- else -%}
+{% comment %}
+For the master docs, there are no releases to link to. So this page will just return an empty string.
+Except for 'calicoctl', as we do host direct downloads to a binary of calicoctl.
+{% endcomment %}
+{%- if include.component == "calicoctl" -%}
+https://www.projectcalico.org/builds/calicoctl
+{%- endif -%}
+
+{%- endif -%}

--- a/master/release-notes/index.md
+++ b/master/release-notes/index.md
@@ -20,7 +20,10 @@ Use the version selector at the top-right of this page to view a different relea
 {% endif %}
 
 | Component              | Version |
-|------------------------|---------|{% for component_name in release.components %}
-| {{ component_name[0] }}   | [{{ component_name[1].version }}]({{ component_name[1].url }}) |{% endfor %}
+|------------------------|---------|
+{% for component in release.components %}
+{%- capture component_name %}{{ component[0] }}{% endcapture -%}
+| {{ component_name }}   | [{{ component[1].version }}]({% include component_url component=component_name release=release %}) |
+{% endfor %}
 
 {% endfor %}

--- a/v3.5/releases/index.md
+++ b/v3.5/releases/index.md
@@ -21,7 +21,10 @@ Use the version selector at the top-right of this page to view a different relea
 {% endif %}
 
 | Component              | Version |
-|------------------------|---------|{% for component_name in release.components %}
-| {{ component_name[0] }}   | [{{ component_name[1].version }}]({{ component_name[1].url }}) |{% endfor %}
+|------------------------|---------|
+{% for component in release.components %}
+{%- capture component_name %}{{ component[0] }}{% endcapture -%}
+| {{ component_name }}   | [{{ component[1].version }}]({% include component_url component=component_name release=release %}) |
+{% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The url's to a component's release rarely change between releases. Instead of repeatedly specifying it in versions.yml, I wrote a function that helps look up a component's release URL based on the component name.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
