### PR TITLE
Doc for selector value substring matching

### DIFF
--- a/_includes/master/selectors.md
+++ b/_includes/master/selectors.md
@@ -1,6 +1,6 @@
 A label selector is an expression which either matches or does not match a resource based on its labels.
 
-{{site.prodname}} label selectors support a number of syntactic primitives.  Each of the following 
+{{site.prodname}} label selectors support a number of syntactic primitives.  Each of the following
 primitive expressions can be combined using the logical operator `&&`.
 
 | Syntax              | Meaning                     |
@@ -12,5 +12,6 @@ primitive expressions can be combined using the logical operator `&&`.
 | !has(k)             | Matches any resource that does not have label 'k'
 | k in { 'v1', 'v2' } | Matches any resource with label 'k' and value in the given set
 | k not in { 'v1', 'v2' } | Matches any resource without label 'k' or any with label 'k' and value _not_ in the given set
+| k contains 's'      | Matches any resource with label 'k' and value containing the substring 's'
 
 

--- a/_includes/master/selectors.md
+++ b/_includes/master/selectors.md
@@ -13,5 +13,7 @@ primitive expressions can be combined using the logical operator `&&`.
 | k in { 'v1', 'v2' } | Matches any resource with label 'k' and value in the given set
 | k not in { 'v1', 'v2' } | Matches any resource without label 'k' or any with label 'k' and value _not_ in the given set
 | k contains 's'      | Matches any resource with label 'k' and value containing the substring 's'
+| k starts with 's'   | Matches any resource with label 'k' and value starting with the substring 's'
+| k ends with 's'     | Matches any resource with label 'k' and value ending with the substring 's'
 
 


### PR DESCRIPTION
## Release Note
```release-note
Selectors now support matching a substring of a label value, with expressions like: k contains 's'.
```
