### PR TITLE
Plugin to prevent special characters in code blocks

### DIFF
--- a/_plugins/code_block_validator.rb
+++ b/_plugins/code_block_validator.rb
@@ -6,8 +6,8 @@ Jekyll::Hooks.register :pages, :pre_render do |post|
     # do nothing if url indicates legal folder
     if !post.path.match(/\/legal\//)
         occurences = []
-        # Check content of the post for code blocks.
-        post.content.scan(/(?:[`]{3}(.*?)[`]{3})/m){ |match|
+        # Check post content and extract code blocks
+        post.content.scan(/(?:[`]{3}|(?<!`)[`](?!`))(.*?)(?:[`]{3}|(?<!`)[`](?!`))/m){ |match|
             # Check all matched cases
             match.each do |block|
                 # convert each character to an array of Decimal numbers
@@ -20,7 +20,7 @@ Jekyll::Hooks.register :pages, :pre_render do |post|
                 end
             end
         }
-        # was there any special characters?
+        # were there any special characters?
         if occurences.length > 0
             occurences.each do |sentence|
                 # printing line to user

--- a/_plugins/code_block_validator.rb
+++ b/_plugins/code_block_validator.rb
@@ -1,0 +1,35 @@
+# Description : This plugin checks code blocks created using `or``` 
+# in their markdown state for special characters that can cause problem in terminal.
+# Authour : Reza R <54559947+frozenprocess@users.noreply.github.com>
+#####
+Jekyll::Hooks.register :pages, :pre_render do |post|
+    # do nothing if url indicates legal folder
+    if !post.path.match(/\/legal\//)
+        occurences = []
+        # Check content of the post for code blocks.
+        post.content.scan(/(?:[`]{3}(.*?)[`]{3})/m){ |match|
+            # Check all matched cases
+            match.each do |block|
+                # convert each character to an array of Decimal numbers
+                # and iterate each character.
+                block.codepoints.each_with_index do |b_chr, idx|
+                    # \n (9) and \t (10) are exceptions for this block
+                    if ( b_chr < 32 && ![9,10].include?(b_chr) ) || b_chr > 126
+                        occurences.append({'code' => block, 'idx' => idx})
+                    end 
+                end
+            end
+        }
+        # was there any special characters?
+        if occurences.length > 0
+            occurences.each do |sentence|
+                # printing line to user
+                print(sentence['code'][sentence['idx']-10..sentence['idx']+10].strip)
+                # printing position of the character
+                print("\n"+" "*10 + "^~~~~~~~~~~~\n")
+            end 
+            # Stop compiling 
+            raise "\n Unexpected character in codeblock detected: #{post.path}"
+        end 
+    end
+end

--- a/networking/bgp.md
+++ b/networking/bgp.md
@@ -69,7 +69,7 @@ The default **node-to-node BGP mesh** must be turned off to enable other BGP top
 Run the following command to disable the BGP full-mesh:
 
 ```
-calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": “false”}}'
+calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": "false"}}'
 ```
 
 >**Note**: If the default BGP configuration resource does not exist, you need to create it first. See [BGP configuration]({{ site.baseurl }}/reference/resources/bgpconfig) for more information.
@@ -104,7 +104,7 @@ metadata:
 spec:
   peerIP: 192.20.30.40
   asNumber: 64567
-  nodeSelector: rack == ‘rack-1’
+  nodeSelector: rack == 'rack-1'
 ```
 #### Configure a node to act as a route reflector
 
@@ -113,7 +113,7 @@ spec:
 To configure a node to be a route reflector with cluster ID 244.0.0.1, run the following command.
 
 ```
-calicoctl patch node my-node -p '{"spec": {“bgp”: {"routeReflectorClusterID": “244.0.0.1”}}}'
+calicoctl patch node my-node -p '{"spec": {"bgp": {"routeReflectorClusterID": "244.0.0.1"}}}'
 ```
 
 Typically, you will want to label this node to indicate that it is a route reflector, allowing it to be easily selected by a BGPPeer resource. You can do this with kubectl. For example:
@@ -130,7 +130,7 @@ metadata:
   name: peer-with-route-reflectors
 spec:
   nodeSelector: all()
-  peerSelector: route-reflector == ‘true’
+  peerSelector: route-reflector == 'true'
 ```
 
 #### View BGP peering status for a node
@@ -152,7 +152,7 @@ A table that lists all of the neighbors and their current status is displayed. S
 By default, all Calico nodes use the 64512 autonomous system, unless a per-node AS has been specified for the node. You can change the global default for all nodes by modifying the default **BGPConfiguration** resource. The following example command sets the global default AS number to **64513**.
 
 ```
-calicoctl patch bgpconfiguration default -p '{"spec": {"asNumber": “64513”}}'
+calicoctl patch bgpconfiguration default -p '{"spec": {"asNumber": "64513"}}'
 ```
 
 >**Note**: If the default BGP configuration resource does not exist, you need to create it first. See [BGP configuration]({{ site.baseurl }}/reference/resources/bgpconfig) for more information.
@@ -163,7 +163,7 @@ calicoctl patch bgpconfiguration default -p '{"spec": {"asNumber": “64513”}}
 You can configure an AS for a particular node by modifying the node object using `calicoctl`. For example, the following command changes the node named **node-1** to belong to **AS 64514**.
 
 ```
-calicoctl patch node node-1 -p '{"spec": {"bgp": {“asNumber”: “64514”}}}'
+calicoctl patch node node-1 -p '{"spec": {"bgp": {"asNumber": "64514"}}}'
 ```
 ### Above and beyond
 

--- a/networking/change-block-size.md
+++ b/networking/change-block-size.md
@@ -111,7 +111,7 @@ temporary-pool        10.0.0.0/16      true   Always     false
 Disable allocations in the default pool.
 
 ```
-calicoctl patch ippool default-ipv4-ippool -p '{"spec": {"disabled": “true”}}'
+calicoctl patch ippool default-ipv4-ippool -p '{"spec": {"disabled": "true"}}'
 ```
 
 Verify the changes.
@@ -175,7 +175,7 @@ calicoctl apply -f pool.yaml
 #### Disable the temporary IP pool
 
 ```
-calicoctl patch ippool temporary-pool -p '{"spec": {"disabled": “true”}}'
+calicoctl patch ippool temporary-pool -p '{"spec": {"disabled": "true"}}'
 ```
 
 #### Delete pods from the temporary IP pool


### PR DESCRIPTION
## Description
@lxpollitt @joshti
This plugin search for special characters in code blocks and prevents compilation cycle from completion with an error message to user.

I intentionally did not modify `networking/bgp.md` and `felix.md` file in order to break Semaphore compile cycle in first compilation attempt, if you like to see the error message created by this plugin please check the first build attempt in Semaphore.


## Related issues/PRs
#3769 Original place that this problem was mentioned.

```release-note
None required
```
