### PR TITLE
Fix indentation for CRD name in patch releases (#3059)

### DIFF
--- a/_includes/v3.10/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/v3.10/charts/calico/templates/kdd-crds.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/_includes/v3.8/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/v3.8/charts/calico/templates/kdd-crds.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org

--- a/_includes/v3.9/charts/calico/templates/kdd-crds.yaml
+++ b/_includes/v3.9/charts/calico/templates/kdd-crds.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-   name: felixconfigurations.crd.projectcalico.org
+  name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org


### PR DESCRIPTION
## Description

For the felixconfigurations.crd.projectcalico.org CRD, indentation of metadata.name is 3 spaces instead of 2.

Adding the fix to 3.8, 3.9 and 3.10.

## Related issues/PRs

https://github.com/projectcalico/calico/pull/3059

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
