### PR TITLE
eks: add link for suggestions for handling webhooks

### DIFF
--- a/getting-started/kubernetes/managed-public-cloud/eks.md
+++ b/getting-started/kubernetes/managed-public-cloud/eks.md
@@ -33,7 +33,8 @@ The geeky details of what you get:
    > will not be able to initiate network connections to {{site.prodname}} pods. (This is a general limitation of EKS's custom networking support,
    > not specific to {{site.prodname}}.) As a workaround, trusted pods that require control plane nodes to connect to them, such as those implementing
    > admission controller webhooks, can include `hostNetwork:true` in their pod spec. See the Kuberentes API
-   > {% include open-new-window.html text='pod spec' url='https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core' %}
+   > {% include open-new-window.html text='pod spec' url='https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core' %}.
+   > Some other solutions for the same are discussed {% include open-new-window.html text='in this blog' url='https://medium.com/@denisstortisilva/kubernetes-eks-calico-and-custom-admission-webhooks-a2956b49bd0d' %}
    > definition for more information on this setting.
    {: .alert .alert-info }
 


### PR DESCRIPTION
## Description

This PR is for adding an extra link in the documentation of running calico in eks. 

The current doc has only one suggestion for using `hostNetwork: true` to solve the webhook problem but people are usually reluctant to do so. This PR adds a doc to suggest a couple of more approaches for solving this problem but for istiod webhook.

Other blog suggestions are welcomed. 


```release-note
None required
```
