### PR TITLE
Exclude html-tags / modal dialogs content from read-time algorithm

### DIFF
--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,4 +1,5 @@
-{% assign words = content | strip_html | number_of_words %}
+<!-- We do not need consider html-tags and modal dialogs content when calculate the total number of words -->
+{% assign words = content | regex_replace: '<div class="modal-body">(.|\n)*?<\/div>', '' | strip_html | number_of_words %}
 {% assign readTime = words | divided_by:180 | round %}
 <div class="read-time">
   <span class="glyphicon glyphicon-time read-time__icon"></span>

--- a/_includes/read_time.html
+++ b/_includes/read_time.html
@@ -1,4 +1,4 @@
-{% assign words = content | number_of_words %}
+{% assign words = content | strip_html | number_of_words %}
 {% assign readTime = words | divided_by:180 | round %}
 <div class="read-time">
   <span class="glyphicon glyphicon-time read-time__icon"></span>

--- a/_plugins/regex-replace.rb
+++ b/_plugins/regex-replace.rb
@@ -1,0 +1,11 @@
+require 'liquid'
+
+module Jekyll
+  module RegexReplace
+    def regex_replace(str, regex, value_replace)
+      return str.gsub(Regexp.new(regex), value_replace, )
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::RegexReplace)


### PR DESCRIPTION
## Description

This PR provides an improved read-time algorithm by excluding html-tags and modal dialogs content while calculating the total number of words. Also, it contains new `regex_replace` plugin in order to be able to get rid of specific (like `<div class='modal-body'>...</div>`) text when parsing page content.