### PR TITLE
Fix: UI visual bug in transition from $screen-md-min to $screen-sm-min.

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -438,7 +438,7 @@ input.gsc-input, .gsc-input-box, .gsc-input-box-hover, .gsc-input-box-focus, .gs
   }
 
   @media (min-width: $screen-sm-min) {
-    grid-template-columns: [sidebar] 20% [article] auto;
+    grid-template-columns: [sidebar] 20% [article] calc(100% - 18% - 40px) auto;
   }
 
   @media (min-width: $screen-md-min) {


### PR DESCRIPTION
## Description
This PR addresses a visual bug in documentation (Chrome, Edge, Firefox)where upon reaching `screen-sm-min` on pages that have `pre` html tag content will leak out of the visible grid.
It is worth mentioning in Safari this bug behaves a bit different.However, this patch fixes that too.

## Steps to reproduce the behavior
Open a page that uses a `pre` [block like this one](https://docs.projectcalico.org/getting-started/kubernetes/self-managed-onprem/onpremises), resize the page until right table of content disappears.

[Fixed version here](https://deploy-preview-4128--calico-master.netlify.app/getting-started/kubernetes/self-managed-onprem/onpremises)
Example
![image](https://user-images.githubusercontent.com/54559947/97380386-2165c700-1884-11eb-8ea0-bfd20e09b378.png)

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
