### PR TITLE
Fix clean to remove pinned_versions.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ _site build: bin/helm
 
 ## Clean enough that a new release build will be clean
 clean:
-	rm -rf _output _site .jekyll-metadata
+	rm -rf _output _site .jekyll-metadata pinned_versions.yaml
 
 ########################################################################################################################
 # Builds locally checked out code using local versions of libcalico, felix, and confd.


### PR DESCRIPTION
similar to other Makefile fixes issued for other repos, working on making the build clean more idempotent.