### PR TITLE
Clarify per-node BGPconfig abilities

### DIFF
--- a/reference/resources/bgpconfig.md
+++ b/reference/resources/bgpconfig.md
@@ -46,7 +46,7 @@ spec:
 | name     | Unique name to describe this resource instance. Required. | Alphanumeric string with optional `.`, `_`, or `-`. | string |
 
 - The resource with the name `default` has a specific meaning - this contains the BGP global default configuration.
-- The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the BGPConfiguration resource associated with the node will also be deleted.
+- The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the BGPConfiguration resource associated with the node will also be deleted. Only Prefix Advertisements, Listen Port, Log Severity and Extensions can be overridden this way.
 
 #### Spec
 

--- a/reference/resources/bgpconfig.md
+++ b/reference/resources/bgpconfig.md
@@ -46,7 +46,7 @@ spec:
 | name     | Unique name to describe this resource instance. Required. | Alphanumeric string with optional `.`, `_`, or `-`. | string |
 
 - The resource with the name `default` has a specific meaning - this contains the BGP global default configuration.
-- The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the BGPConfiguration resource associated with the node will also be deleted. Only prefixAdvertisements, listenPort, logSeverityScreen and Extensions can be overridden this way.
+- The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the BGPConfiguration resource associated with the node will also be deleted. Only prefixAdvertisements, listenPort, and logSeverityScreen can be overridden this way.
 
 #### Spec
 

--- a/reference/resources/bgpconfig.md
+++ b/reference/resources/bgpconfig.md
@@ -46,7 +46,7 @@ spec:
 | name     | Unique name to describe this resource instance. Required. | Alphanumeric string with optional `.`, `_`, or `-`. | string |
 
 - The resource with the name `default` has a specific meaning - this contains the BGP global default configuration.
-- The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the BGPConfiguration resource associated with the node will also be deleted. Only Prefix Advertisements, Listen Port, Log Severity and Extensions can be overridden this way.
+- The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the BGPConfiguration resource associated with the node will also be deleted. Only prefixAdvertisements, listenPort, logSeverityScreen and Extensions can be overridden this way.
 
 #### Spec
 


### PR DESCRIPTION
## Description
Only Prefix Advertisements, Listen Port, and Log Severity can be overridden with per-node BGPConfiguration, so we should say that at the text at the top of the table rather than forcing users to pick that info out of the table.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
