### PR TITLE
Change deprecated apis in calicoctl template

### DIFF
--- a/_includes/non-helm-manifests/calicoctl.yaml
+++ b/_includes/non-helm-manifests/calicoctl.yaml
@@ -36,7 +36,7 @@ spec:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calicoctl
 rules:
@@ -97,7 +97,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calicoctl


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

## Description
rbac.authorization.k8s.io/v1beta1 has been deprecated in favor of v1 but the calicoctl template still contains the old API

## Related issues/PRs

## Todos

- [X] Documentation


## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
