### PR TITLE
Remove leading space in calicoctl install commands

### DIFF
--- a/_includes/content/ctl-binary-install.md
+++ b/_includes/content/ctl-binary-install.md
@@ -7,13 +7,13 @@ you want to install the binary.
 
 1. Use the following command to download the `calicoctl` binary.
 
-   ```
+   ```bash
    curl -O -L  {% include urls component="calicoctl" %}
    ```
 
 1. Set the file to be executable.
 
-   ```
+   ```bash
    chmod +x calicoctl
    ```
 

--- a/_includes/content/ctl-container-install.md
+++ b/_includes/content/ctl-container-install.md
@@ -19,23 +19,23 @@ Use the YAML that matches your datastore type to deploy the `calicoctl` containe
 
 - **etcd**
 
-   ```
-   kubectl apply -f {{ "/manifests/calicoctl-etcd.yaml" | absolute_url }}
-   ```
+  ```
+  kubectl apply -f {{ "/manifests/calicoctl-etcd.yaml" | absolute_url }}
+  ```
 
-   > **Note**: You can also
-   > [view the YAML in a new tab]({{ "/manifests/calicoctl-etcd.yaml" | absolute_url }}){:target="_blank"}.
-   {: .alert .alert-info}
+  > **Note**: You can also
+  > [view the YAML in a new tab]({{ "/manifests/calicoctl-etcd.yaml" | absolute_url }}){:target="_blank"}.
+  {: .alert .alert-info}
 
 - **Kubernetes API datastore**
 
-   ```
-   kubectl apply -f {{ "/manifests/calicoctl.yaml" | absolute_url }}
-   ```
+  ```
+  kubectl apply -f {{ "/manifests/calicoctl.yaml" | absolute_url }}
+  ```
 
-   > **Note**: You can also
-   > [view the YAML in a new tab]({{ "/manifests/calicoctl.yaml" | absolute_url }}){:target="_blank"}.
-   {: .alert .alert-info}
+  > **Note**: You can also
+  > [view the YAML in a new tab]({{ "/manifests/calicoctl.yaml" | absolute_url }}){:target="_blank"}.
+  {: .alert .alert-info}
 
 You can then run commands using kubectl as shown below.
 

--- a/_includes/content/ctl-container-install.md
+++ b/_includes/content/ctl-container-install.md
@@ -3,7 +3,7 @@
 To install `calicoctl` as a container on a single host, log into the
 target host and issue the following command.
 
-```
+```bash
 docker pull {{page.registry}}{{page.imageNames["calicoctl"]}}:{{site.data.versions.first.title}}
 ```
 
@@ -19,7 +19,7 @@ Use the YAML that matches your datastore type to deploy the `calicoctl` containe
 
 - **etcd**
 
-  ```
+  ```bash
   kubectl apply -f {{ "/manifests/calicoctl-etcd.yaml" | absolute_url }}
   ```
 
@@ -29,7 +29,7 @@ Use the YAML that matches your datastore type to deploy the `calicoctl` containe
 
 - **Kubernetes API datastore**
 
-  ```
+  ```bash
   kubectl apply -f {{ "/manifests/calicoctl.yaml" | absolute_url }}
   ```
 
@@ -39,13 +39,13 @@ Use the YAML that matches your datastore type to deploy the `calicoctl` containe
 
 You can then run commands using kubectl as shown below.
 
-```
+```bash
 kubectl exec -ti -n kube-system calicoctl -- /calicoctl get profiles -o wide
 ```
 
 An example response follows.
 
-```bash
+```
 NAME                 TAGS
 kns.default          kns.default
 kns.kube-system      kns.kube-system
@@ -54,13 +54,13 @@ kns.kube-system      kns.kube-system
 
 We recommend setting an alias as follows.
 
-```
+```bash
 alias calicoctl="kubectl exec -i -n kube-system calicoctl -- /calicoctl"
 ```
 
    > **Note**: In order to use the `calicoctl` alias
    > when reading manifests, redirect the file into stdin, for example:
-   > ```
+   > ```bash
    > calicoctl create -f - < my_manifest.yaml
    > ```
    {: .alert .alert-info}


### PR DESCRIPTION
## Description

Many shells are configured out-of-the-box to skip storing commands into shell history if the command has leading spaces.

![image](https://user-images.githubusercontent.com/170076/91892560-badb7880-ec47-11ea-985a-426c33ecf507.png)


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
