### PR TITLE
Calico CNI in EKS - manifest changes

### DIFF
--- a/_includes/charts/calico/templates/calico-config.yaml
+++ b/_includes/charts/calico/templates/calico-config.yaml
@@ -39,7 +39,7 @@ data:
 {{- end }}
 {{- if eq .Values.network "calico" }}
   # Configure the backend to use.
-{{- if .Values.flannel_migration }}
+{{- if or (.Values.flannel_migration) (.Values.eks) }}
   calico_backend: "vxlan"
 {{- else }}
   calico_backend: "bird"

--- a/_includes/charts/calico/templates/calico-config.yaml
+++ b/_includes/charts/calico/templates/calico-config.yaml
@@ -39,7 +39,7 @@ data:
 {{- end }}
 {{- if eq .Values.network "calico" }}
   # Configure the backend to use.
-{{- if or (.Values.flannel_migration) (.Values.eks) }}
+{{- if or (.Values.flannel_migration) (.Values.vxlan) }}
   calico_backend: "vxlan"
 {{- else }}
   calico_backend: "bird"

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -314,6 +314,11 @@ spec:
             - name: CLUSTER_TYPE
               value: "k8s"
 {{- end }}
+{{- if and (eq .Values.network "calico") (.Values.eks) }}
+            # Disable AWS source-destination check on nodes.
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+{{- end }}
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
@@ -346,7 +351,7 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
-{{- if and (eq .Values.network "calico") (not .Values.flannel_migration) }}
+{{- if and (eq .Values.network "calico") (not .Values.flannel_migration) (not .Values.eks) }}
               - -bird-live
 {{- end }}
             periodSeconds: 10
@@ -358,7 +363,7 @@ spec:
               command:
               - /bin/calico-node
               - -felix-ready
-{{- if not .Values.flannel_migration }}
+{{- if and (not .Values.flannel_migration) (not .Values.eks) }}
               - -bird-ready
 {{- end }}
 {{- else if eq .Values.network "flannel" }}

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -314,7 +314,7 @@ spec:
             - name: CLUSTER_TYPE
               value: "k8s"
 {{- end }}
-{{- if and (eq .Values.network "calico") (.Values.eks) }}
+{{- if and (eq .Values.network "calico") (.Values.vxlan) }}
             # Disable AWS source-destination check on nodes.
             - name: FELIX_AWSSRCDSTCHECK
               value: Disable
@@ -351,7 +351,7 @@ spec:
               command:
               - /bin/calico-node
               - -felix-live
-{{- if and (eq .Values.network "calico") (not .Values.flannel_migration) (not .Values.eks) }}
+{{- if and (eq .Values.network "calico") (not .Values.flannel_migration) (not .Values.vxlan) }}
               - -bird-live
 {{- end }}
             periodSeconds: 10
@@ -363,7 +363,7 @@ spec:
               command:
               - /bin/calico-node
               - -felix-ready
-{{- if and (not .Values.flannel_migration) (not .Values.eks) }}
+{{- if and (not .Values.flannel_migration) (not .Values.vxlan) }}
               - -bird-ready
 {{- end }}
 {{- else if eq .Values.network "flannel" }}

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5,5 +5,4 @@ layout: null
 datastore: kubernetes
 network: calico
 vxlan: true
-eks: true
 {% endhelm %}

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5,4 +5,5 @@ layout: null
 datastore: kubernetes
 network: calico
 vxlan: true
+eks: true
 {% endhelm %}


### PR DESCRIPTION
## Description

Calico CNI in EKS - manifest changes:
1. `disable` _aws-src-dst-check_ in felix
2. set `calico_backend` to `vxlan` in calico-config
3. update `calico-node` readiness/liveness checks.

## Release Note

```release-note
Set aws-src-dst-check to disable for Calico CNI in EKS.
```
