### PR TITLE
Fix bare metal docs to run policy only.

### DIFF
--- a/_includes/content/docker-container-service.md
+++ b/_includes/content/docker-container-service.md
@@ -43,7 +43,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged \
  -v /run/docker/plugins:/run/docker/plugins \
  -v /lib/modules:/lib/modules \
  -v /etc/pki:/pki \
- {{page.registry}}{{page.imageNames["calico/node"]}}:{{site.data.versions.first.title}}
+ {{page.registry}}{{page.imageNames["calico/node"]}}:{{site.data.versions.first.title}} /bin/calico-node -felix
 
 ExecStop=-/usr/bin/docker stop {{site.noderunning}}
 

--- a/getting-started/bare-metal/installation/container.md
+++ b/getting-started/bare-metal/installation/container.md
@@ -5,7 +5,7 @@ canonical_url: '/getting-started/bare-metal/installation/container'
 ---
 
 ### Big picture
-Install {{site.prodname}} on non-cluster hosts using a Docker container.
+Install {{site.prodname}} on non-cluster hosts using a Docker container for network policy only.
 
 ### Value
 Installing {{site.prodname}} with a Docker container includes everything you need for both networking and policy. It also automatically adds the appropriate per-node configuration to the datastore.


### PR DESCRIPTION
Fix bare metal docs, such that the right expectations are set until we fully support it.

Previously, when you follow the docs, the container crashes when it tries to create a projectcalico.org/v3 Node, because calico-node starts with a flag to start all daemons. This PR lets it run Felix only, which will allow the user to run policy only without running into problems.