### PR TITLE
Search results triggered on input focus

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -140,7 +140,7 @@ The code is a little roundabout for a few reasons:
           <div class="sidebar-container sidebar-offcanvas">
             <div class="sidebar">
               <div class="search">
-                <div class="search-input-container" data-toggle="popover" data-placement="bottom"></div>
+                <div class="search-input-container" data-toggle="popover" data-trigger="focus" data-placement="bottom"></div>
                 <div class="search-container">
                   <div class="search-container__results"></div>
                   <div class="search-container__pagination"></div>


### PR DESCRIPTION
## Description

Attribute data-trigger sets the option when popover should be shown. Focus option forces popover to be shown when search input is focused. It solves the problem when user typed something in search input then removes focus from input and returns to it and no search results are shown.
