### PR TITLE
Move selector from EntityRule to Spec level

### DIFF
--- a/master/security/kubernetes-node-ports.md
+++ b/master/security/kubernetes-node-ports.md
@@ -61,8 +61,8 @@ spec:
     - action: Allow
       source:
         nets: [1.2.3.4/16, 100.100.100.0/16]
-        selector: has(kubernetes-host)
     - action: Deny
+  selector: has(kubernetes-host)
 ```
 
 #### Allow local host egress traffic   

--- a/v3.8/security/kubernetes-node-ports.md
+++ b/v3.8/security/kubernetes-node-ports.md
@@ -61,8 +61,8 @@ spec:
     - action: Allow
       source:
         nets: [1.2.3.4/16, 100.100.100.0/16]
-        selector: has(kubernetes-host)
     - action: Deny
+  selector: has(kubernetes-host)
 ```
 
 #### Allow local host egress traffic   

--- a/v3.9/security/kubernetes-node-ports.md
+++ b/v3.9/security/kubernetes-node-ports.md
@@ -62,8 +62,8 @@ spec:
     - action: Allow
       source:
         nets: [1.2.3.4/16, 100.100.100.0/16]
-        selector: has(kubernetes-host)
     - action: Deny
+  selector: has(kubernetes-host)
 ```
 
 #### Allow local host egress traffic   


### PR DESCRIPTION
The goal of the selector is to select what hosts to apply the policy to,
not to specify source addresses for matching packets.

## Description

It appears there is a mistake in the "Apply policy to Kubernetes node ports" documentation where the allow-cluster-internal-ingress-only policy sets a selector field in the entityrule for source address selection rather than setting it at the spec level to decide what nodes should apply the rules.