### PR TITLE
Simplify BPF install. Create kubernetes-services-endpoint ConfigMap i…

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/01-configmap-cluster-endpoint.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/01-configmap-cluster-endpoint.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.apiHost -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubernetes-services-endpoint
+  namespace: tigera-operator
+data:
+  KUBERNETES_SERVICE_HOST: {{.Values.apiHost}}
+  KUBERNETES_SERVICE_PORT: "443"
+{{- end -}}

--- a/_plugins/values.rb
+++ b/_plugins/values.rb
@@ -3,6 +3,9 @@ def gen_values(versions, imageNames, imageRegistry, chart)
     versionsYml = <<~EOF
     imagePullSecrets: {}
 
+    # Manually specify Kubernetes API endpoint IP or hostname. Needed when running in BPF mode.
+    apiHost: ""
+
     installation:
       enabled: true
       kubernetesProvider: ""


### PR DESCRIPTION
The [install instructions for BPF mode](https://docs.projectcalico.org/maintenance/ebpf/ebpf-and-eks#configure-calico-to-connect-directly-to-the-api-server) require the creation of a ConfigMap. This should be done by Helm, not by hand.

This PR doesn't update the doc. That's a bit over my head.

P.S. Why is a configmap created just to specify the api endpoint? Can't this be specified inside Installation?