### PR TITLE
Made init containers privileged in order to prevent issues on selinux systems

### DIFF
--- a/_includes/master/charts/calico/templates/calico-node.yaml
+++ b/_includes/master/charts/calico/templates/calico-node.yaml
@@ -67,6 +67,8 @@ spec:
               name: host-local-net-dir
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
+          securityContext:
+            privileged: true
 {{- end }}
         # This container installs the CNI binaries
         # and CNI network config file on each node.
@@ -140,6 +142,8 @@ spec:
             - mountPath: /calico-secrets
               name: etcd-certs
 {{- end }}
+          securityContext:
+            privileged: true
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
@@ -147,6 +151,8 @@ spec:
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
+          securityContext:
+            privileged: true
       containers:
         # Runs {{ include "nodeName" . }} container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/_includes/v3.8/charts/calico/templates/calico-node.yaml
+++ b/_includes/v3.8/charts/calico/templates/calico-node.yaml
@@ -67,6 +67,8 @@ spec:
               name: host-local-net-dir
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
+          securityContext:
+            privileged: true
 {{- end }}
         # This container installs the CNI binaries
         # and CNI network config file on each node.
@@ -140,6 +142,8 @@ spec:
             - mountPath: /calico-secrets
               name: etcd-certs
 {{- end }}
+          securityContext:
+            privileged: true
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver

--- a/_includes/v3.8/charts/calico/templates/calico-node.yaml
+++ b/_includes/v3.8/charts/calico/templates/calico-node.yaml
@@ -151,6 +151,8 @@ spec:
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
+          securityContext:
+            privileged: true
       containers:
         # Runs {{ include "nodeName" . }} container on each Kubernetes node.  This
         # container programs network policy and routes on each


### PR DESCRIPTION
## Description

This is a bug fix for systems running selinux which prevents failures during deployment by having calico-node's init containers run privileged (the same as the calico-node container). This fixes #2704 .

I have not been able to test this change because it uses some form of templating which I'm unfamiliar with. In the issue I talk about doing the same change to the generated manifest yaml, and that works fine.

## Related issues/PRs

fixes #2704 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Make init containers privileged in order to prevent issues on selinux systems
```
