### PR TITLE
Extend kernel dependencies in v3.10 doc

### DIFF
--- a/_includes/master/reqs-kernel.md
+++ b/_includes/master/reqs-kernel.md
@@ -4,12 +4,21 @@
 > satisfy these. 
 {: .alert .alert-success}
 
-- `nf_conntrack_netlink` subsystem
+- `ip_set`
 - `ip_tables` (for IPv4)
 - `ip6_tables` (for IPv6)
-- `ip_set`
-- `xt_set`
-- `ipt_set`
-- `ipt_rpfilter`
 - `ipt_REJECT`
+- `ipt_rpfilter`
+- `ipt_set`
+- `nf_conntrack_netlink` subsystem
+- `xt_addrtype`
+- `xt_conntrack`
+- `xt_icmp` (for IPv4)
+- `xt_icmp6` (for IPv6)
+- `xt_ipvs`
+- `xt_mark`
+- `xt_multiport`
+- `xt_rpfilter`
+- `xt_set`
+- `xt_u32`
 - `ipip` (if using {{site.prodname}} networking)

--- a/_includes/v3.10/reqs-kernel.md
+++ b/_includes/v3.10/reqs-kernel.md
@@ -4,12 +4,21 @@
 > satisfy these. 
 {: .alert .alert-success}
 
-- `nf_conntrack_netlink` subsystem
+- `ip_set`
 - `ip_tables` (for IPv4)
 - `ip6_tables` (for IPv6)
-- `ip_set`
-- `xt_set`
-- `ipt_set`
-- `ipt_rpfilter`
 - `ipt_REJECT`
+- `ipt_rpfilter`
+- `ipt_set`
+- `nf_conntrack_netlink` subsystem
+- `xt_addrtype`
+- `xt_conntrack`
+- `xt_icmp` (for IPv4)
+- `xt_icmp6` (for IPv6)
+- `xt_ipvs`
+- `xt_mark`
+- `xt_multiport`
+- `xt_rpfilter`
+- `xt_set`
+- `xt_u32`
 - `ipip` (if using {{site.prodname}} networking)


### PR DESCRIPTION
## Description

Not all of the Kernel dependencies were mentioned in the documentation.

## Related issues/PRs
partly fixes https://github.com/projectcalico/calicoctl/issues/1444

## Todos

- [ ] Backport to older versions

