### PR TITLE
api-server page improvements

### DIFF
--- a/getting-started/kubernetes/apiserver-preview.md
+++ b/getting-started/kubernetes/apiserver-preview.md
@@ -51,6 +51,9 @@ calicoctl is still required for the following subcommands:
 
 1. Generate a private key and CA bundle using the following openssl command. This certificate will be used by the main API server to authenticate with the Calico API server.
 
+   **Note**: Please note in the following command `-addext` argument requires openssl 1.1.1 or above. You can check your version of openssl using `openssl version`.
+   {:.alert .alert-info}
+
    ```
    openssl req -x509 -nodes -newkey rsa:4096 -keyout apiserver.key -out apiserver.crt -days 365 -subj "/" -addext "subjectAltName = DNS:calico-api.calico-apiserver.svc"
    ```
@@ -117,7 +120,7 @@ You should see output that looks like this:
 To uninstall, delete the API server manifest.
 
    ```
-   kubectl delete -f {{site.baseurl}}/manifests/apiserver.yaml
+   kubectl delete -f {{ "/manifests/apiserver.yaml" | absolute_url }}
    ```
 
 Once removed, you will need to use calicoctl to manage projectcalico.org/v3 APIs.


### PR DESCRIPTION
Fix: Changed url in the clean up section to an absolute.
Update: Old versions of openssl doesn't support `-addext` argument which can cause problems.