### PR TITLE
Enhance documentation to disable node2nodeMesh for bgp when using route reflectors

### DIFF
--- a/networking/bgp.md
+++ b/networking/bgp.md
@@ -113,6 +113,7 @@ spec:
   asNumber: 64567
   nodeSelector: rack == 'rack-1'
 ```
+
 #### Configure a node to act as a route reflector
 
 {{site.prodname}} nodes can be configured to act as route reflectors. To do this, each node that you want to act as a route reflector must have a cluster ID - typically an unused IPv4 address.
@@ -138,6 +139,17 @@ metadata:
 spec:
   nodeSelector: all()
   peerSelector: route-reflector == 'true'
+```
+
+Last, you will need to disable the node-to-node mesh, e.g. by configuring
+
+```
+apiVersion: projectcalico.org/v3
+kind: BGPConfiguration
+metadata:
+  name: default
+spec:
+  nodeToNodeMeshEnabled: false
 ```
 
 #### View BGP peering status for a node


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR enhances the BGP documentation for configuring calico to use only subset of nodes as route reflectors instead of forming a full mesh. The section was so far missing a hint to set the config for `nodeToNodeMesh` to `false`. Otherwise, full peering will still occur in addition to the configured bgp peers. 


## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
