### PR TITLE
Depending on the method you choose, calico-node might be in kube-syst…

### DIFF
--- a/getting-started/kubernetes/minikube.md
+++ b/getting-started/kubernetes/minikube.md
@@ -90,14 +90,14 @@ kubectl apply -f {{ "/manifests/calico.yaml" | absolute_url }}
 You can verify {{site.prodname}} installation in your cluster by issuing the following command.
 
 ```bash
-watch kubectl get pods -l k8s-app=calico-node -n kube-system
+watch kubectl get pods -l k8s-app=calico-node -A
 ```
 
-You should see a result similar to
+You should see a result similar to the below. Note that the namespace might be different, depending on the method you followed.
 
 ```
-NAME                READY   STATUS    RESTARTS   AGE
-calico-node-85s5b   1/1     Running   0          3m31s
+NAMESPACE     NAME                READY   STATUS    RESTARTS   AGE
+kube-system   calico-node-mlqvs   1/1     Running   0          5m18s
 ```
 
 Use `ctrl+c` to break out of watch.


### PR DESCRIPTION
Depending on the method you choose, calico-node might be in kube-system or calico-system.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Documentation.
Fixes minikube getting started instructions.
Depending on the method you choose, calico-node might be in kube-system or calico-system.
Fixed the watch command to show the node either way.
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
