### PR TITLE
Fix navbar

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -158,7 +158,7 @@ The code is a little roundabout for a few reasons:
                         aria-controls="{{ navbar_id }}"
                       >
                         <h4 class="panel-title">
-                            <a href="{{site.baseurl}}{{navbar.path}}" class="{% if navbar.section %}navbar-title--not-clickable{% endif %}">
+                            <a href="{{site.baseurl}}{{navbar.path}}" class="navbar-title--{% if navbar.section %}not-clickable{% else %}clickable{% endif %}">
                               <span>{{ navbar.title }}</span>
                             </a>
                         </h4>
@@ -177,7 +177,7 @@ The code is a little roundabout for a few reasons:
                   <div class="panel panel-default">
                     <div class="panel-heading free-training" role="button" aria-controls="navbar-free-training">
                       <h4 class="panel-title">
-                        <a href="https://www.projectcalico.org/events" target="_blank">
+                        <a href="https://www.projectcalico.org/events" target="_blank" class="navbar-title--clickable">
                           <span>Free training</span>
                         </a>
                       </h4>

--- a/css/sidebar.scss
+++ b/css/sidebar.scss
@@ -56,4 +56,12 @@
   .section {
     padding-left: 15px;
   }
+
+  .navbar-title {
+    &--clickable {
+      display: block;
+      margin: -10px -15px;
+      padding: 10px 15px;
+    }
+  }
 }


### PR DESCRIPTION
## Description

At the moment user is able to navigate to "Release Notes" and "Free training" pages by clicking exactly on the text in matching sidebar's items. This PR provides a fix that will make available the user to navigate to that pages by clicking on any position on sidebar's matching items.