### PR TITLE
move image names & tags in helm values.yaml

### DIFF
--- a/_includes/master/manifests/_functions.tpl
+++ b/_includes/master/manifests/_functions.tpl
@@ -16,28 +16,3 @@ Canal
 Calico
 {{- end -}}
 {{- end -}}
-
-{{/*
-
-Resolves the correct tag for a given image. The input should
-be the name of the component as it appears in versions.yml.
-In order to function, user must pass in versions.yml, _config.yml,
-and a value "page.version" which instructs helm which set of images to use.
-e.g. "-f _config.yml -f _data/versions.yml --set page.version=v3.3"
-
-usage: |
-  {{ tuple "calico/cni" . | include "tag" }}
-return: |
-  v3.3.2
-*/}}
-{{- define "tag" -}}
-{{- /* unpack the passed in args */ -}}
-{{- $component := index . 0 -}}
-{{- $ctx := index . 1 -}}
-
-{{- /* get the specified component  */ -}}
-{{- $component := index $ctx.Values $component -}}
-
-{{- /* get the 'version' of that component */ -}}
-{{- $component.version -}}
-{{- end -}}

--- a/_includes/master/manifests/calico-kube-controllers.yaml
+++ b/_includes/master/manifests/calico-kube-controllers.yaml
@@ -44,7 +44,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: {{.Values.imageRegistry}}{{.Values.imageNames.kubeControllers}}:{{ tuple "calico/kube-controllers" . | include "tag" }}
+          image: {{.Values.imageRegistry}}{{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
           env:
             # The location of the {{.Values.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS

--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -59,7 +59,7 @@ spec:
         # This container installs the {{.Values.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{.Values.imageRegistry}}{{.Values.imageNames.cni}}:{{ tuple "calico/cni" . | include "tag" }}
+          image: {{.Values.imageRegistry}}{{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -129,7 +129,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{.Values.imageRegistry}}{{.Values.imageNames.flexvol}}:{{tuple "flexvol" . | include "tag"}}
+          image: {{.Values.imageRegistry}}{{.Values.flexvol.image}}:{{.Values.flexvol.tag}}
           imagePullPolicy: Always
           volumeMounts:
           - name: flexvol-driver-host
@@ -140,7 +140,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{.Values.imageRegistry}}{{.Values.imageNames.node}}:{{ tuple "calico/node" . | include "tag" }}
+          image: {{.Values.imageRegistry}}{{.Values.node.image}}:{{.Values.node.tag}}
           env:
 {{- if eq .Values.datastore "etcd" }}
             # The location of the {{.Values.prodname}} etcd cluster.

--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -60,7 +60,7 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:{{ tuple "typha" . | include "tag" }}
+      - image: quay.io/calico/typha:{{.Values.typha.tag }}
         name: calico-typha
         ports:
         - containerPort: 5473


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Reformat how image names and tags are formatted in helm. 
- name keys have been changed so none contain slashes `/`
- image names have been moved up into the component block

This should result in no change to the rendered manifests.

Old style:

```yaml
calico/node:
  version: v3.5.1
calicoctl:
  version: v3.5.1
imageNames:
  node: calico/node
  calicoctl: calico/ctl
```

New style
```yaml
node:
  image: calico/node
  tag: v3.5.1
calicoctl:
  image: calico/ctl
  tag: v3.5.1
```

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
