### PR TITLE
feature(Windows): Allow to automatically set up Calico kubeconfig when no platform is identified

### DIFF
--- a/getting-started/windows-calico/quickstart.md
+++ b/getting-started/windows-calico/quickstart.md
@@ -106,7 +106,6 @@ The following steps install a Kubernetes cluster on a single Windows node, with 
    c:\install-calico-windows.ps1 -KubeVersion <your Kubernetes version (e.g. 1.18.6)> \
                                  -Datastore etcdv3
                                  -EtcdEndpoints <your etcd endpoint ip>
-                                 -CalicoKubeConfigSecret <name of calico-node service account> (default not generating Calico kubeconfig automatically)
                                  -ServiceCidr <your service cidr (default 10.96.0.0/12)> \
                                  -DNSServerIPs <your DNS server IPs (default 10.96.0.10)>
    ```

--- a/getting-started/windows-calico/quickstart.md
+++ b/getting-started/windows-calico/quickstart.md
@@ -106,6 +106,7 @@ The following steps install a Kubernetes cluster on a single Windows node, with 
    c:\install-calico-windows.ps1 -KubeVersion <your Kubernetes version (e.g. 1.18.6)> \
                                  -Datastore etcdv3
                                  -EtcdEndpoints <your etcd endpoint ip>
+                                 -CalicoKubeConfigSecret <name of calico-node service account> (default not generating Calico kubeconfig automatically)
                                  -ServiceCidr <your service cidr (default 10.96.0.0/12)> \
                                  -DNSServerIPs <your DNS server IPs (default 10.96.0.10)>
    ```

--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -33,7 +33,6 @@ Param(
     [parameter(Mandatory = $false)] $DownloadOnly="no",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",
     [parameter(Mandatory = $false)] $EtcdEndpoints="",
-    [parameter(Mandatory = $false)] $CalicoKubeConfigSecret="",
     [parameter(Mandatory = $false)] $ServiceCidr="10.96.0.0/12",
     [parameter(Mandatory = $false)] $DNSServerIPs="10.96.0.10"
 )
@@ -214,8 +213,8 @@ if ($platform -EQ "ec2") {
     SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"
     GetCalicoKubeConfig -SecretName 'calico-node'
 }
-if([string]::IsNullOrEmpty($platform) -and (-not [string]::IsNullOrEmpty($CalicoKubeConfigSecret))) {
-    GetCalicoKubeConfig -SecretName "$CalicoKubeConfigSecret"
+if([string]::IsNullOrEmpty($platform)) {
+    GetCalicoKubeConfig -SecretName "calico-node"
 }
 
 if ($DownloadOnly -EQ "yes") {

--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -33,6 +33,7 @@ Param(
     [parameter(Mandatory = $false)] $DownloadOnly="no",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",
     [parameter(Mandatory = $false)] $EtcdEndpoints="",
+    [parameter(Mandatory = $false)] $CalicoKubeConfigSecret="",
     [parameter(Mandatory = $false)] $ServiceCidr="10.96.0.0/12",
     [parameter(Mandatory = $false)] $DNSServerIPs="10.96.0.10"
 )
@@ -212,6 +213,9 @@ if ($platform -EQ "ec2") {
     $awsNodeNameQuote = """$awsNodeName"""
     SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"
     GetCalicoKubeConfig -SecretName 'calico-node'
+}
+if([string]::IsNullOrEmpty($platform) -and (-not [string]::IsNullOrEmpty($CalicoKubeConfigSecret))) {
+    GetCalicoKubeConfig -SecretName "$CalicoKubeConfigSecret"
 }
 
 if ($DownloadOnly -EQ "yes") {


### PR DESCRIPTION
## Description

feature: Add parameter to the installation script of Calico for Windows to allow automatically creating the Calico kubeconfig (https://docs.projectcalico.org/getting-started/windows-calico/kubeconfig) when no platform was identified. 

As all the manifests (https://docs.projectcalico.org/manifests/calico.yaml, https://docs.projectcalico.org/manifests/calico-etcd.yaml) for manually installing Calico on Linux in self-managed clusters do incorporate the service account `calico-node`, it should always be possible to automatically generate the `C:\CalicoWindows\calico-kube-config` file with the `GetCalicoKubeConfig` function, even when no platform was identified by the installation script.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
none
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [] Tests - not needed
- [] Documentation - added to quickstart docs
- [] Release note - not needed

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
