### PR TITLE
Don't need CALICO_IPV6POOL_CIDR for kubeadm clusters

### DIFF
--- a/networking/ipv6.md
+++ b/networking/ipv6.md
@@ -92,7 +92,14 @@ steps below.
    has `"type": "calico-ipam"` then it should be modified to
    [disable IPv4 assignments and enable IPv6
    assigments](/reference/cni-plugin/configuration#ipam).
-1. Add the following environment variables to the calico-node Daemonset in
+1. Add the following environment variable to the calico-node DaemonSet in
+   the `calico.yaml` file.
+   
+   ```yaml
+   - name: IP6
+     value: "autodetect"
+   ```
+1. For clusters **not** provisioned with kubeadm (see note below), also add the following environment variable to the calico-node DaemonSet in
    the `calico.yaml` file. Be sure to set the value for `CALICO_IPV6POOL_CIDR`
    to the desired pool, it should match the `--cluster-cidr` passed to the
    kube-controller-manager and to kube-proxy.
@@ -100,13 +107,14 @@ steps below.
    ```yaml
    - name: CALICO_IPV6POOL_CIDR
      value: "fd20::0/112"
-   - name: IP6
-     value: "autodetect"
    ```
 
 1. Ensure in the `calico.yaml` file that the environment variable
-   `FELIX_IPV6SUPPORT` is set `true` on the calico-node Daemonset.
+   `FELIX_IPV6SUPPORT` is set `true` on the calico-node DaemonSet.
 1. Apply the `calico.yaml` manifest with `kubectl apply -f calico.yaml`.
+
+>**Note**: For clusters provisioned with kubeadm, {{site.prodname}} autodetects the IPv4 and IPv6 pod CIDRs and does not require configuration.
+{: .alert .alert-info}
 
 #### Using only IPv6
 


### PR DESCRIPTION
## Description

... since we have autodetection for kubeadm! 😄

Should backport this to v3.13 too

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
