### PR TITLE
Fix Protect Kubernetes nodes tutorial

### DIFF
--- a/security/kubernetes-nodes.md
+++ b/security/kubernetes-nodes.md
@@ -156,7 +156,7 @@ spec:
   - action: Allow
     destination:
       nets:
-      - 127.0.0.1/32
+      - 127.0.0.0/8
   # This rule is required in multi-master clusters where etcd pods are colocated with the masters.
   # Allow the etcd pods on the masters to communicate with each other. 2380 is the etcd peer port.
   # This rule also allows the masters to access the kubelet API on other masters (including itself).
@@ -198,7 +198,7 @@ spec:
   - action: Allow
     destination:
       nets:
-      - 127.0.0.1/32
+      - 127.0.0.0/8
   # Allow only the masters access to the nodes kubelet API.
   - action: Allow
     protocol: TCP

--- a/security/tutorials/protect-hosts.md
+++ b/security/tutorials/protect-hosts.md
@@ -35,6 +35,10 @@ policy, because:
    Our policy therefore needs to take effect _before_ that DNAT - and that
    means that it must be a pre-DNAT policy.
 
+> Note: This tutorial is intended to be used with named host endpoints, i.e. host endpoints with `interfaceName` set to a specific interface name.
+> This tutorial does not work, as-is, with host endpoints with `interfaceName: "*"`.
+{: .alert .alert-info }
+
 Here is the pre-DNAT policy that we need to disallow incoming external traffic
 in general:
 


### PR DESCRIPTION
## Description

The "Protect Kubernetes nodes" tutorial directs the user to apply policy that won't work if their k8s nodes are running systemd-resolved which proxies DNS through 127.0.0.53
This PR fixes those network policy rules.

This PR also adds a note that the Protect Hosts tutorial does not apply directly to auto host endpoints.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
