### PR TITLE
Update doc and release process for networking-calico

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,10 +35,6 @@ To release Calico, you need **the following permissions**:
     gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
     ```
 
-- You must be [signed up as an OpenStack
-  developer](https://docs.openstack.org/infra/manual/developers.html#account-setup) and a member of the
-  [`networking-calico-release` group on Gerrit](https://review.opendev.org/#/admin/groups/1015,members).
-
 - You must be a member of the Project Calico team on Launchpad, and
   have uploaded a GPG identity to your account, for which you have the
   secret key.
@@ -93,7 +89,7 @@ Before attempting to create a Calico release you must do the following.
    - [calico/typha](https://github.com/projectcalico/typha/releases)
    - [calico/dikastes](https://github.com/projectcalico/app-policy/releases)
    - [calico/pod2daemon-flexvol](https://github.com/projectcalico/pod2daemon/releases)
-   - [networking-calico](https://github.com/openstack/networking-calico)
+   - [networking-calico](https://github.com/projectcalico/networking-calico/releases)
 
    The following components do not share a version with the Calico release, but are included in the documentation.
 
@@ -210,7 +206,7 @@ at the same time that subcomponent release branches are cut, often well before t
 ### Promoting to be the latest release in the docs
 
 This section describes how to create a new major or minor release. It assumes that the release branch has already been created
-as described in the section above. 
+as described in the section above.
 
 - Move current release to the archives
 
@@ -313,7 +309,7 @@ as described in the section above.
    at the newly created commit.
 
    ```
-   make release RELEASE_STREAM=vX.Y 
+   make release RELEASE_STREAM=vX.Y
    ```
 
    Then, publish the tag and release.

--- a/_includes/component_url
+++ b/_includes/component_url
@@ -14,7 +14,7 @@ https://github.com/projectcalico/cni-plugin/releases/tag/{{ release.components[i
 https://github.com/projectcalico/k8s-policy/releases/tag/{{ release.components[include.component].version }}
 
 {%- when 'networking-calico' -%}
-https://opendev.org/openstack/networking-calico/src/tag/{{ release.components[include.component].version }}
+https://github.com/projectcalico/networking-calico/releases/tag/{{ release.components[include.component].version }}
 
 {%- when 'typha' -%}
 https://github.com/projectcalico/typha/releases/tag/{{ release.components[include.component].version }}

--- a/getting-started/openstack/installation/devstack.md
+++ b/getting-started/openstack/installation/devstack.md
@@ -9,7 +9,7 @@ instructions explain how to set up a single or multiple node DevStack/{{site.pro
 system, and then how to see {{site.prodname}} connectivity in action.
 
 > **Note**: networking-calico includes a
-> [shell script](https://git.openstack.org/cgit/openstack/networking-calico/tree/devstack/bootstrap.sh)
+> [shell script](https://github.com/projectcalico/networking-calico/blob/master/devstack/bootstrap.sh)
 > that implements the following setup instructions. You are welcome to use it,
 > but we recommend that you read the following description first anyway, and
 > briefly review the script's code, so that you will understand what the
@@ -27,7 +27,7 @@ and compute functions running on the same node:
 
 2. Add to your DevStack local.conf file:
 
-       enable_plugin networking-calico https://git.openstack.org/openstack/networking-calico
+       enable_plugin networking-calico https://github.com/projectcalico/networking-calico
 
 3. Run `stack.sh`.
 

--- a/getting-started/openstack/overview.md
+++ b/getting-started/openstack/overview.md
@@ -35,9 +35,7 @@ canonical_url: '/getting-started/openstack/index'
 The Etcd, Felix and BIRD pieces are the same as in other {{site.prodname}} integrations,
 and so independent of OpenStack.  The {{site.prodname}} Neutron driver and DHCP agent are
 specific to OpenStack, and are provided by the
-[networking-calico](http://git.openstack.org/cgit/openstack/networking-calico/)
-project.  networking-calico is an [unofficial OpenStack
-project](http://docs.openstack.org/infra/manual/creators.html#decide-status-of-your-project).
+[networking-calico](https://github.com/projectcalico/networking-calico/) project.
 
 From an OpenStack point of view, networking-calico is just one of many possible
 Neutron drivers that provide connectivity between instances (VMs) as specified

--- a/release-scripts/tests/test_openstack_artifacts.py
+++ b/release-scripts/tests/test_openstack_artifacts.py
@@ -21,14 +21,14 @@ def test_rpm_repo_avail():
 
 
 def test_networking_calico_version():
-    assert re.match('v', NETWORKING_VER) is None
+    assert re.match('v', NETWORKING_VER) is not None
 
 
 def test_deb_rpm_versions_match():
-    regex = re.compile('.*%s' % NETWORKING_VER[0:3])
-    assert regex.match(PPA_VER), "%s did not match %s" % (PPA_VER, NETWORKING_VER[0:3])
+    regex = re.compile('.*%s' % NETWORKING_VER[1:4])
+    assert regex.match(PPA_VER), "%s did not match %s" % (PPA_VER, NETWORKING_VER[1:4])
 
 
 def test_networking_calico_tag_avail():
-    req = requests.get("https://opendev.org/openstack/networking-calico/src/tag/%s" % NETWORKING_VER)
+    req = requests.get("https://github.com/projectcalico/networking-calico/releases/tag/%s" % NETWORKING_VER)
     assert req.status_code == 200

--- a/release-scripts/tests/test_tags_tars.py
+++ b/release-scripts/tests/test_tags_tars.py
@@ -106,11 +106,6 @@ for component in components:
                 component_version=versions[0]['components'][component['lookup']]['version'],
                 binary=binary,
             ))
-    elif component['name'] == "networking-calico":
-        component['urls'] = ["https://opendev.org/openstack/networking-calico/src/tag/{component_version}".format(
-            component_version=versions[0]['components'][component['lookup']]['version']
-        )]
-
     elif component['name'] == "flannel":
         component['urls'] = [
             FLANNEL_TAG_URL_TEMPL.format(
@@ -138,7 +133,8 @@ for component in components:
     # dikastes: (as typha)
     #
     # networking-calico:
-    #     https://opendev.org/openstack/networking-calico/src/tag/3.6.0
+    #     https://github.com/projectcalico/networking-calico/archive/v3.6.2.zip
+    #     https://github.com/projectcalico/networking-calico/archive/v3.6.2.tar.gz
     #
     # cni:
     #     https://github.com/projectcalico/cni-plugin/releases/download/v3.6.2/calico-amd64


### PR DESCRIPTION
Reflecting that networking-calico is now a normal Calico repo on GitHub.

Suggested release note:
```release-note
Our OpenStack integration code (aka networking-calico) has moved from OpenStack infrastructure and governance to be a regular Calico project at https://github.com/projectcalico/networking-calico.
```