### PR TITLE
update iptables-remover-ds with new apiVersion to support 1.16+ clusters

### DIFF
--- a/hack/remove-calico-policy/iptables-remover-ds.yaml
+++ b/hack/remove-calico-policy/iptables-remover-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: calico-remove-iptables
@@ -6,6 +6,9 @@ metadata:
   labels:
     k8s-app: calico-remove-iptables
 spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-remove-iptables
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Description
`extensions/v1beta1` being deprecated on `Daemonsets` were removed in [1.16+ clusters](https://github.com/kubernetes/kubernetes/blob/d92b788faa2521a937acc5fdcb66bfdb960dbd48/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals). With upstream versions as new as 1.22, pre-1.16 versions are relatively old. In the quest to remove the orphaned iptables state left over by calico, I  got this error while installing the current iptables-remover daemonset on a 1.19 k8s cluster:
```bash
$kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/iptables-remover-ds.yaml
error: unable to recognize "https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/iptables-remover-ds.yaml": no matches for kind "DaemonSet" in version "extensions/v1beta1"

```
This PR fixes the above error as suggested in https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

> DaemonSet in the extensions/v1beta1 and apps/v1beta2 API versions is no longer served
Migrate to use the apps/v1 API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.
Notable changes:
spec.templateGeneration is removed
spec.selector is now required and immutable after creation; use the existing template labels as the selector for seamless upgrades
spec.updateStrategy.type now defaults to RollingUpdate (the default in extensions/v1beta1 was OnDelete)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
