### PR TITLE
Fix GitHub release note link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,10 +291,17 @@ release-verify: release-prereqs
 
 ifneq (,$(findstring $(RELEASE_STREAM),v3.5 v3.4 v3.3 v3.2 v3.1 v3.0 v2.6))
     # Found: this is an older release.
-    REL_NOTES_PATH:=releases
+    REL_NOTES_PATH:=$(RELEASE_STREAM)/releases
 else
     # Not found: this is a newer release.
-    REL_NOTES_PATH:=release-notes
+    REL_NOTES_PATH:=$(RELEASE_STREAM)/release-notes
+endif
+
+# Check if we're branched off master. We know this if we have a netlify config
+# override file for master. We need to know this to change the release
+# notes path for the release-publish target.
+ifneq ("$(wildcard ./netlify/_config_latest.yml)","")
+REL_NOTES_PATH:=release-notes
 endif
 
 ## Pushes a github release and release artifacts produced by `make release-build`.
@@ -306,7 +313,7 @@ release-publish: release-prereqs
 	# Requires ghr: https://github.com/tcnksm/ghr
 	# Requires GITHUB_TOKEN environment variable set.
 	ghr -u projectcalico -r calico \
-		-b 'Release notes can be found at https://docs.projectcalico.org/$(RELEASE_STREAM)/$(REL_NOTES_PATH)/' \
+		-b 'Release notes can be found at https://docs.projectcalico.org/$(REL_NOTES_PATH)/' \
 		-n $(CALICO_VER) \
 		$(CALICO_VER) $(RELEASE_DIR).tgz
 


### PR DESCRIPTION
## Description

For patch releases, the release note link should be: https://docs.projectcalico.org/$(RELEASE_STREAM)/release-notes/
For minor releases, it should be: https://docs.projectcalico.org/release-notes/
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
