### PR TITLE
Update bgp.md

### DIFF
--- a/networking/bgp.md
+++ b/networking/bgp.md
@@ -76,7 +76,7 @@ The default **node-to-node BGP mesh** must be turned off to enable other BGP top
 Run the following command to disable the BGP full-mesh:
 
 ```
-calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": "false"}}'
+calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": false}}'
 ```
 
 >**Note**: If the default BGP configuration resource does not exist, you need to create it first. See [BGP configuration]({{ site.baseurl }}/reference/resources/bgpconfig) for more information.


### PR DESCRIPTION
## Description
Fix a docs typo.

Without this change, the command given is wrong:
```
$ calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": "false"}}'
Hit error: creating resource from patched data: error parsing document: cannot parse string 'false' into field BGPConfigurationSpec.nodeToNodeMeshEnabled of type bool
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
