### PR TITLE
Update README.md with more documentation links and info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,59 @@
 [![Slack Status](https://slack.projectcalico.org/badge.svg)](https://slack.projectcalico.org)
 [![IRC Channel](https://img.shields.io/badge/irc-%23calico-blue.svg)](https://kiwiirc.com/client/irc.freenode.net/#calico)
 [![Docker Pulls](https://img.shields.io/docker/pulls/calico/node.svg)](https://hub.docker.com/r/calico/node/)
-[![](https://badge.imagelayers.io/calico/node:latest.svg)](https://imagelayers.io/?images=calico/node:latest)
 
 # Calico
 <img src="http://docs.projectcalico.org/images/felix.png" width="100" height="100">
 
-Calico is an open source system enabling cloud native application connectivity and policy. Calico integrates with major orchestration
-systems like [Kubernetes](https://kubernetes.io), [Apache Mesos](http://mesos.apache.org/), [Docker](https://www.docker.com/), [OpenStack](https://www.openstack.org/) and more to provide a seamless
-experience for developers and operators.
+Calico is an open source networking and network security solution for containers, virtual machines, and bare-metal workloads.
+Calico uses standard Linux networking tools to provide two major services for Cloud Native applications:
 
-Calico is a [Tigera](https://www.tigera.io/) open source project, and is primarily maintained by the Tigera team.
+- Network connectivity between workloads.
+- Network security policy enforcement between workloads.
 
-## Get Started Using Calico
+Calico’s flexible architecture supports a wide range of deployment options, using modular components, including:
 
-For users who want to learn more about the project or get started with Calico, see the documentation on [docs.projectcalico.org](https://docs.projectcalico.org).
+- [CNI](https://github.com/projectcalico/cni-plugin) plugins for Kubernetes to provide highly efficient pod networking and IP
+  Address Management (IPAM).
+- A [Neutron ML2](https://github.com/projectcalico/networking-calico) plugin to provide VM networking for OpenStack.
+- A policy engine, [Felix](https://github.com/projectcalico/felix), to provide enforcement of the full set of Kubernetes
+  network policy features, plus for those needing a richer set of policy features, Calico network policies.
+- Both non-overlay and [overlay (via IPIP or VXLAN)](https://docs.projectcalico.org/networking/vxlan-ipip) networking options
+  in either public cloud or on-prem deployments.
+- A [BGP routing stack](https://docs.projectcalico.org/networking/bgp) that can advertise routes for workload and service IP
+  addresses to physical network infrastructure such as Top of Rack routers (ToRs).
+- A simple command line interface, [calicoctl](https://github.com/projectcalico/calicoctl), for managing Calico configuration
+and Calico network policies.
 
-## Get Started Developing Calico
+## Getting Started Running Calico
 
-- [Contribution guidelines](CONTRIBUTING_CODE.md): submitting changes to Calico and contribution workflow.
-- [Developer guide](DEVELOPER_GUIDE.md): how to set up a development environment, build the code, and run tests.
-- [Contributing to the Calico documentation](CONTRIBUTING_DOCS.md): submitting changes to [docs.projectcalico.org](https://docs.projectcalico.org)
+There are many avenues to get started with Calico depending on your situation.
 
-## Support
+- Trying out Kubernetes on a single host or on your own hardware? The
+  [Quick Start Guide](https://docs.projectcalico.org/getting-started/kubernetes/quickstart) will have you up and running in
+  about fifteen minutes.
+- Running a managed public cloud? Use our
+  [guides for enabling Calico Network Policies](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/).
+- Want to go deeper? Visit [https://docs.projectcalico.org](docs.projectcalico.org) for full documentation.
 
-You can get help through one of the [Calico community channels](https://www.projectcalico.org/community).
+## Getting Started Developing Calico
+
+Calico is an open source project, and welcomes your contribution, be it through code, a bug report, a feature request, or user
+feedback.
+
+- [The Contribution Guidelines](CONTRIBUTING_CODE.md) document will get you started on submitting changes to the project.
+- [The Developer Guide](DEVELOPER_GUIDE.md) will walk you through how to set up a development environment, build the code,
+  and run tests.
+- [The Calico Documentation Guide](CONTRIBUTING_DOCS.md) will get you started on making changes to
+  [https://docs.projectcalico.org](docs.projectcalico.org).
+
+## Join the Calico Community!
+
+The Calico community is committed to fostering an open and welcoming environment, with several ways to engage with other users
+and developers. You can find out more about our monthly meetings, Slack group, and Discourse by visiting our
+[Community Repository](https://www.projectcalico.org/community).
 
 ## License
 
 Calico is available under the Apache 2.0 license. See the [LICENSE](LICENSE.md) file for details.
+


### PR DESCRIPTION
Updating the README.md to include more information on the Calico
architecture, links to documentation, and how to get engaged in
the community.

## Description

The PR aims to update the README.md to add some information about Calico architecture, fix some broken links,  and improve on-ramps.

## Related issues/PRs

## Todos

- [X] Documentation

## Release Note


```release-note
None required
```
