### PR TITLE
Fix mismatch between doc and left nav

### DIFF
--- a/_data/master/navbars/networking.yml
+++ b/_data/master/navbars/networking.yml
@@ -8,7 +8,7 @@ toc:
   path: /networking/determine-best-networking
 - title: Configure networking
   section:
-  - title: Configure BGP peers
+  - title: Configure BGP peering
     path: /networking/bgp 
   - title: Connect workloads across networks that you do not control
     path: /networking/vxlan-ipip 


### PR DESCRIPTION
"Configure BGP peers" left nav, does not align with new doc, "Configure BGP peering"

- Can merge at any time
- Only for 3.11 (nightly) +