### PR TITLE
Restore doc for older OpenStack releases with Python 2

### DIFF
--- a/getting-started/openstack/installation/redhat.md
+++ b/getting-started/openstack/installation/redhat.md
@@ -30,22 +30,36 @@ combined control and compute node, work through all three sections.
 Some steps need to be taken on all machines being installed with {{site.prodname}}.
 These steps are detailed in this section.
 
-{% include ppa_repo_name %}
-
 1.  {% include open-new-window.html text='Add the EPEL repository' url='https://fedoraproject.org/wiki/EPEL' %}. You may
     have already added this to install OpenStack.
 
-1.  Configure the {{site.prodname}} repository:
+1.  Configure the {{site.prodname}} repository, using the `calico-3.15` name if your OpenStack
+    install uses Python 3:
 
     ```bash
     cat > /etc/yum.repos.d/calico.repo <<EOF
     [calico]
     name=Calico Repository
-    baseurl=https://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/
+    baseurl=https://binaries.projectcalico.org/rpm/calico-3.15/
     enabled=1
     skip_if_unavailable=0
     gpgcheck=1
-    gpgkey=https://binaries.projectcalico.org/rpm/{{ ppa_repo_name }}/key
+    gpgkey=https://binaries.projectcalico.org/rpm/calico-3.15/key
+    priority=97
+    EOF
+    ```
+
+    Or `calico-3.15-python2` if your OpenStack install uses Python 2:
+
+    ```bash
+    cat > /etc/yum.repos.d/calico.repo <<EOF
+    [calico]
+    name=Calico Repository
+    baseurl=https://binaries.projectcalico.org/rpm/calico-3.15-python2/
+    enabled=1
+    skip_if_unavailable=0
+    gpgcheck=1
+    gpgkey=https://binaries.projectcalico.org/rpm/calico-3.15-python2/key
     priority=97
     EOF
     ```

--- a/getting-started/openstack/installation/redhat.md
+++ b/getting-started/openstack/installation/redhat.md
@@ -64,8 +64,8 @@ These steps are detailed in this section.
     EOF
     ```
 
-1.  Install the `etcd3-gateway` Python package.  A current copy of that code is
-    needed by {{site.prodname}}'s OpenStack driver and DHCP agent, so you
+1.  If your OpenStack install uses Python 3, install the `etcd3-gateway` Python package.  A current
+    copy of that code is needed by {{site.prodname}}'s OpenStack driver and DHCP agent, so you
     should install it with `pip3`.
 
     ```

--- a/getting-started/openstack/installation/ubuntu.md
+++ b/getting-started/openstack/installation/ubuntu.md
@@ -60,13 +60,20 @@ These steps are detailed in this section.
     apt-get update
     ```
 
-1.  Install the `etcd3-gateway` Python package.  A current copy of that code is
-    needed by {{site.prodname}}'s OpenStack driver and DHCP agent, so you
-    should install it with `pip`.
+1.  Install the `etcd3-gateway` Python package.  A current copy of that code is needed by
+    {{site.prodname}}'s OpenStack driver and DHCP agent, so you should install it with `pip3` or
+    `pip`.  If your OpenStack install uses Python 3:
 
     ```
     apt-get install -y python3-pip
     pip3 install git+https://github.com/dims/etcd3-gateway.git@5a3157a122368c2314c7a961f61722e47355f981
+    ```
+
+    Or if your OpenStack install uses Python 2:
+
+    ```
+    apt-get install -y python-pip
+    pip install git+https://github.com/dims/etcd3-gateway.git@5a3157a122368c2314c7a961f61722e47355f981
     ```
 
 1.  Edit `/etc/neutron/neutron.conf`.  Add a `[calico]` section with

--- a/getting-started/openstack/installation/ubuntu.md
+++ b/getting-started/openstack/installation/ubuntu.md
@@ -28,12 +28,17 @@ combined control and compute node, work through all three sections.
 Some steps need to be taken on all machines being installed with {{site.prodname}}.
 These steps are detailed in this section.
 
-{% include ppa_repo_name %}
-
-1.  Configure APT to use the {{site.prodname}} PPA:
+1.  Configure APT to use the {{site.prodname}} `calico-3.15` PPA if your OpenStack install uses
+    Python 3:
 
     ```bash
-    add-apt-repository ppa:project-calico/{{ ppa_repo_name }}
+    add-apt-repository ppa:project-calico/calico-3.15
+    ```
+
+    Or the `calico-3.15-python2` PPA if your OpenStack install uses Python 2:
+
+    ```bash
+    add-apt-repository ppa:project-calico/calico-3.15-python2
     ```
 
 1.  Add the official [BIRD](http://bird.network.cz/) PPA. This PPA contains

--- a/getting-started/openstack/requirements.md
+++ b/getting-started/openstack/requirements.md
@@ -8,13 +8,26 @@ canonical_url: '/getting-started/openstack/requirements'
 
 ## OpenStack requirements
 
-The Calico Neutron driver is written in Python 3 and so requires an OpenStack release that
-runs with Python 3.  Subject to that, we aim to develop and maintain the Neutron driver
-for {{site.prodname}} (networking-calico) so that its master code works with OpenStack
-master or any previous Python 3 release, on any operating system, independently of the
-deployment mechanism that is used to install it.
+We aim to develop and maintain the Neutron driver for {{site.prodname}}
+(networking-calico) so that its master code works with OpenStack master or any
+previous release (back to Liberty), on any operating system, independently of
+the deployment mechanism that is used to install it.
 
-However, we recommend using OpenStack Ussuri or later, and our active support and testing
-of {{site.prodname}} {{page.version}} with OpenStack is with Ussuri.
+However, we recommend using OpenStack Newton or later, and our active support
+and testing of {{site.prodname}} {{page.version}} with OpenStack is limited to
+the following versions:
+
+- Queens (with Python 2)
+- Rocky (with Python 2)
+- Ussuri (with Python 3)
 
 {% include content/reqs-kernel.md %}
+
+## Nova patch needed with Mitaka and earlier
+
+With OpenStack Mitaka and earlier, and if your libvirt is >= 1.3.3 and < 3.1,
+you will need to patch the Nova code post installation, on each compute host,
+as in {% include open-new-window.html text='this change' url='https://review.openstack.org/#/c/411936/' %}.  In case you
+need the same Nova code to work with all possible libvirt versions, you should
+then add {% include open-new-window.html text='this further change' url='https://review.openstack.org/#/c/448203/' %}.
+OpenStack Newton and later already include these two changes.

--- a/networking/ipv6.md
+++ b/networking/ipv6.md
@@ -205,7 +205,7 @@ each Neutron network, with:
 
 -   the IPv6 address range that you want your VMs to use
 -   DHCP enabled
--   IPv6 address mode set to DHCPv6 stateful.
+-   (from Juno onwards) IPv6 address mode set to DHCPv6 stateful.
 
 We suggest initially configuring both IPv4 and IPv6 subnets in each
 network. This allows handling VM images that support only IPv4 alongside

--- a/networking/openstack/configuration.md
+++ b/networking/openstack/configuration.md
@@ -41,6 +41,12 @@ you can, instead, set
 
 and then the further ML2-specific configuration as covered below.
 
+With OpenStack releases earlier than Liberty you will also need:
+
+| Setting                 | Value                    | Meaning                    |
+|-------------------------|--------------------------|----------------------------|
+| dhcp_agents_per_network | 9999                     | Allow unlimited DHCP agents per network |
+
 The following options in the `[calico]` section of `/etc/neutron/neutron.conf` govern how
 the {{site.prodname}} plugin/driver and DHCP agent connect to the {{site.prodname}} etcd
 datastore.  You should set `etcd_host` to the IP of your etcd server, and `etcd_port` if
@@ -85,3 +91,13 @@ settings to configure the ML2 plugin.
 | mechanism_drivers    | calico      | Use {{site.prodname}}             |
 | type_drivers         | local, flat | Allow 'local' and 'flat' networks |
 | tenant_network_types | local, flat | Allow 'local' and 'flat' networks |
+
+### DHCP agent (.../dhcp_agent.ini)
+
+With OpenStack releases earlier than Liberty, in
+`/etc/neutron/dhcp_agent.ini` you need the following setting to
+configure the Neutron DHCP agent.
+
+| Setting          | Value                 | Meaning                                                                                                         |
+|------------------|-----------------------|-----------------------------------------------------------------------------------------------------------------|
+| interface_driver | RoutedInterfaceDriver | Use {{site.prodname}}'s modified DHCP agent support for TAP interfaces that are routed instead of being bridged |


### PR DESCRIPTION
Following the Python 3 work at #3624 it was decided that the v3.15 release series will still support Python 2 as well as Python 3.  This PR restores the associated doc.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
