### PR TITLE
Bring more attention to kubectl vs calicoctl in calico-network-policy

### DIFF
--- a/master/security/calico-network-policy.md
+++ b/master/security/calico-network-policy.md
@@ -68,7 +68,9 @@ metadata:
   name: allow-tcp-port-6379
 ```
 
-**Calico network policies and Calico global network policies** are applied using calicoctl. Syntax is similar to Kubernetes, but there a few differences. For help, see [calicoctl user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/).
+#### kubectl vs calicoctl
+
+Calico network policies and Calico global network policies are applied using calicoctl. Syntax is similar to Kubernetes, but there a few differences. For help, see [calicoctl user reference]({{site.baseurl}}/{{page.version}}/reference/calicoctl/).
 
 #### Ingress and egress
 


### PR DESCRIPTION
As discussed in https://github.com/projectcalico/calico/issues/2784, it would be nice to bring more attention to when calicoctl must be used instead of kubectl.