### PR TITLE
Add necessary permissions for the calicoctl init container

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -171,11 +171,23 @@ rules:
       - globalnetworkpolicies
       - globalnetworksets
       - hostendpoints
-      - ippools
       - networkpolicies
       - networksets
     verbs:
       - create
+  - apiGroups:
+      - crd.projectcalico.org
+    resources:
+      - ippools
+    verbs:
+      - create
+      - list
+  - apiGroups:
+     - crd.projectcalico.org
+    resources:
+      - ipamblocks
+    verbs:
+      - list
   # For AWS security group setup.
   - apiGroups:
       - batch


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/projectcalico/calico/pull/4075 . This differs slightly in that the ippools also need to be added since https://github.com/projectcalico/calico/pull/4060 (which adds ippools) is only made in master.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
