### PR TITLE
Docs-update-noncluster-hosts

### DIFF
--- a/_includes/content/environment-file.md
+++ b/_includes/content/environment-file.md
@@ -19,8 +19,28 @@ Use the following guidelines and sample file to define the environment variables
  [Felix configuration reference]({{site.baseurl}}/reference/felix/configuration).
 {% endif %}
 
+{% tabs %}
+  <label: Kubernetes datastore,active:true>
+  <%
 
-For an etcdv3 datastore set the following
+For a Kubernetes datastore (default) set the following:
+
+| Variable | Configuration guidance |
+|----------|------------------------|
+| {{datastore_type}} | Set to `kubernetes` |
+| KUBECONFIG | Path to kubeconfig file to access the Kubernetes API Server |
+
+{% if include.install == "container" %}
+> **Note**: You will need to volume mount the kubeconfig file into the container at the location specified by the paths mentioned above.
+{: .alert .alert-info}
+{% endif %}
+
+
+%>
+  <label: etcd datastore>
+  <%
+
+For an etcdv3 datastore set the following:
 
 | Variable | Configuration guidance |
 |----------|------------------------|
@@ -30,22 +50,15 @@ For an etcdv3 datastore set the following
 | {{etcd_cert_file}}<br>{{etcd_key_file}} | Paths to certificate and keys used for client authentication to the etcd cluster, if enabled.   |
 
 {% if include.install == "container" %}
-> **Note**: If using certificates and keys, you will need to volume mount them in the container and the path values above are *inside* the container.
+> **Note**: If using certificates and keys, you will need to volume mount them into the container at the location specified by the paths mentioned above.
 {: .alert .alert-info}
 {% endif %}
 
-For a Kubernetes datastore set the following
-
-| Variable | Configuration guidance |
-|----------|------------------------|
-| {{datastore_type}} | Set to `kubernetes` |
-| KUBECONFIG | Path to kubeconfig file to access the Kubernetes API Server |
-
-{% if include.install == "container" %}
-> **Note**: You will need to volume mount the kubeconfig file in the container and the path value above is *inside* the container.
-{: .alert .alert-info}
-
-For either datastore set the following
+%>
+  <label: Either datastore>
+  <%
+  
+For either datastore set the following:
 
 | Variable | Configuration guidance |
 |----------|------------------------|
@@ -54,7 +67,7 @@ For either datastore set the following
 | CALICO_AS | If not specified, {{site.prodname}} uses the currently configured value for the AS Number for the node BGP client—this can be configured through the Node resource. If the Node resource value is not set, Calico inherits the AS Number from the global default value. If you set a value through this environment variable, it reconfigures any value currently set through the Node resource. |
 | NO_DEFAULT_POOLS | Set to true to prevent {{site.prodname}} from creating a default pool if one does not exist. Pools are used for workload endpoints and not required for non-cluster hosts. |
 | CALICO_NETWORKING_BACKEND | The networking backend to use. In `bird` mode, Calico will provide BGP networking using the BIRD BGP daemon; VXLAN networking can also be used. In `vxlan` mode, only VXLAN networking is provided; BIRD and BGP are disabled. If you want to run Calico for policy only, set to `none`. |
-{% endif %}
+
 
 Sample `EnvironmentFile` - save to `/etc/calico/calico.env`
 
@@ -73,3 +86,6 @@ CALICO_AS=""
 CALICO_NETWORKING_BACKEND=bird
 {%- endif %}
 ```
+%>
+
+  {% endtabs %}

--- a/getting-started/bare-metal/about.md
+++ b/getting-started/bare-metal/about.md
@@ -1,56 +1,55 @@
 ---
 title: About non-cluster hosts
-description: Secure hosts not in a cluster by installing Calico with networking and/or networking policy enabled.
+description: Install Calico on hosts not in a cluster with network policy, or networking and network policy.
 canonical_url: '/getting-started/bare-metal/about'
 ---
 
 ### Big picture
 
-Secure hosts not in a cluster by installing {{site.prodname}} with networking and/or networking policy enabled.
+Secure non-cluster hosts by installing {{site.prodname}} for networking and/or networking policy.
 
 ### Value
 
-Not all hosts in your environment run virtualized workloads (i.e. containers managed by Kubernetes or OpenShift, or VMs managed by OpenStack). There may be physical machines or legacy applications that you cannot move into an orchestrated cluster that need to communicate securely with workloads in your cluster. Whether you have a thousand machines or ten, {{site.prodname}} lets you enforce policy on them using the same robust {{site.prodname}} network policy that is used for workloads. 
-
+Not all hosts in your environment run pods/workloads. You may have physical machines or legacy applications that you cannot move into a Kubernetes cluster, but still need to securely communicate with pods in your cluster. {{site.prodname}} lets you enforce policy on these **non-cluster hosts** using the same robust {{site.prodname}} network policy that you use for pods.
 
 ### Concepts
 
-#### Workloads and Hosts
+#### Non-cluster hosts and host endpoints
 
-We use the term workload to mean a pod or VM running as a guest on a computer with {{site.prodname}} installed. If your cluster is a Kubernetes or OpenShift cluster, workloads are pods, if your cluster is an OpenStack cluster, workloads are VMs. 
+A **non-cluster host** is a computer that is running an application that is *not part of a Kubernetes cluster*. Using {{site.prodname}} network policy, you can secure these host interfaces using **host endpoints**. Host endpoints can have labels, and work the same as labels on pods/workload endpoints. 
 
-We use the term host to mean a computer where {{site.prodname}} is installed. These include computers that are part of a cluster and “host” workloads, as well as computers that are not part of the cluster and run applications directly, which we call "non-cluster" hosts.  {{site.prodname}} does not handle the networking from host to host ({{site.prodname}} assumes this is set up), but it can be used to handle networking between hosts and workloads.  {{site.prodname}} can also provide network policy for hosts, regardless of whether or not the hosts run any workloads.  This guide focuses on non-cluster hosts.
+The advantage is, you can write network policy rules to apply to both workload endpoints and host endpoints using label selectors; where each selector can refer to the either type (or be a mix of the two). For example, you can write a cluster-wide policy for non-cluster hosts that is immediately applied to every host. To learn how to restrict traffic to/from hosts using {{site.prodname}} network policy see, [Protect hosts]({{site.baseurl}}/security/protect-hosts). 
 
-#### {{site.prodname}} networking on non-cluster hosts
+If you are using the etcd3 database, you can also install {{site.prodname}} with networking as described below.
 
-When {{site.prodname}} networking is enabled, {{site.prodname}} provides the virtual networking for the workloads in your cluster, allowing them to communicate with one another. It is also responsible for setting up networking so that hosts can communicate with workloads and vice versa.  {{site.prodname}} does not handle networking for host to host communications.
+#### Install options for non-cluster hosts
 
-When {{site.prodname}} networking is enabled...
+| Install {{site.prodname}} with... | Requires                         | Use case                                                     | Supported install methods                      |
+| --------------------------------- | -------------------------------- | ------------------------------------------------------------ | ---------------------------------------------- |
+| Policy only                       | An etcd3 or Kubernetes datastore | Use {{site.prodname}} network policy to control firewalls on non-cluster hosts. | Binary install with/ without a package manager |
+| Networking and network policy     | An etcd3 datastore               | **Networking**<br />Use {{site.prodname}} networking (BGP, or overlay with VXLAN or IP-in-IP) to handle these communications:<br />- pod ↔ pod<br />- pod ↔ host<br /><br />**Note**: {{site.prodname}} does not handle host ↔ host networking; your underlying network must already be set up to handle this. <br /><br />**Policy**<br />Use {{site.prodname}} network policy to control firewalls on your non-cluster hosts. | Docker container                               |
 
-| Communication type   | Handled by         |
-|----------------------|--------------------|
-| Workload ↔ Workload  | {{site.prodname}}  |
-| Workload ↔ Host      | {{site.prodname}}  |
-| Host ↔ Host          | Underlying network |
+### Before you begin
 
-This means that if you are using {{site.prodname}} networking in your cluster, and you want the non-cluster hosts to be able to communicate with workloads in the cluster, you will need to install {{site.prodname}} for networking on your non-cluster hosts.  If you are not using {{site.prodname}} for networking in your cluster (e.g. are using {{site.prodname}} in policy-only mode), or don't need your non-cluster hosts to communicate directly with workloads, you can install {{site.prodname}} in policy-only mode on your non-cluster hosts.
+**Supported**
 
-#### {{site.prodname}} policy on non-cluster hosts
+- All platforms in this release, except Windows  
 
-{{site.prodname}} policy allows you to control firewalls on your non-cluster hosts using the same controls powerful controls as in your cluster.  {{site.prodname}} must be running on each non-cluster host you want to control.
+**Required**
 
-Using {{site.prodname}}, you can secure network interfaces of the host; these interfaces are called **host endpoints** (to distinguish them from **workload endpoints**). Host endpoints can have labels, which work the same as labels on workload endpoints. This allows you to create {{site.prodname}} network policy for either host or workload endpoints, where each selector can refer to the either type (or be a mix of the two) using labels.
+- Non-cluster host meets [system requirements](./requirements) for {{site.prodname}}. If you want to use a package manager for installation, the non-cluster host must be a system derived from Ubuntu or RedHat.
+- Set up a datastore; if {{site.prodname}} is installed on a cluster, you already have a datastore
+- Install `kubectl` or [`calicoctl`]({{site.baseurl}}/getting-started/clis/calicoctl/). (`kubectl` works only with the Kubernetes datastore.)
 
+### Next steps
 
-### Before you begin...
+Select an install method.
 
-1. Check that your hosts meet the [system requirements](./requirements) for {{site.prodname}}
-1. Set up a datastore (if you have installed {{site.prodname}} on a cluster you will already have this)
-1. [Install and configure calicoctl]({{site.baseurl}}/getting-started/clis/calicoctl/)
-1. Choose an install method and whether to use {{site.prodname}} for networking & policy, or policy-only
+>**Note**: {{site.prodname}} must be installed on each non-cluster host that you want to control with networking and/or policy. 
+ {: .alert .alert-info}
 
-| Install method                                                       | Networking | Policy |
-|----------------------------------------------------------------------|------------|--------|
-| [Docker container](./installation/container)                         | ✓          | ✓      |
-| [Binary install with package manager](./installation/binary-mgr)     |            | ✓      |
-| [Binary install without package manager](./installation/binary)      |            | ✓      |
+| Install method                                               | Networking | Policy |
+| ------------------------------------------------------------ | ---------- | ------ |
+| [Docker container](./installation/container)                 | ✓          | ✓      |
+| [Binary install with package manager](./installation/binary-mgr) |            | ✓      |
+| [Binary install without package manager](./installation/binary) |            | ✓      |

--- a/getting-started/bare-metal/installation/binary-mgr.md
+++ b/getting-started/bare-metal/installation/binary-mgr.md
@@ -16,7 +16,7 @@ Packaged binaries of {{site.prodname}} are easy to consume and upgrade. This met
 1. Ensure the host meets the minimum [system requirements](../requirements)
 1. If your system is not an Ubuntu- or RedHat-derived system, you will need to choose a different install method.
 1. If you want to install {{site.prodname}} with networking (so that you can communicate with cluster workloads), you should choose the [container install method](./container)
-1. [Install and configure `calicoctl`]({{site.baseurl}}/getting-started/clis/calicoctl/)
+1. Install `kubectl` (for Kubernetes datastore) or [Install and configure `calicoctl`]({{site.baseurl}}/getting-started/clis/calicoctl/) for etcd3 datastore.
 
 ### How to
 

--- a/getting-started/bare-metal/installation/binary.md
+++ b/getting-started/bare-metal/installation/binary.md
@@ -15,7 +15,7 @@ Install {{site.prodname}} directly when a package manager isn't available, or yo
 1. Ensure the {{site.prodname}} datastore is up and accessible from the host
 1. Ensure the host meets the minimum [system requirements](../requirements)
 1. If you want to install {{site.prodname}} with networking (so that you can communicate with cluster workloads), you should choose the [container install method](./container)
-1. [Install and configure `calicoctl`]({{site.baseurl}}/getting-started/clis/calicoctl/)
+1. Install `kubectl` (for Kubernetes datastore) or [Install and configure `calicoctl`]({{site.baseurl}}/getting-started/clis/calicoctl/) for etcd3 datastore.
 
 ### How to
 


### PR DESCRIPTION
## Update non-cluster host docs 

- Waiting on confirmation from Sujeet on non-cluster hosts and Windows
- Address confusing terminology in "Concepts" 
- Add value statement and clearly show options
- Promote Kubernetes datastore as default
- Merge to /nightly OS (I will update EE version in separate PR to remove etcd3)
- @casey - Do we want to provide env file for container.md file for Kubernetes datastore? If yes, please add. Right now, example shows etcd3.