### PR TITLE
Fix absolute links

### DIFF
--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -185,7 +185,7 @@ To link to a page not named `index.md`, omit the closing slash. To link to a pag
 To create clickable links to other doc site content, use links prefixed with: `{{ site.baseurl }}`. For example:
 
 ```
-[Get started]({{ site.baseurl }}/{{ page.version }}/getting-started/)
+[Get started]({{ site.baseurl }}/getting-started/)
 ```
 
 Will render as:
@@ -194,16 +194,14 @@ Will render as:
 <a href="/v3.8/getting-started/">Getting started</a>
 ```
 
-The `site.baseurl` prefix is not strictly required, but allows greater portability if our docs move in the future.
+**`absolute_url`**
 
-**`site.url`**
+The `absolute_url` filter must be used whenever you are not creating a clickable `<a href='...'>` element, but instead are showing the user a URL to copy locally. A common example is downloading manifests or showing a user how to `kubectl apply -f https://...` them.
 
-The `site.url` prefix must be used whenever you are not creating a clickable `<a href='...'>` element, but instead are showing the user a URL to copy locally. A common example is downloading manifests or showing a user how to `kubectl apply -f https://...` them.
-
-For absolute links, use `{{ site.url }}`. For example:
+For absolute links, use `{{ "/path" | absolute_url }}`. For example:
 
 ```
-kubectl apply -f `{{ site.url }}/{{ page.version }}/manifests/calicoctl.yaml`
+kubectl apply -f `{{ "/manifests/calicoctl.yaml" | absolute_url }}`
 ```
 
 Will render as:
@@ -211,12 +209,6 @@ Will render as:
 ```
 kubectl apply -f `https://docs.tigera.io/v3.8/manifests/calicoctl.yaml`
 ```
-
-**page.version**
-
-Most links should include the prefix `{{ page.version }}`, as seen in the above examples. This allows the content to port across multiple versions without link breakage.
-
-`page.version` is automatically inherited from `_config.yml` for the current page's directory.
 
 ### Case sensitivity
 

--- a/_includes/master/ctl-container-install.md
+++ b/_includes/master/ctl-container-install.md
@@ -20,21 +20,21 @@ Use the YAML that matches your datastore type to deploy the `calicoctl` containe
 - **etcd**
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/calicoctl-etcd.yaml
+   kubectl apply -f {{ "/manifests/calicoctl-etcd.yaml" | absolute_url }}
    ```
 
    > **Note**: You can also
-   > [view the YAML in a new tab]({{ site.url }}/manifests/calicoctl-etcd.yaml){:target="_blank"}.
+   > [view the YAML in a new tab]({{ "/manifests/calicoctl-etcd.yaml" | absolute_url }}){:target="_blank"}.
    {: .alert .alert-info}
 
 - **Kubernetes API datastore**
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/calicoctl.yaml
+   kubectl apply -f {{ "/manifests/calicoctl.yaml" | absolute_url }}
    ```
 
    > **Note**: You can also
-   > [view the YAML in a new tab]({{ site.url }}/manifests/calicoctl.yaml){:target="_blank"}.
+   > [view the YAML in a new tab]({{ "/manifests/calicoctl.yaml" | absolute_url }}){:target="_blank"}.
    {: .alert .alert-info}
 
 You can then run commands using kubectl as shown below.

--- a/_includes/master/install-k8s-addons.md
+++ b/_includes/master/install-k8s-addons.md
@@ -10,7 +10,7 @@ The {{site.prodname}} self-hosted installation consists of three objects in the 
 Install the {{site.prodname}} manifest:
 
 ```shell
-kubectl apply -f {{ site.url }}/getting-started/kubernetes/installation/hosted/calico.yaml
+kubectl apply -f {{ "/getting-started/kubernetes/installation/hosted/calico.yaml" | absolute_url }}
 ```
 
 Issue the following command.
@@ -36,5 +36,5 @@ calico-kube-controller-so4gl    1/1       Running   0          1m
 To install KubeDNS, use the provided manifest.  This enables Kubernetes Service discovery.
 
 ```shell
-kubectl apply -f {{ site.url }}/getting-started/kubernetes/installation/manifests/kubedns.yaml
+kubectl apply -f {{ "/getting-started/kubernetes/installation/manifests/kubedns.yaml" | absolute_url }}
 ```

--- a/getting-started/kubernetes/hardway/the-calico-datastore.md
+++ b/getting-started/kubernetes/hardway/the-calico-datastore.md
@@ -38,7 +38,7 @@ In order to use Kubernetes as the {{site.prodname}} datastore, we need to define
 Download and examine the list of {{site.prodname}} custom resource definitions, and open it in a file editor.
 
 ```
-wget {{ site.url }}/manifests/crds.yaml
+wget {{ "/manifests/crds.yaml" | absolute_url }}
 ```
 
 Create the custom resource definitions in Kubernetes.

--- a/getting-started/kubernetes/index.md
+++ b/getting-started/kubernetes/index.md
@@ -64,11 +64,11 @@ To deploy a cluster suitable for production, refer to [Installation](installatio
 1. Install {{site.prodname}} with the following command.
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/calico.yaml
+   kubectl apply -f {{ "/manifests/calico.yaml" | absolute_url }}
    ```
 
    > **Note**: You can also
-   > [view the YAML in a new tab]({{ site.url }}/manifests/calico.yaml){:target="_blank"}.
+   > [view the YAML in a new tab]({{ "/manifests/calico.yaml" | absolute_url }}){:target="_blank"}.
    {: .alert .alert-info}
 
    You should see the following output.

--- a/getting-started/kubernetes/installation/app-layer-policy.md
+++ b/getting-started/kubernetes/installation/app-layer-policy.md
@@ -67,10 +67,10 @@ The sidecar injector automatically modifies pods as they are created to work wit
 1. Patch the istio-sidecar-injector `ConfigMap` to enable injection of Dikastes alongside Envoy.
 
 ```
-curl {{ site.url }}/manifests/alp/istio-inject-configmap-1.4.2.yaml -o istio-inject-configmap.yaml
+curl {{ "/manifests/alp/istio-inject-configmap-1.4.2.yaml" | absolute_url }} -o istio-inject-configmap.yaml
 kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat istio-inject-configmap.yaml)"
 ```
-[View sample manifest]({{ site.url }}/manifests/alp/istio-inject-configmap-1.3.5.yaml){:target="_blank"}
+[View sample manifest]({{ "/manifests/alp/istio-inject-configmap-1.3.5.yaml" | absolute_url }}){:target="_blank"}
 
 If you installed a different version of Istio, substitute 1.4.2 in the above URL for your Istio version. We have predefined `ConfigMaps` for Istio versions 1.1.0 through 1.1.17, 1.2.0 through 1.2.9, 1.3.0 through 1.3.5, and 1.4.0 through 1.4.2. To customize the standard sidecar injector `ConfigMap` or understand the changes we have made, see [Customizing the manifests]({{ site.url }}/getting-started/kubernetes/installation/config-options).
 
@@ -79,10 +79,10 @@ If you installed a different version of Istio, substitute 1.4.2 in the above URL
 Apply the following manifest to configure Istio to query {{site.prodname}} for application layer policy authorization decisions.
 
 ```
-kubectl apply -f {{site.url}}/{page.version}}/manifests/alp/istio-app-layer-policy.yaml
+kubectl apply -f {{ "/manifests/alp/istio-app-layer-policy.yaml" | absolute_url }}
 ```
 
-[View sample manifest]({{ site.url }}/manifests/alp/istio-app-layer-policy.yaml){:target="_blank"}
+[View sample manifest]({{ "/manifests/alp/istio-app-layer-policy.yaml" | absolute_url }}){:target="_blank"}
 
 #### Add namespace labels
 
@@ -96,7 +96,7 @@ kubectl label namespace <your namespace name> istio-injection=enabled
 
 If the namespace already has pods in it, you must recreate them for this to take effect.
 
->**Note**: Envoy must be able to communicate with the `istio-pilot.istio-system service`. If you apply any egress policies to your pods, you *must* enable access. For example, you could [apply a network policy]({{ site.url }}/getting-started/kubernetes/installation/manifests/app-layer-policy/allow-istio-pilot.yaml).
+>**Note**: Envoy must be able to communicate with the `istio-pilot.istio-system service`. If you apply any egress policies to your pods, you *must* enable access. For example, you could [apply a network policy]({{ "/getting-started/kubernetes/installation/manifests/app-layer-policy/allow-istio-pilot.yaml" | absolute_url }}).
 {: .alert .alert-info}
 
 ### Above and beyond

--- a/getting-started/kubernetes/installation/calico.md
+++ b/getting-started/kubernetes/installation/calico.md
@@ -30,7 +30,7 @@ datastore type and number of nodes.
 1. Download the {{site.prodname}} networking manifest for the Kubernetes API datastore.
 
    ```bash
-   curl {{ site.url }}/manifests/calico.yaml -O
+   curl {{ "/manifests/calico.yaml" | absolute_url }} -O
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}
@@ -49,7 +49,7 @@ datastore type and number of nodes.
 1. Download the {{site.prodname}} networking manifest for the Kubernetes API datastore.
 
    ```bash
-   curl {{ site.url }}/manifests/calico-typha.yaml -o calico.yaml
+   curl {{ "/manifests/calico-typha.yaml" | absolute_url }} -o calico.yaml
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico-typha" %}
@@ -95,7 +95,7 @@ datastore type and number of nodes.
 1. Download the {{site.prodname}} networking manifest for etcd.
 
    ```bash
-   curl {{ site.url }}/manifests/calico-etcd.yaml -o calico.yaml
+   curl {{ "/manifests/calico-etcd.yaml -o calico.yaml" | absolute_url }}
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico-etcd" %}

--- a/getting-started/kubernetes/installation/config-options.md
+++ b/getting-started/kubernetes/installation/config-options.md
@@ -116,12 +116,12 @@ To use these manifests with a TLS-enabled etcd cluster you must do the following
 
    **{{site.prodname}} for policy and networking**
    ```bash
-   curl {{ site.url }}/manifests/calico-etcd.yaml -O
+   curl {{ "/manifests/calico-etcd.yaml" | absolute_url }} -O
    ```
 
    **{{site.prodname}} for policy and flannel for networking**
    ```bash
-   curl {{ site.url }}/manifests/canal.yaml -O
+   curl {{ "/manifests/canal.yaml" | absolute_url }} -O
    ```
 
 1. Within the `ConfigMap` section, uncomment the `etcd_ca`, `etcd_key`, and `etcd_cert`

--- a/getting-started/kubernetes/installation/flannel.md
+++ b/getting-started/kubernetes/installation/flannel.md
@@ -33,7 +33,7 @@ section that matches your type.
 1. Download the flannel networking manifest for the Kubernetes API datastore.
 
    ```bash
-   curl {{ site.url }}/manifests/canal.yaml -O
+   curl {{ "/manifests/canal.yaml" | absolute_url }} -O
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="canal" %}
@@ -55,7 +55,7 @@ etcd, complete the following steps.
 1. Download the {{site.prodname}} networking manifest.
 
    ```bash
-   curl {{ site.url }}/manifests/canal-etcd.yaml -O
+   curl {{ "/manifests/canal-etcd.yaml" | absolute_url }} -O
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="canal-etcd" %}

--- a/getting-started/kubernetes/installation/integration.md
+++ b/getting-started/kubernetes/installation/integration.md
@@ -218,23 +218,23 @@ Apply the manifest appropriate to your cluster configuration.
 - **Kubernetes API datastore with {{site.prodname}} networking**:
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/rbac/rbac-kdd-calico.yaml
+   kubectl apply -f {{ "/manifests/rbac/rbac-kdd-calico.yaml" | absolute_url }}
    ```
 
 - **Kubernetes API datastore with flannel networking**:
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/rbac/rbac-kdd-flannel.yaml
+   kubectl apply -f {{ "/manifests/rbac/rbac-kdd-flannel.yaml" | absolute_url }}
    ```
 
 - **etcd datastore with {{site.prodname}} networking**:
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/rbac/rbac-etcd-calico.yaml
+   kubectl apply -f {{ "/manifests/rbac/rbac-etcd-calico.yaml" | absolute_url }}
    ```
 
 - **etcd datastore with flannel networking**:
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/rbac/rbac-etcd-flannel.yaml
+   kubectl apply -f {{ "/manifests/rbac/rbac-etcd-flannel.yaml" | absolute_url }}
    ```

--- a/getting-started/kubernetes/installation/migration-from-flannel.md
+++ b/getting-started/kubernetes/installation/migration-from-flannel.md
@@ -25,13 +25,13 @@ At the end, you will have a fully-functional Calico cluster using VXLAN networki
 1. First, install Calico.
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/flannel-migration/calico.yaml
+   kubectl apply -f {{ "/manifests/flannel-migration/calico.yaml" | absolute_url }}
    ```
 
    Then, install the migration controller to initiate the migration.
 
    ```
-   kubectl apply -f {{ site.url }}/manifests/flannel-migration/migration-job.yaml
+   kubectl apply -f {{ "/manifests/flannel-migration/migration-job.yaml" | absolute_url }}
    ```
 
    Once applied, you will see nodes begin to update one at a time.
@@ -53,7 +53,7 @@ At the end, you will have a fully-functional Calico cluster using VXLAN networki
 1. After completion, delete the migration controller with the following command.
 
    ```
-   kubectl delete -f {{ site.url }}/manifests/flannel-migration/migration-job.yaml
+   kubectl delete -f {{ "/manifests/flannel-migration/migration-job.yaml" | absolute_url }}
    ```
 # Configuration options
 
@@ -102,8 +102,8 @@ Migration from Calico to flannel is not supported. If you experience a problem d
 1. Remove the migration controller and Calico.
 
    ```
-   kubectl delete -f {{ site.url }}/manifests/flannel-migration/migration-job.yaml
-   kubectl delete -f {{ site.url }}/manifests/flannel-migration/calico.yaml
+   kubectl delete -f {{ "/manifests/flannel-migration/migration-job.yaml" | absolute_url }}
+   kubectl delete -f {{ "/manifests/flannel-migration/calico.yaml" | absolute_url }}
    ```
 
 1. Determine the nodes which have been migrated to Calico.

--- a/getting-started/kubernetes/installation/other.md
+++ b/getting-started/kubernetes/installation/other.md
@@ -24,7 +24,7 @@ complete the following steps.
 1. Download the {{site.prodname}} policy-only manifest for the Kubernetes API datastore.
 
    ```bash
-   curl {{ site.url }}/manifests/calico-policy-only.yaml -O
+   curl {{ "/manifests/calico-policy-only.yaml" | absolute_url }} -O
    ```
 
 {% include {{page.version}}/pod-cidr-sed.md yaml="calico" %}

--- a/maintenance/kubernetes-upgrade.md
+++ b/maintenance/kubernetes-upgrade.md
@@ -23,17 +23,17 @@ procedure varies by datastore type.
 
    **{{site.prodname}} for policy and networking**
    ```bash
-   curl {{ site.url }}/manifests/calico.yaml -O
+   curl {{ "/manifests/calico.yaml" | absolute_url }} -O
    ```
 
    **{{site.prodname}} for policy and flannel for networking**
    ```bash
-   curl {{ site.url }}/manifests/canal.yaml -O
+   curl {{ "/manifests/canal.yaml" | absolute_url }} -O
    ```
 
    **{{site.prodname}} for policy (advanced)**
    ```bash
-   curl {{ site.url }}/manifests/calico-policy-only.yaml -O
+   curl {{ "/manifests/calico-policy-only.yaml" | absolute_url }} -O
    ```
 
    > **Note**: If you manually modified the manifest, you must manually apply the
@@ -85,12 +85,12 @@ procedure varies by datastore type.
 
    **{{site.prodname}} for policy and networking**
    ```bash
-   curl {{ site.url }}/manifests/calico-etcd.yaml -O
+   curl {{ "/manifests/calico-etcd.yaml" | absolute_url }} -O
    ```
 
    **{{site.prodname}} for policy and flannel for networking**
    ```bash
-   curl {{ site.url }}/manifests/canal-etcd.yaml -O
+   curl {{ "/manifests/canal-etcd.yaml" | absolute_url }} -O
    ```
 
    > **Note**: You must must manually apply the changes you made to the manifest
@@ -154,7 +154,7 @@ take the following steps to upgrade the Dikastes sidecars running in your applic
    the full version string of your Istio install, for example `1.4.2`.
 
    ```bash
-   kubectl apply -f {{ site.url }}/manifests/alp/istio-inject-configmap-<your Istio version>.yaml
+   kubectl apply -f {{ "/manifests/alp/istio-inject-configmap-<your Istio version>.yaml" | absolute_url }}
    ```
 
 1. Once the new template is in place, newly created pods use the upgraded version of Dikastes. Perform a rolling update of each of your service deployments

--- a/security/tutorials/app-layer-policy/enforce-policy-istio.md
+++ b/security/tutorials/app-layer-policy/enforce-policy-istio.md
@@ -24,7 +24,7 @@ We will use a simple microservice application to demonstrate {{site.prodname}} a
 
 ```bash
 kubectl apply -f \
-{{ site.url }}/security/tutorials/app-layer-policy/manifests/10-yaobank.yaml
+{{ "/security/tutorials/app-layer-policy/manifests/10-yaobank.yaml" | absolute_url }}
 ```
 
 > **Note**: You can also
@@ -160,7 +160,7 @@ return to the customer pod later).
 
 ```bash
 kubectl apply -f \
-{{ site.url }}/security/tutorials/app-layer-policy/manifests/20-attack-pod.yaml
+{{ "/security/tutorials/app-layer-policy/manifests/20-attack-pod.yaml" | absolute_url }}
 ```
 
 Take a look at the [`20-attack-pod.yaml` manifest in your browser](manifests/20-attack-pod.yaml).
@@ -184,7 +184,7 @@ Return to your web browser and refresh to confirm the new balance.
 
 We can mitigate both of the above deficiencies with a {{site.prodname}} policy.
 
-    wget {{ site.url }}/security/tutorials/app-layer-policy/manifests/30-policy.yaml
+    wget {{ "/security/tutorials/app-layer-policy/manifests/30-policy.yaml" | absolute_url }}
     calicoctl create -f 30-policy.yaml
 
 > **Note**: You can also

--- a/security/tutorials/kubernetes-policy-demo/kubernetes-demo.md
+++ b/security/tutorials/kubernetes-policy-demo/kubernetes-demo.md
@@ -16,11 +16,11 @@ one of our [getting started guides]({{ site.baseurl }}/getting-started/).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml" | absolute_url }}
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml" | absolute_url }}
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml" | absolute_url }}
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml" | absolute_url }}
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml" | absolute_url }}
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -47,8 +47,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{ "/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml" | absolute_url }}
+kubectl create -n client -f {{ "/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml" | absolute_url }}
 ```
 
 #### Confirm isolation
@@ -61,8 +61,8 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml" | absolute_url }}
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml" | absolute_url }}
 ```
 
 After a few seconds, refresh the UI - it should now show the Services, but they should not be able to access each other any more.
@@ -70,7 +70,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml" | absolute_url }}
 ```
 
 Refresh the UI.  You should see the following:
@@ -82,7 +82,7 @@ Refresh the UI.  You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{ site.url }}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{ "/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml" | absolute_url }}
 ```
 
 The client can now access the frontend, but not the backend.  Neither the frontend nor the backend


### PR DESCRIPTION
## Description

Absolute links need to include `site.url` and `site.baseurl` to function properly, e.g.:

```
kubectl apply -f `{{ site.url }}{{ site.baseurl }}/manifests/calicoctl.yaml`
```

Fortunately, this is common in Jekyll, and they provide [a handy `absolute_url` Filter](https://jekyllrb.com/docs/liquid/filters/) for exactly this scenario. The following code accomplishes the same thing:

```
kubectl apply -f `{{ "/manifests/calicoctl.yaml" | absolute_url }}`
```

This PR updates all absolute links to use this format

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
