### PR TITLE
Added descriptions to all pages.

### DIFF
--- a/_data/navbars/getting-started.yml
+++ b/_data/navbars/getting-started.yml
@@ -33,8 +33,6 @@ section:
       path: /getting-started/kubernetes/installation/app-layer-policy
     - title: Customizing the manifests
       path: /getting-started/kubernetes/installation/config-options
-    - title: Integration guide (advanced)
-      path: /getting-started/kubernetes/installation/integration
   - title: Flannel
     path: /getting-started/kubernetes/flannel/
     section:

--- a/_data/navbars/networking.yml
+++ b/_data/navbars/networking.yml
@@ -9,7 +9,7 @@ section:
   section:
   - title: Configure BGP peering
     path: /networking/bgp
-  - title: Connect workloads across networks that you do not control
+  - title: Configure overlay networking
     path: /networking/vxlan-ipip
   - title: Configure MTU to maximize network performance
     path: /networking/mtu

--- a/getting-started/as-service.md
+++ b/getting-started/as-service.md
@@ -1,5 +1,6 @@
 ---
 title: Running calico/node with an init system
+description: Install Calico on a host in Docker or other container type. 
 canonical_url: '/getting-started/as-service'
 ---
 

--- a/getting-started/bare-metal/bare-metal.md
+++ b/getting-started/bare-metal/bare-metal.md
@@ -1,5 +1,6 @@
 ---
-title: Using Calico to Secure Host Interfaces
+title: Useing Calico to secure host interfaces
+description: Learn why securing host interfaces with Calico is important.
 canonical_url: '/getting-started/bare-metal/bare-metal'
 ---
 

--- a/getting-started/bare-metal/index.md
+++ b/getting-started/bare-metal/index.md
@@ -1,5 +1,6 @@
 ---
 title: Bare metal hosts
+description: Install Calico on hosts to secure host communications.
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/bare-metal/index'

--- a/getting-started/bare-metal/index.md
+++ b/getting-started/bare-metal/index.md
@@ -5,6 +5,6 @@ show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/bare-metal/index'
 ---
-
+{{ page.description }}
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/getting-started/bare-metal/installation/binary-mgr.md
+++ b/getting-started/bare-metal/installation/binary-mgr.md
@@ -1,5 +1,6 @@
 ---
 title: Binary install with package manager
+description: Install Calico binary on host using a package manager.
 canonical_url: '/getting-started/bare-metal/installation/binary-mgr'
 ---
 

--- a/getting-started/bare-metal/installation/binary.md
+++ b/getting-started/bare-metal/installation/binary.md
@@ -1,5 +1,6 @@
 ---
 title: Binary install without package manager
+description: Install Calico binary on host without a package manager.
 canonical_url: '/getting-started/bare-metal/installation/binary'
 ---
 

--- a/getting-started/bare-metal/installation/container.md
+++ b/getting-started/bare-metal/installation/container.md
@@ -1,5 +1,6 @@
 ---
 title: Container install
+desription: Install Calico on hosts if you are using Docker.
 canonical_url: '/getting-started/bare-metal/installation/container'
 ---
 

--- a/getting-started/bare-metal/installation/container.md
+++ b/getting-started/bare-metal/installation/container.md
@@ -1,6 +1,6 @@
 ---
 title: Container install
-desription: Install Calico on hosts if you are using Docker.
+description: Install Calico on hosts if you are using Docker.
 canonical_url: '/getting-started/bare-metal/installation/container'
 ---
 

--- a/getting-started/bare-metal/installation/container.md
+++ b/getting-started/bare-metal/installation/container.md
@@ -1,6 +1,6 @@
 ---
 title: Container install
-description: Install Calico on hosts if you are using Docker.
+description: Install Calico on hosts using Docker.
 canonical_url: '/getting-started/bare-metal/installation/container'
 ---
 

--- a/getting-started/bare-metal/installation/index.md
+++ b/getting-started/bare-metal/installation/index.md
@@ -1,4 +1,5 @@
 ---
+description: Install Calico on hosts to secure host communications.
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/bare-metal/installation/overview.md
+++ b/getting-started/bare-metal/installation/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Installing Calico on host endpoints
-description: Choose a method to install Calico on hosts
+description: Choose a method to install Calico on hosts.
 canonical_url: '/getting-started/bare-metal/installation/index'
 ---
 

--- a/getting-started/bare-metal/requirements.md
+++ b/getting-started/bare-metal/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+description: Review node requirements for installing Calico.
 canonical_url: '/getting-started/bare-metal/requirements'
 ---
 

--- a/getting-started/calicoctl/configure/etcd.md
+++ b/getting-started/calicoctl/configure/etcd.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring calicoctl to connect to an etcd datastore
-description: Examples of configuration files with etcd configuration options.
+description: Sample configuration files etcd.
 canonical_url: '/getting-started/calicoctl/configure/etcd'
 ---
 

--- a/getting-started/calicoctl/configure/etcd.md
+++ b/getting-started/calicoctl/configure/etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to an etcd datastore
+description: Examples of configuration files with etcd configuration options.
 canonical_url: '/getting-started/calicoctl/configure/etcd'
 ---
 

--- a/getting-started/calicoctl/configure/index.md
+++ b/getting-started/calicoctl/configure/index.md
@@ -1,4 +1,5 @@
 ---
+description: Configure the calicoctl CLI.
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/calicoctl/configure/index.md
+++ b/getting-started/calicoctl/configure/index.md
@@ -1,5 +1,5 @@
 ---
-description: Configure the calicoctl CLI.
+description: Configure the calicoctl to access your datastore.
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/calicoctl/configure/kdd.md
+++ b/getting-started/calicoctl/configure/kdd.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calicoctl to connect to the Kubernetes API datastore
+description: Sample configuration files for kdd.
 canonical_url: '/getting-started/calicoctl/configure/kdd'
 ---
 

--- a/getting-started/calicoctl/configure/overview.md
+++ b/getting-started/calicoctl/configure/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring calicoctl
-description: Configure calicoctl for datastore access
+description: Configure calicoctl for datastore access.
 canonical_url: '/getting-started/calicoctl/configure/index'
 ---
 

--- a/getting-started/calicoctl/index.md
+++ b/getting-started/calicoctl/index.md
@@ -5,6 +5,6 @@ show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/calicoctl/index'
 ---
-
+{{ page.description }}
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/getting-started/calicoctl/index.md
+++ b/getting-started/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl
+description: The CLI for Calico. 
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/calicoctl/index'

--- a/getting-started/calicoctl/index.md
+++ b/getting-started/calicoctl/index.md
@@ -1,6 +1,6 @@
 ---
 title: calicoctl
-description: The CLI for Calico. 
+description: Install and configure the Calico CLI for managing resources. 
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/calicoctl/index'

--- a/getting-started/calicoctl/install.md
+++ b/getting-started/calicoctl/install.md
@@ -1,5 +1,6 @@
 ---
 title: Installing calicoctl
+description: Install the CLI for Calico.
 canonical_url: '/getting-started/calicoctl/install'
 ---
 

--- a/getting-started/kubernetes/flannel/index.md
+++ b/getting-started/kubernetes/flannel/index.md
@@ -1,6 +1,6 @@
 ---
 title: Flannel
-description: Calico provide network policy integration with flannel. 
+description: Calico provides network policy integration with flannel. 
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/kubernetes/flannel/index'

--- a/getting-started/kubernetes/flannel/index.md
+++ b/getting-started/kubernetes/flannel/index.md
@@ -1,5 +1,6 @@
 ---
 title: Flannel
+description: Install Calico network policy for Flannel. 
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/kubernetes/flannel/index'

--- a/getting-started/kubernetes/flannel/index.md
+++ b/getting-started/kubernetes/flannel/index.md
@@ -1,6 +1,6 @@
 ---
 title: Flannel
-description: Calico provides network policy integration with flannel. 
+description: Calico provides network policy integration with flannel networking. 
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/kubernetes/flannel/index'

--- a/getting-started/kubernetes/flannel/index.md
+++ b/getting-started/kubernetes/flannel/index.md
@@ -6,5 +6,6 @@ show_toc: false
 canonical_url: '/getting-started/kubernetes/flannel/index'
 ---
 
+{{ page.description }}
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/getting-started/kubernetes/flannel/index.md
+++ b/getting-started/kubernetes/flannel/index.md
@@ -1,6 +1,6 @@
 ---
 title: Flannel
-description: Install Calico network policy for Flannel. 
+description: Calico provide network policy integration with flannel. 
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/kubernetes/flannel/index'

--- a/getting-started/kubernetes/hardway/configure-bgp-peering.md
+++ b/getting-started/kubernetes/hardway/configure-bgp-peering.md
@@ -1,5 +1,6 @@
 ---
 title: Configure BGP peering
+description: Quick review of BGP peering options. 
 canonical_url: '/getting-started/kubernetes/hardway/configure-bgp-peering'
 ---
 

--- a/getting-started/kubernetes/hardway/configure-ip-pools.md
+++ b/getting-started/kubernetes/hardway/configure-ip-pools.md
@@ -1,5 +1,6 @@
 ---
 title: Configure IP pools
+description: Quick review of defining IP pools (IP address ranges) in clusters.
 canonical_url: '/getting-started/kubernetes/hardway/configure-ip-pools'
 ---
 

--- a/getting-started/kubernetes/hardway/end-user-rbac.md
+++ b/getting-started/kubernetes/hardway/end-user-rbac.md
@@ -1,5 +1,6 @@
 ---
 title: End user RBAC
+description: Quick review of common roles and access controls for running clusters in production. 
 canonical_url: '/getting-started/kubernetes/hardway/end-user-rbac'
 ---
 

--- a/getting-started/kubernetes/hardway/index.md
+++ b/getting-started/kubernetes/hardway/index.md
@@ -1,4 +1,5 @@
 ---
+description: A deep dive tutorial to learn what happens under the covers during a Calico install. 
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/kubernetes/hardway/index.md
+++ b/getting-started/kubernetes/hardway/index.md
@@ -1,5 +1,5 @@
 ---
-description: A deep dive tutorial to learn what happens under the covers during a Calico install. 
+description: A deep dive tutorial about installing Calico the hard way.
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/kubernetes/hardway/index.md
+++ b/getting-started/kubernetes/hardway/index.md
@@ -1,5 +1,5 @@
 ---
-description: A deep dive tutorial about installing Calico the hard way.
+description: Up for the challenge? Calico the hard way takes you under the covers of a Calico installation.
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/kubernetes/hardway/install-cni-plugin.md
+++ b/getting-started/kubernetes/hardway/install-cni-plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Install CNI plugin
+description: Steps to install the Calico Container Network Interface (CNI)
 canonical_url: '/getting-started/kubernetes/hardway/install-cni-plugin'
 ---
 

--- a/getting-started/kubernetes/hardway/install-node.md
+++ b/getting-started/kubernetes/hardway/install-node.md
@@ -1,5 +1,6 @@
 ---
 title: Install calico/node
+description: Configure and install calico/node as a daemon set.
 canonical_url: '/getting-started/kubernetes/hardway/install-node'
 ---
 

--- a/getting-started/kubernetes/hardway/install-typha.md
+++ b/getting-started/kubernetes/hardway/install-typha.md
@@ -1,5 +1,6 @@
 ---
 title: Install Typha
+description: Learn about Typha for scaling deployment.
 canonical_url: '/getting-started/kubernetes/hardway/install-typha'
 ---
 

--- a/getting-started/kubernetes/hardway/istio-integration.md
+++ b/getting-started/kubernetes/hardway/istio-integration.md
@@ -1,5 +1,6 @@
 ---
 title: Istio integration
+description: Enforce Calico network policy for Istio service mesh applications.
 canonical_url: '/getting-started/kubernetes/hardway/istio-integration'
 ---
 

--- a/getting-started/kubernetes/hardway/overview.md
+++ b/getting-started/kubernetes/hardway/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Calico the hard way
-description: A tutorial (ala Kelsey Hightower) about Calico under the covers 
+description: A deep dive tutorial on how to Calico install the hard way. 
 canonical_url: '/getting-started/kubernetes/hardway/index'
 ---
 

--- a/getting-started/kubernetes/hardway/overview.md
+++ b/getting-started/kubernetes/hardway/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Calico the hard way
-description: A deep dive tutorial on how to Calico install the hard way. 
+description: A tutorial for installing Calico the hard way. 
 canonical_url: '/getting-started/kubernetes/hardway/index'
 ---
 

--- a/getting-started/kubernetes/hardway/standing-up-kubernetes.md
+++ b/getting-started/kubernetes/hardway/standing-up-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Standing up Kubernetes
+description: Get a Kubernetes cluster up and running.
 canonical_url: '/getting-started/kubernetes/hardway/standing-up-kubernetes'
 ---
 

--- a/getting-started/kubernetes/hardway/test-network-policy.md
+++ b/getting-started/kubernetes/hardway/test-network-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Test network policy
-descriptio: Verify that network policy works correctly.
+description: Verify that network policy works correctly.
 canonical_url: '/getting-started/kubernetes/hardway/test-network-policy'
 ---
 

--- a/getting-started/kubernetes/hardway/test-network-policy.md
+++ b/getting-started/kubernetes/hardway/test-network-policy.md
@@ -1,5 +1,6 @@
 ---
 title: Test network policy
+descriptio: Verify that network policy works correctly.
 canonical_url: '/getting-started/kubernetes/hardway/test-network-policy'
 ---
 

--- a/getting-started/kubernetes/hardway/test-networking.md
+++ b/getting-started/kubernetes/hardway/test-networking.md
@@ -1,5 +1,6 @@
 ---
 title: Test networking
+description: Test that networking works correctly.
 canonical_url: '/getting-started/kubernetes/hardway/test-networking'
 ---
 

--- a/getting-started/kubernetes/hardway/the-calico-datastore.md
+++ b/getting-started/kubernetes/hardway/the-calico-datastore.md
@@ -1,5 +1,6 @@
 ---
 title: The Calico datastore
+description: The central datastore for your clusters' operational and configuration state.
 canonical_url: '/getting-started/kubernetes/hardway/the-calico-datastore'
 ---
 

--- a/getting-started/kubernetes/index.md
+++ b/getting-started/kubernetes/index.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes
+description: Get Calico up and running on nodes in your Kubernetes cluster. 
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/kubernetes/installation/calico.md
+++ b/getting-started/kubernetes/installation/calico.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for policy and networking (recommended)
+description: Install both Calico networking and network policy to take advantage of all Calico open source product features.
 canonical_url: '/getting-started/kubernetes/installation/calico'
 ---
 

--- a/getting-started/kubernetes/installation/config-options.md
+++ b/getting-started/kubernetes/installation/config-options.md
@@ -1,5 +1,6 @@
 ---
 title: Customizing the manifests
+description: Customize manifests prior to installing Calico (recommended).
 canonical_url: '/getting-started/kubernetes/installation/config-options'
 ---
 

--- a/getting-started/kubernetes/installation/flannel.md
+++ b/getting-started/kubernetes/installation/flannel.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for policy and flannel for networking
+description: If you use flannel for networking, you can install Calico network policy to secure cluster communications.
 canonical_url: '/getting-started/kubernetes/installation/flannel'
 ---
 

--- a/getting-started/kubernetes/installation/index.md
+++ b/getting-started/kubernetes/installation/index.md
@@ -1,4 +1,5 @@
 ---
+description: Calico provides many options to install networking and/or network policy for your Kubernetes deployment. 
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/kubernetes/installation/index.md
+++ b/getting-started/kubernetes/installation/index.md
@@ -1,5 +1,5 @@
 ---
-description: Calico provides many options to install networking and/or network policy for your Kubernetes deployment. 
+description: The recommended installation is to install both Calico policy and networking for your Kubernetes deployment.  
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/kubernetes/installation/migration-from-flannel.md
+++ b/getting-started/kubernetes/installation/migration-from-flannel.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating a cluster from flannel to Calico
+description: Migrate an existing Kubernetes cluster with flannel networking to use Calico networking.
 ---
 
 # About

--- a/getting-started/kubernetes/installation/other.md
+++ b/getting-started/kubernetes/installation/other.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Calico for policy (advanced)
+description: Install Calico with only network policy enabled.
 canonical_url: '/getting-started/kubernetes/installation/other'
 ---
 

--- a/getting-started/kubernetes/installation/overview.md
+++ b/getting-started/kubernetes/installation/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Installing Calico on Kubernetes
-description: Options for installing Calico on Kubernetes
+description: Options for installing Calico on Kubernetes.
 canonical_url: '/getting-started/kubernetes/installation/index'
 ---
 

--- a/getting-started/kubernetes/managed-public-cloud/aks.md
+++ b/getting-started/kubernetes/managed-public-cloud/aks.md
@@ -1,5 +1,6 @@
 ---
 title: Microsoft Azure Kubernetes Service (AKS)
+description: Enable Calico network policy in AKS.
 ---
 
 ### Big picture

--- a/getting-started/kubernetes/managed-public-cloud/eks.md
+++ b/getting-started/kubernetes/managed-public-cloud/eks.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon Elastic Kubernetes Service (EKS)
+description: Enable Calico network policy in EKS.
 ---
 
 ### Big picture

--- a/getting-started/kubernetes/managed-public-cloud/gke.md
+++ b/getting-started/kubernetes/managed-public-cloud/gke.md
@@ -1,5 +1,6 @@
 ---
 title: Google Kubernetes Engine (GKE)
+description: Enable Calico network policy in GKE.
 ---
 
 ### Big picture

--- a/getting-started/kubernetes/managed-public-cloud/iks.md
+++ b/getting-started/kubernetes/managed-public-cloud/iks.md
@@ -1,5 +1,6 @@
 ---
 title: IBM Cloud Kubernetes Service (IKS)
+description: Use IKS with built-in support for Calico networking and network policy.
 ---
 
 ### Big picture

--- a/getting-started/kubernetes/managed-public-cloud/index.md
+++ b/getting-started/kubernetes/managed-public-cloud/index.md
@@ -1,5 +1,6 @@
 ---
 title: Managed public cloud
+description: Calico is embedded in all of the major Kubernetes managed cloud providers. 
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/kubernetes/managed-public-cloud/index'

--- a/getting-started/kubernetes/managed-public-cloud/index.md
+++ b/getting-started/kubernetes/managed-public-cloud/index.md
@@ -1,6 +1,6 @@
 ---
 title: Managed public cloud
-description: Calico is embedded in all of the major Kubernetes managed cloud providers. 
+description: Follow the steps to enable Calico in your managed public cloud provider.
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/kubernetes/managed-public-cloud/index'

--- a/getting-started/kubernetes/managed-public-cloud/index.md
+++ b/getting-started/kubernetes/managed-public-cloud/index.md
@@ -6,5 +6,7 @@ show_toc: false
 canonical_url: '/getting-started/kubernetes/managed-public-cloud/index'
 ---
 
+{{ page.description }}
+
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/getting-started/kubernetes/quickstart.md
+++ b/getting-started/kubernetes/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart for Calico on Kubernetes
-description: Install a single-host Kubernetes cluster with Calico
+description: Install Calico on a single-host Kubernetes cluster
 canonical_url: '/getting-started/kubernetes/index'
 ---
 

--- a/getting-started/kubernetes/requirements.md
+++ b/getting-started/kubernetes/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+description: Review requirements before installing Calico on nodes to ensure success. 
 canonical_url: '/getting-started/kubernetes/requirements'
 ---
 

--- a/getting-started/openshift/dedicated-etcd.md
+++ b/getting-started/openshift/dedicated-etcd.md
@@ -1,5 +1,6 @@
 ---
 title: Connecting to a dedicated etcd cluster (optional)
+description: Calico provides an OpenShift-ansible integration for connecting to a custom etcd cluster.
 canonical_url: '/getting-started/openshift/dedicated-etcd'
 ---
 

--- a/getting-started/openshift/index.md
+++ b/getting-started/openshift/index.md
@@ -1,5 +1,6 @@
 ---
 title: OpenShift
+description: Install Calico on OpenShift for networking and network policy.
 show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/openshift/index'

--- a/getting-started/openshift/index.md
+++ b/getting-started/openshift/index.md
@@ -5,6 +5,6 @@ show_read_time: false
 show_toc: false
 canonical_url: '/getting-started/openshift/index'
 ---
-
+{{ page.description }}
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -1,5 +1,6 @@
 ---
 title: Installation
+description: Set variables during OpenShift standard install for Calico.
 canonical_url: '/getting-started/openshift/installation'
 ---
 

--- a/getting-started/openshift/requirements.md
+++ b/getting-started/openshift/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+description: Review the requirements for using OpenShift with Calico.
 canonical_url: '/getting-started/openshift/requirements'
 ---
 

--- a/getting-started/openstack/index.md
+++ b/getting-started/openstack/index.md
@@ -1,4 +1,5 @@
 ---
+description: Install Calico networking and network policy for OpenStack.
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/openstack/installation/devstack.md
+++ b/getting-started/openstack/installation/devstack.md
@@ -1,5 +1,6 @@
 ---
 title: DevStack
+description: Quickstart to show connectivity between DevStack and Calico.
 canonical_url: '/getting-started/openstack/installation/devstack'
 ---
 

--- a/getting-started/openstack/installation/index.md
+++ b/getting-started/openstack/installation/index.md
@@ -1,4 +1,5 @@
 ---
+description: Install Calico for OpenStack.
 show_read_time: false
 show_toc: false
 ---

--- a/getting-started/openstack/installation/overview.md
+++ b/getting-started/openstack/installation/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Calico on OpenStack
-description: Choose a method for installing Calico for OpenStack
+description: Choose a method for installing Calico for OpenStack.
 canonical_url: '/getting-started/openstack/installation/index'
 ---
 

--- a/getting-started/openstack/installation/redhat.md
+++ b/getting-started/openstack/installation/redhat.md
@@ -1,5 +1,6 @@
 ---
 title: Red Hat Enterprise Linux
+description: Install Calico on OpenStack, Red Hat Enterprise Linux nodes.
 canonical_url: '/getting-started/openstack/installation/redhat'
 ---
 

--- a/getting-started/openstack/installation/ubuntu.md
+++ b/getting-started/openstack/installation/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: Ubuntu
+description: Install Calico on OpenStack, Ubuntu nodes.
 canonical_url: '/getting-started/openstack/installation/ubuntu'
 ---
 

--- a/getting-started/openstack/overview.md
+++ b/getting-started/openstack/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Calico for OpenStack
-description: Overview of the Calico components for integrating with OpenStack.
+description: Review the Calico components used in an OpenStack deployment.
 canonical_url: '/getting-started/openstack/index'
 ---
 

--- a/getting-started/openstack/overview.md
+++ b/getting-started/openstack/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Calico for OpenStack
-description: Overview of the Calico components for integrating with OpenStack
+description: Overview of the Calico components for integrating with OpenStack.
 canonical_url: '/getting-started/openstack/index'
 ---
 

--- a/getting-started/openstack/requirements.md
+++ b/getting-started/openstack/requirements.md
@@ -1,6 +1,6 @@
 ---
 title: System requirements
-description: Review requirements for installing Calico on OpenStack nodes.
+description: Requirements for installing Calico on OpenStack nodes.
 canonical_url: '/getting-started/openstack/requirements'
 ---
 

--- a/getting-started/openstack/requirements.md
+++ b/getting-started/openstack/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System requirements
+description: Review requirements for installing Calico on OpenStack nodes.
 canonical_url: '/getting-started/openstack/requirements'
 ---
 

--- a/getting-started/openstack/verification.md
+++ b/getting-started/openstack/verification.md
@@ -1,5 +1,6 @@
 ---
 title: Verifying your deployment
+description: Quick steps to test that your Calico-based OpenStack deployment is running correctly.
 canonical_url: '/getting-started/openstack/verification'
 ---
 

--- a/introduction/deployments.md
+++ b/introduction/deployments.md
@@ -1,5 +1,6 @@
 ---
 title: Sample deployments
+description: Where and how Calico is being used.
 canonical_url: '/introduction/deployments'
 ---
 

--- a/introduction/index.md
+++ b/introduction/index.md
@@ -1,5 +1,6 @@
 ---
 title: About Calico
+description: The value of using Calico for networking and network policy for workloads and hosts.
 show_title: false
 canonical_url: '/introduction/index'
 custom_css: css/intro.css

--- a/maintenance/component-logs.md
+++ b/maintenance/component-logs.md
@@ -1,5 +1,6 @@
 ---
 title: Component logs
+description: Where to find logs on Calico components. 
 canonical_url: '/maintenance/component-logs'
 ---
 

--- a/maintenance/decommissioning-a-node.md
+++ b/maintenance/decommissioning-a-node.md
@@ -1,5 +1,6 @@
 ---
 title: Decommissioning a node
+description: Manually remove a node from a cluster that is installed with Calico.
 canonical_url: '/maintenance/decommissioning-a-node'
 ---
 

--- a/maintenance/index.md
+++ b/maintenance/index.md
@@ -1,6 +1,6 @@
 ---
 title: Maintenance
-description: Post-installation tasks for managing Calico including upgrading and troubleshooting
+description: Post-installation tasks for managing Calico including upgrading and troubleshooting.
 canonical_url: '/maintenance/index'
 show_read_time: false
 show_toc: false

--- a/maintenance/kubernetes-upgrade.md
+++ b/maintenance/kubernetes-upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico on Kubernetes
+description: Upgrade to a newer version of Calico for Kubernetes.
 canonical_url: '/maintenance/kubernetes-upgrade'
 ---
 

--- a/maintenance/monitor-component-metrics.md
+++ b/maintenance/monitor-component-metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Monitor Calico component metrics
+description: Use open source Prometheus for monitoring and alerting on Calico components.
 ---
 
 ### Big picture

--- a/maintenance/openstack-upgrade.md
+++ b/maintenance/openstack-upgrade.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading Calico on OpenStack
+description: Upgrade to a newer version of Calico for OpenStack.
 canonical_url: '/maintenance/openstack-upgrade'
 ---
 

--- a/maintenance/troubleshooting.md
+++ b/maintenance/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: View logs and diagnostics, common issues, and where to report issues in github.
 canonical_url: '/maintenance/troubleshooting'
 ---
 

--- a/maintenance/upgrading.md
+++ b/maintenance/upgrading.md
@@ -1,5 +1,6 @@
 ---
 title: Upgrading
+description: Upgrade Calico to a newer version for your orchestrator. 
 show_read_time: false
 show_toc: false
 canonical_url: '/maintenance/upgrading'

--- a/maintenance/upgrading.md
+++ b/maintenance/upgrading.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading
-description: Upgrade Calico to a newer version. 
+description: Upgrade to a newer version of Calico. 
 show_read_time: false
 show_toc: false
 canonical_url: '/maintenance/upgrading'

--- a/maintenance/upgrading.md
+++ b/maintenance/upgrading.md
@@ -1,10 +1,10 @@
 ---
 title: Upgrading
-description: Upgrade Calico to a newer version for your orchestrator. 
+description: Upgrade Calico to a newer version. 
 show_read_time: false
 show_toc: false
 canonical_url: '/maintenance/upgrading'
 ---
-
+{{ page.description }}
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/networking/add-floating-ip.md
+++ b/networking/add-floating-ip.md
@@ -1,6 +1,6 @@
 ---
 title: Add a floating IP to a pod
-Description: Configure one or more floating IPs to use as additional IP addresses for reaching a Kubernetes pod.
+description: Configure one or more floating IPs to use as additional IP addresses for reaching a Kubernetes pod.
 ---
 
 ### Big picture

--- a/networking/advertise-service-ips.md
+++ b/networking/advertise-service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Advertise Kubernetes service IP addresses
-Description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
 ---
 
 ### Big picture

--- a/networking/assign-ip-addresses-topology.md
+++ b/networking/assign-ip-addresses-topology.md
@@ -1,6 +1,6 @@
 ---
 title: Assign IP addresses based on topology
-Description: Configure Calico to use specific IP pools for different topologies including zone, rack, or region. 
+description: Configure Calico to use specific IP pools for different topologies including zone, rack, or region. 
 canonical_url: '/networking/assign-ip-addresses-topology'
 ---
 

--- a/networking/dual-stack.md
+++ b/networking/dual-stack.md
@@ -1,5 +1,6 @@
 ---
 title: Enable dual stack
+description: Configure Kubernetes pods to get both IPv and IPv6 addresses.
 canonical_url: '/networking/dual-stack'
 ---
 

--- a/networking/enabling-ipvs.md
+++ b/networking/enabling-ipvs.md
@@ -1,6 +1,6 @@
 ---
 title: Enable IPVS in Kubernetes
-description: Use IPVS kube-proxy for load balancing traffic across pods
+description: Use IPVS kube-proxy for load balancing traffic across pods.
 canonical_url: '/networking/enabling-ipvs'
 ---
 

--- a/networking/get-started-ip-addresses.md
+++ b/networking/get-started-ip-addresses.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with IP address management
-Description: Learn all about IPAM, how to configure Calico to use Calico IPAM or host-local IPAM, and when you would want to use one versus the other.
+Description: Configure Calico to use Calico IPAM or host-local IPAM, and when to use one or the other.
 ---
 
 ### Big picture

--- a/networking/get-started-ip-addresses.md
+++ b/networking/get-started-ip-addresses.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with IP address management
-Description: Configure Calico to use Calico IPAM or host-local IPAM, and when to use one or the other.
+description: Configure Calico to use Calico IPAM or host-local IPAM, and when to use one or the other.
 ---
 
 ### Big picture

--- a/networking/ip-autodetection.md
+++ b/networking/ip-autodetection.md
@@ -1,5 +1,6 @@
 ---
 title: Configure IP autodetection
+description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it. 
 ---
 
 ### Big picture

--- a/networking/ipam.md
+++ b/networking/ipam.md
@@ -1,7 +1,7 @@
 ---
 title: IP address management
 canonical_url: '/networking/ipam'
-description: Learn the additional IP allocation flexibility and efficiency of Calico IPAM, how to interoperate with legacy firewalls using IP address ranges, and how to advertise Kubernetes service IPs, and more.
+description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
 show_read_time: false
 show_toc: false
 ---

--- a/networking/ipv6.md
+++ b/networking/ipv6.md
@@ -1,6 +1,6 @@
 ---
 title: Enabling IPv6 support
-Description: Enable IPv6 support for workloads on Kubernetes and OpenStack.
+description: Enable IPv6 support for workloads on Kubernetes and OpenStack.
 canonical_url: '/networking/ipv6'
 ---
 

--- a/networking/legacy-firewalls.md
+++ b/networking/legacy-firewalls.md
@@ -1,7 +1,6 @@
 ---
 title: Interoperate with legacy firewalls using IP ranges
 description: Restrict the IP address chosen for a pod to a specific range of IP addresses
-Description: Restrict a pod to use an address from within a specific range.
 ---
 
 ### Big picture

--- a/networking/migrate-pools.md
+++ b/networking/migrate-pools.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from one IP pool to another
-Description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Migrate pods from one IP pool to another on a running cluster without network disruption.
 ---
 
 ### Big picture

--- a/networking/mtu.md
+++ b/networking/mtu.md
@@ -1,6 +1,6 @@
 ---
 title: Configure MTU to maximize network performance
-Description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
 canonical_url: '/networking/mtu'
 ---
 

--- a/networking/node.md
+++ b/networking/node.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring a node IP address and subnet
-description: Describes how to configure IP autodetection
+description: Configure IP autodetection
 canonical_url: '/networking/node'
 ---
 

--- a/networking/openstack/connectivity.md
+++ b/networking/openstack/connectivity.md
@@ -1,6 +1,6 @@
 ---
 title: IP addressing and connectivity
-description: Set up OpenStack networking for Calico
+description: Set up OpenStack networking for Calico.
 canonical_url: '/networking/openstack/connectivity'
 ---
 

--- a/networking/openstack/dev-machine-setup.md
+++ b/networking/openstack/dev-machine-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Set up a development machine
-Description: Configure Calico networking for OpenStack VMs. 
+description: Configure Calico networking for OpenStack VMs. 
 canonical_url: '/networking/openstack/dev-machine-setup'
 ---
 

--- a/networking/openstack/floating-ips.md
+++ b/networking/openstack/floating-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Floating IPs
-description: Configure floating IP in Calico for OpenStack 
+description: Configure floating IP in Calico for OpenStack. 
 canonical_url: '/networking/openstack/floating-ips'
 ---
 

--- a/networking/openstack/host-routes.md
+++ b/networking/openstack/host-routes.md
@@ -1,6 +1,6 @@
 ---
 title: Host routes
-description: Options for host routing with Calico
+description: Options for host routing with Calico.
 canonical_url: '/networking/openstack/host-routes'
 ---
 

--- a/networking/openstack/index.md
+++ b/networking/openstack/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico networking for OpenStack
+description: Configure Calico networking in an OpenStack deployment.
 show_read_time: false
 show_toc: false
 canonical_url: '/networking/openstack/index'

--- a/networking/openstack/kuryr.md
+++ b/networking/openstack/kuryr.md
@@ -1,6 +1,6 @@
 ---
 title: Kuryr
-description: Use Kuryr with Calico networking
+description: Use Kuryr with Calico networking.
 canonical_url: '/networking/openstack/kuryr'
 ---
 

--- a/networking/openstack/labels.md
+++ b/networking/openstack/labels.md
@@ -1,6 +1,6 @@
 ---
 title: Endpoint labels and operator policy
-description: Use Calico labels to define policy for OpenStack VMs
+description: Use Calico labels to define policy for OpenStack VMs.
 canonical_url: '/networking/openstack/labels'
 ---
 

--- a/networking/openstack/neutron-api.md
+++ b/networking/openstack/neutron-api.md
@@ -1,6 +1,6 @@
 ---
 title: Calico's interpretation of Neutron API calls
-description: Effects of the Neutron API calls on the network
+description: Effects of the Neutron API calls on the network.
 canonical_url: '/networking/openstack/neutron-api'
 ---
 

--- a/networking/openstack/service-ips.md
+++ b/networking/openstack/service-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Service IPs
-description: Use a floating or fixed IP for a Calico-networked VM
+description: Use a floating or fixed IP for a Calico-networked VM.
 canonical_url: '/networking/openstack/service-ips'
 ---
 

--- a/networking/sidecar-acceleration.md
+++ b/networking/sidecar-acceleration.md
@@ -1,6 +1,6 @@
 ---
 title: Accelerate Istio network performance
-Description: Use Calico to accelerate network performance of routing network traffic using Istio Envoy sidecar using eBPF.
+description: Use Calico to accelerate network performance of routing network traffic using Istio Envoy sidecar using eBPF.
 ---
 
 ### Big picture

--- a/networking/use-ipvs.md
+++ b/networking/use-ipvs.md
@@ -1,6 +1,6 @@
 ---
 title: Use IPVS kube-proxy
-description: Use IPVS kube-proxy for performance improvements 
+description: Use IPVS kube-proxy for performance improvements. 
 canonical_url: '/networking/use-ipvs'
 ---
 

--- a/networking/use-specific-ip.md
+++ b/networking/use-specific-ip.md
@@ -1,6 +1,6 @@
 ---
 title: Use a specific IP address with a pod
-Description: Specify the IP address for a pod instead of allowing Calico to choose automatically.
+Description: Specify the IP address for a pod instead of allowing Calico to automatically choose one.
 ---
 
 ### Big picture

--- a/networking/use-specific-ip.md
+++ b/networking/use-specific-ip.md
@@ -1,6 +1,6 @@
 ---
 title: Use a specific IP address with a pod
-Description: Specify the IP address for a pod instead of allowing Calico to automatically choose one.
+description: Specify the IP address for a pod instead of allowing Calico to automatically choose one.
 ---
 
 ### Big picture

--- a/networking/vxlan-ipip.md
+++ b/networking/vxlan-ipip.md
@@ -1,6 +1,6 @@
 ---
 title: Overlay networking
-Description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
 ---
 
 ### Big picture

--- a/networking/vxlan-ipip.md
+++ b/networking/vxlan-ipip.md
@@ -1,5 +1,5 @@
 ---
-title: Connect workloads across networks that you do not control
+title: Overlay networking
 Description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
 ---
 

--- a/reference/architecture/data-path.md
+++ b/reference/architecture/data-path.md
@@ -1,5 +1,6 @@
 ---
-title: 'The Calico data path: IP routing and iptables'
+title: The Calico data path: IP routing and iptables
+description: Learn how packets flow between workloads in a datacenter, or between a workload and the internet.
 canonical_url: '/reference/architecture/data-path'
 ---
 

--- a/reference/architecture/data-path.md
+++ b/reference/architecture/data-path.md
@@ -1,5 +1,5 @@
 ---
-title: The Calico data path: IP routing and iptables
+title: 'The Calico data path: IP routing and iptables'
 description: Learn how packets flow between workloads in a datacenter, or between a workload and the internet.
 canonical_url: '/reference/architecture/data-path'
 ---

--- a/reference/architecture/design/index.md
+++ b/reference/architecture/design/index.md
@@ -1,5 +1,6 @@
 ---
 title: Network design
+description: Deep dive into using Calico over Ethernet and IP fabrics.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/architecture/design/l2-interconnect-fabric.md
+++ b/reference/architecture/design/l2-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: Calico over Ethernet fabrics
+description: Understand the interconnect fabric options in a Calico network. 
 canonical_url: '/reference/architecture/design/l2-interconnect-fabric'
 ---
 

--- a/reference/architecture/design/l3-interconnect-fabric.md
+++ b/reference/architecture/design/l3-interconnect-fabric.md
@@ -1,5 +1,6 @@
 ---
 title: Calico over IP fabrics
+description: Understand considerations for implementing interconnect fabrics with Calico.
 canonical_url: '/reference/architecture/design/l3-interconnect-fabric'
 ---
 

--- a/reference/architecture/index.md
+++ b/reference/architecture/index.md
@@ -1,5 +1,6 @@
 ---
 title: Architecture
+description: Understand Calico components, network design, and the data path between workloads.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/architecture/overview.md
+++ b/reference/architecture/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Calico architecture
-description: Understand the Calico components and the basics of BGP networking
+description: Understand the Calico components and the basics of BGP networking.
 canonical_url: '/reference/architecture/index'
 ---
 

--- a/reference/calicoctl/apply.md
+++ b/reference/calicoctl/apply.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl apply
+description: Command to apply a policy. 
 canonical_url: '/reference/calicoctl/apply'
 ---
 

--- a/reference/calicoctl/convert.md
+++ b/reference/calicoctl/convert.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl convert
+description: Command to convert contents of policy.yaml to v3 policy.
 canonical_url: '/reference/calicoctl/convert'
 ---
 

--- a/reference/calicoctl/create.md
+++ b/reference/calicoctl/create.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl create
+description: Command to create a policy. 
 canonical_url: '/reference/calicoctl/create'
 ---
 

--- a/reference/calicoctl/delete.md
+++ b/reference/calicoctl/delete.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl delete
+description: Command to delete a policy.
 canonical_url: '/reference/calicoctl/delete'
 ---
 

--- a/reference/calicoctl/get.md
+++ b/reference/calicoctl/get.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl get
+description: Command to list policies in the default output format.
 canonical_url: '/reference/calicoctl/get'
 ---
 

--- a/reference/calicoctl/index.md
+++ b/reference/calicoctl/index.md
@@ -1,5 +1,6 @@
 ---
 show_read_time: false
+description: Command line interface (CLI) for Calico.
 show_toc: false
 ---
 

--- a/reference/calicoctl/index.md
+++ b/reference/calicoctl/index.md
@@ -1,6 +1,6 @@
 ---
 show_read_time: false
-description: Command line interface (CLI) for Calico.
+description: Command line interface (CLI) to manage Calico resources.
 show_toc: false
 ---
 

--- a/reference/calicoctl/ipam/index.md
+++ b/reference/calicoctl/ipam/index.md
@@ -1,4 +1,5 @@
 ---
+description: calicoctl IPAM commands for Calico-assigned IP addresses.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/calicoctl/ipam/release.md
+++ b/reference/calicoctl/ipam/release.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+description: Command to release an IP address from Calico IP management.
 canonical_url: '/reference/calicoctl/ipam/release'
 ---
 

--- a/reference/calicoctl/ipam/show.md
+++ b/reference/calicoctl/ipam/show.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl ipam
+description: Command to see if IP address is being used.
 canonical_url: '/reference/calicoctl/ipam/show'
 ---
 

--- a/reference/calicoctl/label.md
+++ b/reference/calicoctl/label.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl label
+description: Command to change labels for workload endpoints or nodes. 
 canonical_url: '/reference/calicoctl/label'
 ---
 

--- a/reference/calicoctl/node/checksystem.md
+++ b/reference/calicoctl/node/checksystem.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node checksystem
+description: Command to check compatibility of host to run a Calico node instance.
 canonical_url: '/reference/calicoctl/node/checksystem'
 ---
 

--- a/reference/calicoctl/node/diags.md
+++ b/reference/calicoctl/node/diags.md
@@ -1,6 +1,6 @@
 ---
 title: calicoctl node diags
-decription: Command to get diagnostics from a Calico node.
+description: Command to get diagnostics from a Calico node.
 canonical_url: '/reference/calicoctl/node/diags'
 ---
 

--- a/reference/calicoctl/node/diags.md
+++ b/reference/calicoctl/node/diags.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node diags
+decription: Command to get diagnostics from a Calico node.
 canonical_url: '/reference/calicoctl/node/diags'
 ---
 

--- a/reference/calicoctl/node/index.md
+++ b/reference/calicoctl/node/index.md
@@ -1,4 +1,5 @@
 ---
+description: calicoctl node commands.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/calicoctl/node/overview.md
+++ b/reference/calicoctl/node/overview.md
@@ -1,6 +1,6 @@
 ---
 title: calicoctl node
-description: Commands for calicoctl node 
+description: Commands for calicoctl node. 
 canonical_url: '/reference/calicoctl/node/index'
 ---
 

--- a/reference/calicoctl/node/run.md
+++ b/reference/calicoctl/node/run.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node run
+description: Command and options for running a Calico node.
 canonical_url: '/reference/calicoctl/node/run'
 ---
 

--- a/reference/calicoctl/node/status.md
+++ b/reference/calicoctl/node/status.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl node status
+description: Command to check status of a Calico node instance.
 canonical_url: '/reference/calicoctl/node/status'
 ---
 

--- a/reference/calicoctl/patch.md
+++ b/reference/calicoctl/patch.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl patch
+description: Command to update a node with a patch. 
 canonical_url: '/reference/calicoctl/patch'
 ---
 

--- a/reference/calicoctl/replace.md
+++ b/reference/calicoctl/replace.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl replace
+description: Command to replace an existing policy with a different one.
 canonical_url: '/reference/calicoctl/replace'
 ---
 

--- a/reference/calicoctl/version.md
+++ b/reference/calicoctl/version.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl version
+description: Command to display the calicoctl CLI version. 
 canonical_url: '/reference/calicoctl/version'
 ---
 

--- a/reference/cni-plugin/configuration.md
+++ b/reference/cni-plugin/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico CNI plugins
+description: Details for configuring the Calico CNI plugins.  
 canonical_url: '/reference/cni-plugin/configuration'
 ---
 

--- a/reference/dikastes/configuration.md
+++ b/reference/dikastes/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Dikastes
+description: Details on configuring Dikastes used in application layer policy. 
 canonical_url: '/reference/dikastes/configuration'
 ---
 

--- a/reference/etcd-rbac/calico-etcdv3-paths.md
+++ b/reference/etcd-rbac/calico-etcdv3-paths.md
@@ -1,5 +1,6 @@
 ---
 title: Calico key and path prefixes
+description: Prefixes to configure Calico components to access the etcd datastore. 
 canonical_url: '/reference/etcd-rbac/calico-etcdv3-paths'
 ---
 

--- a/reference/etcd-rbac/certificate-generation.md
+++ b/reference/etcd-rbac/certificate-generation.md
@@ -1,5 +1,6 @@
 ---
 title: Generating certificates
+description: Generate Certificates of Authority (CA) to authenticate users with etcd datastore.
 canonical_url: '/reference/etcd-rbac/certificate-generation'
 ---
 

--- a/reference/etcd-rbac/index.md
+++ b/reference/etcd-rbac/index.md
@@ -1,4 +1,5 @@
 ---
+description: Tasks for protecting your etcd datastore.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/etcd-rbac/kubernetes-advanced.md
+++ b/reference/etcd-rbac/kubernetes-advanced.md
@@ -1,5 +1,6 @@
 ---
 title: Segmenting etcd on Kubernetes (advanced)
+description: Limit user access to Calico components or calicoctl.
 canonical_url: '/reference/etcd-rbac/kubernetes-advanced'
 ---
 

--- a/reference/etcd-rbac/kubernetes.md
+++ b/reference/etcd-rbac/kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Segmenting etcd on Kubernetes (basic)
+description: Limit user access to Kubernetes and Calico components.
 canonical_url: '/reference/etcd-rbac/kubernetes'
 ---
 

--- a/reference/etcd-rbac/users-and-roles.md
+++ b/reference/etcd-rbac/users-and-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Creating users and roles
+description: Provide role-based access control to etcd datastore.
 canonical_url: '/reference/etcd-rbac/users-and-roles'
 ---
 

--- a/reference/faq.md
+++ b/reference/faq.md
@@ -1,5 +1,6 @@
 ---
 title: Frequently asked questions
+description: Common questions that users ask about Calico.
 canonical_url: '/reference/faq'
 ---
 

--- a/reference/felix/configuration.md
+++ b/reference/felix/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Felix
+description: Configure Felix, the daemon that runs on every machine the provide endpoints.
 canonical_url: '/reference/felix/configuration'
 ---
 

--- a/reference/felix/index.md
+++ b/reference/felix/index.md
@@ -1,5 +1,6 @@
 ---
 title: Felix
+description: Felix is a Calico component that runs on every machine that provides endpoints. 
 show_read_time: false
 show_toc: false
 canonical_url: '/reference/felix/index'

--- a/reference/felix/index.md
+++ b/reference/felix/index.md
@@ -5,5 +5,6 @@ show_read_time: false
 show_toc: false
 canonical_url: '/reference/felix/index'
 ---
+{{ page.description }}
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/reference/felix/prometheus.md
+++ b/reference/felix/prometheus.md
@@ -1,5 +1,6 @@
 ---
 title: Prometheus statistics
+description: Review metrics for the Felix component if you are using Prometheus. 
 canonical_url: '/reference/felix/prometheus'
 ---
 

--- a/reference/host-endpoints/connectivity.md
+++ b/reference/host-endpoints/connectivity.md
@@ -1,5 +1,6 @@
 ---
 title: Creating policy for basic connectivity
+description: Customize the Calico failsafe policy to protect host endpoints.
 canonical_url: '/reference/host-endpoints/connectivity'
 ---
 

--- a/reference/host-endpoints/conntrack.md
+++ b/reference/host-endpoints/conntrack.md
@@ -1,5 +1,6 @@
 ---
 title: Connection tracking
+description: Workaround for Linux conntrack if Calico policy is not working as it should.
 canonical_url: '/reference/host-endpoints/conntrack'
 ---
 

--- a/reference/host-endpoints/failsafe.md
+++ b/reference/host-endpoints/failsafe.md
@@ -1,5 +1,6 @@
 ---
 title: Failsafe rules
+description: Avoid cutting off connectivity to hosts because of incorrect network policies. 
 canonical_url: '/reference/host-endpoints/failsafe'
 ---
 

--- a/reference/host-endpoints/forwarded.md
+++ b/reference/host-endpoints/forwarded.md
@@ -1,5 +1,6 @@
 ---
 title: Apply on forwarded traffic
+description: Learn the subtleties using the applyOnForward option in host endpoint policies.
 canonical_url: '/reference/host-endpoints/forwarded'
 ---
 

--- a/reference/host-endpoints/index.md
+++ b/reference/host-endpoints/index.md
@@ -1,4 +1,5 @@
 ---
+description: Protect host endpoints with Calico network policy.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/host-endpoints/objects.md
+++ b/reference/host-endpoints/objects.md
@@ -1,5 +1,6 @@
 ---
 title: Creating host endpoint objects
+description: To protect a host interface, start by creating a host endpoint object in etcd. 
 canonical_url: '/reference/host-endpoints/objects'
 ---
 

--- a/reference/host-endpoints/overview.md
+++ b/reference/host-endpoints/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Host endpoints
-description: Secure the network interfaces of hosts 
+description: Secure host network interfaces. 
 canonical_url: '/reference/host-endpoints/index'
 ---
 

--- a/reference/host-endpoints/pre-dnat.md
+++ b/reference/host-endpoints/pre-dnat.md
@@ -1,5 +1,6 @@
 ---
 title: Pre-DNAT policy
+description: Apply rules in a host endpoint policy before any DNAT.
 canonical_url: '/reference/host-endpoints/pre-dnat'
 ---
 

--- a/reference/host-endpoints/selector.md
+++ b/reference/host-endpoints/selector.md
@@ -1,5 +1,6 @@
 ---
 title: Selector-based policies
+description: Apply ordered policies to endpoints that match specific label selectors.
 canonical_url: '/reference/host-endpoints/selector'
 ---
 

--- a/reference/host-endpoints/summary.md
+++ b/reference/host-endpoints/summary.md
@@ -1,5 +1,6 @@
 ---
 title: Summary
+description: How different host endpoint rules affect packet flows. 
 canonical_url: '/reference/host-endpoints/summary'
 ---
 

--- a/reference/index.md
+++ b/reference/index.md
@@ -1,6 +1,6 @@
 ---
 title: Reference
-description: APIs, CLI, architecture and design, and FAQ
+description: APIs, CLI, architecture and design, and FAQ.
 canonical_url: '/reference/index'
 show_read_time: false
 show_toc: false

--- a/reference/involved.md
+++ b/reference/involved.md
@@ -1,5 +1,6 @@
 ---
 title: Getting involved
+description: Contribute to Calico open source project.
 canonical_url: '/reference/involved'
 ---
 

--- a/reference/kube-controllers/configuration.md
+++ b/reference/kube-controllers/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring the Calico Kubernetes controllers
+description: Calico Kubernetes controllers monitor the Kubernetes API and perform actions based on cluster state.
 ---
 
 The {{site.prodname}} Kubernetes controllers are deployed in a Kubernetes cluster. The different controllers monitor the Kubernetes API

--- a/reference/legal/alp.md
+++ b/reference/legal/alp.md
@@ -1,5 +1,6 @@
 ---
 title: Application layer policy attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/alp'
 ---
 

--- a/reference/legal/calicoctl.md
+++ b/reference/legal/calicoctl.md
@@ -1,5 +1,6 @@
 ---
 title: calicoctl attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/calicoctl'
 ---
 

--- a/reference/legal/cni.md
+++ b/reference/legal/cni.md
@@ -1,5 +1,6 @@
 ---
 title: CNI plugin attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/cni'
 ---
 

--- a/reference/legal/confd.md
+++ b/reference/legal/confd.md
@@ -1,5 +1,6 @@
 ---
 title: confd attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/confd'
 ---
 

--- a/reference/legal/felix.md
+++ b/reference/legal/felix.md
@@ -1,5 +1,6 @@
 ---
 title: Felix attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/felix'
 ---
 

--- a/reference/legal/index.md
+++ b/reference/legal/index.md
@@ -1,5 +1,6 @@
 ---
 title: Attributions
+description: Third-party attributions.
 show_read_time: false
 show_toc: false
 canonical_url: '/reference/legal/index'

--- a/reference/legal/kube-controllers.md
+++ b/reference/legal/kube-controllers.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes controllers attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/kube-controllers'
 ---
 

--- a/reference/legal/node.md
+++ b/reference/legal/node.md
@@ -1,5 +1,6 @@
 ---
 title: calico/node attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/node'
 ---
 

--- a/reference/legal/typha.md
+++ b/reference/legal/typha.md
@@ -1,5 +1,6 @@
 ---
 title: Typha attributions
+description: Dependencies and licenses.
 canonical_url: '/reference/legal/typha'
 ---
 

--- a/reference/node/configuration.md
+++ b/reference/node/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring calico/node
+description: Customize calico/node using environment variables.
 canonical_url: '/reference/node/configuration'
 ---
 

--- a/reference/public-cloud/aws.md
+++ b/reference/public-cloud/aws.md
@@ -1,5 +1,6 @@
 ---
 title: Amazon Web Services
+description: Advantages of using Calico in AWS.
 canonical_url: '/reference/public-cloud/aws'
 ---
 

--- a/reference/public-cloud/azure.md
+++ b/reference/public-cloud/azure.md
@@ -1,5 +1,6 @@
 ---
 title: Azure
+description: Support for Calico in Azure.
 canonical_url: '/reference/public-cloud/azure'
 ---
 

--- a/reference/public-cloud/gce.md
+++ b/reference/public-cloud/gce.md
@@ -1,5 +1,6 @@
 ---
 title: Google Compute Engine
+description: Methods to ensure that traffic between containers on different hosts is not dropped by GCE fabric. 
 canonical_url: '/reference/public-cloud/gce'
 ---
 

--- a/reference/public-cloud/ibm.md
+++ b/reference/public-cloud/ibm.md
@@ -1,5 +1,6 @@
 ---
 title: IBM Cloud
+description: Calico integration with IBM Cloud.
 canonical_url: '/reference/public-cloud/ibm'
 ---
 

--- a/reference/public-cloud/index.md
+++ b/reference/public-cloud/index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration on public clouds
-description: How Calico is integrated in the various public cloud providers.
+description: Tips for configuring Calico in a public cloud provider.
 show_read_time: false
 show_toc: false
 canonical_url: '/reference/public-cloud/index'

--- a/reference/public-cloud/index.md
+++ b/reference/public-cloud/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration on public clouds
+description: How Calico is integrated in the various public cloud providers.
 show_read_time: false
 show_toc: false
 canonical_url: '/reference/public-cloud/index'

--- a/reference/public-cloud/index.md
+++ b/reference/public-cloud/index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration on public clouds
-description: Tips for configuring Calico in a public cloud provider.
+description: Tips for configuring Calico in your public cloud provider.
 show_read_time: false
 show_toc: false
 canonical_url: '/reference/public-cloud/index'

--- a/reference/public-cloud/index.md
+++ b/reference/public-cloud/index.md
@@ -5,6 +5,6 @@ show_read_time: false
 show_toc: false
 canonical_url: '/reference/public-cloud/index'
 ---
-
+{{ page.description }}
 {% capture content %}{% include index.html %}{% endcapture %}
 {{ content | replace: "    ", "" }}

--- a/reference/resources/bgpconfig.md
+++ b/reference/resources/bgpconfig.md
@@ -1,5 +1,6 @@
 ---
 title: BGP configuration
+description: API for this Calico resource.
 canonical_url: '/reference/resources/bgpconfig'
 ---
 

--- a/reference/resources/bgppeer.md
+++ b/reference/resources/bgppeer.md
@@ -1,5 +1,6 @@
 ---
 title: BGP peer
+description: API for this Calico resource.
 canonical_url: '/reference/resources/bgppeer'
 ---
 

--- a/reference/resources/felixconfig.md
+++ b/reference/resources/felixconfig.md
@@ -1,5 +1,6 @@
 ---
 title: Felix configuration
+description: API for this Calico resource.
 canonical_url: '/reference/resources/felixconfig'
 ---
 

--- a/reference/resources/globalnetworkpolicy.md
+++ b/reference/resources/globalnetworkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Global network policy
+description: API for this Calico resource.
 canonical_url: '/reference/resources/globalnetworkpolicy'
 ---
 

--- a/reference/resources/globalnetworkset.md
+++ b/reference/resources/globalnetworkset.md
@@ -1,5 +1,6 @@
 ---
 title: Global network set
+description: API for this Calico resource.
 canonical_url: '/reference/resources/globalnetworkset'
 ---
 

--- a/reference/resources/hostendpoint.md
+++ b/reference/resources/hostendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Host endpoint
+description: API for this Calico resource.
 canonical_url: '/reference/resources/hostendpoint'
 ---
 

--- a/reference/resources/index.md
+++ b/reference/resources/index.md
@@ -1,5 +1,5 @@
 ---
-descriptions: APIs for all Calico networking and network policy resources. 
+description: APIs for all Calico networking and network policy resources. 
 show_read_time: false
 show_toc: false
 ---

--- a/reference/resources/index.md
+++ b/reference/resources/index.md
@@ -1,4 +1,5 @@
 ---
+descriptions: APIs for all Calico networking and network policy resources. 
 show_read_time: false
 show_toc: false
 ---

--- a/reference/resources/ippool.md
+++ b/reference/resources/ippool.md
@@ -1,5 +1,6 @@
 ---
 title: IP pool
+description: API for this Calico resource.
 canonical_url: '/reference/resources/ippool'
 ---
 

--- a/reference/resources/networkpolicy.md
+++ b/reference/resources/networkpolicy.md
@@ -1,5 +1,6 @@
 ---
 title: Network policy
+description: API for this Calico resource.
 canonical_url: '/reference/resources/networkpolicy'
 ---
 

--- a/reference/resources/networkset.md
+++ b/reference/resources/networkset.md
@@ -1,5 +1,6 @@
 ---
 title: Network set
+description: API for this Calico resource.
 canonical_url: '/reference/resources/networkset'
 ---
 

--- a/reference/resources/node.md
+++ b/reference/resources/node.md
@@ -1,5 +1,6 @@
 ---
 title: Node
+description: API for this Calico resource.
 canonical_url: '/reference/resources/node'
 ---
 

--- a/reference/resources/overview.md
+++ b/reference/resources/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Resource definitions
-description: Calico resources (APIs) that you can manage using calicoctl
+description: Calico resources (APIs) that you can manage using calicoctl.
 canonical_url: '/reference/resources/index'
 ---
 

--- a/reference/resources/profile.md
+++ b/reference/resources/profile.md
@@ -1,5 +1,6 @@
 ---
 title: Profile
+description: API for this Calico resource.
 canonical_url: '/reference/resources/profile'
 ---
 

--- a/reference/resources/workloadendpoint.md
+++ b/reference/resources/workloadendpoint.md
@@ -1,5 +1,6 @@
 ---
 title: Workload endpoint
+description: API for this Calico resource.
 canonical_url: '/reference/resources/workloadendpoint'
 ---
 

--- a/reference/typha/configuration.md
+++ b/reference/typha/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Typha
+description: Configure Typha for scaling Kubernetes API datastore (kdd).
 canonical_url: '/reference/typha/configuration'
 ---
 

--- a/reference/typha/index.md
+++ b/reference/typha/index.md
@@ -1,4 +1,5 @@
 ---
+title: Typha
 description: Typha is the component for scaling Kubernetes deployments.
 show_read_time: false
 show_toc: false

--- a/reference/typha/index.md
+++ b/reference/typha/index.md
@@ -1,4 +1,5 @@
 ---
+description: The Typha component used by Calico for scaling deployments.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/typha/index.md
+++ b/reference/typha/index.md
@@ -1,5 +1,5 @@
 ---
-description: The Typha component used by Calico for scaling deployments.
+description: Typha is the component for scaling Kubernetes deployments.
 show_read_time: false
 show_toc: false
 ---

--- a/reference/typha/overview.md
+++ b/reference/typha/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Typha overview
-description: Use the Calico Typha daemon to increase scale and reduce impact on the datastore
+description: Use the Calico Typha daemon to increase scale and reduce impact on the datastore.
 canonical_url: '/reference/typha/index'
 ---
 

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -6,7 +6,8 @@ canonical_url: '/release-notes/index'
 
 The following table shows component versioning for {{site.prodname}}  **{{ page.version }}**.
 
-Use the version selector at the top-right of this page to view a different release.
+
+To select a different version, click **Releases** in the top-right navigation bar.
 
 {% for release in site.data.versions %}
 ## {{ release.title }}

--- a/security/calico-enterprise/index.md
+++ b/security/calico-enterprise/index.md
@@ -1,6 +1,6 @@
 ---
 title: Calico Enterprise
-description: Learn about features in our commercial product, Calico Enterprise. 
+description: Learn about value-added features in our commercial product, Calico Enterprise. 
 show_read_time: false
 show_toc: false
 ---

--- a/security/calico-enterprise/index.md
+++ b/security/calico-enterprise/index.md
@@ -1,5 +1,6 @@
 ---
 title: Calico Enterprise
+description: Learn about features in our commercial product, Calico Enterprise. 
 show_read_time: false
 show_toc: false
 ---

--- a/security/calico-policy.md
+++ b/security/calico-policy.md
@@ -1,5 +1,5 @@
 ---
-description: Calico network policy go way beyond the basic Kubernetes network policy by securing both pods and hosts.
+description: Calico network policy lets you secure both workloads and hosts.
 show_read_time: false
 show_toc: false
 ---

--- a/security/calico-policy.md
+++ b/security/calico-policy.md
@@ -1,4 +1,5 @@
 ---
+description: Calico network policy go way beyond the basic Kubernetes network policy by securing both pods and hosts.
 show_read_time: false
 show_toc: false
 ---

--- a/security/comms/crypto-auth.md
+++ b/security/comms/crypto-auth.md
@@ -1,6 +1,6 @@
 ---
 title: Configure encryption and authentication
-description: Learn how to enable TLS authentication and encryption for various Calico omponents
+description: Enable TLS authentication and encryption for various Calico components.
 canonical_url: '/security/comms/crypto-auth'
 ---
 

--- a/security/comms/index.md
+++ b/security/comms/index.md
@@ -1,5 +1,6 @@
 ---
 title: Secure Calico component communications
+description: Secure communications for Calico components.
 canonical_url: '/security/comms/index'
 show_read_time: false
 show_toc: false

--- a/security/comms/reduce-nodes.md
+++ b/security/comms/reduce-nodes.md
@@ -1,6 +1,6 @@
 ---
 title: Schedule to well-known nodes
-description: configure the Calico Typha TCP port.
+description: Configure the Calico Typha TCP port.
 canonical_url: '/security/comms/reduce-nodes'
 ---
 

--- a/security/comms/reduce-nodes.md
+++ b/security/comms/reduce-nodes.md
@@ -1,6 +1,6 @@
 ---
 title: Schedule to well-known nodes
-description: Learn how to configure the Calico Typha TCP port.
+description: configure the Calico Typha TCP port.
 canonical_url: '/security/comms/reduce-nodes'
 ---
 

--- a/security/comms/secure-metrics.md
+++ b/security/comms/secure-metrics.md
@@ -1,6 +1,6 @@
 ---
 title: Secure Calico Prometheus endpoints
-description: Describes how to limit access to Calico metric endpoints
+description: Limit access to Calico metric endpoints using network policy.
 canonical_url: '/security/comms/secure-metrics'
 ---
 

--- a/security/extreme-traffic.md
+++ b/security/extreme-traffic.md
@@ -1,6 +1,6 @@
 ---
 title: Policy for extreme traffic
-description: Calico network policy early in the Linux packet processing pipeline to avoid DoS attacks, and selectively bypass Linux conntrack for extremely large number of connections.
+description: Use Calico network policy early in the Linux packet processing pipeline to avoid DoS attacks, and selectively bypass Linux conntrack for extremely large number of connections.
 show_read_time: false
 show_toc: false
 ---

--- a/security/extreme-traffic.md
+++ b/security/extreme-traffic.md
@@ -1,6 +1,6 @@
 ---
 title: Policy for extreme traffic
-description: Use Calico network policy early in the Linux packet processing pipeline to avoid DoS attacks, and selectively bypass Linux conntrack for extremely large number of connections.
+description: Use Calico network policy early in the Linux packet processing pipeline to handle extreme traffic scenarios.
 show_read_time: false
 show_toc: false
 ---

--- a/security/get-started.md
+++ b/security/get-started.md
@@ -1,6 +1,6 @@
 ---
 title: Get started
-description: If you are new to Kubernetes, start with "Kubernetes policy" and learn the basics of enforcing policy for workloads. Otherwise, dive in and create more powerful policies using Calico policy. The good news is, Kubernetes and Calico policies are very similar -- so you can easily manage both types.
+description: If you are new to Kubernetes, start with "Kubernetes policy" and learn the basics of enforcing policy for pod traffic. Otherwise, dive in and create more powerful policies with Calico policy. The good news is, Kubernetes and Calico policies are very similar -- so managing both types is easy.
 show_read_time: false
 show_toc: false
 ---

--- a/security/get-started.md
+++ b/security/get-started.md
@@ -1,6 +1,6 @@
 ---
 title: Get started
-description: If you are new to Kubernetes, start with "Kubernetes policy" to learn basic security policy concepts. Otherwise, dive in and create more powerful policies using Calico policy. There's no long learning curve for Calico network policy...it is very similar to Kubernetes network policy.
+description: If you are new to Kubernetes, start with "Kubernetes policy" and learn the basics of enforcing policy for workloads. Otherwise, dive in and create more powerful policies using Calico policy. The good news is, Kubernetes and Calico policies are very similar -- so you can easily manage both types.
 show_read_time: false
 show_toc: false
 ---

--- a/security/get-started.md
+++ b/security/get-started.md
@@ -1,6 +1,6 @@
 ---
 title: Get started
-description: Understand the similarities and differences between Calico network policy and Kubernetes network policy.
+description: If you are new to Kubernetes, start with "Kubernetes policy" to learn basic security policy concepts. Otherwise, dive in and create more powerful policies using Calico policy. There's no long learning curve for Calico network policy...it is very similar to Kubernetes network policy.
 show_read_time: false
 show_toc: false
 ---

--- a/security/host-forwarded-traffic.md
+++ b/security/host-forwarded-traffic.md
@@ -1,6 +1,6 @@
 ---
 title: Apply policy to forwarded traffic
-description: Learn how to apply Calico network policy to traffic being forward by hosts acting as routers or NAT gateways.
+description: Apply Calico network policy to traffic being forward by hosts acting as routers or NAT gateways.
 ---
 
 ### Big picture

--- a/security/hosts.md
+++ b/security/hosts.md
@@ -1,6 +1,6 @@
 ---
 title: Policy for hosts
-description: Use the same Calico network policy configuration for workloads to restrict traffic between hosts and the outside world. 
+description: Use the same Calico network policy for workloads to restrict traffic between hosts and the outside world. 
 show_read_time: false
 show_toc: false
 ---

--- a/security/index.md
+++ b/security/index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-description: Calico Network Policy and Global Network Policy are key to securing workloads and hosts and adopting a zero trust security model. 
+description: Calico Network Policy and Calico Global Network Policy are the fundamental resources to secure workloads and hosts, and to adopt a zero trust security model. 
 canonical_url: '/security/index'
 show_read_time: false
 show_toc: false

--- a/security/istio.md
+++ b/security/istio.md
@@ -1,6 +1,6 @@
 ---
 title: Policy for Istio
-description: Create standard Calico network policies with application layer specific attributes for Istio service mesh.
+description: Configure the Calico "application layer policy" with application layer-specific attributes for Istio service mesh.
 show_read_time: false
 show_toc: false
 ---

--- a/security/kubernetes-node-ports.md
+++ b/security/kubernetes-node-ports.md
@@ -1,6 +1,6 @@
 ---
 title: Apply policy to Kubernetes node ports
-description: Restrict access to Kubernetes node ports using Calico global network policy. Learn the 4 steps to secure the host, the node ports, and the cluster. 
+description: Restrict access to Kubernetes node ports using Calico global network policy. Follow the steps to secure the host, the node ports, and the cluster. 
 ---
 
 ### Big picture

--- a/security/kubernetes-policy.md
+++ b/security/kubernetes-policy.md
@@ -1,4 +1,5 @@
 ---
+description: Manage your Kubernetes network policies right along side the more powerful Calico network policies.
 show_read_time: false
 show_toc: false
 show_read_time: false

--- a/security/namespace-policy.md
+++ b/security/namespace-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Use namespace in policy
-description: Use namespaces and namespaceSelectors in Calico network policy to group or separate resources. Use network policies to allow or deny traffic to/from pods belonging to specific namespaces.
+description: Use namespaces and namespaceSelectors in Calico network policy to group or separate resources. Use network policies to allow or deny traffic to/from pods that belong to specific namespaces.
 ---
 
 ### Big picture

--- a/security/policy-rules.md
+++ b/security/policy-rules.md
@@ -1,6 +1,6 @@
 ---
 title: Policy rules
-description: Learn to control traffic to/from endpoints using namespaces, service accounts, external IPs or networks, and ICMP ping in Calico network policy rules.
+description: Control traffic to/from endpoints using namespaces, service accounts, external IPs or networks, and ICMP ping using Calico network policy rules.
 show_read_time: false
 show_toc: false
 ---

--- a/security/protect-hosts.md
+++ b/security/protect-hosts.md
@@ -1,6 +1,6 @@
 ---
 title: Protect hosts
-description: Calico network policy can protect not only workloads, but also hosts. Create a Calico network policies to restrict traffic to/from hosts.
+description: Calico network policy not only protects workloads, but also hosts. Create a Calico network policies to restrict traffic to/from hosts.
 ---
 
 ### Big picture

--- a/security/services-cluster-ips.md
+++ b/security/services-cluster-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Apply policy to services exposed externally as cluster IPs
-description: Learn how to expose Kuberenetes service cluster IPs over BGP using Calico and restrict who can access them using Calico network policy.
+description: Expose Kuberenetes service cluster IPs over BGP using Calico, and restrict who can access them using Calico network policy.
 ---
 
 ### Big picture

--- a/security/services.md
+++ b/security/services.md
@@ -1,6 +1,6 @@
 ---
 title: Policy for Kubernetes services
-description: Apply policy to Kubernetes node ports, and to services exposed externally as cluster IPs.
+description: Apply policy to Kubernetes node ports, and to services that are exposed externally as cluster IPs.
 show_read_time: false
 show_toc: false
 ---

--- a/security/tutorials/app-layer-policy/enforce-policy-istio.md
+++ b/security/tutorials/app-layer-policy/enforce-policy-istio.md
@@ -1,6 +1,6 @@
 ---
 title: Enforce network policy using Istio tutorial
-description: Learn how Calico integrates with Istio to provide fine-grained access control using Calico network policies enforced within both the service mesh and network layer.
+description: Learn how Calico integrates with Istio to provide fine-grained access control using Calico network policies enforced within the service mesh and network layer.
 canonical_url: '/security/tutorials/app-layer-policy/enforce-policy-istio'
 ---
 

--- a/security/tutorials/kubernetes-policy-demo/kubernetes-demo.md
+++ b/security/tutorials/kubernetes-policy-demo/kubernetes-demo.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes policy, demo
-description: See how applying Kubernetes policy allows and denies connections in this visual demo. 
+description: An interactive demo that visually show how applying Kubernetes policy allows and denies connections. 
 canonical_url: '/security/tutorials/kubernetes-policy-demo/kubernetes-demo'
 ---
 The included demo sets up a frontend and backend service, as well as a client service, all


### PR DESCRIPTION
- Deleted "Integration Guide" in TOC/Get Started per Casey (this doc is replaced by Calico the hardway). It is confusing to leave it there, and I could make a description for it that made any sense.

- Fixed title in Networking that had a PR, but PR got lost in the shuffle and never merged new title: "Configure overlay networking" (old title: "Connect workloads across networks that you do not control")

