### PR TITLE
Revert "Updates for v3.8.6"

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -242,29 +242,6 @@ v3.9:
       version: v3.9.0
 
 v3.8:
-- title: v3.8.6
-  components:
-     typha:
-      version: v3.8.6
-     calicoctl:
-      version: v3.8.6
-     calico/node:
-      version: v3.8.6
-     calico/cni:
-      version: v3.8.6
-     calico/kube-controllers:
-      version: v3.8.6
-     networking-calico:
-      version: 3.8.6
-     flannel:
-      version: v0.11.0
-     calico/dikastes:
-      version: v3.8.6
-     flexvol:
-      version: v3.8.6
-     calico/flannel-migration-controller:
-      version: v3.8.6
-
 - title: v3.8.5
   components:
      typha:

--- a/_includes/v3.8/release-notes/v3.8.6-release-notes.md
+++ b/_includes/v3.8/release-notes/v3.8.6-release-notes.md
@@ -1,9 +1,0 @@
-06 Jan 2019
-
-#### Bug fixes
-
- - Backport fix for Calico IPAM migration [cni-plugin #832](https://github.com/projectcalico/cni-plugin/pull/832) (@sreis)
-
-#### Other changes
-
- - Backport update to libcalico-go to use go-yaml v2.25 [libcalico-go #1188](https://github.com/projectcalico/libcalico-go/pull/1188) (@lmm)


### PR DESCRIPTION
Reverts projectcalico/calico#3104

Wrong branch, this should be in `release-legacy`