### PR TITLE
Remove redundant manifest change

### DIFF
--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -293,11 +293,6 @@ spec:
                 configMapKeyRef:
                   name: {{include "variant_name" . | lower}}-config
                   key: veth_mtu
-{{- if .Values.srcdstcheck }}
-            # Enable AWS source-destination-check.
-            - name: FELIX_AWSSRCDSTCHECK
-              value: "Enable"
-{{- end }}
 {{- else if eq .Values.network "flannel" }}
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -5,5 +5,4 @@ layout: null
 datastore: kubernetes
 network: calico
 vxlan: true
-srcdstcheck: true
 {% endhelm %}


### PR DESCRIPTION
## Description

Remove redundant manifest change

PR #3812 added the manifest change to `disable` source-destination-check. Remove unnecessary edit by PR #3652.


## Release Note

```release-note
None required
```
