### PR TITLE
Fix algolia subsection links

### DIFF
--- a/_includes/section_index.html
+++ b/_includes/section_index.html
@@ -5,11 +5,11 @@
                 {% for nested_item in item.section %}
                     {% capture url %}{{ nested_item.path | relative_url }}{% endcapture %}
                     <div class="section-index__item">
-                        <h4>
+                        <div class="section-index__title">
                             <a href="{{ url }}">
                                 {{ nested_item.title }}
                             </a>
-                        </h4>
+                        </div>
                         <p>
                             {% assign p = site.pages | where: 'url', nested_item.path | first %}
                             {{ p.description | default p.Description | default nested_item.description | default "no description" }}

--- a/css/section_index.scss
+++ b/css/section_index.scss
@@ -10,6 +10,15 @@
     display: flex;
     flex-wrap: wrap;
 
+    &__title {
+        margin-top: 30px;
+        margin-bottom: 11px;
+
+        font-size: 20px;
+        font-weight: 700;
+        line-height: 1.1;
+    }
+
     &__item {
         padding-left: ceil(($grid-gutter-width / 2));
         padding-right: floor(($grid-gutter-width / 2));

--- a/js/searchConfig.js
+++ b/js/searchConfig.js
@@ -145,9 +145,11 @@
         const { hits, widgetParams } = renderOptions;
 
         const content = hits.reduce((currentHtml, hit) => {
+            const topLevelUrl = removeHashFromUrl(hit.url);
+
             if (hit.shouldDisplayTopCategory && hit.hierarchy.lvl0) {
                 currentHtml += `
-                    <a href="${hit.url}" class="search-results__group-header">
+                    <a href="${topLevelUrl}" class="search-results__group-header">
                         ${hit._highlightResult.hierarchy.lvl0.value}
                     </a>
                 `;
@@ -160,7 +162,7 @@
 
             if (hit.hierarchy.lvl1) {
                 currentHtml += `
-                    <a href="${hit.url}" class="search-result__subcategory">
+                    <a href="${topLevelUrl}" class="search-result__subcategory">
                         ${hit._highlightResult.hierarchy.lvl1.value}
                     </a>
                 `;
@@ -208,5 +210,9 @@
                 ${content}
             </div>
         `;
+    }
+
+    function removeHashFromUrl(url) {
+        return url.split('#')[0];
     }
 })();


### PR DESCRIPTION
## Description

This PR contains 2 fixes:

1. Algolia parses pages and provides results based on `<h*>` headers. Our index pages (e.g. `/getting-started/kubernetes/`) also contain `h4` tags which are littering search results. So I replaced them with `div`s with existing styling.
2. Our search result dropdown has 2-column layout. And it was requested to links from 1st column lead to top of the page. This is done by removing hash part from url.
