### PR TITLE
[Patch] Update 3.8, 3.9 and 3.10 liveness probe

### DIFF
--- a/_includes/v3.10/charts/calico/templates/calico-node.yaml
+++ b/_includes/v3.10/charts/calico/templates/calico-node.yaml
@@ -289,6 +289,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+{{- if and (eq .Values.network "calico") (not .Values.flannel_migration) }}
+              - -bird-live
+{{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6

--- a/_includes/v3.8/charts/calico/templates/calico-node.yaml
+++ b/_includes/v3.8/charts/calico/templates/calico-node.yaml
@@ -286,6 +286,23 @@ spec:
           resources:
             requests:
               cpu: 250m
+{{- if eq .Values.network "calico" }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/calico-node
+                - -felix-live
+                - -bird-live
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
+{{- else if eq .Values.network "flannel" }}
           livenessProbe:
             httpGet:
               path: /liveness
@@ -295,18 +312,20 @@ spec:
             initialDelaySeconds: 10
             failureThreshold: 6
           readinessProbe:
-{{- if eq .Values.network "calico" }}
-            exec:
-              command:
-              - /bin/calico-node
-              - -bird-ready
-              - -felix-ready
-{{- else if eq .Values.network "flannel" }}
             httpGet:
               path: /readiness
               port: 9099
               host: localhost
 {{- else }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/calico-node
+                - -felix-live
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
             exec:
               command:
               - /bin/calico-node

--- a/_includes/v3.9/charts/calico/templates/calico-node.yaml
+++ b/_includes/v3.9/charts/calico/templates/calico-node.yaml
@@ -289,6 +289,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+{{- if and (eq .Values.network "calico") (not .Values.flannel_migration) }}
+              - -bird-live
+{{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6

--- a/v3.10/getting-started/kubernetes/installation/config-options.md
+++ b/v3.10/getting-started/kubernetes/installation/config-options.md
@@ -70,10 +70,16 @@ be undone):
 - Optionally, (to save some resources if you're running a VXLAN-only cluster) completely disable Calico's BGP-based
   networking:
   - Replace `calico_backend: "bird"` with `calico_backend: "vxlan"`.  This disables BIRD.
-  - Comment out the line `- -bird-ready` from the calico/node readiness check (otherwise disabling BIRD will cause the
-    readiness check to fail on every node):
+  - Comment out the line `- -bird-ready`/`- -bird-live` from the calico/node readiness/liveness check (otherwise disabling BIRD will cause the
+    readiness/liveness check to fail on every node):
 
 ```yaml
+          livenessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              # - -bird-live
+              - -felix-live
           readinessProbe:
             exec:
               command:

--- a/v3.8/getting-started/kubernetes/installation/config-options.md
+++ b/v3.8/getting-started/kubernetes/installation/config-options.md
@@ -69,10 +69,16 @@ be undone):
 - Optionally, (to save some resources if you're running a VXLAN-only cluster) completely disable Calico's BGP-based
   networking:
   - Replace `calico_backend: "bird"` with `calico_backend: "vxlan"`.  This disables BIRD.
-  - Comment out the line `- -bird-ready` from the calico/node readiness check (otherwise disabling BIRD will cause the
-    readiness check to fail on every node):
+  - Comment out the line `- -bird-ready`/`- -bird-live` from the calico/node readiness/liveness check (otherwise disabling BIRD will cause the
+    readiness/liveness check to fail on every node):
 
 ```yaml
+          livenessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              # - -bird-live
+              - -felix-live
           readinessProbe:
             exec:
               command:

--- a/v3.9/getting-started/kubernetes/installation/config-options.md
+++ b/v3.9/getting-started/kubernetes/installation/config-options.md
@@ -69,10 +69,16 @@ be undone):
 - Optionally, (to save some resources if you're running a VXLAN-only cluster) completely disable Calico's BGP-based
   networking:
   - Replace `calico_backend: "bird"` with `calico_backend: "vxlan"`.  This disables BIRD.
-  - Comment out the line `- -bird-ready` from the calico/node readiness check (otherwise disabling BIRD will cause the
-    readiness check to fail on every node):
+  - Comment out the line `- -bird-ready`/`- -bird-live` from the calico/node readiness/liveness check (otherwise disabling BIRD will cause the
+    readiness/liveness check to fail on every node):
 
 ```yaml
+          livenessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              # - -bird-live
+              - -felix-live
           readinessProbe:
             exec:
               command:


### PR DESCRIPTION
## Description

Adding a check for bird and confd as part of the liveness check.

## Related issues/PRs

fixes #2889
projectcalico/node#369

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```
Adding -bird-live/-bird6-live option to check for bird, bird6 and conf as part of the liveness prob
```
