### PR TITLE
YAO Bank manifest updates for k8s 1.16

### DIFF
--- a/master/security/tutorials/app-layer-policy/manifests/10-yaobank.yaml
+++ b/master/security/tutorials/app-layer-policy/manifests/10-yaobank.yaml
@@ -32,12 +32,15 @@ metadata:
   labels:
     app: yaobank
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: database
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: database
   template:
     metadata:
       labels:
@@ -79,12 +82,15 @@ metadata:
     app: yaobank
     database: reader
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: summary
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: summary
   template:
     metadata:
       labels:
@@ -120,12 +126,15 @@ metadata:
     app: yaobank
     summary: reader
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: customer
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: customer
   template:
     metadata:
       labels:

--- a/master/security/tutorials/app-layer-policy/manifests/20-attack-pod.yaml
+++ b/master/security/tutorials/app-layer-policy/manifests/20-attack-pod.yaml
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: attack
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: attack
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Update YAO Bank manifests to use the apps/v1 api, since the extensions/v1beta1 api is deprecated and not enabled by default in K8s 1.16.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
