### PR TITLE
Remove config to disable aws-src-dst-check in release v3.17

### DIFF
--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -329,11 +329,6 @@ spec:
             - name: CLUSTER_TYPE
               value: "k8s"
 {{- end }}
-{{- if and (eq .Values.network "calico") (.Values.vxlan) }}
-            # Disable AWS source-destination check on nodes.
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
-{{- end }}
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.


### PR DESCRIPTION
## Description

Remove config to disable aws-src-dst-check in release v3.17.
Verified that `VXLANMode` is set to `Always` (and not `CrossSubnet`)

## Todos

- [x] Release note

## Release Note

```release-note
This fix will avoid running into issue 4154 with calico-node not being Ready.
```
