### PR TITLE
Add install manifest for eBPF mode.

### DIFF
--- a/_includes/charts/calico/templates/calico-config.yaml
+++ b/_includes/charts/calico/templates/calico-config.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{include "variant_name" . | lower}}-config
   namespace: kube-system
 data:
+{{- if .Values.bpf }}
+  # Set these to the IP and port of your API server; In BPF mode, we need to connect directly to the
+  # API server because we take over kube-proxy's role.
+  kubernetes_service_host: ""
+  kubernetes_service_port: ""
+{{ end -}}
+
 {{- if eq .Values.datastore "etcd" }}
   # Configure this with the location of your etcd cluster.
   etcd_endpoints: "{{ required "must set etcd.endpoints if using etcd mode" .Values.etcd.endpoints }}"
@@ -26,7 +33,7 @@ data:
   # You must set a non-zero value for Typha replicas below.
   typha_service_name: "calico-typha"
 {{- else }}
-  # Typha is disabled.
+  # Typha is disabled. {{- if .Values.bpf }} Typha is not supported in BPF mode.{{ end }}
   typha_service_name: "none"
 
 {{- end }}

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -57,6 +57,19 @@ spec:
           image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           env:
+{{- if .Values.bpf }}
+            # Overrides for kubernetes API server host/port.  Needed in BPF mode.
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_host
+            - name: KUBERNETES_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_port
+{{- end }}
             - name: KUBERNETES_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -80,6 +93,19 @@ spec:
           image: {{.Values.cni.image}}:{{ .Values.cni.tag }}
           command: ["/install-cni.sh"]
           env:
+{{- if .Values.bpf }}
+            # Overrides for kubernetes API server host/port.  Needed in BPF mode.
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_host
+            - name: KUBERNETES_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_port
+{{- end }}
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-{{include "variant_name" . | lower}}.conflist"
@@ -164,6 +190,22 @@ spec:
         - name: calico-node
           image: {{.Values.node.image}}:{{.Values.node.tag}}
           env:
+{{- if .Values.bpf }}
+            # Overrides for kubernetes API server host/port.  Needed in BPF mode.
+            - name: KUBERNETES_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_host
+            - name: KUBERNETES_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: kubernetes_service_port
+            # Actually enable BPF mode.
+            - name: FELIX_BPFENABLED
+              value: "true"
+{{- end }}
 {{- if eq .Values.datastore "etcd" }}
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS
@@ -235,7 +277,7 @@ spec:
               value: "autodetect"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
+              value: "{{- if .Values.bpf -}} CrossSubnet {{- else -}} Always {{- end -}}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:
@@ -341,6 +383,13 @@ spec:
 {{- end }}
             - name: policysync
               mountPath: /var/run/nodeagent
+{{- if .Values.bpf }}
+            # We need to mount the BPF filesystem at /sys/fs/bpf and we need that mount to persist
+            # even if {{ include "nodeName" . }} is restarted.
+            - name: sysfs
+              mountPath: /sys/fs/
+              mountPropagation: Bidirectional
+{{- end }}
 {{- if eq .Values.network "flannel" }}
   {{- if eq .Values.datastore "kubernetes" }}
         # This container runs flannel using the kube-subnet-mgr backend
@@ -470,6 +519,12 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
+{{- if .Values.bpf }}
+        - name: sysfs
+          hostPath:
+            path: /sys/fs/
+            type: DirectoryOrCreate
+{{- end }}
 {{- if and (eq .Values.network "flannel") (eq .Values.datastore "kubernetes") }}
         # Used by flannel.
         - name: flannel-cfg

--- a/_includes/charts/calico/templates/calico-typha.yaml
+++ b/_includes/charts/calico/templates/calico-typha.yaml
@@ -74,6 +74,19 @@ spec:
           name: calico-typha
           protocol: TCP
         env:
+{{- if .Values.bpf }}
+          # Overrides for kubernetes API server host/port.  Needed in BPF mode.
+          - name: KUBERNETES_SERVICE_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: kubernetes_service_host
+          - name: KUBERNETES_SERVICE_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: kubernetes_service_port
+{{- end }}
           # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
           - name: TYPHA_LOGSEVERITYSCREEN
             value: "info"

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -1,0 +1,8 @@
+---
+layout: null
+---
+{% helm %}
+datastore: kubernetes
+network: calico
+bpf: true
+{% endhelm %}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Add install manifest for eBPF mode. 

* In eBPF mode we need to connect directly to the datastore; add config map
  parameters for that.
* We had FUD about adding such parameters to the mainline manifests in case they
  broke certain cluster topologies.
* In BPF mode, we need the BPF file system to be mounted in but there's a chance that would break on some distros.
* Play it safe by introducing a new manifest.
* Pre-enable BPF mode in the new manifest.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Main Felix PR: projectcalico/felix#2219
Blog post: https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```