### PR TITLE
Docs Fix for (#3271) NetworkManager managing vxlan.calico interface 

### DIFF
--- a/_includes/content/reqs-sys.md
+++ b/_includes/content/reqs-sys.md
@@ -19,6 +19,7 @@
 
 - {{site.prodname}} must be able to manage `cali*` interfaces on the host. When IPIP is
   enabled (the default), {{site.prodname}} also needs to be able to manage `tunl*` interfaces.
+  When VXLAN is enabled, {{site.prodname}} also needs to be able to manage the `vxlan.calico` interface.
 
   > **Note**: Many Linux distributions, such as most of the above, include NetworkManager.
   > By default, NetworkManager does not allow {{site.prodname}} to manage interfaces.

--- a/maintenance/troubleshoot/troubleshooting.md
+++ b/maintenance/troubleshoot/troubleshooting.md
@@ -117,7 +117,7 @@ NetworkManager from interfering with the interfaces:
 
 ```conf
 [keyfile]
-unmanaged-devices=interface-name:cali*;interface-name:tunl*
+unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico
 ```
 
 ### Errors when running sudo calicoctl


### PR DESCRIPTION
## Description

Document that NetworkManager needs to be stopped from managing Calico VXLAN interfaces.

## Related issues/PRs

https://github.com/projectcalico/calico/issues/3271

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
