### PR TITLE
Update beta.kubernetes.io/os label

### DIFF
--- a/_includes/master/charts/calico/templates/calico-kube-controllers.yaml
+++ b/_includes/master/charts/calico/templates/calico-kube-controllers.yaml
@@ -25,7 +25,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly

--- a/_includes/master/charts/calico/templates/calico-node.yaml
+++ b/_includes/master/charts/calico/templates/calico-node.yaml
@@ -28,7 +28,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 {{- if .Values.flannel_migration}}
         # Only run Calico on nodes that have been migrated.
         projectcalico.org/node-network-during-migration: calico

--- a/_includes/master/charts/calico/templates/calico-typha.yaml
+++ b/_includes/master/charts/calico/templates/calico-typha.yaml
@@ -53,7 +53,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.

--- a/_includes/master/charts/calico/templates/configure-canal.yaml
+++ b/_includes/master/charts/calico/templates/configure-canal.yaml
@@ -14,7 +14,7 @@ spec:
       name: configure-canal
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       restartPolicy: OnFailure
       containers:

--- a/_includes/master/non-helm-manifests/calicoctl-etcd.yaml
+++ b/_includes/master/non-helm-manifests/calicoctl-etcd.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: kube-system
 spec:
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   hostNetwork: true
   containers:
   - name: calicoctl

--- a/_includes/master/non-helm-manifests/calicoctl.yaml
+++ b/_includes/master/non-helm-manifests/calicoctl.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: kube-system
 spec:
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   hostNetwork: true
   serviceAccountName: calicoctl
   containers:

--- a/_includes/master/non-helm-manifests/flannel-migration/migration-job.yaml
+++ b/_includes/master/non-helm-manifests/flannel-migration/migration-job.yaml
@@ -142,7 +142,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly

--- a/master/getting-started/kubernetes/hardway/install-node.md
+++ b/master/getting-started/kubernetes/hardway/install-node.md
@@ -168,7 +168,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
         # Make sure calico-node gets scheduled on all nodes.


### PR DESCRIPTION
## Description

The beta.kubernetes.io/os label is deprecated since v1.14 and targeted for removal in v1.18.
https://github.com/kubernetes/kubernetes/issues/73084

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
The "beta.kubernetes.io/os" label was deprecated and is replaced by "kubernetes.io/os", available since Kubernetes 1.14.
```
