### PR TITLE
networking-calico version for Calico v3.8.6 was actually 3.9.2

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -313,7 +313,7 @@ v3.8:
      calico/kube-controllers:
       version: v3.8.6
      networking-calico:
-      version: 3.8.6
+      version: 3.9.2
      flannel:
       version: v0.11.0
      calico/dikastes:


### PR DESCRIPTION
This is horribly confused, but 3.9.2 really is what we should be
saying here.

- We tagged 3.8.6 at what was the networking-calico HEAD at the time.
Whereas it should have been at the same place as the existing 3.8.5
tag.  So "3.8.6" was the wrong code for that release.

- The packages in the calico-3.8 PPA [1] have version 3.9.2 and say
that they were built from Git commit 79bdf49, which is the commit with
tag 3.9.2, and also the same place as 3.8.5.  This is the correct
networking-calico code for this release.

[1] https://launchpad.net/~project-calico/+archive/ubuntu/calico-3.8/+packages

Hence to describe what we actually released, and what we should have
released, we could equally say "3.8.5" or "3.9.2", but I think "3.9.2"
is better so as to match the PPA package version.
