### PR TITLE
Added default host deny behavior to reference for Host Endpoint. Per …

### DIFF
--- a/master/reference/resources/hostendpoint.md
+++ b/master/reference/resources/hostendpoint.md
@@ -18,10 +18,10 @@ interfaces.
 Each host endpoint may include a set of labels and list of profiles that {{site.prodname}}
 will use to apply
 [policy]({{site.baseurl}}/{{page.version}}/reference/resources/networkpolicy)
-to the interface. 
+to the interface.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored. 
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/reference/host-endpoints/pre-dnat) is

--- a/master/reference/resources/hostendpoint.md
+++ b/master/reference/resources/hostendpoint.md
@@ -18,8 +18,10 @@ interfaces.
 Each host endpoint may include a set of labels and list of profiles that {{site.prodname}}
 will use to apply
 [policy]({{site.baseurl}}/{{page.version}}/reference/resources/networkpolicy)
-to the interface.  If no profiles or labels are applied, {{site.prodname}} will not apply
-any policy.
+to the interface. 
+
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored. 
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/reference/host-endpoints/pre-dnat) is

--- a/master/reference/resources/hostendpoint.md
+++ b/master/reference/resources/hostendpoint.md
@@ -21,7 +21,8 @@ will use to apply
 to the interface.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/reference/host-endpoints/pre-dnat) is

--- a/v3.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.0/reference/calicoctl/resources/hostendpoint.md
@@ -20,7 +20,8 @@ aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `
 {: .alert .alert-danger}
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 ### Sample YAML
 

--- a/v3.0/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.0/reference/calicoctl/resources/hostendpoint.md
@@ -19,6 +19,9 @@ aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `
 > is omitted then security rules that use labels will fail to match this endpoint.
 {: .alert .alert-danger}
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 ### Sample YAML
 
 ```yaml

--- a/v3.1/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.1/reference/calicoctl/resources/hostendpoint.md
@@ -20,7 +20,8 @@ aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `
 {: .alert .alert-danger}
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 ### Sample YAML
 

--- a/v3.1/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.1/reference/calicoctl/resources/hostendpoint.md
@@ -19,6 +19,9 @@ aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `
 > is omitted then security rules that use labels will fail to match this endpoint.
 {: .alert .alert-danger}
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 ### Sample YAML
 
 ```yaml

--- a/v3.2/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.2/reference/calicoctl/resources/hostendpoint.md
@@ -20,7 +20,8 @@ aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `
 {: .alert .alert-danger}
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 ### Sample YAML
 

--- a/v3.2/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.2/reference/calicoctl/resources/hostendpoint.md
@@ -19,6 +19,9 @@ aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `
 > is omitted then security rules that use labels will fail to match this endpoint.
 {: .alert .alert-danger}
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 ### Sample YAML
 
 ```yaml

--- a/v3.3/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.3/reference/calicoctl/resources/hostendpoint.md
@@ -14,6 +14,9 @@ any policy.
 For `calicoctl` [commands]({{site.baseurl}}/{{page.version}}/reference/calicoctl/commands/) that specify a resource type on the CLI, the following
 aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 > **Important**: When rendering security rules on other hosts, {{site.prodname}} uses the
 > `expectedIPs` field to resolve label selectors to IP addresses. If the `expectedIPs` field
 > is omitted then security rules that use labels will fail to match this endpoint.

--- a/v3.3/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.3/reference/calicoctl/resources/hostendpoint.md
@@ -15,7 +15,8 @@ For `calicoctl` [commands]({{site.baseurl}}/{{page.version}}/reference/calicoctl
 aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Important**: When rendering security rules on other hosts, {{site.prodname}} uses the
 > `expectedIPs` field to resolve label selectors to IP addresses. If the `expectedIPs` field

--- a/v3.4/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.4/reference/calicoctl/resources/hostendpoint.md
@@ -22,7 +22,8 @@ to the interface.  If no profiles or labels are applied, {{site.prodname}} will 
 any policy.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/policy/pre-dnat) is

--- a/v3.4/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.4/reference/calicoctl/resources/hostendpoint.md
@@ -21,6 +21,9 @@ will use to apply
 to the interface.  If no profiles or labels are applied, {{site.prodname}} will not apply
 any policy.
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/policy/pre-dnat) is
 > implemented.

--- a/v3.5/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.5/reference/calicoctl/resources/hostendpoint.md
@@ -22,7 +22,8 @@ to the interface.  If no profiles or labels are applied, {{site.prodname}} will 
 any policy.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/policy/pre-dnat) is

--- a/v3.5/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.5/reference/calicoctl/resources/hostendpoint.md
@@ -21,6 +21,9 @@ will use to apply
 to the interface.  If no profiles or labels are applied, {{site.prodname}} will not apply
 any policy.
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/getting-started/bare-metal/policy/pre-dnat) is
 > implemented.

--- a/v3.6/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.6/reference/calicoctl/resources/hostendpoint.md
@@ -22,7 +22,8 @@ to the interface.  If no profiles or labels are applied, {{site.prodname}} will 
 any policy.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/security/host-endpoints/pre-dnat) is

--- a/v3.6/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.6/reference/calicoctl/resources/hostendpoint.md
@@ -21,6 +21,9 @@ will use to apply
 to the interface.  If no profiles or labels are applied, {{site.prodname}} will not apply
 any policy.
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/security/host-endpoints/pre-dnat) is
 > implemented.

--- a/v3.7/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.7/reference/calicoctl/resources/hostendpoint.md
@@ -22,7 +22,8 @@ to the interface.  If no profiles or labels are applied, {{site.prodname}} will 
 any policy.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/security/host-endpoints/pre-dnat) is

--- a/v3.7/reference/calicoctl/resources/hostendpoint.md
+++ b/v3.7/reference/calicoctl/resources/hostendpoint.md
@@ -21,6 +21,9 @@ will use to apply
 to the interface.  If no profiles or labels are applied, {{site.prodname}} will not apply
 any policy.
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/security/host-endpoints/pre-dnat) is
 > implemented.

--- a/v3.8/reference/resources/hostendpoint.md
+++ b/v3.8/reference/resources/hostendpoint.md
@@ -23,7 +23,8 @@ to the interface.  If no profiles or labels are applied, {{site.prodname}} will 
 any policy.
 
 **Default behavior of external traffic to/from host**
-If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
+If a host endpoint is added and network policy is not in place, the {{ site.prodname }} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, {{ site.prodname }} blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
 
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/security/host-endpoints/pre-dnat) is

--- a/v3.8/reference/resources/hostendpoint.md
+++ b/v3.8/reference/resources/hostendpoint.md
@@ -22,6 +22,9 @@ will use to apply
 to the interface.  If no profiles or labels are applied, {{site.prodname}} will not apply
 any policy.
 
+**Default behavior of external traffic to/from host**
+If a host endpoint is added and network policy is not in place, the Calico default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules). For host endpoints, Calico blocks traffic only to/from interfaces that it’s been explicitly told about in network policy. Traffic to/from other interfaces is ignored.
+
 > **Note**: Currently, for host endpoints with `interfaceName: *`, only [pre-DNAT
 > policy]({{site.baseurl}}/{{page.version}}/security/host-endpoints/pre-dnat) is
 > implemented.


### PR DESCRIPTION
Customer was confused about default deny behavior for host endpoint.
Per Alex, add text from Get Started with Calico Network Policy about host endpoint
behavior to Reference, Host Endpoint.

- Can merge immediately to 3.8
- Backport to versions 3.7 > 3.0

Previews:

https://deploy-preview-2810--calico.netlify.com/v3.8/reference/resources/hostendpoint
https://deploy-preview-2810--calico.netlify.com/v3.7/reference/calicoctl/resources/hostendpoint