### PR TITLE
Fix version skew between Dikastes and calico-node in Hardway

### DIFF
--- a/master/getting-started/kubernetes/hardway/istio-integration.md
+++ b/master/getting-started/kubernetes/hardway/istio-integration.md
@@ -35,9 +35,67 @@ total 5.0M
 ```
 {: .no-select-button}
 
-## Enable application layer policy
+## Enable policy sync API
 
-Your cluster is now ready to enable application layer policy, and you can do so using [the standard instructions](/{{page.version}}/getting-started/kubernetes/installation/app-layer-policy).
+Application layer policy requires the policy sync API to be enabled on Felix. To do this cluster-wide, modify the `default`
+FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`.  The following example uses `sed` to modify your
+existing default config before re-applying it.
+
+```bash
+calicoctl get felixconfiguration default --export -o yaml | \
+sed -e '/  policySyncPathPrefix:/d' \
+    -e '$ a\  policySyncPathPrefix: /var/run/nodeagent' > felix-config.yaml
+calicoctl apply -f felix-config.yaml
+```
+
+## Installing Istio
+
+Install Istio 1.1.7, including mutually authenticated TLS for service to service communication.
+
+```bash
+curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.1.7 sh -
+cd $(ls -d istio-*)
+kubectl apply -f install/kubernetes/helm/istio-init/files/
+kubectl apply -f install/kubernetes/istio-demo-auth.yaml
+```
+
+> **Note**: If an "unable to recognize" error occurs after applying `install/kubernetes/istio-demo-auth.yaml` it is likely a race
+> condition between creating an Istio CRD and then a resource of that type. Re-run the `kubectl apply`.
+{: .alert .alert-info}
+
+## Updating the Istio sidecar injector
+
+The sidecar injector automatically modifies pods as they are created to work
+with Istio. This step modifies the injector configuration to add Dikastes, a
+{{site.prodname}} component, as sidecar containers.
+
+Apply the following ConfigMap to enable injection of Dikastes alongside Envoy.
+
+   ```bash
+   kubectl apply -f {{site.url}}/v3.8/manifests/alp/istio-inject-configmap-1.1.7.yaml
+   ```
+
+## Adding {{site.prodname}} authorization services to the mesh
+
+Apply the following manifest to configure Istio to query {{site.prodname}} for application layer policy authorization decisions
+
+```bash
+kubectl apply -f {{site.url}}/v3.8/manifests/alp/istio-app-layer-policy.yaml
+```
+
+## Adding namespace labels
+
+Application layer policy is only enforced on pods that are started with the
+Envoy and Dikastes sidecars.  Pods that do not have these sidecars will
+only enforce standard {{site.prodname}} network policy.
+
+You can control this on a per-namespace basis.  To enable Istio and application
+layer policy in a namespace, add the label `istio-injection=enabled`.
+
+Label the default namespace, which you will use for the tutorial.
+
+	kubectl label namespace default istio-injection=enabled
+
 
 ## Test application layer policy
 


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

"Calico the hard way" at present links to the generic instructions to install Dikastes. This leads to version skew where Dikastes is installed at the page version, but calico-node is pinned to 3.8. At present this breaks the guide because `master` Dikastes runs non-root, but `3.8` Felix makes the policy sync API socket only readable by root.  This PR incorporates the install instructions directly into "Calico the hard way," pinning the Dikastes version in the process (and simplifying the text for the narrowed use case of "Calico the hard way").

## Related issues/PRs

OS-4925

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Documentation

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
