### PR TITLE
Fix ConfigMap namespace

### DIFF
--- a/maintenance/ebpf/ebpf-and-eks.md
+++ b/maintenance/ebpf/ebpf-and-eks.md
@@ -233,7 +233,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: kubernetes-services-endpoint
-  namespace: calico-system
+  namespace: tigera-operator
 data:
   KUBERNETES_SERVICE_HOST: "<API server host>"
   KUBERNETES_SERVICE_PORT: "443"


### PR DESCRIPTION
This is a mistake in the EKS page. The main page shows the correct namespace https://docs.projectcalico.org/maintenance/ebpf/enabling-bpf#configure-calico-to-talk-directly-to-the-api-server