### PR TITLE
How to use Multus, Calico and AWS-CNI in EKS

### DIFF
--- a/_data/navbars/getting-started.yml
+++ b/_data/navbars/getting-started.yml
@@ -12,6 +12,8 @@ section:
     section:
     - title: Amazon Elastic Kubernetes Service (EKS)
       path: /getting-started/kubernetes/managed-public-cloud/eks
+    - title: Amazon Elastic Kubernetes Service (EKS) Multiple CNI
+      path: /getting-started/kubernetes/managed-public-cloud/eks-multus
     - title: Google Kubernetes Engine (GKE)
       path: /getting-started/kubernetes/managed-public-cloud/gke
     - title: IBM Cloud Kubernetes Service (IKS)

--- a/getting-started/kubernetes/managed-public-cloud/eks-multus.md
+++ b/getting-started/kubernetes/managed-public-cloud/eks-multus.md
@@ -1,0 +1,233 @@
+---
+title: Amazon Elastic Kubernetes Service (EKS) Using Calico and Multus
+description: Using Multus in an EKS environment
+---
+
+### Big picture
+
+Enabling multiple CNI plugins in an EKS cluster using Multus-CNI.
+
+### Value
+
+Multus CNI is an open source Kubernetes CNI plugin, it allows attaching multiple interfaces to pods. By acting as a `meta-plugin` Multus can 
+override Kubernetes default network CNI configuration and assign interfaces to different CNI plugin.
+
+Multus integration with {{site.prodname}} offers great flexibility in EKS clusters, it can be a solution for EKS control plane limitations 
+when using custom networking in a managed nodes cluster environment.
+
+> **Note**: {{site.prodname}} networking cannot currently be installed on the EKS control plane nodes. As a result the control plane nodes
+> will not be able to initiate network connections to {{site.prodname}} pods. (This is a general limitation of EKS's custom networking support,
+> not specific to {{site.prodname}}.) 
+{: .alert .alert-info }
+
+### How to
+
+This tutorial will guide you to install Multus, {{site.prodname}} and aws-k8s-cni in a Kubernetes cluster, we will use `eksctl` to provision the cluster. However, you can use any of the methods in {% include open-new-window.html text='Getting Started with Amazon EKS' url='https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html' %}
+
+Before you get started, make sure you have downloaded and configured the {% include open-new-window.html text='necessary prerequisites' url='https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html#eksctl-prereqs' %}
+
+#### Create the cluster
+
+Create an Amazon EKS cluster without any nodes.
+
+```bash
+eksctl create cluster --name calico-multus --without-nodegroup
+```
+
+> **Note**: Multus scans `/etc/cni/net.d/` folder in alphabetic order for files with `conf` or `conflist` 
+extension. To promote {{site.prodname}} as your primary CNI you have to delete `aws-node` from your cluster.
+{: .alert .alert-info }
+
+Delete `amazon-vpc-cni-k8s` daemonset
+
+```bash
+kubectl delete daemonset -n kube-system aws-node
+```
+
+You should see an output similar to
+
+```
+daemonset.apps "aws-node" deleted
+```
+
+#### Install {{ site.prodname }}
+
+Now that you have a cluster configured, you can install {{site.prodname}}.
+
+```bash
+kubectl apply -f {{ "/manifests/calico-vxlan.yaml" | absolute_url }}
+```
+
+Add nodes to the cluster.
+
+```bash
+eksctl create nodegroup --cluster calico-multus --node-type t3.medium --node-ami auto --max-pods-per-node 100
+```
+
+> **Tip**: Without the --max-pods-per-node option above, EKS will limit the number of pods based on node-type. 
+> See eksctl create nodegroup --help for the full set of node group options.
+{: .alert .alert-info }
+
+#### Install Multus and aws-k8s-cni in the cluster
+
+Install Multus
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openshift/multus-cni/master/images/multus-daemonset.yml
+```
+
+Install `aws-k8s-cni` plugin
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.6/aws-k8s-cni.yaml
+```
+
+#### Add aws-k8s-cni to Multus
+
+Multus uses custom resources to configure different CNI plugins.
+
+Create `NetworkAttachmentDefinition` and add `aws-k8s-cni` plugin configuration.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: aws-cni
+  namespace: kube-system
+spec:
+  config: '{
+  "cniVersion": "0.3.1",
+  "name": "aws-cni",
+  "plugins": [
+    {
+      "name": "aws-cni",
+      "type": "aws-cni",
+      "vethPrefix": "eni",
+      "mtu": "9001",
+      "pluginLogFile": "/var/log/aws-routed-eni/plugin.log",
+      "pluginLogLevel": "Debug"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true},
+      "snat": true
+    }
+  ]
+}'
+EOF
+```
+
+Congratulations! your EKS cluster is now equipped with three CNI plugins.
+
+### Demo 
+
+Create a namespace to isolate your demo resources.
+
+```bash
+kubectl create namespace calico-multus-demo
+```
+
+Use `v1.multus-cni.io/default-network: aws-cni` annotation in pod manifest to attach it to the VPC network.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: calico-multus-demo
+  name: awspod
+  labels:
+    app: awspod
+  annotations:
+    v1.multus-cni.io/default-network: aws-cni
+spec:
+  containers:
+  - name: awspod
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+EOF
+```
+
+Create another pod using {{site.prodname}} networking.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: calico-multus-demo
+  name: calicopod
+  labels:
+    app: calicopod
+spec:
+  containers:
+  - name: calicopod
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+EOF
+```
+
+Create a service for each pod.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: calicopod-service
+  namespace: calico-multus-demo
+spec:
+  selector:
+    app: calicopod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: awspod-service
+  namespace: calico-multus-demo
+spec:
+  selector:
+    app: awspod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+EOF
+```
+
+> kubectl `proxy` provides access to Kubernetes API using apiserver.
+>
+> If you like to learn more about this feature {% include open-new-window.html text="click here." url='https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-services/' %}
+{: .alert .alert-info}
+
+Run kubectl in proxy mode
+
+```bash
+kubectl proxy
+```
+
+You should see an output similar to
+
+```
+Starting to serve on 127.0.0.1:8001
+```
+
+At this point you should be able to browse `awspod` home page using `http://localhost:8001/api/v1/namespaces/calico-multus-demo/services/awspod-service/proxy/` or {% include open-new-window.html text='by clicking here.' url='http://localhost:8001/api/v1/namespaces/calico-multus-demo/services/awspod-service/proxy/' %}.
+
+{% include open-new-window.html text='Pod not reachable by conrol plane.' url='http://localhost:8001/api/v1/namespaces/calico-multus-demo/services/calicopod-service/proxy/' %}
+
+
+#### Cleanup
+
+Remove demo resources
+
+```bash
+kubectl delete namespace calico-multus-demo
+```

--- a/getting-started/kubernetes/managed-public-cloud/eks.md
+++ b/getting-started/kubernetes/managed-public-cloud/eks.md
@@ -29,7 +29,7 @@ The geeky details of what you get:
 
    > **Note**: {{site.prodname}} networking cannot currently be installed on the EKS control plane nodes. As a result the control plane nodes
    > will not be able to initiate network connections to {{site.prodname}} pods. (This is a general limitation of EKS's custom networking support,
-   > not specific to {{site.prodname}}.) As a workaround, trusted pods that require control plane nodes to connect to them, such as those implementing
+   > not specific to {{site.prodname}}.) As a workaround, you can setup a multi CNI cluster using Multus or modify trusted pods that require control plane nodes to connect to them, such as those implementing
    > admission controller webhooks, can include `hostNetwork:true` in their pod spec. See the Kuberentes API
    > {% include open-new-window.html text='pod spec' url='https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core' %}
    > definition for more information on this setting.
@@ -56,8 +56,10 @@ Before you get started, make sure you have downloaded and configured the {% incl
    ```bash
    kubectl apply -f {{ "/manifests/calico-vxlan.yaml" | absolute_url }}
    ```
-
-1. Finally, add nodes to the cluster.
+{% tabs %}
+<label:EKS,active:true>
+<%
+   Finally, add nodes to the cluster.
 
    ```bash
    eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --node-ami auto --max-pods-per-node 100
@@ -65,7 +67,192 @@ Before you get started, make sure you have downloaded and configured the {% incl
 
    > **Tip**: Without the `--max-pods-per-node` option above, EKS will limit the {% include open-new-window.html text='number of pods based on node-type' url='https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt' %}. See `eksctl create nodegroup --help` for the full set of node group options.
    {: .alert .alert-success}
+%>
+<label:Multus>
+<%
 
+> Multus CNI is an open source Kubernetes CNI plugin, it allows attaching multiple interfaces to pods. By acting as a `meta-plugin` Multus can 
+> override Kubernetes default network CNI configuration and assign interfaces to different CNI plugin.
+{: .alert .alert-info}
+
+**Installing Multus**
+
+You can install Multus using manifest.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openshift/multus-cni/master/images/multus-daemonset.yml
+```
+
+**Installing aws-k8s-cni**
+
+> **Note**: Using default configuration with AWS CNI causes IPAMD to consume all available IP addresses in EC2 instances participating in the node group at the beginning. You can alter this behavior by using environment variables such as `MINIMUM_IP_TARGET` and `WARM_IP_TARGET`. 
+>
+> **Note**: It is important to use AWS CNI plugin version **1.6.0** or higher because older releases do not support `MINIMUM_IP_TARGET` environment variable.
+> 
+> More details can be found {% include open-new-window.html text="at this page." url='https://github.com/aws/amazon-vpc-cni-k8s' %}
+{: .alert .alert-info }
+
+Install `aws-k8s-cni` plugin
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.6/aws-k8s-cni.yaml
+```
+
+**Add aws-k8s-cni configuration to Multus**
+
+Multus uses custom resources to configure different CNI plugins.
+
+You can add `aws-k8s-cni` to Multus by Creating a `NetworkAttachmentDefinition` with plugin configuration parameters.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: aws-cni
+  namespace: kube-system
+spec:
+  config: '{
+  "cniVersion": "0.3.1",
+  "name": "aws-cni",
+  "plugins": [
+    {
+      "name": "aws-cni",
+      "type": "aws-cni",
+      "vethPrefix": "eni",
+      "mtu": "9001",
+      "pluginLogFile": "/var/log/aws-routed-eni/plugin.log",
+      "pluginLogLevel": "Debug"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true},
+      "snat": true
+    }
+  ]
+}'
+EOF
+```
+
+Congratulations! your EKS cluster is now equipped with three CNI plugins.
+
+**Demo** 
+
+Create a namespace to isolate demo resources.
+
+```bash
+kubectl create namespace calico-multus-demo
+```
+
+By using `v1.multus-cni.io/default-network` annotation and providing `aws-cni` as value you
+can 
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: calico-multus-demo
+  name: awspod
+  labels:
+    app: awspod
+  annotations:
+    v1.multus-cni.io/default-network: aws-cni
+spec:
+  containers:
+  - name: awspod
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+EOF
+```
+
+Create a different Pod without applying Multus crd annotations. This causes the Pod to acquire an IP address from {{site.prodname}}.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: calico-multus-demo
+  name: calicopod
+  labels:
+    app: calicopod
+spec:
+  containers:
+  - name: calicopod
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+EOF
+```
+
+Create a service for each pod.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: calicopod-service
+  namespace: calico-multus-demo
+spec:
+  selector:
+    app: calicopod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: awspod-service
+  namespace: calico-multus-demo
+spec:
+  selector:
+    app: awspod
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+EOF
+```
+
+**Testing control plane connectivity**
+
+> kubectl `proxy` provides access to Kubernetes API using apiserver.
+>
+> If you like to learn more about this feature {% include open-new-window.html text="click here." url='https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-services/' %}
+{: .alert .alert-info}
+
+Run kubectl in proxy mode
+
+```bash
+kubectl proxy
+```
+
+You should see an output similar to
+
+```
+Starting to serve on 127.0.0.1:8001
+```
+
+At this point you should be able to browse `awspod` home page {% include open-new-window.html text='by clicking here.' url='http://localhost:8001/api/v1/namespaces/calico-multus-demo/services/awspod-service/proxy/' %}
+
+{% include open-new-window.html text='Pod not reachable by conrol plane.' url='http://localhost:8001/api/v1/namespaces/calico-multus-demo/services/calicopod-service/proxy/' %}
+
+
+**Cleanup**
+
+Remove demo resources
+
+```bash
+kubectl delete namespace calico-multus-demo
+```
+
+%>
+{% endtabs %}
 ### Next steps
 
 **Required**


### PR DESCRIPTION
# Although this PR is ready please consult with @caseydavenport before merging it.
I have added Multus instruction to the original EKS document as well.

## Description
Tutorial on how to use Multus and Calico in EKS environment.

## Related issues/PRs
EKS Control plane can not reach Calico pods.
https://calicousers.slack.com/archives/CPEPQE8CS/p1594387383176700

EKS control plane can only communicate with IP Addresses assigned to ENI interfaces.

some of the features/services that are affected
```
api-server
metric-server
webhooks
kubectl proxy
```
 