### PR TITLE
Add kube-controllers deployment to Canal

### DIFF
--- a/_includes/charts/calico/templates/calico-kube-controllers.yaml
+++ b/_includes/charts/calico/templates/calico-kube-controllers.yaml
@@ -1,4 +1,3 @@
-{{- if or (eq .Values.datastore "etcd") (eq .Values.network "calico") }}
 # See https://github.com/projectcalico/kube-controllers
 apiVersion: apps/v1
 kind: Deployment
@@ -88,7 +87,7 @@ spec:
           secret:
             secretName: calico-etcd-secrets
             defaultMode: 0400
-{{- else if eq .Values.network "calico" }}
+{{- else }}
       containers:
         - name: calico-kube-controllers
           image: {{.Values.kubeControllers.image}}:{{ .Values.kubeControllers.tag }}
@@ -112,4 +111,3 @@ kind: ServiceAccount
 metadata:
   name: calico-kube-controllers
   namespace: kube-system
-{{- end -}}

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -615,4 +615,10 @@ rules:
       - namespaces
     verbs:
       - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
 {{- end }}

--- a/_includes/charts/calico/templates/rbac.yaml
+++ b/_includes/charts/calico/templates/rbac.yaml
@@ -40,7 +40,7 @@ subjects:
   name: calico-kube-controllers
   namespace: kube-system
 ---
-{{- else if eq .Values.network "calico" }}
+{{- else }}
 # Include a clusterrole for the kube-controllers component,
 # and bind it to the calico-kube-controllers serviceaccount.
 kind: ClusterRole


### PR DESCRIPTION
## Description

This PR modifies the Canal manifests so that kube-controllers is installed as well.
Kube-controllers is needed for auto host endpoints.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
