### PR TITLE
require openshift 4.3 or newer

### DIFF
--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -19,13 +19,13 @@ to install {{site.prodname}}.
 
 - Ensure that your environment meets the {{site.prodname}} [system requirements]({{site.baseurl}}/getting-started/openshift/requirements).
 
-- **If installing on AWS**, ensure that you have {% include open-new-window.html text='configured an AWS account' url='https://docs.openshift.com/container-platform/4.2/installing/installing_aws/installing-aws-account.html' %} appropriate for OpenShift 4,
+- **If installing on AWS**, ensure that you have {% include open-new-window.html text='configured an AWS account' url='https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html' %} appropriate for OpenShift 4,
   and have {% include open-new-window.html text='set up your AWS credentials' url='https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html' %}.
-  Note that the OpenShift installer supports a subset of {% include open-new-window.html text='AWS regions' url='https://docs.openshift.com/container-platform/4.2/installing/installing_aws/installing-aws-account.html#installation-aws-regions_installing-aws-account' %}.
+  Note that the OpenShift installer supports a subset of {% include open-new-window.html text='AWS regions' url='https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html#installation-aws-regions_installing-aws-account' %}.
 
 - Ensure that you have a {% include open-new-window.html text='RedHat account' url='https://cloud.redhat.com/' %}. A RedHat account is required to obtain the pull secret necessary to provision an OpenShift cluster.
 
-- Ensure that you have installed the OpenShift installer **v4.2 or later** and OpenShift command line interface from {% include open-new-window.html text='cloud.redhat.com' url='https://cloud.redhat.com/openshift/install/aws/installer-provisioned' %}.
+- Ensure that you have installed the OpenShift installer **v4.3 or later** and OpenShift command line interface from {% include open-new-window.html text='cloud.redhat.com' url='https://cloud.redhat.com/openshift/install/aws/installer-provisioned' %}.
 
 - Ensure that you have {% include open-new-window.html text='generated a local SSH private key' url='https://docs.openshift.com/container-platform/4.1/installing/installing_aws/installing-aws-default.html#ssh-agent-using_installing-aws-default' %} and have added it to your ssh-agent
 

--- a/getting-started/openshift/requirements.md
+++ b/getting-started/openshift/requirements.md
@@ -10,10 +10,10 @@ canonical_url: /getting-started/openshift/requirements
 
 {{site.prodname}} {{page.version}} supports:
 
-- OpenShift Container Platform 4.2+
+- OpenShift Container Platform 4.3+
 
 Refer to the OpenShift documentation for additional requirements.
 
-- {% include open-new-window.html text='OpenShift Container Platform' url='https://docs.openshift.com/container-platform/4.2/welcome/index.html' %}
+- {% include open-new-window.html text='OpenShift Container Platform' url='https://docs.openshift.com/container-platform/4.3/welcome/index.html' %}
 
 {% include content/reqs-kernel.md %}


### PR DESCRIPTION
## Description

Due to compatibility issues with Openshift 4.2, require Openshift 4.3 or newer.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
