### PR TITLE
Docs-seo-networking-ebpf

### DIFF
--- a/_data/navbars/about.yml
+++ b/_data/navbars/about.yml
@@ -8,7 +8,7 @@ section:
 - title: Networking
   path: /about/about-networking
 - title: Kubernetes Networking
-  path: /about/about-kubernetes-networking
+  path: /about/about-k8s-networking
 - title: Network Policy
   path: /about/about-network-policy
 - title: Kubernetes Services

--- a/about/about-ebpf.md
+++ b/about/about-ebpf.md
@@ -1,7 +1,7 @@
 ---
 title: About eBPF
 description: Learn about eBPF!
-canonical_url: '/about/about-ebpf'
+canonical_url: 'https://www.tigera.io/learn/guides/ebpf/'
 ---
 
 > <span class="glyphicon glyphicon-info-sign"></span> This guide provides optional background education, including

--- a/about/about-k8s-networking.md
+++ b/about/about-k8s-networking.md
@@ -1,6 +1,7 @@
 ---
 title: About Kubernetes Networking
 description: Learn about Kubernetes networking!
+canonical_url: 'https://www.tigera.io/learn/guides/kubernetes-networking/'
 ---
 
 > <span class="glyphicon glyphicon-info-sign"></span> This guide provides optional background education, not specific to {{site.prodname}}.

--- a/about/about-network-policy.md
+++ b/about/about-network-policy.md
@@ -28,7 +28,7 @@ device constructs were virtualized in the cloud, and the same techniques for cre
 additional network design to update the network topology and network device configuration to provide the desired
 security.
 
-In contrast, the [Kubernetes network model]({{site.baseurl}}/about/about-kubernetes-networking) defines a "flat"
+In contrast, the [Kubernetes network model]({{site.baseurl}}/about/about-k8s-networking) defines a "flat"
 network in which every pod can communicate with all other pods in the cluster using pod IP addresses. This approach
 massively simplifies network design and allows new workloads to be scheduled dynamically anywhere in the cluster with no
 dependencies on the network design.


### PR DESCRIPTION
## Updates for SEO

- Added canonical URLs for "Kubernetes Networking" and "About eBPF"
- Rename Kubernetes Networking .md to break connection with old version of doc
- Merge to nightly and cherrypick to 3.20

