### PR TITLE
Remove vars that aren't actually needed for dual stack

### DIFF
--- a/master/networking/dual-stack.md
+++ b/master/networking/dual-stack.md
@@ -55,8 +55,6 @@ To enable dual stack IP address allocation, edit the manifest as follows:
    | ------------- | ----- |
    | `IP6`         | `autodetect` |
    | `CALICO_IPV6POOL_CIDR` | the same as the IPv6 range you configured as the cluster CIDR to kube-controller-manager and kube-proxy |
-   | `CALICO_IPV6POOL_IPIP` | `Never` |
-   | `CALICO_IPV6POOL_NAT_OUTGOING` | `false` |
    | `FELIX_IPV6SUPPORT` | `true` |
 
 Now apply the edited manifest with `kubectl apply -f`.


### PR DESCRIPTION
CALICO_IPV6POOL_NAT_OUTGOING setting not needed because it defaults to
"false".

CALICO_IPV6POOL_IPIP setting not needed because node startup.go does
not honour that variable at all; instead it hardcodes "Never".
