### PR TITLE
Cleanup images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ imageNames:
   cni: calico/cni
   kubeControllers: calico/kube-controllers
   calico-upgrade: calico/upgrade
-  flannel: coreos/flannel
+  flannel: quay.io/coreos/flannel
   dikastes: calico/dikastes
   pilot-webhook: calico/pilot-webhook
   flexvol: calico/pod2daemon-flexvol

--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -2310,7 +2310,7 @@ master:
      networking-calico:
       version: master
      flannel:
-      version: v0.9.1
+      version: v0.11.0
      calico/dikastes:
       version: master 
      flexvol:

--- a/_includes/master/charts/calico/values.yaml
+++ b/_includes/master/charts/calico/values.yaml
@@ -5,9 +5,6 @@ datastore: kdd
 # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
 network: "none"
 
-# Global docker image registry. This will set the image registry for all images *except* flannel.
-imageRegistry: "calico/"
-
 calico_ipam: false
 app_layer_policy: false
 

--- a/_includes/master/manifests/calico-kube-controllers.yaml
+++ b/_includes/master/manifests/calico-kube-controllers.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: {{.Values.imageRegistry}}{{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
+          image: {{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
           env:
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -124,7 +124,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: {{.Values.imageRegistry}}{{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
+          image: {{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -49,7 +49,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{.Values.imageRegistry}}{{.Values.cni.image}}:{{ .Values.cni.tag }}
+          image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -70,7 +70,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{.Values.imageRegistry}}{{.Values.cni.image}}:{{ .Values.cni.tag }}
+          image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -140,7 +140,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{.Values.imageRegistry}}{{.Values.flexvol.image}}:{{.Values.flexvol.tag}}
+          image: {{.Values.flexvol.image}}:{{.Values.flexvol.tag}}
           imagePullPolicy: Always
           volumeMounts:
           - name: flexvol-driver-host
@@ -151,7 +151,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{.Values.imageRegistry}}{{.Values.node.image}}:{{.Values.node.tag}}
+          image: {{.Values.node.image}}:{{.Values.node.tag}}
           env:
 {{- if eq .Values.datastore "etcd" }}
             # The location of the etcd cluster.

--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -329,7 +329,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.11.0
+          image: {{ .Values.flannel.image }}:{{ .Values.flannel.tag }}
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -362,7 +362,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: quay.io/coreos/flannel:v0.9.1
+          image: {{ .Values.flannel.image }}:{{ .Values.flannel.tag }}
           env:
             # The location of the etcd cluster.
             - name: FLANNELD_ETCD_ENDPOINTS

--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -60,7 +60,7 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:{{.Values.typha.tag }}
+      - image: {{ .Values.typha.image }}:{{.Values.typha.tag }}
         name: calico-typha
         ports:
         - containerPort: 5473

--- a/_includes/v3.6/charts/calico/values.yaml
+++ b/_includes/v3.6/charts/calico/values.yaml
@@ -5,9 +5,6 @@ datastore: kdd
 # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
 network: "none"
 
-# Global docker image registry. This will set the image registry for all images *except* flannel.
-imageRegistry: "calico/"
-
 calico_ipam: false
 app_layer_policy: false
 

--- a/_includes/v3.6/manifests/calico-kube-controllers.yaml
+++ b/_includes/v3.6/manifests/calico-kube-controllers.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: {{.Values.imageRegistry}}{{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
+          image: {{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
           env:
             # The location of the {{.Values.prodname}} etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -126,7 +126,7 @@ spec:
       serviceAccountName: calico-kube-controllers
       containers:
         - name: calico-kube-controllers
-          image: {{.Values.imageRegistry}}{{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
+          image: {{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/_includes/v3.6/manifests/calico-node.yaml
+++ b/_includes/v3.6/manifests/calico-node.yaml
@@ -329,7 +329,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.9.1
+          image: {{ .Values.flannel.image }}:{{ .Values.flannel.tag }}
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -362,7 +362,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: quay.io/coreos/flannel:v0.9.1
+          image: {{ .Values.flannel.image }}:{{ .Values.flannel.tag }}
           env:
             # The location of the etcd cluster.
             - name: FLANNELD_ETCD_ENDPOINTS

--- a/_includes/v3.6/manifests/calico-node.yaml
+++ b/_includes/v3.6/manifests/calico-node.yaml
@@ -49,7 +49,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{.Values.imageRegistry}}{{.Values.cni.image}}:{{ .Values.cni.tag }}
+          image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
             - name: KUBERNETES_NODE_NAME
@@ -70,7 +70,7 @@ spec:
         # This container installs the {{.Values.prodname}} CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{.Values.imageRegistry}}{{.Values.cni.image}}:{{ .Values.cni.tag }}
+          image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -140,7 +140,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{.Values.imageRegistry}}{{.Values.flexvol.image}}:{{.Values.flexvol.tag}}
+          image: {{.Values.flexvol.image}}:{{.Values.flexvol.tag}}
           imagePullPolicy: Always
           volumeMounts:
           - name: flexvol-driver-host
@@ -151,7 +151,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{.Values.imageRegistry}}{{.Values.node.image}}:{{.Values.node.tag}}
+          image: {{.Values.node.image}}:{{.Values.node.tag}}
           env:
 {{- if eq .Values.datastore "etcd" }}
             # The location of the {{.Values.prodname}} etcd cluster.

--- a/_includes/v3.6/manifests/calico-typha.yaml
+++ b/_includes/v3.6/manifests/calico-typha.yaml
@@ -60,7 +60,7 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:{{.Values.typha.tag }}
+      - image: {{ .Values.typha.image }}:{{.Values.typha.tag }}
         name: calico-typha
         ports:
         - containerPort: 5473

--- a/_plugins/lib.rb
+++ b/_plugins/lib.rb
@@ -2,29 +2,28 @@ def gen_values(versions, imageNames, version, imageRegistry)
     components = versions[version][0]["components"]
     versionsYml = <<~EOF
     node:
-      image: #{imageNames["node"]}
+      image: #{imageRegistry}#{imageNames["node"]}
       tag: #{components["calico/node"]["version"]}
     calicoctl:
-      image: #{imageNames["calicoctl"]}
+      image: #{imageRegistry}#{imageNames["calicoctl"]}
       tag: #{components["calicoctl"]["version"]}
     typha:
-      image: #{imageNames["typha"]}
+      image: #{imageRegistry}#{imageNames["typha"]}
       tag: #{components["typha"]["version"]}
     cni:
-      image: #{imageNames["cni"]}
+      image: #{imageRegistry}#{imageNames["cni"]}
       tag: #{components["calico/cni"]["version"]}
     kubeControllers:
-      image: #{imageNames["kubeControllers"]}
+      image: #{imageRegistry}#{imageNames["kubeControllers"]}
       tag: #{components["calico/kube-controllers"]["version"]}
     flannel:
       image: #{imageNames["flannel"]}
       tag: #{components["flannel"]["version"]}
     dikastes:
-      image: #{imageNames["dikastes"]}
+      image: #{imageRegistry}#{imageNames["dikastes"]}
       tag: #{components["calico/dikastes"]["version"]}
     flexvol:
-      image: #{imageNames["flexvol"]}
+      image: #{imageRegistry}#{imageNames["flexvol"]}
       tag: #{components["flexvol"]["version"]}
-    imageRegistry: #{imageRegistry}
     EOF
 end


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
1. Removed imageRegistry from manifest templates. It's now handled in the ruby plugin, it's a 1:1 change, so though files in v3.6 were modified there was no noticeable change to rendered manifests :+1: 
1. clean up versioning for flannel. Looks like we were using two different versions in master, and ignoring the one in versions.yml. :man_facepalming: 
   - Also changed the v3.6 manifest but since they already agreed on the flannel version, it's a 1:1 change with no noticeable difference in rendered manifests.
1. fix typha image in manifest - looks like we weren't using the imageName in config.yml, and instead were using `quay.io`. Note I changed this in v3.6 which impacts the live manifests


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
