### PR TITLE
Process versions.yml file during helm template rendering

### DIFF
--- a/_includes/master/manifests/_functions.tpl
+++ b/_includes/master/manifests/_functions.tpl
@@ -35,12 +35,8 @@ return: |
 {{- $component := index . 0 -}}
 {{- $ctx := index . 1 -}}
 
-{{- /* The remaining lines parse versions.yml to get the tag for the "component" for the given "page.version". */ -}}
-{{- /* First, grab the latest revision release from versions.yml for the given "page.version"  */ -}}
-{{- $release := index $ctx.Values $ctx.Values.page.version | first -}}
-
 {{- /* get the specified component  */ -}}
-{{- $component := index $release.components $component -}}
+{{- $component := index $ctx.Values $component -}}
 
 {{- /* get the 'version' of that component */ -}}
 {{- $component.version -}}

--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -1,5 +1,6 @@
 require "jekyll"
 require "tempfile"
+require "yaml"
 
 # This plugin enables jekyll to render helm charts.
 # Traditionally, Jekyll will render files which make use of the Liquid templating language.
@@ -23,7 +24,16 @@ module Jekyll
 
       version = context.registers[:page]["version"]
       imageRegistry = context.registers[:page]["registry"]
-      
+
+      # Load the versions.yml file so it can be rewritten in a standard helm format.
+      versionFile = YAML::load_file('_data/versions.yml')
+      components = versionFile[version][0]["components"]
+
+      # Write the yaml values to a temp file for reading.
+      tv = Tempfile.new("temp_versions.yml")
+      tv.write(components.to_yaml)
+      tv.close
+
       # Here we execute helm. In order to preserve backwards compatibility with the existing template system,
       # we pass the entire versions.yml and config.yml. Our chart templates use the passed in "version" to parse
       # out the correct image tags accordingly.
@@ -31,10 +41,11 @@ module Jekyll
         --set page.version=#{version} \
         --set imageRegistry=#{imageRegistry} \
         -f _config.yml \
-        -f _data/versions.yml \
+        -f #{tv.path} \
         -f #{t.path}`
       
       t.unlink
+      tv.unlink
       return out
     end
   end


### PR DESCRIPTION
## Description

Processing the versions.yml file requires special helm functions in order to access the values. This makes it strange to override the image tags with another `versions.yml` file since it would need to be formatted similarly to:
```
v3.5:
- title: v3.5.0
  components:
    calico/node:
      version: v3.5.0
```

By processing the versions file before passing it into helm, we can modify the helm templates so that they can now accept a more standard looking `versions.yml` override:
```
calico/node:
  version: v3.5.0
```



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
