### PR TITLE
Fix default-app-policy namespaceSelector

### DIFF
--- a/about/about-network-policy.md
+++ b/about/about-network-policy.md
@@ -201,7 +201,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: default-app-policy
 spec:
-  namespaceSelector: projectcalico.org/name != "kube-system"
+  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system"}
   types:
   - Ingress
   - Egress

--- a/security/kubernetes-default-deny.md
+++ b/security/kubernetes-default-deny.md
@@ -77,7 +77,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: 'projectcalico.org/name != "kube-system" && projectcalico.org/name != "calico-system"'
+  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system"}
   types:
   - Ingress
   - Egress


### PR DESCRIPTION
Exclude non-namespaced endpoints (heps) from default-app-policy. 