### PR TITLE
Updated felixconf CRD with missing wg flags

### DIFF
--- a/_includes/charts/calico/crds/kdd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/_includes/charts/calico/crds/kdd/crd.projectcalico.org_felixconfigurations.yaml
@@ -443,6 +443,12 @@ spec:
                   to false. This reduces the number of metrics reported, reducing
                   Prometheus load. [Default: true]'
                 type: boolean
+              prometheusWireGuardMetricsEnabled:
+                description: 'PrometheusWireGuardMetricsEnabled disables wireguard
+                  metrics collection, which the Prometheus client does by default,
+                  when set to false. This reduces the number of metrics reported,
+                  reducing Prometheus load. [Default: true]'
+                type: boolean
               removeExternalRoutes:
                 description: Whether or not to remove device routes that have not
                   been programmed by Felix. Disabling this will allow external applications
@@ -523,6 +529,10 @@ spec:
               wireguardEnabled:
                 description: 'WireguardEnabled controls whether Wireguard is enabled.
                   [Default: false]'
+                type: boolean
+              wireguardHostEncryptionEnabled:
+                description: 'WireguardHostEncryptionEnabled controls whether Wireguard
+                  host-to-host encryption is enabled. [Default: false]'
                 type: boolean
               wireguardInterfaceName:
                 description: 'WireguardInterfaceName specifies the name to use for


### PR DESCRIPTION
## Description

Some WireGuard flags in the felixconf CRD were not added to the docs site when they were added to libcalico-go.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added missing flags prometheusWireGuardMetricsEnabled and wireguardHostEncryptionEnabled to the felixconf CRD.
```
