### PR TITLE
remove tracking jekyll cache during local website dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ pinned_images.yml
 
 # This prevents us from checking in a supplementary values.yaml file
 _includes/charts/*/values.yaml
+
+# ignore changes during local website development
+.jekyll-cache


### PR DESCRIPTION
## Description

- this is a tweak to the .gitignore to provide a nicer DX when working on the website locally
- local dev will create a lot of file diffs in this directory, and we definitely don't want them tracked in source

## Related issues/PRs

N/A

```release-note
None required
```
