### PR TITLE
Components versions update

### DIFF
--- a/_includes/v3.8/charts/calico/templates/calico-config.yaml
+++ b/_includes/v3.8/charts/calico/templates/calico-config.yaml
@@ -53,7 +53,7 @@ data:
   cni_network_config: |-
     {
         "name": "canal",
-        "cniVersion": "0.3.0",
+        "cniVersion": "0.3.1",
         "plugins": [
             {
                 "type": "flannel",
@@ -86,7 +86,7 @@ data:
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
-      "cniVersion": "0.3.0",
+      "cniVersion": "0.3.1",
       "plugins": [
         {
           "type": "calico",

--- a/_includes/v3.8/charts/calico/templates/calico-typha.yaml
+++ b/_includes/v3.8/charts/calico/templates/calico-typha.yaml
@@ -64,7 +64,7 @@ spec:
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
       containers:
-      - image: {{ .Values.typha.image }}:{{.Values.typha.tag }}
+      - image: {{ .Values.typha.image }}:{{ .Values.typha.tag }}
         name: calico-typha
         ports:
         - containerPort: 5473

--- a/_includes/v3.8/non-helm-manifests/calicoctl.yaml
+++ b/_includes/v3.8/non-helm-manifests/calicoctl.yaml
@@ -32,7 +32,7 @@ spec:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calicoctl
 rules:
@@ -80,7 +80,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calicoctl


### PR DESCRIPTION
## Description

- I've found couple remaining old rbac api endpoints.
- Also IMHO... since you have officially update network plugins to 0.7.5 in https://github.com/projectcalico/cni-plugin/pull/713 i thought it's would be appropriate to update cniVersion in config too. I always do that in my clusters.

But, if there is any plans to further update cni-plugins and CNI-spec in config?:
https://github.com/containernetworking/plugins/releases/tag/v0.8.1
https://github.com/containernetworking/cni/releases/tag/spec-v0.4.0

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes. -->
https://github.com/projectcalico/calico/issues/2548

<!-- If appropriate, add links to any number of PRs documented by this PR -->


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
