### PR TITLE
Update MicroK8s Documentation page is outdated

### DIFF
--- a/getting-started/kubernetes/microk8s.md
+++ b/getting-started/kubernetes/microk8s.md
@@ -26,8 +26,11 @@ Use this quickstart to quickly and easily try {{site.prodname}} features with Mi
 1. Initialize the node using the following command.
    
    ```
-   snap install microk8s --classic --channel=edge/ha-preview
+   snap install microk8s --classic
    ```
+
+   > You can check out other versions of Kubernetes MicroK8s implementation published in snap using `snap info microk8s` command.
+   {: .alert .alert-info }
 
 1. Enable dns services.
  


### PR DESCRIPTION
 MicroK8s --channel=edge/ha-preview is no longer working, this update fixes the doc.

```release-note
None required
```
@lxpollitt 