### PR TITLE
Fix IPIP comment in calico.yaml

### DIFF
--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -275,7 +275,7 @@ spec:
             # Auto-detect the BGP IP address.
             - name: IP
               value: "autodetect"
-            # {{- if .Values.bpf -}} For best performance, disable {{- else -}} Enable {{- end -}} IPIP
+            # {{- if .Values.bpf }} For best performance, disable {{- else }} Enable {{- end }} IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{- if .Values.bpf -}} Never {{- else -}} Always {{- end -}}"
             # Set MTU for tunnel device used if ipip is enabled


### PR DESCRIPTION
Some of our tooling hooks into some of our manifests based off of the
manifest files' comments.

The latest manifest looks like:
```
            #EnableIPIP
            - name: CALICO_IPV4POOL_IPIP
              value: "Always"
```
whereas we want:

```
# Enable IPIP
```
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
