### PR TITLE
Update WireGuard docs for OpenShift installation

### DIFF
--- a/_includes/charts/calico/crds/kdd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/_includes/charts/calico/crds/kdd/crd.projectcalico.org_felixconfigurations.yaml
@@ -514,7 +514,7 @@ spec:
                 type: boolean
               wireguardInterfaceName:
                 description: 'WireguardInterfaceName specifies the name to use for
-                  the Wireguard interface. [Default: wg.calico]'
+                  the Wireguard interface. [Default: wireguard.cali]'
                 type: string
               wireguardListeningPort:
                 description: 'WireguardListeningPort controls the listening port used

--- a/security/encrypt-cluster-pod-traffic.md
+++ b/security/encrypt-cluster-pod-traffic.md
@@ -59,7 +59,7 @@ To install WireGuard for OpenShift v4.3:
 
   This approach uses kernel modules via container installation as outlined here https://github.com/projectcalico/atomic-wireguard
 
-   1. Create MachineConfig for WireGuard.
+   1. Create MachineConfig for WireGuard on your local machine.
    ```bash
    cat <<EOF > mc-wg-worker.yaml
    apiVersion: machineconfiguration.openshift.io/v1
@@ -89,7 +89,7 @@ To install WireGuard for OpenShift v4.3:
    EOF
    ```
 
-   3. Configure files.
+   3. Download and configure the tools needed for kmods.
    ```bash
    FAKEROOT=$(mktemp -d)
    git clone https://github.com/kmods-via-containers/kmods-via-containers
@@ -102,21 +102,15 @@ To install WireGuard for OpenShift v4.3:
    cd ..
    ```
 
-   4. You must set the URLs for the `KERNEL_CORE_RPM`, `KERNEL_DEVEL_RPM` and `KERNEL_MODULES_RPM` vars for the correct host kernel in the conf file `$FAKEROOT/etc/kvc/wireguard-kmod.conf`. You can determine the host kernel by running `uname -r` on a host in your cluster. 
-  
-  Example:
-  ```
-  KERNEL_CORE_RPM=https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/kernel-core-4.18.0-240.15.1.el8_3.x86_64.rpm
-  KERNEL_DEVEL_RPM=https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/kernel-devel-4.18.0-240.15.1.el8_3.x86_64.rpm
-  KERNEL_MODULES_RPM=https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/kernel-modules-4.18.0-240.15.1.el8_3.x86_64.rpm
-  ```
+   4. You must then set the value for the `KERNEL_CORE_RPM`, `KERNEL_DEVEL_RPM` and `KERNEL_MODULES_RPM` packages in the conf file `$FAKEROOT/etc/kvc/wireguard-kmod.conf`. These will be URLs to the RPMs. You can determine the host kernel version to use in the URL by running `uname -r` on a host in your cluster. You can find links to  official packages in your Red Hat subscription at https://access.redhat.com/downloads/content/package-browser 
 
-   5. Get RHEL Entitlement data from your own RHEL8 system.
+
+   5. Get RHEL Entitlement data from your own RHEL8 system from a host in your cluster.
    ```bash
    # tar -czf subs.tar.gz /etc/pki/entitlement/ /etc/rhsm/ /etc/yum.repos.d/redhat.repo
    ```
 
-   6. Copy the `subs.tar.gz` file to your workspace and use the following command to add it to the MachineConfig.
+   6. Copy the `subs.tar.gz` file to your workspace and then extract the contents using the following command.
    ```bash
    tar -x -C ${FAKEROOT} -f subs.tar.gz
    ```

--- a/security/encrypt-cluster-pod-traffic.md
+++ b/security/encrypt-cluster-pod-traffic.md
@@ -55,9 +55,9 @@ To install WireGuard on the default Amazon Machine Image (AMI):
 %>
 <label:OpenShift>
 <%
-To install WireGuard for OpenShift v4.3:
+To install WireGuard for OpenShift v4.6:
 
-  This approach uses kernel modules via container installation as outlined here https://github.com/projectcalico/atomic-wireguard
+  This approach uses kernel modules via container installation as outlined here {% include open-new-window.html text='atmoic wireguard' url='https://github.com/projectcalico/atomic-wireguard' %} 
 
    1. Create MachineConfig for WireGuard on your local machine.
    ```bash
@@ -102,12 +102,12 @@ To install WireGuard for OpenShift v4.3:
    cd ..
    ```
 
-   4. You must then set the value for the `KERNEL_CORE_RPM`, `KERNEL_DEVEL_RPM` and `KERNEL_MODULES_RPM` packages in the conf file `$FAKEROOT/etc/kvc/wireguard-kmod.conf`. These will be URLs to the RPMs. You can determine the host kernel version to use in the URL by running `uname -r` on a host in your cluster. You can find links to  official packages in your Red Hat subscription at https://access.redhat.com/downloads/content/package-browser 
+   4. You must then set the URLs for the `KERNEL_CORE_RPM`, `KERNEL_DEVEL_RPM` and `KERNEL_MODULES_RPM` packages in the conf file `$FAKEROOT/etc/kvc/wireguard-kmod.conf`. You can determine the host kernel version to use in the URL by running `uname -r` on a host in your cluster. You can find links to  official packages in your {% include open-new-window.html text='Red Hat subscription' url='https://access.redhat.com/downloads/content/package-browser' %} 
 
 
    5. Get RHEL Entitlement data from your own RHEL8 system from a host in your cluster.
    ```bash
-   # tar -czf subs.tar.gz /etc/pki/entitlement/ /etc/rhsm/ /etc/yum.repos.d/redhat.repo
+   tar -czf subs.tar.gz /etc/pki/entitlement/ /etc/rhsm/ /etc/yum.repos.d/redhat.repo
    ```
 
    6. Copy the `subs.tar.gz` file to your workspace and then extract the contents using the following command.


### PR DESCRIPTION
## Description

Doc update for WireGuard installation instructions on OpenShift, correcting some errors for repo links and adding better descriptions to the steps.

Also includes correcting a default value in a yaml file for OCP which was incorrect. 
 
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
