### PR TITLE
Update ctl-container-install.md

### DIFF
--- a/_includes/content/ctl-container-install.md
+++ b/_includes/content/ctl-container-install.md
@@ -55,7 +55,7 @@ kns.kube-system      kns.kube-system
 We recommend setting an alias as follows.
 
 ```
-alias calicoctl="kubectl exec -i -n kube-system calicoctl /calicoctl -- "
+alias calicoctl="kubectl exec -i -n kube-system calicoctl -- /calicoctl "
 ```
 
    > **Note**: In order to use the `calicoctl` alias


### PR DESCRIPTION
## Description
Fixing documentation example alias for use with calicoctl.

Using the existing alias:
`▶ calicoctl version
OCI runtime exec failed: exec failed: container_linux.go:346: starting container process caused "exec: \"version\": executable file not found in $PATH": unknown
command terminated with exit code 126`

Using the updated alias:
`▶ calicoctl version
Client Version:    v3.13.3
Git commit:        eb796e31
Cluster Version:   v3.13.3
Cluster Type:      kops,bgp,kdd,k8s`
