### PR TITLE
Add liveness and readiness probes to Dikastes

### DIFF
--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-inject-configmap.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/istio-inject-configmap.yaml
@@ -148,6 +148,20 @@ data:
       - name: dikastes
         image: {{page.registry}}{{site.imageNames["dikastes"]}}:{{site.data.versions[page.version].first.components["calico/dikastes"].version}}
         args: ["/dikastes", "server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
+        livenessProbe:
+          exec:
+            command:
+            - /healthz
+            - liveness
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          exec:
+            command:
+            - /healthz
+            - readiness
+          initialDelaySeconds: 3
+          periodSeconds: 3
         volumeMounts:
         - mountPath: /var/run/dikastes
           name: dikastes-sock


### PR DESCRIPTION
## Description

Adds probes to the Dikastes sidecar that make use of the new `/healthz` binary that retrieves liveness/readiness status.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add readiness and liveness probes to Dikastes
```
