### PR TITLE
Fix deprecated env ( #579 )

### DIFF
--- a/reference/architecture/overview.md
+++ b/reference/architecture/overview.md
@@ -49,7 +49,7 @@ Depending on the specific orchestrator environment, Felix is responsible for:
 
     Provides network health data. In particular, it reports errors and problems when configuring its host. This data is written to the datastore so it visible to other components and operators of the network.
 
-> **Note**: `{{site.nodecontainer}}` can be run in *policy only mode* where Felix runs without BIRD and confd. This provides policy management without route distribution between hosts, and is used for deployments like managed cloud providers. You enable this mode by setting the environment variable, `CALICO_NETWORKING=false` before starting the node.
+> **Note**: `{{site.nodecontainer}}` can be run in *policy only mode* where Felix runs without BIRD and confd. This provides policy management without route distribution between hosts, and is used for deployments like managed cloud providers. You enable this mode by setting the environment variable, `CALICO_NETWORKING_BACKEND=none` before starting the node.
 {: .alert .alert-info}
 
 ### BIRD


### PR DESCRIPTION
## Description

Fix deprecated env's CALICO_NETWORKING to CALICO_NETWORKING_BACKEND

## Related issues/PRs

projectcalico/calico#579

## Todos

- [x] Tests ( `make serve` )
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
