### PR TITLE
Add Tip to Global Network Policy Section

### DIFF
--- a/security/calico-network-policy.md
+++ b/security/calico-network-policy.md
@@ -68,7 +68,7 @@ metadata:
   name: allow-tcp-port-6379
 ```
 
-Because Global Network Policy uses **kind: GlobalNetworkPolicy**, they are grouped seperately from **kind: NetworkPolicy**. For example, Global Network Policies will not be returned from `calicoctl get NetworkPolicy`, and are rather returned from `calicoctl get GlobalNetworkPolicy`.
+Because global network policies use **kind: GlobalNetworkPolicy**, they are grouped seperately from **kind: NetworkPolicy**. For example, global network policies will not be returned from `calicoctl get networkpolicy`, and are rather returned from `calicoctl get globalnetworkpolicy`.
 
 #### kubectl vs calicoctl
 

--- a/security/calico-network-policy.md
+++ b/security/calico-network-policy.md
@@ -68,6 +68,8 @@ metadata:
   name: allow-tcp-port-6379
 ```
 
+Because Global Network Policy uses **kind: GlobalNetworkPolicy**, they are grouped seperately from **kind: NetworkPolicy**. For example, Global Network Policies will not be returned from `calicoctl get NetworkPolicy`, and are rather returned from `calicoctl get GlobalNetworkPolicy`.
+
 #### kubectl vs calicoctl
 
 Calico network policies and Calico global network policies are applied using calicoctl. Syntax is similar to Kubernetes, but there a few differences. For help, see [calicoctl user reference]({{ site.baseurl }}/reference/calicoctl/overview).


### PR DESCRIPTION
## Description

When I first started working with Calico, I ran into an issue where new network policies I was creating were not behaving as they should. I could not find any network policy that was causing this, but later found out that there was a lingering Global Network Policy that was behind the issue. This tip could have saved me the time I spent trying to address this issue.

## Related issues/PRs

## Todos

## Release Note

