### PR TITLE
Remove dev-vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ RELEASE_BRANCH_REPOS=$(sort $(RELEASE_REPOS) libcalico-go confd)
 TAG_COMMAND=git describe --tags --dirty --always --long
 REGISTRY?=calico
 LOCAL_BUILD=true
-.PHONY: dev-image dev-test dev-vendor dev-clean
+.PHONY: dev-image dev-test dev-clean
 ## Build a local version of Calico based on the checked out codebase.
-dev-image: dev-vendor $(addsuffix -dev-image, $(filter-out calico felix, $(RELEASE_REPOS)))
+dev-image: $(addsuffix -dev-image, $(filter-out calico felix, $(RELEASE_REPOS)))
 $(addsuffix -dev-image,$(RELEASE_REPOS)): %-dev-image: ../%
 	@cd $< && export TAG=$$($(TAG_COMMAND)); make image tag-images \
 		BUILD_IMAGE=$(REGISTRY)/$* \
@@ -110,13 +110,9 @@ $(addsuffix -dev-push,$(RELEASE_REPOS)): %-dev-push: ../%
 		IMAGETAG=$$TAG
 
 ## Run all tests against currently checked out code. WARNING: This takes a LONG time.
-dev-test: dev-vendor $(addsuffix -dev-test, $(filter-out calico, $(RELEASE_REPOS)))
+dev-test:  $(addsuffix -dev-test, $(filter-out calico, $(RELEASE_REPOS)))
 $(addsuffix -dev-test,$(RELEASE_REPOS)): %-dev-test: ../%
 	@cd $< && make test LOCAL_BUILD=$(LOCAL_BUILD)
-
-dev-vendor: $(addsuffix -dev-vendor, $(filter-out calico, $(RELEASE_BRANCH_REPOS)))
-$(addsuffix -dev-vendor,$(RELEASE_BRANCH_REPOS)): %-dev-vendor: ../%
-	@cd $< && make vendor
 
 ## Run `make clean` across all repos.
 dev-clean: $(addsuffix -dev-clean, $(filter-out calico felix, $(RELEASE_REPOS)))


### PR DESCRIPTION
Sounds like dev-vendor needs to be removed entirely at this point from the global make instructions.

- The build  breaks if you try to build all the containers using the top level makefile...  am assuming we might want some CI around that codepath at some point. 
- `calicoctl` doesnt supprt this anymore (i.e. looks like it was removed possibly here, https://github.com/projectcalico/calicoctl/commit/38230ea38996fa1c97c83719d5fb96ad4d7eeb7d#diff-b67911656ef5d18c4ae36cb6741b7965), so i assume it cant be a global step in the build process anymore.

This should fix #2840

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
