### PR TITLE
Route reflector documentation

### DIFF
--- a/_data/navbars/reference.yml
+++ b/_data/navbars/reference.yml
@@ -146,6 +146,11 @@ section:
     path: /reference/kube-controllers/configuration
   - title: Prometheus statistics
     path: /reference/kube-controllers/prometheus
+- title: Route reflector controller
+  path: /reference/route-reflector-ctrl/
+  section:
+  - title: Configuration
+    path: /reference/route-reflector-ctrl/configuration
 - title: Configuration on public clouds
   path: /reference/public-cloud/
   section:

--- a/_includes/charts/calico/templates/calico-kube-controllers-rbac.yaml
+++ b/_includes/charts/calico/templates/calico-kube-controllers-rbac.yaml
@@ -105,12 +105,25 @@ rules:
     verbs:
       # read its own config
       - get
+      # list its own config
+      - list
       # create a default if none exists
       - create
       # update status
       - update
       # watch for changes
       - watch
+  # Needs access to configure route reflectors.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgppeers
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+      - delete
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/getting-started/kubernetes/hardway/configure-bgp-peering.md
+++ b/getting-started/kubernetes/hardway/configure-bgp-peering.md
@@ -153,6 +153,10 @@ No IPv6 peers found.
 ```
 {: .no-select-button}
 
+# Topology autoscaling
+
+By default BGP topology is configured manually by the user. Doing the re-configuration each time when the cluster size or state changes is an expensive and boring operation. {{site.prodname}} has a built in `kubernetes` controller under [kubernetes-controllers]({{site.baseurl}}/reference/kube-controllers/configuration)`, to achieve BGP topology autoscaling. Multiple topologies are supported, for more details follow the controller's [documentation]({{site.baseurl}}/reference/route-reflector-ctrl/configuration).
+
 ## Next
 
 [Test networking](./test-networking)

--- a/getting-started/kubernetes/hardway/configure-bgp-peering.md
+++ b/getting-started/kubernetes/hardway/configure-bgp-peering.md
@@ -155,7 +155,7 @@ No IPv6 peers found.
 
 # Topology autoscaling
 
-By default BGP topology is configured manually by the user. Doing the re-configuration each time when the cluster size or state changes is an expensive and boring operation. {{site.prodname}} has a built in `kubernetes` controller under [kubernetes-controllers]({{site.baseurl}}/reference/kube-controllers/configuration)`, to achieve BGP topology autoscaling. Multiple topologies are supported, for more details follow the controller's [documentation]({{site.baseurl}}/reference/route-reflector-ctrl/configuration).
+By default BGP topology is configured manually by the user. Doing the re-configuration each time when the cluster size or state changes is an expensive and boring operation. {{site.prodname}} has a built in `kubernetes` controller under [kubernetes-controllers]({{site.baseurl}}/reference/kube-controllers/configuration), to achieve BGP topology autoscaling. Multiple topologies are supported, for more details follow the controller's [documentation]({{site.baseurl}}/reference/route-reflector-ctrl/configuration).
 
 ## Next
 

--- a/reference/kube-controllers/configuration.md
+++ b/reference/kube-controllers/configuration.md
@@ -150,7 +150,7 @@ This controller is only valid when using etcd as the {{site.prodname}} datastore
 ### Route reflector controller
 
 The route reflector controller scales BGP topology inside the cluster based on the given configuration.
-The controller continously watches Kubernetes node changes and re-calculate BGP peerings to achieve high availability and cluster stability.
+The controller continously watches Kubernetes node changes and re-calculates BGP peerings to achieve high availability and cluster stability.
 
 To enable the route reflector controller when using `kubernetes`, set the list of enabled controllers
 in the environment for kube-controllers to `routereflector`. For example: `ENABLED_CONTROLLERS=routereflector`

--- a/reference/kube-controllers/configuration.md
+++ b/reference/kube-controllers/configuration.md
@@ -147,5 +147,15 @@ The service account controller is enabled by default if `ENABLED_CONTROLLERS` is
 
 This controller is only valid when using etcd as the {{site.prodname}} datastore.
 
+### Route reflector controller
+
+The route reflector controller scales BGP topology inside the cluster based on the given configuration.
+The controller continously watches Kubernetes node changes and re-calculate BGP peerings to achieve high availability and cluster stability.
+
+To enable the route reflector controller when using `kubernetes`, set the list of enabled controllers
+in the environment for kube-controllers to `routereflector`. For example: `ENABLED_CONTROLLERS=routereflector`
+
+Multiple topologies are supported, for more details follow the controller's [documentation]({{site.baseurl}}/reference/route-reflector-ctrl/configuration).
+
 [in-cluster-config]: https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
 [kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/

--- a/reference/kube-controllers/prometheus.md
+++ b/reference/kube-controllers/prometheus.md
@@ -21,6 +21,11 @@ existing metrics.
 | `ipam_blocks_per_node` | Number of IPAM blocks, indexed by the node to which they have affinity. |
 | `ipam_allocations_per_node` | Number of Calico IP allocations, indexed by node on which the allocation was made. |
 | `ipam_borrowed_allocations_per_node` | Number of Calico IP allocations borrowed from a non-affine block, indexed by node on which the allocation was made. |
+| `route_reflector_total_count` | Actual number of route reflectors. |
+| `route_reflector_bgp_updated` | BGP peer config operations per type. |
+| `route_reflector_total_missing_count` | Total number of missing route reflectors. |
+| `route_reflector_revert_count` | Total number of reverts need to be applied in controller per node. |
+| `route_reflector_error_count` | Total number of errors in controller per node. |
 
 Prometheus metrics are self-documenting, with metrics turned on, `curl` can be used to list the
 metrics along with their help text and type information.

--- a/reference/resources/kubecontrollersconfig.md
+++ b/reference/resources/kubecontrollersconfig.md
@@ -130,7 +130,7 @@ The route reflector controller scales BGP topology inside the cluster based on t
 | zoneLabel | ZoneLabel zone label on Kubernetes nodes | string | failure-domain.beta.kubernetes.io/zone |
 | min | The minimum number of route refletors | integer | 3 |
 | max | The maxium number of route refletors | integer | 10 |
-| ratio | ration of route reflectors and clients, between 0.001 and 0.05 | float | 0.005 |
+| ratio | ration of route reflectors and clients, between 0.001 and 0.05 | number | 0.005 |
 | routeReflectorLabelKey | label key of route reflector selector | string | calico-route-reflector |
 | routeReflectorLabelValue | label value of route reflector selector | string | |
 | incompatibleLabels | List of node labels to disallow route reflector selection | string | |

--- a/reference/resources/kubecontrollersconfig.md
+++ b/reference/resources/kubecontrollersconfig.md
@@ -127,7 +127,8 @@ The route reflector controller scales BGP topology inside the cluster based on t
 |------------------|-----------------------------------------------------------------------|-----------------------------------|---------|
 | reconcilerPeriod | Period to perform reconciliation with the {{site.prodname}} datastore | [Duration string][parse-duration] | 5m      |
 | clusterId | Route reflector cluster id | string | 224.0.0.0 |
-| zoneLabel | ZoneLabel zone label on Kubernetes nodes | string | failure-domain.beta.kubernetes.io/zone |
+| hostnameLabel | hostname label on Kubernetes nodes | string | kubernetes.io/hostname |
+| zoneLabel | zone label on Kubernetes nodes | string | failure-domain.beta.kubernetes.io/zone |
 | min | The minimum number of route refletors | integer | 3 |
 | max | The maxium number of route refletors | integer | 10 |
 | ratio | ration of route reflectors and clients, between 0.001 and 0.05 | number | 0.005 |

--- a/reference/resources/kubecontrollersconfig.md
+++ b/reference/resources/kubecontrollersconfig.md
@@ -132,7 +132,7 @@ The route reflector controller scales BGP topology inside the cluster based on t
 | minReplicas | Minimum number of route refletors | integer | 3 |
 | maxReplicas | Maxium number of route refletors | integer | 10 |
 | routeReflectorRatio | Ration of route reflectors and clients, between 0.001 and 0.05 | number | 0.005 |
-| incompatibleLabels | Set of node labels to disallow route reflector selection | string | |
+| incompatibleLabels | Set of node labels to disallow route reflector selection | map | |
 
 ### Supported operations
 

--- a/reference/resources/kubecontrollersconfig.md
+++ b/reference/resources/kubecontrollersconfig.md
@@ -127,13 +127,14 @@ The route reflector controller scales BGP topology inside the cluster based on t
 |------------------|-----------------------------------------------------------------------|-----------------------------------|---------|
 | reconcilerPeriod | Period to perform reconciliation with the {{site.prodname}} datastore | [Duration string][parse-duration] | 5m      |
 | clusterId | Route reflector cluster id | string | 224.0.0.0 |
-| hostnameLabel | hostname label on Kubernetes nodes | string | kubernetes.io/hostname |
-| zoneLabel | zone label on Kubernetes nodes | string | failure-domain.beta.kubernetes.io/zone |
-| min | The minimum number of route refletors | integer | 3 |
-| max | The maxium number of route refletors | integer | 10 |
-| ratio | ration of route reflectors and clients, between 0.001 and 0.05 | number | 0.005 |
-| routeReflectorLabelKey | label key of route reflector selector | string | calico-route-reflector |
-| routeReflectorLabelValue | label value of route reflector selector | string | |
+| hostnameLabel | Hostname label on Kubernetes nodes | string | kubernetes.io/hostname |
+| zoneLabel | Zone label on Kubernetes nodes | string | failure-domain.beta.kubernetes.io/zone |
+| routeReflectorsPerNode | Route reflectors per node | integer | 3 |
+| min | Minimum number of route refletors | integer | 3 |
+| max | Maxium number of route refletors | integer | 10 |
+| ratio | Ration of route reflectors and clients, between 0.001 and 0.05 | number | 0.005 |
+| routeReflectorLabelKey | Label key of route reflector selector | string | calico-route-reflector |
+| routeReflectorLabelValue | Label value of route reflector selector | string | |
 | incompatibleLabels | List of node labels to disallow route reflector selection | string | |
 
 ### Supported operations

--- a/reference/resources/kubecontrollersconfig.md
+++ b/reference/resources/kubecontrollersconfig.md
@@ -127,15 +127,12 @@ The route reflector controller scales BGP topology inside the cluster based on t
 |------------------|-----------------------------------------------------------------------|-----------------------------------|---------|
 | reconcilerPeriod | Period to perform reconciliation with the {{site.prodname}} datastore | [Duration string][parse-duration] | 5m      |
 | clusterId | Route reflector cluster id | string | 224.0.0.0 |
-| hostnameLabel | Hostname label on Kubernetes nodes | string | kubernetes.io/hostname |
-| zoneLabel | Zone label on Kubernetes nodes | string | failure-domain.beta.kubernetes.io/zone |
-| routeReflectorsPerNode | Route reflectors per node | integer | 3 |
-| min | Minimum number of route refletors | integer | 3 |
-| max | Maxium number of route refletors | integer | 10 |
-| ratio | Ration of route reflectors and clients, between 0.001 and 0.05 | number | 0.005 |
-| routeReflectorLabelKey | Label key of route reflector selector | string | calico-route-reflector |
-| routeReflectorLabelValue | Label value of route reflector selector | string | |
-| incompatibleLabels | List of node labels to disallow route reflector selection | string | |
+| zoneLabel | Zone label on Kubernetes nodes | string | topology.kubernetes.io/zone |
+| clientConnectionRedundancy | Route reflectors per client | integer | 3 |
+| minReplicas | Minimum number of route refletors | integer | 3 |
+| maxReplicas | Maxium number of route refletors | integer | 10 |
+| routeReflectorRatio | Ration of route reflectors and clients, between 0.001 and 0.05 | number | 0.005 |
+| incompatibleLabels | Set of node labels to disallow route reflector selection | string | |
 
 ### Supported operations
 

--- a/reference/resources/kubecontrollersconfig.md
+++ b/reference/resources/kubecontrollersconfig.md
@@ -119,6 +119,22 @@ The namespace controller syncs Kubernetes namespace label changes to the {{site.
 |------------------|-----------------------------------------------------------------------|-----------------------------------|---------|
 | reconcilerPeriod | Period to perform reconciliation with the {{site.prodname}} datastore | [Duration string][parse-duration] | 5m      |
 
+#### RouteReflectorController
+
+The route reflector controller scales BGP topology inside the cluster based on the given configuration.
+
+| Field            | Description                                                           | Schema                            | Default |
+|------------------|-----------------------------------------------------------------------|-----------------------------------|---------|
+| reconcilerPeriod | Period to perform reconciliation with the {{site.prodname}} datastore | [Duration string][parse-duration] | 5m      |
+| clusterId | Route reflector cluster id | string | 224.0.0.0 |
+| zoneLabel | ZoneLabel zone label on Kubernetes nodes | string | failure-domain.beta.kubernetes.io/zone |
+| min | The minimum number of route refletors | integer | 3 |
+| max | The maxium number of route refletors | integer | 10 |
+| ratio | ration of route reflectors and clients, between 0.001 and 0.05 | float | 0.005 |
+| routeReflectorLabelKey | label key of route reflector selector | string | calico-route-reflector |
+| routeReflectorLabelValue | label value of route reflector selector | string | |
+| incompatibleLabels | List of node labels to disallow route reflector selection | string | |
+
 ### Supported operations
 
 | Datastore type        | Create  | Delete (Global `default`)  |  Update  | Get/List | Notes

--- a/reference/route-reflector-ctrl/configuration.md
+++ b/reference/route-reflector-ctrl/configuration.md
@@ -1,0 +1,52 @@
+---
+title: Route reflector controller
+description: Route reflector opertor scales the BGP topology inside the cluster based on given config.
+---
+
+The route reflector controller is one of the operators within [kubernetes-controllers]({{site.baseurl}}/reference/kube-controllers/configuration).
+
+{{site.prodname}} by default doesn't manage BGP peer configuration actively. The user has to design the right topology for the specific cluster.
+Route reflector controller aims to extend {{site.prodname}}'s static configurations with autoscaling based on different variables like number of active nodes or available route reflectors per zone.
+The controller support multiple topologies and uses `kubernetes` custom resource for configuration, just like opther controllers.
+
+## Topologies
+
+Different clusters require different topologies, it depends on many parameters like size of the cluster or the number of zones. There are 3 main characteristics of a topology:
+
+ * Number of client session
+ * Number of BGP messages
+ * Size of BGP messages
+
+Each topology has different numbers, so selecting the right one needs some extra care from the user side.
+
+### Single cluster topology
+
+The simplest route reflector topology contains only one cluster ID. There are only one group of route reflectors and one group for clients. This topology doesn't scale well and useful only for single zone or single region clusters. The number of client connections per route reflector should go high on larger clusters than 500 nodes.
+
+### Multi cluster topology
+
+In this topology each Route Reflector has its own cluster ID. Clients are connecting to 3 different clusters by default and route reflectors are constituting one mesh. The size of the BGP update message should be the bottleneck near 2000 nodes, because all route reflectors advertise the full table to all other route reflectors.
+
+## Configuration
+
+To enable the route reflector controller, set the list of enabled controllers
+in the environment for kube-controllers to `routereflector`. For example: `ENABLED_CONTROLLERS=routereflector`
+
+Disable the node-to-node mesh
+
+```bash
+calicoctl create -f - <<EOF
+ apiVersion: projectcalico.org/v3
+ kind: BGPConfiguration
+ metadata:
+   name: default
+ spec:
+   nodeToNodeMeshEnabled: false
+   asNumber: 64512
+EOF
+```
+
+Customise topology via [resource definition]({{site.baseurl}}/reference/resources/kubecontrollersconfig).
+
+[in-cluster-config]: https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+[kubeconfig]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/

--- a/reference/route-reflector-ctrl/configuration.md
+++ b/reference/route-reflector-ctrl/configuration.md
@@ -7,7 +7,7 @@ The route reflector controller is one of the operators within [kubernetes-contro
 
 {{site.prodname}} by default doesn't manage BGP peer configuration actively. The user has to design the right topology for the specific cluster.
 Route reflector controller aims to extend {{site.prodname}}'s static configurations with autoscaling based on different variables like number of active nodes or available route reflectors per zone.
-The controller support multiple topologies and uses `kubernetes` custom resource for configuration, just like opther controllers.
+The controller supports multiple topologies and uses `kubernetes` custom resource as configuration, just like other controllers.
 
 ## Topologies
 

--- a/reference/route-reflector-ctrl/index.md
+++ b/reference/route-reflector-ctrl/index.md
@@ -1,0 +1,10 @@
+---
+description: Route reflector controller scales the BGP topology inside the cluster based on given config
+show_read_time: false
+show_toc: false
+---
+
+{{ page.description }}
+
+{% capture content %}{% include index.html %}{% endcapture %}
+{{ content | replace: "    ", "" }}


### PR DESCRIPTION
## Description

This change introduces route reflector controller related documentation.

## Related issues/PRs

documents https://github.com/projectcalico/kube-controllers/pull/514

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Route reflector controller is a new Tech Preview feature of Calico and gives the ability to scale BGP topology automatically based on cluster state.
```
