### PR TITLE
automatically detect release stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ HP_IGNORE_LOCAL_DIRS="/v1.5/,/v1.6/,/v2.0/,/v2.1/,/v2.2/,/v2.3/,/v2.4/,/v2.5/,/v
 
 ##############################################################################
 # Version information used for cutting a release.
-RELEASE_STREAM?=
+RELEASE_STREAM := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '[0].title' | grep --only-matching --extended-regexp '(v[0-9]+\.[0-9]+)|master')
 
 # Use := so that these V_ variables are computed only once per make run.
 CALICO_VER := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '[0].title')
@@ -213,10 +213,6 @@ kubeval: _site
 	rm filtered.out
 
 helm-tests: vendor bin/helm values.yaml
-ifndef RELEASE_STREAM
-	# Default the version to master if not set
-	$(eval RELEASE_STREAM = master)
-endif
 	mkdir -p .go-pkg-cache && \
 		docker run --rm \
 		--net=host \
@@ -273,7 +269,7 @@ release: release-prereqs
 	@echo ""
 	@echo "Release build complete. Next, push the release."
 	@echo ""
-	@echo "  make RELEASE_STREAM=$(RELEASE_STREAM) release-publish"
+	@echo "  make release-publish"
 	@echo ""
 
 ## Produces a git tag for the release.
@@ -333,9 +329,6 @@ endif
 
 # release-prereqs checks that the environment is configured properly to create a release.
 release-prereqs:
-ifndef RELEASE_STREAM
-	$(error RELEASE_STREAM is undefined - run using make release RELEASE_STREAM=vX.Y)
-endif
 	@if [ $(CALICO_VER) != $(NODE_VER) ]; then \
 		echo "Expected CALICO_VER $(CALICO_VER) to equal NODE_VER $(NODE_VER)"; \
 		exit 1; fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -309,13 +309,13 @@ as described in the section above.
    at the newly created commit.
 
    ```
-   make release RELEASE_STREAM=vX.Y
+   make release
    ```
 
    Then, publish the tag and release.
 
    ```
-   make release-publish RELEASE_STREAM=vX.Y
+   make release-publish
    ```
 1. Merge the PR. This will cause the live docs site to be updated (after a few minutes).
 
@@ -341,7 +341,7 @@ release notes for a given version, perform the following steps.
 1. Run the following command to collect all release notes for the given version.
 
    ```
-   make RELEASE_STREAM=vX.Y release-notes
+   make release-notes
    ```
 
    A file called `<VERSION>-release-notes.md` will be created with the raw release note content.


### PR DESCRIPTION
## Description

RELEASE_STREAM represents the minor version (vX.Y). On legacy docs, we
were unable to detect the release stream because multiple release
streams were stored on the same branch / tree, thus requiring the user
to specify it when executing Make actions.

Today, each branch only has one release stream in the tree, so we can
automatically detect it by parsing versions.yml.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```