### PR TITLE
[cherry-pick] public helm chart repo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -63,6 +63,13 @@
   jekyll build --config _config.yml,$(pwd)/netlify/_config_noindex.yml --baseurl /master --destination _site/master
   '''
 
+# proxy redirect for Helm chart repo
+[[redirects]]
+   from = "/charts/*"
+   to = "https://calico-public.s3.amazonaws.com/charts/:splat"
+   status = 200
+   headers = {X-From = "Netlify"}
+
 # proxy redirects for website and manifests for v3.19
 [[redirects]]
   from = "/archive/v3.19/*"


### PR DESCRIPTION
Updates now that bucket is available

this should enable testing repo v3.20 release

## Related issues/PRs

- #4514 
- #4629 

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
