### PR TITLE
fix baseurl bug for archive releases

### DIFF
--- a/netlify/build.sh
+++ b/netlify/build.sh
@@ -67,7 +67,7 @@ function build_archives() {
             if [ -z "$CUSTOM_ARCHIVE_PATH" ]; then
                 build release-${branch} /${branch}
             else
-                build release-${branch} /$CUSTOM_ARCHIVE_PATH/${branch}
+                build release-${branch} $CUSTOM_ARCHIVE_PATH/${branch}
                 EXTRA_CONFIG=$EXTRA_CONFIG,$(pwd)/netlify/_manifests_only.yml build release-${branch} /${branch}
             fi
         fi

--- a/releases.md
+++ b/releases.md
@@ -9,7 +9,7 @@ layout: docwithnav
 {%- for version in site.data.archives -%}
 {%- if version.first -%}
     {%- for v in version["legacy"] %}
-- [{{ v }}](/{{ v }}){: data-proofer-ignore=""}
+- [{{ v }}](/archive/{{ v }}){: data-proofer-ignore=""}
     {%- endfor -%}
 {%- else -%}
 - [{{ version }}](/archive/{{ version }})


### PR DESCRIPTION
## Description

Fixes an issue where baseurl was set with erroneous `/` prefix rendering network assets unreachable on older releases.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```