### PR TITLE
Add OCP operator deployment manifest that excludes initContainer

### DIFF
--- a/manifests/ocp/tigera-operator/02-tigera-operator-no-resource-loading.yaml
+++ b/manifests/ocp/tigera-operator/02-tigera-operator-no-resource-loading.yaml
@@ -1,0 +1,10 @@
+---
+layout: null
+---
+# This operator deployment should be used only for generating ClusterServiceVersions for OpenShift.
+# This deployment manifest excludes the initContainer that is normally included
+# to install install-time resources.
+{% helm tigera-operator --execute templates/tigera-operator/02-tigera-operator.yaml %}
+installation:
+  kubernetesProvider: not-used
+{% endhelm %}


### PR DESCRIPTION
## Description

This PR adds a version of the OpenShift operator deployment manifest that excludes the init container and volumes used to create cluster-install-time resources.

This manifest will be used to generate ClusterServiceVersions.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
