### PR TITLE
Add documentation for missing felix parameters

### DIFF
--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -111,6 +111,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -62,9 +62,9 @@ The full list of parameters which can be set is as follows.
 | `VXLANVNI`                        | `FELIX_VXLANVNI`                        | The virtual network ID to use for VXLAN. [Default: `4096`] | int |
 | `XDPRefreshInterval`              | `FELIX_XDPREFRESHINTERVAL`              | Period, in seconds, at which Felix re-checks the XDP state in the dataplane to ensure that no other process has accidentally broken {{site.prodname}}'s rules. Set to 0 to disable XDP refresh. [Default: `90`] | int |
 | `XDPEnabled`                      | `FELIX_XDPENABLED        `              | Enable XDP acceleration for host endpoint policies. [Default: `true`] | boolean |
-| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address of the Typha service used to connect to it. | string |
-| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha kubernetes service | string |
-| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
+| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address at which Felix should connect to Typha. [Default: none] | string |
+| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha Kubernetes service | string |
+| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Enable {{site.prodname}} networking and security for IPv6 traffic as well as for IPv4. | boolean |
 
 
 #### etcd datastore configuration
@@ -111,8 +111,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -62,6 +62,9 @@ The full list of parameters which can be set is as follows.
 | `VXLANVNI`                        | `FELIX_VXLANVNI`                        | The virtual network ID to use for VXLAN. [Default: `4096`] | int |
 | `XDPRefreshInterval`              | `FELIX_XDPREFRESHINTERVAL`              | Period, in seconds, at which Felix re-checks the XDP state in the dataplane to ensure that no other process has accidentally broken {{site.prodname}}'s rules. Set to 0 to disable XDP refresh. [Default: `90`] | int |
 | `XDPEnabled`                      | `FELIX_XDPENABLED        `              | Enable XDP acceleration for host endpoint policies. [Default: `true`] | boolean |
+| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address of the Typha service used to connect to it. | string |
+| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha kubernetes service | string |
+| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
 
 
 #### etcd datastore configuration

--- a/master/reference/felix/configuration.md
+++ b/master/reference/felix/configuration.md
@@ -111,8 +111,6 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.6/reference/felix/configuration.md
+++ b/v3.6/reference/felix/configuration.md
@@ -100,6 +100,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.6/reference/felix/configuration.md
+++ b/v3.6/reference/felix/configuration.md
@@ -51,6 +51,9 @@ The full list of parameters which can be set is as follows.
 | `UsageReportingEnabled`           | `FELIX_USAGEREPORTINGENABLED`           | Reports anonymous {{site.prodname}} version number and cluster size to projectcalico.org. Logs warnings returned by the usage server. For example, if a significant security vulnerability has been discovered in the version of {{site.prodname}} being used. [Default: `true`] | boolean |
 | `UsageReportingInitialDelaySecs`  | `FELIX_USAGEREPORTINGINITIALDELAYSECS`  | Minimum delay before first usage report, in seconds. [Default: `300`] | int |
 | `UsageReportingIntervalSecs`      | `FELIX_USAGEREPORTINGINTERVALSECS`      | Interval at which to make usage reports, in seconds. [Default: `86400`] | int |
+| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address of the Typha service used to connect to it. | string |
+| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha kubernetes service | string |
+| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
 
 
 #### etcd datastore configuration

--- a/v3.6/reference/felix/configuration.md
+++ b/v3.6/reference/felix/configuration.md
@@ -51,9 +51,9 @@ The full list of parameters which can be set is as follows.
 | `UsageReportingEnabled`           | `FELIX_USAGEREPORTINGENABLED`           | Reports anonymous {{site.prodname}} version number and cluster size to projectcalico.org. Logs warnings returned by the usage server. For example, if a significant security vulnerability has been discovered in the version of {{site.prodname}} being used. [Default: `true`] | boolean |
 | `UsageReportingInitialDelaySecs`  | `FELIX_USAGEREPORTINGINITIALDELAYSECS`  | Minimum delay before first usage report, in seconds. [Default: `300`] | int |
 | `UsageReportingIntervalSecs`      | `FELIX_USAGEREPORTINGINTERVALSECS`      | Interval at which to make usage reports, in seconds. [Default: `86400`] | int |
-| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address of the Typha service used to connect to it. | string |
-| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha kubernetes service | string |
-| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
+| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address at which Felix should connect to Typha. [Default: none] | string |
+| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha Kubernetes service | string |
+| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Enable {{site.prodname}} networking and security for IPv6 traffic as well as for IPv4. | boolean |
 
 
 #### etcd datastore configuration
@@ -100,8 +100,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.6/reference/felix/configuration.md
+++ b/v3.6/reference/felix/configuration.md
@@ -100,8 +100,6 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.7/reference/felix/configuration.md
+++ b/v3.7/reference/felix/configuration.md
@@ -57,9 +57,9 @@ The full list of parameters which can be set is as follows.
 | `VXLANMTU`                        | `FELIX_VXLANMTU`                        | The MTU to set on the VXLAN tunnel device. See [Configuring MTU]({{site.baseurl}}/{{page.version}}/networking/mtu) [Default: `1410`] | int |
 | `VXLANPort`                       | `FELIX_VXLANPORT`                       | The UDP port to use for VXLAN. [Default: `4789`] | int |
 | `VXLANVNI`                        | `FELIX_VXLANVNI`                        | The virtual network ID to use for VXLAN. [Default: `4096`] | int |
-| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address of the Typha service used to connect to it. | string |
-| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha kubernetes service | string |
-| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
+| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address at which Felix should connect to Typha. [Default: none] | string |
+| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha Kubernetes service | string |
+| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Enable {{site.prodname}} networking and security for IPv6 traffic as well as for IPv4. | boolean |
 
 
 #### etcd datastore configuration
@@ -105,8 +105,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.7/reference/felix/configuration.md
+++ b/v3.7/reference/felix/configuration.md
@@ -105,8 +105,6 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.7/reference/felix/configuration.md
+++ b/v3.7/reference/felix/configuration.md
@@ -105,6 +105,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.7/reference/felix/configuration.md
+++ b/v3.7/reference/felix/configuration.md
@@ -57,6 +57,9 @@ The full list of parameters which can be set is as follows.
 | `VXLANMTU`                        | `FELIX_VXLANMTU`                        | The MTU to set on the VXLAN tunnel device. See [Configuring MTU]({{site.baseurl}}/{{page.version}}/networking/mtu) [Default: `1410`] | int |
 | `VXLANPort`                       | `FELIX_VXLANPORT`                       | The UDP port to use for VXLAN. [Default: `4789`] | int |
 | `VXLANVNI`                        | `FELIX_VXLANVNI`                        | The virtual network ID to use for VXLAN. [Default: `4096`] | int |
+| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address of the Typha service used to connect to it. | string |
+| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha kubernetes service | string |
+| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
 
 
 #### etcd datastore configuration

--- a/v3.8/reference/felix/configuration.md
+++ b/v3.8/reference/felix/configuration.md
@@ -59,7 +59,9 @@ The full list of parameters which can be set is as follows.
 | `VXLANPort`                       | `FELIX_VXLANPORT`                       | The UDP port to use for VXLAN. [Default: `4789`] | int |
 | `VXLANTunnelMACAddr`              |                                         | MAC address of the VXLAN tunnel. This is system configured and should not be updated manually. | string |
 | `VXLANVNI`                        | `FELIX_VXLANVNI`                        | The virtual network ID to use for VXLAN. [Default: `4096`] | int |
-
+| `TyphaAddr`			    | `FELIX_TYPHAADDR`			      | IPv4 address of the Typha service used to connect to it. | string |
+| `TyphaK8sServiceName`		    | `FELIX_TYPHAK8SSERVICENAME`	      | Name of the Typha kubernetes service | string |
+| `Ipv6Support`			    | `FELIX_IPV6SUPPORT`		      | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
 
 #### etcd datastore configuration
 

--- a/v3.8/reference/felix/configuration.md
+++ b/v3.8/reference/felix/configuration.md
@@ -59,9 +59,9 @@ The full list of parameters which can be set is as follows.
 | `VXLANPort`                       | `FELIX_VXLANPORT`                       | The UDP port to use for VXLAN. [Default: `4789`] | int |
 | `VXLANTunnelMACAddr`              |                                         | MAC address of the VXLAN tunnel. This is system configured and should not be updated manually. | string |
 | `VXLANVNI`                        | `FELIX_VXLANVNI`                        | The virtual network ID to use for VXLAN. [Default: `4096`] | int |
-| `TyphaAddr`			    | `FELIX_TYPHAADDR`			      | IPv4 address of the Typha service used to connect to it. | string |
-| `TyphaK8sServiceName`		    | `FELIX_TYPHAK8SSERVICENAME`	      | Name of the Typha kubernetes service | string |
-| `Ipv6Support`			    | `FELIX_IPV6SUPPORT`		      | Set this to True when IPv6 is supported. [Default: `False`] | boolean |
+| `TyphaAddr`                      | `FELIX_TYPHAADDR`                       | IPv4 address at which Felix should connect to Typha. [Default: none] | string |
+| `TyphaK8sServiceName`                    | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha Kubernetes service | string |
+| `Ipv6Support`                            | `FELIX_IPV6SUPPORT`                     | Enable {{site.prodname}} networking and security for IPv6 traffic as well as for IPv4. | boolean |
 
 #### etcd datastore configuration
 
@@ -107,8 +107,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.8/reference/felix/configuration.md
+++ b/v3.8/reference/felix/configuration.md
@@ -107,6 +107,8 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
+| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the kubernetes service | string |
+| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.

--- a/v3.8/reference/felix/configuration.md
+++ b/v3.8/reference/felix/configuration.md
@@ -107,8 +107,6 @@ The Kubernetes API datastore driver reads its configuration from Kubernetes-prov
 | Configuration parameter | Environment variable       | Description  | Schema |
 | ------------------------|----------------------------| ------------ | ------ |
 | `KubeNodePortRanges`    | `FELIX_KUBENODEPORTRANGES` | A list of port ranges that Felix should treat as Kubernetes node ports.  Only when `kube-proxy` is configured to use IPVS mode:  Felix assumes that traffic arriving at the host one one of these ports will ultimately be forwarded instead of being terminated by a host process.  [Default: `30000:32767`] <a id="ipvs-portranges"></a>  | Comma-delimited list of `<min>:<max>` port ranges or single ports. |
-| `KubeServiceHost`       | `KUBERNETES_SERVICE_HOST`  | IP address of the Kubernetes service | string |
-| `KubeServicePort`       | `KUBERNETES_SERVICE_PORT`  | Port number on which the Kubernetes service is listening | int |
 
 
 > **Note**: <a id="ipvs-bits"></a> When using {{site.prodname}} with Kubernetes' `kube-proxy` in IPVS mode, {{site.prodname}} uses additional iptables mark bits to store an ID for each local {{site.prodname}} endpoint.


### PR DESCRIPTION
## Description
Added documentation for following felix parameters:
FELIX_TYPHAADDR
FELIX_TYPHAK8SSERVICENAME
FELIX_IPV6SUPPORT

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes. -->
fixes <ISSUE LINK>

<!-- If appropriate, add links to any number of PRs documented by this PR -->
documents <PR LINK>

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
