### PR TITLE
Update Calico the Hard Way guide

### DIFF
--- a/getting-started/kubernetes/hardway/install-cni-plugin.md
+++ b/getting-started/kubernetes/hardway/install-cni-plugin.md
@@ -32,7 +32,7 @@ sudo openssl x509 -req -in cni.csr \
                   -CAcreateserial \
                   -out cni.crt \
                   -days 365
-sudo chown ubuntu:ubuntu cni.crt
+sudo chown $(id -u):$(id -g) cni.crt
 ```
 
 Next, we create a kubeconfig file for the CNI plugin to use to access Kubernetes.

--- a/getting-started/kubernetes/hardway/istio-integration.md
+++ b/getting-started/kubernetes/hardway/istio-integration.md
@@ -19,7 +19,7 @@ On each node in the cluster, execute the following commands to install the FlexV
 sudo mkdir -p /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
 sudo docker run --rm \
   -v /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds:/host/driver \
-  calico/pod2daemon-flexvol:v3.8.0
+  calico/pod2daemon-flexvol:v3.20.0
 ```
 
 Verify the `uds` binary is present
@@ -31,60 +31,17 @@ ls -lh /usr/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds
 Result
 
 ```
-total 5.0M
--r-xr-x--- 1 root root 5.0M Jul 25 22:31 uds
+total 5.2M
+-r-xr-x--- 1 root root 5.2M Jul 25 22:31 uds
 ```
 {: .no-select-button}
 
-## Enable policy sync API
+## Install Istio
 
-Application layer policy requires the policy sync API to be enabled on Felix. To do this cluster-wide, modify the `default`
-FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`.  The following example uses `sed` to modify your
-existing default config before re-applying it.
+[Follow the instructions here]({{site.baseurl}}/security/app-layer-policy) to enable application layer policy, install Istio, update the
+Istio sidecar injector and add Calico authorization services to the Istio mesh.
 
-```bash
-calicoctl get felixconfiguration default --export -o yaml | \
-sed -e '/  policySyncPathPrefix:/d' \
-    -e '$ a\  policySyncPathPrefix: /var/run/nodeagent' > felix-config.yaml
-calicoctl apply -f felix-config.yaml
-```
-
-## Installing Istio
-
-Install Istio 1.1.7, including mutually authenticated TLS for service to service communication.
-
-```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.1.7 sh -
-cd $(ls -d istio-*)
-kubectl apply -f install/kubernetes/helm/istio-init/files/
-kubectl apply -f install/kubernetes/istio-demo-auth.yaml
-```
-
-> **Note**: If an "unable to recognize" error occurs after applying `install/kubernetes/istio-demo-auth.yaml` it is likely a race
-> condition between creating an Istio CRD and then a resource of that type. Re-run the `kubectl apply`.
-{: .alert .alert-info}
-
-## Updating the Istio sidecar injector
-
-The sidecar injector automatically modifies pods as they are created to work
-with Istio. This step modifies the injector configuration to add Dikastes, a
-{{site.prodname}} component, as sidecar containers.
-
-Apply the following ConfigMap to enable injection of Dikastes alongside Envoy.
-
-   ```bash
-   kubectl apply -f {{site.url}}/v3.8/manifests/alp/istio-inject-configmap-1.1.7.yaml
-   ```
-
-## Adding {{site.prodname}} authorization services to the mesh
-
-Apply the following manifest to configure Istio to query {{site.prodname}} for application layer policy authorization decisions
-
-```bash
-kubectl apply -f {{site.url}}/v3.8/manifests/alp/istio-app-layer-policy.yaml
-```
-
-## Adding namespace labels
+## Add Istio namespace label to the default namespace
 
 Application layer policy is only enforced on pods that are started with the
 Envoy and Dikastes sidecars.  Pods that do not have these sidecars will
@@ -95,7 +52,9 @@ layer policy in a namespace, add the label `istio-injection=enabled`.
 
 Label the default namespace, which you will use for the tutorial.
 
-	kubectl label namespace default istio-injection=enabled
+```bash
+kubectl label namespace default istio-injection=enabled
+```
 
 
 ## Test application layer policy

--- a/getting-started/kubernetes/hardway/standing-up-kubernetes.md
+++ b/getting-started/kubernetes/hardway/standing-up-kubernetes.md
@@ -9,7 +9,7 @@ We will install {{site.prodname}} on a Kubernetes cluster. To demonstrate a high
 ## Provision EC2 Nodes
 
 1. Provision five nodes
-    1. Ubuntu 18.04 LTS
+    1. Ubuntu 20.04 LTS - Focal
     1. T2.medium
     1. Ensure the instances are in the same subnet, and security group policy allows them communicate freely with one another.
     1. Disable Source / Destination Checks on the Elastic Network Interface for each instance

--- a/getting-started/kubernetes/hardway/the-calico-datastore.md
+++ b/getting-started/kubernetes/hardway/the-calico-datastore.md
@@ -56,7 +56,7 @@ To interact directly with the {{site.prodname}} datastore, use the `calicoctl` c
 1. Download the `calicoctl` binary to a Linux host with access to Kubernetes.
 
    ```bash
-   wget https://github.com/projectcalico/calicoctl/releases/download/v3.14.0/calicoctl
+   wget https://github.com/projectcalico/calicoctl/releases/download/v3.20.0/calicoctl
    chmod +x calicoctl
    sudo mv calicoctl /usr/local/bin/
    ```

--- a/security/tutorials/app-layer-policy/enforce-policy-istio.md
+++ b/security/tutorials/app-layer-policy/enforce-policy-istio.md
@@ -146,7 +146,7 @@ information.
 Imagine what would happen if an attacker were to gain control of the customer web pod in our
 application. Let's simulate this by executing a remote shell inside that pod.
 
-    kubectl exec -ti customer-<fill in pod ID> -c customer bash
+    kubectl exec -ti customer-<fill in pod ID> -c customer -- bash
 
 Notice that from here, we get direct access to the backend database.  For example, we can list all the entries in the database like this:
 


### PR DESCRIPTION
## Description

Update Calico the Hard Way to latest versions: Ubuntu 20.04 LTS, k8s 1.22, Calico 3.20, Istio 1.10.2. Tested on a 5 node cluster on AWS like the guide instructs. Everything works, but the istio tutorial that is linked after the very last step of the last part, more on this below.

Not all steps of https://docs.projectcalico.org/security/tutorials/app-layer-policy/enforce-policy-istio work, but that says it's for Istio 1.4.2 (which does not work on k8s 1.22), so that tutorial probably needs to be updated.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
