### PR TITLE
Add missing caliconodestatuses resource to apiserver role

### DIFF
--- a/_includes/non-helm-manifests/apiserver.yaml
+++ b/_includes/non-helm-manifests/apiserver.yaml
@@ -176,6 +176,7 @@ rules:
   - ipreservations
   - ipamblocks
   - blockaffinities
+  - caliconodestatuses
   verbs:
   - get
   - list


### PR DESCRIPTION
## Description

While deploying calico v3.21.0 with calico apiserver from the manifests in the
release archives, our automation stumbled onto:
```
error: error pruning nonNamespaced object projectcalico.org/v3, Kind=CalicoNodeStatus: connection is unauthorized: caliconodestatuses.crd.projectcalico.org is forbidden: User "system:serviceaccount:kube-system:calico-apiserver" cannot list resource "caliconodestatuses" in API group "crd.projectcalico.org" at the cluster scope
```
This is adding the missing permissions

## Release Note

```release-note
None required
```
