### PR TITLE
Use calicoctl patch rather than get/sed/apply

### DIFF
--- a/master/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/master/getting-started/kubernetes/installation/app-layer-policy.md
@@ -21,14 +21,11 @@ operate.
  - [calicoctl installed](/{{page.version}}/getting-started/calicoctl/install) & [configured](/{{page.version}}/getting-started/calicoctl/configure/)
 
 Application layer policy requires the Policy Sync API to be enabled on Felix. To do this cluster-wide, modify the `default`
-FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`.  The following example uses `sed` to modify your
-existing default config before re-applying it.
+FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`.
 
 ```bash
-calicoctl get felixconfiguration default --export -o yaml | \
-sed -e '/  policySyncPathPrefix:/d' \
-    -e '$ a\  policySyncPathPrefix: /var/run/nodeagent' > felix-config.yaml
-calicoctl apply -f felix-config.yaml
+calicoctl patch FelixConfiguration default --patch \
+   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
 ```
 
 ## Installing Istio


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
At the time ALP docs were written, calicoctl didn't support the `patch` command, so we used a `calicoctl get`, modified with `sed`, then applied with `calicoctl apply`.  Now that `patch` is supported we can simplify the commands.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [x] Release note not required

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
