### PR TITLE
[release-v3.18] Pick windows: wni and wmcb binaries aren't available for 4.6 (#4410)

### DIFF
--- a/getting-started/windows-calico/openshift/installation.md
+++ b/getting-started/windows-calico/openshift/installation.md
@@ -119,6 +119,9 @@ calicoctl ipam configure --strictaffinity=true
 
 Download the latest {% include open-new-window.html text='Windows Node Installer (WNI)' url='https://github.com/openshift/windows-machine-config-bootstrapper/releases' %} binary `wni` that matches your OpenShift minor version.
 
+> **Note**: For OpenShift 4.6, use the latest wni for OpenShift 4.5. A wni binary for OpenShift 4.6 is not published yet.
+{: .alert .alert-info}
+
 Next, determine the AMI id corresponding to Windows Server 1903 (build 18317) or greater. `wni` defaults to using Windows Server 2019 (build 10.0.17763) which does not include WinDSR support.
 One way to do this is by searching for AMI's matching the string `Windows_Server-1903-English-Core-ContainersLatest` in the Amazon EC2 console
 
@@ -178,7 +181,7 @@ aws ec2 get-password-data --instance-id <instance id> --priv-launch-key <aws pri
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to the file **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file (default location: openshift-tigera-install/auth/kubeconfig), to the file **c:\k\config**.
 
 1. Download the powershell script, **install-calico-windows.ps1**.
 
@@ -222,6 +225,9 @@ From the Windows node, download the Windows Machine Config Bootstrapper `wmcb.ex
 ```powershell
 curl https://github.com/openshift/windows-machine-config-bootstrapper/releases/download/v4.5.2-alpha/wmcb.exe -o c:\wmcb.exe
 ```
+
+> **Note**: For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.ex binary for OpenShift 4.6 is not published yet.
+{: .alert .alert-info}
 
 Next, we will download the the `worker.ign` file from the API server:
 


### PR DESCRIPTION
## Description

Pick of https://github.com/projectcalico/calico/pull/4410
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
