### PR TITLE
More restrictive etcdv3 paths for RBAC

### DIFF
--- a/master/reference/etcd-rbac/calico-etcdv3-paths.md
+++ b/master/reference/etcd-rbac/calico-etcdv3-paths.md
@@ -13,11 +13,16 @@ component needs access to in etcd to function successfully.
 
 ## {{site.nodecontainer}}
 
-| Path                                      | Access |
-|-------------------------------------------|--------|
-| /calico/felix/v1/\*                       |   RW   |
-| /calico/ipam/v2/\*                        |   RW   |
-| /calico/resources/v3/projectcalico.org/\* |   RW   |
+| Path                                                          | Access |
+|---------------------------------------------------------------|--------|
+| /calico/felix/v1/\*                                           |   RW   |
+| /calico/ipam/v2/\*                                            |   RW   |
+| /calico/resources/v3/projectcalico.org/felixconfigurations/\* |   RW   |
+| /calico/resources/v3/projectcalico.org/nodes/\*               |   RW   |
+| /calico/resources/v3/projectcalico.org/workloadendpoints/\*   |   RW   |
+| /calico/resources/v3/projectcalico.org/clusterinformations/\* |   RW   |
+| /calico/resources/v3/projectcalico.org/ippools/\*             |   RW   |
+| /calico/resources/v3/projectcalico.org/\*                     |   R    |
 
 ## Felix as a stand alone process
 
@@ -28,17 +33,33 @@ component needs access to in etcd to function successfully.
 
 ## CNI-plugin
 
-| Path                                      | Access |
-|-------------------------------------------|--------|
-| /calico/ipam/v2/\*                        |   RW   |
-| /calico/resources/v3/projectcalico.org/\* |   RW   |
+| Path                                                          | Access |
+|---------------------------------------------------------------|--------|
+| /calico/ipam/v2/\*                                            |   RW   |
+| /calico/resources/v3/projectcalico.org/workloadendpoints/\*   |   RW   |
+| /calico/resources/v3/projectcalico.org/ippools/\*             |   R    |
+| /calico/resources/v3/projectcalico.org/clusterinformations/\* |   R    |
 
 ## calico/kube-controllers
 
-| Path                                      | Access |
-|-------------------------------------------|--------|
-| /calico/ipam/v2/\*                        |   RW   |
-| /calico/resources/v3/projectcalico.org/\* |   RW   |
+| Path                                                          | Access |
+|---------------------------------------------------------------|--------|
+| /calico/ipam/v2/\*                                            |   RW   |
+| /calico/resources/v3/projectcalico.org/profiles/\*            |   RW   |
+| /calico/resources/v3/projectcalico.org/networkpolicies/\*     |   RW   |
+| /calico/resources/v3/projectcalico.org/nodes/\*               |   RW   |
+| /calico/resources/v3/projectcalico.org/clusterinformations/\* |   RW   |
+| /calico/resources/v3/projectcalico.org/\*                     |   R    |
+
+> **Note**: By default, `calico/kube-controllers` performs periodic 
+> compaction of the etcd data store. If you limit it to just these
+> paths it will be unauthorized to perform this compaction, as that
+> operation requires root privileges on the etcd cluster. You should
+> [configure auto-compaction](https://etcd.io/docs/v3.3.12/op-guide/maintenance/)
+> on your etcd cluster and 
+> [disable `calico/kube-controllers` periodic compaction](/{{page.version}}/reference/kube-controllers/configuration).
+{: .alert .alert-info}
+
 
 ## OpenStack Calico driver for Neutron
 

--- a/master/reference/kube-controllers/configuration.md
+++ b/master/reference/kube-controllers/configuration.md
@@ -64,6 +64,7 @@ The following environment variables can be used to configure the {{site.prodname
 | `LOG_LEVEL`           | Minimum log level to be displayed. | debug, info, warning, error | info
 | `KUBECONFIG`          | Path to a kubeconfig file for Kubernetes API access | path |
 | `SYNC_NODE_LABELS`    | When enabled, Kubernetes node labels will be copied to Calico node objects. | boolean | true
+| `COMPACTION_PERIOD` | Compact the etcd database on this interval. Set to "0" to disable. | [duration](https://golang.org/pkg/time/#ParseDuration) | 10m
 
 ## About each controller
 


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Document more restrictive etcd RBAC roles for Calico.  This prevents hosts from getting write access to all Calico resources (if implemented by customers).

While testing, I noticed that `kube-controllers` runs compaction on the etcd data store, and this fails auth is enabled for any role other than root. Not strictly related to the more restrictive paths, but I've added some clarifying notes to the docs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
