### PR TITLE
Fix broken link to Istio documentation

### DIFF
--- a/security/tutorials/app-layer-policy/enforce-policy-istio.md
+++ b/security/tutorials/app-layer-policy/enforce-policy-istio.md
@@ -14,7 +14,7 @@ This tutorial sets up a microservices application, then demonstrates how to use 
   - If Calico is already installed on Kubernetes, verify that [Calico networking]({{ site.baseurl }}/getting-started/kubernetes/installation/) (or a non-Calico CNI) and Calico network policy are installed. 
 3. Install the [calicoctl command line tool]({{ site.baseurl }}/getting-started/calicoctl/install).   
   **Note**: Ensure calicoctl is configured to connect with your datastore.  
-4. [Enable application layer policy[Enable application layer policy]({{site.baseurl}}/security/app-layer-policy).  
+4. [Enable application layer policy]({{site.baseurl}}/security/app-layer-policy).  
   **Note**: Label the default namespace for the Istio sidecar injection (`istio-injection=enabled`).
   `kubectl label namespace default istio-injection=enabled`
 
@@ -296,4 +296,4 @@ account we disallow the connection.
  [etcd]: https://github.com/coreos/etcd
  [struts cve]: https://nvd.nist.gov/vuln/detail/CVE-2017-5638
  [heartbleed]: http://heartbleed.com/
- [ingress host port]: https://istio.io/docs/tasks/traffic-management/ingress/#determining-the-ingress-ip-and-ports 
+ [ingress host port]: https://istio.io/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports


### PR DESCRIPTION
Fixes a broken link to Istio documentation for determining ingress IP and port.

## Description

Broken link to Istio docs.
## Todos

Simple docs fix

## Release Note

```release-note
None required
```
