### PR TITLE
add rel attributes to make cross-domain links safer

### DIFF
--- a/_includes/docs_ad.html
+++ b/_includes/docs_ad.html
@@ -5,11 +5,11 @@
 
 	<strong><i class="fa fa-graduation-cap" aria-hidden="true"></i>&nbsp; New Training Courses</strong><br /><br />
 	Learn industry best practices and master Kubernetes networking and security with instructor-led training.<br /><br />
-	<a href="https://tigera.io/training" target="_blank" style="color: #f69432;">View Courses</a>
+	<a href="https://tigera.io/training" target="_blank" rel="noopener noreferrer" style="color: #f69432;">View Courses</a>
 
 {% else %}
 	<strong><i class="fa fa-graduation-cap" aria-hidden="true"></i>&nbsp; New Training Courses</strong><br /><br />
-	<a href="https://tigera.io/training" target="_blank" style="color: #f69432;">View Courses</a>
+	<a href="https://tigera.io/training" target="_blank" rel="noopener noreferrer" style="color: #f69432;">View Courses</a>
 
 {% endif %}
 </div>

--- a/_includes/enterprise_header.html
+++ b/_includes/enterprise_header.html
@@ -1,4 +1,4 @@
 <div id="enterprise-header">
     <img class="calico-enterprise-img" src="/images/calico-enterprise-logo-128px.png" alt="Calico Enterprise">
-    <a href="https://www.tigera.io/tigera-products/calico-enterprise-trial?utm_referring_url=dynamic&utm_source=projectcalico-docs&utm_medium=website&utm_campaign=calico-docs-conversion" class="request-demo-button" target="_blank">Try it now!</a>
+    <a href="https://www.tigera.io/tigera-products/calico-enterprise-trial?utm_referring_url=dynamic&utm_source=projectcalico-docs&utm_medium=website&utm_campaign=calico-docs-conversion" class="request-demo-button" target="_blank" rel="noopener noreferreer">Try it now!</a>
 </div> 

--- a/_includes/open-new-window.html
+++ b/_includes/open-new-window.html
@@ -1,1 +1,1 @@
-<a href="{{include.url}}" target="_blank">{{include.text}}<span class="glyphicon glyphicon-new-window open-new-window" aria-hidden="true" style="font-size: 13px; padding-left: 4px;"></span></a>
+<a href="{{include.url}}" target="_blank" rel="noopener noreferrer">{{include.text}}<span class="glyphicon glyphicon-new-window open-new-window" aria-hidden="true" style="font-size: 13px; padding-left: 4px;"></span></a>

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -121,14 +121,14 @@ The code is a little roundabout for a few reasons:
                     <!--<li><a href="https://www.projectcalico.org/tutorials"><i class="fa fa-file-code-o" aria-hidden="true"></i> &nbsp; Tutorials &amp; Examples</a></li>
                     <li><a href=""><i class="fa fa-paper-plane-o" aria-hidden="true"></i> &nbsp; Online Workshops</a></li>-->
                     <li><a href="https://www.projectcalico.org/community">Community Support</a></li>
-                    <li><a href="https://www.tigera.io/tigera-products/calico-essentials/" target="_blank">Commercial Support</a></li>
-                    <li><a href="https://www.tigera.io/training/" target="_blank">Training</a></li>
+                    <li><a href="https://www.tigera.io/tigera-products/calico-essentials/" target="_blank" rel="noopener noreferrer">Commercial Support</a></li>
+                    <li><a href="https://www.tigera.io/training/" target="_blank" rel="noopener noreferrer">Training</a></li>
                     <li><a href="https://www.projectcalico.org/security-bulletins">Security Bulletins</a></li>
                     <li><a href="https://www.projectcalico.org/vulnerability-disclosure">Report Security Issue</a></li>
                 </ul>
               </li>
               <li><a href="https://www.projectcalico.org/blog">Blog</a></li>
-              <li><a href="https://github.com/projectcalico/calico" target="_blank">Github</a></li>
+              <li><a href="https://github.com/projectcalico/calico" target="_blank" rel="noopener noreferrer">Github</a></li>
               <li><a href="{{site.baseurl}}/calico-enterprise/">Enterprise</a></li>
               <li><a href="https://www.projectcalico.org/events" class="free-training">Free training</a></li>              
             </ul>
@@ -188,7 +188,7 @@ The code is a little roundabout for a few reasons:
                   <div class="panel panel-default">
                     <div class="panel-heading free-training" role="button" aria-controls="navbar-free-training">
                       <h4 class="panel-title">
-                        <a href="https://www.projectcalico.org/events" target="_blank" class="navbar-title--clickable">
+                        <a href="https://www.projectcalico.org/events" target="_blank" rel="noopener noreferrer" class="navbar-title--clickable">
                           <span>Free training</span>
                         </a>
                       </h4>
@@ -208,7 +208,7 @@ The code is a little roundabout for a few reasons:
               </p>
               <!-- TOP DOCUMENTATION PAGE NAVBAR -->
               {% capture edit_page %}
-                  <a data-proofer-ignore href="https://github.com/projectcalico/calico/tree/master/{{page.path}}" class="edit-page-link" target="_blank">
+                  <a data-proofer-ignore href="https://github.com/projectcalico/calico/tree/master/{{page.path}}" class="edit-page-link" target="_blank" rel="noopener noreferrer">
                     <i class="fa fa-github" aria-hidden="true"></i>
                     Edit this page
                   </a>
@@ -241,12 +241,12 @@ The code is a little roundabout for a few reasons:
 
               <!-- BOTTOM DOCUMENTATION PAGE NAVBAR -->
               <div style="margin-top: 60px; margin-bottom: 40px; padding-top: 20px; border-top: 1px solid #999; text-align: left; color: #999;">
-                <a href="https://slack.projectcalico.org/" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i>&nbsp;Slack</a>
-                <a href="https://discuss.projectcalico.org/" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank"><i class="fa fa-comments" aria-hidden="true"></i>&nbsp;Discourse</a>
-                <a href="https://github.com/projectcalico/calico" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank"><i class="fa fa-github" aria-hidden="true"></i>&nbsp;GitHub</a>
-                <a href="https://twitter.com/projectcalico" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i> Twitter</a>
-                <a href="https://www.youtube.com/channel/UCFpTnXDNcBoXI4gqCDmegFA" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank"><i class="fa fa-youtube-play" aria-hidden="true"></i>&nbsp;YouTube</a>
-                <a href="https://www.tigera.io/tigera-products/calico-essentials/" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank"><i class="fa fa-graduation-cap" aria-hidden="true"></i>&nbsp;Training</a>
+                <a href="https://slack.projectcalico.org/" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank" rel="noopener noreferrer"><i class="fa fa-slack" aria-hidden="true"></i>&nbsp;Slack</a>
+                <a href="https://discuss.projectcalico.org/" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank" rel="noopener noreferrer"><i class="fa fa-comments" aria-hidden="true"></i>&nbsp;Discourse</a>
+                <a href="https://github.com/projectcalico/calico" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank" rel="noopener noreferrer"><i class="fa fa-github" aria-hidden="true"></i>&nbsp;GitHub</a>
+                <a href="https://twitter.com/projectcalico" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank" rel="noopener noreferrer"><i class="fa fa-twitter" aria-hidden="true"></i> Twitter</a>
+                <a href="https://www.youtube.com/channel/UCFpTnXDNcBoXI4gqCDmegFA" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank" rel="noopener noreferrer"><i class="fa fa-youtube-play" aria-hidden="true"></i>&nbsp;YouTube</a>
+                <a href="https://www.tigera.io/tigera-products/calico-essentials/" style="margin-left: 30px; color: #999; text-decoration: none;" target="_blank" rel="noopener noreferrer"><i class="fa fa-graduation-cap" aria-hidden="true"></i>&nbsp;Training</a>
               </div>
               <!-- END BOTTOM DOCUMENTATION PAGE NAVBAR -->
             </div>


### PR DESCRIPTION


## Description

using `target="_blank"` opens up the possibility of clickjacking unless we explicitly forbid the browser from doing that. So we can add `rel="noopener noreferrer"` to make the links safe again.

Generally, `noopener` is supported by most modern browsers, but adding `noreferrer` makes it a bit more generally applicable.

## Related issues/PRs

N/A


```release-note
None required
```
