### PR TITLE
Reflect different names in apply statement

### DIFF
--- a/master/getting-started/kubernetes/installation/calico.md
+++ b/master/getting-started/kubernetes/installation/calico.md
@@ -50,7 +50,7 @@ datastore type and number of nodes.
    curl {{site.url}}/{{page.version}}/manifests/calico-typha.yaml -o calico.yaml
    ```
 
-{% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}
+{% include {{page.version}}/pod-cidr-sed.md yaml="calico-typha" %}
 
 1. Modify the replica count in the`Deployment` named `calico-typha`
    to the desired number of replicas.
@@ -82,7 +82,7 @@ datastore type and number of nodes.
 1. Apply the manifest.
 
    ```bash
-   kubectl apply -f calico.yaml
+   kubectl apply -f calico-typha.yaml
    ```
 
 1. If you wish to enforce application layer policies and secure workload-to-workload
@@ -96,7 +96,7 @@ datastore type and number of nodes.
    curl {{site.url}}/{{page.version}}/manifests/calico-etcd.yaml -o calico.yaml
    ```
 
-{% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}
+{% include {{page.version}}/pod-cidr-sed.md yaml="calico-etcd" %}
 
 1. In the `ConfigMap` named `calico-config`, set the value of
    `etcd_endpoints` to the IP address and port of your etcd server.
@@ -107,7 +107,7 @@ datastore type and number of nodes.
 1. Apply the manifest using the following command.
 
    ```bash
-   kubectl apply -f calico.yaml
+   kubectl apply -f calico-etcd.yaml
    ```
 
 1. If you wish to enforce application layer policies and secure workload-to-workload

--- a/v3.8/getting-started/kubernetes/installation/calico.md
+++ b/v3.8/getting-started/kubernetes/installation/calico.md
@@ -51,7 +51,7 @@ datastore type and number of nodes.
    curl {{site.url}}/{{page.version}}/manifests/calico-typha.yaml -O
    ```
 
-{% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}
+{% include {{page.version}}/pod-cidr-sed.md yaml="calico-typha" %}
 
 1. Modify the replica count in the`Deployment` named `calico-typha`
    to the desired number of replicas.
@@ -83,7 +83,7 @@ datastore type and number of nodes.
 1. Apply the manifest.
 
    ```bash
-   kubectl apply -f calico.yaml
+   kubectl apply -f calico-typha.yaml
    ```
 
 1. If you wish to enforce application layer policies and secure workload-to-workload
@@ -97,7 +97,7 @@ datastore type and number of nodes.
    curl {{site.url}}/{{page.version}}/manifests/calico-etcd.yaml -O
    ```
 
-{% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}
+{% include {{page.version}}/pod-cidr-sed.md yaml="calico-etcd" %}
 
 1. In the `ConfigMap` named `calico-config`, set the value of
    `etcd_endpoints` to the IP address and port of your etcd server.
@@ -108,7 +108,7 @@ datastore type and number of nodes.
 1. Apply the manifest using the following command.
 
    ```bash
-   kubectl apply -f calico.yaml
+   kubectl apply -f calico-etcd.yaml
    ```
 
 1. If you wish to enforce application layer policies and secure workload-to-workload


### PR DESCRIPTION
Downloading calico-etcd.yaml gives a file named calico-etcd.yaml and not named calico.yaml. Also the CIDR warning should reflect this.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
