### PR TITLE
Add option to override kubernetes API host/port to YAMLs.

### DIFF
--- a/_includes/charts/calico/templates/calico-config.yaml
+++ b/_includes/charts/calico/templates/calico-config.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{include "variant_name" . | lower}}-config
   namespace: kube-system
 data:
+  # If specified, these values override the host and port that will be used to connect to
+  # the API server.  If these are not set, we use the in-cluster configuration provided
+  # by Kubernetes, which introduces a dependency on kube-proxy.
+  kubernetes_service_host: ""
+  kubernetes_service_port: ""
+
 {{- if eq .Values.datastore "etcd" }}
   # Configure this with the location of your etcd cluster.
   etcd_endpoints: "{{ required "must set etcd.endpoints if using etcd mode" .Values.etcd.endpoints }}"

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -57,6 +57,16 @@ spec:
           image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_host
+            - name: KUBERNETES_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_port
             - name: KUBERNETES_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -80,6 +90,17 @@ spec:
           image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/install-cni.sh"]
           env:
+            # (Optional) overrides for kubernetes API server host/port.
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_host
+            - name: KUBERNETES_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_port
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-{{include "variant_name" . | lower}}.conflist"
@@ -164,6 +185,17 @@ spec:
         - name: calico-node
           image: {{.Values.node.image}}:{{.Values.node.tag}}
           env:
+            # (Optional) overrides for kubernetes API server host/port.
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_host
+            - name: KUBERNETES_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_port
 {{- if eq .Values.datastore "etcd" }}
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS

--- a/_includes/charts/calico/templates/calico-typha.yaml
+++ b/_includes/charts/calico/templates/calico-typha.yaml
@@ -74,6 +74,17 @@ spec:
           name: calico-typha
           protocol: TCP
         env:
+          # (Optional) overrides for kubernetes API server host/port.
+          - name: KUBERNETES_SERVICE_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: kubernetes_service_host
+          - name: KUBERNETES_SERVICE_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: kubernetes_service_port
           # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
           - name: TYPHA_LOGSEVERITYSCREEN
             value: "info"


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add config-map options to override kubernetes host/port.  Useful for
systems where kube-proxy is not running.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```