### PR TITLE
Fix name of calico-config configmap in command

### DIFF
--- a/networking/mtu.md
+++ b/networking/mtu.md
@@ -74,7 +74,7 @@ When you set the MTU, it applies to new workloads. To apply MTU changes to exist
 Edit the `calico-config` ConfigMap to set values in FelixConfiguration. For example:
 
 ```bash
-kubectl patch configmap/{{site.prodname}}-config -n kube-system --type merge \
+kubectl patch configmap/calico-config -n kube-system --type merge \
   -p '{"data":{"veth_mtu": "1440"}}'
 ```
 


### PR DESCRIPTION
## Description

Fixes a bug in the documented command for updating the MTU.

## Related issues/PRs

None

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
