### PR TITLE
Update to require calicoctl

### DIFF
--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -22,6 +22,8 @@ This how-to guide uses the following {{site.prodname}} features:
 
 ### Before you begin...
 
+[Install and configure calicoctl]({{site.prodname}}/getting-started/clis/calicoctl/)
+
 Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 
 > **Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -22,9 +22,8 @@ This how-to guide uses the following {{site.prodname}} features:
 
 ### Before you begin...
 
-[Install and configure calicoctl]({{site.baseurl}}/getting-started/clis/calicoctl/install)
-
-Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
+- [Install and configure calicoctl]({{site.baseurl}}/getting-started/clis/calicoctl/install)
+- Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 
 > **Note**: WireGuard in {{site.prodname}} does not support IPv6 at this time.
 {: .alert .alert-info}

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -22,7 +22,7 @@ This how-to guide uses the following {{site.prodname}} features:
 
 ### Before you begin...
 
-[Install and configure calicoctl]({{site.prodname}}/getting-started/clis/calicoctl/)
+[Install and configure calicoctl]({{site.prodname}}/getting-started/clis/calicoctl/install)
 
 Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 

--- a/security/try-node-to-node-encryption.md
+++ b/security/try-node-to-node-encryption.md
@@ -22,7 +22,7 @@ This how-to guide uses the following {{site.prodname}} features:
 
 ### Before you begin...
 
-[Install and configure calicoctl]({{site.prodname}}/getting-started/clis/calicoctl/install)
+[Install and configure calicoctl]({{site.baseurl}}/getting-started/clis/calicoctl/install)
 
 Verify the operating system(s) running on the nodes in the cluster {% include open-new-window.html text='support WireGuard' url='https://www.wireguard.com/install/' %}.
 


### PR DESCRIPTION
## Description

Update node-to-node encryption doc to require calicoctl. Based on OS website user comment.

- Merge to nightly
- Cherry pick to /master