### PR TITLE
Remove aws-src-dst-check setting in the default config

### DIFF
--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -329,11 +329,6 @@ spec:
             - name: CLUSTER_TYPE
               value: "k8s"
 {{- end }}
-{{- if and (eq .Values.network "calico") (.Values.vxlan) }}
-            # Disable AWS source-destination check on nodes.
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
-{{- end }}
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.


### PR DESCRIPTION
## Description

Remove `awsSrcDstCheck` setting in the default config.
This temporary change is to avoid running into installation issues while we investigate the RC.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests - verified that using the proposed change, calico-node becomes ready after the installation.
- [ ] ~Documentation~
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
