### PR TITLE
Correct description for docker container install on non-cluster node doc 

### DIFF
--- a/getting-started/bare-metal/installation/container.md
+++ b/getting-started/bare-metal/installation/container.md
@@ -5,7 +5,7 @@ canonical_url: '/getting-started/bare-metal/installation/container'
 ---
 
 ### Big picture
-Install {{site.prodname}} on non-cluster hosts using a Docker container for network policy only.
+Install {{site.prodname}} on non-cluster hosts using a Docker container for both networking and policy.
 
 ### Value
 Installing {{site.prodname}} with a Docker container includes everything you need for both networking and policy. It also automatically adds the appropriate per-node configuration to the datastore.


### PR DESCRIPTION
Fix opening sentence to state that this doc is for both networking and policy, instead of just policy.

## Description

Existing sentence was in contradiction with the document which is for both networking and policy. 

## Related issues/PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
