### PR TITLE
add null converter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ ifneq ($(IMAGES_FILE),)
 	CONFIG:=$(CONFIG),/config_images.yml
 endif
 
+# Set DEV_NULL=true to enable the Null Converter which renders the docs site as markdown. 
+# This is useful for comparing changes to templates & includes.
+ifeq ($(DEV_NULL),true)
+	CONFIG:=$(CONFIG),_config_null.yml
+endif
+
 GO_BUILD_VER?=v0.22
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
 LOCAL_USER_ID?=$(shell id -u $$USER)

--- a/_config_null.yml
+++ b/_config_null.yml
@@ -1,0 +1,9 @@
+# Pass this config file to jekyll to render all pages as raw markdown.
+markdown: NullConverter
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      layout: null
+      version: master

--- a/_config_null.yml
+++ b/_config_null.yml
@@ -1,9 +1,2 @@
 # Pass this config file to jekyll to render all pages as raw markdown.
 markdown: NullConverter
-defaults:
-  -
-    scope:
-      path: ""
-    values:
-      layout: null
-      version: master

--- a/_plugins/null_converter.rb
+++ b/_plugins/null_converter.rb
@@ -2,12 +2,23 @@
 # to the markdown when it converts it. This is useful in development if you want to see what the rendered markdown looks like
 # after "include" statements are processed but before it's converted into a full html page. Specifically, this makes it trivial
 # to diff rendered markdown changes made to include statements. 
-# To activate, set "markdown: NullConverter" in config.yml, and default all pages to "layout: null" 
-class Jekyll::Converters::Markdown::NullConverter
-    def initialize(config)
+# To activate, set "markdown: NullConverter" in config.yml.
+module Jekyll
+    class Converters::Markdown::NullConverter
+        def initialize(config)
+        end
+
+        def convert(content)
+            content
+        end
     end
 
-    def convert(content)
-        content
+    # This after_init register sets layout=null for all pages if the NullConverter is in use.
+    Hooks.register :site, :after_init do |site|
+        if site.config["markdown"] == "NullConverter"
+            site.config["defaults"].each do |defaults|
+                defaults["values"]["layout"] = nil
+            end
+        end
     end
 end

--- a/_plugins/null_converter.rb
+++ b/_plugins/null_converter.rb
@@ -1,0 +1,13 @@
+# NullConverter implements the Jekyll Markdown Converter but doesn't actually make any modifications
+# to the markdown when it converts it. This is useful in development if you want to see what the rendered markdown looks like
+# after "include" statements are processed but before it's converted into a full html page. Specifically, this makes it trivial
+# to diff rendered markdown changes made to include statements. 
+# To activate, set "markdown: NullConverter" in config.yml, and default all pages to "layout: null" 
+class Jekyll::Converters::Markdown::NullConverter
+    def initialize(config)
+    end
+
+    def convert(content)
+        content
+    end
+end


### PR DESCRIPTION
## Description

This is a second go at #2559 but with actual instructions, comments, and use cases.

Adds a "null converter" and some config files and shortcuts to use it.

When enabled, this will render `{% include %}` statements in the docs but stop short of converting the compiled markdown into html.

This is extremely useful when trying to `diff` the changes to the docs when tweaking `include` and templating logic.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
