### PR TITLE
Doc: fix external links

### DIFF
--- a/_data/navbars/security.yml
+++ b/_data/navbars/security.yml
@@ -4,8 +4,6 @@ order: 3
 section:
 - title: Adopt a zero trust network model for security
   path: /security/adopt-zero-trust
-- title: Try out the node-to-node encryption tech preview
-  path: /security/try-node-to-node-encryption
 - title: Get started with policy
   path: /security/get-started
   section:
@@ -78,6 +76,8 @@ section:
     path: /security/high-connection-workloads
   - title: Defend against DoS attacks
     path: /security/defend-dos-attack
+- title: Try out the node-to-node encryption tech preview
+  path: /security/try-node-to-node-encryption
 - title: Secure Calico component communications
   path: /security/comms/
   section:

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -42,9 +42,10 @@ This how-to guide uses the following {{site.prodname}} features:
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).  
 
    >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
-  {: .alert .alert-info}
+{: .alert .alert-info}
 
-  To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:
+To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:
+
   ```
   calicoctl patch felixconfiguration <Host-Name> --type='merge' -p '{"spec":{"wireguardEnabled":false}}'
   ```

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -24,14 +24,17 @@ This how-to guide uses the following {{site.prodname}} features:
 
 Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 
->**Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time. {: .alert .alert-info}
+>**Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
+{: .alert .alert-info}
 
->**Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require {{site.prodname}} to use an overlay. For example, a cluster with a routed network topology. {: .alert .alert-info}
+>**Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require {{site.prodname}} to use an overlay. For example, a cluster with a routed network topology. 
+{: .alert .alert-info}
 
 ### How to
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
-   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. {: .alert .alert-info}
+   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
+{: .alert .alert-info}
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
      calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'
@@ -46,7 +49,6 @@ To disable WireGuard on a specific node with WireGuard installed, modify the hos
   ```
   calicoctl patch felixconfiguration <Host-Name> --type='merge' -p '{"spec":{"wireguardEnabled":false}}'
   ```
-
 #### Troubleshoot
 
 To verify that the nodes are configured for WireGuard encryption, check the node status set by Felix using `calicoctl`. For example:
@@ -59,7 +61,6 @@ To verify that the nodes are configured for WireGuard encryption, check the node
      wireguardPublicKey: jlkVyQYooZYzI2wFfNhSZez5eWh44yfq1wKVjLvSXgY=
      ...
    ```
-
 ### Above and beyond
 
 - [Secure Calico component communications]({{ site.baseurl }}/security/comms)

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -31,7 +31,6 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 ### How to
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
-
    >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
 {: .alert .alert-info}
 1. Enable WireGuard encryption across all the nodes using the following command.

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -35,6 +35,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.  
    >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
 {: .alert .alert-info}
+
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
      calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -34,8 +34,8 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
 
-> **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
-{: .alert .alert-info}
+    > **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
+    {: .alert .alert-info}
 
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
@@ -43,8 +43,8 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
     ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).    
 
-> **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
-{: .alert .alert-info}
+    > **Note**: The above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+    {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:
 

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -24,17 +24,15 @@ This how-to guide uses the following {{site.prodname}} features:
 
 Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 
-> **Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
-{: .alert .alert-info}
+>**Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time. {: .alert .alert-info}
 
-> **Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require {{site.prodname}} to use an overlay. For example, a cluster with a routed network topology.
-{: .alert .alert-info}
+>**Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require {{site.prodname}} to use an overlay. For example, a cluster with a routed network topology. {: .alert .alert-info}
 
 ### How to
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
 
-    >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
+   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
 {: .alert .alert-info}
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -22,11 +22,13 @@ This how-to guide uses the following {{site.prodname}} features:
 
 ### Before you begin...
 
-- Verify the operating system(s) running on the nodes in the cluster [support WireGuard](https://www.wireguard.com/install/).
+Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 
-    >**Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
-    {: .alert .alert-info}
-- In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require Calico to use an overlay. For example, a cluster with a routed network topology.
+>**Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
+{: .alert .alert-info}
+
+>**Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require Calico to use an overlay. For example, a cluster with a routed network topology.
+{: .alert .alert-info}
 
 ### How to
 
@@ -37,8 +39,8 @@ This how-to guide uses the following {{site.prodname}} features:
 
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
-   calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'
-   ```
+     calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'
+    ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).  
 
    >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -33,7 +33,7 @@ This how-to guide uses the following {{site.prodname}} features:
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}
 
    >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
-   {: .alert .alert-info}
+{: .alert .alert-info}
 
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -31,8 +31,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 ### How to
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
-   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
-{: .alert .alert-info}
+   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. {: .alert .alert-info}
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
      calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -32,7 +32,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 
 ### How to
 
-1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}
+1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
 
    > **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
 {: .alert .alert-info}
@@ -43,7 +43,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
     ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).  
 
-   >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+   > **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
 {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -12,13 +12,13 @@ Enable WireGuard to secure node-to-node traffic in a {{site.prodname}} cluster.
 
 ### Value
 
-{{ site.prodname }} supports WireGuard tunnels between nodes providing transport-level security for node-to-node traffic. WireGuard provides [formally verified](https://www.wireguard.com/formal-verification/) secure and [performant tunnels](https://www.wireguard.com/performance/) without any specialized hardware. For a deep dive in to WireGuard implementation, see [whitepaper](https://www.wireguard.com/papers/wireguard.pdf).
+{{ site.prodname }} supports WireGuard tunnels between nodes providing transport-level security for node-to-node traffic. WireGuard provides {% include open-new-window.html text='formally verified' url='https://www.wireguard.com/formal-verification/' %} secure and {% include open-new-window.html text='performant tunnels' url='https://www.wireguard.com/performance/' %} without any specialized hardware. For a deep dive in to WireGuard implementation, see {% include open-new-window.html text='whitepaper' url='https://www.wireguard.com/papers/wireguard.pdf' %}.
 
 ### Features
 
 This how-to guide uses the following {{site.prodname}} features:
 
-- **Felix configuration resource** with WireGuard configuration parameters.
+- **Felix configuration resource** with WireGuard configuration parameters
 
 ### Before you begin...
 
@@ -30,7 +30,7 @@ This how-to guide uses the following {{site.prodname}} features:
 
 ### How to
 
-1. Install WireGuard on cluster nodes using these [instructions for your operating system](https://www.wireguard.com/install/).
+1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}
 
    >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
    {: .alert .alert-info}
@@ -41,19 +41,19 @@ This how-to guide uses the following {{site.prodname}} features:
    calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'
    ```
 
-For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).
+  For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).
 
->**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
-   {: .alert .alert-info}
+  >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+  {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:
 ```
 calicoctl patch felixconfiguration <Host-Name> --type='merge' -p '{"spec":{"wireguardEnabled":false}}'
 ```
 
-#### Troubleshooting
+#### Troubleshoot
 
-- To verify that the nodes are configured for WireGuard encryption, check the node status set by Felix using `calicoctl`. For example:
+To verify that the nodes are configured for WireGuard encryption, check the node status set by Felix using `calicoctl`. For example:
 
    ```
    $ calicoctl get node <NODE-NAME> -o yaml
@@ -67,4 +67,3 @@ calicoctl patch felixconfiguration <Host-Name> --type='merge' -p '{"spec":{"wire
 ### Above and beyond
 
 - [Secure Calico component communications]({{ site.baseurl }}/security/comms)
-

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -36,12 +36,10 @@ This how-to guide uses the following {{site.prodname}} features:
    {: .alert .alert-info}
 
 1. Enable WireGuard encryption across all the nodes using the following command.
-
-   ```
+    ```
    calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'
    ```
-
-  For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).
+   For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).  
 
   >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
   {: .alert .alert-info}
@@ -59,7 +57,7 @@ To verify that the nodes are configured for WireGuard encryption, check the node
    $ calicoctl get node <NODE-NAME> -o yaml
    ...
    status:
-     ..
+     ...
      wireguardPublicKey: jlkVyQYooZYzI2wFfNhSZez5eWh44yfq1wKVjLvSXgY=
      ...
    ```

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -32,7 +32,8 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 
 ### How to
 
-1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.  
+1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
+
    >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
 {: .alert .alert-info}
 

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -8,7 +8,7 @@ description: Try out enabling WireGuard for state-of-the-art cryptographic secur
 Enable WireGuard to secure node-to-node traffic in a {{site.prodname}} cluster.
 
 > **Warning!** Node-to-node encryption is a tech preview and should not be used in production clusters. It has had very limited testing and it will contain bugs (please report these on the {{site.prodname}} Users Slack or GitHub). This feature is currently not supported with overlay networks (IP in IP, VXLAN) due to known issues with NodePort services.
-{: .alert .alert-danger }
+{: .alert .alert-danger}
 
 ### Value
 
@@ -34,9 +34,8 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
 
-   > **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
+    >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
 {: .alert .alert-info}
-
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
      calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -43,7 +43,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
     ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).    
 
-   > **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+   >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
 {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -32,8 +32,8 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 
 ### How to
 
-1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
->**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
+1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.  
+   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
 {: .alert .alert-info}
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
@@ -41,7 +41,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
     ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).    
 
-> **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+   > **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
 {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: Try out the node-to-node encryption tech preview
-description: Try out enabling WireGuard for state-of-the-art cryptographic security between pods for Calico clusters.
+description: Try out enabling WireGuard for state-of-the-art cryptographic security between nodes for Calico clusters.
 ---
 
 ### Big picture

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -41,13 +41,13 @@ This how-to guide uses the following {{site.prodname}} features:
    ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).  
 
-  >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+   >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
   {: .alert .alert-info}
 
-To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:
-```
-calicoctl patch felixconfiguration <Host-Name> --type='merge' -p '{"spec":{"wireguardEnabled":false}}'
-```
+  To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:
+  ```
+  calicoctl patch felixconfiguration <Host-Name> --type='merge' -p '{"spec":{"wireguardEnabled":false}}'
+  ```
 
 #### Troubleshoot
 

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -7,7 +7,7 @@ description: Try out enabling WireGuard for state-of-the-art cryptographic secur
 
 Enable WireGuard to secure node-to-node traffic in a {{site.prodname}} cluster.
 
-> **Warning!** Node-to-node encryption is a tech preview and should not be used in production clusters. It has had very limited testing and it will contain bugs (please report these on the {{site.prodname}} Users Slack or GitHub). This feature is currently not supported with overlay networks (IP in IP, VXLAN) due to known issues with NodePort services.
+> **Warning!** Node-to-node encryption is a tech preview and should not be used in production clusters. It has had very limited testing and it will contain bugs (please report these on the Calico Users Slack or GitHub). This feature is currently not supported with overlay networks (IP in IP, VXLAN) due to known issues with NodePort services.
 {: .alert .alert-danger}
 
 ### Value
@@ -24,17 +24,17 @@ This how-to guide uses the following {{site.prodname}} features:
 
 Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 
->**Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
+> **Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
 {: .alert .alert-info}
 
->**Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require {{site.prodname}} to use an overlay. For example, a cluster with a routed network topology. 
+> **Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require {{site.prodname}} to use an overlay. For example, a cluster with a routed network topology. 
 {: .alert .alert-info}
 
 ### How to
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
 
-   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
+> **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
 {: .alert .alert-info}
 
 1. Enable WireGuard encryption across all the nodes using the following command.
@@ -43,7 +43,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
     ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).    
 
-   >**Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+> **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
 {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -34,8 +34,8 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
 
-    > **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
-    {: .alert .alert-info}
+   > **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
+   {: .alert .alert-info}
 
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
@@ -43,8 +43,8 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
     ```
    For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).    
 
-    > **Note**: The above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
-    {: .alert .alert-info}
+   > **Note**: The above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+   {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:
 

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -33,15 +33,15 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 ### How to
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
-   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
+>**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
 {: .alert .alert-info}
 1. Enable WireGuard encryption across all the nodes using the following command.
     ```
      calicoctl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true}}'
     ```
-   For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).  
+   For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources]({{ site.baseurl }}/getting-started/openshift/installation#optionally-provide-additional-configuration).    
 
-   > **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
+> **Note**: This above command can be used to change other WireGuard attributes. For a list of other WireGuard parameters and configuration evaluation, see the [Felix configuration]({{ site.baseurl }}/reference/resources/felixconfig#felix-configuration-definition).
 {: .alert .alert-info}
 
 To disable WireGuard on a specific node with WireGuard installed, modify the host-specific Felix configuration. For example:

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -7,7 +7,7 @@ description: Try out enabling WireGuard for state-of-the-art cryptographic secur
 
 Enable WireGuard to secure node-to-node traffic in a {{site.prodname}} cluster.
 
-> **Warning!** Node-to-node encryption is a tech preview and should not be used in production clusters. It has had very limited testing and it will contain bugs (please report these on the Calico Users Slack or GitHub). This feature is currently not supported with overlay networks (IP in IP, VXLAN) due to known issues with NodePort services.
+> **Warning!** Node-to-node encryption is a tech preview and should not be used in production clusters. It has had very limited testing and it will contain bugs (please report these on the {{site.prodname}} Users Slack or GitHub). This feature is currently not supported with overlay networks (IP in IP, VXLAN) due to known issues with NodePort services.
 {: .alert .alert-danger }
 
 ### Value
@@ -24,17 +24,17 @@ This how-to guide uses the following {{site.prodname}} features:
 
 Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 
->**Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
+> **Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
 {: .alert .alert-info}
 
->**Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require Calico to use an overlay. For example, a cluster with a routed network topology.
+> **Note**: In the tech preview release, node-to-node encryption is supported on an underlying network that doesn’t require {{site.prodname}} to use an overlay. For example, a cluster with a routed network topology.
 {: .alert .alert-info}
 
 ### How to
 
 1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}
 
-   >**Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
+   > **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard.
 {: .alert .alert-info}
 
 1. Enable WireGuard encryption across all the nodes using the following command.


### PR DESCRIPTION
Fix external links and minor formatting issues in Try out node-to-node encryption doc. 

- Request from Alex P.
- Merge to OS 
- Cherry pick to /master