### PR TITLE
Fix GitHub anchor label

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -128,7 +128,7 @@ The code is a little roundabout for a few reasons:
                 </ul>
               </li>
               <li><a href="https://www.projectcalico.org/blog">Blog</a></li>
-              <li><a href="https://github.com/projectcalico/calico" target="_blank" rel="noopener noreferrer">Github</a></li>
+              <li><a href="https://github.com/projectcalico/calico" target="_blank" rel="noopener noreferrer">GitHub</a></li>
               <li><a href="{{site.baseurl}}/calico-enterprise/">Enterprise</a></li>
               <li><a href="https://www.projectcalico.org/events" class="free-training">Free training</a></li>              
             </ul>


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR is for documentation.

The official name of GitHub is "GitHub" not "Github". This PR just fixes the case of "h".

I tested locally using `make serve`. The following is the screenshot showing the change:

![Screenshot from 2020-10-10 23-14-21](https://user-images.githubusercontent.com/1425259/95657279-9760f300-0b4e-11eb-990c-889d7a9761e5.png)

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Nothing related

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

Sorry, I don't know what this "Todos" means...

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
