### PR TITLE
windows: Replace the expanded installation dir if it already exists

### DIFF
--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -213,7 +213,7 @@ if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
 Write-Host "Download Calico for Windows release..."
 DownloadFile -Url $ReleaseBaseURL/$ReleaseFile -Destination c:\calico-windows.zip
 Write-Host "Unzip Calico for Windows release..."
-Expand-Archive c:\calico-windows.zip c:\
+Expand-Archive -Force c:\calico-windows.zip c:\
 
 Write-Host "Setup Calico for Windows..."
 SetConfigParameters -OldString '<your datastore type>' -NewString $Datastore


### PR DESCRIPTION
## Description

In case we re-run the Windows installation script, forcefully overwrite the installation directory. Tested this and it seems to work?  I'm not sure if this is kosher though (replacing a running exe in-place).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
