### PR TITLE
Docs-add-private-registry

### DIFF
--- a/_data/navbars/maintenance.yml
+++ b/_data/navbars/maintenance.yml
@@ -11,11 +11,15 @@ section:
     path: /maintenance/openshift-upgrade
   - title: OpenStack
     path: /maintenance/openstack-upgrade
-- title: Deploy image options
-  path: /maintenance/image-options/
-  section:
-  - title: Deploy images by digest
-    path: /maintenance/image-options/imageset
+- title: Deploy images by digest
+  path: /maintenance/image-options/digest/imageset
+- title: Deploy images from private private registry
+  path: /maintenance/image-options/private-registry/
+  section: 
+  - title: Install using default directories
+    path: /maintenance/image-options/private-registry/private-registry-regular  
+  - title: Install using custom directories
+    path: /maintenance/image-options/private-registry/private-registry-image-path  
 - title: Migrate datastore from etcd to Kubernetes
   path: /maintenance/datastore-migration
 - title: The eBPF dataplane

--- a/_includes/content/private-registry-image-path.md
+++ b/_includes/content/private-registry-image-path.md
@@ -1,0 +1,128 @@
+#### Push {{ site.prodname }} images to your private registry image path
+
+In order to install images from your private registry, you must first pull the images from Tigera's registry, re-tag them with your own registry, and then push the newly tagged images to your own registry.
+
+1. Use the following commands to pull the required {{site.prodname}} images.
+
+   ```bash
+   docker pull {{ operator.registry }}/{{ operator.image }}:{{ operator.version }}
+   {% for component in site.data.versions.first.components -%}
+   {% if component[1].image -%}
+   {% if component[1].registry %}{% assign registry = component[1].registry | append: "/" %}{% else %}{% assign registry = page.registry -%} {% endif -%}
+   docker pull {{ registry }}{{ component[1].image }}:{{component[1].version}}
+   {% endif -%}
+   {% endfor -%}
+   ```
+
+1. Retag the images with the name of your private registry `$PRIVATE_REGISTRY` and `$IMAGE_PATH`.
+
+   ```bash
+   docker tag {{ operator.registry }}/{{ operator.image }}:{{ operator.version }} $PRIVATE_REGISTRY/$IMAGE_PATH/{{ operator.image | split: "/" | last }}:{{ operator.version }}
+   {% for component in site.data.versions.first.components -%}
+   {% if component[1].image -%}
+   {% if component[1].registry %}{% assign registry = component[1].registry | append: "/" %}{% else %}{% assign registry = page.registry -%} {% endif -%}
+   docker tag {{ registry }}{{ component[1].image }}:{{component[1].version}} $PRIVATE_REGISTRY/$IMAGE_PATH/{{ component[1].image | split: "/" | last }}:{{component[1].version}}
+   {% endif -%}
+   {% endfor -%}
+   ```
+
+1. Push the images to your private registry.
+
+   ```bash
+   docker push $PRIVATE_REGISTRY/$IMAGE_PATH/{{ operator.image | split: "/" | last }}:{{ operator.version }}
+   {% for component in site.data.versions.first.components -%}
+   {% if component[1].image -%}
+   docker push $PRIVATE_REGISTRY/$IMAGE_PATH/{{ component[1].image | split: "/" | last}}:{{component[1].version}}
+   {% endif -%}
+   {% endfor -%}
+   ```
+
+   > **Important**: Do not push the private {{site.prodname}} images to a public registry.
+   {: .alert .alert-danger}
+
+#### Run the operator using images from your private registry image path
+
+Before applying `tigera-operator.yaml`, modify registry references to use your custom registry:
+
+```bash
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" tigera-operator.yaml
+{% endif -%}
+sed -ie "s?quay.io.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" tigera-operator.yaml
+```
+{% comment %} The second 'sed' should be removed once operator launches Prometheus & Alertmanager {% endcomment %}
+
+Next, ensure that an image pull secret has been configured for your custom registry. Set the enviroment variable `PRIVATE_REGISTRY_PULL_SECRET` to the secret name.
+Then add the image pull secret to the operator deployment spec:
+
+```bash
+sed -ie "/serviceAccountName: tigera-operator/a \      imagePullSecrets:\n\      - name: $PRIVATE_REGISTRY_PULL_SECRET"  tigera-operator.yaml
+```
+
+If you are installing Prometheus operator as part of {{ site.prodname }}, then before applying `tigera-prometheus-operator.yaml`, modify registry references to use your custom registry:
+
+```bash
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" tigera-prometheus-operator.yaml
+{% endif -%}
+sed -ie "s?quay.io.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" tigera-prometheus-operator.yaml
+sed -ie "/serviceAccountName: calico-prometheus-operator/a \      imagePullSecrets:\n\      - name: $PRIVATE_REGISTRY_PULL_SECRET"  tigera-prometheus-operator.yaml
+```
+{% comment %} The second 'sed' should be removed once operator launches Prometheus & Alertmanager {% endcomment %}
+
+Before applying `custom-resources.yaml`, modify registry references to use your custom registry:
+
+```bash
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" custom-resources.yaml
+{% endif -%}
+sed -ie "s?quay.io.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" custom-resources.yaml
+```
+{% comment %} The second 'sed' should be removed once operator launches Prometheus & Alertmanager {% endcomment %}
+
+For <b>Openshift</b>, after downloading all manifests modify the following to use your custom registry:
+
+```bash
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/02-tigera-operator.yaml
+{% endif -%}
+sed -ie "s?quay.io.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/02-tigera-operator.yaml
+
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/04-deployment-prometheus-operator.yaml
+{% endif -%}
+sed -ie "s?quay.io.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/04-deployment-prometheus-operator.yaml
+sed -ie "s?containers:?imagePullSecrets:\n        - name: tigera-pull-secret \n      containers:?" manifests/04-deployment-prometheus-operator.yaml
+
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/01-cr-prometheus.yaml
+{% endif -%}
+sed -ie "s?quay.io.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/01-cr-prometheus.yaml
+sed -ie "s?nodeSelector:?imagePullSecrets:\n    - name: tigera-pull-secret \n  nodeSelector:?" manifests/01-cr-prometheus.yaml
+
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/01-cr-alertmanager.yaml
+{% endif -%}
+sed -ie "s?quay.io.*/?$PRIVATE_REGISTRY/$IMAGE_PATH/?" manifests/01-cr-alertmanager.yaml
+sed -ie "s?nodeSelector:?imagePullSecrets:\n    - name: tigera-pull-secret \n  nodeSelector:?" manifests/01-cr-alertmanager.yaml
+
+```
+>**Note:** Add the image pull secret for your `registry` to the secret `tigera-pull-secret`
+{: .alert .alert-info }
+
+#### Configure the operator to use images from your private registry image path.
+
+Set the `spec.registry` and `spec.imagePath` field of your Installation resource to the name of your custom registry. For example:
+
+<pre>
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  variant: TigeraSecureEnterprise
+  imagePullSecrets:
+    - name: tigera-pull-secret
+  <b>registry: myregistry.com</b>
+  <b>imagePath: my-image-path</b>
+</pre>

--- a/_includes/content/private-registry-regular.md
+++ b/_includes/content/private-registry-regular.md
@@ -1,0 +1,96 @@
+#### Push {{ site.prodname }} images to your private registry
+
+In order to install images from your private registry, you must first pull the images from Tigera's registry, re-tag them with your own registry, and then push the newly tagged images to your own registry.
+
+1. Use the following commands to pull the required {{site.prodname}} images.
+
+   ```bash
+   docker pull {{ operator.registry }}/{{ operator.image }}:{{ operator.version }}
+   {% for component in site.data.versions.first.components -%}
+   {% if component[1].image -%}
+   {% if component[1].registry %}{% assign registry = component[1].registry | append: "/" %}{% else %}{% assign registry = page.registry -%} {% endif -%}
+   docker pull {{ registry }}{{ component[1].image }}:{{component[1].version}}
+   {% endif -%}
+   {% endfor -%}
+   ```
+
+1. Retag the images with the name of your private registry `$PRIVATE_REGISTRY`.
+
+   ```bash
+   docker tag {{ operator.registry }}/{{ operator.image }}:{{ operator.version }} $PRIVATE_REGISTRY/{{ operator.image }}:{{ operator.version }}
+   {% for component in site.data.versions.first.components -%}
+   {% if component[1].image -%}
+   {% if component[1].registry %}{% assign registry = component[1].registry | append: "/" %}{% else %}{% assign registry = page.registry -%} {% endif -%}
+   docker tag {{ registry }}{{ component[1].image }}:{{component[1].version}} $PRIVATE_REGISTRY/{{ component[1].image }}:{{component[1].version}}
+   {% endif -%}
+   {% endfor -%}
+   ```
+
+1. Push the images to your private registry.
+
+   ```bash
+   docker push $PRIVATE_REGISTRY/{{ operator.image }}:{{ operator.version }}
+   {% for component in site.data.versions.first.components -%}
+   {% if component[1].image -%}
+   docker push $PRIVATE_REGISTRY/{{ component[1].image }}:{{component[1].version}}
+   {% endif -%}
+   {% endfor -%}
+   ```
+
+   > **Important**: Do not push the private {{site.prodname}} images to a public registry.
+   {: .alert .alert-danger}
+
+#### Run the operator using images from your private registry
+
+Before applying `tigera-operator.yaml`, modify registry references to use your custom registry:
+
+```bash
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}?$PRIVATE_REGISTRY?g" tigera-operator.yaml
+{% endif -%}
+sed -ie "s?quay.io?$PRIVATE_REGISTRY?g" tigera-operator.yaml
+```
+
+Next, ensure that an image pull secret has been configured for your custom registry. Set the enviroment variable `PRIVATE_REGISTRY_PULL_SECRET` to the secret name.
+Then add the image pull secret to the operator deployment spec:
+
+```bash
+sed -ie "/serviceAccountName: tigera-operator/a \      imagePullSecrets:\n\      - name: $PRIVATE_REGISTRY_PULL_SECRET"  tigera-operator.yaml
+```
+
+{% comment %} The second 'sed' should be removed once operator launches Prometheus & Alertmanager {% endcomment %}
+
+If you are installing Prometheus operator as part of {{ site.prodname }}, then before applying `tigera-prometheus-operator.yaml`, modify registry references to use your custom registry:
+
+```bash
+{% if page.registry != "quay.io/" -%}
+sed -ie "s?{{ page.registry }}?$PRIVATE_REGISTRY?g" tigera-prometheus-operator.yaml
+{% endif -%}
+sed -ie "s?quay.io?$PRIVATE_REGISTRY?g" tigera-prometheus-operator.yaml
+sed -ie "/serviceAccountName: calico-prometheus-operator/a \      imagePullSecrets:\n\      - name: $PRIVATE_REGISTRY_PULL_SECRET"  tigera-prometheus-operator.yaml
+```
+{% comment %} The second 'sed' should be removed once operator launches Prometheus & Alertmanager {% endcomment %}
+
+
+Before applying `custom-resources.yaml`, modify registry references to use your custom registry:
+
+```bash
+sed -ie "s?quay.io?$PRIVATE_REGISTRY?g" custom-resources.yaml
+```
+{% comment %} This step should be removed once operator launches Prometheus & Alertmanager {% endcomment %}
+
+#### Configure the operator to use images from your private registry.
+
+Set the `spec.registry` field of your Installation resource to the name of your custom registry. For example:
+
+<pre>
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  variant: TigeraSecureEnterprise
+  imagePullSecrets:
+    - name: tigera-pull-secret
+  <b>registry: myregistry.com</b>
+</pre>

--- a/maintenance/image-options/digest/imageset.md
+++ b/maintenance/image-options/digest/imageset.md
@@ -1,6 +1,7 @@
 ---
 title: Deploy images by digest
 description: Specify the digests the operator will use to deploy images.
+canonical_url: '/maintenance/image-options/digest/imageset'
 ---
 
 {% assign operator = site.data.versions.first.tigera-operator %}

--- a/maintenance/image-options/digest/index.md
+++ b/maintenance/image-options/digest/index.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy image options
 description: Tasks for configuring different image deployment options.
-canonical_url: '/maintenance/image-options/index'
+canonical_url: '/maintenance/image-options/digest/index'
 ---
 
 {{ page.description }}

--- a/maintenance/image-options/private-registry/index.md
+++ b/maintenance/image-options/private-registry/index.md
@@ -1,0 +1,10 @@
+---
+title: Install from a private registry
+description: Install Calico Enterprise using a private registry.
+canonical_url: '/maintenance/image-options/private-registry/index'
+---
+
+{{ page.description }}
+
+{% capture content %}{% include index.html %}{% endcapture %}
+{{ content | replace: "    ", "" }}

--- a/maintenance/image-options/private-registry/private-registry-archive.md
+++ b/maintenance/image-options/private-registry/private-registry-archive.md
@@ -1,0 +1,20 @@
+---
+title: Install from a private registry
+description: Install and configure Calico Enterprise in a private registry. 
+layout: null
+---
+
+[//]: #  This is used in manifests archive, though it doesn't appear on the website
+
+{% assign operator = site.data.versions.first.tigera-operator %}
+
+### Before you begin...
+
+- Configure pull access to your private registry
+- [Configure pull access to Tigera's private container registry]({{ "/getting-started/calico-enterprise#get-private-registry-credentials-and-license-key" | absolute_url }} ).
+
+
+{% include content/private-registry-regular.md %}
+
+>**Note:** See [the Installation resource reference page]( {{ "/reference/installation/api" | absolute_url }} ) for more information on the `imagePullSecrets` and `registry` fields.
+

--- a/maintenance/image-options/private-registry/private-registry-image-path.md
+++ b/maintenance/image-options/private-registry/private-registry-image-path.md
@@ -1,0 +1,38 @@
+---
+title: Install from an image path in a private registry
+description: Install and configure Calico Enterprise using an image path in a private registry.
+canonical_url: '/maintenance/image-options/private-registry/private-registry-image-path'
+---
+
+{% assign operator = site.data.versions.first.tigera-operator %}
+
+### Big picture
+
+Move {{site.prodname}} container images to an image path in a private registry and configure {{site.prodname}} to pull images from it.
+
+### Value
+
+Install {{site.prodname}} in clusters where pulling from third-party private repos is not an option, and all images are desired to be part of a single directory in the private registry.
+
+### Concepts
+
+A **container image registry** (often referred to as a **registry**) is a service where container images are pushed to, stored, and pulled from. A registry is said to be "private" if it requires users authenticate before accessing images.
+
+An **image path** is a directory in the private registry that contains images required to install {{site.prodname}}.
+
+An **image pull secret** is used in Kubernetes to deploy container images from a private container image registry.
+
+### Before you begin...
+
+- Configure pull access to your private registry
+
+### How to
+
+- [Push {{ site.prodname }} images to your private registry](#push-{{site.prodname | slugify }}-images-to-your-private-registry-image-path)
+- [Run the operator using images from your private registry](#run-the-operator-using-images-from-your-private-registry-image-path)
+- [Configure the operator to use images from your private registry](#configure-the-operator-to-use-images-from-your-private-registry-image-path)
+
+{% include content/private-registry-image-path.md %}
+
+>**Note:** See [the Installation resource reference page]({{site.baseurl}}/reference/installation/api) for more information on the `imagePullSecrets`, `registry` and `imagePath` fields.
+{: .alert .alert-info }

--- a/maintenance/image-options/private-registry/private-registry-regular.md
+++ b/maintenance/image-options/private-registry/private-registry-regular.md
@@ -1,0 +1,39 @@
+---
+title: Install from a private registry
+description: Install and configure Calico Enterprise in a private registry. 
+canonical_url: '/maintenance/image-options/private-registry/private-registry-regular'
+---
+
+{% assign operator = site.data.versions.first.tigera-operator %}
+
+### Big picture
+
+Move {{site.prodname}} container images to a private registry and configure {{site.prodname}} to pull images from it.
+
+### Value
+
+Install {{site.prodname}} in clusters where pulling from third-party private repos is not an option, such as airgapped clusters, or clusters with bandwidth constraints or security constraints.
+
+### Concepts
+
+A **container image registry** (often referred to as a **registry**) is a service where container images are pushed to, stored, and pulled from. A registry is said to be "private" if it requires users authenticate before accessing images.
+
+An **image pull secret** is used in Kubernetes to deploy container images from a private container image registry.
+
+### Before you begin...
+
+- Configure pull access to your private registry
+
+### How to
+
+- [Push {{site.prodname}} images to your private registry](#push-{{ site.prodname | slugify }}-images-to-your-private-registry)
+- [Run the operator using images from your private registry](#run-the-operator-using-images-from-your-private-registry)
+- [Configure the operator to use images from your private registry](#configure-the-operator-to-use-images-from-your-private-registry)
+
+{% include content/private-registry-regular.md %}
+
+>**Note:** See [Install from an image path in a private registry]({{site.baseurl}}/maintenance/image-options/private-registry/private-registry-image-path#big-picture) page for more information on installing using a private registry image path.
+{: .alert .alert-info }
+
+>**Note:** See [the Installation resource reference page]({{site.baseurl}}/reference/installation/api) for more information on the `imagePullSecrets` and `registry` fields.
+{: .alert .alert-info }


### PR DESCRIPTION
## Add private registry docs

https://tigera.atlassian.net/jira/software/projects/DOCS/boards/69?selectedIssue=DOCS-165

- Deploy from private registry is now supported for OS via operator
- Remove OpenShift note (approved by Karthik)
- Requires QA/Dev review of images shown in docs
- Merge to /nightly
- EE version docs are here: https://docs.tigera.io/master/getting-started/private-registry/. I took out reference to "get a license"