### PR TITLE
fix a bug with alp manifests in helm

### DIFF
--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -13,6 +13,12 @@ require "yaml"
 # {% endhelm %}
 module Jekyll
   class RenderHelmTagBlock < Liquid::Block
+    def initialize(tag_name, extra_args, liquid_options)
+      super
+      if not extra_args.empty?
+        @extra_args = extra_args
+      end
+    end
     def render(context)
       text = super
 
@@ -72,13 +78,19 @@ module Jekyll
       tv.close
 
       # execute helm.
-      out = `helm template _includes/#{version}/charts/calico \
+      cmd = """helm template _includes/#{version}/charts/calico \
         --set imageRegistry=#{imageRegistry} \
         --set prodname=#{configYml["prodname"]} \
         --set nodecontainer=#{configYml["nodecontainer"]} \
         -f #{tv.path} \
-        -f #{t.path}`
-      
+        -f #{t.path}"""
+
+      if @extra_args
+        cmd += " " + @extra_args
+      end
+
+      out = `#{cmd}`
+
       t.unlink
       tv.unlink
       return out

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-{% helm %}
+{% helm --execute=templates/calico-node.yaml %}
 datastore: etcd
 network: calico
 calico_ipam: true

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-{% helm %}
+{% helm --execute=templates/calico-node.yaml %}
 datastore: kdd
 network: calico
 typha:

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/calico-node.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-{% helm %}
+{% helm --execute=templates/calico-node.yaml %}
 datastore: kdd
 network: flannel
 app_layer_policy: true

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-{% helm %}
+{% helm --execute=templates/calico-node.yaml %}
 datastore: kdd
 typha:
   enabled: true


### PR DESCRIPTION
When helm functionality was added, it went unnoticed that some of the
ALP manifests rendered _only_ calico-node, and not the entire manifest
suite.

Fortunately, helm has a flag for the 'template' subcommand which only
renders a single manifest. This PR adds the ability to use that flag by
passing an arg in the '{% helm %}' tag

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
