### PR TITLE
openshift: add instructions to integrate with OLM

### DIFF
--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -120,10 +120,10 @@ oc get tigerastatus
 #### Integrate with Operator Lifecycle Manager (OLM)
 
 In OpenShift Container Platform, the [Operator Lifecycle Manager](https://docs.openshift.com/container-platform/4.3/operators/understanding_olm/olm-understanding-olm.html#olm-overview_olm-understanding-olm) helps
-cluster admins manage the lifecycle of operators running in their cluster. Most operators can be installed directly from the OpenShift Console.
-But {{site.prodname}}'s operator provides OpenShift networking so the operator must be installed when the cluster is provisioned.
+cluster admins manage the lifecycle of operators running in their cluster. We can get the benefits of managing the {{site.prodname}}
+operator with OLM by registering the operator.
 
-In order to register the running Calico operator with OLM, you will need to create an OperatorGroup for the operator:
+In order to register the running {{site.prodname}} operator with OLM, first you will need to create an OperatorGroup for the operator:
 
 ```bash
 oc apply -f - <<EOF
@@ -138,7 +138,9 @@ spec:
 EOF
 ```
 
-Next, you will create a Subscription to the operator:
+Next, you will create a Subscription to the operator. By subscribing to the operator package, the {{site.prodname}} operator will be managed by OLM.
+
+> **Note**: This will trigger the operator deployment to be recreated and all of its resources (pods, deployments, etc.) to be recreated.
 
 ```bash
 oc apply -f - <<EOF
@@ -156,6 +158,13 @@ spec:
   startingCSV: tigera-operator.{{page.version}}
 EOF
 ```
+
+Once this is complete, the {{site.prodname}} will be appear as an installed operator in the OpenShift console.
+The user-interface provides options for editing the operator installation, viewing the operator's status, and more.
+
+> **Note**: Upgrading the operator is enabled via the OpenShift console. But **always** refer to the upgrade instructions first at [https://docs.projectcalico.org/maintenance/upgrading](https://docs.projectcalico.org/maintenance/upgrading).
+{: .alert .alert-danger}
+
 
 ### Above and beyond
 

--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -1,12 +1,12 @@
 ---
-title: Install an OpenShift v4 cluster with Calico
-description: Install Calico on an OpenShift v4 cluster.
+title: Install an OpenShift 4 cluster with Calico
+description: Install Calico on OpenShift Container Platform 4.
 canonical_url: '/getting-started/openshift/installation'
 ---
 
 ### Big picture
 
-Install an OpenShift v4 cluster with {{site.prodname}}.
+Install an OpenShift Container Platform 4 cluster with {{site.prodname}}.
 
 ### Value
 
@@ -19,15 +19,16 @@ to install {{site.prodname}}.
 
 - Ensure that your environment meets the {{site.prodname}} [system requirements]({{site.baseurl}}/getting-started/openshift/requirements).
 
-- **If installing on AWS**, ensure that you have {% include open-new-window.html text='configured an AWS account' url='https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html' %} appropriate for OpenShift v4,
+- **If installing on AWS**, ensure that you have {% include open-new-window.html text='configured an AWS account' url='https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html' %} appropriate for OpenShift 4,
   and have {% include open-new-window.html text='set up your AWS credentials' url='https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html' %}.
   Note that the OpenShift installer supports a subset of {% include open-new-window.html text='AWS regions' url='https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html#installation-aws-regions_installing-aws-account' %}.
 
 - Ensure that you have a {% include open-new-window.html text='RedHat account' url='https://cloud.redhat.com/' %}. A RedHat account is required to obtain the pull secret necessary to provision an OpenShift cluster.
 
-- Ensure that you have installed the OpenShift installer **v4.3 or later** and OpenShift command line interface from {% include open-new-window.html text='cloud.redhat.com' url='https://cloud.redhat.com/openshift/install/aws/installer-provisioned' %}.
+- Ensure that you have installed the OpenShift installer **v4.3 or later** and OpenShift CLI from {% include open-new-window.html text='cloud.redhat.com' url='https://cloud.redhat.com/openshift/install/aws/installer-provisioned' %}.
 
 - Ensure that you have {% include open-new-window.html text='generated a local SSH private key' url='https://docs.openshift.com/container-platform/4.1/installing/installing_aws/installing-aws-default.html#ssh-agent-using_installing-aws-default' %} and have added it to your ssh-agent
+
 
 #### Create a configuration file for the OpenShift installer
 
@@ -95,7 +96,7 @@ To include [Calico resources]({{site.baseurl}}/reference/resources) during insta
 
 > **Note**: If you have a directory with the Calico resources, you can create the file with the command:
 > ```
-> kubectl create configmap -n tigera-operator calico-resources \
+> oc create configmap -n tigera-operator calico-resources \
 >   --from-file=<resource-directory> --dry-run -o yaml \
 >   > manifests/02-configmap-calico-resources.yaml
 > ```

--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -116,6 +116,46 @@ oc get tigerastatus
 
 > **Note**: To get more information, add `-o yaml` to the above command.
 
+#### Integrate with Operator Lifecycle Manager (OLM)
+
+In OpenShift Container Platform, the [Operator Lifecycle Manager](https://docs.openshift.com/container-platform/4.3/operators/understanding_olm/olm-understanding-olm.html#olm-overview_olm-understanding-olm) helps
+cluster admins manage the lifecycle of operators running in their cluster. Most operators can be installed directly from the OpenShift Console.
+But {{site.prodname}}'s operator provides OpenShift networking so the operator must be installed when the cluster is provisioned.
+
+In order to register the running Calico operator with OLM, you will need to create an OperatorGroup for the operator:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: tigera-operator
+  namespace: tigera-operator
+spec:
+  targetNamespaces:
+    - tigera-operator
+EOF
+```
+
+Next, you will create a Subscription to the operator:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tigera-operator
+  namespace: tigera-operator
+spec:
+  channel: stable
+  installPlanApproval: Manual
+  name: tigera-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: tigera-operator.{{page.version}}
+EOF
+```
+
 ### Above and beyond
 
 - [Get started with Kubernetes network policy]({{site.baseurl}}/security/kubernetes-network-policy)

--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -19,13 +19,13 @@ to install {{site.prodname}}.
 
 - Ensure that your environment meets the {{site.prodname}} [system requirements]({{site.baseurl}}/getting-started/openshift/requirements).
 
-- **If installing on AWS**, ensure that you have {% include open-new-window.html text='configured an AWS account' url='https://docs.openshift.com/container-platform/4.2/installing/installing_aws/installing-aws-account.html' %} appropriate for OpenShift v4,
+- **If installing on AWS**, ensure that you have {% include open-new-window.html text='configured an AWS account' url='https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html' %} appropriate for OpenShift v4,
   and have {% include open-new-window.html text='set up your AWS credentials' url='https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html' %}.
-  Note that the OpenShift installer supports a subset of {% include open-new-window.html text='AWS regions' url='https://docs.openshift.com/container-platform/4.2/installing/installing_aws/installing-aws-account.html#installation-aws-regions_installing-aws-account' %}.
+  Note that the OpenShift installer supports a subset of {% include open-new-window.html text='AWS regions' url='https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html#installation-aws-regions_installing-aws-account' %}.
 
 - Ensure that you have a {% include open-new-window.html text='RedHat account' url='https://cloud.redhat.com/' %}. A RedHat account is required to obtain the pull secret necessary to provision an OpenShift cluster.
 
-- Ensure that you have installed the OpenShift installer **v4.2 or later** and OpenShift command line interface from {% include open-new-window.html text='cloud.redhat.com' url='https://cloud.redhat.com/openshift/install/aws/installer-provisioned' %}.
+- Ensure that you have installed the OpenShift installer **v4.3 or later** and OpenShift command line interface from {% include open-new-window.html text='cloud.redhat.com' url='https://cloud.redhat.com/openshift/install/aws/installer-provisioned' %}.
 
 - Ensure that you have {% include open-new-window.html text='generated a local SSH private key' url='https://docs.openshift.com/container-platform/4.1/installing/installing_aws/installing-aws-default.html#ssh-agent-using_installing-aws-default' %} and have added it to your ssh-agent
 


### PR DESCRIPTION
## Description

Once our operator is certified and published in the RedHat catalog, we'll want users to be able to manage the operator via the Operator Lifecycle Manager (OLM).

This PR adds extra instructions at the end of the OpenShift install page to do so, with a warning about upgrading. It also instructs users to install the latest stable v4.3.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
