### PR TITLE
Add disableBGPExport to IPPool spec

### DIFF
--- a/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ippools.yaml
+++ b/_includes/charts/calico/crds/kdd/crd.projectcalico.org_ippools.yaml
@@ -47,6 +47,10 @@ spec:
                 description: When disabled is true, Calico IPAM will not assign addresses
                   from this pool.
                 type: boolean
+              disableBGPExport:
+                description: 'Disable exporting routes from this IP Pool’s CIDR over
+                  BGP. [Default: false]'
+                type: boolean
               ipip:
                 description: 'Deprecated: this field is only used for APIv1 backwards
                   compatibility. Setting this field is not allowed, this field is

--- a/reference/resources/ippool.md
+++ b/reference/resources/ippool.md
@@ -46,6 +46,7 @@ spec:
 | vxlanMode | The mode defining when VXLAN will be used. Cannot be set at the same time as `ipipMode`. | Always, CrossSubnet, Never | string| `Never` |
 | natOutgoing | When enabled, packets sent from {{site.prodname}} networked containers in this pool to destinations outside of this pool will be masqueraded. | true, false | boolean | `false` |
 | disabled | When set to true, {{site.prodname}} IPAM will not assign addresses from this pool. | true, false | boolean | `false` |
+| disableBGPExport _(since v3.21.0)_ | Disable exporting routes from this IP Pool’s CIDR over BGP. | true, false | boolean | `false` |
 | nodeSelector | Selects the nodes that {{site.prodname}} IPAM should assign addresses from this pool to. | | [selector](#node-selector) | all() |
 | allowedUses _(since v3.21.0)_ | Controls whether the pool will be used for automatic assignments of certain types.  See [below](#allowed-uses). | Workload, Tunnel | list of strings | `["Workload", "Tunnel"]` |
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [X] Documentation
- [X] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added support for disabling exporting of IP pool CIDRs over BGP.
```
