### PR TITLE
Docs-fix-redirects-release-v3.20

### DIFF
--- a/about/about-ebpf.md
+++ b/about/about-ebpf.md
@@ -4,6 +4,10 @@ description: Learn about eBPF!
 canonical_url: 'https://www.tigera.io/learn/guides/ebpf/'
 ---
 
+{% comment %}
+Do not change the canonical_url above *or the title*. Content is shared with Marketing and is used for SEO purposes. If you change the title, it will screw up Marketing metrics. 
+{% endcomment %}
+
 > <span class="glyphicon glyphicon-info-sign"></span> This guide provides optional background education, including
 > education that is not specific to {{site.prodname}}.
 {: .alert .alert-info}

--- a/about/about-k8s-networking.md
+++ b/about/about-k8s-networking.md
@@ -2,7 +2,12 @@
 title: About Kubernetes Networking
 description: Learn about Kubernetes networking!
 canonical_url: 'https://www.tigera.io/learn/guides/kubernetes-networking/'
+redirect_to: 'https://www.tigera.io/learn/guides/kubernetes-networking/'
 ---
+
+{% comment %}
+Do not change the canonical_url above *or the title*. Content is shared with Marketing and is used for SEO purposes. If you change the title, it will screw up Marketing metrics. 
+{% endcomment %}
 
 > <span class="glyphicon glyphicon-info-sign"></span> This guide provides optional background education, not specific to {{site.prodname}}.
 {: .alert .alert-info}


### PR DESCRIPTION
## Fix redirect links for Marketing

- Fixes that we did for Marketing redirects only in place for 3.19 and backwards