### PR TITLE
Auto-detect Pod CIDR on kubeadm

### DIFF
--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -266,8 +266,8 @@ spec:
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
-            - name: CALICO_IPV4POOL_CIDR
-              value: "192.168.0.0/16"
+            # - name: CALICO_IPV4POOL_CIDR
+            #   value: "192.168.0.0/16"
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/_includes/charts/calico/templates/rbac.yaml
+++ b/_includes/charts/calico/templates/rbac.yaml
@@ -237,6 +237,12 @@ rules:
       - daemonsets
     verbs:
       - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
 {{- end }}
 {{- end }}
 ---


### PR DESCRIPTION
Suggested release notes:
```release-note
- Calico now auto-detects the IP Pool CIDR when running on kubeadm
- The section of the calico manifest that sets CALICO_IPV4POOL_CIDR has been commented out, but the default CIDR remains the same.
```