### PR TITLE
Add cautionary note about enabling auto host endpoints.

### DIFF
--- a/_includes/content/auto-hostendpoints-migrate.md
+++ b/_includes/content/auto-hostendpoints-migrate.md
@@ -4,6 +4,9 @@
 > This may result in unexpected behavior and data.
 {: .alert .alert-danger}
 
+> **Important**: Only enable auto host endpoints after all Calico components have been upgraded otherwise it may result in an outage.
+{: .alert .alert-danger}
+
 In order to migrate existing all-interfaces host endpoints to {{site.prodname}}-managed auto host endpoints:
 
 1. Add any labels on existing all-interfaces host endpoints to their corresponding {{include.orch}} nodes. {{site.prodname}} manages labels on automatic host endpoints by syncing


### PR DESCRIPTION
One scenario in which this outage could occur:
- Update kube-controllers but not calico-node
- Enable auto host endpoints
- Instead of a profile applying to the auto host endpoints, Felix
doesn't find the 'projectcalico-default-allow' profile.
- The auto host endpoints cut off all traffic

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
