### PR TITLE
Add liveness probe for calico-kube-controllers

### DIFF
--- a/_includes/charts/calico/templates/calico-kube-controllers.yaml
+++ b/_includes/charts/calico/templates/calico-kube-controllers.yaml
@@ -73,11 +73,20 @@ spec:
             # Mount in the etcd TLS secrets.
             - mountPath: /calico-secrets
               name: etcd-certs
+          livenessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -l
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
           readinessProbe:
             exec:
               command:
               - /usr/bin/check-status
               - -r
+            periodSeconds: 10
       volumes:
         # Mount in the etcd TLS secrets with mode 400.
         # See https://kubernetes.io/docs/concepts/configuration/secret/
@@ -95,11 +104,20 @@ spec:
               value: node
             - name: DATASTORE_TYPE
               value: kubernetes
+          livenessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -l
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
           readinessProbe:
             exec:
               command:
               - /usr/bin/check-status
               - -r
+            periodSeconds: 10
 {{- end }}
 
 ---


### PR DESCRIPTION
## Description

Due to https://github.com/kubernetes/client-go/issues/374, `calico-kube-controllers` takes a very long time to get ready when upgrading a cluster, as described in https://github.com/projectcalico/calico/issues/3751.

The underlying issue was fixed by https://github.com/projectcalico/libcalico-go/pull/1356, but only for v3.18.
This change is a workaround that can be cherry-picked to v3.17 and earlier, but it's also a good practice for liveness probe to be added, same as for other calico components.

## Related issues/PRs

https://github.com/projectcalico/libcalico-go/issues/1267

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add liveness probe for calico-kube-controllers
```
