### PR TITLE
Add missing RBAC for NetworkSets

### DIFF
--- a/_includes/master/non-helm-manifests/calicoctl.yaml
+++ b/_includes/master/non-helm-manifests/calicoctl.yaml
@@ -66,6 +66,7 @@ rules:
       - globalnetworksets
       - ippools
       - networkpolicies
+      - networksets
       - hostendpoints
       - ipamblocks
       - blockaffinities
@@ -91,4 +92,3 @@ subjects:
 - kind: ServiceAccount
   name: calicoctl
   namespace: kube-system
-

--- a/_includes/v3.7/non-helm-manifests/calicoctl.yaml
+++ b/_includes/v3.7/non-helm-manifests/calicoctl.yaml
@@ -66,6 +66,7 @@ rules:
       - globalnetworksets
       - ippools
       - networkpolicies
+      - networksets
       - hostendpoints
       - ipamblocks
       - blockaffinities
@@ -91,4 +92,3 @@ subjects:
 - kind: ServiceAccount
   name: calicoctl
   namespace: kube-system
-

--- a/master/reference/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/etcd-rbac/calico-etcdv3-paths.md
@@ -70,6 +70,7 @@ component needs access to in etcd to function successfully.
 | /calico/resources/v3/projectcalico.org/globalnetworkpolicies/\* |   RW   |
 | /calico/resources/v3/projectcalico.org/globalnetworksets/\*     |   RW   |
 | /calico/resources/v3/projectcalico.org/networkpolicies/\*       |   RW   |
+| /calico/resources/v3/projectcalico.org/networksets/\*           |   RW   |
 | /calico/resources/v3/projectcalico.org/profiles/\*              |   RW   |
 
 ## calicoctl (full read/write access)

--- a/v3.7/reference/etcd-rbac/calico-etcdv3-paths.md
+++ b/v3.7/reference/etcd-rbac/calico-etcdv3-paths.md
@@ -70,6 +70,7 @@ component needs access to in etcd to function successfully.
 | /calico/resources/v3/projectcalico.org/globalnetworkpolicies/\* |   RW   |
 | /calico/resources/v3/projectcalico.org/globalnetworksets/\*     |   RW   |
 | /calico/resources/v3/projectcalico.org/networkpolicies/\*       |   RW   |
+| /calico/resources/v3/projectcalico.org/networksets/\*           |   RW   |
 | /calico/resources/v3/projectcalico.org/profiles/\*              |   RW   |
 
 ## calicoctl (full read/write access)


### PR DESCRIPTION
The required RBAC was already present in some
places (e.g. _includes/v3.7/manifests/rbac.yaml) but not all the places
where it appears to be needed.
