### PR TITLE
Documentation for default BGP Configuration serviceExternalIPs

### DIFF
--- a/master/reference/resources/bgpconfig.md
+++ b/master/reference/resources/bgpconfig.md
@@ -43,7 +43,7 @@ spec:
 | logSeverityScreen | Global log level | Debug, Info, Warning, Error, Fatal | string | `Info` |
 | nodeToNodeMeshEnabled | Full BGP node-to-node mesh. Only valid on the global `default` BGPConfiguration. | true, false  | string | true |
 | asNumber | The default local AS Number that {{site.prodname}} should use when speaking with BGP peers. Only valid on the global `default` BGPConfiguration; to set a per-node override, use the `bgp` field on the [Node resource](./node). | A valid AS Number, may be specified in dotted notation. | integer/string | 64512 |
-| serviceExternalIPs | The CIDR blocks for Kubernetes service External IPs. Kubernetes service External IPs will only be advertised if they are within one of these blocks. Only valid on the global `default` BGPConfiguration: will be ignored otherwise. | A list of valid IPv4 CIDR blocks. | List of `cidr: XXX.XXX.XXX.XXX/XX` values. | Empty List |
+| serviceExternalIPs | The CIDR blocks for Kubernetes Service External IPs. Kubernetes Service External IPs will only be advertised if they are within one of these blocks. Only valid on the global `default` BGPConfiguration: will be ignored otherwise. | A list of valid IPv4 CIDR blocks. | List of `cidr: XXX.XXX.XXX.XXX/XX` values. | Empty List |
 
 ### Supported operations
 

--- a/master/reference/resources/bgpconfig.md
+++ b/master/reference/resources/bgpconfig.md
@@ -20,6 +20,9 @@ spec:
   logSeverityScreen: Info
   nodeToNodeMeshEnabled: true
   asNumber: 63400
+  serviceExternalIPs:
+  - cidr: 104.244.42.129/32
+  - cidr: 172.217.3.0/24
 ```
 
 ### BGP configuration definition
@@ -40,6 +43,7 @@ spec:
 | logSeverityScreen | Global log level | Debug, Info, Warning, Error, Fatal | string | `Info` |
 | nodeToNodeMeshEnabled | Full BGP node-to-node mesh. Only valid on the global `default` BGPConfiguration. | true, false  | string | true |
 | asNumber | The default local AS Number that {{site.prodname}} should use when speaking with BGP peers. Only valid on the global `default` BGPConfiguration; to set a per-node override, use the `bgp` field on the [Node resource](./node). | A valid AS Number, may be specified in dotted notation. | integer/string | 64512 |
+| serviceExternalIPs | The CIDR blocks for Kubernetes service External IPs. Kubernetes service External IPs will only be advertised if they are within one of these blocks. Only valid on the global `default` BGPConfiguration: will be ignored otherwise. | A list of valid IPv4 CIDR blocks. | List of `cidr: XXX.XXX.XXX.XXX/XX` values. | empty list |
 
 ### Supported operations
 

--- a/master/reference/resources/bgpconfig.md
+++ b/master/reference/resources/bgpconfig.md
@@ -43,7 +43,7 @@ spec:
 | logSeverityScreen | Global log level | Debug, Info, Warning, Error, Fatal | string | `Info` |
 | nodeToNodeMeshEnabled | Full BGP node-to-node mesh. Only valid on the global `default` BGPConfiguration. | true, false  | string | true |
 | asNumber | The default local AS Number that {{site.prodname}} should use when speaking with BGP peers. Only valid on the global `default` BGPConfiguration; to set a per-node override, use the `bgp` field on the [Node resource](./node). | A valid AS Number, may be specified in dotted notation. | integer/string | 64512 |
-| serviceExternalIPs | The CIDR blocks for Kubernetes service External IPs. Kubernetes service External IPs will only be advertised if they are within one of these blocks. Only valid on the global `default` BGPConfiguration: will be ignored otherwise. | A list of valid IPv4 CIDR blocks. | List of `cidr: XXX.XXX.XXX.XXX/XX` values. | empty list |
+| serviceExternalIPs | The CIDR blocks for Kubernetes service External IPs. Kubernetes service External IPs will only be advertised if they are within one of these blocks. Only valid on the global `default` BGPConfiguration: will be ignored otherwise. | A list of valid IPv4 CIDR blocks. | List of `cidr: XXX.XXX.XXX.XXX/XX` values. | Empty List |
 
 ### Supported operations
 


### PR DESCRIPTION
## Description

Add documentation for the new `ServiceExternalIPs` BGP Configuration field.

## Related issues/PRs

https://github.com/projectcalico/calico/issues/2770
https://github.com/projectcalico/libcalico-go/pull/1123
https://github.com/projectcalico/confd/pull/266

## Release Note

```release-note
Support sending BGP advertisements for Kubernetes Service External IPs that fall within a set of whitelisted CIDR blocks.
```
