### PR TITLE
fix apiversion in Chart.yaml

### DIFF
--- a/_includes/charts/tigera-operator/Chart.yaml
+++ b/_includes/charts/tigera-operator/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v3
+apiVersion: v2
 name: tigera-operator
 description: Installs the Tigera operator for Calico
 


### PR DESCRIPTION
## Description

Running helm lint over the helm charts fails:
```
$ helm lint tigera-operator.tgz 
==> Linting tigera-operator.tgz
[ERROR] Chart.yaml: apiVersion 'v3' is not valid. The value must be either "v1" or "v2"
[INFO] Chart.yaml: icon is recommended
Error: 1 chart(s) linted, 1 chart(s) failed
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
