### PR TITLE
Kind local-up-cluster from source implementation, for linux native de…

### DIFF
--- a/hack/development-environment/.gitignore
+++ b/hack/development-environment/.gitignore
@@ -1,0 +1,2 @@
+calico-conf.yaml
+kind

--- a/hack/development-environment/README.md
+++ b/hack/development-environment/README.md
@@ -16,13 +16,20 @@ It then uses vagrant to
 
 ## How to use the Kind Recipe (Recommended)
 
+Options:
+
+	- BUILD_CALICO: if "false", wont compile all the source before deploying.
+	- ROOT_CALICO_REPOS_DIR: the place where all your source is stored.
+
 Example:
 
 ```
-	ROOT_CALICO_REPOS_DIR=/home/jayunit100/calico_all ./kind-local-up.sh
+	ROOT_CALICO_REPOS_DIR=~/calico_all/ BUILD_CALICO=true ./kind-local-up.sh
 	echo "play with your cluster for a while"
-	kind delete cluster
+	kind delete cluster calico-test
 ```
+
+
 
 The kind recipe uses kubernetes' kind to run locally build images and starts a kind cluster, you can run
 it easily, and it will *build* all of calico for you as well, by just running "ROOT_CALICO_REPOS_DIR=/calico_all kind-local-up.sh" .  Of course, that assumes you've cloned all of the calico repositories into /calico_all.  IF they are somewhere else, thats also fine.  Make sure you can run *docker* as the user who starts this script, and that you've installed *kind* as well as *kubectl*.  IF you don't have any of these tools, the Vagrant recipe might be easier for you to adopt, as it

--- a/hack/development-environment/README.md
+++ b/hack/development-environment/README.md
@@ -1,4 +1,4 @@
-# A canonical Development Environment for Calico
+# A canonical Development Environment for Calico.
 
 This directory takes as input every calico source dependency (See DEVELOPER_GUIDE.md for details on those), and assumes they
 are one level above the calico repository.
@@ -14,7 +14,29 @@ It then uses vagrant to
 - installs the new images that were made from your current branch
 - smoke tests that all calico containers are running.
 
-# How to use this recipe
+## How to use the Kind Recipe (Recommended)
+
+Example:
+
+```
+	ROOT_CALICO_REPOS_DIR=/home/jayunit100/calico_all ./kind-local-up.sh
+	echo "play with your cluster for a while"
+	kind delete cluster
+```
+
+The kind recipe uses kubernetes' kind to run locally build images and starts a kind cluster, you can run
+it easily, and it will *build* all of calico for you as well, by just running "ROOT_CALICO_REPOS_DIR=/calico_all kind-local-up.sh" .  Of course, that assumes you've cloned all of the calico repositories into /calico_all.  IF they are somewhere else, thats also fine.  Make sure you can run *docker* as the user who starts this script, and that you've installed *kind* as well as *kubectl*.  IF you don't have any of these tools, the Vagrant recipe might be easier for you to adopt, as it
+will bootstrap your entire machine for you.
+
+## How to use this recipe: Centos
+
+Example:
+
+```
+	vagrant up
+	echo "play with your cluster for a while..."
+	vagrant destroy --force
+```
 
 - You can use the `vagrant up` command to test that the changes you made to any calico repository wont break CI,
 or reproduce a failure in CI.

--- a/hack/development-environment/kind-local-up.sh
+++ b/hack/development-environment/kind-local-up.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+cat << EOF > calico-conf.yaml
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  disableDefaultCNI: true # disable kindnet
+  podSubnet: 192.168.0.0/16 # set to Calico's default subnet
+EOF
+
+# Where all your source lives...
+ROOT_CALICO_REPOS_DIR="${ROOT_CALICO_REPOS_DIR:-/home/$USER/calico_all}"
+
+if [[ -v ROOT_CALICO_REPOS_DIR ]] ;  then
+    echo "foudn input var for ROOT_CALICO_REPOS_DIR =  $ROOT_CALICO_REPOS_DIR"
+else
+    ROOT_CALICO_REPOS_DIR ?="~/calico_all/"
+fi
+echo "calico source ---> $ROOT_CALICO_REPOS_DIR"
+
+echo "$ROOT_CALICO_REPOS_DIR is the input dir for calico sources"
+if [[ ! -d $ROOT_CALICO_REPOS_DIR/node ]]; then
+    ls -altrh $ROOT_CALICO_REPOS_DIR
+    echo "clone down all the calico repos before starting/"
+    exit 1
+fi
+
+function build() {
+    pushd $ROOT_CALICO_REPOS_DIR/calico/
+	echo "MAKE DEV_IMAGE ***********************************************"
+	make dev-image REGISTRY=cd LOCAL_BUILD=true TAG_COMMAND='echo latest'
+	echo "MAKE DEV_MANIFESTS *******************************************"
+        make dev-manifests REGISTRY=cd TAG_COMMAND='echo latest'
+    popd
+}
+
+function load_images() {
+	# Now, we need to copy local docker images into the container
+	# daemon running inside kind.
+	echo "Copying images into kind cluster !!!"
+	for i in cni-plugin node pod2daemon kube-controllers; do 
+		echo "...$i"
+		kind load docker-image cd/$i-amd64
+	done
+
+}
+function install_k8s() {
+    kind create cluster --config calico-conf.yaml
+    export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+    chmod 755 ~/.kube/kind-config-kind
+    until kubectl cluster-info;  do
+        echo "`date`waiting for cluster..."
+        sleep 2
+    done
+}
+
+function install_calico() {
+    kubectl get pods
+        pushd $ROOT_CALICO_REPOS_DIR/calico/_output/dev-manifests
+            kubectl apply -f ./calico.yaml 
+            kubectl get pods -n kube-system
+        popd
+    sleep 5 ; kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
+    sleep 5 ; kubectl -n kube-system get pods | grep calico-node
+    echo "will wait for calico to start running now... "
+    while true ; do
+        kubectl -n kube-system get pods
+        sleep 3
+    done
+}
+
+build
+install_k8s
+load_images
+install_calico

--- a/hack/development-environment/kind-local-up.sh
+++ b/hack/development-environment/kind-local-up.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 # Thanks to https://alexbrand.dev/post/creating-a-kind-cluster-with-calico-networking/ for this snippet :)
 cat << EOF > calico-conf.yaml
 kind: Cluster
@@ -11,20 +12,14 @@ EOF
 
 # Where all your source lives...
 ROOT_CALICO_REPOS_DIR="${ROOT_CALICO_REPOS_DIR:-/home/$USER/calico_all}"
-
-if [[ -v ROOT_CALICO_REPOS_DIR ]] ;  then
-    echo "foudn input var for ROOT_CALICO_REPOS_DIR =  $ROOT_CALICO_REPOS_DIR"
-else
-    ROOT_CALICO_REPOS_DIR ?="~/calico_all/"
-fi
-echo "calico source ---> $ROOT_CALICO_REPOS_DIR"
-
-echo "$ROOT_CALICO_REPOS_DIR is the input dir for calico sources"
-if [[ ! -d $ROOT_CALICO_REPOS_DIR/node ]]; then
-    ls -altrh $ROOT_CALICO_REPOS_DIR
-    echo "clone down all the calico repos before starting/"
-    exit 1
-fi
+function check() {
+	if [[ ! -v ROOT_CALICO_REPOS_DIR ]] ;  then
+		echo "Need to specify ROOT_CALICO_REPOS_DIR = "
+	fi
+	if [[ ! -v BUILD_CALICO ]] ; then 
+		BUILD_CALICO="true"
+	fi
+}
 
 function build() {
     pushd $ROOT_CALICO_REPOS_DIR/calico/
@@ -39,16 +34,15 @@ function load_images() {
 	# Now, we need to copy local docker images into the container
 	# daemon running inside kind.
 	echo "Copying images into kind cluster !!!"
-	for i in cni-plugin node pod2daemon kube-controllers; do 
+	for i in "cni-plugin" "node" "pod2daemon" "kube-controllers"; do 
 		echo "...$i"
-		kind load docker-image cd/$i-amd64
+		kind load docker-image cd/$i:latest-amd64 --name calico-test
 	done
-
 }
 function install_k8s() {
-    kind create cluster --config calico-conf.yaml
-    export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-    chmod 755 ~/.kube/kind-config-kind
+    kind delete cluster --name calico-test
+    kind create cluster --name calico-test --config calico-conf.yaml
+    export KUBECONFIG="$(kind get kubeconfig-path --name=calico-test)"
     until kubectl cluster-info;  do
         echo "`date`waiting for cluster..."
         sleep 2
@@ -57,10 +51,10 @@ function install_k8s() {
 
 function install_calico() {
     kubectl get pods
-        pushd $ROOT_CALICO_REPOS_DIR/calico/_output/dev-manifests
-            kubectl apply -f ./calico.yaml 
-            kubectl get pods -n kube-system
-        popd
+    pushd ${ROOT_CALICO_REPOS_DIR}/calico/_output/dev-manifests
+    	kubectl apply -f ./calico.yaml 
+    	kubectl get pods -n kube-system
+    popd
     sleep 5 ; kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
     sleep 5 ; kubectl -n kube-system get pods | grep calico-node
     echo "will wait for calico to start running now... "
@@ -70,7 +64,14 @@ function install_calico() {
     done
 }
 
-build
+check
+if [[ ! "${BUILD_CALICO}" == "false" ]] ; then
+	build
+fi
+if [[ ! -d ${ROOT_CALICO_REPOS_DIR}/calico/_output ]] ; then
+	echo "No build output directory ! Provide a build of calico before we finish installation"
+	exit 1
+fi
 install_k8s
 load_images
 install_calico

--- a/hack/development-environment/kind-local-up.sh
+++ b/hack/development-environment/kind-local-up.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Thanks to https://alexbrand.dev/post/creating-a-kind-cluster-with-calico-networking/ for this snippet :)
 cat << EOF > calico-conf.yaml
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3


### PR DESCRIPTION
This adds a `Kind` developement environment to calico.  This is meant for people who are doing more advanced calico work and already have a linux machine w/ kubernetes set up. 

The existing Vagrant recipe can be used to bootstrap a development environment if someone doesn't already have one.  WE can phase the existing Vagrant one out eventually if nobody needs it, or refactor it to *only* bootstrap the VM, and then use kind for all other testing.