### PR TITLE
Automated cherry pick of #4790: Add `allow-version-mismatch` to calicoctl because

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -74,6 +74,7 @@ spec:
           command:
             - calicoctl
           args:
+            - --allow-version-mismatch
             - create
             - --skip-exists
             - --skip-empty


### PR DESCRIPTION
Cherry pick of #4790 on release-v3.20.

#4790: Add `allow-version-mismatch` to calicoctl because