### PR TITLE
Remove deprecated critical-pod annotation

### DIFF
--- a/_includes/charts/calico/templates/calico-kube-controllers.yaml
+++ b/_includes/charts/calico/templates/calico-kube-controllers.yaml
@@ -20,8 +20,6 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -20,12 +20,6 @@ spec:
     metadata:
       labels:
         k8s-app: {{include "nodeName" . }}
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/_includes/charts/calico/templates/calico-typha.yaml
+++ b/_includes/charts/calico/templates/calico-typha.yaml
@@ -46,10 +46,6 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
-        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
-        # add-on, ensuring it gets priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       nodeSelector:

--- a/_includes/non-helm-manifests/flannel-migration/migration-job.yaml
+++ b/_includes/non-helm-manifests/flannel-migration/migration-job.yaml
@@ -138,8 +138,6 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: flannel-migration-controller
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/getting-started/kubernetes/hardway/install-node.md
+++ b/getting-started/kubernetes/hardway/install-node.md
@@ -161,12 +161,6 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/getting-started/kubernetes/hardway/install-typha.md
+++ b/getting-started/kubernetes/hardway/install-typha.md
@@ -155,10 +155,6 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
-        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
-        # add-on, ensuring it gets priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
       hostNetwork: true


### PR DESCRIPTION
## Description

`scheduler.alpha.kubernetes.io/critical-pod` is deprecated as of Kubernetes 1.13.
It is replaced by `priorityClassName` set as `system-cluster-critical` or `system-node-critical` that can be used starting with Kubernetes 1.10.

https://v1-15.docs.kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
