### PR TITLE
Enable inertia scrolling on iOS

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -33,6 +33,7 @@ html {
 }
 body {
   height: 100%;
+  -webkit-overflow-scrolling: auto;
 }
 
 h2,h3,h4,h5,h6 {

--- a/css/style.scss
+++ b/css/style.scss
@@ -33,7 +33,7 @@ html {
 }
 body {
   height: 100%;
-  -webkit-overflow-scrolling: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 h2,h3,h4,h5,h6 {


### PR DESCRIPTION
## Description

Added `-webkit-overflow-scrolling: touch` to body in css to enable inertia scrolling on iOS.

Preview tested successfully on iPhone Safari and Mac Chrome & Safari.

