### PR TITLE
Added blockaffinities to cluster role

### DIFF
--- a/_includes/master/charts/calico/templates/rbac.yaml
+++ b/_includes/master/charts/calico/templates/rbac.yaml
@@ -175,6 +175,7 @@ rules:
       - networksets
       - clusterinformations
       - hostendpoints
+      - blockaffinities
     verbs:
       - get
       - list


### PR DESCRIPTION
The `blockaffinities` resource was missing from the `calico-node` cluster role in `rbac.yaml`.

fixes https://github.com/projectcalico/calico/issues/2744

