### PR TITLE
clean up makefile targets for charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ _site build: bin/helm
 
 ## Clean enough that a new release build will be clean
 clean:
-	rm -rf _output _site .jekyll-metadata pinned_versions.yaml
+	rm -rf _output _site .jekyll-metadata pinned_versions.yaml _includes/charts/*/values.yaml
 
 ########################################################################################################################
 # Builds locally checked out code using local versions of libcalico, felix, and confd.
@@ -458,12 +458,12 @@ bin/helm:
 	mv $(TMP)/linux-amd64/helm bin/helm
 
 .PHONY: values.yaml
-values.yaml: values.yaml/calico values.yaml/tigera-operator
-values.yaml/%:
+values.yaml: _includes/charts/calico/values.yaml _includes/charts/tigera-operator/values.yaml
+_includes/charts/%/values.yaml:
 	docker run --rm \
 	  -v $$PWD:/calico \
 	  -w /calico \
-	  ruby:2.5 ruby ./hack/gen_values_yml.rb --chart $(@F) > _includes/charts/$(@F)/values.yaml
+	  ruby:2.5 ruby ./hack/gen_values_yml.rb --chart $* > $@
 
 ## Create the vendor directory
 vendor: glide.yaml


### PR DESCRIPTION
## Description

Small cleanup of makefile targets I'd been meaning to do.

Makefile targets should just be the actual path to the file whenever possible. doing `$CHART/versions.yml` is better than `versions.yml/$CHART`

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
