### PR TITLE
Fix building of release-archive on earlier releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,16 @@ RELEASE_DIR?=$(OUTPUT_DIR)/$(RELEASE_DIR_NAME)
 RELEASE_DIR_K8S_MANIFESTS?=$(RELEASE_DIR)/k8s-manifests
 RELEASE_DIR_IMAGES?=$(RELEASE_DIR)/images
 RELEASE_DIR_BIN?=$(RELEASE_DIR)/bin
-MANIFEST_SRC ?= ./_site/$(RELEASE_STREAM)/manifests
+
+# Determine where the manifests live. For older versions we used
+# a different location, but we still need to package them up for patch
+# releases.
+DEFAULT_MANIFEST_SRC=./_site/$(RELEASE_STREAM)/manifests
+OLD_VERSIONS := v3.0 v3.1 v3.2 v3.3 v3.4 v3.5 v3.6
+ifneq ($(filter $(RELEASE_STREAM),$(OLD_VERSIONS)),)
+DEFAULT_MANIFEST_SRC=./_site/$(RELEASE_STREAM)/getting-started/kubernetes/installation
+endif
+MANIFEST_SRC?=$(DEFAULT_MANIFEST_SRC)
 
 ## Create an archive that contains a complete "Calico" release
 release-archive: release-prereqs $(RELEASE_DIR).tgz


### PR DESCRIPTION
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->


<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->


- [ ] Tests
- [ ] Documentation
- [ ] Release note


<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

Fixes https://github.com/projectcalico/calico/issues/2777

We moved where the manifests are in v3.7 but didn't handle building patch releases of earlier versions. 

```release-note
None required
```