### PR TITLE
Note that 'ports' has a dependency on 'protocol'

### DIFF
--- a/_includes/v3.10/entityrule.md
+++ b/_includes/v3.10/entityrule.md
@@ -5,7 +5,7 @@
 | selector    | Positive match on selected endpoints. If a `namespaceSelector` is also defined, the set of endpoints this applies to is limited to the endpoints in the selected namespaces. | Valid selector | [selector](#selector) | |
 | notSelector | Negative match on selected endpoints. If a `namespaceSelector` is also defined, the set of endpoints this applies to is limited to the endpoints in the selected namespaces. | Valid selector | [selector](#selector) | |
 | namespaceSelector | Positive match on selected namespaces. If specified, only workload endpoints in the selected Kubernetes namespaces are matched. Matches namespaces based on the labels that have been applied to the namespaces. Defines the context that selectors will apply to, if not defined then selectors apply to the NetworkPolicy's namespace. | Valid selector | [selector](#selector) | |
-| ports | Positive match on the specified ports | | list of [ports](#ports) | |
+| ports | Positive match on the specified ports. If you specify `ports` you must also specify a `protocol` at the Rule level. | | list of [ports](#ports) | |
 | notPorts | Negative match on the specified ports | | list of [ports](#ports) | |
 | serviceAccounts | Match endpoints running under service accounts. If a `namespaceSelector` is also defined, the set of service accounts this applies to is limited to the service accounts in the selected namespaces. | | [ServiceAccountMatch](#serviceaccountmatch) | |
 


### PR DESCRIPTION
If you specify `ports` in an Entity Rule, the match will fail unless you also specify a particular protocol at the `Rule`. This is picked up by `calicoctl` validation but appears to be an undocumented dependency.