### PR TITLE
Fixed typo in calicoctl alias

### DIFF
--- a/_includes/content/ctl-container-install.md
+++ b/_includes/content/ctl-container-install.md
@@ -55,7 +55,7 @@ kns.kube-system      kns.kube-system
 We recommend setting an alias as follows.
 
 ```
-alias calicoctl="kubectl exec -i -n kube-system calicoctl /calicoctl -- "
+alias calicoctl="kubectl exec -i -n kube-system calicoctl -- /calicoctl"
 ```
 
    > **Note**: In order to use the `calicoctl` alias


### PR DESCRIPTION
## Description

The alias for setting up calicoctl as an alias was incorrect. Fixed.

## Related issues/PRs

none

## Todos

none

## Release Note
```release-note
None required
```
