### PR TITLE
use Hash.fetch when accessing version data in helm

### DIFF
--- a/_plugins/master/values.rb
+++ b/_plugins/master/values.rb
@@ -16,53 +16,53 @@ def gen_values_master(versions, imageNames, imageRegistry)
     ipam: calico-ipam
 
     node:
-      image: #{imageRegistry}#{imageNames["node"]}
-      tag: #{versions["calico/node"]}
+      image: #{imageRegistry}#{imageNames.fetch("node")}
+      tag: #{versions.fetch("calico/node")}
       env:
         # Optional environment variables for configuring Calico node.
         # These should match the EnvVar spec of the corev1 Kubernetes API. For example:
         # - name: FELIX_LOGSEVERITYSCREEN
         #   value: "debug"
     calicoctl:
-      image: #{imageRegistry}#{imageNames["calicoctl"]}
-      tag: #{versions["calicoctl"]}
+      image: #{imageRegistry}#{imageNames.fetch("calicoctl")}
+      tag: #{versions.fetch("calicoctl")}
     typha:
-      image: #{imageRegistry}#{imageNames["typha"]}
-      tag: #{versions["typha"]}
+      image: #{imageRegistry}#{imageNames.fetch("typha")}
+      tag: #{versions.fetch("typha")}
       env:
         # Optional environment variables for configuring Typha.
         # These should match the EnvVar spec of the corev1 Kubernetes API. For example:
         # - name: TYPHA_LOGSEVERITYSYS
         #   value: debug
     cni:
-      image: #{imageRegistry}#{imageNames["cni"]}
-      tag: #{versions["calico/cni"]}
+      image: #{imageRegistry}#{imageNames.fetch("cni")}
+      tag: #{versions.fetch("calico/cni")}
       env:
         # Optional environment variables for configuring Calico CNI.
         # These should match the EnvVar spec of the corev1 Kubernetes API. For example:
         # - name: FOO
         #   value: bar
     kubeControllers:
-      image: #{imageRegistry}#{imageNames["kubeControllers"]}
-      tag: #{versions["calico/kube-controllers"]}
+      image: #{imageRegistry}#{imageNames.fetch("kubeControllers")}
+      tag: #{versions.fetch("calico/kube-controllers")}
       env:
         # Optional environment variables for configuring Calico kube controllers.
         # These should match the EnvVar spec of the corev1 Kubernetes API. For example:
         # - name: LOG_LEVEL
         #   value: debug
     flannel:
-      image: #{imageNames["flannel"]}
-      tag: #{versions["flannel"]}
+      image: #{imageNames.fetch("flannel")}
+      tag: #{versions.fetch("flannel")}
       env:
         # Optional environment variables for configuring Flannel.
         # These should match the EnvVar spec of the corev1 Kubernetes API. For example:
         # - name: FOO
         #   value: bar
     dikastes:
-      image: #{imageRegistry}#{imageNames["dikastes"]}
-      tag: #{versions["calico/dikastes"]}
+      image: #{imageRegistry}#{imageNames.fetch("dikastes")}
+      tag: #{versions.fetch("calico/dikastes")}
     flexvol:
-      image: #{imageRegistry}#{imageNames["flexvol"]}
-      tag: #{versions["flexvol"]}
+      image: #{imageRegistry}#{imageNames.fetch("flexvol")}
+      tag: #{versions.fetch("flexvol")}
     EOF
 end


### PR DESCRIPTION
Hash.fetch will raise an exception if the key is not present in the
Hash. The current method which uses bracket accessors will silently fail
and return nil (which is emitted as an empty string) if the key does not
exist.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes. -->
fixes <ISSUE LINK>

<!-- If appropriate, add links to any number of PRs documented by this PR -->
documents <PR LINK>

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
