### PR TITLE
Replace right single quotes with regular single quotes

### DIFF
--- a/master/networking/service-advertisement.md
+++ b/master/networking/service-advertisement.md
@@ -36,7 +36,7 @@ of `10.0.0.0/24`.
 
 ```bash
 kubectl patch ds -n kube-system calico-node --patch \
-    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}’
+    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}'
 ```
 
 ## Behavior

--- a/v3.4/usage/service-advertisement.md
+++ b/v3.4/usage/service-advertisement.md
@@ -36,7 +36,7 @@ of `10.0.0.0/24`.
 
 ```bash
 kubectl patch ds -n kube-system calico-node --patch \
-    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}’
+    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}'
 ```
 
 ## Behavior

--- a/v3.5/usage/service-advertisement.md
+++ b/v3.5/usage/service-advertisement.md
@@ -36,7 +36,7 @@ of `10.0.0.0/24`.
 
 ```bash
 kubectl patch ds -n kube-system calico-node --patch \
-    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}’
+    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}'
 ```
 
 ## Behavior

--- a/v3.6/networking/service-advertisement.md
+++ b/v3.6/networking/service-advertisement.md
@@ -36,7 +36,7 @@ of `10.0.0.0/24`.
 
 ```bash
 kubectl patch ds -n kube-system calico-node --patch \
-    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}’
+    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}'
 ```
 
 ## Behavior

--- a/v3.7/networking/service-advertisement.md
+++ b/v3.7/networking/service-advertisement.md
@@ -37,7 +37,7 @@ of `10.0.0.0/24`.
 
 ```bash
 kubectl patch ds -n kube-system calico-node --patch \
-    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}’
+    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}'
 ```
 
 ## Behavior

--- a/v3.8/networking/service-advertisement.md
+++ b/v3.8/networking/service-advertisement.md
@@ -36,7 +36,7 @@ of `10.0.0.0/24`.
 
 ```bash
 kubectl patch ds -n kube-system calico-node --patch \
-    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}’
+    '{"spec": {"template": {"spec": {"containers": [{"name": "calico-node", "env": [{"name": "CALICO_ADVERTISE_CLUSTER_IPS", "value": "10.0.0.0/24"}]}]}}}}'
 ```
 
 ## Behavior


### PR DESCRIPTION
## Description

The service advertisement docs contain broken kubectl commands due to right single quotes.

## Related issues/PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
