### PR TITLE
fix markdown

### DIFF
--- a/reference/felix/configuration.md
+++ b/reference/felix/configuration.md
@@ -86,7 +86,7 @@ The full list of parameters which can be set is as follows.
 | `TyphaK8sServiceName`             | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha Kubernetes service | string |
 | `Ipv6Support`                     | `FELIX_IPV6SUPPORT`                     | Enable {{site.prodname}} networking and security for IPv6 traffic as well as for IPv4. | boolean |
 | `RouteSource`                     | `FELIX_ROUTESOURCE`                     | Where Felix gets is routing information from for VXLAN and the BPF dataplane. The CalicoIPAM setting is more efficient because it supports route aggregation, but it only works when Calico's IPAM or host-local IPAM is in use. Use the WorkloadIPs setting if you are using Calico's VXLAN or BPF dataplane and not using Calico IPAM or host-local IPAM. [Default: "CalicoIPAM"] | 'CalicoIPAM', or 'WorkloadIPs' |
-| `mtuIfacePattern`                 | `FELIX_MTUIFACEPATTERN`                 | Pattern used to discover the host's interface for MTU auto-detection. [Default: "^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)" | regex |
+| `mtuIfacePattern`                 | `FELIX_MTUIFACEPATTERN`                 | Pattern used to discover the host's interface for MTU auto-detection. [Default: `^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)` | regex |
 
 #### etcd datastore configuration
 


### PR DESCRIPTION
## Description
default value for FELIX_MTUIFACEPATTERN is not correctly rendered due to format error 
applying "code" format to default value as a work-around
## Related issues/PRs
## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note


```release-note
None required
```
