### PR TITLE
Split out the values.yaml generation by version

### DIFF
--- a/_plugins/helm.rb
+++ b/_plugins/helm.rb
@@ -48,7 +48,7 @@ module Jekyll
         end
       end
 
-      versionsYml = gen_values(vs, imageNames, imageRegistry)
+      versionsYml = gen_values(version, vs, imageNames, imageRegistry)
 
       tv = Tempfile.new("temp_versions.yml")
       tv.write(versionsYml)

--- a/_plugins/lib.rb
+++ b/_plugins/lib.rb
@@ -1,49 +1,3 @@
-def gen_values(versions, imageNames, imageRegistry)
-    versionsYml = <<~EOF
-    datastore: kubernetes
-    # Config for etcd
-    etcd:
-      # Endpoints for the etcd instances. This can be a comma separated list of endpoints.
-      endpoints: null
-      # Authentication information for accessing secure etcd instances.
-      tls:
-        crt: null
-        ca: null
-        key: null
-    # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
-    network: calico
-    # Sets the ipam. Can be 'calico-ipam' or 'host-local'
-    ipam: calico-ipam
-    app_layer_policy: false
-
-    node:
-      image: #{imageRegistry}#{imageNames["node"]}
-      tag: #{versions["calico/node"]}
-    calicoctl:
-      image: #{imageRegistry}#{imageNames["calicoctl"]}
-      tag: #{versions["calicoctl"]}
-    typha:
-      image: #{imageRegistry}#{imageNames["typha"]}
-      tag: #{versions["typha"]}
-    cni:
-      image: #{imageRegistry}#{imageNames["cni"]}
-      tag: #{versions["calico/cni"]}
-    kubeControllers:
-      image: #{imageRegistry}#{imageNames["kubeControllers"]}
-      tag: #{versions["calico/kube-controllers"]}
-    flannel:
-      image: #{imageNames["flannel"]}
-      tag: #{versions["flannel"]}
-    dikastes:
-      image: #{imageRegistry}#{imageNames["dikastes"]}
-      tag: #{versions["calico/dikastes"]}
-    flexvol:
-      image: #{imageRegistry}#{imageNames["flexvol"]}
-      tag: #{versions["flexvol"]}
-    EOF
-end
-
-
 # Takes versions_yml which is structured as follows:
 #
 # {"v3.6"=>
@@ -63,4 +17,16 @@ def parse_versions(versions_yml, version)
 
   components = versions_yml[version][0]["components"].clone
   return components.each { |key,val| components[key] = val["version"] }
+end
+
+
+def gen_values(version, vs, imageNames, imageRegistry)
+  # Use the gen_values function for this version
+  begin
+    require_relative "#{version}/values"
+  rescue LoadError
+    raise "tried to load base values for #{version} but _plugins/#{version}/values.rb does not exist"
+  end
+  gen_func_name = "gen_values_#{version.tr(".", "_")}"
+  return send(gen_func_name, vs, imageNames, imageRegistry)
 end

--- a/_plugins/master/values.rb
+++ b/_plugins/master/values.rb
@@ -1,0 +1,44 @@
+def gen_values_master(versions, imageNames, imageRegistry)
+    versionsYml = <<~EOF
+    datastore: kubernetes
+    # Config for etcd
+    etcd:
+      # Endpoints for the etcd instances. This can be a comma separated list of endpoints.
+      endpoints: null
+      # Authentication information for accessing secure etcd instances.
+      tls:
+        crt: null
+        ca: null
+        key: null
+    # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
+    network: calico
+    # Sets the ipam. Can be 'calico-ipam' or 'host-local'
+    ipam: calico-ipam
+    app_layer_policy: false
+
+    node:
+      image: #{imageRegistry}#{imageNames["node"]}
+      tag: #{versions["calico/node"]}
+    calicoctl:
+      image: #{imageRegistry}#{imageNames["calicoctl"]}
+      tag: #{versions["calicoctl"]}
+    typha:
+      image: #{imageRegistry}#{imageNames["typha"]}
+      tag: #{versions["typha"]}
+    cni:
+      image: #{imageRegistry}#{imageNames["cni"]}
+      tag: #{versions["calico/cni"]}
+    kubeControllers:
+      image: #{imageRegistry}#{imageNames["kubeControllers"]}
+      tag: #{versions["calico/kube-controllers"]}
+    flannel:
+      image: #{imageNames["flannel"]}
+      tag: #{versions["flannel"]}
+    dikastes:
+      image: #{imageRegistry}#{imageNames["dikastes"]}
+      tag: #{versions["calico/dikastes"]}
+    flexvol:
+      image: #{imageRegistry}#{imageNames["flexvol"]}
+      tag: #{versions["flexvol"]}
+    EOF
+end

--- a/_plugins/v3.6/values.rb
+++ b/_plugins/v3.6/values.rb
@@ -1,0 +1,44 @@
+def gen_values_v3_6(versions, imageNames, imageRegistry)
+    versionsYml = <<~EOF
+    datastore: kubernetes
+    # Config for etcd
+    etcd:
+      # Endpoints for the etcd instances. This can be a comma separated list of endpoints.
+      endpoints: null
+      # Authentication information for accessing secure etcd instances.
+      tls:
+        crt: null
+        ca: null
+        key: null
+    # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
+    network: calico
+    # Sets the ipam. Can be 'calico-ipam' or 'host-local'
+    ipam: calico-ipam
+    app_layer_policy: false
+
+    node:
+      image: #{imageRegistry}#{imageNames["node"]}
+      tag: #{versions["calico/node"]}
+    calicoctl:
+      image: #{imageRegistry}#{imageNames["calicoctl"]}
+      tag: #{versions["calicoctl"]}
+    typha:
+      image: #{imageRegistry}#{imageNames["typha"]}
+      tag: #{versions["typha"]}
+    cni:
+      image: #{imageRegistry}#{imageNames["cni"]}
+      tag: #{versions["calico/cni"]}
+    kubeControllers:
+      image: #{imageRegistry}#{imageNames["kubeControllers"]}
+      tag: #{versions["calico/kube-controllers"]}
+    flannel:
+      image: #{imageNames["flannel"]}
+      tag: #{versions["flannel"]}
+    dikastes:
+      image: #{imageRegistry}#{imageNames["dikastes"]}
+      tag: #{versions["calico/dikastes"]}
+    flexvol:
+      image: #{imageRegistry}#{imageNames["flexvol"]}
+      tag: #{versions["flexvol"]}
+    EOF
+end

--- a/_plugins/v3.7/values.rb
+++ b/_plugins/v3.7/values.rb
@@ -1,0 +1,44 @@
+def gen_values_v3_7(versions, imageNames, imageRegistry)
+    versionsYml = <<~EOF
+    datastore: kubernetes
+    # Config for etcd
+    etcd:
+      # Endpoints for the etcd instances. This can be a comma separated list of endpoints.
+      endpoints: null
+      # Authentication information for accessing secure etcd instances.
+      tls:
+        crt: null
+        ca: null
+        key: null
+    # Sets the networking mode. Can be 'calico', 'flannel', or 'none'
+    network: calico
+    # Sets the ipam. Can be 'calico-ipam' or 'host-local'
+    ipam: calico-ipam
+    app_layer_policy: false
+
+    node:
+      image: #{imageRegistry}#{imageNames["node"]}
+      tag: #{versions["calico/node"]}
+    calicoctl:
+      image: #{imageRegistry}#{imageNames["calicoctl"]}
+      tag: #{versions["calicoctl"]}
+    typha:
+      image: #{imageRegistry}#{imageNames["typha"]}
+      tag: #{versions["typha"]}
+    cni:
+      image: #{imageRegistry}#{imageNames["cni"]}
+      tag: #{versions["calico/cni"]}
+    kubeControllers:
+      image: #{imageRegistry}#{imageNames["kubeControllers"]}
+      tag: #{versions["calico/kube-controllers"]}
+    flannel:
+      image: #{imageNames["flannel"]}
+      tag: #{versions["flannel"]}
+    dikastes:
+      image: #{imageRegistry}#{imageNames["dikastes"]}
+      tag: #{versions["calico/dikastes"]}
+    flexvol:
+      image: #{imageRegistry}#{imageNames["flexvol"]}
+      tag: #{versions["flexvol"]}
+    EOF
+end

--- a/hack/gen_values_yml.rb
+++ b/hack/gen_values_yml.rb
@@ -47,4 +47,4 @@ imageNames = config["imageNames"]
 versions_yml = YAML::load_file(@path_to_versions)
 versions = parse_versions(versions_yml, @version)
 
-print gen_values(versions, imageNames, @image_registry)
+print gen_values(@version, versions, imageNames, @image_registry)

--- a/release-scripts/do_release.py
+++ b/release-scripts/do_release.py
@@ -49,6 +49,7 @@ def release():
     # https://github.com/jekyll/jekyll/issues/5429 - Fixed in Jekyll 3.3
     shutil.copytree("./_data/master", "./_data/%s" % new_version.replace(".", "_"))
     shutil.copytree("./_includes/master", "./_includes/%s" % new_version, symlinks=True)
+    shutil.copytree("./_plugins/master", "./_plugins/%s" % new_version)
 
 if __name__ == "__main__":
     arguments = docopt(__doc__)


### PR DESCRIPTION
## Description

Split out the values.yaml generating functions into separate version specific folders. Since ruby `require` works on a global scope, the functions cannot be named the same thing (or one will overwrite the other). This makes it so the function names need to be dynamically generated so they are called appropriately.



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
