### PR TITLE
Update OpenShift operator RBAC for certification

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -178,13 +178,16 @@ rules:
       - update
       - delete
       - watch
-  # For host network access.
+  # The following rule is only for operator certification purposes.
+  # The operator normally runs in a namespace with openshift.io/run-level=0 which bypasses SCC.
+  # However in certification tests, the operator is run in a normal namespace so this
+  # rule is needed for host networking and hostPath volume access.
   - apiGroups:
       - security.openshift.io
     resources:
       - securitycontextconstraints
     resourceNames:
-      - hostnetwork
+      - hostaccess
     verbs:
       - use
   # Need these permissions for the calicoctl init container.


### PR DESCRIPTION
## Description

The SCC rule in the operator's cluster role is only for operator certification purposes.
The operator normally runs in a namespace with openshift.io/run-level=0 so SCC is bypassed.
However, in certification tests the operator is run in a normal namespace so this
rule is needed for host networking and hostPath volume access. Host path volume access is needed for Calico v3.18+

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
