### PR TITLE
Rene typha log spam

### DIFF
--- a/_includes/master/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/master/charts/calico/templates/kdd-crds.yaml
@@ -73,6 +73,7 @@ spec:
     singular: ipamconfig
 
 ---
+{{- end }}
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -88,7 +89,6 @@ spec:
     singular: bgppeer
 
 ---
-{{- end }}
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/_includes/master/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/master/charts/calico/templates/kdd-crds.yaml
@@ -12,7 +12,6 @@ spec:
     plural: felixconfigurations
     singular: felixconfiguration
 ---
-{{- if eq .Values.network "calico" }}
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -73,7 +72,6 @@ spec:
     singular: ipamconfig
 
 ---
-{{- end }}
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/master/getting-started/kubernetes/installation/other.md
+++ b/master/getting-started/kubernetes/installation/other.md
@@ -51,11 +51,6 @@ complete the following steps.
    failures.  The number of replicas should always be less than the number of nodes, otherwise 
    rolling upgrades will stall. In addition, Typha only helps with scale if there are fewer 
    Typha instances than there are nodes.
-   
-   > **Tip**: If you set `typha_service_name` without increasing the replica
-   > count from its default of `0` Felix will try to connect to Typha, find no
-   > Typha instances to connect to, and fail to start.
-   {: .alert .alert-success}
 
 1. Apply the manifest using the following command.
 

--- a/master/getting-started/kubernetes/installation/other.md
+++ b/master/getting-started/kubernetes/installation/other.md
@@ -31,35 +31,31 @@ complete the following steps.
 
 1. If your cluster contains more than 50 nodes:
 
-   - In the `ConfigMap` named `calico-config`, locate the `typha_service_name`,
-     delete the `none` value, and replace it with `calico-typha`.
-
-   - Modify the replica count in the`Deployment` named `calico-typha`
-     to the desired number of replicas.
-
-     ```
-     apiVersion: apps/v1beta1
-     kind: Deployment
-     metadata:
-       name: calico-typha
-       ...
-     spec:
-       ...
-       replicas: <number of replicas>
-     ```
-     {: .no-select-button}
-
-     We recommend at least one replica for every 200 nodes and no more than
-     20 replicas. In production, we recommend a minimum of three replicas to reduce
-     the impact of rolling upgrades and failures.  The number of replicas should
-     always be less than the number of nodes, otherwise rolling upgrades will stall.
-     In addition, Typha only helps with scale if there are fewer Typha instances than
-     there are nodes.
-
-     > **Tip**: If you set `typha_service_name` without increasing the replica
-     > count from its default of `0` Felix will try to connect to Typha, find no
-     > Typha instances to connect to, and fail to start.
-     {: .alert .alert-success}
+   By default the replica count in the `Deployment` named `calico-typha` is set to 1. 
+   You may want to consider changing this for large clusters or production environments.
+   
+   ```
+   apiVersion: apps/v1beta1
+   kind: Deployment
+   metadata:
+   name: calico-typha
+   ...
+   spec:
+   ...
+   replicas: <number of replicas>
+   ```
+   {: .no-select-button}
+   
+   We recommend at least one replica for every 200 nodes up to a maximum of 20. In production, 
+   we recommend a minimum of three replicas to reduce the impact of rolling upgrades and 
+   failures.  The number of replicas should always be less than the number of nodes, otherwise 
+   rolling upgrades will stall. In addition, Typha only helps with scale if there are fewer 
+   Typha instances than there are nodes.
+   
+   > **Tip**: If you set `typha_service_name` without increasing the replica
+   > count from its default of `0` Felix will try to connect to Typha, find no
+   > Typha instances to connect to, and fail to start.
+   {: .alert .alert-success}
 
 1. Apply the manifest using the following command.
 

--- a/master/getting-started/kubernetes/installation/other.md
+++ b/master/getting-started/kubernetes/installation/other.md
@@ -35,14 +35,14 @@ complete the following steps.
    You may want to consider changing this for large clusters or production environments.
    
    ```
-   apiVersion: apps/v1beta1
+   apiVersion: apps/v1
    kind: Deployment
    metadata:
-   name: calico-typha
-   ...
+     name: calico-typha
+     ...
    spec:
-   ...
-   replicas: <number of replicas>
+     ...
+     replicas: <number of replicas>
    ```
    {: .no-select-button}
    


### PR DESCRIPTION
Make some changes to installing calico for policy only. Before this change, the yaml does not does include BGPPeers CRD. The absence of this will make the Typha node spam messages every 200ms. Also made textual update for outdated docs, which was not aware that Typha is included by default for all installations.
TLDR:
- Made template change to include this CRD
- Make textual change

## Related issues/PRs
fixes https://github.com/projectcalico/typha/issues/271

## Release Note
Not required for this change.



-- update --
Preview of the changes: https://deploy-preview-2741--calico.netlify.com/master/getting-started/kubernetes/installation/other

If you now download the yaml, you see that it includes the CRD.