### PR TITLE
bug fix pod-cidr-sed.md to make kubernetes/installation/calico.md have a right network config

### DIFF
--- a/_includes/v3.10/pod-cidr-sed.md
+++ b/_includes/v3.10/pod-cidr-sed.md
@@ -1,9 +1,9 @@
-1. If you are using pod CIDR {% if include.yaml == "calico" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %}, skip to the next step. If you
+1. If you are using pod CIDR {% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %}, skip to the next step. If you
    are using a different pod CIDR, use the following commands to set an environment
    variable called `POD_CIDR` containing your pod CIDR and
-   replace {% if include.yaml == "calico" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %} in the manifest with your pod CIDR.
+   replace {% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %} in the manifest with your pod CIDR.
 
    ```bash
    POD_CIDR="<your-pod-cidr>" \
-   sed -i -e "s?{% if include.yaml == "calico" %}192.168.0.0/16{% else %}10.244.0.0/16{% endif %}?$POD_CIDR?g" {{include.yaml}}.yaml
+   sed -i -e "s?{% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}192.168.0.0/16{% else %}10.244.0.0/16{% endif %}?$POD_CIDR?g" {{include.yaml}}.yaml
    ```

--- a/_includes/v3.8/pod-cidr-sed.md
+++ b/_includes/v3.8/pod-cidr-sed.md
@@ -1,9 +1,9 @@
-1. If you are using pod CIDR {% if include.yaml == "calico" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %}, skip to the next step. If you
+1. If you are using pod CIDR {% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %}, skip to the next step. If you
    are using a different pod CIDR, use the following commands to set an environment
    variable called `POD_CIDR` containing your pod CIDR and
-   replace {% if include.yaml == "calico" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %} in the manifest with your pod CIDR.
+   replace {% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %} in the manifest with your pod CIDR.
 
    ```bash
    POD_CIDR="<your-pod-cidr>" \
-   sed -i -e "s?{% if include.yaml == "calico" %}192.168.0.0/16{% else %}10.244.0.0/16{% endif %}?$POD_CIDR?g" {{include.yaml}}.yaml
+   sed -i -e "s?{% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}192.168.0.0/16{% else %}10.244.0.0/16{% endif %}?$POD_CIDR?g" {{include.yaml}}.yaml
    ```

--- a/_includes/v3.9/pod-cidr-sed.md
+++ b/_includes/v3.9/pod-cidr-sed.md
@@ -1,9 +1,9 @@
-1. If you are using pod CIDR {% if include.yaml == "calico" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %}, skip to the next step. If you
+1. If you are using pod CIDR {% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %}, skip to the next step. If you
    are using a different pod CIDR, use the following commands to set an environment
    variable called `POD_CIDR` containing your pod CIDR and
-   replace {% if include.yaml == "calico" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %} in the manifest with your pod CIDR.
+   replace {% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}`192.168.0.0/16`{% else %}`10.244.0.0/16`{% endif %} in the manifest with your pod CIDR.
 
    ```bash
    POD_CIDR="<your-pod-cidr>" \
-   sed -i -e "s?{% if include.yaml == "calico" %}192.168.0.0/16{% else %}10.244.0.0/16{% endif %}?$POD_CIDR?g" {{include.yaml}}.yaml
+   sed -i -e "s?{% if include.yaml == "calico" or include.yaml == "calico-typha" or include.yaml == "calico-etcd" %}192.168.0.0/16{% else %}10.244.0.0/16{% endif %}?$POD_CIDR?g" {{include.yaml}}.yaml
    ```


### PR DESCRIPTION
fix pod-cidr-sed.md to make kubernetes/installation/calico.md have a right network config

## Description
https://docs.projectcalico.org/v3.10/getting-started/kubernetes/installation/calico#installing-with-the-etcd-datastore
https://docs.projectcalico.org/v3.10/getting-started/kubernetes/installation/calico#installing-with-the-kubernetes-api-datastoremore-than-50-nodes
are all not right with network config subcidr(10.244.0.0/16), because in https://github.com/projectcalico/calico/blob/master/v3.10/getting-started/kubernetes/installation/calico.md#installing-with-the-kubernetes-api-datastoremore-than-50-nodes, the include.yaml is "calico-typha", and "calico-etcd", not "calico"
