### PR TITLE
Switch to vanilla san-serif font

### DIFF
--- a/_sass/bootstrap/bootstrap/_variables.scss
+++ b/_sass/bootstrap/bootstrap/_variables.scss
@@ -43,7 +43,7 @@ $link-hover-decoration: underline !default;
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-$font-family-calico:      "Work Sans", sans-serif;
+$font-family-calico:      sans-serif;
 $font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.


### PR DESCRIPTION
We were missing the link to load Work Sans font, so even though we specified it in css, for most people they have just been seeing plain sans-serif.  This PR removes Work Sans from the css so that everyone gets plain sans-serif.