### PR TITLE
Adding -bird-live option to the liveness check

### DIFF
--- a/_includes/master/charts/calico/templates/calico-node.yaml
+++ b/_includes/master/charts/calico/templates/calico-node.yaml
@@ -295,6 +295,7 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+              - -bird-live
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6


### PR DESCRIPTION
## Description
Adding a check for bird and confd as part of the liveness check

## Related issues/PRs
fixes projectcalico/calico#2889
https://github.com/projectcalico/node/pull/369


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
```
Adding -bird-live/-bird6-live option to check for bird, bird6 and conf as part of the liveness probe.
```
