### PR TITLE
Replace modal headers with styled div

### DIFF
--- a/_includes/geek-details.html
+++ b/_includes/geek-details.html
@@ -15,7 +15,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal">&times;</button>
-                        <h4 class="modal-title">{{ kv[1] }} {{ kv[0] }}</h4>
+                        <div class="modal-title">{{ kv[1] }} {{ kv[0] }}</div>
                         </div>
                         <div class="modal-body">
                         {% capture geek-details-file %}geek-details/{{kv[0] | downcase}}-{{kv[1] | downcase | replace: " ", "-"}}.md{% endcapture %}
@@ -43,7 +43,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal">&times;</button>
-                <h4 class="modal-title">Calico Deployment Options</h4>
+                <div class="modal-title">Calico Deployment Options</div>
                 </div>
                 <div class="modal-body">
                 {% capture geek-details-md %}{% include geek-details/info.md %}{% endcapture %}

--- a/css/style.scss
+++ b/css/style.scss
@@ -310,6 +310,10 @@ input.gsc-input, .gsc-input-box, .gsc-input-box-hover, .gsc-input-box-focus, .gs
   cursor: pointer;
 }
 
+.geek-details-wrapper .modal-title {
+  font-size: 20px;
+  font-weight: 700;
+}
 
 .geek-detail-value:hover {
   background-color: #93c47d;


### PR DESCRIPTION
The titles of the geek details modal popups show up in the right nav ToC.  This quick fix replaces header elements with styled divs.  This quick fix is sufficient so long as we do not ever put headers inside the md for the modal content.  @alexvarsh is going to look at if there's a better long term fix.


