### PR TITLE
Make calico-node containers run as nonprivileged

### DIFF
--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -84,7 +84,8 @@ spec:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
           securityContext:
-            privileged: true
+            privileged: false
+            runAsUser: 1000
 {{- end }}
         # This container installs the CNI binaries
         # and CNI network config file on each node.
@@ -177,7 +178,9 @@ spec:
               name: etcd-certs
 {{- end }}
           securityContext:
-            privileged: true
+            privileged: false
+            # Need root to copy files to /opt/cni/bin
+            runAsUser: 0
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
@@ -186,7 +189,9 @@ spec:
           - name: flexvol-driver-host
             mountPath: /host/driver
           securityContext:
-            privileged: true
+            privileged: false
+            # Need root in order to write to flexvol driver. (.uds)
+            runAsUser: 0
       containers:
         # Runs {{ include "nodeName" . }} container on each Kubernetes node. This
         # container programs network policy and routes on each
@@ -354,7 +359,13 @@ spec:
 {{ toYaml .Values.node.env | indent 12 }}
 {{- end }}
           securityContext:
-            privileged: true
+            privileged: false
+            # Need root in order to write files to hostpath volume /var/lib/calico
+            runAsUser: 0
+            capabilities:
+              add:
+              - NET_RAW
+              - NET_ADMIN
           resources:
             requests:
               cpu: 250m
@@ -427,7 +438,12 @@ spec:
           image: {{ .Values.flannel.image }}:{{ .Values.flannel.tag }}
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
-            privileged: true
+            privileged: false
+            # Need root in order to write files to hostpath volume /run/xtables.lock
+            runAsUser: 0
+            capabilities:
+              add:
+              - NET_ADMIN
           env:
             - name: POD_NAME
               valueFrom:
@@ -523,7 +539,12 @@ spec:
 {{ toYaml .Values.flannel.env | indent 12 }}
 {{- end }}
           securityContext:
-            privileged: true
+            privileged: false
+            # Need root in order to write files to hostpath volume /run/flannel
+            runAsUser: 0
+            capabilities:
+              add:
+              - NET_ADMIN
           volumeMounts:
             - mountPath: /etc/resolv.conf
               name: resolv

--- a/getting-started/kubernetes/hardway/install-node.md
+++ b/getting-started/kubernetes/hardway/install-node.md
@@ -241,7 +241,13 @@ spec:
             - name: FELIX_TYPHAKEYFILE
               value: /calico-node-certs/calico-node.key
           securityContext:
-            privileged: true
+            privileged: false
+            # Need root in order to write files to hostpath volume /var/lib/calico
+            runAsUser: 0
+            capabilities:
+              add:
+              - NET_RAW
+              - NET_ADMIN
           resources:
             requests:
               cpu: 250m


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Stops running the `calico-node` containers as privileged.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
calico-node is no longer run with privileged containers.
```
