### PR TITLE
Typo configuration to configuration.md

### DIFF
--- a/master/reference/felix/prometheus.md
+++ b/master/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric reference
 

--- a/v2.1/reference/felix/prometheus.md
+++ b/v2.1/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v2.2/reference/felix/prometheus.md
+++ b/v2.2/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v2.3/reference/felix/prometheus.md
+++ b/v2.3/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v2.4/reference/felix/prometheus.md
+++ b/v2.4/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v2.5/reference/felix/prometheus.md
+++ b/v2.5/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v2.6/reference/felix/prometheus.md
+++ b/v2.6/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v3.0/reference/felix/prometheus.md
+++ b/v3.0/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v3.1/reference/felix/prometheus.md
+++ b/v3.1/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v3.10/reference/felix/prometheus.md
+++ b/v3.10/reference/felix/prometheus.md
@@ -5,7 +5,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric reference
 

--- a/v3.2/reference/felix/prometheus.md
+++ b/v3.2/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v3.3/reference/felix/prometheus.md
+++ b/v3.3/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v3.4/reference/felix/prometheus.md
+++ b/v3.4/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v3.5/reference/felix/prometheus.md
+++ b/v3.5/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric Reference
 

--- a/v3.6/reference/felix/prometheus.md
+++ b/v3.6/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric reference
 

--- a/v3.7/reference/felix/prometheus.md
+++ b/v3.7/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric reference
 

--- a/v3.8/reference/felix/prometheus.md
+++ b/v3.8/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric reference
 

--- a/v3.9/reference/felix/prometheus.md
+++ b/v3.9/reference/felix/prometheus.md
@@ -4,7 +4,7 @@ canonical_url: 'https://docs.projectcalico.org/v3.9/reference/felix/prometheus'
 ---
 
 Felix can be configured to report a number of metrics through Prometheus.  See the
-[configuration reference](configuration) for how to enable metrics reporting.
+[configuration reference](configuration.md) for how to enable metrics reporting.
 
 ## Metric reference
 


### PR DESCRIPTION
## Description

The link destination of the document is 404.
This returns 404 because there is no extension for the link destination.
> ex) https://github.com/projectcalico/calico/blob/master/v3.10/reference/felix/configuration

If you add `.md` here, the link will succeed.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] ~~Release note~~

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
