### PR TITLE
Update enabling-bpf.md

### DIFF
--- a/maintenance/ebpf/enabling-bpf.md
+++ b/maintenance/ebpf/enabling-bpf.md
@@ -160,7 +160,7 @@ First, make a note of the address of the API server:
 > **Tip**: If your cluster uses a ConfigMap to configure `kube-proxy` you can find the "right" way to reach the API
 > server by examining the config map.  For example:
 > ```
-> $ kubectl get configmap -n kube-system kube-proxy -o jsonpath='{.data.kubeconfig}' | grep server`
+> $ kubectl get configmap -n kube-system kube-proxy -o yaml | grep server`
 >     server: https://d881b853ae312e00302a84f1e346a77.gr7.us-west-2.eks.amazonaws.com
 > ```
 > In this case, the server is `d881b853aea312e00302a84f1e346a77.gr7.us-west-2.eks.amazonaws.com` and the port is


### PR DESCRIPTION
Small tweak to how to get k8s-apiserver IP and port - k8s 1.20 now puts it in `data.kubeconfig.conf`

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
