### PR TITLE
Make 'release-notes' a phony target so it actually runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,7 @@ helm-index: release-prereqs
 	rm -rf charts
 
 ## Generates release notes for the given version.
+.PHONY: release-notes
 release-notes: #release-prereqs
 	VERSION=$(CALICO_VER) GITHUB_TOKEN=$(GITHUB_TOKEN) python2 ./release-scripts/generate-release-notes.py
 


### PR DESCRIPTION
## Description

This target was probably created before the 'release-notes' folder existed in the root of the repo. Maybe renaming the target would be better but it's nice that release-related targets look like `make release-*`

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
