### PR TITLE
Doc new project parent ID label for OpenStack

### DIFF
--- a/master/networking/openstack/labels.md
+++ b/master/networking/openstack/labels.md
@@ -40,17 +40,29 @@ recommended for [multiple region deployments](multiple-regions)) the namespace w
 "openstack-region-" followed by the configured region name.  Otherwise it is simply
 "openstack".
 
-> **Note**: Calico only allows certain characters in label names and values
+> **Note**: To allow {{site.prodname}} to provide the project name and parent ID labels,
+> you must give Neutron the 'admin' role within your cluster:
+> ```
+> openstack role add --project service --user neutron admin
+> ```
+> or some equivalent privilege that allows the Neutron server to do admin-level queries of
+> the Keystone database.  This is because {{site.prodname}}'s driver runs as part of the
+> Neutron server, and needs to query the Keystone database for the information for those
+> labels.  If Neutron isn't sufficiently privileged, {{site.prodname}} will fall back to
+> not generating those labels.
+{: .alert .alert-info}
+
+> **Note**: {{site.prodname}} only allows certain characters in label names and values
 > (alphanumerics, '-', '\_', '.' and '/'), so if a project or security group name normally
 > has other characters, those will be replaced here by '\_'.  Also there is a length
 > limit, so particularly long names may be truncated.
 {: .alert .alert-info}
 
-> **Note**: Calico does not support changing project name or security group name for a
-> given ID associated with a VM after the VM has been created.  It is recommended that
-> operators avoid any possible confusion here by not changing project name for a
-> particular project ID or security group name for particular security group ID,
-> post-creation.
+> **Note**: {{site.prodname}} does not support changing project name or security group
+> name for a given ID associated with a VM after the VM has been created.  It is
+> recommended that operators avoid any possible confusion here by not changing project
+> name for a particular project ID or security group name for particular security group
+> ID, post-creation.
 {: .alert .alert-info}
 
 ## Configuring operator policy

--- a/master/networking/openstack/labels.md
+++ b/master/networking/openstack/labels.md
@@ -13,11 +13,12 @@ security groups, and that cannot be overridden by user-level security group conf
 
 For the VM's OpenStack project (previously known as 'tenant'), those labels are:
 
-| Label Name                                 | Value                     |
-|--------------------------------------------|---------------------------|
-| `projectcalico.org/openstack-project-id`   | `<the VM's project ID>`   |
-| `projectcalico.org/openstack-project-name` | `<the VM's project name>` |
-|--------------------------------------------|---------------------------|
+| Label Name                                      | Value                          |
+|-------------------------------------------------|--------------------------------|
+| `projectcalico.org/openstack-project-id`        | `<the VM's project ID>`        |
+| `projectcalico.org/openstack-project-name`      | `<the VM's project name>`      |
+| `projectcalico.org/openstack-project-parent-id` | `<the VM's parent project ID>` |
+|-------------------------------------------------|--------------------------------|
 
 For each security group that the VM belongs to, those labels are:
 


### PR DESCRIPTION
## Release Note
```release-note
OpenStack VM endpoints now have a label for the parent ID of the VM's project.
```
