### PR TITLE
Docs-fix-redirects-release-v3.21

### DIFF
--- a/about/about-k8s-networking.md
+++ b/about/about-k8s-networking.md
@@ -2,6 +2,7 @@
 title: About Kubernetes Networking
 description: Learn about Kubernetes networking!
 canonical_url: 'https://www.tigera.io/learn/guides/kubernetes-networking/'
+redirect_to: 'https://www.tigera.io/learn/guides/kubernetes-networking/'
 ---
 
 {% comment %}


### PR DESCRIPTION
## Fix redirect links for Marketing

- Fixes we made for Marketing only made it into 3.19. Add redirect link.