### PR TITLE
Don't indicate that externalTrafficPolicy is required

### DIFF
--- a/master/networking/service-advertisement.md
+++ b/master/networking/service-advertisement.md
@@ -47,8 +47,7 @@ using normal BGP route processing and ECMP routing.
 -  traffic to the cluster IP for a service with `externalTrafficPolicy: Local` will be load-balanced across the
    nodes with endpoints for that service
 
--  traffic to the cluster IP for a service with `externalTrafficPolicy: Cluster` will be load-balanced across all
-   the nodes in the cluster.
+-  traffic to the cluster IP for other services will be load-balanced across all the nodes in the cluster.
 
 In order to implement this behavior, Calico does the following.
 

--- a/v3.4/usage/service-advertisement.md
+++ b/v3.4/usage/service-advertisement.md
@@ -47,8 +47,7 @@ using normal BGP route processing and ECMP routing.
 -  traffic to the cluster IP for a service with `externalTrafficPolicy: Local` will be load-balanced across the
    nodes with endpoints for that service
 
--  traffic to the cluster IP for a service with `externalTrafficPolicy: Cluster` will be load-balanced across all
-   the nodes in the cluster.
+-  traffic to the cluster IP for other services will be load-balanced across all the nodes in the cluster.
 
 In order to implement this behavior, {{site.prodname}} does the following.
 

--- a/v3.5/usage/service-advertisement.md
+++ b/v3.5/usage/service-advertisement.md
@@ -47,8 +47,7 @@ using normal BGP route processing and ECMP routing.
 -  traffic to the cluster IP for a service with `externalTrafficPolicy: Local` will be load-balanced across the
    nodes with endpoints for that service
 
--  traffic to the cluster IP for a service with `externalTrafficPolicy: Cluster` will be load-balanced across all
-   the nodes in the cluster.
+-  traffic to the cluster IP for other services will be load-balanced across all the nodes in the cluster.
 
 In order to implement this behavior, Calico does the following.
 

--- a/v3.6/networking/service-advertisement.md
+++ b/v3.6/networking/service-advertisement.md
@@ -47,8 +47,7 @@ using normal BGP route processing and ECMP routing.
 -  traffic to the cluster IP for a service with `externalTrafficPolicy: Local` will be load-balanced across the
    nodes with endpoints for that service
 
--  traffic to the cluster IP for a service with `externalTrafficPolicy: Cluster` will be load-balanced across all
-   the nodes in the cluster.
+-  traffic to the cluster IP for other services will be load-balanced across all the nodes in the cluster.
 
 In order to implement this behavior, Calico does the following.
 

--- a/v3.7/networking/service-advertisement.md
+++ b/v3.7/networking/service-advertisement.md
@@ -47,8 +47,7 @@ using normal BGP route processing and ECMP routing.
 -  traffic to the cluster IP for a service with `externalTrafficPolicy: Local` will be load-balanced across the
    nodes with endpoints for that service
 
--  traffic to the cluster IP for a service with `externalTrafficPolicy: Cluster` will be load-balanced across all
-   the nodes in the cluster.
+-  traffic to the cluster IP for other services will be load-balanced across all the nodes in the cluster.
 
 In order to implement this behavior, Calico does the following.
 

--- a/v3.8/networking/service-advertisement.md
+++ b/v3.8/networking/service-advertisement.md
@@ -48,8 +48,7 @@ using normal BGP route processing and ECMP routing.
 -  traffic to the cluster IP for a service with `externalTrafficPolicy: Local` will be load-balanced across the
    nodes with endpoints for that service
 
--  traffic to the cluster IP for a service with `externalTrafficPolicy: Cluster` will be load-balanced across all
-   the nodes in the cluster.
+-  traffic to the cluster IP for other services will be load-balanced across all the nodes in the cluster.
 
 In order to implement this behavior, Calico does the following.
 


### PR DESCRIPTION
The previous wording confused some of our users because it made it sound
like the externalTrafficPolicy attribute is required for the service
attribute feature.  (And that would be a problem for ClusterIP services,
which don't support the externalTrafficPolicy attribute.)
