### PR TITLE
Add deb and rpm checks

### DIFF
--- a/release-scripts/tests/test_openstack_artifacts.py
+++ b/release-scripts/tests/test_openstack_artifacts.py
@@ -9,7 +9,7 @@ DOCS_PATH = os.environ.get("CALICO_DOCS_PATH") or "/docs"
 RELEASE_STREAM = os.environ.get("RELEASE_STREAM")
 PPA_VER = RELEASE_STREAM.replace("v", "calico-")
 UBUNTU_VERSIONS = ["bionic", "focal", "trusty", "xenial"]
-components =["felix"]
+components = ["felix"]
 PPA_IMAGE_URL_TEMPL = (
     # e.g. http://ppa.launchpad.net/project-calico/calico-3.19/ubuntu/pool/main/f/felix/calico-felix_3.19.2-focal_amd64.deb
     "http://ppa.launchpad.net/project-calico/{ppa_ver}/ubuntu/pool/main/f/felix/calico-{component}_{component_version}-{ubuntu_version}_amd64.deb"
@@ -27,7 +27,9 @@ for component in components:
         RPM_URL_TEMPL.format(
             ppa_ver=PPA_VER,
             component=component,
-            component_version=versions[0]["components"]["calico/node"]["version"].replace("v", ""),
+            component_version=versions[0]["components"]["calico/node"][
+                "version"
+            ].replace("v", ""),
         )
     )
     for UBUNTU_VERSION in UBUNTU_VERSIONS:
@@ -35,16 +37,20 @@ for component in components:
             PPA_IMAGE_URL_TEMPL.format(
                 ppa_ver=PPA_VER,
                 component=component,
-                component_version=versions[0]["components"]["calico/node"]["version"].replace("v", ""),
-                ubuntu_version = UBUNTU_VERSION,
+                component_version=versions[0]["components"]["calico/node"][
+                    "version"
+                ].replace("v", ""),
+                ubuntu_version=UBUNTU_VERSION,
             )
         )
+
 
 @parameterized(unrolled_urls)
 def test_artifact_url(url):
     resp = requests.get(url, stream=True)
     print("[INFO] %s: %s" % (resp.status_code, url))
     assert resp.status_code == 200
+
 
 with open("%s/_data/versions.yml" % DOCS_PATH) as f:
     versions = yaml.safe_load(f)

--- a/release-scripts/tests/test_openstack_artifacts.py
+++ b/release-scripts/tests/test_openstack_artifacts.py
@@ -3,10 +3,48 @@ import os
 import re
 import requests
 import yaml
+from parameterized import parameterized
 
 DOCS_PATH = os.environ.get("CALICO_DOCS_PATH") or "/docs"
 RELEASE_STREAM = os.environ.get("RELEASE_STREAM")
 PPA_VER = RELEASE_STREAM.replace("v", "calico-")
+UBUNTU_VERSIONS = ["bionic", "focal", "trusty", "xenial"]
+components =["felix"]
+PPA_IMAGE_URL_TEMPL = (
+    # e.g. http://ppa.launchpad.net/project-calico/calico-3.19/ubuntu/pool/main/f/felix/calico-felix_3.19.2-focal_amd64.deb
+    "http://ppa.launchpad.net/project-calico/{ppa_ver}/ubuntu/pool/main/f/felix/calico-{component}_{component_version}-{ubuntu_version}_amd64.deb"
+)
+RPM_URL_TEMPL = (
+    # e.g. http://binaries.projectcalico.org/rpm/calico-3.19/x86_64/calico-felix-3.19.2-1.el7.x86_64.rpm"
+    "http://binaries.projectcalico.org/rpm/{ppa_ver}/x86_64/calico-{component}-{component_version}-1.el7.x86_64.rpm"
+)
+
+unrolled_urls = []
+with open("%s/_data/versions.yml" % DOCS_PATH) as f:
+    versions = yaml.safe_load(f)
+for component in components:
+    unrolled_urls.append(
+        RPM_URL_TEMPL.format(
+            ppa_ver=PPA_VER,
+            component=component,
+            component_version=versions[0]["components"]["calico/node"]["version"].replace("v", ""),
+        )
+    )
+    for UBUNTU_VERSION in UBUNTU_VERSIONS:
+        unrolled_urls.append(
+            PPA_IMAGE_URL_TEMPL.format(
+                ppa_ver=PPA_VER,
+                component=component,
+                component_version=versions[0]["components"]["calico/node"]["version"].replace("v", ""),
+                ubuntu_version = UBUNTU_VERSION,
+            )
+        )
+
+@parameterized(unrolled_urls)
+def test_artifact_url(url):
+    resp = requests.get(url, stream=True)
+    print("[INFO] %s: %s" % (resp.status_code, url))
+    assert resp.status_code == 200
 
 with open("%s/_data/versions.yml" % DOCS_PATH) as f:
     versions = yaml.safe_load(f)


### PR DESCRIPTION
## Description
With the release of v3.19.2, the release process went wrong and the rpms and debs weren't pushed to launchpad and binaries.projectcalico.org

The post-release checks didn't spot this, so this PR adds some more that should.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Backport to v3.19
- [ ] Backport to v3.20

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
