### PR TITLE
NetworkManager shouldn't manage wireguard interface

### DIFF
--- a/maintenance/troubleshoot/troubleshooting.md
+++ b/maintenance/troubleshoot/troubleshooting.md
@@ -117,7 +117,7 @@ NetworkManager from interfering with the interfaces:
 
 ```conf
 [keyfile]
-unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico
+unmanaged-devices=interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:wireguard.cali
 ```
 
 ### Errors when running sudo calicoctl


### PR DESCRIPTION
## Description

Since Calico interfaces shouldn't be managed by NetworkManager wireguard should be added to the dropin file as well.

This is partially to get clarification myself.
Let me know if this is not the case for the wireguard interface and why that is.

## Related issues/PRs

--

## Todos

--

## Release Note

```release-note
None required
```