### PR TITLE
Automated cherry pick of #4245: With v3.17.0 the default datastore is kubernetes

### DIFF
--- a/getting-started/clis/calicoctl/configure/etcd.md
+++ b/getting-started/clis/calicoctl/configure/etcd.md
@@ -8,7 +8,7 @@ canonical_url: '/getting-started/clis/calicoctl/configure/etcd'
 
 | Configuration file option | Environment variable | Description                                                                           | Schema
 | --------------------------| -------------------- | ------------------------------------------------------------------------------------- | ------
-| `datastoreType`           | `DATASTORE_TYPE`     | Indicates the datastore to use. If unspecified, defaults to `etcdv3`. (optional)      | `kubernetes`, `etcdv3`
+| `datastoreType`           | `DATASTORE_TYPE`     | Indicates the datastore to use. If unspecified, defaults to `kubernetes`. (optional)      | `kubernetes`, `etcdv3`
 | `etcdEndpoints`           | `ETCD_ENDPOINTS`     | A comma-separated list of etcd endpoints. Example: `http://127.0.0.1:2379,http://127.0.0.2:2379` (required) | string
 | `etcdDiscoverySrv`        | `ETCD_DISCOVERY_SRV` | Domain name to discover etcd endpoints via SRV records. Mutually exclusive with `etcdEndpoints`. Example: `example.com` (optional) | string
 | `etcdUsername`            | `ETCD_USERNAME`      | User name for RBAC. Example: `user` (optional)                                        | string
@@ -23,7 +23,7 @@ canonical_url: '/getting-started/clis/calicoctl/configure/etcd'
 > **Note**:
 > - If you are running with TLS enabled, ensure your endpoint addresses use HTTPS.
 > - When specifying through environment variables, the `DATASTORE_TYPE` environment
->   is not required for etcdv3.
+>   is required for etcdv3.
 > - All environment variables may also be prefixed with `CALICO_`, for example
 >   `CALICO_DATASTORE_TYPE` and `CALICO_ETCD_ENDPOINTS` etc. may also be used.
 >   This is useful if the non-prefixed names clash with existing environment

--- a/getting-started/clis/calicoctl/configure/kdd.md
+++ b/getting-started/clis/calicoctl/configure/kdd.md
@@ -14,7 +14,7 @@ If the default kubeconfig does not exist, or you would like to specify alternati
 
 | Configuration file option | Environment variable | Description                                                                                               | Schema
 | --------------------------|----------------------| ----------------------------------------------------------------------------------------------------------|
-| `datastoreType`           | `DATASTORE_TYPE`     | Indicates the datastore to use. [Default: `etcdv3`]                                                       | `kubernetes`, `etcdv3`
+| `datastoreType`           | `DATASTORE_TYPE`     | Indicates the datastore to use. [Default: `kubernetes`]                                                       | `kubernetes`, `etcdv3`
 | `kubeconfig`              | `KUBECONFIG`         | When using the Kubernetes datastore, the location of a kubeconfig file to use, e.g. /path/to/kube/config. | string
 | `k8sAPIEndpoint`          | `K8S_API_ENDPOINT`   | Location of the Kubernetes API. Not required if using kubeconfig. [Default: `https://kubernetes-api:443`] | string
 | `k8sCertFile`             | `K8S_CERT_FILE`      | Location of a client certificate for accessing the Kubernetes API, e.g., `/path/to/cert`.                 | string

--- a/reference/kube-controllers/configuration.md
+++ b/reference/kube-controllers/configuration.md
@@ -60,7 +60,7 @@ The following environment variables can be used to configure the {{site.prodname
 
 | Environment   | Description | Schema | Default |
 | ------------- | ----------- | ------ | -------
-| `DATASTORE_TYPE`      | Which datastore type to use | etcdv3, kubernetes | etcdv3
+| `DATASTORE_TYPE`      | Which datastore type to use | etcdv3, kubernetes | kubernetes
 | `ENABLED_CONTROLLERS` | Which controllers to run    | namespace, node, policy, serviceaccount, workloadendpoint | policy,namespace,serviceaccount,workloadendpoint,node
 | `LOG_LEVEL`           | Minimum log level to be displayed. | debug, info, warning, error | info
 | `KUBECONFIG`          | Path to a kubeconfig file for Kubernetes API access | path |

--- a/reference/node/configuration.md
+++ b/reference/node/configuration.md
@@ -62,7 +62,7 @@ below.
 
 | Environment   | Description | Schema |
 | ------------- | ----------- | ------ |
-| DATASTORE_TYPE | Type of datastore. [Default: `etcdv3`] | kubernetes, etcdv3 |
+| DATASTORE_TYPE | Type of datastore. [Default: `kubernetes`] | kubernetes, etcdv3 |
 
 #### Configuring Kubernetes Datastore Access
 


### PR DESCRIPTION
Cherry pick of #4245 on release-v3.17.

#4245: With v3.17.0 the default datastore is kubernetes
