### PR TITLE
Fix default deny example in About Network Policy

### DIFF
--- a/about/about-network-policy.md
+++ b/about/about-network-policy.md
@@ -199,7 +199,7 @@ For example, you might use the following policy to default-deny all (non-system)
 apiVersion: projectcalico.org/v3
 kind: GlobalNetworkPolicy
 metadata:
-  name: default-deny-except-dns
+  name: default-app-policy
 spec:
   selector: projectcalico.org/namespace != "kube-system"
   types:
@@ -207,10 +207,11 @@ spec:
   - Egress
   egress:
     - action: Allow
-        destination:
+      protocol: UDP
+      destination:
+        selector: k8s-app == "kube-dns"
         ports:
         - 53
-        selector: k8s-app == "kube-dns"
 ```
 
 #### Hierarchical policy

--- a/about/about-network-policy.md
+++ b/about/about-network-policy.md
@@ -201,7 +201,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: default-app-policy
 spec:
-  selector: projectcalico.org/namespace != "kube-system"
+  namespaceSelector: projectcalico.org/name != "kube-system"
   types:
   - Ingress
   - Egress


### PR DESCRIPTION
Missing protocol field.
Using less intuitive selector.
Not great policy name.