### PR TITLE
monitor-component-metrics.md complete rewrite.

### DIFF
--- a/maintenance/monitor-component-metrics.md
+++ b/maintenance/monitor-component-metrics.md
@@ -36,8 +36,8 @@ In this tutorial we assume that you have completed all other introductory tutori
 ## How to
 
 This tutorial will go through the necessary steps to implement basic monitoring of {{site.prodname}} with Prometheus.
-1. This section will teach you how to configure {{site.prodname}} to export its own metrics.
-2. In this section you will learn to isolate the resources and create necessary permissions for future steps.
+1. This section will describe how to configure {{site.prodname}} to export its own metrics.
+2. In this section you will isolate the resources and create necessary permissions for future steps.
 3. In this section you will configure Prometheus and create its instance in the cluster.
 4. You will be able to visit Prometheus dashboard and create a simple graph.
 
@@ -103,7 +103,7 @@ You can enable Typha metrics to be consumed by Prometheus via [two ways](http://
 
 By using services you will be able to dynamically discover endpoints. Here you will create a service named `typha-metrics-svc` which will receive requests from port 9091 and forward it to port 9090 of pods that are participating in `kube-system` namespace and share `k8s-app: calico-typha` label.
 
-> **Note**: Typha uses **port 9091** TCP by default to publish its metrics. However, if {{site.prodname}} yaml is installed by using [Amazon yaml file](https://github.com/aws/amazon-vpc-cni-k8s/blob/b001dc6a8fff52926ed9a93ee6c4104f02d365ab/config/v1.5/calico.yaml#L535-L536) this port is set to 9093 via **TYPHA_PROMETHEUSMETRICSPORT** environment variable.
+> **Note**: Typha uses **port 9091** TCP by default to publish its metrics. However, if {{site.prodname}} is installed using [Amazon yaml file](https://github.com/aws/amazon-vpc-cni-k8s/blob/b001dc6a8fff52926ed9a93ee6c4104f02d365ab/config/v1.5/calico.yaml#L535-L536) this port will be 9093 as its set manually via **TYPHA_PROMETHEUSMETRICSPORT** environment variable.
    {: .alert .alert-warning}
 
 ``` bash
@@ -144,7 +144,7 @@ EOF
 
 ####  Service account creation
 
-You need to give Prometheus a serviceAccount with required permissions to collect information from {{site.prodname}}.
+You need to provide Prometheus a serviceAccount with required permissions to collect information from {{site.prodname}}.
 
 > **Note**: A comprehensive guide to user roles and authentication can be [found at this link](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
    {: .alert .alert-info}
@@ -297,14 +297,13 @@ Push the `Add Graph` button, You should be able to see the metric plotted on a G
 
 ## Cleanup
 
-By executing below commands, you will delete all the resources and services created by following this tutorial.
+By executing below commands, you will delete all the resource and services created by following this tutorial.
 
 ```bash
 kubectl delete service felix-metrics-svc -n kube-system
 kubectl delete service typha-metrics-svc -n kube-system
 kubectl delete namespace calico-monitoring
 kubectl delete ClusterRole calico-prometheus-user
-kubectl delete ServiceAccount calico-prometheus-user
 kubectl delete clusterrolebinding calico-prometheus-user
 ```
 

--- a/maintenance/monitor-component-metrics.md
+++ b/maintenance/monitor-component-metrics.md
@@ -3,43 +3,261 @@ title: Monitor Calico component metrics
 description: Use open source Prometheus for monitoring and alerting on Calico components.
 ---
 
-### Big picture
+* TOC
+{:toc}
 
-Use Prometheus configured for {{site.prodname}} components to get valuable metrics about the health of your network.
+# Introduction
 
-### Value
+Use Prometheus configured for {{site.prodname}} components to get valuable metrics about the health of your network. 
+Using the open-source Prometheus monitoring and alerting toolkit, you can view time-series metrics from {{site.prodname}} components in the Prometheus or Grafana interfaces. The Prometheus monitoring tool scrapes metrics from instrumented jobs and displays time series data in a visualizer (such as Grafana). For {{site.prodname}}, the “jobs” that Prometheus can harvest metrics from are the Felix and Typha components. Felix is a daemon that runs on every machine that provides endpoints ({{site.prodname}} nodes. Felix is the brains of {{site.prodname}}. Typha is an optional daemon that extends Felix to scale traffic between {{site.prodname}} nodes and the datastore. Typha is used to avoid bottlenecks and performance issues in the datastore when you have over 50 {{site.prodname}} nodes.
 
-Using the open-source Prometheus monitoring and alerting toolkit, you can view time-series metrics from {{site.prodname}} components in the Prometheus or Grafana interfaces.  
+## Requirements
 
-### Features
+In this tutorial we assume that you have completed all other introductory sections and possess a running Kubernetes cluster with {{site.prodname}} and calicoctl installed.
 
-This how-to guide uses the following {{site.prodname}} features:
+> **Note** Typha implementation is optional, if you don't have Typha in your cluster you should skip step 4 and 7 of this tutorial.
+   {: .alert .alert-warning}
 
-**Felix** and **Typha** components configured with Prometheus configuration parameters (for consumption by Prometheus).
+# How to
 
-### Concepts
+In this section we will go through the necessary steps to implement basic monitoring with Prometheus. You will assign required permission to a service account, create a permanent configuration and store it via configmaps, create services to discover endpoints dynamically, create a Prometheus pod, change Felix configuration and create a basic graph using consumed Felix metrics.
 
-#### About Prometheus
+## 1. Allowing user access to metrics
 
-The Prometheus monitoring tool scrapes metrics from instrumented jobs and displays time series data in a visualizer (such as Grafana). For {{site.prodname}}, the “jobs” that Prometheus can harvest metrics from are the Felix and Typha components. 
+You need to give a user account required permissions to be able to collect information from the nodes.
 
-#### About {{site.prodname}} Felix and Typha components
+> **Note**: A comprehensive guide to user roles and authentication can be [found at this link](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+   {: .alert .alert-info}
 
-**Felix** is a daemon that runs on every machine that provides endpoints ({{site.prodname}} nodes). Felix is the brains of {{site.prodname}}. Typha is an optional daemon that extends Felix to scale traffic between {{site.prodname}} nodes and the datastore. **Typha** is used to avoid bottlenecks and performance issues in the datastore when you have over 50 {{site.prodname}} nodes. 
+```bash
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-rbac
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```
+## 2. Creating permanent config file
 
-You can configure Felix and/or Typha to provide metrics to Prometheus.
+Since containers are ephemeral, it is best to store configuration file to a permanent storage solution and link it to your pod. 
+
+> **Note**: A comprehensive guide about configuration file can be [found at this link](https://prometheus.io/docs/prometheus/latest/configuration/configuration/).
+   {: .alert .alert-info}
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval:   15s
+      external_labels:
+        monitor: 'tutorial-monitor'
+    scrape_configs:
+    - job_name: 'prometheus'
+      scrape_interval: 5s
+      static_configs:
+      - targets: ['localhost:9090']
+    - job_name: 'felix_metrics'
+      scrape_interval: 5s
+      scheme: http
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name]
+        regex: felix-demo-svc
+        replacement: $1
+        action: keep
+    - job_name: 'typha_metrics'
+      scrape_interval: 5s
+      scheme: http
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name]
+        regex: typha-demo-svc
+        replacement: $1
+        action: keep
+EOF
+```
+
+## 3. Creating a service to expose Felix metrics
+
+Your prometheus configuration is going to check services and catch endpoints related to felix-demo-svc service, you need to create a service with that name to expose Felix metrics. This will help in discovery of your services and **makes** it dynamic. 
+
+> **Note**: Felix uses port 9091 TCP to publish its metrics.
+   {: .alert .alert-info}
+
+``` bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: felix-demo-svc
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: calico-node
+  ports:
+  - port: 9091
+    targetPort: 9091
+EOF
+```
+
+## 4. Creating a service to expose Typha metrics
+
+You need to create a service that exposes your typha instance metrics to Prometheus.
+
+> **Note**: Typha uses **port 9091** TCP to publish its metrics. However, in AWS Implementation of calico port is set to TCP Port 9093 via **TYPHA_PROMETHEUSMETRICSPORT** environment variable.
+   {: .alert .alert-warning}
+
+``` bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: typha-demo-svc
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: calico-typha
+  ports:
+  - port: 9093
+    targetPort: 9093
+EOF
+```
+
+## 5. Creating Prometheus pod
+
+Now that you allowed the user to view the metrics and have a valid config file for your Prometheus, it's time to create the pod.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: prometheus-pod
+  labels:
+    app: prometheus-pod
+    role: monitoring
+spec:
+  containers:
+  - name: prometheus-pod
+    image: prom/prometheus
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+    volumeMounts:
+    - name: config-volume
+      mountPath: /etc/prometheus/prometheus.yml
+      subPath: prometheus.yml
+    ports:
+    - containerPort: 9090
+  volumes:
+  - name: config-volume
+    configMap:
+      name: prometheus-config
+EOF
+```
+
+Check your cluster running pods to assure pod creation was successful.
+    
+    
+```bash
+kubectl get pods prometheus-pod
+```
+It should return something like the following.
+
+```
+NAME             READY   STATUS    RESTARTS   AGE
+prometheus-pod   1/1     Running   0          16s
+```
+
+You can access prometheus dashboard by using port-forwarding feature.
+
+```bash
+kubectl port-forward pod/prometheus-pod 9090:9090
+```
+
+Browse to [http://localhost:9090](http://localhost:9090) you should be able to see prometheus dashboard.
+
+## 6. Enabling Felix metrics
+
+Prometheus metric microservice is set to **false** by default. You have to manually change your Felix configuration (**prometheusMetricsEnabled**) via calicoctl in order to use this feature.
+
+> **Note**: A comprehensive list of configuration values can be [found at this link]({{ site.baseurl }}/reference/felix/configuration).
+   {: .alert .alert-info}
 
 
-### How to
 
-#### Enable Prometheus metrics for and Felix and Typha
+```bash
+calicoctl replace -f - <<EOF
+apiVersion: projectcalico.org/v3
+kind: FelixConfiguration
+metadata:
+  creationTimestamp: null
+  name: default
+spec:
+  bpfLogLevel: ""
+  logSeverityScreen: Info
+  prometheusMetricsEnabled: true
+  reportingInterval: 0s
+EOF
+```
 
-1. Using the Prometheus documentation, configure one or more [Prometheus servers](https://prometheus.io/docs/introduction/overview/).  
-1. To enable [Felix]({{ site.baseurl }}/reference/felix/configuration) for metrics, set **PrometheusMetricsEnabled = true**.
-1. To enable [Typha]({{ site.baseurl }}/reference/typha/configuration) for metrics, set **PrometheusMetricsEnabled = true**.
-1. If required for Felix and/or Typha, change the default TCP port (9091) for your Prometheus metrics server using the parameter, **PrometheusMetricsPort**.
+You are almost done. browse to Prometheus dashboard and type **felix_active_local_endpoints** in the Expression input textbox then hit the execute button. Console table should be populated with the node ips in your cluster.
 
-#### Best practices
+> **Note**: A comprehensive list of metrics can be [found at this link]({{ site.baseurl }}/reference/felix/prometheus).
+   {: .alert .alert-info}
+
+Push the Add Graph button, You should be able to see the metric plotted on a Graph.
+
+## 7. Explanation for Typha metrics
+
+If you are using Typha you can enable metrics to be consumed by Prometheus as well. This section we assume that you have an AWS eks cluster setup and Typha enabled. {{site.prodname}} AWS implementation uses **TYPHA_PROMETHEUSGOMETRICSENABLED** environment variable by default.
+If you are uncertain about typha in your cluster you can examine it by running the following code
+
+```bash
+kubectl get pods -A | grep typha
+```
+
+This should give you a result similar to following
+
+> **Note** The name suffix of pods shown below was dynamically generated. Your typha instance might have a different suffix.
+   {: .alert .alert-info}
+
+```
+kube-system     calico-typha-56fccfcdc4-z27xj                         1/1     Running   0          28h
+kube-system     calico-typha-horizontal-autoscaler-74f77cd87c-6hx27   1/1     Running   0          28h
+```
+
+
+
+# Cleanup
+
+By executing below commands, you will delete all the resources and services created by following this tutorial.
+
+```bash
+kubectl delete svc felix-demo-svc -n kube-system
+kubectl delete svc typha-demo-svc -n kube-system
+kubectl delete pod prometheus-pod
+kubectl delete configmap prometheus-config
+kubectl delete clusterrolebinding prometheus-rbac
+```
+
+# Best practices
 
 If you enable {{site.prodname}} metrics to Prometheus, a best practice is to use network policy to limit access to the {{site.prodname}} metrics endpoints. For details, see [Secure {{site.prodname}} Prometheus endpoints]({{ site.baseurl }}/security/comms/secure-metrics).  
 

--- a/maintenance/monitor-component-metrics.md
+++ b/maintenance/monitor-component-metrics.md
@@ -98,7 +98,7 @@ kube-system     calico-typha-56fccfcdc4-z27xj                         1/1     Ru
 kube-system     calico-typha-horizontal-autoscaler-74f77cd87c-6hx27   1/1     Running   0          28h
 ```
 
-You can enable Typha metrics to be consumed by Prometheus via [two ways](http://localhost:4000/reference/typha/configuration).
+You can enable Typha metrics to be consumed by Prometheus via [two ways]({{ site.baseurl }}/reference/typha/configuration).
 ##### **Creating a service to expose Typha metrics**
 
 By using services you will be able to dynamically discover endpoints. Here you will create a service named `typha-metrics-svc` which will receive requests from port 9091 and forward it to port 9090 of pods that are participating in `kube-system` namespace and share `k8s-app: calico-typha` label.

--- a/maintenance/monitor-component-metrics.md
+++ b/maintenance/monitor-component-metrics.md
@@ -43,7 +43,7 @@ This tutorial will go through the necessary steps to implement basic monitoring 
 
 
 #### 1. Configure Calico to enable metrics reporting
-##### Felix configuration
+##### **Felix configuration**
 Felix prometheus metrics are **disabled** by default. You have to manually change your Felix configuration (**prometheusMetricsEnabled**) via calicoctl in order to use this feature.
 
 > **Note**: A comprehensive list of configuration values can be [found at this link]({{ site.baseurl }}/reference/felix/configuration).
@@ -57,7 +57,7 @@ You should see an output like below:
 Successfully patched 1 'FelixConfiguration' resource
 ```
 
-###### **Creating a service to expose Felix metrics**
+##### **Creating a service to expose Felix metrics**
 Promethues uses Kubernetes services to dynamically discover endpoints. Here you will create a service named `felix-metrics-svc` which Prometheus will use to discover all the Felix metrics endpoints.
 
 > **Note**: Felix by default uses port 9091 TCP to publish its metrics.
@@ -79,7 +79,7 @@ spec:
 EOF
 ```
 
-##### Typha Configuration
+##### **Typha Configuration**
 > **Note** Typha implementation is optional, if you don't have Typha in your cluster you should skip [Typha configuration]({{ site.baseurl }}/maintenance/monitor-component-metrics#typha-configuration) section.
    {: .alert .alert-danger}
 
@@ -99,7 +99,7 @@ kube-system     calico-typha-horizontal-autoscaler-74f77cd87c-6hx27   1/1     Ru
 ```
 
 You can enable Typha metrics to be consumed by Prometheus via [two ways]({{ site.baseurl }}/reference/typha/configuration).
-###### **Creating a service to expose Typha metrics**
+##### **Creating a service to expose Typha metrics**
 
 > **Note**: Typha uses **port 9091** TCP by default to publish its metrics. However, if {{site.prodname}} is installed using [Amazon yaml file](https://github.com/aws/amazon-vpc-cni-k8s/blob/b001dc6a8fff52926ed9a93ee6c4104f02d365ab/config/v1.5/calico.yaml#L535-L536) this port will be 9093 as its set manually via **TYPHA_PROMETHEUSMETRICSPORT** environment variable.
    {: .alert .alert-warning}
@@ -122,7 +122,7 @@ EOF
 
 #### 2. Cluster preparation
 
-##### Namespace creation
+##### **Namespace creation**
 
 `Namespace` isolates resources in your cluster. Here you will create a Namespace called `calico-monitoring` to hold your monitoring resources.
 > **Note**: Kubernetes namespaces guide can be [found at this link](https://kubernetes.io/docs/tasks/administer-cluster/namespaces/).
@@ -140,7 +140,7 @@ metadata:
 EOF
 ```
 
-#####  Service account creation
+##### **Service account creation**
 
 You need to provide Prometheus a serviceAccount with required permissions to collect information from {{site.prodname}}.
 
@@ -184,7 +184,7 @@ subjects:
 EOF
 ```
 #### 3. Install prometheus
-##### Creating prometheus config file
+##### **Create prometheus config file**
 
 We can configure Prometheus using a ConfigMap to persistently store the desired settings. 
 
@@ -231,7 +231,7 @@ data:
         action: keep
 EOF
 ```
-##### Creating Prometheus pod
+##### **Create Prometheus pod**
 
 Now that you have a `serviceaccount` with permissions to gather metrics and have a valid config file for your Prometheus, it's time to create the Prometheus pod.
 

--- a/maintenance/monitor-component-metrics.md
+++ b/maintenance/monitor-component-metrics.md
@@ -3,28 +3,148 @@ title: Monitor Calico component metrics
 description: Use open source Prometheus for monitoring and alerting on Calico components.
 ---
 
-* TOC
-{:toc}
+## Big picture
 
-# Introduction
+Use Prometheus configured for {{site.prodname}} components to get valuable metrics about the health of {{site.prodname}}.
 
-Use Prometheus configured for {{site.prodname}} components to get valuable metrics about the health of your network. 
-Using the open-source Prometheus monitoring and alerting toolkit, you can view time-series metrics from {{site.prodname}} components in the Prometheus or Grafana interfaces. The Prometheus monitoring tool scrapes metrics from instrumented jobs and displays time series data in a visualizer (such as Grafana). For {{site.prodname}}, the “jobs” that Prometheus can harvest metrics from are the Felix and Typha components. Felix is a daemon that runs on every machine that provides endpoints ({{site.prodname}} nodes. Felix is the brains of {{site.prodname}}. Typha is an optional daemon that extends Felix to scale traffic between {{site.prodname}} nodes and the datastore. Typha is used to avoid bottlenecks and performance issues in the datastore when you have over 50 {{site.prodname}} nodes.
+## Value
 
-## Requirements
+Using the open-source Prometheus monitoring and alerting toolkit, you can view time-series metrics from {{site.prodname}} components in the Prometheus or Grafana interfaces.  
 
-In this tutorial we assume that you have completed all other introductory sections and possess a running Kubernetes cluster with {{site.prodname}} and calicoctl installed.
+## Features
 
-> **Note** Typha implementation is optional, if you don't have Typha in your cluster you should skip step 4 and 7 of this tutorial.
+This how-to guide uses the following {{site.prodname}} features:
+
+**Felix** and **Typha** components configured with Prometheus configuration parameters (for consumption by Prometheus).
+
+## Concepts
+
+### About Prometheus
+
+The Prometheus monitoring tool scrapes metrics from instrumented jobs and displays time series data in a visualizer (such as Grafana). For {{site.prodname}}, the “jobs” that Prometheus can harvest metrics from are the Felix and Typha components. 
+
+### About {{site.prodname}} Felix and Typha components
+
+**Felix** is a daemon that runs on every machine that provides endpoints ({{site.prodname}} nodes). Felix is the brains of {{site.prodname}}. Typha is an optional daemon that extends Felix to scale traffic between {{site.prodname}} nodes and the datastore. **Typha** is used to avoid bottlenecks and performance issues in the datastore when you have over 50 {{site.prodname}} nodes. 
+
+You can configure Felix and/or Typha to provide metrics to Prometheus.
+
+## Before you begin...
+
+In this tutorial we assume that you have completed all other introductory tutorials and possess a running Kubernetes cluster with {{site.prodname}}, calicoctl and kubectl installed.
+
+## How to
+
+This tutorial will go through the necessary steps to implement basic monitoring of {{site.prodname}} with Prometheus.
+1. This section will teach you how to configure {{site.prodname}} to export its own metrics.
+2. In this section you will learn to isolate the resources and create necessary permissions for future steps.
+3. In this section you will configure Prometheus and create its instance in the cluster.
+4. You will be able to visit Prometheus dashboard and create a simple graph.
+
+
+### 1. Configure Calico to enable metrics reporting
+#### Felix configuration
+Felix prometheus metrics are **disabled** by default. You have to manually change your Felix configuration (**prometheusMetricsEnabled**) via calicoctl in order to use this feature.
+
+> **Note**: A comprehensive list of configuration values can be [found at this link]({{ site.baseurl }}/reference/felix/configuration).
+   {: .alert .alert-info}
+
+```bash
+calicoctl patch felixConfiguration default  --patch '{"spec":{"prometheusMetricsEnabled": true}}'
+```
+You should see an output like below:
+```
+Successfully patched 1 'FelixConfiguration' resource
+```
+
+##### **Creating a service to expose Felix metrics**
+By using services you will be able to dynamically discover endpoints. Here you will create a service named `felix-metrics-svc` which will receive requests from port 9091 and forward it to port 9090 of pods that are participating in `kube-system` namespace and share `k8s-app: calico-node` label.
+
+> **Note**: Felix by default uses port 9091 TCP to publish its metrics.
+   {: .alert .alert-info}
+
+``` bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: felix-metrics-svc
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: calico-node
+  ports:
+  - port: 9091
+    targetPort: 9091
+EOF
+```
+
+#### Typha Configuration
+> **Note** Typha implementation is optional, if you don't have Typha in your cluster you should skip [Typha configuration]({{ site.baseurl }}/maintenance/monitor-component-metrics#typha-configuration) section.
+   {: .alert .alert-danger}
+
+If you are uncertain about `Typha` in your cluster execute the following code:
+
+```bash
+kubectl get pods -A | grep typha
+```
+If your result is similar to what is shown below you are using Typha in your cluster.
+
+> **Note** The name suffix of pods shown below was dynamically generated. Your typha instance might have a different suffix.
    {: .alert .alert-warning}
 
-# How to
+```
+kube-system     calico-typha-56fccfcdc4-z27xj                         1/1     Running   0          28h
+kube-system     calico-typha-horizontal-autoscaler-74f77cd87c-6hx27   1/1     Running   0          28h
+```
 
-In this section we will go through the necessary steps to implement basic monitoring with Prometheus. You will assign required permission to a service account, create a permanent configuration and store it via configmaps, create services to discover endpoints dynamically, create a Prometheus pod, change Felix configuration and create a basic graph using consumed Felix metrics.
+You can enable Typha metrics to be consumed by Prometheus via [two ways](http://localhost:4000/reference/typha/configuration).
+##### **Creating a service to expose Typha metrics**
 
-## 1. Allowing user access to metrics
+By using services you will be able to dynamically discover endpoints. Here you will create a service named `typha-metrics-svc` which will receive requests from port 9091 and forward it to port 9090 of pods that are participating in `kube-system` namespace and share `k8s-app: calico-typha` label.
 
-You need to give a user account required permissions to be able to collect information from the nodes.
+> **Note**: Typha uses **port 9091** TCP by default to publish its metrics. However, if {{site.prodname}} yaml is installed by using [Amazon yaml file](https://github.com/aws/amazon-vpc-cni-k8s/blob/b001dc6a8fff52926ed9a93ee6c4104f02d365ab/config/v1.5/calico.yaml#L535-L536) this port is set to 9093 via **TYPHA_PROMETHEUSMETRICSPORT** environment variable.
+   {: .alert .alert-warning}
+
+``` bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: typha-metrics-svc
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: calico-typha
+  ports:
+  - port: 9093
+    targetPort: 9093
+EOF
+```
+
+### 2. Cluster preparation
+
+#### Namespace creation
+
+`Namespace` isolates resources in your cluster. Here you will create a Namespace called `calico-monitoring` to hold your monitoring resources.
+> **Note**: Kubernetes namespaces guide can be [found at this link](https://kubernetes.io/docs/tasks/administer-cluster/namespaces/).
+   {: .alert .alert-info}
+
+```bash
+kubectl apply -f -<<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: calico-monitoring
+  labels:
+    app:  ns-calico-monitoring
+    role: monitoring
+EOF
+```
+
+####  Service account creation
+
+You need to give Prometheus a serviceAccount with required permissions to collect information from {{site.prodname}}.
 
 > **Note**: A comprehensive guide to user roles and authentication can be [found at this link](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
    {: .alert .alert-info}
@@ -32,20 +152,41 @@ You need to give a user account required permissions to be able to collect infor
 ```bash
 kubectl apply -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: calico-prometheus-user
+rules:
+- apiGroups: [""]
+  resources:
+  - endpoints
+  - services
+  - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-prometheus-user
+  namespace: calico-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-rbac
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: default
+  name: calico-prometheus-user
 roleRef:
-  kind: ClusterRole
-  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-prometheus-user
+subjects:
+- kind: ServiceAccount
+  name: calico-prometheus-user
+  namespace: calico-monitoring
 EOF
 ```
-## 2. Creating permanent config file
+### 3. Install prometheus
+#### Creating prometheus config file
 
 Since containers are ephemeral, it is best to store configuration file to a permanent storage solution and link it to your pod. 
 
@@ -58,6 +199,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
+  namespace: calico-monitoring
 data:
   prometheus.yml: |-
     global:
@@ -76,7 +218,7 @@ data:
       - role: endpoints
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
-        regex: felix-demo-svc
+        regex: felix-metrics-svc
         replacement: $1
         action: keep
     - job_name: 'typha_metrics'
@@ -86,61 +228,14 @@ data:
       - role: endpoints
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
-        regex: typha-demo-svc
+        regex: typha-metrics-svc
         replacement: $1
         action: keep
 EOF
 ```
+#### Creating Prometheus pod
 
-## 3. Creating a service to expose Felix metrics
-
-Your prometheus configuration is going to check services and catch endpoints related to felix-demo-svc service, you need to create a service with that name to expose Felix metrics. This will help in discovery of your services and **makes** it dynamic. 
-
-> **Note**: Felix uses port 9091 TCP to publish its metrics.
-   {: .alert .alert-info}
-
-``` bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: felix-demo-svc
-  namespace: kube-system
-spec:
-  selector:
-    k8s-app: calico-node
-  ports:
-  - port: 9091
-    targetPort: 9091
-EOF
-```
-
-## 4. Creating a service to expose Typha metrics
-
-You need to create a service that exposes your typha instance metrics to Prometheus.
-
-> **Note**: Typha uses **port 9091** TCP to publish its metrics. However, in AWS Implementation of calico port is set to TCP Port 9093 via **TYPHA_PROMETHEUSMETRICSPORT** environment variable.
-   {: .alert .alert-warning}
-
-``` bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: typha-demo-svc
-  namespace: kube-system
-spec:
-  selector:
-    k8s-app: calico-typha
-  ports:
-  - port: 9093
-    targetPort: 9093
-EOF
-```
-
-## 5. Creating Prometheus pod
-
-Now that you allowed the user to view the metrics and have a valid config file for your Prometheus, it's time to create the pod.
+Now that you have a `serviceaccount` with permissions to gather metrics and have a valid config file for your Prometheus, it's time to create the pod.
 
 ```bash
 kubectl apply -f - <<EOF
@@ -148,10 +243,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: prometheus-pod
+  namespace: calico-monitoring
   labels:
     app: prometheus-pod
     role: monitoring
 spec:
+  serviceAccountName: calico-prometheus-user
   containers:
   - name: prometheus-pod
     image: prom/prometheus
@@ -172,11 +269,11 @@ spec:
 EOF
 ```
 
-Check your cluster running pods to assure pod creation was successful.
+Check your cluster pods to assure pod creation was successful and prometheus pod is `Running`.
     
     
 ```bash
-kubectl get pods prometheus-pod
+kubectl get pods prometheus-pod -n calico-monitoring
 ```
 It should return something like the following.
 
@@ -184,80 +281,34 @@ It should return something like the following.
 NAME             READY   STATUS    RESTARTS   AGE
 prometheus-pod   1/1     Running   0          16s
 ```
-
+### 4. View metrics
 You can access prometheus dashboard by using port-forwarding feature.
 
 ```bash
-kubectl port-forward pod/prometheus-pod 9090:9090
+kubectl port-forward pod/prometheus-pod 9090:9090 -n calico-monitoring
 ```
 
-Browse to [http://localhost:9090](http://localhost:9090) you should be able to see prometheus dashboard.
-
-## 6. Enabling Felix metrics
-
-Prometheus metric microservice is set to **false** by default. You have to manually change your Felix configuration (**prometheusMetricsEnabled**) via calicoctl in order to use this feature.
-
-> **Note**: A comprehensive list of configuration values can be [found at this link]({{ site.baseurl }}/reference/felix/configuration).
-   {: .alert .alert-info}
-
-
-
-```bash
-calicoctl replace -f - <<EOF
-apiVersion: projectcalico.org/v3
-kind: FelixConfiguration
-metadata:
-  creationTimestamp: null
-  name: default
-spec:
-  bpfLogLevel: ""
-  logSeverityScreen: Info
-  prometheusMetricsEnabled: true
-  reportingInterval: 0s
-EOF
-```
-
-You are almost done. browse to Prometheus dashboard and type **felix_active_local_endpoints** in the Expression input textbox then hit the execute button. Console table should be populated with the node ips in your cluster.
+Browse to [http://localhost:9090](http://localhost:9090) you should be able to see prometheus dashboard. Type **felix_active_local_endpoints** in the Expression input textbox then hit the execute button. Console table should be populated with all your nodes and quantity of endpoints in each of them.
 
 > **Note**: A comprehensive list of metrics can be [found at this link]({{ site.baseurl }}/reference/felix/prometheus).
    {: .alert .alert-info}
 
-Push the Add Graph button, You should be able to see the metric plotted on a Graph.
+Push the `Add Graph` button, You should be able to see the metric plotted on a Graph.
 
-## 7. Explanation for Typha metrics
-
-If you are using Typha you can enable metrics to be consumed by Prometheus as well. This section we assume that you have an AWS eks cluster setup and Typha enabled. {{site.prodname}} AWS implementation uses **TYPHA_PROMETHEUSGOMETRICSENABLED** environment variable by default.
-If you are uncertain about typha in your cluster you can examine it by running the following code
-
-```bash
-kubectl get pods -A | grep typha
-```
-
-This should give you a result similar to following
-
-> **Note** The name suffix of pods shown below was dynamically generated. Your typha instance might have a different suffix.
-   {: .alert .alert-info}
-
-```
-kube-system     calico-typha-56fccfcdc4-z27xj                         1/1     Running   0          28h
-kube-system     calico-typha-horizontal-autoscaler-74f77cd87c-6hx27   1/1     Running   0          28h
-```
-
-
-
-# Cleanup
+## Cleanup
 
 By executing below commands, you will delete all the resources and services created by following this tutorial.
 
 ```bash
-kubectl delete svc felix-demo-svc -n kube-system
-kubectl delete svc typha-demo-svc -n kube-system
-kubectl delete pod prometheus-pod
-kubectl delete configmap prometheus-config
-kubectl delete clusterrolebinding prometheus-rbac
+kubectl delete service felix-metrics-svc -n kube-system
+kubectl delete service typha-metrics-svc -n kube-system
+kubectl delete namespace calico-monitoring
+kubectl delete ClusterRole calico-prometheus-user
+kubectl delete ServiceAccount calico-prometheus-user
+kubectl delete clusterrolebinding calico-prometheus-user
 ```
 
-# Best practices
+## Best practices
 
 If you enable {{site.prodname}} metrics to Prometheus, a best practice is to use network policy to limit access to the {{site.prodname}} metrics endpoints. For details, see [Secure {{site.prodname}} Prometheus endpoints]({{ site.baseurl }}/security/comms/secure-metrics).  
 

--- a/maintenance/monitor-component-metrics.md
+++ b/maintenance/monitor-component-metrics.md
@@ -3,37 +3,37 @@ title: Monitor Calico component metrics
 description: Use open source Prometheus for monitoring and alerting on Calico components.
 ---
 
-## Big picture
+### Big picture
 
 Use Prometheus configured for {{site.prodname}} components to get valuable metrics about the health of {{site.prodname}}.
 
-## Value
+### Value
 
 Using the open-source Prometheus monitoring and alerting toolkit, you can view time-series metrics from {{site.prodname}} components in the Prometheus or Grafana interfaces.  
 
-## Features
+### Features
 
 This how-to guide uses the following {{site.prodname}} features:
 
 **Felix** and **Typha** components configured with Prometheus configuration parameters (for consumption by Prometheus).
 
-## Concepts
+### Concepts
 
-### About Prometheus
+#### About Prometheus
 
 The Prometheus monitoring tool scrapes metrics from instrumented jobs and displays time series data in a visualizer (such as Grafana). For {{site.prodname}}, the “jobs” that Prometheus can harvest metrics from are the Felix and Typha components. 
 
-### About {{site.prodname}} Felix and Typha components
+#### About {{site.prodname}} Felix and Typha components
 
 **Felix** is a daemon that runs on every machine that provides endpoints ({{site.prodname}} nodes). Felix is the brains of {{site.prodname}}. Typha is an optional set of pods that extends Felix to scale traffic between {{site.prodname}} nodes and the datastore. 
 
 You can configure Felix and/or Typha to provide metrics to Prometheus.
 
-## Before you begin...
+### Before you begin...
 
 In this tutorial we assume that you have completed all other introductory tutorials and possess a running Kubernetes cluster with {{site.prodname}}, calicoctl and kubectl installed.
 
-## How to
+### How to
 
 This tutorial will go through the necessary steps to implement basic monitoring of {{site.prodname}} with Prometheus.
 1. Configure {{site.prodname}} to enable the metrics reporting.
@@ -42,8 +42,8 @@ This tutorial will go through the necessary steps to implement basic monitoring 
 4. View the metrics in the Prometheus dashboard and create a simple graph.
 
 
-### 1. Configure Calico to enable metrics reporting
-#### Felix configuration
+#### 1. Configure Calico to enable metrics reporting
+##### Felix configuration
 Felix prometheus metrics are **disabled** by default. You have to manually change your Felix configuration (**prometheusMetricsEnabled**) via calicoctl in order to use this feature.
 
 > **Note**: A comprehensive list of configuration values can be [found at this link]({{ site.baseurl }}/reference/felix/configuration).
@@ -57,7 +57,7 @@ You should see an output like below:
 Successfully patched 1 'FelixConfiguration' resource
 ```
 
-##### **Creating a service to expose Felix metrics**
+###### **Creating a service to expose Felix metrics**
 Promethues uses Kubernetes services to dynamically discover endpoints. Here you will create a service named `felix-metrics-svc` which Prometheus will use to discover all the Felix metrics endpoints.
 
 > **Note**: Felix by default uses port 9091 TCP to publish its metrics.
@@ -79,7 +79,7 @@ spec:
 EOF
 ```
 
-#### Typha Configuration
+##### Typha Configuration
 > **Note** Typha implementation is optional, if you don't have Typha in your cluster you should skip [Typha configuration]({{ site.baseurl }}/maintenance/monitor-component-metrics#typha-configuration) section.
    {: .alert .alert-danger}
 
@@ -99,7 +99,7 @@ kube-system     calico-typha-horizontal-autoscaler-74f77cd87c-6hx27   1/1     Ru
 ```
 
 You can enable Typha metrics to be consumed by Prometheus via [two ways]({{ site.baseurl }}/reference/typha/configuration).
-##### **Creating a service to expose Typha metrics**
+###### **Creating a service to expose Typha metrics**
 
 > **Note**: Typha uses **port 9091** TCP by default to publish its metrics. However, if {{site.prodname}} is installed using [Amazon yaml file](https://github.com/aws/amazon-vpc-cni-k8s/blob/b001dc6a8fff52926ed9a93ee6c4104f02d365ab/config/v1.5/calico.yaml#L535-L536) this port will be 9093 as its set manually via **TYPHA_PROMETHEUSMETRICSPORT** environment variable.
    {: .alert .alert-warning}
@@ -120,9 +120,9 @@ spec:
 EOF
 ```
 
-### 2. Cluster preparation
+#### 2. Cluster preparation
 
-#### Namespace creation
+##### Namespace creation
 
 `Namespace` isolates resources in your cluster. Here you will create a Namespace called `calico-monitoring` to hold your monitoring resources.
 > **Note**: Kubernetes namespaces guide can be [found at this link](https://kubernetes.io/docs/tasks/administer-cluster/namespaces/).
@@ -140,7 +140,7 @@ metadata:
 EOF
 ```
 
-####  Service account creation
+#####  Service account creation
 
 You need to provide Prometheus a serviceAccount with required permissions to collect information from {{site.prodname}}.
 
@@ -183,8 +183,8 @@ subjects:
   namespace: calico-monitoring
 EOF
 ```
-### 3. Install prometheus
-#### Creating prometheus config file
+#### 3. Install prometheus
+##### Creating prometheus config file
 
 We can configure Prometheus using a ConfigMap to persistently store the desired settings. 
 
@@ -231,7 +231,7 @@ data:
         action: keep
 EOF
 ```
-#### Creating Prometheus pod
+##### Creating Prometheus pod
 
 Now that you have a `serviceaccount` with permissions to gather metrics and have a valid config file for your Prometheus, it's time to create the Prometheus pod.
 
@@ -279,7 +279,7 @@ It should return something like the following.
 NAME             READY   STATUS    RESTARTS   AGE
 prometheus-pod   1/1     Running   0          16s
 ```
-### 4. View metrics
+#### 4. View metrics
 You can access prometheus dashboard by using port-forwarding feature.
 
 ```bash
@@ -293,7 +293,7 @@ Browse to [http://localhost:9090](http://localhost:9090) you should be able to s
 
 Push the `Add Graph` button, You should be able to see the metric plotted on a Graph.
 
-## Cleanup
+### Cleanup
 
 By executing below commands, you will delete all the resource and services created by following this tutorial.
 
@@ -305,7 +305,7 @@ kubectl delete ClusterRole calico-prometheus-user
 kubectl delete clusterrolebinding calico-prometheus-user
 ```
 
-## Best practices
+### Best practices
 
 If you enable {{site.prodname}} metrics to Prometheus, a best practice is to use network policy to limit access to the {{site.prodname}} metrics endpoints. For details, see [Secure {{site.prodname}} Prometheus endpoints]({{ site.baseurl }}/security/comms/secure-metrics).  
 


### PR DESCRIPTION
## Description

- This pull rewrites the documentation page regarding how to implement prometheus in Kubernetes cluster and enable Felix, Typha metric features and what to do next.
- Old monitoring page was vague and did not show any example or how to implement.
- I have tested the tutorial on EKS cluster

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- documentation
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Grammatical check
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
