### PR TITLE
support custom certs for helmerator

### DIFF
--- a/_includes/charts/tigera-operator/templates/certs/certs-node.yaml
+++ b/_includes/charts/tigera-operator/templates/certs/certs-node.yaml
@@ -1,0 +1,13 @@
+{{/* if any of .Values.certs.node or .Values.certs.typha is not nil */}}
+{{ if without (concat (values .Values.certs.node) (values .Values.certs.typha)) nil }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: node-certs
+  namespace: tigera-operator
+type: Opaque
+data:
+  cert.crt: {{ required "must set certs.node.cert" .Values.certs.node.cert | b64enc }}
+  key.key: {{ required "must set certs.node.key" .Values.certs.node.key | b64enc }}
+  common-name: {{ required "must set certs.node.commonName" .Values.certs.node.commonName | b64enc }}
+{{ end }}

--- a/_includes/charts/tigera-operator/templates/certs/certs-typha.yaml
+++ b/_includes/charts/tigera-operator/templates/certs/certs-typha.yaml
@@ -1,0 +1,23 @@
+{{/* if any of .Values.certs.node or .Values.certs.typha is not nil */}}
+{{ if without (concat (values .Values.certs.node) (values .Values.certs.typha)) nil }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: typha-ca
+  namespace: tigera-operator
+data:
+  caBundle: |
+{{ required "must set certs.typha.caBundle" .Values.certs.typha.caBundle | indent 4}}
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: typha-certs
+  namespace: tigera-operator
+type: Opaque
+data:
+  cert.crt: {{ required "must set certs.typha.cert" .Values.certs.typha.cert | b64enc }}
+  key.key: {{ required "must set certs.typha.key" .Values.certs.typha.key | b64enc }}
+  common-name: {{ required "must set certs.typha.commonName" .Values.certs.typha.commonName | b64enc }}
+{{ end }}

--- a/_plugins/values.rb
+++ b/_plugins/values.rb
@@ -7,6 +7,17 @@ def gen_values(versions, imageNames, imageRegistry, chart)
       enabled: true
       kubernetesProvider: ""
 
+    certs:
+      node:
+        key:
+        cert:
+        commonName:
+      typha:
+        key:
+        cert:
+        commonName:
+        caBundle:
+
     # Configuration for the tigera operator
     tigeraOperator:
       image: #{versions.fetch("tigera-operator").image}


### PR DESCRIPTION
## Description

For validation, I ran an install with the following values.yaml:

```yaml
certs:
    node:
        key: foo
        cert: foo
        commonName: foo
    typha:
        key: foo
        cert: foo
        commonName: foo
        caBundle: foo
```

I validated that Operator detected the certs and attempted to use them for mTLS between felix and typha. Of course, felix and typha crash looped because those are not valid certs. I hope to be able to test valid certs soon.

I also ran basic validation that specifying only one value in `certs.node` or `certs.typha` raises an error

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```