### PR TITLE
calicoctl --context update

### DIFF
--- a/reference/calicoctl/apply.md
+++ b/reference/calicoctl/apply.md
@@ -49,6 +49,7 @@ Options:
                             Only applicable to NetworkPolicy and WorkloadEndpoint.
                             Only applicable to NetworkPolicy, NetworkSet, and WorkloadEndpoint.
                             Uses the default namespace if not specified.
+  --context=<context>       The name of the kubeconfig context to use.
 
 Description:
   The apply command is used to create or replace a set of resources by filename

--- a/reference/calicoctl/create.md
+++ b/reference/calicoctl/create.md
@@ -50,6 +50,7 @@ Options:
   -n --namespace=<NS>       Namespace of the resource.
                             Only applicable to NetworkPolicy, NetworkSet, and WorkloadEndpoint.
                             Uses the default namespace if not specified.
+  --context=<context>       The name of the kubeconfig context to use.
 
 Description:
   The create command is used to create a set of resources by filename or stdin.

--- a/reference/calicoctl/delete.md
+++ b/reference/calicoctl/delete.md
@@ -56,6 +56,7 @@ Options:
   -n --namespace=<NS>       Namespace of the resource.
                             Only applicable to NetworkPolicy and WorkloadEndpoint.
                             Uses the default namespace if not specified.
+  --context=<context>       The name of the kubeconfig context to use.
 
 Description:
   The delete command is used to delete a set of resources by filename or stdin,

--- a/reference/calicoctl/get.md
+++ b/reference/calicoctl/get.md
@@ -59,6 +59,7 @@ Options:
   --export                     If present, returns the requested object(s) stripped of
                                cluster-specific information. This flag will be ignored
                                if <NAME> is not specified.
+  --context=<context>          The name of the kubeconfig context to use.
 
 Description:
   The get command is used to display a set of resources by filename or stdin,

--- a/reference/calicoctl/label.md
+++ b/reference/calicoctl/label.md
@@ -54,6 +54,7 @@ Options:
   --remove                     If true, remove the specified key in labels of the
                                resource. Reports error when specified key does not
                                exist. Can not be used with --overwrite.
+  --context=<context>          The name of the kubeconfig context to use.
 
 Description:
   The label command is used to add or update a label on a resource. Resource types

--- a/reference/calicoctl/overview.md
+++ b/reference/calicoctl/overview.md
@@ -49,6 +49,7 @@ Options:
   -h --help               Show this screen.
   -l --log-level=<level>  Set the log level (one of panic, fatal, error,
                           warn, info, debug) [default: panic]
+  --context=<context>	    The name of the kubeconfig context to use.
 
 Description:
   The calicoctl command line tool is used to manage Calico network and security
@@ -58,6 +59,10 @@ Description:
   See 'calicoctl <command> --help' to read about a specific subcommand.
 ```
 {: .no-select-button}
+
+
+> **Note:** In a multi cluster environment if you have a {% include open-new-window.html url="https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/" text="kubeconfig" %} file with multiple cluster contexts it is possible to directly change the context using calicoctl `--context` argument.
+{: .alert .alert-info}
 
 ## Top level command line options
 

--- a/reference/calicoctl/patch.md
+++ b/reference/calicoctl/patch.md
@@ -38,6 +38,7 @@ Options:
   -n --namespace=<NS>        Namespace of the resource.
                              Only applicable to NetworkPolicy, NetworkSet, and WorkloadEndpoint.
                              Uses the default namespace if not specified.
+  --context=<context>        The name of the kubeconfig context to use.
 
 Description:
   The patch command is used to patch a specific resource by type and identifiers in place.

--- a/reference/calicoctl/replace.md
+++ b/reference/calicoctl/replace.md
@@ -48,6 +48,7 @@ Options:
   -n --namespace=<NS>        Namespace of the resource.
                              Only applicable to NetworkPolicy, NetworkSet, and WorkloadEndpoint.
                              Uses the default namespace if not specified.
+  --context=<context>        The name of the kubeconfig context to use.
 
 Description:
   The replace command is used to replace a set of resources by filename or


### PR DESCRIPTION
This PR updates `calicoctl` documents to include --context https://github.com/projectcalico/calicoctl/pull/2212

@caseydavenport @lxpollitt 
```release-note
None required
```
