### PR TITLE
Update "Hard Way" tutorial to the latest version of Calico

### DIFF
--- a/getting-started/kubernetes/hardway/install-cni-plugin.md
+++ b/getting-started/kubernetes/hardway/install-cni-plugin.md
@@ -128,9 +128,9 @@ sudo su
 Install the CNI plugin Binaries
 
 ```bash
-curl -L -o /opt/cni/bin/calico https://github.com/projectcalico/cni-plugin/releases/download/v3.8.0/calico-amd64
+curl -L -o /opt/cni/bin/calico https://github.com/projectcalico/cni-plugin/releases/download/v3.13.3/calico-amd64
 chmod 755 /opt/cni/bin/calico
-curl -L -o /opt/cni/bin/calico-ipam https://github.com/projectcalico/cni-plugin/releases/download/v3.8.0/calico-ipam-amd64
+curl -L -o /opt/cni/bin/calico-ipam https://github.com/projectcalico/cni-plugin/releases/download/v3.13.3/calico-ipam-amd64
 chmod 755 /opt/cni/bin/calico-ipam
 ```
 
@@ -176,6 +176,12 @@ cat > /etc/cni/net.d/10-calico.conflist <<EOF
   ]
 }
 EOF
+```
+
+Step back to normal user.
+
+```bash
+exit
 ```
 
 ## Next

--- a/getting-started/kubernetes/hardway/install-cni-plugin.md
+++ b/getting-started/kubernetes/hardway/install-cni-plugin.md
@@ -128,9 +128,9 @@ sudo su
 Install the CNI plugin Binaries
 
 ```bash
-curl -L -o /opt/cni/bin/calico https://github.com/projectcalico/cni-plugin/releases/download/v3.13.3/calico-amd64
+curl -L -o /opt/cni/bin/calico https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-amd64
 chmod 755 /opt/cni/bin/calico
-curl -L -o /opt/cni/bin/calico-ipam https://github.com/projectcalico/cni-plugin/releases/download/v3.13.3/calico-ipam-amd64
+curl -L -o /opt/cni/bin/calico-ipam https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-ipam-amd64
 chmod 755 /opt/cni/bin/calico-ipam
 ```
 
@@ -178,13 +178,13 @@ cat > /etc/cni/net.d/10-calico.conflist <<EOF
 EOF
 ```
 
-Step back to normal user.
+Exit from su and go back to the logged in user.
 
 ```bash
 exit
 ```
 
-At this point Kubernetes nodes must became to `Ready` state, because Kubernetes has all the network configuration.
+At this point Kubernetes nodes will become `Ready` because Kubernetes has a networking provider and configuration installed.
 
 Write the CNI configuration
 ```bash

--- a/getting-started/kubernetes/hardway/install-cni-plugin.md
+++ b/getting-started/kubernetes/hardway/install-cni-plugin.md
@@ -184,6 +184,13 @@ Step back to normal user.
 exit
 ```
 
+At this point Kubernetes nodes must became to `Ready` state, because Kubernetes has all the network configuration.
+
+Write the CNI configuration
+```bash
+kubectl get nodes
+```
+
 ## Next
 
 [Install Typha](./install-typha)

--- a/getting-started/kubernetes/hardway/install-cni-plugin.md
+++ b/getting-started/kubernetes/hardway/install-cni-plugin.md
@@ -186,7 +186,6 @@ exit
 
 At this point Kubernetes nodes will become `Ready` because Kubernetes has a networking provider and configuration installed.
 
-Write the CNI configuration
 ```bash
 kubectl get nodes
 ```

--- a/getting-started/kubernetes/hardway/install-node.md
+++ b/getting-started/kubernetes/hardway/install-node.md
@@ -69,6 +69,12 @@ rules:
       - list
       # Used to discover Typhas.
       - get
+  # Pod CIDR auto-detection on kubeadm needs access to config maps.
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs:
+      - get
   - apiGroups: [""]
     resources:
       - nodes/status

--- a/getting-started/kubernetes/hardway/standing-up-kubernetes.md
+++ b/getting-started/kubernetes/hardway/standing-up-kubernetes.md
@@ -33,7 +33,7 @@ We will install {{site.prodname}} on a Kubernetes cluster. To demonstrate a high
 
        `kubectl get nodes`
 
-       Verify all nodes have joined. At this point nodes have joined but they are in `NotReady` state, because Kubernetes can't find network a provider and configuration.
+       Verify all nodes have joined. At this point nodes have joined but they are in `NotReady` state, because Kubernetes can't find a networking provider and configuration.
 
 ## Next
 

--- a/getting-started/kubernetes/hardway/standing-up-kubernetes.md
+++ b/getting-started/kubernetes/hardway/standing-up-kubernetes.md
@@ -33,7 +33,7 @@ We will install {{site.prodname}} on a Kubernetes cluster. To demonstrate a high
 
        `kubectl get nodes`
 
-       Verify all nodes have joined. At this point nodes are joined but in `NotReady` state, because Kubernetes can't find network provider and configuration.
+       Verify all nodes have joined. At this point nodes have joined but they are in `NotReady` state, because Kubernetes can't find network a provider and configuration.
 
 ## Next
 

--- a/getting-started/kubernetes/hardway/standing-up-kubernetes.md
+++ b/getting-started/kubernetes/hardway/standing-up-kubernetes.md
@@ -20,20 +20,20 @@ We will install {{site.prodname}} on a Kubernetes cluster. To demonstrate a high
 
 ## Install Kubernetes
 
-1. Install kubeadm
+1. Install kubeadm, kubelet, kubectl by following (official documentation)[https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl].
 1. Choose one node as your Kubernetes master. On that node
-   `kubeadm init --pod-network-cidr=192.168.0.0/16`
+   `sudo kubeadm init --pod-network-cidr=192.168.0.0/16`
 
    The Kubernetes `pod-network-cidr` is the IP prefix for all pods in the Kubernetes cluster. This range must not clash with other networks in your VPC.
 1. On all other nodes
-   `kubeadm join <output from kubeadm init>`
+   `sudo kubeadm join <output from kubeadm init>`
 1. Copy admin credentials
 1. Test Access
     1. Run
 
        `kubectl get nodes`
 
-       Verify all nodes have joined
+       Verify all nodes have joined. At this point nodes are joined but in `NotReady` state, because Kubernetes can't find network provider and configuration.
 
 ## Next
 

--- a/getting-started/kubernetes/hardway/the-calico-datastore.md
+++ b/getting-started/kubernetes/hardway/the-calico-datastore.md
@@ -56,7 +56,7 @@ To interact directly with the {{site.prodname}} datastore, use the `calicoctl` c
 1. Download the `calicoctl` binary to a Linux host with access to Kubernetes.
 
    ```bash
-   wget https://github.com/projectcalico/calicoctl/releases/download/v3.13.3/calicoctl
+   wget https://github.com/projectcalico/calicoctl/releases/download/v3.14.0/calicoctl
    chmod +x calicoctl
    sudo mv calicoctl /usr/local/bin/
    ```

--- a/getting-started/kubernetes/hardway/the-calico-datastore.md
+++ b/getting-started/kubernetes/hardway/the-calico-datastore.md
@@ -56,7 +56,7 @@ To interact directly with the {{site.prodname}} datastore, use the `calicoctl` c
 1. Download the `calicoctl` binary to a Linux host with access to Kubernetes.
 
    ```bash
-   wget https://github.com/projectcalico/calicoctl/releases/download/v3.8.0/calicoctl
+   wget https://github.com/projectcalico/calicoctl/releases/download/v3.13.3/calicoctl
    chmod +x calicoctl
    sudo mv calicoctl /usr/local/bin/
    ```


### PR DESCRIPTION
## Description

The Hard way section of the documentation used some old Calico version. This PR updates to the latest: 3.13.3.

## Related issues/PRs
fixes https://github.com/projectcalico/calico/issues/3446

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
