### PR TITLE
remove superfluous support link due to missing image

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -132,9 +132,6 @@ The code is a little roundabout for a few reasons:
                 </ul>
               </li>
               <li><a href="https://www.projectcalico.org/support">Support</a></li>
-              <li class="hidden-xs"><a href="https://www.projectcalico.org/support">
-                <img class="desktopImage" width="30" align="absmiddle" src="https://www.projectcalico.org/images/tigera_trans_sm.png" alt="Tigera"></a>
-              </li>
             </ul>
             <form class="navbar-form visible-xs">
               <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
## Description

Clean up the the top navbar by removing a second link to "support" url to address now missing `tigera_trans_sm.png` image. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
