### PR TITLE
Fix names of config params

### DIFF
--- a/reference/felix/configuration.md
+++ b/reference/felix/configuration.md
@@ -74,8 +74,8 @@ The full list of parameters which can be set is as follows.
 | `VXLANPort`                       | `FELIX_VXLANPORT`                       | The UDP port to use for VXLAN. [Default: `4789`] | int |
 | `VXLANTunnelMACAddr`              |                                         | MAC address of the VXLAN tunnel. This is system configured and should not be updated manually. | string |
 | `VXLANVNI`                        | `FELIX_VXLANVNI`                        | The virtual network ID to use for VXLAN. [Default: `4096`] | int |
-| `AllowVXLANPacketsFromWorkload`   | `FELIX_ALLOWVXLANPACKETSFROMWORKLOAD`   | Set to `true` to allow VXLAN encapsulated traffic from workloads. [Default: `false`] | boolean |
-| `AllowIPIPPacketsFromWorkload`    | `FELIX_ALLOWIPIPPACKETSFROMWORKLOAD`    | Set to `true` to allow IPIP encapsulated traffic from workloads. [Default: `false`] | boolean |
+| `AllowVXLANPacketsFromWorkloads`  | `FELIX_ALLOWVXLANPACKETSFROMWORKLOADS`  | Set to `true` to allow VXLAN encapsulated traffic from workloads. [Default: `false`] | boolean |
+| `AllowIPIPPacketsFromWorkloads`   | `FELIX_ALLOWIPIPPACKETSFROMWORKLOADS`   | Set to `true` to allow IPIP encapsulated traffic from workloads. [Default: `false`] | boolean |
 | `XDPRefreshInterval`              | `FELIX_XDPREFRESHINTERVAL`              | Period, in seconds, at which Felix re-checks the XDP state in the dataplane to ensure that no other process has accidentally broken {{site.prodname}}'s rules. Set to 0 to disable XDP refresh. [Default: `90`] | int |
 | `XDPEnabled`                      | `FELIX_XDPENABLED`                      | Enable XDP acceleration for host endpoint policies. [Default: `true`] | boolean |
 | `TyphaAddr`                       | `FELIX_TYPHAADDR`                       | IPv4 address at which Felix should connect to Typha. [Default: none] | string |

--- a/reference/resources/felixconfig.md
+++ b/reference/resources/felixconfig.md
@@ -94,8 +94,8 @@ spec:
 | vxlanMTU                           | MTU to use for the VXLAN tunnel device. Zero value means auto-detect. Also controls NodePort MTU when eBPF enabled. | int | int | `0` |
 | vxlanPort                          | Port to use for VXLAN traffic. A value of `0` means "use the kernel default". | int | int | `4789` |
 | vxlanVNI                           | Virtual network ID to use for VXLAN traffic. A value of `0` means "use the kernel default". | int | int | `4096` |
-| allowVXLANPacketsFromWorkload      | Set to `true` to allow VXLAN encapsulated traffic from workloads. | boolean | boolean | `false` |
-| allowIPIPPacketsFromWorkload       | Set to `true` to allow IPIP encapsulated traffic from workloads. | boolean | boolean | `false` |
+| allowVXLANPacketsFromWorkloads     | Set to `true` to allow VXLAN encapsulated traffic from workloads. | boolean | boolean | `false` |
+| allowIPIPPacketsFromWorkloads      | Set to `true` to allow IPIP encapsulated traffic from workloads. | boolean | boolean | `false` |
 | wireguardEnabled                   | Enable encryption on WireGuard supported nodes in cluster. When enabled, pod to pod traffic will be sent over encrypted tunnels between the nodes. | `true`, `false` | boolean | `false` |
 | wireguardInterfaceName             | Name of the WireGuard interface created by Felix. If you change the name, and want to clean up the previously-configured interface names on each node, this is a manual process. | string | string | wireguard.cali |
 | wireguardListeningPort             | Port used by WireGuard tunnels. Felix sets up WireGuard tunnel on each node specified by this port. Available for configuration only in the global FelixConfiguration resource; setting it per host, config-file or environment variable will not work. | 1-65535 | int | 51820 |


### PR DESCRIPTION
## Description
the allowXXXXPacketsFromWorkloads fields are wrong in the docs - missing an 's' on the end.  

They are correct in the manifest specs however.

`allowVXLANPacketsFromWorkload` should be `allowVXLANPacketsFromWorkloads`
`allowIPIPPacketsFromWorkload` should be `allowIPIPPacketsFromWorkloads`


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
