### PR TITLE
Installation instructions for certificate management

### DIFF
--- a/_data/navbars/maintenance.yml
+++ b/_data/navbars/maintenance.yml
@@ -40,3 +40,5 @@ section:
     path: /maintenance/troubleshoot/component-logs
   - title: eBPF Dataplane
     path: /maintenance/troubleshoot/troubleshoot-ebpf
+- title: Certificate Management
+  path: /maintenance/certificate-management

--- a/maintenance/certificate-management.md
+++ b/maintenance/certificate-management.md
@@ -1,0 +1,104 @@
+---
+title: Manage TLS certificates used by Calico
+description: Control the issuer of certificates used by Calico
+---
+
+### Big picture
+
+Bring your own certificate request signer and approver and have control over the TLS certificates for {{site.prodname}} components.
+
+### Value
+
+- With this feature enabled private keys will never be stored outside of the pod that uses it.
+- Have control over the trusted certificates in your cluster.
+
+### How to
+
+#### Enable certificate management
+This section covers how to enable certificate management in a single step, followed by three ways to monitor and verify that the feature works as expected. 
+
+1. Modify your [the installation reference]({{site.baseurl}}/reference/installation/api#operator.tigera.io/v1.Installation)
+resource and add the `certificateManagement` section. Apply the following change to your cluster.
+```
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  ...
+  certificateManagement:
+    rootCA: <Your CA Cert in Pem format>
+    signerName: example.com/rene
+    signatureAlgorithm: SHA384WithRSA # optional
+    keyAlgorithm: RSAWithSize2048 # optional
+    ...
+```
+Done! If you have an automatic signer and approver, there is nothing left to do. The following steps explain in more detail what just happened.
+
+1. (Optional) Monitor your pods as they come up:
+```
+$ kubectl get pod -n calico-system -w
+NAMESPACE                  NAME                                       READY   STATUS             RESTARTS   AGE
+calico-system              calico-node-5ckvq                          0/1     Pending            0          0s
+calico-system              calico-typha-688c9957f5-h9c5w              0/1     Pending            0          0s
+calico-system              calico-node-5ckvq                          0/1     Init:0/3           0          1s
+calico-system              calico-typha-688c9957f5-h9c5w              0/1     Init:0/1           0          1s
+calico-system              calico-node-5ckvq                          0/1     PodInitializing    0          2s
+calico-system              calico-typha-688c9957f5-h9c5w              0/1     PodInitializing    0          2s
+calico-system              calico-node-5ckvq                          1/1     Running            0          3s
+calico-system              calico-typha-688c9957f5-h9c5w              1/1     Running            0          3s
+```
+During the `Init` phase a certificate signing request (CSR) is created by an init container of the pod. It will be stuck in the 
+`Init` phase. Once the CSR has been approved and signed by the certificate authority, the pod continues with `PodInitializing`
+and eventually `Running`.
+
+1. (Optional) Monitor certificate signing requests:
+```
+$ kubectl get csr -w
+NAME                                                 AGE   REQUESTOR                                          CONDITION
+calico-system:calico-node-5ckvq:9a3a10               0s    system:serviceaccount:calico-system:calico-node    Pending
+calico-system:calico-node-5ckvq:9a3a10               0s    system:serviceaccount:calico-system:calico-node    Pending,Issued
+calico-system:calico-node-5ckvq:9a3a10               0s    system:serviceaccount:calico-system:calico-node    Approved,Issued
+calico-system:typha-688c9957f5-h9c5w:2b0d82          0s    system:serviceaccount:calico-system:calico-typha   Pending
+calico-system:typha-688c9957f5-h9c5w:2b0d82          0s    system:serviceaccount:calico-system:calico-typha   Pending,Issued
+calico-system:typha-688c9957f5-h9c5w:2b0d82          0s    system:serviceaccount:calico-system:calico-typha   Approved,Issued
+```
+A CSR will be `Pending` until it has been `Issued` and `Approved`. The name of a CSR is based on the namespace, the pod
+name and the first 6 characters of the pod's UID. The pod will be `Pending` until the CSR has been `Approved`
+
+1. (Optional) Monitor the status of this feature using the `TigeraStatus`:
+```
+$ kubectl get tigerastatus
+NAME     AVAILABLE   PROGRESSING   DEGRADED   SINCE
+calico   True        False         False      2m40s
+```
+ 
+#### Implement your own signing and approval process
+
+**Necessary steps**
+
+This feature uses api version `certificates.k8s.io/v1` for [certificate signing requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/). 
+To automate signing and approval process,
+you want to run a server that performs the following actions:
+- Watch `CertificateSigningRequests` resources with status `Pending` and `spec.signerName=<your-signer-name>`
+- For each `Pending` CSR perform (security) checks (see next heading)
+- Issue a certificate and update `.spec.status.certificate`
+- Approve the CSR update `.spec.status.conditions`
+
+**Security checks**
+
+Based on your requirements you may want to implement custom checks to make sure that no certificates are issued for a malicious user.
+When a CSR is created, the kube-apiserver adds immutable fields to the spec to help you perform checks:
+- `.spec.username` contains the username of the requester.
+- `.spec.groups` contains the groups that the requester belongs to.
+- `.spec.request` contains the certificate request in pem format. Verify that the user and/or group match with the requested certificate subject (alt) names.
+
+**Implement your signer and approver using golang**
+- Use [client-go](https://github.com/kubernetes/client-go) to create a clientset
+- To watch CSRs, use `clientset.CertificatesV1beta1().CertificateSigningRequests().Watch(..)`
+- To Issue the certificate use `clientset.CertificatesV1beta1().CertificateSigningRequests().UpdateStatus(...)`
+- To Approve the CSR use `clientset.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(...)`
+
+#### Further reading
+- Read [kubernetes certificate signing requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for more information on CSRs.
+- Use [client-go](https://github.com/kubernetes/client-go) to implement a controller to sign and approve a CSR.

--- a/maintenance/certificate-management.md
+++ b/maintenance/certificate-management.md
@@ -5,19 +5,27 @@ description: Control the issuer of certificates used by Calico
 
 ### Big picture
 
-Bring your own certificate request signer and approver and have control over the TLS certificates for {{site.prodname}} components.
+Enable custom workflows for issuing and signing certificates used to secure communication between {{site.prodname}} components.
 
 ### Value
 
-- With this feature enabled private keys will never be stored outside of the pod that uses it.
-- Have control over the trusted certificates in your cluster.
+Some deployments have security requirements that strictly minimize or eliminate the access to private keys and/or 
+requirements to control the trusted certificates throughout clusters. Using the Kubernetes Certificates API that automates 
+certificate issuance, {{site.prodname}} provides a simple custom resource that you add to your installation.
+
+### Before you begin
+
+**Supported algorithms:
+- Private Key Pair: RSA (size: 2048|4096|8192), ECDSA (curve: 256|384|521)
+- Certificate Signature: RSA (sha: 256|384|512), ECDSA (sha: 256|384|512)
 
 ### How to
+- [Enable certificate management](#enable-certificate-management)
+- [Verify and monitor](#verify-and-monitor)
+- [Implement your own signing/approval process](#implement-your-own-signing-and-approval-process)
 
 #### Enable certificate management
-This section covers how to enable certificate management in a single step, followed by three ways to monitor and verify that the feature works as expected. 
-
-1. Modify your [the installation reference]({{site.baseurl}}/reference/installation/api#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource]({{site.baseurl}}/reference/installation/api#operator.tigera.io/v1.Installation)
 resource and add the `certificateManagement` section. Apply the following change to your cluster.
 ```
 apiVersion: operator.tigera.io/v1
@@ -25,18 +33,18 @@ kind: Installation
 metadata:
   name: default
 spec:
-...
   certificateManagement:
-    rootCA: <Your CA Cert in Pem format>
-    signerName: <your-domain>/<signer-name>
-    signatureAlgorithm: SHA512WithRSA # Optional
-    keyAlgorithm: RSAWithSize4096 # Optional
-...
+       rootCA: <Your CA Cert in Pem format>
+       signerName: <your-domain>/<signer-name>
+       signatureAlgorithm: SHA512WithRSA
+       keyAlgorithm: RSAWithSize4096
 ```
 
-Done! If you have an automatic signer and approver, there is nothing left to do. The following steps explain in more detail what just happened.
+Done! If you have an automatic signer and approver, there is nothing left to do. The next section explains in more detail
+how to verify and monitor the status.
 
-1. (Optional) Monitor your pods as they come up:
+#### Verify and monitor
+1. Monitor your pods as they come up:
 ```
 $ kubectl get pod -n calico-system -w
 NAMESPACE                  NAME                                       READY   STATUS             RESTARTS   AGE
@@ -53,7 +61,7 @@ During the `Init` phase a certificate signing request (CSR) is created by an ini
 `Init` phase. Once the CSR has been approved and signed by the certificate authority, the pod continues with `PodInitializing`
 and eventually `Running`.
 
-1. (Optional) Monitor certificate signing requests:
+1. Monitor certificate signing requests:
 ```
 $ kubectl get csr -w
 NAME                                                 AGE   REQUESTOR                                          CONDITION
@@ -67,7 +75,7 @@ calico-system:typha-688c9957f5-h9c5w:2b0d82          0s    system:serviceaccount
 A CSR will be `Pending` until it has been `Issued` and `Approved`. The name of a CSR is based on the namespace, the pod
 name and the first 6 characters of the pod's UID. The pod will be `Pending` until the CSR has been `Approved`
 
-1. (Optional) Monitor the status of this feature using the `TigeraStatus`:
+1. Monitor the status of this feature using the `TigeraStatus`:
 ```
 $ kubectl get tigerastatus
 NAME     AVAILABLE   PROGRESSING   DEGRADED   SINCE
@@ -76,26 +84,28 @@ calico   True        False         False      2m40s
  
 #### Implement your own signing and approval process
 
-**Necessary steps**
+**Required steps**
 
 This feature uses api version `certificates.k8s.io/v1beta1` for [certificate signing requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/). 
-To automate signing and approval process,
-you want to run a server that performs the following actions:
+To automate the signing and approval process, run a server that performs the following actions:
 1. Watch `CertificateSigningRequests` resources with status `Pending` and `spec.signerName=<your-signer-name>`
+
+   > **Note**: The signerName field was introduced in [Kubernetes v1.18](https://github.com/kubernetes/kubernetes/pull/86476). If you use an older version, you should skip the signerName check in step 1.
+   {: .alert .alert-info}
+
 1. For each `Pending` CSR perform (security) checks (see next heading)
 1. Issue a certificate and update `.spec.status.certificate`
 1. Approve the CSR and update `.spec.status.conditions`
 
-> **Note**: The signerName field was introduced in [Kubernetes v1.18](https://github.com/kubernetes/kubernetes/pull/86476). If you use an older version, you should skip the signerName check in step 1.
-{: .alert .alert-info}
-
-**Security checks**
+**Security requirements**
 
 Based on your requirements you may want to implement custom checks to make sure that no certificates are issued for a malicious user.
 When a CSR is created, the kube-apiserver adds immutable fields to the spec to help you perform checks:
-- `.spec.username` contains the username of the requester.
-- `.spec.groups` contains the groups that the requester belongs to.
-- `.spec.request` contains the certificate request in pem format. Verify that the user and/or group match with the requested certificate subject (alt) names.
+- `.spec.username`: username of the requester
+- `.spec.groups`: user groups of the requester
+- `.spec.request`: certificate request in pem format
+
+Verify that the user and/or group match with the requested certificate subject (alt) names.
 
 **Implement your signer and approver using golang**
 - Use [client-go](https://github.com/kubernetes/client-go) to create a clientset
@@ -103,6 +113,6 @@ When a CSR is created, the kube-apiserver adds immutable fields to the spec to h
 - To issue the certificate use `clientset.CertificatesV1beta1().CertificateSigningRequests().UpdateStatus(...)`
 - To approve the CSR use `clientset.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(...)`
 
-#### Further reading
+#### Above and beyond
 - Read [kubernetes certificate signing requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for more information on CSRs.
 - Use [client-go](https://github.com/kubernetes/client-go) to implement a controller to sign and approve a CSR.

--- a/maintenance/certificate-management.md
+++ b/maintenance/certificate-management.md
@@ -15,7 +15,7 @@ certificate issuance, {{site.prodname}} provides a simple configuration option t
 
 ### Before you begin
 
-**Supported algorithms:
+**Supported algorithms**
 - Private Key Pair: RSA (size: 2048|4096|8192), ECDSA (curve: 256|384|521)
 - Certificate Signature: RSA (sha: 256|384|512), ECDSA (sha: 256|384|512)
 

--- a/maintenance/certificate-management.md
+++ b/maintenance/certificate-management.md
@@ -16,8 +16,8 @@ certificate issuance, {{site.prodname}} provides a simple configuration option t
 ### Before you begin
 
 **Supported algorithms**
-- Private Key Pair: RSA (size: 2048|4096|8192), ECDSA (curve: 256|384|521)
-- Certificate Signature: RSA (sha: 256|384|512), ECDSA (sha: 256|384|512)
+- Private Key Pair: RSA (size: 2048,4096,8192), ECDSA (curve: 256,384,521)
+- Certificate Signature: RSA (sha: 256,384,512), ECDSA (sha: 256,384,512)
 
 ### How to
 - [Enable certificate management](#enable-certificate-management)

--- a/maintenance/certificate-management.md
+++ b/maintenance/certificate-management.md
@@ -16,8 +16,8 @@ certificate issuance, {{site.prodname}} provides a simple configuration option t
 ### Before you begin
 
 **Supported algorithms**
-- Private Key Pair: RSA (size: 2048,4096,8192), ECDSA (curve: 256,384,521)
-- Certificate Signature: RSA (sha: 256,384,512), ECDSA (sha: 256,384,512)
+- Private Key Pair: RSA (size: 2048, 4096, 8192), ECDSA (curve: 256, 384, 521)
+- Certificate Signature: RSA (sha: 256, 384, 512), ECDSA (sha: 256, 384, 512)
 
 ### How to
 - [Enable certificate management](#enable-certificate-management)
@@ -73,7 +73,7 @@ calico-system:typha-688c9957f5-h9c5w:2b0d82          0s    system:serviceaccount
 calico-system:typha-688c9957f5-h9c5w:2b0d82          0s    system:serviceaccount:calico-system:calico-typha   Approved,Issued
 ```
 A CSR will be `Pending` until it has been `Issued` and `Approved`. The name of a CSR is based on the namespace, the pod
-name and the first 6 characters of the pod's UID. The pod will be `Pending` until the CSR has been `Approved`
+name and the first 6 characters of the pod's UID. The pod will be `Pending` until the CSR has been `Approved`.
 
 1. Monitor the status of this feature using the `TigeraStatus`:
 ```
@@ -88,9 +88,9 @@ calico   True        False         False      2m40s
 
 This feature uses api version `certificates.k8s.io/v1beta1` for [certificate signing requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/). 
 To automate the signing and approval process, run a server that performs the following actions:
-1. Watch `CertificateSigningRequests` resources with status `Pending` and `spec.signerName=<your-signer-name>`
+1. Watch `CertificateSigningRequests` resources with status `Pending` and `spec.signerName=<your-signer-name>`.
 
-   > **Note**: The signerName field was introduced in [Kubernetes v1.18](https://github.com/kubernetes/kubernetes/pull/86476). If you use an older version, you should skip the signerName check in step 1.
+   > **Note**: You can skip this step if you are using a version before Kubernetes v1.18; (the signerName field was not available).
    {: .alert .alert-info}
 
 1. For each `Pending` CSR perform (security) checks (see next heading)
@@ -114,5 +114,5 @@ Verify that the user and/or group match with the requested certificate subject (
 - To approve the CSR use `clientset.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(...)`
 
 #### Above and beyond
-- Read [kubernetes certificate signing requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for more information on CSRs.
-- Use [client-go](https://github.com/kubernetes/client-go) to implement a controller to sign and approve a CSR.
+- Read [kubernetes certificate signing requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) for more information on CSRs
+- Use [client-go](https://github.com/kubernetes/client-go) to implement a controller to sign and approve a CSR

--- a/maintenance/certificate-management.md
+++ b/maintenance/certificate-management.md
@@ -11,7 +11,7 @@ Enable custom workflows for issuing and signing certificates used to secure comm
 
 Some deployments have security requirements that strictly minimize or eliminate the access to private keys and/or 
 requirements to control the trusted certificates throughout clusters. Using the Kubernetes Certificates API that automates 
-certificate issuance, {{site.prodname}} provides a simple custom resource that you add to your installation.
+certificate issuance, {{site.prodname}} provides a simple configuration option that you add to your installation.
 
 ### Before you begin
 


### PR DESCRIPTION
Adds instructions for certificate management for operator users who would like to bring their own signer and approver of certificate signing requests using the v1beta1 api: https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/

