### PR TITLE
Fix typo in network policy manifest

### DIFF
--- a/security/kubernetes-network-policy.md
+++ b/security/kubernetes-network-policy.md
@@ -174,7 +174,7 @@ metadata:
 spec:
   podSelector:
     matchLabels: {}
-  types:
+  policyTypes:
   - Ingress
   - Egress
 ```


### PR DESCRIPTION
The network policy manifest at the end of the document uses Calico rather than Kubernetes syntax. Correct `types` to `policyTypes`.

## Description

The manifest in the tutorial uses Calico instead of Kubernetes syntax. This patch fixes the manifest.

## Todos

Simple fix.

## Release Note

```release-note
None required
```
