### PR TITLE
Set VXLANMode to CrossSubnet

### DIFF
--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -289,7 +289,7 @@ spec:
               value: "{{- if .Values.bpf -}} Never {{- else if .Values.vxlan -}} Never {{- else -}} Always {{- end -}}"
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
-              value: "{{- if .Values.vxlan -}} Always {{- else -}} Never {{- end -}}"
+              value: "{{- if .Values.vxlan -}} CrossSubnet {{- else -}} Never {{- end -}}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:


### PR DESCRIPTION
## Description

Set `VXLANMode` to `CrossSubnet` for EKS/Calico-CNI manifest.


## Related issues/PRs

https://github.com/projectcalico/felix/pull/2592

## Todos

- [x] Release note

## Release Note

```release-note
Set VXLANMode to CrossSubnet when using EKS with Calico CNI.
```
