### PR TITLE
Fix indentation for CRD name

### DIFF
--- a/_includes/master/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/master/charts/calico/templates/kdd-crds.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org


### PR DESCRIPTION
## Description

For the `felixconfigurations.crd.projectcalico.org` CRD, indentation of `metadata.name` is 3 spaces instead of 2.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
