### PR TITLE
refactor imagenames to allow unset versions

### DIFF
--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -33,14 +33,8 @@ module Jekyll
       imageNames = context.registers[:site].config["imageNames"]
       versions = context.registers[:site].data["versions"]
 
-      # Load the versions.yml file so it can be rewritten in a standard helm format.
-      if not versions.key?(version)
-        puts "skipping because #{version} not present in _versions.yml"
-        t.unlink
-        return
-      end
-
-      versionsYml = gen_values(versions, imageNames, version, imageRegistry)
+      vs = parse_versions(versions, version)
+      versionsYml = gen_values(vs, imageNames, imageRegistry)
 
       tv = Tempfile.new("temp_versions.yml")
       tv.write(versionsYml)

--- a/_plugins/lib.rb
+++ b/_plugins/lib.rb
@@ -1,29 +1,50 @@
-def gen_values(versions, imageNames, version, imageRegistry)
-    components = versions[version][0]["components"]
+def gen_values(versions, imageNames, imageRegistry)
     versionsYml = <<~EOF
     node:
       image: #{imageRegistry}#{imageNames["node"]}
-      tag: #{components["calico/node"]["version"]}
+      tag: #{versions["calico/node"]}
     calicoctl:
       image: #{imageRegistry}#{imageNames["calicoctl"]}
-      tag: #{components["calicoctl"]["version"]}
+      tag: #{versions["calicoctl"]}
     typha:
       image: #{imageRegistry}#{imageNames["typha"]}
-      tag: #{components["typha"]["version"]}
+      tag: #{versions["typha"]}
     cni:
       image: #{imageRegistry}#{imageNames["cni"]}
-      tag: #{components["calico/cni"]["version"]}
+      tag: #{versions["calico/cni"]}
     kubeControllers:
       image: #{imageRegistry}#{imageNames["kubeControllers"]}
-      tag: #{components["calico/kube-controllers"]["version"]}
+      tag: #{versions["calico/kube-controllers"]}
     flannel:
       image: #{imageNames["flannel"]}
-      tag: #{components["flannel"]["version"]}
+      tag: #{versions["flannel"]}
     dikastes:
       image: #{imageRegistry}#{imageNames["dikastes"]}
-      tag: #{components["calico/dikastes"]["version"]}
+      tag: #{versions["calico/dikastes"]}
     flexvol:
       image: #{imageRegistry}#{imageNames["flexvol"]}
-      tag: #{components["flexvol"]["version"]}
+      tag: #{versions["flexvol"]}
     EOF
+end
+
+
+# Takes versions_yml which is structured as follows:
+#
+# {"v3.6"=>
+#     ["components"=>
+#        {"calico/node"=>{"version"=>"v3.6.0"},
+#         "typha"=>{"version"=>"v3.6.0"}}]
+#
+# And for a given version, return a Hash of each components' version by component name e.g:
+#
+# {"calico/node"=>"v3.6.0",
+#   "typha"=>"v3.6.0"}
+#
+def parse_versions(versions_yml, version)
+  if not versions_yml.key?(version)
+    raise IndexError.new "requested version '#{version}' not present in versions.yml"
+  end
+
+  components = versions_yml[version][0]["components"].clone
+  return components.each { |key,val| components[key] = val["version"] }
 end

--- a/hack/gen_values_yml.rb
+++ b/hack/gen_values_yml.rb
@@ -44,12 +44,7 @@ end
 config = YAML::load_file(@path_to_config)
 imageNames = config["imageNames"]
 
-versions = YAML::load_file(@path_to_versions)
+versions_yml = YAML::load_file(@path_to_versions)
+versions = parse_versions(versions_yml, @version)
 
-# Load the versions.yml file so it can be rewritten in a standard helm format.
-if not versions.key?(@version)
-    puts "Error: version '#{@version}' not present in _versions.yml"
-    exit 1
-end
-
-print gen_values(versions, imageNames, @version, @image_registry)
+print gen_values(versions, imageNames, @image_registry)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Besides just a general code cleanup here, there's also a functionality change.

Previously, if a component was missing from `versions.yml` an exception would be thrown because the first key lookup would return nil (e.g. `tag: #{components["not-a-real-component"]["version"]}`)

This is a problem if a new release of Calico adds a component. All releases of Calico share the same `lib.rb` which generates the `values.yaml` for helm. If a new release adds a component, it will be added to `lib.rb`, and previous releases will call `components["new-component"]["version"]` even though their versions.yml does not contain the new component. This lookup will return nil and throw an exception.

This PR slims down the hash map to 1 level which means that if a component is added in future release, previous releases won't raise exception to it.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
