### PR TITLE
Fix Istio 1.0.x config maps

### DIFF
--- a/master/manifests/alp/istio-inject-configmap-1.0.6.yaml
+++ b/master/manifests/alp/istio-inject-configmap-1.0.6.yaml
@@ -159,6 +159,7 @@ data:
 {% include {{page.version}}/non-helm-manifests/istio-proxy-volume-mounts %}
 {% include {{page.version}}/non-helm-manifests/dikastes-container %}
       volumes:
+{% include {{page.version}}/non-helm-manifests/istio-volumes %}
       - emptyDir:
           medium: Memory
         name: istio-envoy
@@ -170,4 +171,3 @@ data:
           [[ else -]]
           secretName: [[ printf "istio.%s" .Spec.ServiceAccountName ]]
           [[ end -]]
-{% include {{page.version}}/non-helm-manifests/istio-volumes %}

--- a/master/manifests/alp/istio-inject-configmap-1.0.7.yaml
+++ b/master/manifests/alp/istio-inject-configmap-1.0.7.yaml
@@ -159,6 +159,7 @@ data:
 {% include {{page.version}}/non-helm-manifests/istio-proxy-volume-mounts %}
 {% include {{page.version}}/non-helm-manifests/dikastes-container %}
       volumes:
+{% include {{page.version}}/non-helm-manifests/istio-volumes %}
       - emptyDir:
           medium: Memory
         name: istio-envoy
@@ -170,4 +171,3 @@ data:
           [[ else -]]
           secretName: [[ printf "istio.%s" .Spec.ServiceAccountName ]]
           [[ end -]]
-{% include {{page.version}}/non-helm-manifests/istio-volumes %}


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

In the existing version, the templating in the `istio-sidecar-injector` configmap includes a `[[ end -]]` directive just before the text we insert. The `-]]` means trim right whitespace, which causes our injected text to be at the wrong indent level and the YAML to be invalid. This fixes the issue by moving the volumes we want to insert above the problematic templating.


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
