### PR TITLE
Fix missing calicoctl URL

### DIFF
--- a/master/getting-started/kubernetes/installation/integration.md
+++ b/master/getting-started/kubernetes/installation/integration.md
@@ -50,7 +50,7 @@ done using the `calicoctl` utility.
 
 ```
 # Download and install calicoctl
-wget {% include urls component=calicoctl %}
+wget {% include urls component="calicoctl" %}
 sudo chmod +x calicoctl
 
 # Run the {{site.nodecontainer}} container

--- a/v3.3/getting-started/kubernetes/installation/integration.md
+++ b/v3.3/getting-started/kubernetes/installation/integration.md
@@ -50,7 +50,7 @@ done using the `calicoctl` utility.
 
 ```
 # Download and install calicoctl
-wget {% include urls component=calicoctl %}
+wget {% include urls component="calicoctl" %}
 sudo chmod +x calicoctl
 
 # Run the {{site.nodecontainer}} container

--- a/v3.4/getting-started/kubernetes/installation/integration.md
+++ b/v3.4/getting-started/kubernetes/installation/integration.md
@@ -50,7 +50,7 @@ done using the `calicoctl` utility.
 
 ```
 # Download and install calicoctl
-wget {% include urls component=calicoctl %}
+wget {% include urls component="calicoctl" %}
 sudo chmod +x calicoctl
 
 # Run the {{site.nodecontainer}} container

--- a/v3.5/getting-started/kubernetes/installation/integration.md
+++ b/v3.5/getting-started/kubernetes/installation/integration.md
@@ -51,7 +51,7 @@ done using the `calicoctl` utility.
 
 ```
 # Download and install calicoctl
-wget {% include urls component=calicoctl %}
+wget {% include urls component="calicoctl" %}
 sudo chmod +x calicoctl
 
 # Run the {{site.nodecontainer}} container


### PR DESCRIPTION
## Description

This fixes the missing calicoctl URL on the [integration guide](https://docs.projectcalico.org/v3.5/getting-started/kubernetes/installation/integration#installing-caliconode) as seen below:

![image](https://user-images.githubusercontent.com/170076/53274405-ff2da600-36ab-11e9-9763-4c6c2c77c69c.png)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
