### PR TITLE
Use IMDSv2 to fetch instance hostname

### DIFF
--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -357,7 +357,8 @@ if ($platform -EQ "aks") {
 if ($platform -EQ "eks") {
     EnableWinDsrForEKS
 
-    $awsNodeName = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT –Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for EKS, node name $awsNodeName ..."
     $Backend = "none"
     $awsNodeNameQuote = """$awsNodeName"""
@@ -369,7 +370,8 @@ if ($platform -EQ "eks") {
     GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
 }
 if ($platform -EQ "ec2") {
-    $awsNodeName = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT –Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for AWS, node name $awsNodeName ..."
     $awsNodeNameQuote = """$awsNodeName"""
     SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"


### PR DESCRIPTION
## Description
When attempting to install Calico for Windows on AWS instances that have no access to IMDSv1, a 401 Unauthorized error is logged when the script tries to fetch the hostname from the IMDSv1 endpoint.

This change means the installation script will now fetch instance metadata from the IMDSv2 endpoint.