### PR TITLE
Add the description about the logical OR operator of label selector

### DIFF
--- a/_includes/master/selectors.md
+++ b/_includes/master/selectors.md
@@ -1,7 +1,7 @@
 A label selector is an expression which either matches or does not match a resource based on its labels.
 
 {{site.prodname}} label selectors support a number of syntactic primitives.  Each of the following
-primitive expressions can be combined using the logical operator `&&`.
+primitive expressions can be combined using the logical operator `&&` and `||`.
 
 | Syntax              | Meaning                     |
 |---------------------|-----------------------------|


### PR DESCRIPTION
## Description

From the beginning of libcalico-go [1], `||` operator can be used
for label selector. It is also tested since then [2]. Add the description
of it.

[1] https://github.com/projectcalico/libcalico-go/commit/edacd2825053476830a832969c526e29fd350091#diff-e89ca2c7d45afb10e9b6ea966a13ab80R36
[2] https://github.com/projectcalico/libcalico-go/commit/edacd2825053476830a832969c526e29fd350091#diff-4b722fc8108b1054cf799bcc9d2bb615R52

- the type of fix

bug fix

- some details on _why_ this PR should be merged

the `||` operator is very convenient for selecting labels

- the details of the testing you've done on it (both manual and automated)

Follow the official workflow.

https://github.com/projectcalico/calico/blob/master/CONTRIBUTING_DOCS.md#building-the-doc-site-locally

- which components are affected by this PR

Document about label selector

- links to issues that this PR addresses
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
