### PR TITLE
rename 'calico_ipam' to 'ipam' in helm options

### DIFF
--- a/_includes/master/charts/calico/values.yaml
+++ b/_includes/master/charts/calico/values.yaml
@@ -15,6 +15,7 @@ etcd:
 # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
 network: calico
 
-calico_ipam: true
+# Sets the ipam. Can be 'calico-ipam' or 'host-local'
+ipam: calico-ipam
 app_layer_policy: false
 

--- a/_includes/master/manifests/calico-config.yaml
+++ b/_includes/master/manifests/calico-config.yaml
@@ -105,16 +105,12 @@ data:
   {{- else if eq .Values.network "none" }}
           "mtu": 1500,
   {{- end }}
-  {{- if .Values.calico_ipam }}
           "ipam": {
-              "type": "calico-ipam"
+              "type": "{{ .Values.ipam }}"
+              {{- if eq .Values.ipam "host-local" }},
+              "subnet": "usePodCidr"
+              {{- end }}
           },
-  {{- else }}
-          "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
-          },
-  {{- end }}
           "policy": {
               "type": "k8s"
           },

--- a/master/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -4,5 +4,4 @@ layout: null
 {% helm %}
 datastore: etcd
 network: calico
-calico_ipam: true
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/canal/canal.yaml
@@ -4,5 +4,5 @@ layout: null
 {% helm %}
 datastore: kdd
 network: flannel
-calico_ipam: false
+ipam: host-local
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -4,5 +4,4 @@ layout: null
 {% helm %}
 datastore: kdd
 network: calico
-calico_ipam: true
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/typha/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/typha/calico.yaml
@@ -4,7 +4,6 @@ layout: null
 {% helm %}
 datastore: kdd
 network: calico
-calico_ipam: true
 typha:
   enabled: true
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -6,5 +6,5 @@ datastore: kdd
 typha:
   enabled: true
 network: none
-calico_ipam: false
+ipam: host-local
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
@@ -4,7 +4,6 @@ layout: null
 {% helm --execute=templates/calico-node.yaml %}
 datastore: etcd
 network: calico
-calico_ipam: true
 app_layer_policy: true
 {% endhelm %}
 

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico.yaml
@@ -4,6 +4,5 @@ layout: null
 {% helm %}
 datastore: etcd
 network: calico
-calico_ipam: true
 app_layer_policy: true
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
@@ -4,7 +4,6 @@ layout: null
 {% helm --execute=templates/calico-node.yaml %}
 datastore: kdd
 network: calico
-calico_ipam: true
 typha:
   enabled: true
 app_layer_policy: true

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico.yaml
@@ -7,5 +7,5 @@ network: calico
 typha:
   enabled: true
 app_layer_policy: true
-calico_ipam: false
+ipam: host-local
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/canal.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/canal.yaml
@@ -5,5 +5,5 @@ layout: null
 datastore: kdd
 network: flannel
 app_layer_policy: true
-calico_ipam: false
+ipam: host-local
 {% endhelm %}

--- a/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico.yaml
+++ b/master/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico.yaml
@@ -7,5 +7,5 @@ typha:
   enabled: true
 app_layer_policy: true
 network: none
-calico_ipam: false
+ipam: host-local
 {% endhelm %}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Previously, `calico_ipam: false` translated to 'host-local'. This is both non-obvious behavior, and doesn't allow for other ipam options we may add in the future (like azure-ipam).

Now, the behavior is more obvious:

```yaml
# Sets the ipam. Can be 'calico-ipam' or 'host-local'
ipam: calico-ipam
```

If this LGTM, I need to backport to v3.6 before merging

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
