### PR TITLE
Fix manifests for calico policy only

### DIFF
--- a/master/manifests/calico-policy-only.yaml
+++ b/master/manifests/calico-policy-only.yaml
@@ -6,4 +6,5 @@ datastore: kdd
 typha:
   enabled: true
 ipam: host-local
+network: none
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/policy-only/1.7/calico.yaml
@@ -6,4 +6,5 @@ datastore: kdd
 ipam: host-local
 typha:
   enabled: true
+network: none
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico-node.yaml
@@ -7,4 +7,5 @@ ipam: host-local
 typha:
   enabled: true
 app_layer_policy: true
+network: none
 {% endhelm %}

--- a/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico.yaml
+++ b/v3.6/getting-started/kubernetes/installation/manifests/app-layer-policy/kubernetes-datastore/policy-only/calico.yaml
@@ -7,4 +7,5 @@ ipam: host-local
 typha:
   enabled: true
 app_layer_policy: true
+network: none
 {% endhelm %}

--- a/v3.7/manifests/calico-policy-only.yaml
+++ b/v3.7/manifests/calico-policy-only.yaml
@@ -6,4 +6,5 @@ datastore: kdd
 typha:
   enabled: true
 ipam: host-local
+network: none
 {% endhelm %}


### PR DESCRIPTION
## Description

Network configuration appears in some of the manifests for installing Calico for policy only. These changes will fix that by setting the appropriate network value for helm rendering.



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
