### PR TITLE
Dev environment 2929

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -25,34 +25,49 @@ You will need the following repositories cloned on your development machine:
 
 ```
 BASEDIR
-└───calico (https://github.com/projectcalico/calico.git)
-└───libcalico-go (https://github.com/projectcalico/libcalico-go.git)
-└───confd git (https://github.com/projectcalico/confd.git)
-└───felix git (https://github.com/projectcalico/felix.git)
-└───typha git (https://github.com/projectcalico/typha.git)
-└───kube-controllers (https://github.com/projectcalico/kube-controllers.git)
-└───calicoctl (https://github.com/projectcalico/calicoctl.git)
-└───app-policy (https://github.com/projectcalico/app-policy.git)
-└───pod2daemon (https://github.com/projectcalico/pod2daemon.git)
-└───node git (https://github.com/projectcalico/node.git)
-└───cni-plugin (https://github.com/projectcalico/cni-plugin.git)
+└─── [calico](https://github.com/projectcalico/calico.git)
+└─── [libcalico-go](https://github.com/projectcalico/libcalico-go.git)
+└─── [confd](https://github.com/projectcalico/confd.git)
+└─── [felix](https://github.com/projectcalico/felix.git)
+└─── [typha](https://github.com/projectcalico/typha.git)
+└─── [kube-controllers](https://github.com/projectcalico/kube-controllers.git)
+└─── [calicoctl](https://github.com/projectcalico/calicoctl.git)
+└─── [app-policy](https://github.com/projectcalico/app-policy.git)
+└─── [pod2daemon](https://github.com/projectcalico/pod2daemon.git)
+└─── [node](https://github.com/projectcalico/node.git)
+└─── [cni-plugin](https://github.com/projectcalico/cni-plugin.git)
 ```
 
-## Building the code
+## Building Calico from scratch
 
 ### Building everything
 
-Once the code is checked out, try building it to make sure your development environment is configured properly. Run the following command from within the `calico` repository to build all container images from your locally checked out code.
+Once the code for all subrepositories is checked out, try building it to make sure your development environment is configured properly. Run the following command from within the `calico` repository to build all container images from your locally checked out code.
 
-```
-make dev-image
-```
+#### Automated dev environment
 
-This will build a number of `calico/X` images, tagged by git commit hash. To build images with a specific
-container registry, set the `REGISTRY` environment variable.
+Note: There is a `vagrant` recipe attempts to canonicalize instructions for a simple dev environment that is reproducible, see `hack/development-environment/` for details.  You can use it to quickly spin up a calico build and smoke test.
 
+#### Manually create a dev environment (on Linux)
+
+- First, build the images:
 ```
 make dev-image REGISTRY=my-registry
+```
+
+This will build a all of the required `calico/` images, tagged by git commit hash, appended with the docker registry 'my-registry', i.e. 
+```
+REPOSITORY                            TAG                                     IMAGE ID            CREATED             SIZE
+...
+my-registry/cni-plugin                         v3.11.0-0.dev-3-g9755771-dirty-amd64    422e9c706bcd        2 hours ago         163MB
+...
+```.
+
+
+- Now, build the YAML manifests that are used to install calico:
+
+```
+make dev-manifests
 ```
 
 The build uses the go package cache and local vendor caching to increase build speed. To perform a clean build, use the `dev-clean` target.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -8,7 +8,7 @@ This guide is broken into the following main sections:
 - [Deploying your code on Kubernetes](#deploying-your-code-on-kubernetes)
 - [Running automated tests](#running-automated-tests)
 
-## Requirements
+## Prerequisites:
 
 These build instructions assume you have a Linux build environment
 with:
@@ -19,32 +19,30 @@ with:
 
 ## Checking out the code
 
-Calico code is distributed across several different components, each of which lives in its own git repository. To build
-all of Calico, you will need to check out each repository into a common base directory (for example, `$GOPATH/src/github.com/projectcalico`).
+Calico code is distributed across several different components, each of which lives in its own git repository (inside of projectcalico on github). To build *all* of Calico, you will need to check out each repository into a common base directory (for example, `$GOPATH/src/github.com/projectcalico`).
 
 You will need the following repositories cloned on your development machine:
 
 ```
 BASEDIR
-└───calico
-└───libcalico-go
-└───confd
-└───felix
-└───typha
-└───kube-controllers
-└───calicoctl
-└───app-policy
-└───pod2daemon
-└───node
-└───cni-plugin
+└───calico (https://github.com/projectcalico/calico.git)
+└───libcalico-go (https://github.com/projectcalico/libcalico-go.git)
+└───confd git (https://github.com/projectcalico/confd.git)
+└───felix git (https://github.com/projectcalico/felix.git)
+└───typha git (https://github.com/projectcalico/typha.git)
+└───kube-controllers (https://github.com/projectcalico/kube-controllers.git)
+└───calicoctl (https://github.com/projectcalico/calicoctl.git)
+└───app-policy (https://github.com/projectcalico/app-policy.git)
+└───pod2daemon (https://github.com/projectcalico/pod2daemon.git)
+└───node git (https://github.com/projectcalico/node.git)
+└───cni-plugin (https://github.com/projectcalico/cni-plugin.git)
 ```
 
 ## Building the code
 
 ### Building everything
 
-Once the code is checked out, try building it to make sure your development environment is configured properly. Run the following command from
-within the `calico` repository to build all container images from your locally checked out code.
+Once the code is checked out, try building it to make sure your development environment is configured properly. Run the following command from within the `calico` repository to build all container images from your locally checked out code.
 
 ```
 make dev-image
@@ -127,3 +125,4 @@ the following command in the `calico` repo.
 ```
 make dev-test
 ```
+

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PACKAGE_NAME?=github.com/projectcalico/calico
 
 # Determine whether there's a local yaml installed or use dockerized version.
 # Note in order to install local (faster) yaml: "go get github.com/mikefarah/yq.v2"
-YAML_CMD:=$(shell which yq.v2 || echo docker run --rm -i calico/yaml)
+YAML_CMD:=$(shell which yq.v2 || echo sudo docker run --rm -i calico/yaml)
 
 # Local directories to ignore when running htmlproofer
 HP_IGNORE_LOCAL_DIRS="/v1.5/,/v1.6/,/v2.0/,/v2.1/,/v2.2/,/v2.3/,/v2.4/,/v2.5/,/v2.6/,/v3.0/"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PACKAGE_NAME?=github.com/projectcalico/calico
 
 # Determine whether there's a local yaml installed or use dockerized version.
 # Note in order to install local (faster) yaml: "go get github.com/mikefarah/yq.v2"
-YAML_CMD:=$(shell which yq.v2 || echo sudo docker run --rm -i calico/yaml)
+YAML_CMD:=$(shell which yq.v2 || echo docker run --rm -i calico/yaml)
 
 # Local directories to ignore when running htmlproofer
 HP_IGNORE_LOCAL_DIRS="/v1.5/,/v1.6/,/v2.0/,/v2.1/,/v2.2/,/v2.3/,/v2.4/,/v2.5/,/v2.6/,/v3.0/"

--- a/_plugins/lib.rb
+++ b/_plugins/lib.rb
@@ -9,10 +9,9 @@
 #
 # {"calico/node"=>"v3.6.0",
 #   "typha"=>"v3.6.0"}
-#
 def parse_versions(versions_yml, version)
   if not versions_yml.key?(version)
-    raise IndexError.new "requested version '#{version}' not present in versions.yml"
+    raise IndexError.new "requested version '#{version}' not present in provided versions.yml input: #{versions_yml}).  Cannot proceed !!!"
   end
 
   components = versions_yml[version][0]["components"].clone

--- a/hack/development-environment/README.md
+++ b/hack/development-environment/README.md
@@ -1,0 +1,34 @@
+# A canonical Development Environment for Calico
+
+This directory takes as input every calico source dependency (See DEVELOPER_GUIDE.md for details on those), and assumes they
+are one level above the calico repository.
+
+It then uses vagrant to 
+
+- create a linux vm
+- build all calico images from calico/ ecosystem projects
+- mounts these into /calico/all
+- runs the `make` targets for creating all docker images for calico
+- makes calico orchestration files (i.e. calico.yaml)
+- installs a quick kubeadm (single node) and sets relevant iptables/swap rules
+- installs the new images that were made from your current branch
+- smoke tests that all calico containers are running.
+
+# How to use this recipe
+
+- You can use the `vagrant up` command to test that the changes you made to any calico repository wont break CI,
+or reproduce a failure in CI.
+- You can use `vagrant up` followed by `vagrant ssh` to get into a kube cluster running the exact source of your
+calico build.
+- You can use the install.sh script as a quick start for your own dev worklow or automation tooling if you are using
+your own calico builds in house. 
+
+# What this recipe is not
+
+- This is not a CI system for upstream calico, for that, see the contributor and developer docs.
+- This is not a full test suite: It doesnt run any kind of unit or performance tests.  Patches
+are welcome to extendt the install.sh with other optional test/make targets, but ideally, the smoke
+test for building calico from scratch should be able to run in under 10 minutes, so that it is 
+developer friendly.
+- 
+

--- a/hack/development-environment/Vagrantfile
+++ b/hack/development-environment/Vagrantfile
@@ -1,0 +1,29 @@
+
+Vagrant.configure("2") do |config|
+  config.vm.box_check_update = false
+  config.vm.provider 'virtualbox' do |vb|
+   vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
+  end  
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.synced_folder "../../../", "/calico_all", type: "rsync"
+  $num_instances = 1
+  (1..$num_instances).each do |i|
+    config.vm.define "node#{i}" do |node|
+      node.vm.box = "centos/7"
+      node.vm.hostname = "node#{i}"
+      ip = "172.17.8.#{i+100}"
+      node.vm.network "private_network", ip: ip
+      node.vm.provider "virtualbox" do |vb|
+        vb.memory = "16000"
+        vb.cpus = 3
+        vb.name = "node#{i}"
+      end
+      if (node.vm.hostname == "node1")
+        node.vm.provision "shell", path: "install.sh", args: [i, ip, "master"]
+      else
+	# Note that be default, with 1 instance, you only have a master.
+        node.vm.provision "shell", path: "install.sh", args: [i, ip, "worker"]
+      end
+    end
+  end
+end

--- a/hack/development-environment/Vagrantfile
+++ b/hack/development-environment/Vagrantfile
@@ -14,8 +14,8 @@ Vagrant.configure("2") do |config|
       ip = "172.17.8.#{i+100}"
       node.vm.network "private_network", ip: ip
       node.vm.provider "virtualbox" do |vb|
-        vb.memory = "16000"
-        vb.cpus = 3
+        vb.memory = "8192"
+        vb.cpus = 2
         vb.name = "node#{i}"
       end
       if (node.vm.hostname == "node1")

--- a/hack/development-environment/install.sh
+++ b/hack/development-environment/install.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+echo "This recipe setsup a k8s cluster w/ calico"
+
+MASTER_OR_WORKER="$3"
+
+# Setup a k8s baseline
+function setup() {
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
+    sudo yum install -y git wget 
+    sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    sudo yum install -y docker-ce docker-ce-cli containerd.io
+    sudo systemctl enable docker
+}
+
+# build all images for deploying from src
+function build {
+	cd /calico_all/calico ;
+	sudo setenforce 0
+	sudo systemctl restart docker
+	make dev-image REGISTRY=cd LOCAL_BUILD=true
+    make dev-manifests REGISTRY=cd
+}
+
+# A smoke test for docker image build
+function smoketest {
+	RESULT="pass"
+	for c in "node" "pod2daemon" "calicoctl" "kube" "typha" ;
+		 do 
+			if docker images | grep cd | grep $c -q ; then echo "calico image build success for $c" ; else echo "calico image build failed for $c" && RESULT="fail" ; fi  ; 
+		done
+	
+	if [[ "$RESULT" == "fail" ]];  then 
+		exit 1
+	fi
+}
+
+#####################################################################################
+############# This is work in progress, will add more over time ##################### 
+#####################################################################################
+function k8s_install() {
+    swapoff -a
+    echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
+    # Set SELinux in permissive mode (effectively disabling it)
+    setenforce 0
+    source /vagrant/kubeadmrepo.sh
+    sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+    yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
+    systemctl enable --now docker
+    systemctl enable --now kubelet
+
+    if [[ "$MASTER_OR_WORKER" == "master" ]]; then
+        # install calico
+        sudo kubeadm init --pod-network-cidr=192.168.0.0/16 --ignore-preflight-errors=NumCPU
+        systemctl daemon-reload
+        systemctl restart kubelet
+    else
+	echo "$MASTER_OR_WORKER <- node type"
+    fi
+    mkdir -p ~/.kube/
+    cp /etc/kubernetes/admin.conf ~/.kube/config
+    chmod 755 ~/.kube/config
+}
+
+function calico_install {
+    pushd /calico_all/calico/_output/dev-manifests
+        kubectl apply -f ./calico.yaml 
+        kubectl get pods -n kube-system
+    popd
+}
+
+CALICO_SUCCESS="false"
+function calico_test {
+    for i in {0..10}; do
+        numpods=`kubectl get pods -n kube-system | grep calico | grep Running | wc -l`
+        set x
+        if [[ $numpods -eq 2 ]]; then 
+                CALICO_SUCCESS="passed"
+                return
+        else
+                CALICO_SUCCESS="*** Error: Number of running pods != 2...  $numpods \n`kubectl get pods -n kube-system | grep calico` \n ***"
+        fi
+        sleep 5
+    done
+}
+
+echo "############## Building Calico from source ############################"
+setup
+build
+smoketest
+
+echo "############## Images built.  Now deploying kubernetes ################"
+k8s_install
+calico_install
+calico_test
+
+kubectl get pods --all-namespaces
+echo "Your dev VM is up, vagrant ssh to access it.   TEST RESULT: $CALICO_SUCCESS."
+if [[ $CALICO_SUCCESS == "passed" ]] ; then
+    exit 0
+else
+    echo "FAILED: Calico installation failed...  Error : $CALICO_SUCCESS"
+    exit 1
+fi

--- a/hack/development-environment/kubeadmrepo.sh
+++ b/hack/development-environment/kubeadmrepo.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
+


### PR DESCRIPTION
## Description

The following is the developement recipe that solves #2929 , focusing the canonical Mac/Windows friendly build-from-source environment based on vagrant.  The final output after running `vagrant up` looks like this:

```
    node1: Successfully tagged cd/node:latest-amd64
    node1: touch .calico_node.created-amd64
    node1: docker tag cd/node:latest-amd64 cd/node:v3.11.0-0.dev-19-g151c81a-dirty-amd64
    node1: make[1]: Leaving directory `/calico_all/node'
    node1: calico build passed node
    node1: calico build passed pod2daemon
    node1: calico build passed calicoctl
    node1: calico build passed kube
    node1: calico build passed typha
```



## Related issues/PRs

 #2929
is complimented by https://github.com/projectcalico/app-policy/pull/116 , but this can still work
without that 116 merge, since it spins up a 'mostly' working dev environment either way, and then the install.sh can be run manually, but would like to merge it alongside 116 since they are synergistic.

## Release Note

```release-note
Automated developer tooling for testing all calico repos on K8s from source.
```
