### PR TITLE
Update k8s tutorials to work with k8s 1.18

### DIFF
--- a/security/tutorials/kubernetes-policy-advanced.md
+++ b/security/tutorials/kubernetes-policy-advanced.md
@@ -31,7 +31,7 @@ We'll use a new namespace for this guide.  Run the following commands to create 
 
 ```bash
 kubectl create ns advanced-policy-demo
-kubectl run --namespace=advanced-policy-demo nginx --replicas=2 --image=nginx
+kubectl create deployment --namespace=advanced-policy-demo nginx --image=nginx
 kubectl expose --namespace=advanced-policy-demo deployment nginx --port=80
 ```
 
@@ -134,7 +134,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      run: nginx
+      app: nginx
   ingress:
     - from:
       - podSelector:
@@ -285,7 +285,7 @@ Even though DNS egress traffic is now working, all other egress traffic from all
 
 ### 6. Allow egress traffic to nginx
 
-Run the following to create a `NetworkPolicy` which allows egress traffic from any pods in the `advanced-policy-demo` namespace to pods with labels matching `run: nginx` in the same namespace.
+Run the following to create a `NetworkPolicy` which allows egress traffic from any pods in the `advanced-policy-demo` namespace to pods with labels matching `app: nginx` in the same namespace.
 
 ```bash
 kubectl create -f - <<EOF
@@ -303,7 +303,7 @@ spec:
   - to:
     - podSelector:
         matchLabels:
-          run: nginx
+          app: nginx
 EOF
 ```
 
@@ -339,7 +339,7 @@ wget: download timed out
 ```
 {: .no-select-button}
 
-Access to `google.com` times out because it can resolve DNS but has no egress access to anything other than pods with labels matching `run: nginx` in the `advanced-policy-demo` namespace.
+Access to `google.com` times out because it can resolve DNS but has no egress access to anything other than pods with labels matching `app: nginx` in the `advanced-policy-demo` namespace.
 
 ## 7. Clean up namespace
 

--- a/security/tutorials/kubernetes-policy-basic.md
+++ b/security/tutorials/kubernetes-policy-basic.md
@@ -23,7 +23,7 @@ We'll use Kubernetes `Deployment` objects to easily create pods in the namespace
 1. Create some nginx pods in the `policy-demo` namespace.
 
    ```bash
-   kubectl run --namespace=policy-demo nginx --replicas=2 --image=nginx
+   kubectl create deployment --namespace=policy-demo nginx --image=nginx
    ```
 
 1. Expose them through a service.
@@ -130,7 +130,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      run: nginx
+      app: nginx
   ingress:
     - from:
       - podSelector:
@@ -140,9 +140,9 @@ EOF
 ```
 
 > **Note**: The NetworkPolicy allows traffic from Pods with
-> the label `run: access` to Pods with the label `run: nginx`. These
-> are the labels automatically added to Pods started via `kubectl run`
-> based on the name of the `Deployment`.
+> the label `run: access` to Pods with the label `app: nginx`. The
+> labels are automatically added by kubectl and
+> are based on the name of the resource.
 {: .alert .alert-info}
 
 We should now be able to access the service from the `access` pod.


### PR DESCRIPTION
## Description

Update the K8s policy-demo and advanced-policy-demo tutorials.

The `kubectl create deployment` commands produce pods with the label `app: nginx` when using kubectl versions 1.15 and 1.18 so this should fix the tutorials for both.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Kubernetes network tutorials updated for v1.18.
```
