### PR TITLE
Update index.md

### DIFF
--- a/v3.6/security/stars-policy/index.md
+++ b/v3.6/security/stars-policy/index.md
@@ -16,11 +16,11 @@ one of our [getting started guides]({{site.baseurl}}/{{page.version}}/getting-st
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/manifests/00-namespace.yaml
-kubectl create -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/manifests/01-management-ui.yaml
-kubectl create -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/manifests/02-backend.yaml
-kubectl create -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/manifests/03-frontend.yaml
-kubectl create -f {{site.url}}/{{page.version}}/getting-started/kubernetes/tutorials/stars-policy/manifests/04-client.yaml
+kubectl create -f {{site.url}}/{{page.version}}/security/stars-policy/manifests/00-namespace.yaml
+kubectl create -f {{site.url}}/{{page.version}}/security/stars-policy/manifests/01-management-ui.yaml
+kubectl create -f {{site.url}}/{{page.version}}/security/stars-policy/manifests/02-backend.yaml
+kubectl create -f {{site.url}}/{{page.version}}/security/stars-policy/manifests/03-frontend.yaml
+kubectl create -f {{site.url}}/{{page.version}}/security/stars-policy/manifests/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.


### PR DESCRIPTION
Update manifest path to reflect the changes for 3.6 version of documentation

## Description

[Documentation] Manifest resources have moved from `/getting-started/kubernetes/tutorials/stars-policy/manifests/` to `/security/stars-policy/manifests/`.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
