### PR TITLE
Update operator-migration.md

### DIFF
--- a/maintenance/operator-migration.md
+++ b/maintenance/operator-migration.md
@@ -34,7 +34,7 @@ There are a few key differences to be aware of, if you are familiar with manifes
 
 #### Operator migration
 
-For new clusters, you can simply follow the steps in the [quickstart guide]({{site.prodname}}/getting-started/kubernetes/quickstart) to get started with the operator.
+For new clusters, you can simply follow the steps in the [quickstart guide]({{site.baseurl}}/getting-started/kubernetes/quickstart) to get started with the operator.
 
 For existing clusters using the `calico.yaml` manifest to install {{site.prodname}}, upon installing the operator, it will detect the existing {{site.prodname}} resources on the cluster
 and calculate how to take ownership of them. The operator will maintain existing customizations, if supported, and warn about any unsupported configurations that it detects.


### PR DESCRIPTION
## Description
In https://docs.projectcalico.org/maintenance/operator-migration#operator-migration

there is a link to the operator-quickstart which is wrong and links to https://docs.projectcalico.org/maintenance/Calico/getting-started/kubernetes/quickstart

This PR fixes the link. 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
