### PR TITLE
fix hashreleases

### DIFF
--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -27,6 +27,12 @@ module Jekyll
 
       # Load the versions.yml file so it can be rewritten in a standard helm format.
       versionFile = YAML::load_file('_data/versions.yml')
+      if not versionFile.key?(version)
+        puts "skipping because #{version} not present in _versions.yml"
+        t.unlink
+        return
+      end
+
       components = versionFile[version][0]["components"]
 
       # Write the yaml values to a temp file for reading.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fix a bug in our hash release generation which occurs when executing a jekyll build with a versions.yml that omits a release. 

The hash releases craft up a custom versions.yml that only includes the version it is trying to render. The new helm plugin needs to not fail in those scenarios to match previous behavior.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
