### PR TITLE
Render mtu options for Canal/flannel

### DIFF
--- a/_includes/master/charts/calico/templates/calico-config.yaml
+++ b/_includes/master/charts/calico/templates/calico-config.yaml
@@ -49,6 +49,9 @@ data:
   # Whether or not to masquerade traffic to destinations not within
   # the pod network.
   masquerade: "true"
+
+  # Configure the MTU to use
+  veth_mtu: "1450"
 {{- end }}
 
   # The CNI network configuration to install on each node.  The special
@@ -104,7 +107,7 @@ data:
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
   {{- end }}
-  {{- if eq .Values.network "calico" }}
+  {{- if or (eq .Values.network "calico") (eq .Values.network "flannel") }}
           "mtu": __CNI_MTU__,
   {{- else if eq .Values.network "none" }}
           "mtu": 1500,

--- a/_includes/master/charts/calico/templates/calico-node.yaml
+++ b/_includes/master/charts/calico/templates/calico-node.yaml
@@ -123,7 +123,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
 {{- end }}
-{{- if eq .Values.network "calico" }}
+{{- if or (eq .Values.network "calico") (eq .Values.network "flannel") }}
             # CNI MTU Config variable
             - name: CNI_MTU
               valueFrom:


### PR DESCRIPTION
## Description

Currently the yaml for Flannel/Canal does not include the option to set the mtu.  This PR adds those options to the rendered content.  There is one more section for Calico that deals with mtu for IPinIP [here](https://github.com/projectcalico/calico/blob/master/_includes/master/charts/calico/templates/calico-node.yaml#L239-L244) but I left that out as I'm not sure if that applies to flannel.

I think 1450 is a sane default for the flannel mtu but this changes the default behavior of Canal.  In my environment when I run the default yaml, the flannel interface has an mtu of 9000 but the pod network devices are set to an mtu of 1500.  With these changes the network devices are set to an mtu of 1450.  I'd be interested to see what the pod network device mtu would be before this PR when the has an network mtu of 1500 and the flannel interface has an mtu of 1450.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

Fixes #2588 
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
