### PR TITLE
allow pages to hide title while still setting one (for seo)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,6 +51,7 @@ defaults:
       path: ""
     values:
       layout: docwithnav
+      show_title: true
       version: master
       sitemap: true
       registry:

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -201,7 +201,9 @@ The code is a little roundabout for a few reasons:
               <a data-proofer-ignore href="https://github.com/projectcalico/calico/tree/master/{{page.path}}" style="color: #999; text-decoration: none; float: right;" target="_blank"><i class="fa fa-github" aria-hidden="true"></i> Edit this page</a></div>
               <!-- END TOP DOCUMENTATION PAGE NAVBAR -->
               {% include version_warning.html %}
+              {% if page.show_title -%}
               <h1>{{ page.title }}</h1>
+              {% endif -%}
               {{ content }}
 
               <!-- BOTTOM DOCUMENTATION PAGE NAVBAR -->

--- a/master/introduction/index.md
+++ b/master/introduction/index.md
@@ -1,5 +1,6 @@
 ---
-title: ''
+title: About Calico
+show_title: false
 canonical_url: 'https://docs.projectcalico.org/v3.9/introduction/index'
 custom_css: css/intro.css
 ---

--- a/v3.9/introduction/index.md
+++ b/v3.9/introduction/index.md
@@ -1,5 +1,6 @@
 ---
-title: ''
+title: About Calico
+show_title: false
 redirect_from: latest/introduction/index
 canonical_url: 'https://docs.projectcalico.org/v3.9/introduction/index'
 custom_css: css/intro.css


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

`page.title` is not just used by `layout.html`  but also by our SEO plugin.

There is a desire on our intro page to not show the page title but still provide one to google SEO.

This PR makes that possible

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
