### PR TITLE
BPF install updates for operator

### DIFF
--- a/maintenance/ebpf/enabling-bpf.md
+++ b/maintenance/ebpf/enabling-bpf.md
@@ -310,7 +310,7 @@ kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"
 <label:Operator,active:true>
 <%
 
-If you installed {{site.prodname}} using the operator, change the `spec.calicoNetowrk.linuxDataplane` parameter in 
+If you installed {{site.prodname}} using the operator, change the `spec.calicoNetwork.linuxDataplane` parameter in 
 the operator's `Installation` resource to `"BPF"`:
 
 ```bash

--- a/maintenance/ebpf/enabling-bpf.md
+++ b/maintenance/ebpf/enabling-bpf.md
@@ -317,6 +317,11 @@ the operator's `Installation` resource to `"BPF"`:
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
+> **Note**: the operator rolls out the change with a rolling update which means that some nodes will be in eBPF mode
+> before others.  This can disrupt the flow of traffic through node ports.  We plan to improve this in an upcoming release
+> by having the operator do the update in two phases.
+{: .alert .alert-info}
+
 %>
 <label:Manifest>
 <%
@@ -355,8 +360,14 @@ Switching external traffic mode can disrupt in-progress connections.
 
 To revert to standard Linux networking:
 
-1. Disable Calico eBPF mode:
+1. (Depending on whether you installed Calico with the operator or with a manifest) reverse the changes to the operator's `Installation` or the `FelixConfiguration` resource:
 
+   ```bash
+   kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"Iptables"}}}'
+   ```
+   
+   or:
+   
    ```
    calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": false}}'
    ```

--- a/maintenance/ebpf/enabling-bpf.md
+++ b/maintenance/ebpf/enabling-bpf.md
@@ -131,7 +131,7 @@ This section explains how to make sure your cluster is suitable for eBPF mode.
    none on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime,mode=700)
    ```
 
-   If you see no output, then the BPF filesystem is not mounted; consult the documentation for your OS distribution to see how to make sure the file system is mounted at boot in its standard location  /sys/fs/bpf.  This may involve editing `/etc/fstab` or adding a `systemd` unit, depending on your distribution. If the file system is not mounted on the host then eBPF mode will work normally until {{site.prodname}} is restarted, at which point workload netowrking will be disrupted for several seconds.
+   If you see no output, then the BPF filesystem is not mounted; consult the documentation for your OS distribution to see how to make sure the file system is mounted at boot in its standard location  /sys/fs/bpf.  This may involve editing `/etc/fstab` or adding a `systemd` unit, depending on your distribution. If the file system is not mounted on the host then eBPF mode will work normally until {{site.prodname}} is restarted, at which point workload networking will be disrupted for several seconds.
 
 #### Configure {{site.prodname}} to talk directly to the API server
 
@@ -167,7 +167,7 @@ First, make a note of the address of the API server:
 > 443 (the standard HTTPS port).
 {: .alert .alert-success}
 
-The next step depends on whether you installed {{site.prodname}} using the operator, or a manifest:
+**The next step depends on whether you installed {{site.prodname}} using the operator, or a manifest:**
 
 {% tabs tab-group:grp1 %}
 <label:Operator,active:true>
@@ -304,11 +304,31 @@ kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"
 
 #### Enable eBPF mode
 
-To enable eBPF mode, change Felix configuration parameter  `BPFEnabled` to `true`.  This can be done with `calicoctl`, as follows:
+**The next step depends on whether you installed {{site.prodname}} using the operator, or a manifest:**
+
+{% tabs tab-group:grp2 %}
+<label:Operator,active:true>
+<%
+
+If you installed {{site.prodname}} using the operator, change the `spec.calicoNetowrk.linuxDataplane` parameter in 
+the operator's `Installation` resource to `"BPF"`:
+
+```bash
+kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
+```
+
+%>
+<label:Manifest>
+<%
+
+If you installed {{site.prodname}} using a manifest, change Felix configuration parameter  `BPFEnabled` to `true`.  This can be done with `calicoctl`, as follows:
 
 ```
 calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true}}'
 ```
+
+%>
+{% endtabs %}
 
 Enabling eBPF mode should not disrupt existing connections but existing connections will continue to use the standard 
 Linux datapath. You may wish to restart pods to ensure that they start new connections using the BPF dataplane.  

--- a/reference/installation/_api.html
+++ b/reference/installation/_api.html
@@ -568,6 +568,22 @@ Calico Enterprise installation.</p>
 <tbody>
 <tr>
 <td>
+<code>linuxDataplane</code><br>
+<em>
+<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+LinuxDataplaneOption
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it
+causes the operator to add required mounts and environment variables for the particular dataplane.
+If not specified, iptables mode is used.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bgp</code><br>
 <em>
 <a href="#operator.tigera.io/v1.BGPOption">
@@ -1365,6 +1381,12 @@ InstallationSpec
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+</p>
 <h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
@@ -1506,6 +1528,11 @@ a node that violates one or more of the expressions.</p>
 </p>
 <p>ProductVariant represents the variant of the product.</p>
 <p>One of: Calico, TigeraSecureEnterprise</p>
+<h3 id="operator.tigera.io/v1.PromptType">PromptType
+(<code>string</code> alias)</h3>
+<p>PromptType is a value that specifies whether the identity provider prompts the end user for re-authentication and
+consent.
+One of: None, Login, Consent, SelectAccount.</p>
 <h3 id="operator.tigera.io/v1.Provider">Provider
 (<code>string</code> alias)</h3>
 <p>


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Update BPF install docs to cover new operator parameter.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
When using the operator to install Calico, the process for enabling eBPF mode has changed to require an update to the operator's installation resource.  This allows for the operator to add the required bpffs mount point to the calico-node container.
```
