### PR TITLE
add shortName 'gnp' to GlobalNetworkPolicy #2651

### DIFF
--- a/_includes/master/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/master/charts/calico/templates/kdd-crds.yaml
@@ -162,6 +162,8 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+    shortNames:
+      - gnp
 
 ---
 

--- a/_includes/v3.7/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/v3.7/charts/calico/templates/kdd-crds.yaml
@@ -162,6 +162,8 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+    shortNames:
+      - gnp
 
 ---
 


### PR DESCRIPTION
## Description

add shortName 'gnp' to GlobalNetworkPolicy

I have modified the both files `_includes/master/charts/calico/templates/kdd-crds.yaml` and `_includes/v3.7/charts/calico/templates/kdd-crds.yaml`  but there are many files defining the crd, so please tell me if i forgot one 

fix #2652 


## Todos

- [X] Tests (manually tested )
- [X] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
GlobalNetworkPolicy CRD  can now use with shortName gnp. eg kubectl get gnp
```
