### PR TITLE
Claify datastore types  for calicoctl documentation

### DIFF
--- a/getting-started/clis/calicoctl/install.md
+++ b/getting-started/clis/calicoctl/install.md
@@ -10,7 +10,7 @@ canonical_url: '/getting-started/clis/calicoctl/install'
 from the command line. {{site.prodname}} objects are stored in one of two datastores,
 either etcd or Kubernetes. The choice of datastore is determined at the time Calico
 is installed. Typically for Kubernetes installations the Kubernetes datastore is the
-default
+default.
 
 You can run `calicoctl` on any host with network access to the
 {{site.prodname}} datastore as either a binary or a container.

--- a/getting-started/clis/calicoctl/install.md
+++ b/getting-started/clis/calicoctl/install.md
@@ -7,7 +7,10 @@ canonical_url: '/getting-started/clis/calicoctl/install'
 ## About installing calicoctl
 
 `calicoctl` allows you to create, read, update, and delete {{site.prodname}} objects
-from the command line.
+from the command line. {{site.prodname}} objects are stored in one of two datastores,
+either etcd or Kubernetes. The choice of datastore is determined at the time Calico
+is installed. Typically for Kubernetes installations the Kubernetes datastore is the
+default
 
 You can run `calicoctl` on any host with network access to the
 {{site.prodname}} datastore as either a binary or a container.


### PR DESCRIPTION
## Description

Clarify the types of available datastore for the install calicoctl documentation

## Related issues/PRs

## Release Note

```release-note
None required
```
