### PR TITLE
Bump Istio to 1.0.7

### DIFF
--- a/master/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/master/getting-started/kubernetes/installation/app-layer-policy.md
@@ -72,7 +72,7 @@ Application layer policy [requires Istio](../requirements#application-layer-poli
 Install Istio according to the [Istio project documentation](https://istio.io/docs/setup/kubernetes/), making sure to enable mutual TLS authentication. For example:
 
 ```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.6 sh -
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.7 sh -
 cd $(ls -d istio-*)
 kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
 kubectl apply -f install/kubernetes/istio-demo-auth.yaml

--- a/v3.2/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/v3.2/getting-started/kubernetes/installation/app-layer-policy.md
@@ -73,7 +73,7 @@ correctly. We support Istio version 1.0.0 or newer.
 Install Istio according to the [Istio project documentation](https://istio.io/docs/setup/kubernetes/), making sure to enable mutual TLS authentication. For example:
 
 ```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.6 sh -
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.7 sh -
 cd $(ls -d istio-*)
 kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
 kubectl apply -f install/kubernetes/istio-demo-auth.yaml

--- a/v3.3/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/v3.3/getting-started/kubernetes/installation/app-layer-policy.md
@@ -72,7 +72,7 @@ Application layer policy [requires Istio](../requirements#application-layer-poli
 Install Istio according to the [Istio project documentation](https://istio.io/docs/setup/kubernetes/), making sure to enable mutual TLS authentication. For example:
 
 ```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.6 sh -
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.7 sh -
 cd $(ls -d istio-*)
 kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
 kubectl apply -f install/kubernetes/istio-demo-auth.yaml

--- a/v3.4/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/v3.4/getting-started/kubernetes/installation/app-layer-policy.md
@@ -72,7 +72,7 @@ Application layer policy [requires Istio](../requirements#application-layer-poli
 Install Istio according to the [Istio project documentation](https://istio.io/docs/setup/kubernetes/), making sure to enable mutual TLS authentication. For example:
 
 ```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.6 sh -
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.7 sh -
 cd $(ls -d istio-*)
 kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
 kubectl apply -f install/kubernetes/istio-demo-auth.yaml

--- a/v3.5/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/v3.5/getting-started/kubernetes/installation/app-layer-policy.md
@@ -72,7 +72,7 @@ Application layer policy [requires Istio](../requirements#application-layer-poli
 Install Istio according to the [Istio project documentation](https://istio.io/docs/setup/kubernetes/), making sure to enable mutual TLS authentication. For example:
 
 ```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.6 sh -
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.7 sh -
 cd $(ls -d istio-*)
 kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
 kubectl apply -f install/kubernetes/istio-demo-auth.yaml

--- a/v3.6/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/v3.6/getting-started/kubernetes/installation/app-layer-policy.md
@@ -73,7 +73,7 @@ Application layer policy [requires Istio](../requirements#application-layer-poli
 Install Istio according to the [Istio project documentation](https://istio.io/docs/setup/kubernetes/), making sure to enable mutual TLS authentication. For example:
 
 ```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.6 sh -
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.0.7 sh -
 cd $(ls -d istio-*)
 kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
 kubectl apply -f install/kubernetes/istio-demo-auth.yaml


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

Bump Istio version to 1.0.7, which is a security release.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
