### PR TITLE
Add GlobalNetworkPolicy short name

### DIFF
--- a/_includes/charts/calico/crds/kdd/02-crd-globalnetworkpolicy.yaml
+++ b/_includes/charts/calico/crds/kdd/02-crd-globalnetworkpolicy.yaml
@@ -10,3 +10,5 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+    shortNames:
+    - gnp

--- a/upgrade/v2.5/manifests/crds.yaml
+++ b/upgrade/v2.5/manifests/crds.yaml
@@ -59,3 +59,5 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+    shortNames:
+    - gnp


### PR DESCRIPTION
## Description
This PR introduces a short name for GlobalNetworkPolicy Custom Resource make it more easier to create policies via `kubectl` CLI.

## Related issues/PRs
fixes https://github.com/projectcalico/calico/issues/2651

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
GlobalNetworkPolicy Custom Resource definition has a new alias `gnp` to make `kubectl` commands more simple.
```
