### PR TITLE
calicoctl cmds use stdin

### DIFF
--- a/_includes/master/ctl-container-install.md
+++ b/_includes/master/ctl-container-install.md
@@ -57,3 +57,10 @@ We recommend setting an alias as follows.
 ```
 alias calicoctl="kubectl exec -i -n kube-system calicoctl /calicoctl -- "
 ```
+
+   > **Note**: In order to use the `calicoctl` alias
+   > when reading manifests, redirect the file into stdin, for example:
+   > ```
+   > calicoctl create -f - < my_manifest.yaml
+   > ```
+   {: .alert .alert-info}

--- a/_includes/v3.6/ctl-container-install.md
+++ b/_includes/v3.6/ctl-container-install.md
@@ -59,3 +59,10 @@ We recommend setting an alias as follows.
 ```
 alias calicoctl="kubectl exec -i -n kube-system calicoctl /calicoctl -- "
 ```
+
+   > **Note**: In order to use the `calicoctl` alias
+   > when reading manifests, redirect the file into stdin, for example:
+   > ```
+   > calicoctl create -f - < my_manifest.yaml
+   > ```
+   {: .alert .alert-info}

--- a/_includes/v3.7/ctl-container-install.md
+++ b/_includes/v3.7/ctl-container-install.md
@@ -57,3 +57,10 @@ We recommend setting an alias as follows.
 ```
 alias calicoctl="kubectl exec -i -n kube-system calicoctl /calicoctl -- "
 ```
+
+   > **Note**: In order to use the `calicoctl` alias
+   > when reading manifests, redirect the file into stdin, for example:
+   > ```
+   > calicoctl create -f - < my_manifest.yaml
+   > ```
+   {: .alert .alert-info}


### PR DESCRIPTION
## Description

Update `calicoctl` example commands in docs to ingest yaml files via stdin in order to work with containerized version of `calicoctl`.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
