### PR TITLE
Update calico-etcdv3-paths.md

### DIFF
--- a/reference/etcd-rbac/calico-etcdv3-paths.md
+++ b/reference/etcd-rbac/calico-etcdv3-paths.md
@@ -45,17 +45,17 @@ component needs access to in etcd to function successfully.
 
 ## calico/kube-controllers
 
-| Path                                                                   | Access |
-|------------------------------------------------------------------------|--------|
-| /calico/ipam/v2/\*                                                     |   RW   |
-| /calico/resources/v3/projectcalico.org/profiles/*                      |   RW   |
-| /calico/resources/v3/projectcalico.org/networkpolicies/*               |   RW   |
-| /calico/resources/v3/projectcalico.org/nodes/*                         |   RW   |
-| /calico/resources/v3/projectcalico.org/clusterinformations/*           |   RW   |
-| /calico/resources/v3/projectcalico.org/hostendpoints/*                 |   RW   |
-| /calico/resources/v3/projectcalico.org/kubecontrollersconfigurations/* |   RW   |
-| /calico/resources/v3/projectcalico.org/*                               |   R    |
-
+| Path                                                                    | Access |
+|-------------------------------------------------------------------------|--------|
+| /calico/ipam/v2/\*                                                      |   RW   |
+| /calico/resources/v3/projectcalico.org/profiles/\*                      |   RW   |
+| /calico/resources/v3/projectcalico.org/networkpolicies/\*               |   RW   |
+| /calico/resources/v3/projectcalico.org/nodes/\*                         |   RW   |
+| /calico/resources/v3/projectcalico.org/clusterinformations/\*           |   RW   |
+| /calico/resources/v3/projectcalico.org/hostendpoints/\*                 |   RW   |
+| /calico/resources/v3/projectcalico.org/kubecontrollersconfigurations/\* |   RW   |
+| /calico/resources/v3/projectcalico.org/\*                               |   R    |
+ 
 > **Note**: By default, `calico/kube-controllers` performs periodic
 > compaction of the etcd data store. If you limit it to just these
 > paths it will be unauthorized to perform this compaction, as that

--- a/reference/etcd-rbac/calico-etcdv3-paths.md
+++ b/reference/etcd-rbac/calico-etcdv3-paths.md
@@ -45,14 +45,16 @@ component needs access to in etcd to function successfully.
 
 ## calico/kube-controllers
 
-| Path                                                          | Access |
-|---------------------------------------------------------------|--------|
-| /calico/ipam/v2/\*                                            |   RW   |
-| /calico/resources/v3/projectcalico.org/profiles/\*            |   RW   |
-| /calico/resources/v3/projectcalico.org/networkpolicies/\*     |   RW   |
-| /calico/resources/v3/projectcalico.org/nodes/\*               |   RW   |
-| /calico/resources/v3/projectcalico.org/clusterinformations/\* |   RW   |
-| /calico/resources/v3/projectcalico.org/\*                     |   R    |
+| Path                                                                   | Access |
+|------------------------------------------------------------------------|--------|
+| /calico/ipam/v2/\*                                                     |   RW   |
+| /calico/resources/v3/projectcalico.org/profiles/*                      |   RW   |
+| /calico/resources/v3/projectcalico.org/networkpolicies/*               |   RW   |
+| /calico/resources/v3/projectcalico.org/nodes/*                         |   RW   |
+| /calico/resources/v3/projectcalico.org/clusterinformations/*           |   RW   |
+| /calico/resources/v3/projectcalico.org/hostendpoints/*                 |   RW   |
+| /calico/resources/v3/projectcalico.org/kubecontrollersconfigurations/* |   RW   |
+| /calico/resources/v3/projectcalico.org/*                               |   R    |
 
 > **Note**: By default, `calico/kube-controllers` performs periodic
 > compaction of the etcd data store. If you limit it to just these


### PR DESCRIPTION
## Description
The RBAC rules https://docs.projectcalico.org/reference/etcd-rbac/calico-etcdv3-paths is outdated. For v3.14 automatic host endpoints features, calico kube-controller need read write permission to the hostendpoint and kubecontrollerconfigurations ETCD path. Adding this to the documentation page.
 
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
