### PR TITLE
Add FelixConfiguration permissions to tigera-operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ bin
 vendor
 pinned_versions.yml
 pinned_images.yml
-charts
+# Ignore the charts directory created by the Makefile where temporary files are placed
+/charts
 
 # This prevents us from checking in a supplementary values.yaml file
 _includes/charts/*/values.yaml

--- a/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/_includes/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -99,7 +99,11 @@ rules:
     resources:
     - felixconfigurations
     verbs:
+    - create
     - patch
+    - list
+    - get
+    - watch
   - apiGroups:
     - crd.projectcalico.org
     resources:


### PR DESCRIPTION
Cherry-picking aws-cni operator fix for 3.20 

Adjust ignore so helm chart files are not ignored.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
