### PR TITLE
Fix 'Standard install' link

### DIFF
--- a/_data/navbars/getting-started.yml
+++ b/_data/navbars/getting-started.yml
@@ -60,7 +60,7 @@ section:
     - title: Basic policy demo
       path: /getting-started/windows-calico/demo
     - title: Standard install
-      path: /getting-started/windows-calico/
+      path: /getting-started/windows-calico/requirements
       section:
       - title: Requirements
         path: /getting-started/windows-calico/requirements


### PR DESCRIPTION
## Description

This PR will fix incorrect 'Standard install' link in 'Calico on Windows' section.