### PR TITLE
Helm values generator

### DIFF
--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -30,22 +30,23 @@ module Jekyll
 
       version = context.registers[:page]["version"]
       imageRegistry = context.registers[:page]["registry"]
+      imageNames = context.registers[:site].config["imageNames"]
+      versions = context.registers[:site].data["versions"]
+      prodname = context.registers[:site].config["prodname"]
+      nodecontainer = context.registers[:site].config["nodecontainer"]
 
       # Load the versions.yml file so it can be rewritten in a standard helm format.
-      versionFile = YAML::load_file('_data/versions.yml')
-      if not versionFile.key?(version)
+      if not versions.key?(version)
         puts "skipping because #{version} not present in _versions.yml"
         t.unlink
         return
       end
 
-      components = versionFile[version][0]["components"]
+      components = versions[version][0]["components"]
 
       # In order to preserve backwards compatibility with the existing template system,
       # we process config.yml for imageNames and _versions.yml for tags,
       # then write them in a more standard helm format.
-      configYml = YAML::load_file('_config.yml')
-      imageNames = configYml["imageNames"]
       versionsYml = <<~EOF
         node:
           image: #{imageNames["node"]}
@@ -80,8 +81,8 @@ module Jekyll
       # execute helm.
       cmd = """helm template _includes/#{version}/charts/calico \
         --set imageRegistry=#{imageRegistry} \
-        --set prodname=#{configYml["prodname"]} \
-        --set nodecontainer=#{configYml["nodecontainer"]} \
+        --set prodname=#{prodname} \
+        --set nodecontainer=#{nodecontainer} \
         -f #{tv.path} \
         -f #{t.path}"""
 

--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -1,6 +1,6 @@
 require "jekyll"
 require "tempfile"
-require "yaml"
+require_relative "./lib"
 
 # This plugin enables jekyll to render helm charts.
 # Traditionally, Jekyll will render files which make use of the Liquid templating language.
@@ -42,37 +42,7 @@ module Jekyll
         return
       end
 
-      components = versions[version][0]["components"]
-
-      # In order to preserve backwards compatibility with the existing template system,
-      # we process config.yml for imageNames and _versions.yml for tags,
-      # then write them in a more standard helm format.
-      versionsYml = <<~EOF
-        node:
-          image: #{imageNames["node"]}
-          tag: #{components["calico/node"]["version"]}
-        calicoctl:
-          image: #{imageNames["calicoctl"]}
-          tag: #{components["calicoctl"]["version"]}
-        typha:
-          image: #{imageNames["typha"]}
-          tag: #{components["typha"]["version"]}
-        cni:
-          image: #{imageNames["cni"]}
-          tag: #{components["calico/cni"]["version"]}
-        kubeControllers:
-          image: #{imageNames["kubeControllers"]}
-          tag: #{components["calico/kube-controllers"]["version"]}
-        flannel:
-          image: #{imageNames["flannel"]}
-          tag: #{components["flannel"]["version"]}
-        dikastes:
-          image: #{imageNames["dikastes"]}
-          tag: #{components["calico/dikastes"]["version"]}
-        flexvol:
-          image: #{imageNames["flexvol"]}
-          tag: #{components["flexvol"]["version"]}
-        EOF
+      versionsYml = gen_values(versions, imageNames, version, prodname, nodecontainer, imageRegistry)
 
       tv = Tempfile.new("temp_versions.yml")
       tv.write(versionsYml)
@@ -80,9 +50,6 @@ module Jekyll
 
       # execute helm.
       cmd = """helm template _includes/#{version}/charts/calico \
-        --set imageRegistry=#{imageRegistry} \
-        --set prodname=#{prodname} \
-        --set nodecontainer=#{nodecontainer} \
         -f #{tv.path} \
         -f #{t.path}"""
 

--- a/_plugins/lib.rb
+++ b/_plugins/lib.rb
@@ -1,0 +1,32 @@
+def gen_values(versions, imageNames, version, prodname, nodecontainer, imageRegistry)
+    components = versions[version][0]["components"]
+    versionsYml = <<~EOF
+    node:
+      image: #{imageNames["node"]}
+      tag: #{components["calico/node"]["version"]}
+    calicoctl:
+      image: #{imageNames["calicoctl"]}
+      tag: #{components["calicoctl"]["version"]}
+    typha:
+      image: #{imageNames["typha"]}
+      tag: #{components["typha"]["version"]}
+    cni:
+      image: #{imageNames["cni"]}
+      tag: #{components["calico/cni"]["version"]}
+    kubeControllers:
+      image: #{imageNames["kubeControllers"]}
+      tag: #{components["calico/kube-controllers"]["version"]}
+    flannel:
+      image: #{imageNames["flannel"]}
+      tag: #{components["flannel"]["version"]}
+    dikastes:
+      image: #{imageNames["dikastes"]}
+      tag: #{components["calico/dikastes"]["version"]}
+    flexvol:
+      image: #{imageNames["flexvol"]}
+      tag: #{components["flexvol"]["version"]}
+    prodname: #{prodname}
+    nodecontainer: #{nodecontainer}
+    imageRegistry: #{imageRegistry}
+    EOF
+end

--- a/hack/gen_values_yml.rb
+++ b/hack/gen_values_yml.rb
@@ -1,0 +1,57 @@
+require "optparse"
+require "yaml"
+require_relative "../_plugins/lib"
+
+usage = "ruby hack/gen_values_yaml.rb <version> [arguments...]
+
+It's recommended to run this from the root of the Calico repository,
+as the default paths assume as much.
+
+<version> should be the major.minor version (e.g. v3.6) or master.
+
+--config    Path to the jekyll config. [default: _config.yml]
+--versions  Path to the versions.yml. [default: _data/versions.yml]
+--registry  The registry prefix. [default: quay.io]
+"
+
+OptionParser.new do |parser|
+    parser.on("-c", "--config=CONFIG") do |config|
+        @path_to_config = config
+    end
+
+    parser.on("-v", "--versions=VERSIONS") do |versions|
+        @path_to_versions = versions
+    end
+
+    parser.on("-r", "--registry=REGISTRY") do |registry|
+        @image_registry = registry
+    end
+end.parse!
+
+@version = ARGV.pop
+if !@version
+    print usage
+    exit
+end
+
+@path_to_config ||= "_config.yml"
+@path_to_versions ||= "_data/versions.yml"
+@image_registry ||= "quay.io"
+
+# In order to preserve backwards compatibility with the existing template system,
+# we process config.yml for imageNames and _versions.yml for tags,
+# then write them in a more standard helm format.
+config = YAML::load_file(@path_to_config)
+imageNames = config["imageNames"]
+prodname = config["prodname"]
+nodecontainer = config["nodecontainer"]
+
+versions = YAML::load_file(@path_to_versions)
+
+# Load the versions.yml file so it can be rewritten in a standard helm format.
+if not versions.key?(@version)
+    puts "Error: version '#{@version}' not present in _versions.yml"
+    exit 1
+end
+
+print gen_values(versions, imageNames, @version, prodname, nodecontainer, @image_registry)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

There's two commits in this PR, I'd recommend viewing each commit first to understand.

The first commit is a cleanup of the ruby processing. We were loading `_config.yml` from disk when we didn't have to - jekyll already does that and loads it into `context.registers[:site]`. The first commit uses that value instead.

The second commit moves the values.yaml generation into a separate ruby file, then attaches a CLI frontend onto it. This will allow us to quickly generate a valid values.yaml file for helm without having to duplicate or move around any of the information stored in `_data/versions.yml`. 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
