### PR TITLE
Update install-typha.md

### DIFF
--- a/getting-started/kubernetes/hardway/install-typha.md
+++ b/getting-started/kubernetes/hardway/install-typha.md
@@ -69,7 +69,7 @@ Define a cluster role for Typha with permission to watch {{site.prodname}} datas
 ```bash
 kubectl apply -f - <<EOF
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-typha
 rules:


### PR DESCRIPTION
- **Issue:** `apiVersion: rbac.authorization.k8s.io/v1beta1` as `ClusterRole` is deprecated in k8s v1.17+. So using that as `apiVersion` shows an warning. It will be unavailable in v1.22+. 

- **Solution:** `apiVersion: rbac.authorization.k8s.io/v1` should be used instead.