### PR TITLE
update etcd rbac paths document for cni plugin

### DIFF
--- a/reference/etcd-rbac/calico-etcdv3-paths.md
+++ b/reference/etcd-rbac/calico-etcdv3-paths.md
@@ -42,6 +42,7 @@ component needs access to in etcd to function successfully.
 | /calico/resources/v3/projectcalico.org/workloadendpoints/\*   |   RW   |
 | /calico/resources/v3/projectcalico.org/ippools/\*             |   R    |
 | /calico/resources/v3/projectcalico.org/clusterinformations/\* |   R    |
+| /calico/resources/v3/projectcalico.org/nodes/\*               |   R    |
 
 ## calico/kube-controllers
 


### PR DESCRIPTION
## Description

For v3.18, calico CNI plugin need read permission to `/calico/resources/v3/projectcalico.org/nodes/*` on etcd.

https://github.com/projectcalico/libcalico-go/blob/release-v3.18/lib/ipam/ipam.go#L319

```log
2021-03-19 19:24:32.351 [DEBUG][187045] ipam.go 1806: Using hostname=xxx
2021-03-19 19:24:32.351 [INFO][187045] ipam.go 95: Auto-assign 1 ipv4, 0 ipv6 addrs for host 'xxx'
2021-03-19 19:24:32.351 [DEBUG][187045] ipam.go 101: Assigning IPv4 addresses
2021-03-19 19:24:32.351 [INFO][187045] ipam.go 550: Looking up existing affinities for host handle="k8s-pod-network.a8dd203d478f5800c7cfcc4c9cbff3678620405d55a9756ff0f54ec0ebbd82b3" host="xxx"
2021-03-19 19:24:32.351 [DEBUG][187045] etcdv3.go 356: Processing Get request model-etcdKey=Node(xxx) rev=""
2021-03-19 19:24:32.351 [DEBUG][187045] etcdv3.go 380: Calling Get on etcdv3 client etcdv3-etcdKey="/calico/resources/v3/projectcalico.org/nodes/xxx" model-etcdKey=Node(xxx) rev=""
2021-03-19 19:24:32.364 [DEBUG][187045] etcdv3.go 383: Error returned from etcdv3 client error=etcdserver: permission denied etcdv3-etcdKey="/calico/resources/v3/projectcalico.org/nodes/xxx" model-etcdKey=Node(xxx) rev=""
2021-03-19 19:24:32.364 [ERROR][187045] ipam.go 321: failed to get node for host error=etcdserver: permission denied node="xxx"
2021-03-19 19:24:32.364 [ERROR][187045] ipam.go 109: Error assigning IPV4 addresses: etcdserver: permission denied
2021-03-19 19:24:32.364 [INFO][187045] ipam_plugin.go 276: Calico CNI IPAM assigned addresses IPv4=[] IPv6=[] ContainerID="a8dd203d478f5800c7cfcc4c9cbff3678620405d55a9756ff0f54ec0ebbd82b3" HandleID="k8s-pod-network.a8dd203d478f5800c7cfcc4c9cbff3678620405d55a9756ff0f54ec0ebbd82b3" Workload="xxx-k8s-busybox--6c8d59455f--d2k7c-eth0"
2021-03-19 19:24:32.370 [ERROR][187024] plugin.go 119: Final result of CNI ADD was an error. error=etcdserver: permission denied
2021-03-19 19:24:32.697 [DEBUG][187080] plugin.go 537: /var/lib/calico/nodename exists
```

calico CNI plugin works, after executing
```bash
etcdctl role grant-permission calico-cni-plugin --prefix=true read /calico/resources/v3/projectcalico.org/nodes/
```




## Related issues/PRs



## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note



```release-note
None required
```
