### PR TITLE
Remove site.prodname from Networking docs section

### DIFF
--- a/networking/determine-best-networking.md
+++ b/networking/determine-best-networking.md
@@ -1,6 +1,6 @@
 ---
 title: Determine best networking option
-description: Learn about the different networking options {{site.prodname}} supports so you can choose the best option for your needs.
+description: Learn about the different networking options Calico supports so you can choose the best option for your needs.
 ---
 
 ### Big picture


### PR DESCRIPTION
## Description

Remove {{site.prodname}} from https://docs.projectcalico.org/networking/.

It does not appear variables are supported in Jekyll front matter.
