### PR TITLE
Add the role label to Windows nodes

### DIFF
--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -420,3 +420,10 @@ StartCalico
 if ($Backend -NE "none") {
     New-NetFirewallRule -Name KubectlExec10250 -Description "Enable kubectl exec and log" -Action Allow -LocalPort 10250 -Enabled True -DisplayName "kubectl exec 10250" -Protocol TCP -ErrorAction SilentlyContinue
 }
+
+$nodeName = Get-Content $RootDir\nodename
+if ((c:\k\kubectl.exe --kubeconfig c:\k\config get node $nodeName -o jsonpath='{.metadata.labels}' | Select-String "kubernetes.io/role") -EQ $null)
+{
+   Write-Host "Node $nodeName is missing worker role label, adding it"
+   c:\k\kubectl.exe --kubeconfig c:\k\config label node $nodeName kubernetes.io/role=worker
+}


### PR DESCRIPTION
## Description

When adding a new Windows kubernetes node we should ensure that the `kubernetes.io/role: worker` role is on the node.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
