### PR TITLE
Update Canal RBAC manifest: Removed calico-node ClusterRoleBinding

### DIFF
--- a/_includes/master/charts/calico/templates/rbac.yaml
+++ b/_includes/master/charts/calico/templates/rbac.yaml
@@ -239,6 +239,7 @@ rules:
 {{- end }}
 {{- end }}
 ---
+{{- if eq .Values.network "calico" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -252,7 +253,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 ---
-{{- if eq .Values.network "flannel" }}
+{{- else if eq .Values.network "flannel" }}
 # Flannel ClusterRole
 # Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
 kind: ClusterRole

--- a/_includes/v3.6/manifests/rbac.yaml
+++ b/_includes/v3.6/manifests/rbac.yaml
@@ -238,6 +238,7 @@ rules:
 {{- end }}
 {{- end }}
 ---
+{{- if eq .Values.network "calico" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -251,7 +252,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 ---
-{{- if eq .Values.network "flannel" }}
+{{- else if eq .Values.network "flannel" }}
 # Flannel ClusterRole
 # Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
 kind: ClusterRole

--- a/_includes/v3.7/manifests/rbac.yaml
+++ b/_includes/v3.7/manifests/rbac.yaml
@@ -239,6 +239,7 @@ rules:
 {{- end }}
 {{- end }}
 ---
+{{- if eq .Values.network "calico" }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -252,7 +253,7 @@ subjects:
   name: calico-node
   namespace: kube-system
 ---
-{{- if eq .Values.network "flannel" }}
+{{- else if eq .Values.network "flannel" }}
 # Flannel ClusterRole
 # Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
 kind: ClusterRole


### PR DESCRIPTION
**Fix type:** Manifest fix for Canal install
**Details:** Removes unnecessary ClusterRoleBinding relating to `calico-node` ServiceAccount

## Todos

- [x] Tests (N/A)
- [x] Documentation
- [x] Release note

## Release Note

```release-note
None required
```

I don't believe there's any specific tests to update here or whether a release note is required, as it's just updating the RBAC manifest to drop a CRB that isn't actually applicable. Please correct me if I'm wrong though!