### PR TITLE
Revert "Updates for v3.10.3"

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -46,29 +46,6 @@ v3.11:
       version: v3.11.0
 
 v3.10:
-- title: v3.10.3
-  components:
-     typha:
-      version: v3.10.3
-     calicoctl:
-      version: v3.10.3
-     calico/node:
-      version: v3.10.3
-     calico/cni:
-      version: v3.10.3
-     calico/kube-controllers:
-      version: v3.10.3
-     networking-calico:
-      version: 3.10.3
-     flannel:
-      version: v0.11.0
-     calico/dikastes:
-      version: v3.10.3
-     flexvol:
-      version: v3.10.3
-     calico/flannel-migration-controller:
-      version: v3.10.3
-
 - title: v3.10.2
   components:
      typha:

--- a/_includes/v3.10/release-notes/v3.10.3-release-notes.md
+++ b/_includes/v3.10/release-notes/v3.10.3-release-notes.md
@@ -1,9 +1,0 @@
-06 Jan 2019
-
-#### Bug fixes
-
- - Backport fix for Calico IPAM migration [cni-plugin #830](https://github.com/projectcalico/cni-plugin/pull/830) (@sreis)
-
-#### Other changes
-
- - Backport update to libcalico-go to use go-yaml v2.25 [libcalico-go #1186](https://github.com/projectcalico/libcalico-go/pull/1186) (@lmm)


### PR DESCRIPTION
Reverts projectcalico/calico#3106

Wrong branch, this should be in `release-legacy`