### PR TITLE
Wrap each table to be responsive

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -37,4 +37,6 @@ $(document).ready(function(){
       return false;
     }
   });
+
+  $('table').wrap($('<div />', { class: 'table-responsive' }));
 });


### PR DESCRIPTION
## Description

In order to fix table layouts we can wrap each table with `div` with bootstrap's `table-responsive` class. [See docs](https://getbootstrap.com/docs/4.0/content/tables/#responsive-tables).