### PR TITLE
remove url from v3.5 versions

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -3,59 +3,43 @@ v3.5:
   components:
     calico/node:
       version: v3.5.2
-      url: https://github.com/projectcalico/node/releases/tag/v3.5.2
     calicoctl:
       version: v3.5.2
-      url: https://github.com/projectcalico/calicoctl/releases/tag/v3.5.2
     calico/cni:
       version: v3.5.2
-      url: https://github.com/projectcalico/cni-plugin/releases/tag/v3.5.2
     calico/kube-controllers:
       version: v3.5.2
-      url: https://github.com/projectcalico/k8s-policy/releases/tag/v3.5.2
     networking-calico:
       version: v3.4.0
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=3.4.0
     typha:
       version: v3.5.2
-      url: https://github.com/projectcalico/typha/releases/tag/v3.5.2
     flannel:
       version: v0.9.1
     calico/dikastes:
       version: v3.5.2
-      url: https://github.com/projectcalico/app-policy/releases/tag/v3.5.2
     flexvol:
       version: v3.5.2
-      url: https://github.com/projectcalico/pod2daemon/releases/tag/v3.5.2
 
 - title: v3.5.1
   components:
     calico/node:
       version: v3.5.1
-      url: https://github.com/projectcalico/node/releases/tag/v3.5.1
     calicoctl:
       version: v3.5.1
-      url: https://github.com/projectcalico/calicoctl/releases/tag/v3.5.1
     calico/cni:
       version: v3.5.1
-      url: https://github.com/projectcalico/cni-plugin/releases/tag/v3.5.1
     calico/kube-controllers:
       version: v3.5.1
-      url: https://github.com/projectcalico/k8s-policy/releases/tag/v3.5.1
     networking-calico:
       version: v3.4.0
-      url: http://git.openstack.org/cgit/openstack/networking-calico/commit/?h=3.4.0
     typha:
       version: v3.5.1
-      url: https://github.com/projectcalico/typha/releases/tag/v3.5.1
     flannel:
       version: v0.9.1
     calico/dikastes:
       version: v3.5.1
-      url: https://github.com/projectcalico/app-policy/releases/tag/v3.5.1
     flexvol:
       version: v3.5.1
-      url: https://github.com/projectcalico/pod2daemon/releases/tag/v3.5.1
 
 - title: v3.5.0
   components:


### PR DESCRIPTION
v3.5 onward does not need to specify the URL in versions.yml as logic
has been added to calculate it based on the component and version.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
