### PR TITLE
Fix the calicoctl datastore migrate page to display commands correctly

### DIFF
--- a/_data/navbars/reference.yml
+++ b/_data/navbars/reference.yml
@@ -55,7 +55,7 @@ section:
     - title: Overview
       path: /reference/calicoctl/datastore/overview
     - title: Migrate
-      path: /reference/calicoctl/datastore/migrate
+      path: /reference/calicoctl/datastore/migrate/
       section:
       - title: Overview
         path: /reference/calicoctl/datastore/migrate/overview


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Cherry-pick of https://github.com/projectcalico/calico/pull/4348

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
