### PR TITLE
archives: build latest release

### DIFF
--- a/_data/archives.yml
+++ b/_data/archives.yml
@@ -6,5 +6,6 @@
 # To support 'branch-per-directory', an entry named 'legacy' can be specified which is a dictionary describing
 # all releases using the old model.
 # Order matters - place latest releases first
+- v3.13
 - v3.12
 - legacy: [v3.11, v3.10, v3.9, v3.8, v3.7, v3.6, v3.5, v3.4, v3.3, v3.2, v3.1, v3.0, v2.6, v2.5, v2.4, v2.3, v2.2, v2.1, v2.0, v1.6, v1.5]

--- a/_data/archives.yml
+++ b/_data/archives.yml
@@ -6,6 +6,5 @@
 # To support 'branch-per-directory', an entry named 'legacy' can be specified which is a dictionary describing
 # all releases using the old model.
 # Order matters - place latest releases first
-- v3.13
 - v3.12
 - legacy: [v3.11, v3.10, v3.9, v3.8, v3.7, v3.6, v3.5, v3.4, v3.3, v3.2, v3.1, v3.0, v2.6, v2.5, v2.4, v2.3, v2.2, v2.1, v2.0, v1.6, v1.5]

--- a/netlify/build.sh
+++ b/netlify/build.sh
@@ -55,7 +55,7 @@ function build_master() {
 # and is built into _site directly (the legacy docs were a version per dir).
 # Newer archive versions are built into its own directory for that version.
 function build_archives() {
-    (echo "v$CURRENT_RELEASE" && grep -oP '^- \K(.*)' _data/archives.yml) | while read branch; do
+    (echo "$CURRENT_RELEASE" && grep -oP '^- \K(.*)' _data/archives.yml) | while read branch; do
         EXTRA_CONFIG=$EXTRA_CONFIG,$(pwd)/netlify/_config_noindex.yml
         if [[ "$branch" == legacy* ]]; then
             if [ -z "$CUSTOM_ARCHIVE_PATH" ]; then

--- a/netlify/build.sh
+++ b/netlify/build.sh
@@ -55,7 +55,7 @@ function build_master() {
 # and is built into _site directly (the legacy docs were a version per dir).
 # Newer archive versions are built into its own directory for that version.
 function build_archives() {
-    grep -oP '^- \K(.*)' _data/archives.yml | while read branch; do
+    (echo "v$CURRENT_RELEASE" && grep -oP '^- \K(.*)' _data/archives.yml) | while read branch; do
         EXTRA_CONFIG=$EXTRA_CONFIG,$(pwd)/netlify/_config_noindex.yml
         if [[ "$branch" == legacy* ]]; then
             if [ -z "$CUSTOM_ARCHIVE_PATH" ]; then
@@ -85,9 +85,6 @@ mv _site/sitemap.xml _site/release-legacy-sitemap.xml
 echo "[INFO] building current release"
 EXTRA_CONFIG=$(pwd)/netlify/_config_latest.yml build release-$CURRENT_RELEASE
 mv _site/sitemap.xml _site/latest-sitemap.xml
-
-echo "[INFO] building permalink for current release"
-EXTRA_CONFIG=$(pwd)/netlify/_config_latest.yml build release-$CURRENT_RELEASE /$CURRENT_RELEASE
 
 if [ ! -z "$CANDIDATE_RELEASE" ]; then
     echo "[INFO] building candidate release"


### PR DESCRIPTION
## Description

Build the latest release for the archives section of the docs site. This is in efforts for being able to statically link to pages while they're in production and maintain reach-ability when these versions of docs are moved into the archives. 

```release-note
None required
```
