### PR TITLE
add fsgroup in security context

### DIFF
--- a/_includes/master/charts/calico/templates/calico-typha.yaml
+++ b/_includes/master/charts/calico/templates/calico-typha.yaml
@@ -63,6 +63,9 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
+      # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573 
+      securityContext:
+        fsGroup: 65534
       containers:
       - image: {{ .Values.typha.image }}:{{.Values.typha.tag }}
         name: calico-typha


### PR DESCRIPTION
Fixes errors related to reading serviceaccount token by adding fsGroup for the non-root user. This issue is described here kubernetes/kubernetes#82573 

`2019-10-10 17:34:52.521 [ERROR][6] daemon.go 227: Failed to connect to datastore error=open /var/run/secrets/kubernetes.io/serviceaccount/token: permission denied`

```release-note
Run typha in fsGroup to allow access to serviceaccount token
```