### PR TITLE
Fix release notes breadcrumbs path

### DIFF
--- a/_data/navbars/release-notes.yml
+++ b/_data/navbars/release-notes.yml
@@ -1,5 +1,5 @@
 title: Release notes
-path: /release-notes
+path: /release-notes/
 order: 6
 toc:
 - title: Release notes


### PR DESCRIPTION
Breadcrumbs for the release notes page are broken. This fixes it!