### PR TITLE
Removed incorrect text that service accounts is only for application …

### DIFF
--- a/_includes/master/entityrule.md
+++ b/_includes/master/entityrule.md
@@ -7,5 +7,5 @@
 | namespaceSelector | Positive match on selected namespaces. If specified, only workload endpoints in the selected Kubernetes namespaces are matched. Matches namespaces based on the labels that have been applied to the namespaces. Defines the context that selectors will apply to, if not defined then selectors apply to the NetworkPolicy's namespace. | Valid selector | [selector](#selector) | |
 | ports | Positive match on the specified ports | | list of [ports](#ports) | |
 | notPorts | Negative match on the specified ports | | list of [ports](#ports) | |
-| serviceAccounts | Match endpoints running under service accounts. If a `namespaceSelector` is also defined, the set of service accounts this applies to is limited to the service accounts in the selected namespaces. Application layer policy must be enabled to use this field. | | [ServiceAccountMatch](#serviceaccountmatch) | |
+| serviceAccounts | Match endpoints running under service accounts. If a `namespaceSelector` is also defined, the set of service accounts this applies to is limited to the service accounts in the selected namespaces. | | [ServiceAccountMatch](#serviceaccountmatch) | |
 

--- a/_includes/v3.7/entityrule.md
+++ b/_includes/v3.7/entityrule.md
@@ -7,5 +7,5 @@
 | namespaceSelector | Positive match on selected namespaces. If specified, only workload endpoints in the selected Kubernetes namespaces are matched. Matches namespaces based on the labels that have been applied to the namespaces. Defines the context that selectors will apply to, if not defined then selectors apply to the NetworkPolicy's namespace. | Valid selector | [selector](#selector) | |
 | ports | Positive match on the specified ports | | list of [ports](#ports) | |
 | notPorts | Negative match on the specified ports | | list of [ports](#ports) | |
-| serviceAccounts | Match endpoints running under service accounts. If a `namespaceSelector` is also defined, the set of service accounts this applies to is limited to the service accounts in the selected namespaces. Application layer policy must be enabled to use this field. | | [ServiceAccountMatch](#serviceaccountmatch) | |
+| serviceAccounts | Match endpoints running under service accounts. If a `namespaceSelector` is also defined, the set of service accounts this applies to is limited to the service accounts in the selected namespaces. | | [ServiceAccountMatch](#serviceaccountmatch) | |
 


### PR DESCRIPTION
OS-4437 - Text is not valid in network policy and global network policy "Application layer policy must be enabled to use this field." Verified by Matt.
