### PR TITLE
Adding Operator permissions for IPPools and FelixConfigurations

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -84,6 +84,20 @@ rules:
       - delete
       - watch
   - apiGroups:
+    - crd.projectcalico.org
+    resources:
+    - felixconfigurations
+    verbs:
+    - patch
+  - apiGroups:
+    - crd.projectcalico.org
+    resources:
+    - ippools
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
       - scheduling.k8s.io
     resources:
       - priorityclasses


### PR DESCRIPTION
## Description

The operator needs some additional permissions for Calico resources IPPools and FelixConfiguration, this is due to merging the migration changes in from the tech-preview-migrate-install branch.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
