### PR TITLE
Minor style tweaks. Change color of warn box, align breadcrumbs with …

### DIFF
--- a/_sass/bootstrap/bootstrap/_breadcrumbs.scss
+++ b/_sass/bootstrap/bootstrap/_breadcrumbs.scss
@@ -5,7 +5,6 @@
 
 .breadcrumb {
   padding: $breadcrumb-padding-vertical $breadcrumb-padding-horizontal;
-  margin-bottom: $line-height-computed;
   list-style: none;
   background-color: $breadcrumb-bg;
   border-radius: $border-radius-base;
@@ -17,7 +16,7 @@
       // [converter] Workaround for https://github.com/sass/libsass/issues/1115
       $nbsp: "\00a0";
       content: "#{$breadcrumb-separator}#{$nbsp}"; // Unicode space added since inline-block means non-collapsing white-space
-      padding: 0 5px;
+      padding: 0 3px;
       color: $breadcrumb-color;
     }
   }

--- a/_sass/bootstrap/bootstrap/_type.scss
+++ b/_sass/bootstrap/bootstrap/_type.scss
@@ -25,7 +25,7 @@ h1, .h1,
 h2, .h2,
 h3, .h3 {
   margin-top: $line-height-computed;
-  margin-bottom: ($line-height-computed / 2);
+  margin-bottom: ($line-height-computed / 2.2);
 
   small,
   .small {

--- a/_sass/bootstrap/bootstrap/_variables.scss
+++ b/_sass/bootstrap/bootstrap/_variables.scss
@@ -793,7 +793,7 @@ $badge-border-radius:         10px !default;
 //
 //##
 
-$breadcrumb-padding-vertical:   8px !default;
+$breadcrumb-padding-vertical:   3px !default;
 $breadcrumb-padding-horizontal: 15px !default;
 //** Breadcrumb background color
 $breadcrumb-bg:                 #f5f5f5 !default;

--- a/css/style.scss
+++ b/css/style.scss
@@ -35,14 +35,14 @@ $sticky-top: $header-height + $navbar-margin-bottom;
   }
 }
 
-h4 {
-  font-weight: 700;
+h1 {
+  font-size: 38px;
 }
 
-// Default blockquotes are too big in Bootstrap.
-// Shrink them down
-blockquote {
-  font-size: inherit;
+h4 {
+  margin: 22px 0px 8px 0px;
+  font-weight: 700;
+  font-size: 20px;
 }
 
 // Set height to prevent weird bug where sidebar is clipped at bottom.
@@ -62,8 +62,8 @@ body {
   }
 }
 
-h2,h3,h4,h5,h6 {
-  margin-top: 30px;
+h2,h3 {
+  margin-top: 28px;
 }
 
 pre code {
@@ -71,7 +71,7 @@ pre code {
 }
 
 div.alert-warning {
-  background-color: #FFFF7E;
+  background-color: #FFE3AB;
   color: #C7254E;
 }
 
@@ -502,7 +502,7 @@ $max-toc-height: calc(100vh - #{$sticky-top + $navbar-margin-bottom});
 }
 
 .breadcrumb-item {
-  font-size: 14px;
+  font-size: 12px;
 }
 
 .general-tab-header {


### PR DESCRIPTION
This PR contains a few style tweaks. Since our template has many headers on each page, the aim is to lower the margins/padding slightly, so you can see instructions without scrolling down.

Changes:
- Change the color of the warning box from cringe-yellow to a light orange. Aligns better with the Tigera orange.
- Lower margins especially of h4, which is now rarely used.
- Make breadcrumbs font and margin slightly smaller. (Many pages had breadcrumbs too wide for 1 line, resulting even in double padding)

![image](https://user-images.githubusercontent.com/15924949/86174296-3dc04580-bad6-11ea-9f63-c073c59d189d.png)

