### PR TITLE
Include networking-calico in v3.8.7 release

### DIFF
--- a/_data/versions.yml
+++ b/_data/versions.yml
@@ -313,7 +313,7 @@ v3.8:
      calico/kube-controllers:
       version: v3.8.7
      networking-calico:
-      version: 3.9.2
+      version: v3.8.7
      flannel:
       version: v0.11.0
      calico/dikastes:

--- a/_includes/component_url
+++ b/_includes/component_url
@@ -14,7 +14,7 @@ https://github.com/projectcalico/cni-plugin/releases/tag/{{ release.components[i
 https://github.com/projectcalico/k8s-policy/releases/tag/{{ release.components[include.component].version }}
 
 {%- when 'networking-calico' -%}
-https://opendev.org/openstack/networking-calico/src/tag/{{ release.components[include.component].version }}
+https://github.com/projectcalico/networking-calico/releases/tag/{{ release.components[include.component].version }}
 
 {%- when 'typha' -%}
 https://github.com/projectcalico/typha/releases/tag/{{ release.components[include.component].version }}


### PR DESCRIPTION
Also update the URL to GitHub, as all networking-calico releases (including past releases) are now on GitHub.
