### PR TITLE
Automated cherry pick of #4050: Non-namespaced section redone.

### DIFF
--- a/security/kubernetes-default-deny.md
+++ b/security/kubernetes-default-deny.md
@@ -45,9 +45,9 @@ Although you can use any of the following policies to create default deny policy
 
 #### Enable default deny {{site.prodname}} global network policy, non-namespaced
 
-You can use a {{site.prodname}} global network policy to enable a default deny across the whole of your cluster. Following example applies to all workloads (VMs and containers) in all namespaces, as well as hosts (computers that run the hypervisor for VMs, or container runtime for containers).
+You can use a {{site.prodname}} global network policy to enable a default deny across your whole cluster. The following example applies to all workloads (VMs and containers) in all namespaces, as well as hosts (computers that run the hypervisor for VMs, or container runtime for containers).
 
-> **Note**: Before applying the following policy please continue reading the rest of this section to find out why this might not be the best policy to apply to your cluster.
+> **Note**: Before applying the following please continue reading the rest of this section to find out why this might not be the best policy to apply to your cluster.
 {: .alert .alert-info }
 
 ```yaml

--- a/security/kubernetes-default-deny.md
+++ b/security/kubernetes-default-deny.md
@@ -67,7 +67,7 @@ Such policy has the potential to break your cluster if you do have not already h
 Calico [failsafe ports]({{site.baseurl}}/reference/felix/configuration) in place to ensure control plane traffic does not get blocked.
 
 As an alternative best practice we recommend to use the following examples depending on your {{site.prodname}} installation method, which apply 
-a default-deny behaviour to all non-system pods. (Separately you can specific policies for each control plane component to secure the 
+a default-deny behaviour to all non-system pods. (Separately you can write specific policies for each control plane component to secure the 
 control plane.)
 
 {% tabs %}

--- a/security/kubernetes-default-deny.md
+++ b/security/kubernetes-default-deny.md
@@ -1,6 +1,7 @@
 ---
 title: Enable default deny for Kubernetes pods
 description: Create a default deny network policy so pods that are missing policy are not allowed traffic until appropriate network policy is defined.
+canonical_url: '/security/kubernetes-default-deny'
 ---
 
 ### Big picture
@@ -44,7 +45,10 @@ Although you can use any of the following policies to create default deny policy
 
 #### Enable default deny {{site.prodname}} global network policy, non-namespaced
 
-In the following example, we enable a default deny **GlobalNetworkPolicy** for all workloads and hosts.
+You can use a {{site.prodname}} global network policy to enable a default deny across the whole of your cluster. Following example applies to all workloads (VMs and containers) in all namespaces, as well as hosts (computers that run the hypervisor for VMs, or container runtime for containers).
+
+> **Note**: Before applying the following policy please continue reading the rest of this section to find out why this might not be the best policy to apply to your cluster.
+{: .alert .alert-info }
 
 ```yaml
 apiVersion: projectcalico.org/v3
@@ -57,6 +61,57 @@ spec:
   - Ingress
   - Egress
 ```
+
+The above policy applies to all pods, hosts and endpoints, including Kubernetes and {{site.prodname}} control plane pods. Such policy has the potential to interrupt your cluster if you have not the correct "Allow" policies in place to keep the control plane functioning properly.
+
+As a best practice we recommend to use the following examples depending on your {{site.prodname}} installation method.
+
+{% tabs %}
+<label:Manifest,active:true>
+<%
+```yaml
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: deny-app-policy
+spec:
+  selector: 'projectcalico.org/namespace != "kube-system"'
+  types:
+  - Ingress
+  - Egress
+  egress:
+  # allow all namespaces to communicate to DNS pods
+  - action: Allow
+    protocol: UDP
+    destination:
+      selector: 'k8s-app == "kube-dns"'
+      ports:
+      - 53
+```
+%>
+<label:Operator>
+<%
+```yaml
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: deny-app-policy
+spec:
+  selector: 'projectcalico.org/namespace != "kube-system" || projectcalico.org/namespace != "calico-system"'
+  types:
+  - Ingress
+  - Egress
+  egress:
+  # allow all namespaces to communicate to DNS pods
+  - action: Allow
+    protocol: UDP
+    destination:
+      selector: 'k8s-app == "kube-dns"'
+      ports:
+      - 53
+```
+%>
+{% endtabs %}
 
 #### Enable default deny {{site.prodname}} network policy, namespaced
 

--- a/security/kubernetes-default-deny.md
+++ b/security/kubernetes-default-deny.md
@@ -62,9 +62,12 @@ spec:
   - Egress
 ```
 
-The above policy applies to all pods, hosts and endpoints, including Kubernetes and {{site.prodname}} control plane pods. Such policy has the potential to interrupt your cluster if you have not the correct "Allow" policies in place to keep the control plane functioning properly.
+The above policy applies to all pods, hosts and endpoints, including Kubernetes control plane and {{site.prodname}} control plane pods.
+Such policy has the potential to break your cluster if you do have not already have the correct "Allow" policies and 
+Calico [failsafe ports]({{site.baseurl}}/reference/felix/configuration) in place so thatcontrol plane traffic does not get blocked.
 
-As a best practice we recommend to use the following examples depending on your {{site.prodname}} installation method.
+As a best practice we recommend to use the following examples depending on your {{site.prodname}} installation method, which apply 
+a default-deny behaviour to all non-system pods.
 
 {% tabs %}
 <label:Manifest,active:true>
@@ -97,7 +100,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  selector: 'projectcalico.org/namespace != "kube-system" || projectcalico.org/namespace != "calico-system"'
+  selector: 'projectcalico.org/namespace != "kube-system" && projectcalico.org/namespace != "calico-system"'
   types:
   - Ingress
   - Egress

--- a/security/kubernetes-default-deny.md
+++ b/security/kubernetes-default-deny.md
@@ -64,10 +64,11 @@ spec:
 
 The above policy applies to all pods, hosts and endpoints, including Kubernetes control plane and {{site.prodname}} control plane pods.
 Such policy has the potential to break your cluster if you do have not already have the correct "Allow" policies and 
-Calico [failsafe ports]({{site.baseurl}}/reference/felix/configuration) in place so thatcontrol plane traffic does not get blocked.
+Calico [failsafe ports]({{site.baseurl}}/reference/felix/configuration) in place to ensure control plane traffic does not get blocked.
 
-As a best practice we recommend to use the following examples depending on your {{site.prodname}} installation method, which apply 
-a default-deny behaviour to all non-system pods.
+As an alternative best practice we recommend to use the following examples depending on your {{site.prodname}} installation method, which apply 
+a default-deny behaviour to all non-system pods. (Separately you can specific policies for each control plane component to secure the 
+control plane.)
 
 {% tabs %}
 <label:Manifest,active:true>


### PR DESCRIPTION
Cherry pick of #4050 on release-v3.16.

#4050: Non-namespaced section redone.