### PR TITLE
Document ENABLE_BFD env variable

### DIFF
--- a/reference/node/configuration.md
+++ b/reference/node/configuration.md
@@ -40,6 +40,7 @@ exist in the cluster. The following options control the paramaters on the create
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. [Default: `false`] | boolean |
 | CALICO_IPV6POOL_NODE_SELECTOR | Controls the NodeSelector for the IPv6 Pool created at start up. [Default: `all()`] | [selector]({{site.baseurl}}/reference/resources/ippool#node-selector) |
 | NO_DEFAULT_POOLS | Prevents  {{site.prodname}} from creating a default pool if one does not exist. [Default: `false`] | boolean |
+| ENABLE_BFD | Sets up BFD (Bidirectional Forwarding Detection) on the BGP protocols. Improves failure detection times. [Default: `false`] | boolean |
 
 ### Configuring BGP Networking
 


### PR DESCRIPTION
## Description

In https://github.com/projectcalico/confd/pull/515 a new environmental
variable is being introduced, named ENABLE_BFD. Add documentation for
that variable in this repo. This should only be merged if the above change is merged as is

## Related issues/PRs

fixes #4607 

## Todos

- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
Support added for BFD (Bidirectional Forwarding Detection) in calico/node. Gated by the ENABLE_BFD environmental variable
```
