### PR TITLE
Fix description for landing page

### DIFF
--- a/security/kubernetes-nodes.md
+++ b/security/kubernetes-nodes.md
@@ -1,6 +1,6 @@
 ---
 title: Protect Kubernetes nodes
-Description: Protect Kubernetes nodes with host endpoints managed by Calico
+description: Protect Kubernetes nodes with host endpoints managed by Calico
 ---
 
 ### Big picture


### PR DESCRIPTION
## Description

Protect Kubernetes nodes doc had a description, but it was init caps "Description" so the description is not visible on the landing page. Semaphore currently does not flag this. 

- Merge and cherry pick to OS
- Merge and cherry pick to Enterprise