### PR TITLE
Update current release for v3.12 branch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   RUBY_VERSION = "2.5.4"
   CANDIDATE_RELEASE = ""
-  CURRENT_RELEASE = "v3.11"
+  CURRENT_RELEASE = "v3.12"
 
 [[headers]]
   for = "/*.yaml"


### PR DESCRIPTION
## Description

Bumped into this in another [PR](https://github.com/projectcalico/calico/pull/3357) on the release-v3.12 branch. My deploy preview there was failing because it was trying to checkout `release-v3.11` which doesn't exist.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
