### PR TITLE
Add ControlPlaneReplicas in Installations CRD

### DIFF
--- a/_includes/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
+++ b/_includes/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
@@ -341,6 +341,13 @@ spec:
                   nodes on which to run Calico components. This is globally applied
                   to all resources created by the operator excluding daemonsets.
                 type: object
+              controlPlaneReplicas:
+                description: ControlPlaneReplicas defines how many replicas of the
+                  control plane core components will be deployed. This field applies
+                  to all control plane components that support High Availability.
+                  Defaults to 2.
+                format: int32
+                type: integer
               controlPlaneTolerations:
                 description: ControlPlaneTolerations specify tolerations which are
                   then globally applied to all resources created by the operator.
@@ -1036,6 +1043,13 @@ spec:
                       plane nodes on which to run Calico components. This is globally
                       applied to all resources created by the operator excluding daemonsets.
                     type: object
+                  controlPlaneReplicas:
+                    description: ControlPlaneReplicas defines how many replicas of
+                      the control plane core components will be deployed. This field
+                      applies to all control plane components that support High Availability.
+                      Defaults to 2.
+                    format: int32
+                    type: integer
                   controlPlaneTolerations:
                     description: ControlPlaneTolerations specify tolerations which
                       are then globally applied to all resources created by the operator.

--- a/reference/installation/_api.html
+++ b/reference/installation/_api.html
@@ -326,6 +326,19 @@ created by the operator.</p>
 </tr>
 <tr>
 <td>
+<code>controlPlaneReplicas</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed.
+This field applies to all control plane components that support High Availability. Defaults to 2.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>nodeMetricsPort</code><br>
 <em>
 int32
@@ -1261,6 +1274,19 @@ components. This is globally applied to all resources created by the operator ex
 <em>(Optional)</em>
 <p>ControlPlaneTolerations specify tolerations which are then globally applied to all resources
 created by the operator.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controlPlaneReplicas</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed.
+This field applies to all control plane components that support High Availability. Defaults to 2.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Description

This change adds ControlPlaneReplicas filed in the Installation CRD to
support Calico core components HA.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
