### PR TITLE
add permission to patch pods for calico-node for upgrade-ipam

### DIFF
--- a/_includes/master/charts/calico/templates/rbac.yaml
+++ b/_includes/master/charts/calico/templates/rbac.yaml
@@ -157,6 +157,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/status
+      - pods
     verbs:
       - patch
   # Calico monitors various CRDs for config.

--- a/_includes/v3.4/manifests/rbac.yaml
+++ b/_includes/v3.4/manifests/rbac.yaml
@@ -110,6 +110,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/status
+      - pods
     verbs:
       - patch
   # Calico monitors various CRDs for config.

--- a/_includes/v3.5/manifests/rbac.yaml
+++ b/_includes/v3.5/manifests/rbac.yaml
@@ -110,6 +110,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/status
+      - pods
     verbs:
       - patch
   # Calico monitors various CRDs for config.

--- a/_includes/v3.6/charts/calico/templates/rbac.yaml
+++ b/_includes/v3.6/charts/calico/templates/rbac.yaml
@@ -157,6 +157,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/status
+      - pods
     verbs:
       - patch
   # Calico monitors various CRDs for config.

--- a/_includes/v3.7/charts/calico/templates/rbac.yaml
+++ b/_includes/v3.7/charts/calico/templates/rbac.yaml
@@ -157,6 +157,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods/status
+      - pods
     verbs:
       - patch
   # Calico monitors various CRDs for config.


### PR DESCRIPTION
## Description

When I updated from 3.2 to 3.7 calico I got error:
```
Warning  FailedCreatePodSandBox  69s                kubelet, node1  Failed create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container 
 48d353baafd47dc4fbd12261f6462b8fe707f0866d01c6e5a21ff2849c6a6630" network for pod "calico-kube-controllers-76bc4fc56b-zljvk": NetworkPlugin cni failed to set up pod "calico-kube-controllers-76bc4fc56b-zljvk_kube-system" network: connection is unauthorized: pods "calico-kube-controllers-76bc4fc56b-zljvk" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot patch resource "pods" in API group "" in the namespace "kube-system"
```

