### PR TITLE
Update hostnetwork/3 node notes in install-typha.md 

### DIFF
--- a/v3.9/getting-started/kubernetes/hardway/install-typha.md
+++ b/v3.9/getting-started/kubernetes/hardway/install-typha.md
@@ -4,7 +4,7 @@ redirect_from: latest/getting-started/kubernetes/hardway/install-typha
 canonical_url: 'https://docs.projectcalico.org/v3.9/getting-started/kubernetes/hardway/install-typha'
 ---
 
-**Typha** sits between the Kubernetes API server and per-node daemons like **Felix** and **confd** (running in `calico/node`).
+**Typha** is an optional add on to calico for performance optimization when you have a large number of nodes in a cluster.  It sits between the Kubernetes API server and per-node daemons like **Felix** and **confd** (running in `calico/node`).
 It watches the Kubernetes resources and {{site.prodname}} custom resources used by these daemons, and whenever a resource changes
 it fans out the update to the daemons. This reduces the number of watches the Kubernetes API server needs to serve
 and improves scalability of the cluster.

--- a/v3.9/getting-started/kubernetes/hardway/install-typha.md
+++ b/v3.9/getting-started/kubernetes/hardway/install-typha.md
@@ -56,7 +56,7 @@ Store the Typha key and certificate in a secret that Typha will access
 kubectl create secret generic -n kube-system calico-typha-certs --from-file=typha.key --from-file=typha.crt
 ```
 
-## Provision RBAC
+## Provision RBAC rules for Typha API access 
 
 Create a ServiceAccount that will be used to run Typha.
 
@@ -129,11 +129,9 @@ Bind the cluster role to the `calico-typha` ServiceAccount.
 kubectl create clusterrolebinding calico-typha --clusterrole=calico-typha --serviceaccount=kube-system:calico-typha
 ```
 
-## Install Deployment
+## Install Typha Deployment
 
-Since Typha is required by `calico/node`, and `calico/node` establishes the pod network, we run Typha as a host networked pod to avoid
-a chicken-and-egg problem.  We run 3 replicas of Typha so that even during a rolling update, a single failure does not
-make Typha unavailable.
+Since Typha is required by `calico/node`, and `calico/node` establishes the pod network, we run Typha as a host networked pod to avoid a chicken-and-egg problem.  We run 3 replicas of Typha so that even during a rolling update, a single failure does not make Typha unavailable.  
 
 ```
 kubectl apply -f - <<EOF
@@ -234,13 +232,13 @@ EOF
 We set `TYPHA_CLIENTCN` to `calico-node` which is the common name we will use on the certificate `calico/node` will use in the
 next lab.
 
-Verify Typha is up an running with three instances
+Verify Typha is up an running with three instances (NOTE: all typha pods bind to a host port, as described above.  IF you have less then 3 nodes in your cluster, some typha instances will not be up).
 
 ```
 kubectl get pods -l k8s-app=calico-typha -n kube-system
 ```
 
-Result:
+Typical Result (For a cluster with 3+ nodes):
 
 ```
 NAME                            READY   STATUS    RESTARTS   AGE

--- a/v3.9/getting-started/kubernetes/hardway/install-typha.md
+++ b/v3.9/getting-started/kubernetes/hardway/install-typha.md
@@ -131,7 +131,9 @@ kubectl create clusterrolebinding calico-typha --clusterrole=calico-typha --serv
 
 ## Install Typha Deployment
 
-Since Typha is required by `calico/node`, and `calico/node` establishes the pod network, we run Typha as a host networked pod to avoid a chicken-and-egg problem.  We run 3 replicas of Typha so that even during a rolling update, a single failure does not make Typha unavailable.  
+The pod network is *not* available when initially installing `calico/node`, and if using `calico/node` with `typha`, typha is required for pod network establishment. Thus, we cannot rely on the pod network at the time of `calico/node` installation in this scenario, and we bind `typha` to the `hostNetwork`, for direct, non k8s communication during bootstrapping.  We run 3 replicas of Typha so that even during a rolling update, a single failure does not make Typha unavailable.  
+
+Thus, the following deployment will only completely schedule if there are 3 nodes  in your cluster - that is ok, however, since you only need 1 healthy typha endpoint per host.
 
 ```
 kubectl apply -f - <<EOF

--- a/v3.9/getting-started/kubernetes/hardway/install-typha.md
+++ b/v3.9/getting-started/kubernetes/hardway/install-typha.md
@@ -240,7 +240,7 @@ Verify Typha is up an running with three instances (NOTE: all typha pods bind to
 kubectl get pods -l k8s-app=calico-typha -n kube-system
 ```
 
-Typical Result (For a cluster with 3+ nodes):
+Typical Result:
 
 ```
 NAME                            READY   STATUS    RESTARTS   AGE


### PR DESCRIPTION
We should probably clarify the situation with typha pods for smaller clusters a little bit ... 

.. Also tangential.., should  `Typha` be a daemonset or static pod of some sort?