### PR TITLE
use export flag while modifying felixconfig resource

### DIFF
--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -172,7 +172,7 @@ a global setting and a per-host override.
 1. Get the current felixconfig settings.
 
    ```bash
-   calicoctl get felixconfig -o yaml > felix.yaml
+   calicoctl get felixconfig default -o yaml --export > felix.yaml
    ```
 
 1. Modify logFilePath to your intended path, e.g. "/tmp/felix.log"

--- a/v3.0/reference/felix/configuration.md
+++ b/v3.0/reference/felix/configuration.md
@@ -120,7 +120,7 @@ a global setting and a per-host override.
 
 ```
 # Get the current felixconfig settings
-$ calicoctl get felixconfig -o yaml > felix.yaml
+$ calicoctl get felixconfig default -o yaml --export > felix.yaml
 
 # Modify logFilePath to your intended path, e.g. "/tmp/felix.log"
 #   Global change: set name to "default"

--- a/v3.1/reference/felix/configuration.md
+++ b/v3.1/reference/felix/configuration.md
@@ -145,7 +145,7 @@ a global setting and a per-host override.
 
 ```
 # Get the current felixconfig settings
-$ calicoctl get felixconfig -o yaml > felix.yaml
+$ calicoctl get felixconfig default -o yaml --export > felix.yaml
 
 # Modify logFilePath to your intended path, e.g. "/tmp/felix.log"
 #   Global change: set name to "default"

--- a/v3.2/reference/felix/configuration.md
+++ b/v3.2/reference/felix/configuration.md
@@ -162,7 +162,7 @@ a global setting and a per-host override.
 
 ```
 # Get the current felixconfig settings
-$ calicoctl get felixconfig -o yaml > felix.yaml
+$ calicoctl get felixconfig default -o yaml --export > felix.yaml
 
 # Modify logFilePath to your intended path, e.g. "/tmp/felix.log"
 #   Global change: set name to "default"

--- a/v3.3/reference/felix/configuration.md
+++ b/v3.3/reference/felix/configuration.md
@@ -162,7 +162,7 @@ a global setting and a per-host override.
 
 ```
 # Get the current felixconfig settings
-$ calicoctl get felixconfig -o yaml > felix.yaml
+$ calicoctl get felixconfig default -o yaml --export > felix.yaml
 
 # Modify logFilePath to your intended path, e.g. "/tmp/felix.log"
 #   Global change: set name to "default"

--- a/v3.4/reference/felix/configuration.md
+++ b/v3.4/reference/felix/configuration.md
@@ -163,7 +163,7 @@ a global setting and a per-host override.
 1. Get the current felixconfig settings.
 
    ```bash
-   calicoctl get felixconfig -o yaml > felix.yaml
+   calicoctl get felixconfig default -o yaml --export > felix.yaml
    ```
 
 1. Modify logFilePath to your intended path, e.g. "/tmp/felix.log"

--- a/v3.5/reference/felix/configuration.md
+++ b/v3.5/reference/felix/configuration.md
@@ -163,7 +163,7 @@ a global setting and a per-host override.
 1. Get the current felixconfig settings.
 
    ```bash
-   calicoctl get felixconfig -o yaml > felix.yaml
+   calicoctl get felixconfig default -o yaml --export > felix.yaml
    ```
 
 1. Modify logFilePath to your intended path, e.g. "/tmp/felix.log"

--- a/v3.6/reference/felix/configuration.md
+++ b/v3.6/reference/felix/configuration.md
@@ -170,7 +170,7 @@ a global setting and a per-host override.
 1. Get the current felixconfig settings.
 
    ```bash
-   calicoctl get felixconfig -o yaml > felix.yaml
+   calicoctl get felixconfig default -o yaml --export > felix.yaml
    ```
 
 1. Modify logFilePath to your intended path, e.g. "/tmp/felix.log"


### PR DESCRIPTION
## Description

Instructions for modifying `felixconfig` resource fail because `calicoctl` includes resource versioned fields in the yaml output, e.g. `resourceVersion`, `creationTimestamp`, `uid`.

Add `--export` flag to strip the extraneous fields away. This fixes instructions at the bottom of https://docs.projectcalico.org/v3.6/reference/felix/configuration.

Note we'll need to cherry pick the v3.6 update into calico-private/master as well.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
