### PR TITLE
feature(Windows): Allow to specify etcd TLS filepaths or auto download them in installation script

### DIFF
--- a/getting-started/windows-calico/quickstart.md
+++ b/getting-started/windows-calico/quickstart.md
@@ -106,6 +106,10 @@ The following steps install a Kubernetes cluster on a single Windows node, with 
    c:\install-calico-windows.ps1 -KubeVersion <your Kubernetes version (e.g. 1.18.6)> \
                                  -Datastore etcdv3
                                  -EtcdEndpoints <your etcd endpoint ip>
+                                 -EtcdTlsSecretName <your etcd TLS secret name in kube-system namespace> (default no etcd TLS secret is used)
+                                 -EtcdKey <path to key file> (default not using TLS)
+                                 -EtcdCert <path to cert file> (default not using TLS)
+                                 -EtcdCaCert <path to ca cert file> (default not using TLS)
                                  -ServiceCidr <your service cidr (default 10.96.0.0/12)> \
                                  -DNSServerIPs <your DNS server IPs (default 10.96.0.10)>
    ```
@@ -250,6 +254,10 @@ The following steps install a Kubernetes cluster on a single Windows node, with 
 | DownloadOnly       | Download without installing {{site.prodnameWindows}}. Set to `yes` to manually install and configure {{site.prodnameWindows}}. For example, {{site.prodnameWindows}} the hard way. | no |
 | Datastore          | {{site.prodnameWindows}} datastore type [`kubernetes` or `etcdv3`] for reading endpoints and policy information. | kubernetes |
 | EtcdEndpoints      | Comma-delimited list of etcd connection endpoints. Example: `http://127.0.0.1:2379,http://127.0.0.2:2379`. Valid only if `Datastore` is set to `etcdv3`. | "" |
+| EtcdTlsSecretName  | Name of a secret in `kube-system` namespace which contains `etcd-key`, `etcd-cert`, `etcd-ca` for automatically configuring TLS. Either use this or parameters `EtcdKey`, `EtcdCert`, `EtcdCaCert` below. | "" |
+| EtcdKey            | Path to key file for etcd TLS connection. | "" |
+| EtcdCert           | Path to certificate file for etcd TLS connection. | "" |
+| EtcdCaCert         | Path to CA certificate file for etcd TLS connection. | "" |
 | ServiceCidr        | Service IP range of the Kubernetes cluster. Not required for most managed Kubernetes clusters. Note: EKS has non-default value. | 10.96.0.0/12 |
 | DNSServerIPs       | Comma-delimited list of DNS service IPs used by Windows pod. Not required for most managed Kubernetes clusters. Note: EKS has a non-default value. | 10.96.0.10 |
 


### PR DESCRIPTION
## Description

feature: Add parameters to the Calico for Windows installation script to automatically set up the Calico for Windows configuration for etcd TLS. The parameters allow to either
a) manually specify the paths to the etcd certs and key.
b) automatically get the etcd TLS files from the Kubernetes secret `calico-etcd-secrets` (created by Calico manifest https://docs.projectcalico.org/manifests/calico-etcd.yaml)

As Kubernetes clusters often get set up with etcd and TLS (e.g. per default via `kubeadm`), it makes sense to allow the user to automatically set this up instead of manually modifying the config file. 

**This PR depends on https://github.com/projectcalico/node/pull/570**

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
none
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] https://github.com/projectcalico/node/pull/570 needs to be merged
- [] Tests - not needed
- [] Documentation - Added new parameters to the quickstart docs
- [] Release note - not needed

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
