### PR TITLE
Use new IPAM changes in v3.6

### DIFF
--- a/_includes/v3.6/charts/calico/values.yaml
+++ b/_includes/v3.6/charts/calico/values.yaml
@@ -1,11 +1,12 @@
 # Select which datastore mode. Can be 'etcd' or 'kdd'.
-# Note: Changing this after installation is not supported. 
+# Note: Changing this after installation is not supported.
 datastore: kdd
 
 # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
 network: "none"
 
-calico_ipam: false
+# Sets the ipam. Can be 'calico-ipam' or 'host-local'
+ipam: calico-ipam
 app_layer_policy: false
 
 prodname: Calico

--- a/_includes/v3.6/manifests/calico-config.yaml
+++ b/_includes/v3.6/manifests/calico-config.yaml
@@ -99,16 +99,12 @@ data:
   {{- else if eq .Values.network "none" }}
           "mtu": 1500,
   {{- end }}
-  {{- if .Values.calico_ipam }}
           "ipam": {
-              "type": "calico-ipam"
-          },
-  {{- else }}
-          "ipam": {
-            "type": "host-local",
+            "type": "{{ .Values.ipam }}"
+            {{- if eq .Values.ipam "host-local" }},
             "subnet": "usePodCidr"
+            {{- end }}
           },
-  {{- end }}
           "policy": {
               "type": "k8s"
           },

--- a/master/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/master/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -4,4 +4,5 @@ layout: null
 {% helm %}
 datastore: etcd
 network: flannel
+ipam: host-local
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/hosted/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/hosted/calico.yaml
@@ -4,5 +4,4 @@ layout: null
 {% helm %}
 datastore: etcd
 network: calico
-calico_ipam: true
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
+++ b/v3.6/getting-started/kubernetes/installation/hosted/canal/canal-etcd.yaml
@@ -4,4 +4,5 @@ layout: null
 {% helm %}
 datastore: etcd
 network: flannel
+ipam: host-local
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/hosted/canal/canal.yaml
+++ b/v3.6/getting-started/kubernetes/installation/hosted/canal/canal.yaml
@@ -4,4 +4,5 @@ layout: null
 {% helm %}
 datastore: kdd
 network: flannel
+ipam: host-local
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
@@ -4,5 +4,4 @@ layout: null
 {% helm %}
 datastore: kdd
 network: calico
-calico_ipam: true
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/typha/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/typha/calico.yaml
@@ -4,7 +4,6 @@ layout: null
 {% helm %}
 datastore: kdd
 network: calico
-calico_ipam: true
 typha:
   enabled: true
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -3,6 +3,7 @@ layout: null
 ---
 {% helm %}
 datastore: kdd
+ipam: host-local
 typha:
   enabled: true
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico-node.yaml
@@ -4,7 +4,6 @@ layout: null
 {% helm --execute=templates/calico-node.yaml %}
 datastore: etcd
 network: calico
-calico_ipam: true
 app_layer_policy: true
 {% endhelm %}
 

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/etcd/calico-networking/calico.yaml
@@ -4,6 +4,5 @@ layout: null
 {% helm %}
 datastore: etcd
 network: calico
-calico_ipam: true
 app_layer_policy: true
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/calico-networking/calico-node.yaml
@@ -4,7 +4,6 @@ layout: null
 {% helm --execute=templates/calico-node.yaml %}
 datastore: kdd
 network: calico
-calico_ipam: true
 typha:
   enabled: true
 app_layer_policy: true

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/canal.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/flannel/canal.yaml
@@ -4,5 +4,6 @@ layout: null
 {% helm %}
 datastore: kdd
 network: flannel
+ipam: host-local
 app_layer_policy: true
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
@@ -3,6 +3,7 @@ layout: null
 ---
 {% helm --execute=templates/calico-node.yaml %}
 datastore: kdd
+ipam: host-local
 typha:
   enabled: true
 app_layer_policy: true

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico.yaml
@@ -3,6 +3,7 @@ layout: null
 ---
 {% helm %}
 datastore: kdd
+ipam: host-local
 typha:
   enabled: true
 app_layer_policy: true


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->




- [ ] Tests
- [ ] Documentation
- [ ] Release note


<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that the Kubernetes API datastore application-layer policy manifest was using host-local IPAM instead of Calico IPAM
```