### PR TITLE
Helm: add ability to specify imagePullSecrets

### DIFF
--- a/_includes/charts/calico/templates/calico-kube-controllers.yaml
+++ b/_includes/charts/calico/templates/calico-kube-controllers.yaml
@@ -31,6 +31,10 @@ spec:
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
 {{- if eq .Values.datastore "etcd" }}
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.

--- a/_includes/charts/calico/templates/calico-node.yaml
+++ b/_includes/charts/calico/templates/calico-node.yaml
@@ -42,6 +42,10 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
       initContainers:
 {{- if and (eq .Values.network "calico") (eq .Values.datastore "kubernetes") }}
         # This container performs upgrade from host-local IPAM to calico-ipam.

--- a/_includes/charts/calico/templates/calico-typha.yaml
+++ b/_includes/charts/calico/templates/calico-typha.yaml
@@ -59,6 +59,10 @@ spec:
       # as a host-networked pod.
       serviceAccountName: calico-node
       priorityClassName: system-cluster-critical
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
       # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
       securityContext:
         fsGroup: 65534

--- a/_includes/charts/calico/templates/configure-canal.yaml
+++ b/_includes/charts/calico/templates/configure-canal.yaml
@@ -17,6 +17,10 @@ spec:
         kubernetes.io/os: linux
       hostNetwork: true
       restartPolicy: OnFailure
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
       containers:
         # Writes basic flannel configuration to etcd.
         - name: configure-flannel


### PR DESCRIPTION
## Description

When deploying `calico` Helm chart using private secure registry for Images we need to set `imagePullSecrets` option for deployment in order to make it work properly. Documentation for reference: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

This PR is intended to add ability to pass `imagePullSecrets` via Helm `values.yaml`.
If `imagePullSecrets` are not set (default) this setting will not be rendered;

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
