### PR TITLE
Update liveness checks to be used only network is calico 

### DIFF
--- a/_includes/master/charts/calico/templates/calico-node.yaml
+++ b/_includes/master/charts/calico/templates/calico-node.yaml
@@ -295,7 +295,9 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
+{{- if and (eq .Values.network "calico") (not .Values.flannel_migration) }}
               - -bird-live
+{{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6

--- a/master/getting-started/kubernetes/installation/config-options.md
+++ b/master/getting-started/kubernetes/installation/config-options.md
@@ -69,10 +69,16 @@ be undone):
 - Optionally, (to save some resources if you're running a VXLAN-only cluster) completely disable Calico's BGP-based
   networking:
   - Replace `calico_backend: "bird"` with `calico_backend: "vxlan"`.  This disables BIRD.
-  - Comment out the line `- -bird-ready` from the calico/node readiness check (otherwise disabling BIRD will cause the
-    readiness check to fail on every node):
+  - Comment out the line `- -bird-ready` and `- -bird-live` from the calico/node readiness/liveness check (otherwise disabling BIRD will cause the
+    readiness/liveness check to fail on every node):
 
 ```yaml
+          livenessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-live
+             # - -bird-live
           readinessProbe:
             exec:
               command:


### PR DESCRIPTION
## Description

Update liveness checks to `-bird-live` or `-bird6-live` only when the network is calico.

 
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
