### PR TITLE
Add a note about rebooting in WireGuard installation

### DIFF
--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -32,7 +32,7 @@ Verify the operating system(s) running on the nodes in the cluster {% include op
 
 ### How to
 
-1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}.
+1. Install WireGuard on cluster nodes using these {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}. Note that you may need to reboot your nodes after installing WireGuard to make the kernel modules available on your system.
 
    > **Note**: Nodes that do not support WireGuard will not be secured by WireGuard tunnels, even if traffic running on the node to and from the pods goes to nodes that do support WireGuard. 
    {: .alert .alert-info}


### PR DESCRIPTION
WireGuard depends on a kernel module that may not be available until node reboot. Adds a note to the installation instructions regarding this.

## Description

Documentation update for WireGuard preview.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
