### PR TITLE
Fix: Table content overflow out of visible area

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -1,3 +1,6 @@
+---
+layout: responsive_tables
+---
 <!-- Set this_pages_navbar  -->
 {% comment %}
 Here, we loop through site.data for the current view

--- a/_layouts/responsive_tables.html
+++ b/_layouts/responsive_tables.html
@@ -1,0 +1,4 @@
+
+{% assign content_ = content | replace: '<table', '<div class="table-responsive"><table' %}
+{% assign content_ = content_ | replace: '</table>', '</table></div>' %}
+{{ content_ }}

--- a/css/style.scss
+++ b/css/style.scss
@@ -68,6 +68,12 @@ body {
   }
 }
 
+td {
+  @media (max-width: $screen-xs-max) {
+    white-space: pre-wrap !important;
+  }
+}
+
 h2,h3 {
   margin-top: 28px;
 }


### PR DESCRIPTION
This PR fixes a visual bug caused by html table element not using `.table` css element from bootstarp.
Issue was raised by slack user `Mateusz Gozdek (Kinvolk)` [in this conversation](https://calicousers.slack.com/archives/CPGAD6BEX/p1600940939001400).

@lxpollitt 
## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
