### PR TITLE
WIP: Add docs for traffic shaping with calico

### DIFF
--- a/_includes/master/charts/calico/templates/calico-config.yaml
+++ b/_includes/master/charts/calico/templates/calico-config.yaml
@@ -126,6 +126,10 @@ data:
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
+        },
+        {
+          "type": "bandwidth",
+          "capabilities": {"bandwidth": true}
         }
       ]
     }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR documents the traffic shaping capability with Kubernetes added in https://github.com/projectcalico/cni-plugin/pull/745 and https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-traffic-shaping.

Do you think it's a good idea to activate the `bandwidth` plugin per default?

## Related issues/PRs

documents:
- https://github.com/projectcalico/calico/issues/797#issuecomment-493210584
- https://github.com/projectcalico/cni-plugin/pull/745


## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico supports now directly traffic shaping with the bandwidth plugin see: https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-traffic-shaping
```
