### PR TITLE
add security context for typha

### DIFF
--- a/_includes/master/manifests/calico-typha.yaml
+++ b/_includes/master/manifests/calico-typha.yaml
@@ -102,6 +102,9 @@ spec:
             host: localhost
           periodSeconds: 30
           initialDelaySeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
         readinessProbe:
           httpGet:
             path: /readiness


### PR DESCRIPTION
Note this change is dependent on https://github.com/projectcalico/typha/pull/312 - so should be merged after https://github.com/projectcalico/typha/pull/312 is merged. 