### PR TITLE
test: remove VERSION variable from release-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,6 @@ release-test: release-test-image
 	docker run --rm \
 	-v $(PWD):/docs \
 	-e RELEASE_STREAM=$(RELEASE_STREAM) \
-	-e VERSION=$(VERSION) \
 	$(DOCS_TEST_CONTAINER) sh -c \
 	"nosetests . -e "$(EXCLUDE_REGEX)" \
 	-s -v --with-xunit \

--- a/release-scripts/tests/test_windows_artifacts.py
+++ b/release-scripts/tests/test_windows_artifacts.py
@@ -1,8 +1,20 @@
 import os
+import yaml
 import requests
 
-assert os.environ.get('VERSION')
-version = os.environ.get('VERSION')
+#
+# Note: this test is only valid for versions >= v3.16.0
+#
+DOCS_PATH = '/docs' if os.environ.get('CALICO_DOCS_PATH') is None else os.environ.get('CALICO_DOCS_PATH')
+
+with open('%s/_data/versions.yml' % DOCS_PATH) as f:
+    versions = yaml.safe_load(f)
+    RELEASE_VERSION = versions[0]['title']
+    print('[INFO] using _data/versions.yaml, discovered version: %s' % RELEASE_VERSION)
+
+# Windows zip version is the calico/node version.
+version = versions[0]['components']['calico/node']['version']
+print('[INFO] using calico/node version for Windows artifacts: %s' % version)
 
 def test_node_release_has_windows_zip():
     req = requests.head("https://github.com/projectcalico/node/releases/download/%s/calico-windows-%s.zip" % (version, version))


### PR DESCRIPTION
## Description

Remove the `VERSION` requirement from the test target, and extract the version from the release-notes page.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
