### PR TITLE
Correct command to wait for pods

### DIFF
--- a/getting-started/kubernetes/quickstart.md
+++ b/getting-started/kubernetes/quickstart.md
@@ -102,7 +102,7 @@ To deploy a cluster suitable for production, refer to [Installation](installatio
 1. Confirm that all of the pods are running with the following command.
 
    ```
-   watch kubectl get pods --all-namespaces
+   kubectl get pods --all-namespaces --watch
    ```
 
    Wait until each pod has the `STATUS` of `Running`.


### PR DESCRIPTION
Changed  `watch kubectl get pods --all-namespaces` to `kubectl get pods --all-namespaces --watch`

## Description

This is a documentation fix. The merge would create more accurate documentation, but the change is minor.