### PR TITLE
format calicoctl samples to match one accepted by kubectl

### DIFF
--- a/security/tutorials/protect-hosts.md
+++ b/security/tutorials/protect-hosts.md
@@ -40,30 +40,31 @@ in general:
 
 ```bash
 calicoctl apply -f - <<EOF
-- apiVersion: projectcalico.org/v3
-  kind: GlobalNetworkPolicy
-  metadata:
-    name: allow-cluster-internal-ingress
-  spec:
-    order: 10
-    preDNAT: true
-    applyOnForward: true
-    ingress:
-      - action: Allow
-        source:
-          nets: [10.240.0.0/16, 192.168.0.0/16]
-    selector: has(host-endpoint)
-- apiVersion: projectcalico.org/v3
-  kind: GlobalNetworkPolicy
-  metadata:
-    name: drop-other-ingress
-  spec:
-    order: 20
-    preDNAT: true
-    applyOnForward: true
-    ingress:
-      - action: Deny
-    selector: has(host-endpoint)
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: allow-cluster-internal-ingress
+spec:
+  order: 10
+  preDNAT: true
+  applyOnForward: true
+  ingress:
+    - action: Allow
+      source:
+        nets: [10.240.0.0/16, 192.168.0.0/16]
+  selector: has(host-endpoint)
+---
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: drop-other-ingress
+spec:
+  order: 20
+  preDNAT: true
+  applyOnForward: true
+  ingress:
+    - action: Deny
+  selector: has(host-endpoint) 
 EOF
 ```
 
@@ -90,17 +91,17 @@ egress traffic will be allowed from local processes (except for traffic that is
 allowed by the [failsafe rules]({{ site.baseurl }}/reference/host-endpoints/failsafe). Because there is no default-deny
 rule for forwarded traffic, forwarded traffic will be allowed for host endpoints.
 
-```
+```bash
 calicoctl apply -f - <<EOF
-- apiVersion: projectcalico.org/v3
-  kind: GlobalNetworkPolicy
-  metadata:
-    name: allow-outbound-external
-  spec:
-    order: 10
-    egress:
-      - action: Allow
-    selector: has(host-endpoint)
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: allow-outbound-external
+spec:
+  order: 10
+  egress:
+    - action: Allow
+  selector: has(host-endpoint)
 EOF
 ```
 
@@ -127,15 +128,15 @@ definitions.  For example, for `eth0` on `node1`:
 
 ```bash
 calicoctl apply -f - <<EOF
-- apiVersion: projectcalico.org/v3
-  kind: HostEndpoint
-  metadata:
-    name: node1-eth0
-    labels:
-      host-endpoint: ingress
-  spec:
-    interfaceName: eth0
-    node: node1
+apiVersion: projectcalico.org/v3
+kind: HostEndpoint
+metadata:
+  name: node1-eth0
+  labels:
+    host-endpoint: ingress
+spec:
+  interfaceName: eth0
+  node: node1
 EOF
 ```
 
@@ -154,21 +155,21 @@ pre-DNAT policy like this:
 
 ```bash
 calicoctl apply -f - <<EOF
-- apiVersion: projectcalico.org/v3
-  kind: GlobalNetworkPolicy
-  metadata:
-    name: allow-nodeport
-  spec:
-    preDNAT: true
-    applyOnForward: true
-    order: 10
-    ingress:
-      - action: Allow
-        protocol: TCP
-        destination:
-          selector: has(host-endpoint)
-          ports: [31852]
-    selector: has(host-endpoint)
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: allow-nodeport
+spec:
+  preDNAT: true
+  applyOnForward: true
+  order: 10
+  ingress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        selector: has(host-endpoint)
+        ports: [31852]
+  selector: has(host-endpoint)
 EOF
 ```
 


### PR DESCRIPTION
## Description
formatting samples in protect-hosts tutorial to match the format accepted by `kubectl` command, not liking the list `-` dash notation at the beginning of the config file


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [X ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
