### PR TITLE
fix sitemap

### DIFF
--- a/netlify/build.sh
+++ b/netlify/build.sh
@@ -64,11 +64,15 @@ build_master
 
 echo "[INFO] building archives"
 build_archives
+mv _site/sitemap.xml _site/release-legacy-sitemap.xml
 
 echo "[INFO] building current release"
 EXTRA_CONFIG=$(pwd)/netlify/_config_latest.yml build release-$CURRENT_RELEASE
+mv _site/sitemap.xml _site/latest-sitemap.xml
 
 if [ ! -z "$CANDIDATE_RELEASE" ]; then
     echo "[INFO] building candidate release"
     build release-$CANDIDATE_RELEASE /$CANDIDATE_RELEASE
 fi
+
+mv _netlify/sitemap-index.xml _site/sitemap.xml

--- a/netlify/sitemap-index.xml
+++ b/netlify/sitemap-index.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://docs.projectcalico.org/release-legacy-sitemap.xml</loc></sitemap>
+  <sitemap><loc>https://docs.projectcalico.org/latest-sitemap.xml</loc></sitemap>
+  <sitemap><loc>https://docs.projectcalico.org/master/sitemap.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
use a sitemap index to point to other sitemaps. This isn't a permanent
solution, but should suffice temporarily. 

A permanent solution would dynamically generate the index sitemap.xml.

Also note that unfortunately, the jekyll-sitemap plugin does not let you specify the name of the generated
sitemap file so we use a few 'mv' commands to get everything in place.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
