### PR TITLE
Fixed calicoctl not being able to list networkpolicies

### DIFF
--- a/_includes/master/non-helm-manifests/calicoctl.yaml
+++ b/_includes/master/non-helm-manifests/calicoctl.yaml
@@ -77,6 +77,12 @@ rules:
       - list
       - update
       - delete
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
 
 ---
 


### PR DESCRIPTION
## Description

added permission to get and list networkpolicies.networking.k8s.io 

## Related issues/PRs

fixes #2749 



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix missing calicoctl RBAC for viewing networking.k8s.io network policies
```
