### PR TITLE
Allow version mismatch for OCP operator manifest

### DIFF
--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -74,6 +74,7 @@ spec:
           command:
             - calicoctl
           args:
+            - --allow-version-mismatch
             - create
             - --skip-exists
             - --skip-empty


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

On upgrade, there will always be a version mismatch. The assertion behavior is really meant for local binary installations of calicoctl. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```