### PR TITLE
Docs Typo in Install calicoctl

### DIFF
--- a/getting-started/clis/calicoctl/install.md
+++ b/getting-started/clis/calicoctl/install.md
@@ -134,7 +134,7 @@ you want to install the binary.
    {: .alert .alert-success}
 
 ```
-Invoke-WebRequest -Uri "https://github.com/projectcalico/calicoctl/releases/{{ version }}/calicoctl-windows-amd64.exe" -OutFile "calicocttl.exe" 
+Invoke-WebRequest -Uri "https://github.com/projectcalico/calicoctl/releases/{{ version }}/calicoctl-windows-amd64.exe" -OutFile "calicoctl.exe" 
 ```
 
 %>

--- a/maintenance/clis/calicoctl/install.md
+++ b/maintenance/clis/calicoctl/install.md
@@ -134,7 +134,7 @@ you want to install the binary.
    {: .alert .alert-success}
 
 ```
-Invoke-WebRequest -Uri "https://github.com/projectcalico/calicoctl/releases/{{ version }}/calicoctl-windows-amd64.exe" -OutFile "calicocttl.exe" 
+Invoke-WebRequest -Uri "https://github.com/projectcalico/calicoctl/releases/{{ version }}/calicoctl-windows-amd64.exe" -OutFile "calicoctl.exe" 
 ```
 
 %>


### PR DESCRIPTION
## Description

- Fixed a typo in [Install calicoctl](https://docs.projectcalico.org/getting-started/clis/calicoctl/install) on Install calicoctl as a binary on a single host -> Windows Tab -> PowerShell command. Changing `-OutFile "calicocttl.exe"` to `-OutFile "calicoctl.exe"`

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
