### PR TITLE
Fixed missing calico tutorials file.

### DIFF
--- a/v3.5/getting-started/kubernetes/tutorials/using-calicoctl.md
+++ b/v3.5/getting-started/kubernetes/tutorials/using-calicoctl.md
@@ -1,0 +1,22 @@
+---
+title: Using calicoctl in Kubernetes
+canonical_url: 'https://docs.projectcalico.org/v3.1/getting-started/kubernetes/tutorials/using-calicoctl'
+---
+
+`calicoctl` allows you to create, read, update, and delete {{site.prodname}} objects
+from the command line. [Installing `calicoctl` as a binary](/{{page.version}}/usage/calicoctl/install#installing-calicoctl-as-a-binary-on-a-single-host)
+will provide you with maximum functionality, including access to the
+`node` commands.
+
+However, you can also [install `calicoctl` as a pod](/{{page.version}}/usage/calicoctl/install#installing-calicoctl-as-a-kubernetes-pod) and run `calicoctl`
+commands using `kubectl`:
+
+```
+$ kubectl exec -ti -n kube-system calicoctl -- /calicoctl get profiles -o wide
+NAME                 TAGS
+kns.default          kns.default
+kns.kube-system      kns.kube-system
+```
+
+See the [calicoctl reference guide]({{site.baseurl}}/{{page.version}}/reference/calicoctl)
+for more information.


### PR DESCRIPTION
To reproduce missing link issue, from www.projectcalico.org, click resources, tutorials and examples, then "Read It" for "How to use calicoctl in Kubernetes"

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - Missing file for link destination
- Using Calicoctl.md has been missing since 3.1
- Manually tested links in calicoctl.md - links look like they will work.
- which components are affected by this PR -- Nothing that I know of
- links to issues that this PR addresses -- None that I know of.
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
Copied old calicoctl.md file back to link destination location.
-->

```release-note
None required
```
