### PR TITLE
openshift: use release-vX.Y channel for OLM integration

### DIFF
--- a/getting-started/openshift/installation.md
+++ b/getting-started/openshift/installation.md
@@ -126,6 +126,8 @@ EOF
 ```
 
 Next, you will create a Subscription to the operator. By subscribing to the operator package, the {{site.prodname}} operator will be managed by OLM.
+{% assign operator_version = site.data.versions.first.tigera-operator.version %}
+{% assign operator_version_parts = operator_version | split: "." %}
 
 ```bash
 oc apply -f - <<EOF
@@ -135,12 +137,12 @@ metadata:
   name: tigera-operator
   namespace: tigera-operator
 spec:
-  channel: stable
+  channel: release-{{operator_version_parts[0]}}.{{operator_version_parts[1]}}
   installPlanApproval: Manual
   name: tigera-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: tigera-operator.{{site.data.versions.first.tigera-operator.version}}
+  startingCSV: tigera-operator.{{operator_version}}
 EOF
 ```
 


### PR DESCRIPTION
## Description

Update the OLM integration instructions to use the right channel for the subscription.

Here is what these changes look like on release-v3.19:
![image](https://user-images.githubusercontent.com/170076/126012242-b36d3148-fdfc-464b-b773-cc3273768ddc.png)


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
