### PR TITLE
add docs for wireguard basic prometheus stats and its config flag

### DIFF
--- a/reference/felix/configuration.md
+++ b/reference/felix/configuration.md
@@ -64,6 +64,7 @@ The full list of parameters which can be set is as follows.
 | `PrometheusMetricsHost`           | `FELIX_PROMETHEUSMETRICSHOST`           | TCP network address that the Prometheus metrics server should bind to. [Default: `""`] | string |
 | `PrometheusMetricsPort`           | `FELIX_PROMETHEUSMETRICSPORT`           | TCP port that the Prometheus metrics server should bind to. [Default: `9091`] | int |
 | `PrometheusProcessMetricsEnabled` | `FELIX_PROMETHEUSPROCESSMETRICSENABLED` | Set to `false` to disable process metrics collection, which the Prometheus client does by default. This reduces the number of metrics reported, reducing Prometheus load. [Default: `true`] | boolean |
+| `PrometheusWireguardMetricsEnabled` | `FELIX_PROMETHEUSWIREGUARDMETRICSENABLED` | Set to `false` to disable wireguard device metrics collection, which Felix does by default. [Default: `true`] | boolean |
 | `RemoveExternalRoutes`            | `FELIX_REMOVEEXTERNALROUTES`            | Whether or not to remove device routes that have not been programmed by Felix. Disabling this will allow external applications to also add device routes. [Default: `true`] | bool |
 | `ReportingIntervalSecs`           | `FELIX_REPORTINGINTERVALSECS`           | Interval at which Felix reports its status into the datastore or `0` to disable. Must be non-zero in OpenStack deployments. [Default: `30`] | int |
 | `ReportingTTLSecs`                | `FELIX_REPORTINGTTLSECS`                | Time-to-live setting for process-wide status reports. [Default: `90`] | int |

--- a/reference/felix/prometheus.md
+++ b/reference/felix/prometheus.md
@@ -114,3 +114,16 @@ include:
 | `process_resident_memory_bytes` | Resident memory size in bytes. |
 | `process_start_time_seconds` | Start time of the process since unix epoch in seconds. |
 | `process_virtual_memory_bytes` | Virtual memory size in bytes. |
+
+
+#### Wireguard Metrics
+
+Felix also exports wireguard device stats if found/detected. Can be disabled via Felix configuration.
+
+
+| Name          | Description     |
+| ------------- | --------------- |
+| `wireguard_meta` | Gauge. Device / interface information for a felix/calico node, values are in this metric's labels |
+| `wireguard_bytes_rcvd` | Counter. Current bytes received from a peer identified by a peer public key and endpoint |
+| `wireguard_bytes_sent` | Counter. Current bytes sent to a peer identified by a peer public key and endpoint |
+| `wireguard_latest_handshake_seconds` | Gauge. Last handshake with a peer, unix timestamp in seconds. |


### PR DESCRIPTION
## Description

Documentation for basic prometheus stats and configuration flag for it

Preview / screenshot snippets of additions:

1. reference/felix/configuration
![image](https://user-images.githubusercontent.com/794828/127331232-564d331b-33a9-4edc-97c6-c1b905a79577.png)

1. reference/felix/prometheus
![image](https://user-images.githubusercontent.com/794828/127331457-6576ac2a-23cd-4aa0-b46f-ff43823888f3.png)


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```