### PR TITLE
Fixed formatting for DEVELOPER_GUIDE.md

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -61,7 +61,7 @@ REPOSITORY                            TAG                                     IM
 ...
 my-registry/cni-plugin                         v3.11.0-0.dev-3-g9755771-dirty-amd64    422e9c706bcd        2 hours ago         163MB
 ...
-```.
+```
 
 
 - Now, build the YAML manifests that are used to install calico:


### PR DESCRIPTION
## Description

In the markdown documentation, removed a period from the DEVELOPER_GUIDE.md that was causing the formatting to get thrown off. Verified on my fork that it fixed the format issue on GitHub.