### PR TITLE
Remove duplicate word in cni-plugin configuration readme.

### DIFF
--- a/reference/cni-plugin/configuration.md
+++ b/reference/cni-plugin/configuration.md
@@ -166,7 +166,7 @@ When using the {{site.prodname}} CNI plugin with Kubernetes, the plugin must be 
 }
 ```
 
-As a convenience, the API location location can also be configured directly, e.g.
+As a convenience, the API location can also be configured directly, e.g.
 
 ```json
 {


### PR DESCRIPTION
## Description

The **Kubernetes specific** section had the word **location** written twice. This PR removes the duplicate.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
