### PR TITLE
docs: change namespace name to check pods

### DIFF
--- a/getting-started/kubernetes/quickstart.md
+++ b/getting-started/kubernetes/quickstart.md
@@ -91,7 +91,7 @@ The geeky details of what you get:
 1. Confirm that all of the pods are running with the following command.
 
    ```
-   watch kubectl get pods -n calico-system
+   watch kubectl get pods -n tigera-operator
    ```
 
    Wait until each pod has the `STATUS` of `Running`.


### PR DESCRIPTION
## Description

When we try to check pods creation with this command: 
```
watch kubectl get pods -n calico-system
```

We receive an error such as: `No resources found in default namespace.`.
This happen because the `Namespace` name is now changed in `tigera-operator` (check [https://docs.projectcalico.org/manifests/tigera-operator.yaml](https://docs.projectcalico.org/manifests/tigera-operator.yaml) for more details).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
