### PR TITLE
Improve BPF docs and manifests.

### DIFF
--- a/_includes/charts/calico/templates/calico-config.yaml
+++ b/_includes/charts/calico/templates/calico-config.yaml
@@ -45,10 +45,14 @@ data:
   calico_backend: "bird"
 {{- end }}
 
-  # Configure the MTU to use
   {{- if .Values.bpf }}
+  # Configure the MTU for workload interfaces and VXLAN encap.
+  # In BPF mode, this should be set to your netowrk MTU - 50.
   veth_mtu: "1410"
   {{- else }}
+  # Configure the MTU to use for workload interfaces and the
+  # tunnels.  For IPIP, set to your network MTU - 20; for VXLAN
+  # set to your network MTU - 50.
   veth_mtu: "1440"
   {{- end}}
 {{- else if eq .Values.network "flannel" }}

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -284,6 +284,12 @@ spec:
                 configMapKeyRef:
                   name: {{include "variant_name" . | lower}}-config
                   key: veth_mtu
+            # Set MTU for the VXLAN tunnel device.
+            - name: FELIX_VXLANMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: {{include "variant_name" . | lower}}-config
+                  key: veth_mtu
 {{- else if eq .Values.network "flannel" }}
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND

--- a/getting-started/kubernetes/trying-ebpf.md
+++ b/getting-started/kubernetes/trying-ebpf.md
@@ -52,9 +52,7 @@ In the tech preview release, eBPF mode has the following pre-requisites:
 - An underlying network that doesn't require Calico to use an overlay.  The instructions below guide you through setting up a cluster in a single AWS subnet; an alternative would be to set up your cluster on-prem with a routed network topology.
 - The network must be configured to allow VXLAN packets between  {{site.prodname}}  hosts.
 - Single-homed hosts; eBPF mode currently assumes a single "main" host IP and interface.
-- Must use the Calico CNI plugin and Calico IPAM.  It is not yet compatible with third-party CNI plugins (AWS CNI/Azure CNI/GKE CNI/flannel etc).
 - IPv4 only.  The tech preview release does not support IPv6.
-- The MTU used by the BPF programs when doing encapsulation is hard coded (with the inner MTU limited to 1410 bytes).
 - Kubernetes API Datastore only.
 - Typha is not supported in the tech preview. 
 - The base [requirements]({{site.baseurl}}/getting-started/kubernetes/requirements) also apply.
@@ -63,6 +61,7 @@ In the tech preview release, eBPF mode has the following pre-requisites:
 
 - [Set up a suitable cluster](#set-up-a-suitable-cluster)
 - [Install Calico on nodes](#install-calico-on-nodes)
+- [Try out DSR mode](#try-out-dsr-mode)
 - [Toggle between eBPF and the standard linux networking pipeline](#toggle-between-ebpf-and-the-standard-linux-networking-pipeline)
 
 #### Set up a suitable cluster
@@ -132,7 +131,7 @@ For the tech preview, only the Kubernetes API Datastore is supported.  Since {{s
    * use the Kubernetes API Datastore
    * turn on BPF mode
    * use no encapsulation (which requires using a single subnet in AWS).
-   
+
 1. Find the real IP and port of your API server.  One way to do this is to run the following command:
    ```bash
    kubectl get endpoints kubernetes
@@ -144,6 +143,7 @@ For the tech preview, only the Kubernetes API Datastore is supported.  Since {{s
    kubernetes   <IP>:<port>         43h
    ```
    Record the `<IP>` and `<port>`.
+
 1. Modify the `kubernetes_service_host` and `kubernetes_service_port` variables in the config map at the top of the manifest.  Set `kubernetes_service_host` to the IP you recorded above.  Set `kubernetes_service_port` to the port.
    ```yaml
    kind: ConfigMap
@@ -155,6 +155,20 @@ For the tech preview, only the Kubernetes API Datastore is supported.  Since {{s
      ...
      kubernetes_service_host: "<IP>"
      kubernetes_service_port: "<port>"
+     ...
+   ```
+
+1. If the underlying network MTU of your cluster is less then 1460, set the `veth_mtu` configuration parameter to your `MTU - 50` (to allow for the VXLAN header).
+
+   ```yaml
+   kind: ConfigMap
+   apiVersion: v1
+   metadata:
+     name: calico-config
+     namespace: kube-system
+   data:
+     ...
+     veth_mtu: "<MTU>"
      ...
    ```
    
@@ -191,6 +205,16 @@ For the tech preview, only the Kubernetes API Datastore is supported.  Since {{s
    kube-controller-manager-host-name               1/1     Running   0          46m
    kube-scheduler-host-name                        1/1     Running   0          46m
    ``` 
+
+#### Try out DSR mode
+
+Direct return mode skips a hop through the network for traffic to services (such as node ports) from outside the cluster.  This reduces latency and CPU overhead but it requires the underlying network to allow nodes to send traffic with each other's IPs.  In AWS, this requires all your nodes to be in the same subnet and for the source/dest check to be disabled.
+
+DSR mode is disabled by default; to enable it, set the `BPFExternalServiceMode` felix configuration parameter to `"DSR"`.  One way to do that is to set the corresponding environment variable on the calico-node `DaemonSet`:
+
+```bash
+kubectl set env -n kube-system ds/calico-node FELIX_BPFExternalServiceMode="DSR"
+```
 
 #### Toggle between eBPF and the standard linux networking pipeline 
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

* Set the VXLAN MTU in the calico-node manifest so there's only a
  single place to change in the config map.
* Improve the docs in the manifest to explain the correct values for
  MTU.
* Add section to the BPF guide explaining MTU set-up.
* Add section to the BPF guide explaining how to turn on DSR.
* Remove obsolete limitations form BPF guide.

Spun up a cluster in AWS with  the new manifest, seemed to work as expected.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

documents https://github.com/projectcalico/felix/pull/2219
documents https://github.com/projectcalico/felix/pull/2251

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
