### PR TITLE
fixed description

### DIFF
--- a/networking/determine-best-networking.md
+++ b/networking/determine-best-networking.md
@@ -1,6 +1,6 @@
 ---
 title: Determine best networking option
-Description: Calico provides several networking implementations based on IP routing without the need for encapsulation. But encapsulation is supported when you need it.
+description: Calico provides several networking implementations based on IP routing without the need for encapsulation. But encapsulation is supported when you need it.
 ---
 
 ### Big picture


### PR DESCRIPTION
Fixed description (init caps), which causes description to not display in landing page. 

- Merge ASAP