### PR TITLE
Adds instructions for configuring FELIX_ROUTETABLERANGE

### DIFF
--- a/_includes/content/install-awscni-routetable-issue.md
+++ b/_includes/content/install-awscni-routetable-issue.md
@@ -1,0 +1,16 @@
+> As discussed [here](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html){:target="_blank"}, AWS CNI provisions multiple ENIs per node as the number of pods on the node increases.
+> AWS CNI will add entries for the primary ENI into the main routing table, and will then create routing tables for each additional ENI, starting at index 2.
+> By default, Felix considers routing table indexes from 1-250 to be under its control, and hence will remove the routing tables created by AWS CNI. This can cause loss of connectivity between pods if they are not on the primary ENI.
+>
+> **Note**: The following steps will result in loss of connectivity between some pods. It is recommended to only make such changes during a maintenance window.
+> To ensure that AWS CNI and Felix manage separate ranges of routing tables, you must do the following:
+>
+> 1. Configure Felix to manage a routing table range which is distinct from the range used by AWS CNI:
+>     ```bash
+>     kubectl patch felixconfiguration default --type='merge' -p '{"spec": {"routeTableRange":{"min": 31, "max": 250}}}'
+>     ````
+>
+> 1. Delete any routing rules and tables in the range 1-30 as they could be damaged or incomplete
+>
+> 1. Kill all the aws-node pods, which will force AWS CNI to recreate its routing rules and tables. 
+{: .alert .alert-info}

--- a/getting-started/kubernetes/managed-public-cloud/eks.md
+++ b/getting-started/kubernetes/managed-public-cloud/eks.md
@@ -22,6 +22,8 @@ The geeky details of what you get:
 
 To enable {{site.prodname}} network policy enforcement on an EKS cluster using the AWS VPC CNI plugin, follow these step-by-step instructions: {% include open-new-window.html text='Installing Calico on Amazon EKS' url='https://docs.aws.amazon.com/eks/latest/userguide/calico.html' %}
 
+{% include /content/install-awscni-routetable-issue.md %}
+
 #### Install EKS with {{site.prodname}} networking
 
 The geeky details of what you get:

--- a/getting-started/kubernetes/self-managed-public-cloud/aws.md
+++ b/getting-started/kubernetes/self-managed-public-cloud/aws.md
@@ -76,6 +76,8 @@ Then install {{site.prodname}} for network policy only after the cluster is up a
 The geeky details of what you get:
 {% include geek-details.html details='Policy:Calico,IPAM:AWS,CNI:AWS,Overlay:No,Routing:VPC Native,Datastore:Kubernetes' %}
 
+{% include /content/install-awscni-routetable-issue.md %}
+
 ##### Kubespray
 
 {% include open-new-window.html text='Kubespray' url='https://kubespray.io/' %} is a tool for provisioning and managing Kubernetes clusters with support for multiple clouds including Amazon Web Services. {{site.prodname}} is the default networking provider, or you can set the `kube_network_plugin` variable to `calico`. See the {% include open-new-window.html text='Kubespray docs' url='https://kubespray.io/#/?id=network-plugins' %} for more details.


### PR DESCRIPTION
## Description

This is an update to the docs for Installing Calico Enterprise with AWS CNI, to rectify the problem where AWS CNI and Felix fight over routing tables.

## Related issues/PRs

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

May require a release note, still TBD.
