### PR TITLE
Update document link to latest version 3.10

### DIFF
--- a/v3.10/introduction/index.md
+++ b/v3.10/introduction/index.md
@@ -2,7 +2,7 @@
 title: About Calico
 redirect_from: latest/introduction/index
 show_title: false
-canonical_url: 'https://docs.projectcalico.org/v3.9/introduction/index'
+canonical_url: 'https://docs.projectcalico.org/v3.10/introduction/index'
 custom_css: css/intro.css
 ---
 


### PR DESCRIPTION
## Description

Currently the Calico home page links to the 3.9 version of the documentation. This patch updates the documentation link for the 3.10 release to point to the correct page. 

## Related issues/PRs
None

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
None required
```
