### PR TITLE
Include optional configmap to override k8s endpoint

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -42,6 +42,10 @@ spec:
               value: "tigera-operator"
             - name: TIGERA_OPERATOR_INIT_IMAGE_VERSION
               value: {{.Values.tigeraOperator.version}}
+          envFrom:
+            - configMapRef:
+                name: kubernetes-services-endpoint
+                optional: true
 {{- if eq .Values.installation.kubernetesProvider "openshift" }}
       initContainers:
         - name: create-initial-resources


### PR DESCRIPTION
The config map should contain these env vars:

KUBERNETES_SERVICE_HOST
KUBERNETES_SERVICE_PORT

This is (only) required when enabling eBPF dataplance as kube-proxy
needs to be turned off and without kube-proxy, the kubernetes services
cannot be used.

If the map is not set, the env vars are not set either, so this does not
have any implication for non-bpf setups.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
