### PR TITLE
Use IMDSv2 to fetch instance metadata

### DIFF
--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -357,7 +357,8 @@ if ($platform -EQ "aks") {
 if ($platform -EQ "eks") {
     EnableWinDsrForEKS
 
-    $awsNodeName = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT –Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for EKS, node name $awsNodeName ..."
     $Backend = "none"
     $awsNodeNameQuote = """$awsNodeName"""
@@ -369,7 +370,8 @@ if ($platform -EQ "eks") {
     GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
 }
 if ($platform -EQ "ec2") {
-    $awsNodeName = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT –Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for AWS, node name $awsNodeName ..."
     $awsNodeNameQuote = """$awsNodeName"""
     SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"


### PR DESCRIPTION
## Description
Fetch instance metadata using Instance Metadata Service v2 - avoids install script errors when attempting to install Calico on Windows AWS instances that have IMDSv2 enforced.