### PR TITLE
Assign calico components critical priority

### DIFF
--- a/_includes/master/manifests/calico-kube-controllers.yaml
+++ b/_includes/master/manifests/calico-kube-controllers.yaml
@@ -33,6 +33,7 @@ spec:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
           image: {{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
@@ -122,6 +123,7 @@ spec:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
           image: {{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}

--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -43,6 +43,7 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
       initContainers:
 {{- if and (eq .Values.network "calico") (eq .Values.datastore "kdd") }}
         # This container performs upgrade from host-local IPAM to calico-ipam.

--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -59,6 +59,7 @@ spec:
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node
+      priorityClassName: system-cluster-critical
       containers:
       - image: {{ .Values.typha.image }}:{{.Values.typha.tag }}
         name: calico-typha


### PR DESCRIPTION
Any other components besides node, controllers and typha? Etcd seems to be excluded since 3.6

## Description


As of k8s 1.14 the critical annotation is deprecated by setting
priorities. k8s define system-node/cluster-critical priorities in the
reserved range to be assigned to critical components.

Critical annotations remain set for compatibility with previous k8s
versions.

fixes OS-3511


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Tests

Not sure how to test this beyond verifying that the priorities are set 

```
Namespace:          kube-system
Priority:           2000001000
PriorityClassName:  system-node-critical
Node:               minikube/10.0.2.15
Start Time:         Thu, 18 Apr 2019 17:05:44 -0700
Labels:             controller-revision-hash=6bfbcd8744
                    k8s-app=calico-node
                    pod-template-generation=1
Annotations:        scheduler.alpha.kubernetes.io/critical-pod: 
Status:             Running
IP:                 10.0.2.15
Controlled By:      DaemonSet/calico-node
...
```



## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Assign priority classes to Calico components
```
