### PR TITLE
update to newer yq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PACKAGE_NAME?=github.com/projectcalico/calico
 
 # Determine whether there's a local yaml installed or use dockerized version.
 # Note in order to install local (faster) yaml: "go get github.com/mikefarah/yq.v2"
-YAML_CMD:=$(shell which yq.v2 || echo docker run --rm -i calico/yaml)
+YAML_CMD:=$(shell which yq.v2 || echo docker run --rm -i mikefarah/yq:2.4.2 yq)
 
 # Local directories to ignore when running htmlproofer
 HP_IGNORE_LOCAL_DIRS="/v1.5/,/v1.6/,/v2.0/,/v2.1/,/v2.2/,/v2.3/,/v2.4/,/v2.5/,/v2.6/,/v3.0/"


### PR DESCRIPTION
## Description

We're using a version of `yq` that is from over 2 years ago. So old that it doesn't even support a `version` subcommand to see how old it is :expressionless:  

Looks like we built our own calico/yaml container presumably because mikefarah/yq did not have an official one. But they do now, so we should use it.

The reason this change is coming about is that versions.yaml format changed from a toplevel dictionary to list, and we're getting different behavior from the older version of yq when trying to access the first item in a toplevel list e.g. `yq read [0].title`. More recent versions of yq handle this properly.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
