### PR TITLE
Add Pod Disruption Budget to Kube Controller

### DIFF
--- a/_includes/charts/calico/templates/calico-kube-controllers.yaml
+++ b/_includes/charts/calico/templates/calico-kube-controllers.yaml
@@ -109,3 +109,20 @@ kind: ServiceAccount
 metadata:
   name: calico-kube-controllers
   namespace: kube-system
+
+---
+
+# This manifest creates a Pod Disruption Budget for Controller to allow K8s Cluster Autoscaler to evict
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers


### PR DESCRIPTION
## Description

Currently, if a kubernetes node is running calico-kube-controller pod, autoscaler is unable to decomission the node:

`I0924 08:38:10.849971 1 cluster.go:93] Fast evaluation: xyz.internal for removal │
│ I0924 08:38:10.850003 1 cluster.go:107] Fast evaluation: node xyz.internal cannot be removed: non-daemonset, non-mirrored, non-pdb-assigned kube-system pod present: calico-kube-controllers-67fcb4f4c9-x46l9`

This PR add Pod Disruption Budget to Kube Controller manifest so that autoscaler is able to properly scale down.

## Release Note

```release-note
Add PodDisruptionBudget for kube-controllers when installed in kube-system
```
