### PR TITLE
operator-init container needs to create kubecontrollersconfigurations

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -115,6 +115,7 @@ rules:
       - bgpconfigurations
       - bgppeers
       - felixconfigurations
+      - kubecontrollersconfigurations
       - globalnetworkpolicies
       - globalnetworksets
       - hostendpoints

--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -102,6 +102,10 @@ To include [Calico resources]({{site.baseurl}}/reference/resources) during insta
 > With recent versions of kubectl it is necessary to have a kubeconfig configured or add `--server='127.0.0.1:443'`
 > even though it is not used.
 
+> **Note**: If you have provided a `calico-resources` configmap and the tigera-operator pod fails to come up with `Init:CrashLoopBackOff`,
+> check the output of the init-container with `kubectl logs -n tigera-operator -l k8s-app=tigera-operator -c create-initial-resources`.
+{: .alert .alert-info}
+
 #### Create the cluster
 
 Start the cluster creation with the following command and wait for it to complete.


### PR DESCRIPTION
## Description

This PR updates the tigera-operator clusterrole so that the init-container can create kubecontrollersconfigurations.

> semaphore@semaphore-vm:~/462be04a-2aef-4164-823f-b97e5d632dc9$ kubectl logs -n tigera-operator tigera-operator-64666bf448-ln22n -c create-initial-resources
> Resource already exists /calico-resources/felixconfig.yaml
> Failed to create from /calico-resources/kubecontrollersconfig.yaml, Failed to create 'KubeControllersConfiguration' resource: [connection is unauthorized: kubecontrollersconfigurations.crd.projectcalico.org is forbidden: User "system:serviceaccount:tigera-operator:tigera-operator" cannot create resource "kubecontrollersconfigurations" in API group "crd.projectcalico.org" at the cluster scope]

Links to the changes:
- https://deploy-preview-3482--calico.netlify.app/master/manifests/ocp/tigera-operator/02-role-tigera-operator.yaml
- https://deploy-preview-3482--calico.netlify.app/master/getting-started/openshift/installation#optionally-provide-additional-configuration

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
