### PR TITLE
vpp: use latest release manifests

### DIFF
--- a/getting-started/kubernetes/vpp/getting-started.md
+++ b/getting-started/kubernetes/vpp/getting-started.md
@@ -84,11 +84,11 @@ Before you get started, make sure you have downloaded and configured the {% incl
 
    Standard install:
    ```bash
-   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/generated/calico-vpp-eks.yaml
+   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v0.14.0-calicov3.19.0/yaml/generated/calico-vpp-eks.yaml
    ```
    Install using the optional DPDK driver for better networking performance:
    ```bash
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/generated/calico-vpp-eks-dpdk.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v0.14.0-calicov3.19.0/yaml/generated/calico-vpp-eks-dpdk.yaml
 ```
 
 1. Finally, add nodes to the cluster.
@@ -134,11 +134,11 @@ For some hardware, the following hugepages configuration may enable VPP to use m
 Start by getting the appropriate yaml manifest for the {{ site.prodname }} VPP dataplane:
 ```bash
 # If you have configured hugepages on your machines
-curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/generated/calico-vpp.yaml
+curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v0.14.0-calicov3.19.0/yaml/generated/calico-vpp.yaml
 ```
 ```bash
 # If not, or if you're unsure
-curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/generated/calico-vpp-nohuge.yaml
+curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v0.14.0-calicov3.19.0/yaml/generated/calico-vpp-nohuge.yaml
 ```
 
 Then configure these parameters in the `calico-vpp-config` ConfigMap in the yaml manifest.

--- a/getting-started/kubernetes/vpp/ipsec.md
+++ b/getting-started/kubernetes/vpp/ipsec.md
@@ -18,6 +18,8 @@ In order to enable IPsec encryption, you will need a Kubernetes cluster with:
 - the [VPP dataplane]({{ site.baseurl }}/getting-started/kubernetes/vpp/getting-started) configured
 - [IP-in-IP encapsulation]({{ site.baseurl }}/networking/vxlan-ipip) configured between the nodes
 
+Also ensure that all the pods in your cluster are running and all containers are ready using `kubectl get pods -o wide -A` before attempting to enable IPsec.
+
 ### How to
 
 - [Create the IKEv2 PSK](#create-the-ikev2-psk)
@@ -35,7 +37,7 @@ kubectl -n calico-vpp-dataplane create secret generic calicovpp-ipsec-secret \
 
 To enable IPsec, you need to configure two environment variables on the `calico-vpp-node` pod. You can do so with the following kubectl command:
 ````bash
-kubectl -n calico-vpp-dataplane patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/patches/ipsec.yaml)"
+kubectl -n calico-vpp-dataplane patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v0.14.0-calicov3.19.0/yaml/patches/ipsec.yaml)"
 ````
 
 Once IPsec is enabled, all the traffic that uses IP-in-IP encapsulation in the cluster will be automatically encrypted.

--- a/maintenance/troubleshoot/vpp.md
+++ b/maintenance/troubleshoot/vpp.md
@@ -16,7 +16,7 @@ If you're encountering issues with the VPP dataplane, feel free to reach out to 
 
 * With curl
 ````bash
-curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/test/scripts/vppdev.sh \
+curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v0.14.0-calicov3.19.0/test/scripts/vppdev.sh \
   | tee /usr/bin/calivppctl
 chmod +x /usr/bin/calivppctl
 ````


### PR DESCRIPTION
This updates the manifests to use the vpp dataplane release v0.14.0, and adds a small caveat for the IPsec instructions as suggested by @lwr20 .
