### PR TITLE
Align topics OS

### DIFF
--- a/_data/navbars/getting-started.yml
+++ b/_data/navbars/getting-started.yml
@@ -1,4 +1,4 @@
-title: "Getting started"
+title: "Get started"
 path: /getting-started/
 order: 1
 section:
@@ -39,16 +39,16 @@ section:
   - title: Flannel
     path: /getting-started/kubernetes/flannel/
     section:
-    - title: Installing Calico for policy and flannel for networking
+    - title: Install Calico for policy and flannel for networking
       path: /getting-started/kubernetes/installation/flannel
-    - title: Migrating a cluster from flannel to Calico
+    - title: Migrate a cluster from flannel to Calico
       path: /getting-started/kubernetes/installation/migration-from-flannel     
   - title: Calico the hard way
     path: /getting-started/kubernetes/hardway/
     section:
     - title: Introduction
       path: /getting-started/kubernetes/hardway/overview
-    - title: Standing up Kubernetes
+    - title: Stand up Kubernetes
       path: /getting-started/kubernetes/hardway/standing-up-kubernetes
     - title: The Calico datastore
       path: /getting-started/kubernetes/hardway/the-calico-datastore
@@ -95,7 +95,7 @@ section:
       path: /getting-started/openstack/installation/redhat
     - title: DevStack
       path: /getting-started/openstack/installation/devstack
-    - title: Verifying your deployment
+    - title: Verify your deployment
       path: /getting-started/openstack/verification
 - title: Non-cluster hosts
   path: /getting-started/bare-metal/
@@ -116,14 +116,14 @@ section:
 - title: calicoctl
   path: /getting-started/calicoctl/
   section:
-  - title: Installing calicoctl
+  - title: Install calicoctl
     path: /getting-started/calicoctl/install
-  - title: Configuring calicoctl
+  - title: Configure calicoctl
     path: /getting-started/calicoctl/configure/
     section:
     - title: Overview
       path: /getting-started/calicoctl/configure/overview
-    - title: Configuring calicoctl to connect to an etcd datastore
+    - title: Configure calicoctl to connect to an etcd datastore
       path: /getting-started/calicoctl/configure/etcd
-    - title: Configuring calicoctl to connect to the Kubernetes API datastore
+    - title: Configure calicoctl to connect to the Kubernetes API datastore
       path: /getting-started/calicoctl/configure/kdd

--- a/getting-started/calicoctl/configure/etcd.md
+++ b/getting-started/calicoctl/configure/etcd.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring calicoctl to connect to an etcd datastore
+title: Configure calicoctl to connect to an etcd datastore
 description: Sample configuration files etcd.
 canonical_url: '/getting-started/calicoctl/configure/etcd'
 ---

--- a/getting-started/calicoctl/configure/kdd.md
+++ b/getting-started/calicoctl/configure/kdd.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring calicoctl to connect to the Kubernetes API datastore
+title: Configure calicoctl to connect to the Kubernetes API datastore
 description: Sample configuration files for kdd.
 canonical_url: '/getting-started/calicoctl/configure/kdd'
 ---

--- a/getting-started/calicoctl/configure/overview.md
+++ b/getting-started/calicoctl/configure/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring calicoctl
+title: Configure calicoctl
 description: Configure calicoctl for datastore access.
 canonical_url: '/getting-started/calicoctl/configure/index'
 ---

--- a/getting-started/calicoctl/install.md
+++ b/getting-started/calicoctl/install.md
@@ -1,5 +1,5 @@
 ---
-title: Installing calicoctl
+title: Install calicoctl
 description: Install the CLI for Calico.
 canonical_url: '/getting-started/calicoctl/install'
 ---

--- a/getting-started/kubernetes/installation/flannel.md
+++ b/getting-started/kubernetes/installation/flannel.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Calico for policy and flannel for networking
+title: Install Calico for policy and flannel for networking
 description: If you use flannel for networking, you can install Calico network policy to secure cluster communications.
 canonical_url: '/getting-started/kubernetes/installation/flannel'
 ---

--- a/getting-started/kubernetes/installation/migration-from-flannel.md
+++ b/getting-started/kubernetes/installation/migration-from-flannel.md
@@ -1,5 +1,5 @@
 ---
-title: Migrating a cluster from flannel to Calico
+title: Migrate a cluster from flannel to Calico
 description: Migrate an existing Kubernetes cluster with flannel networking to use Calico networking.
 ---
 

--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -1,5 +1,5 @@
 ---
-title: Installing
+title: Install an OpenShift v4 cluster with Calico
 description: Set variables during OpenShift standard install for Calico.
 canonical_url: '/getting-started/openshift/installation'
 ---

--- a/getting-started/openstack/verification.md
+++ b/getting-started/openstack/verification.md
@@ -1,5 +1,5 @@
 ---
-title: Verifying your deployment
+title: Verify your deployment
 description: Quick steps to test that your Calico-based OpenStack deployment is running correctly.
 canonical_url: '/getting-started/openstack/verification'
 ---


### PR DESCRIPTION
As part of rework effort, doc titles should align to active verb (Configure, not Configuring).

- Updated TOC
- Updated associated docs
- Merge into nightly and latest
