### PR TITLE
VPP: Update docs to account for the namespace change

### DIFF
--- a/getting-started/kubernetes/vpp/getting-started.md
+++ b/getting-started/kubernetes/vpp/getting-started.md
@@ -141,7 +141,7 @@ curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-data
 curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/generated/calico-vpp-nohuge.yaml
 ```
 
-Then configure these parameters in the `calico-config` ConfigMap in the yaml manifest.
+Then configure these parameters in the `calico-vpp-config` ConfigMap in the yaml manifest.
 
 **Required**
 
@@ -154,7 +154,6 @@ If this command doesn't return anything, you can leave the default value of `10.
 
 **Optional**
 
-* `default_ipv4_pool_cidr` allows you to customize the default {{ site.prodname }} IPv4 pool. For details, see [reference]({{ site.baseurl }}/reference/node/configuration)
 * `vpp_uplink_driver` configures how VPP grabs the physical interface, available values are:
   * `""` : will automatically select and try drivers based on available resources, starting with the fastest
   * `avf` : use the native AVF driver
@@ -170,14 +169,15 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: calico-config
-  namespace: kube-system
+  namespace: calico-vpp-dataplane
 data:
   service_prefix: 10.96.0.0/12
   vpp_dataplane_interface: eth1
-  default_ipv4_pool_cidr: 172.16.0.0/16
   vpp_uplink_driver: ""
   ...
 ````
+
+**Note** {{ site.prodname }} uses `192.168.0.0/16` as the IP range for the pods by default. If this IP range is used somewhere else in your environment, you should further [customize the manifest]({{ site.baseurl }}/getting-started/kubernetes/installation/config-options) to change it.
 
 #### Apply the configuration
 

--- a/getting-started/kubernetes/vpp/ipsec.md
+++ b/getting-started/kubernetes/vpp/ipsec.md
@@ -1,6 +1,6 @@
 ---
-title: IPsec configuration
-description: Enable IPsec for faster encryption between nodes when using the VPP data plane.
+title: IPsec configuration with VPP
+description: Enable IPsec for faster encryption between nodes when using the VPP dataplane.
 canonical_url: '/getting-started/kubernetes/vpp/ipsec'
 ---
 
@@ -27,7 +27,7 @@ In order to enable IPsec encryption, you will need a Kubernetes cluster with:
 
 Create a Kubernetes secret that contains the PSK used for the IKEv2 exchange between the nodes. You can use the following command to create a random PSK. It will generate a unique random key. You may also replace the part after `psk=` with a key of your choice.
 ```bash
-kubectl -n kube-system create secret generic calicovpp-ipsec-secret \
+kubectl -n calico-vpp-dataplane create secret generic calicovpp-ipsec-secret \
    --from-literal=psk="$(dd if=/dev/urandom bs=1 count=36 2>/dev/null | base64)"
 ```
 
@@ -35,7 +35,7 @@ kubectl -n kube-system create secret generic calicovpp-ipsec-secret \
 
 To enable IPsec, you need to configure two environment variables on the `calico-vpp-node` pod. You can do so with the following kubectl command:
 ````bash
-kubectl -n kube-system patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/patches/ipsec.yaml)"
+kubectl -n calico-vpp-dataplane patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/patches/ipsec.yaml)"
 ````
 
 Once IPsec is enabled, all the traffic that uses IP-in-IP encapsulation in the cluster will be automatically encrypted.

--- a/maintenance/troubleshoot/vpp.md
+++ b/maintenance/troubleshoot/vpp.md
@@ -27,8 +27,8 @@ docker cp ${vppcontainer}:/usr/bin/calivppctl /usr/bin/calivppctl
 ````
 * With kubectl (and a cluster with calico-vpp runnning)
 ````bash
-vpppod=$(kubectl -n kube-system get pods -o wide | grep calico-vpp-node- | awk '{ print $1 }' | head -1)
-kubectl -n kube-system exec -it ${vpppod} -c vpp -- cat /usr/bin/calivppctl | tee /usr/bin/calivppctl > /dev/null
+vpppod=$(kubectl -n calico-vpp-dataplane get pods -o wide | grep calico-vpp-node- | awk '{ print $1 }' | head -1)
+kubectl -n calico-vpp-dataplane exec -it ${vpppod} -c vpp -- cat /usr/bin/calivppctl | tee /usr/bin/calivppctl > /dev/null
 chmod +x /usr/bin/calivppctl
 ````
 
@@ -49,7 +49,7 @@ Once the cluster is correctly started, the next issue can come from the Daemonse
 Best is to start by inspecting the pods : are they running correctly ?
 Usually configuration issues (available hugepages, memory, ...) will be reported here
 ````bash
-kubectl -n kube-system describe pod/calico-vpp-node-XXXXX
+kubectl -n calico-vpp-dataplane describe pod/calico-vpp-node-XXXXX
 ````
 
  >**Note** If at this point you don't have enough hugepages, you'll have to restart kubelet

--- a/reference/vpp/uplink-configuration.md
+++ b/reference/vpp/uplink-configuration.md
@@ -27,7 +27,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: calico-vpp-node
-  namespace: kube-system
+  namespace: calico-vpp-dataplane
 spec:
   template:
     spec:
@@ -65,7 +65,7 @@ You can use this driver if your primary interface is virtio [`realpath /sys/bus/
 
 ## Using the native AVF driver
 
-You can use this driver if your primary interface is supported by AVF [`realpath /sys/bus/pci/devices/<PCI_ID>/driver` gives `... i40e`]
+You can use this driver if your primary interface is supported by AVF [`realpath /sys/bus/pci/devices/<PCI_ID>/driver` gives `.../i40e`]
 
 * Ensure `vfio-pci` is loaded (`sudo modprobe vfio-pci`)
 
@@ -82,13 +82,13 @@ You can use this driver if your primary interface is supported by AVF [`realpath
 * Also ensure that your vpp config has no `dpdk` stanza and its plugin disabled
 * Optionally `CALICOVPP_RX_QUEUES` controls the number of queues used, `CALICOVPP_RING_SIZE` their size
 * `CALICOVPP_RX_MODE` controls whether we busy-poll the interface (`polling`), only use interrupts to wake us up (`interrupt`) or switch between both depending on the load (`adaptive`)
-* Finally `FELIX_XDPENABLED` should be set to `false` otherwise felix will periodically cleanup the VPP configuration
+* Finally `FELIX_XDPENABLED` should be set to `false` on the `calico-node` container otherwise felix will periodically cleanup the VPP configuration
 ````yaml
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: calico-vpp-node
-  namespace: kube-system
+  namespace: calico-vpp-dataplane
 spec:
   template:
     spec:
@@ -103,6 +103,16 @@ spec:
               value: "1"
             - name: CALICOVPP_RX_MODE
               value: "polling"
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
         - name: calico-node
           env:
             - name: FELIX_XDPENABLED
@@ -230,7 +240,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: calico-vpp-node
-  namespace: kube-system
+  namespace: calico-vpp-dataplane
 spec:
   template:
     spec:


### PR DESCRIPTION
## Description
This PR updates the VPP docs to account for the last changes requested during the review process for #4383, namely:
- Remove the default_ipv4pool_cidr configuration option from the ConfigMap
- Move all the VPP specific settings to a new `calico-vpp-config` ConfigMap
- Move all the VPP resources to a new `calico-vpp-dataplane` namespace.