### PR TITLE
Update 'Apply policy to forwarded traffic' page and related reference pages

### DIFF
--- a/reference/resources/hostendpoint.md
+++ b/reference/resources/hostendpoint.md
@@ -21,16 +21,21 @@ will use to apply
 [policy]({{ site.baseurl }}/reference/resources/networkpolicy)
 to the interface.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
-
-**Default behavior of external traffic to/from host**
-
-If a host endpoint is created and network policy is not in place, the {{site.prodname}} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules).
-For a named host endpoint (i.e. a host endpoint representing a specific interface), {{site.prodname}} blocks traffic only to/from the interface specified in the host endpoint. Traffic to/from other interfaces is ignored.
+> **Important**: When rendering security rules on other hosts, {{site.prodname}} uses the
+> `expectedIPs` field to resolve label selectors to IP addresses. If the `expectedIPs` field
+> is omitted then security rules that use labels will fail to match this endpoint.
+{: .alert .alert-danger}
 
 > **Note**: Host endpoints with `interfaceName: *` do not support [untracked policy]({{ site.baseurl }}/security/high-connection-workloads).
 {: .alert .alert-info}
+
+For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
+aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
+
+### Default behavior of external traffic to/from host
+
+If a host endpoint is created and network policy is not in place, the {{site.prodname}} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules).
+For a named host endpoint (i.e. a host endpoint representing a specific interface), {{site.prodname}} blocks traffic only to/from the interface specified in the host endpoint. Traffic to/from other interfaces is ignored.
 
 For a wildcard host endpoint (i.e. a host endpoint representing all of a host's interfaces), {{site.prodname}} blocks traffic to/from _all_ interfaces on the host (except for traffic allowed by failsafe rules).
 
@@ -43,12 +48,7 @@ Note: If you have custom iptables rules, using host endpoints with allow-all rul
 > Auto host endpoints specify the `projectcalico-default-allow` profile so they behave similarly to pod workload endpoints.
 {: .alert .alert-info}
 
-> **Important**: When rendering security rules on other hosts, {{site.prodname}} uses the
-> `expectedIPs` field to resolve label selectors to IP addresses. If the `expectedIPs` field
-> is omitted then security rules that use labels will fail to match this endpoint.
-{: .alert .alert-danger}
-
-**Host to local workload traffic**
+### Host to local workload traffic
 
 Traffic from a host to its workload endpoints (e.g. Kubernetes pods) is always allowed, despite any policy in place. This ensures that `kubelet` liveness and readiness probes always work.
 

--- a/reference/resources/profile.md
+++ b/reference/resources/profile.md
@@ -9,7 +9,7 @@ policy rules, but that feature is deprecated in favor of the much more
 flexible [NetworkPolicy]({{ site.baseurl }}/reference/resources/networkpolicy) and
 [GlobalNetworkPolicy]({{ site.baseurl }}/reference/resources/globalnetworkpolicy) resources.
 
-Each {{site.prodname}} endpoint or host endpoint can be assigned to zero or more profiles.
+Each {{site.prodname}} endpoint or host endpoint can be assigned to zero or more profiles. {{site.prodname}} provides a default profile resource named `projectcalico-default-allow` that consists of allow-all ingress and egress rules. Adding that profile to host endpoints will change the default behaviour of traffic originating from or terminating at the host. See the [host endpoint reference]({{site.baseurl}}/reference/resources/hostendpoint#default-behavior-of-external-traffic-tofrom-host) for more information.
 
 For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
 aliases are supported (all case insensitive): `profile`, `profiles`, `pro`, `pros`.

--- a/security/host-forwarded-traffic.md
+++ b/security/host-forwarded-traffic.md
@@ -42,15 +42,20 @@ In contrast, if applyOnForward is set to true for a policy that selects a HEP, t
 - Egress policy on HEP eth1 affects connections 2, 3, and 4
 
 There are also different default action semantics for **applyOnForward: true policy** versus **applyOnForward: false policy**.
-An applyOnForward: true policy affects all traffic through the HEP (connections 1-4). If no applyOnForward policy selects the HEP and direction (ingress versus egress), then forwarded traffic is allowed.  If no policy (regardless of applyOnForward) selects the HEP and direction, then local traffic is denied.
+An applyOnForward: true policy affects all traffic through the HEP (connections 1-4). If no applyOnForward policy selects the HEP and direction (ingress versus egress), then forwarded traffic is allowed.  If no policy (regardless of applyOnForward) selects the HEP and direction, then local traffic is denied unless if the HEP has the `projectcalico-default-allow` profile.
 
-| **HEP defined?** | **Traffic Type** | **applyOnForward defined?** | **Any policy defined?** | **Default Action** |
-| ---------------- | ---------------- | --------------------------- | ----------------------- | ------------------ |
-| No               | Any              | n/a                         | n/a                     | Allow              |
-| Yes              | Forwarded        | No                          | Any                     | Allow              |
-| Yes              | Forwarded        | Yes                         | Yes                     | Deny               |
-| Yes              | Local            | n/a                         | No                      | Deny               |
-| Yes              | Local            | n/a                         | Yes                     | Deny               |
+| **HEP defined?** | **Traffic Type** | **applyOnForward defined?** | **Any policy defined?** | **Has allow-all profile** | **Default Action** |
+| ---------------- | ---------------- | --------------------------- | ----------------------- | ------------------------- | ------------------ |
+| No               | Any              | N/A                         | N/A                     | N/A                       | Allow              |
+| Yes              | Forwarded        | No                          | Any                     | N/A                       | Allow              |
+| Yes              | Forwarded        | Yes                         | Yes                     | N/A                       | Deny               |
+| Yes              | Local            | N/A                         | No                      | No                        | Deny               |
+| Yes              | Local            | N/A                         | No                      | Yes                       | Allow              |
+| Yes              | Local            | N/A                         | Yes                     | N/A                       | Deny               |
+
+> **Note**: The `projectcalico-default-allow` is a built-in profile provided by {{site.prodname}} that consists of allow-all ingress and egress rules.
+> HEPs with this profile will have an Allow default action instead of Deny, in the absence of policy. [Auto host endpoints]({{site.baseurl}}/security/kubernetes-nodes#automatic-host-endpoints) always have this profile. For more information about the default behavior for traffic originating/terminating at the host, see the [host endpoint reference]({{site.baseurl}}/reference/resources/hostendpoint#default-behavior-of-external-traffic-tofrom-host).
+{: .alert .alert-info}
 
 **{{site.prodname}} namespaced network policies** do not have an applyOnForward setting. HEPs are always cluster global, not namespaced, so network policies cannot select them.
 

--- a/security/host-forwarded-traffic.md
+++ b/security/host-forwarded-traffic.md
@@ -44,16 +44,16 @@ In contrast, if applyOnForward is set to true for a policy that selects a HEP, t
 There are also different default action semantics for **applyOnForward: true policy** versus **applyOnForward: false policy**.
 An applyOnForward: true policy affects all traffic through the HEP (connections 1-4). If no applyOnForward policy selects the HEP and direction (ingress versus egress), then forwarded traffic is allowed.  If no policy (regardless of applyOnForward) selects the HEP and direction, then local traffic is denied unless if the HEP has the `projectcalico-default-allow` profile.
 
-| **HEP defined?** | **Traffic Type** | **applyOnForward defined?** | **Any policy defined?** | **Has allow-all profile** | **Default Action** |
-| ---------------- | ---------------- | --------------------------- | ----------------------- | ------------------------- | ------------------ |
-| No               | Any              | N/A                         | N/A                     | N/A                       | Allow              |
-| Yes              | Forwarded        | No                          | Any                     | N/A                       | Allow              |
-| Yes              | Forwarded        | Yes                         | Yes                     | N/A                       | Deny               |
-| Yes              | Local            | N/A                         | No                      | No                        | Deny               |
-| Yes              | Local            | N/A                         | No                      | Yes                       | Allow              |
-| Yes              | Local            | N/A                         | Yes                     | N/A                       | Deny               |
+| **HEP defined?** | **Traffic Type** | **applyOnForward defined?** | **Any policy defined?** | **Has projectcalico-default-allow profile** [†](##note-about-default-allow-profile) | **Default Action** |
+| ---------------- | ---------------- | --------------------------- | ----------------------- | ----------------------------------------------------------------------------------- | ------------------ |
+| No               | Any              | N/A                         | N/A                     | N/A                                                                                 | Allow              |
+| Yes              | Forwarded        | No                          | Either                  | N/A                                                                                 | Allow              |
+| Yes              | Forwarded        | Yes                         | Yes                     | N/A                                                                                 | Deny               |
+| Yes              | Local            | N/A                         | No                      | No                                                                                  | Deny               |
+| Yes              | Local            | N/A                         | No                      | Yes                                                                                 | Allow              |
+| Yes              | Local            | N/A                         | Yes                     | N/A                                                                                 | Deny               |
 
-> **Note**: The `projectcalico-default-allow` is a built-in profile provided by {{site.prodname}} that consists of allow-all ingress and egress rules.
+> **[Note †](#note-about-default-allow-profile)**: The `projectcalico-default-allow` is a built-in profile provided by {{site.prodname}} that consists of allow-all ingress and egress rules.
 > HEPs with this profile will have an Allow default action instead of Deny, in the absence of policy. [Auto host endpoints]({{site.baseurl}}/security/kubernetes-nodes#automatic-host-endpoints) always have this profile. For more information about the default behavior for traffic originating/terminating at the host, see the [host endpoint reference]({{site.baseurl}}/reference/resources/hostendpoint#default-behavior-of-external-traffic-tofrom-host).
 {: .alert .alert-info}
 


### PR DESCRIPTION
## Description

This PR corrects the apply-on-forward page by accounting for host endpoints that have the `projectcalico-default-allow` profile https://docs.projectcalico.org/security/host-forwarded-traffic#applyonforward
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
