### PR TITLE
Add read access to canal cluster role for namespaces

### DIFF
--- a/_includes/master/manifests/calico-node.yaml
+++ b/_includes/master/manifests/calico-node.yaml
@@ -535,6 +535,7 @@ rules:
     resources:
       - pods
       - nodes
+      - namespaces
     verbs:
       - get
 {{- end }}

--- a/_includes/v3.7/manifests/calico-node.yaml
+++ b/_includes/v3.7/manifests/calico-node.yaml
@@ -534,6 +534,7 @@ rules:
     resources:
       - pods
       - nodes
+      - namespaces
     verbs:
       - get
 {{- end }}


### PR DESCRIPTION
## Description

Add read access to canal cluster role to include namespaces to the manifest for canal with etcd datastore. This changes will be applied for versions after 3.6.

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
Enhance canal manifest with etcd datastore to include read access to namespaces for canal cluster role.
```
