### PR TITLE
rbac.authorization.k8s.io/v1beta -> v1

### DIFF
--- a/getting-started/kubernetes/hardway/end-user-rbac.md
+++ b/getting-started/kubernetes/hardway/end-user-rbac.md
@@ -17,7 +17,7 @@ Create the role
 ```bash
 kubectl apply -f - <<EOF
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: network-admin
 rules:
@@ -161,7 +161,7 @@ Define the role
 ```bash
 kubectl apply -f - <<EOF
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: network-service-owner
 rules:

--- a/maintenance/monitor/monitor-component-metrics.md
+++ b/maintenance/monitor/monitor-component-metrics.md
@@ -185,7 +185,7 @@ You need to provide Prometheus a serviceAccount with required permissions to col
 
 ```bash
 kubectl apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: calico-prometheus-user
@@ -205,7 +205,7 @@ metadata:
   name: calico-prometheus-user
   namespace: calico-monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-prometheus-user


### PR DESCRIPTION
## Description

According to this warning:

Warning: rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole

looks like v1.22 removes the v1beta1 support fo roles etc.

I've left the manifests in the v2.5 upgrade docs unchanged since this is referring to k8s 1.7



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
