### PR TITLE
Doc-Bug-Kubernetes-Install

### DIFF
--- a/master/getting-started/kubernetes/installation/calico.md
+++ b/master/getting-started/kubernetes/installation/calico.md
@@ -47,7 +47,7 @@ datastore type and number of nodes.
 1. Download the {{site.prodname}} networking manifest for the Kubernetes API datastore.
 
    ```bash
-   curl {{site.url}}/{{page.version}}/manifests/calico-typha.yaml -O
+   curl {{site.url}}/{{page.version}}/manifests/calico.yaml -O
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}
@@ -93,7 +93,7 @@ datastore type and number of nodes.
 1. Download the {{site.prodname}} networking manifest for etcd.
 
    ```bash
-   curl {{site.url}}/{{page.version}}/manifests/calico-etcd.yaml -O
+   curl {{site.url}}/{{page.version}}/manifests/calico.yaml -O
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}

--- a/master/getting-started/kubernetes/installation/calico.md
+++ b/master/getting-started/kubernetes/installation/calico.md
@@ -47,7 +47,7 @@ datastore type and number of nodes.
 1. Download the {{site.prodname}} networking manifest for the Kubernetes API datastore.
 
    ```bash
-   curl {{site.url}}/{{page.version}}/manifests/calico.yaml -O
+   curl {{site.url}}/{{page.version}}/manifests/calico-typha.yaml -o calico.yaml
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}
@@ -93,7 +93,7 @@ datastore type and number of nodes.
 1. Download the {{site.prodname}} networking manifest for etcd.
 
    ```bash
-   curl {{site.url}}/{{page.version}}/manifests/calico.yaml -O
+   curl {{site.url}}/{{page.version}}/manifests/calico-etcd.yaml -o calico.yaml
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}


### PR DESCRIPTION
User sent email regarding error in docs: Calico, Kubernetes Install, 50 nodes or more. 

Per slack discussion with ET, Lance, KP, I made the following changes. 
Replaced "calico-typha.yaml" and "calico-etcd.yaml" in etcd section with calico.yaml.

