### PR TITLE
Add post-release check to test operator images are correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -573,6 +573,7 @@ release-test-image:
 .PHONY: release-test
 release-test: release-test-image
 	docker run --rm \
+	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v $(PWD):/docs \
 	-e RELEASE_STREAM=$(RELEASE_STREAM) \
 	$(DOCS_TEST_CONTAINER) sh -c \

--- a/release-scripts/tests/test_images.py
+++ b/release-scripts/tests/test_images.py
@@ -15,6 +15,23 @@ EXCLUDED_IMAGES = ["calico/pilot-webhook", "calico/upgrade", "quay.io/coreos/fla
 GCR_IMAGES = ["calico/node", "calico/cni", "calico/typha"]
 EXPECTED_ARCHS = ["amd64", "arm64", "ppc64le"]
 
+VERSIONS_WITHOUT_IMAGE_LIST = [
+    "v1.13",
+    "v1.12",
+    "v1.11",
+    "v1.10",
+    "v1.9",
+    "v1.8",
+    "v1.7",
+    "v1.6",
+    "v1.5",
+    "v1.4",
+    "v1.3",
+    "v1.2",
+    "v1.1",
+    "v1.0",
+]
+
 VERSIONS_WITHOUT_FLANNEL_MIGRATION = [
     "v3.8",
     "v3.7",
@@ -127,3 +144,41 @@ def test_docker_release_tag_present():
                     found_archs.append(platform["platform"]["architecture"])
 
                 assert EXPECTED_ARCHS.sort() == found_archs.sort()
+
+
+def test_operator_images():
+    with open("%s/_data/versions.yml" % DOCS_PATH) as versionsFile:
+        versions = yaml.safe_load(versionsFile)
+        for version in versions:
+            if version["title"] == RELEASE_VERSION:
+                # Found matching version. Perform the test.
+                operator = version["tigera-operator"]
+                img = "%s/%s:%s" % (
+                    operator["registry"],
+                    operator["image"],
+                    operator["version"],
+                )
+                break
+    if operator["version"] not in VERSIONS_WITHOUT_IMAGE_LIST:
+        print("[INFO] getting image list from %s" % img)
+        cmd = 'docker pull %s' % img
+        req = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        output = req.stdout.read()
+        print("[INFO] Pulling operator image:\n%s" % output)
+
+        cmd = 'docker run --rm -t %s -print-images list' % img
+        req = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        output = req.stdout.read()
+        image_list = output.splitlines()
+        print("[INFO] got image list:\n%s" % image_list)
+
+        with open("%s/_config.yml" % DOCS_PATH) as config:
+            images = yaml.safe_load(config)
+            for image in images["imageNames"]:
+                image_name = images["imageNames"][image]
+                if image_name not in EXCLUDED_IMAGES:
+                    this_image = "%s:%s" % (image_name, RELEASE_VERSION)
+                    print("[INFO] checking %s is in the operator image list" % this_image )
+                    assert this_image in image_list, "%s not found in operator image list" % this_image
+    else:
+        print("[INFO] This version of operator does not have an image list")


### PR DESCRIPTION
## Description

This test downloads the tigera-operator image, runs it with flags to get it to print out the list of images it installs, then compares that list against the images listed in the docs for this release.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
