### PR TITLE
Fix AMD64 reference in requirements

### DIFF
--- a/_includes/content/reqs-sys.md
+++ b/_includes/content/reqs-sys.md
@@ -1,6 +1,6 @@
 ## Node requirements
 
-- x86-64
+- x86-64 processor
 
 - Linux kernel 3.10 or later with [required dependencies](#kernel-dependencies).
   The following distributions have the required kernel, its dependencies, and are

--- a/_includes/content/reqs-sys.md
+++ b/_includes/content/reqs-sys.md
@@ -1,6 +1,6 @@
 ## Node requirements
 
-- AMD64 processor
+- x86-64
 
 - Linux kernel 3.10 or later with [required dependencies](#kernel-dependencies).
   The following distributions have the required kernel, its dependencies, and are


### PR DESCRIPTION
Change all occurrences of "AMD64 processor" to "x86-64"

- Backlog OS item
- Terminology approved by Casey
- Merge to nightly