### PR TITLE
Add ability to configure etcd through the Helm CLI

### DIFF
--- a/_includes/master/charts/calico/values.yaml
+++ b/_includes/master/charts/calico/values.yaml
@@ -2,6 +2,16 @@
 # Note: Changing this after installation is not supported. 
 datastore: kdd
 
+# Config for etcd
+etcd:
+  # Endpoints for the etcd instances. This can be a comma separated list of endpoints.
+  endpoints: null
+  # Authentication information for accessing secure etcd instances.
+  tls:
+    crt: null
+    ca: null
+    key: null
+
 # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
 network: "none"
 

--- a/_includes/master/manifests/_functions.tpl
+++ b/_includes/master/manifests/_functions.tpl
@@ -16,3 +16,12 @@ Canal
 Calico
 {{- end -}}
 {{- end -}}
+
+{{- define "calico.etcd.tls" -}}
+{{- if or (or .Values.etcd.tls.crt .Values.etcd.tls.ca) .Values.etcd.tls.key -}}
+{{- $_ := required "Must specify all or none of etcd_crt, etcd_ca, etcd_key" .Values.etcd.tls.crt -}}
+{{- $_ := required "Must specify all or none of etcd_crt, etcd_ca, etcd_key" .Values.etcd.tls.ca -}}
+{{- $_ := required "Must specify all or none of etcd_crt, etcd_ca, etcd_key" .Values.etcd.tls.key -}}
+true
+{{- end -}}
+{{- end -}}

--- a/_includes/master/manifests/calico-config.yaml
+++ b/_includes/master/manifests/calico-config.yaml
@@ -7,13 +7,19 @@ metadata:
 data:
 {{- if eq .Values.datastore "etcd" }}
   # Configure this with the location of your etcd cluster.
-  etcd_endpoints: "http://<ETCD_IP>:<ETCD_PORT>"
+  etcd_endpoints: "{{ .Values.etcd.endpoints }}"
 
+{{- if include "calico.etcd.tls" . }}
+  etcd_ca: "/calico-secrets/etcd-ca"
+  etcd_cert: "/calico-secrets/etcd-cert"
+  etcd_key: "/calico-secrets/etcd-key"
+{{- else }}
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.
   etcd_ca: ""   # "/calico-secrets/etcd-ca"
   etcd_cert: "" # "/calico-secrets/etcd-cert"
   etcd_key: ""  # "/calico-secrets/etcd-key"
+{{- end }}
 
 {{- end }}
 {{- if .Values.typha.enabled }}

--- a/_includes/master/manifests/calico-etcd-secrets.yaml
+++ b/_includes/master/manifests/calico-etcd-secrets.yaml
@@ -8,6 +8,11 @@ metadata:
   name: calico-etcd-secrets
   namespace: kube-system
 data:
+{{- if include "calico.etcd.tls" . }}
+  etcd-key: {{ .Values.etcd.tls.key | b64enc }}
+  etcd-ca: {{ .Values.etcd.tls.ca | b64enc }}
+  etcd-cert: {{ .Values.etcd.tls.crt | b64enc }}
+{{- else }}
   # Populate the following with etcd TLS configuration if desired, but leave blank if
   # not using TLS for etcd.
   # The keys below should be uncommented and the values populated with the base64
@@ -16,4 +21,5 @@ data:
   # etcd-key: null
   # etcd-cert: null
   # etcd-ca: null
+{{- end -}}
 {{- end -}}

--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -46,10 +46,12 @@ module Jekyll
       tv.write(versionsYml)
       tv.close
 
-      # execute helm.
+      # Execute helm.
+      # Set the default etcd endpoint placeholder for rendering in the docs.
       cmd = """helm template _includes/#{version}/charts/calico \
         -f #{tv.path} \
-        -f #{t.path}"""
+        -f #{t.path}
+        --set etcd.endpoints=http://<ETCD_IP>:<ETCD_PORT>"""
 
       if @extra_args
         cmd += " " + @extra_args


### PR DESCRIPTION
## Description

Now that Calico docs are rendered using helm templates, add the appropriate variables and defaults for setting the etcd configuration through the Helm CLI.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
