### PR TITLE
remove dated IPVS warning for k8s v1.10

### DIFF
--- a/master/networking/enabling-ipvs.md
+++ b/master/networking/enabling-ipvs.md
@@ -17,9 +17,6 @@ However, it comes with some limitations.  In IPVS mode:
   do use NodePorts outside {{site.prodname}}'s expected range,
   {{site.prodname}} will treat traffic to those ports as host traffic instead
   of pod traffic.
-- {{site.prodname}} does not support Kubernetes services that make use of a
-  locally-assigned `ExternalIP` for Kubernetes v1.10. This is due to a kube-proxy issue
-  and has been fixed in Kubernetes v1.11.
 
  {{site.prodname}} will detect if you change `kube-proxy`'s proxy mode after 
  {{site.prodname}} has been deployed. Any Kubernetes `ipvs`-specific configuration 

--- a/v3.6/networking/enabling-ipvs.md
+++ b/v3.6/networking/enabling-ipvs.md
@@ -17,9 +17,6 @@ However, it comes with some limitations.  In IPVS mode:
   do use NodePorts outside {{site.prodname}}'s expected range,
   {{site.prodname}} will treat traffic to those ports as host traffic instead
   of pod traffic.
-- {{site.prodname}} does not support Kubernetes services that make use of a
-  locally-assigned `ExternalIP` for Kubernetes v1.10. This is due to a kube-proxy issue
-  and has been fixed in Kubernetes v1.11.
 
  {{site.prodname}} will detect if you change `kube-proxy`'s proxy mode after 
  {{site.prodname}} has been deployed. Any Kubernetes `ipvs`-specific configuration 

--- a/v3.7/networking/enabling-ipvs.md
+++ b/v3.7/networking/enabling-ipvs.md
@@ -17,9 +17,6 @@ However, it comes with some limitations.  In IPVS mode:
   do use NodePorts outside {{site.prodname}}'s expected range,
   {{site.prodname}} will treat traffic to those ports as host traffic instead
   of pod traffic.
-- {{site.prodname}} does not support Kubernetes services that make use of a
-  locally-assigned `ExternalIP` for Kubernetes v1.10. This is due to a kube-proxy issue
-  and has been fixed in Kubernetes v1.11.
 
  {{site.prodname}} will detect if you change `kube-proxy`'s proxy mode after 
  {{site.prodname}} has been deployed. Any Kubernetes `ipvs`-specific configuration 

--- a/v3.8/networking/enabling-ipvs.md
+++ b/v3.8/networking/enabling-ipvs.md
@@ -17,9 +17,6 @@ However, it comes with some limitations.  In IPVS mode:
   do use NodePorts outside {{site.prodname}}'s expected range,
   {{site.prodname}} will treat traffic to those ports as host traffic instead
   of pod traffic.
-- {{site.prodname}} does not support Kubernetes services that make use of a
-  locally-assigned `ExternalIP` for Kubernetes v1.10. This is due to a kube-proxy issue
-  and has been fixed in Kubernetes v1.11.
 
  {{site.prodname}} will detect if you change `kube-proxy`'s proxy mode after 
  {{site.prodname}} has been deployed. Any Kubernetes `ipvs`-specific configuration 

--- a/v3.9/networking/enabling-ipvs.md
+++ b/v3.9/networking/enabling-ipvs.md
@@ -18,9 +18,6 @@ However, it comes with some limitations.  In IPVS mode:
   do use NodePorts outside {{site.prodname}}'s expected range,
   {{site.prodname}} will treat traffic to those ports as host traffic instead
   of pod traffic.
-- {{site.prodname}} does not support Kubernetes services that make use of a
-  locally-assigned `ExternalIP` for Kubernetes v1.10. This is due to a kube-proxy issue
-  and has been fixed in Kubernetes v1.11.
 
  {{site.prodname}} will detect if you change `kube-proxy`'s proxy mode after 
  {{site.prodname}} has been deployed. Any Kubernetes `ipvs`-specific configuration 


### PR DESCRIPTION
## Description

Remove a dated warning about locally-assigned `ExternalIP` for Kubernetes v1.10 in releases that no longer support K8s v1.10.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
