### PR TITLE
Add note to documentation about nftables incompatibility in Calico legacy.

### DIFF
--- a/v2.6/getting-started/docker/installation/requirements.md
+++ b/v2.6/getting-started/docker/installation/requirements.md
@@ -10,6 +10,10 @@ in order for Calico to function properly with Docker.
 
 As with all Calico clusters, all hosts should have IP connectivity between them.
 
+### iptables
+
+Note that on some systems, iptables runs in nftables compatibility mode by default. Calico v2.6 is not compatible with this and it will likely result in network connectivity issues. To fix this, run the following command to configure iptables to run in legacy mode: `sudo update-alternatives --set iptables /usr/sbin/iptables-legacy`. You will need to reboot for the change to take effect.
+
 ### etcd
 
 You will also need an etcd cluster accessible from each host which Calico

--- a/v2.6/getting-started/docker/installation/requirements.md
+++ b/v2.6/getting-started/docker/installation/requirements.md
@@ -12,7 +12,7 @@ As with all Calico clusters, all hosts should have IP connectivity between them.
 
 ### iptables
 
-Note that on some systems, iptables runs in nftables compatibility mode by default. Calico v2.6 is not compatible with this and it will likely result in network connectivity issues. To fix this, run the following command to configure iptables to run in legacy mode: `sudo update-alternatives --set iptables /usr/sbin/iptables-legacy`. You will need to reboot for the change to take effect.
+Note that on some systems, iptables runs in nftables compatibility mode by default. Calico v2.6 is not compatible with this and it will likely result in network connectivity issues. To fix this on Debian-based systems, run the following command to configure iptables to run in legacy mode: `sudo update-alternatives --set iptables /usr/sbin/iptables-legacy`. You will need to reboot for the change to take effect.
 
 ### etcd
 


### PR DESCRIPTION
## Description
I faced an issue using Debian Buster64 which runs iptables in nftables compatibility mode by default. It was pretty tough to track down the problem, just seemed like Calico wasn't working at all. Setting iptables to run in legacy compatibility mode fixed the issue. Thanks to @fasaxc for his assistance in figuring this out.

## Todos

- [ ] Tests - N/A
- [x] Documentation
- [ ] Release note - N/A
