### PR TITLE
updated developer-guide.md to mention cni-plugin as dependency

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -36,6 +36,8 @@ BASEDIR
 └───app-policy
 └───pod2daemon
 └───node
+└───node
+└───cni-bin
 ```
 
 ## Building the code

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -37,7 +37,7 @@ BASEDIR
 └───pod2daemon
 └───node
 └───node
-└───cni-bin
+└───cni-plugin
 ```
 
 ## Building the code

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -36,7 +36,6 @@ BASEDIR
 └───app-policy
 └───pod2daemon
 └───node
-└───node
 └───cni-plugin
 ```
 


### PR DESCRIPTION
## Expected Behavior
```
BASEDIR
└───calico
└───libcalico-go
└───confd
└───felix
└───typha
└───kube-controllers
└───calicoctl
└───app-policy
└───pod2daemon
└───node
└───cni-plugin
```

## Current Behavior
```
BASEDIR
└───calico
└───libcalico-go
└───confd
└───felix
└───typha
└───kube-controllers
└───calicoctl
└───app-policy
└───pod2daemon
└───node
```

## Possible Solution
We need to update Developer-Guide.md

## Steps to Reproduce (for bugs)
```
BASEDIR
└───calico
└───libcalico-go
└───confd
└───felix
└───typha
└───kube-controllers
└───calicoctl
└───app-policy
└───pod2daemon
└───node
```

1 - Clone the repositories into your development environment
2 - Run `make dev-image`.

It will throw below error and exit : 

```
[INFO]	Removing: /go/src/github.com/projectcalico/calicoctl/vendor/github.com/onsi/ginkgo/integration/_fixtures/focused_fixture_with_vendor/vendor
make: *** No rule to make target `../cni-plugin', needed by `cni-plugin-dev-vendor'.  Stop.
```

## Context
Developers cannot get a build without cni-plugin project


