### PR TITLE
Fix typo in NAT section on about-networking.md

### DIFF
--- a/about/about-networking.md
+++ b/about/about-networking.md
@@ -138,7 +138,7 @@ apply to the source or destination IP address, or to both addresses.
 One common use case for NAT is to allow devices with private IP address to talk to devices with public IP address across
 the internet. For example, if a device with a private IP address attempts to connect to a public IP address, then the
 router at the border of the private network will typically use SNAT (Source Network Address Translation) to map the
-private source IP address of tha packet to the router's own public IP address before forwarding it on to the internet.
+private source IP address of the packet to the router's own public IP address before forwarding it on to the internet.
 The router then maps response packets coming in the opposite direction back to the original private IP address, so
 packets flow end-to-end in both directions, with neither source or destination being aware the mapping is happening. The
 same technique is commonly used to allow devices connected to an overlay network to connect with devices outside of the


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->Found typo or mistyped word on about-networking.md line 141  
Below is git diff  on the mistyped section  

        -private source IP address of tha packet to the router's own public IP address before forwarding it on to the internet.
        +private source IP address of the packet to the router's own public IP address before forwarding it on to the internet.  

previously it was typed tha packet, proposed to change to the packet so that the sentence does not have typo

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
