### PR TITLE
Remove meta description from layout

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -42,9 +42,6 @@ The code is a little roundabout for a few reasons:
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="docsearch:version" content="{{page.version}}">
-    {% if page.description %}
-    <meta name="description" content="{{ page.description }}">
-    {% endif %}
     <link rel="shortcut icon" type="image/png" href="{{site.baseurl}}/images/favicon.png">
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">


### PR DESCRIPTION
Don't need meta description in layout because SEO plugin already does this