### PR TITLE
btn-copy-code: set position absolute

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -43,14 +43,17 @@ pre code {
   white-space: pre;
 }
 
+div.highlight {
+  position: relative;
+}
+
 // copy btn style
 .btn-copy-code {
   color: #FF7E00;
-  padding-right: 0px;
-  float: right;
   border: 0;
   font-size: 16px;
-  margin-top: -3px;
+  position: absolute;
+  right: 10px;
   &:hover {
     cursor: pointer;
   }


### PR DESCRIPTION
## Description
I noticed a small style bug in Mozilla Firefox Ubuntu 68.0.2 that makes the `.btn-copy-code` scroll with content on mobile devices:
![image](https://user-images.githubusercontent.com/3449337/63962868-97845900-ca48-11e9-8407-234ea10a1c59.png)

With fix:
![image](https://user-images.githubusercontent.com/3449337/63962842-89ced380-ca48-11e9-87e7-c36e045bc3d5.png)


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
