### PR TITLE
[EV-1366] adding redirects for domain change

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,10 +32,18 @@
     # generate the website which is served at /archive/<version>/
     jekyll build --config _config.yml,$(pwd)/netlify/_config_noindex.yml --baseurl /archive/$RELEASE_VERSION --destination _site/archive/$RELEASE_VERSION
 
-    mv _site/sitemap.xml _site/release-legacy-sitemap.xml
-    mv _site/sitemap.xml _site/latest-sitemap.xml
-    mv netlify/sitemap-index.xml _site/sitemap.xml
-    mv netlify/_redirects _site/_redirects
+    # keep the production build if it's not docs.projectcalico.org (off of v3.21 branch) site
+    # REDIRECT_TO_LATEST is set in Netlify UI for environment-variables ONLY for docs.projectcalico.org site.
+    if [ -z "$REDIRECT_TO_LATEST" ]; then
+      mv _site/sitemap.xml _site/release-legacy-sitemap.xml
+      mv _site/sitemap.xml _site/latest-sitemap.xml
+      mv netlify/sitemap-index.xml _site/sitemap.xml
+      mv netlify/_redirects _site/_redirects
+
+    else
+      mv netlify/_redirects_v3.21 _site/_redirects
+    fi
+
   fi
   '''
 
@@ -50,7 +58,14 @@
   export PATH=$PATH:$(pwd)/bin
   echo "url: $DEPLOY_PRIME_URL" > _config_url.yml
   jekyll build --config _config.yml,_config_url.yml
-  mv netlify/_redirects _site/_redirects
+
+  # keep the old build if it's not docs.projectcalico.org (off of v3.21 branch) site
+  if [ -z "$REDIRECT_TO_LATEST" ]; then
+    mv netlify/_redirects _site/_redirects
+  else
+    mv netlify/_redirects_v3.21 _site/_redirects
+  fi
+
   '''
 
 # Deploys master branch as a seperate individual site, master build is diffrent from branch deploys

--- a/netlify/_redirects_v3.21
+++ b/netlify/_redirects_v3.21
@@ -1,0 +1,254 @@
+# These rules are specific to docs.projectcalico.org site, backed by release-v3.21 branch, which is the last production version hosted at docs.projectcalico.org.
+
+# All future versions will be hosted at https://projectcalico.docs.tigera.io/
+# Following proxy rules (ending with 200 status) ensures continued access to manifests for v3.21 and below through docs.projectcalico.org path.
+# Last rule in this file is a forced 301 redirect (301!) to new domain, for everything else that's not specified in proxy.
+
+# proxy rules to keep helm charts working
+
+/charts/*                                                         https://calico-public.s3.amazonaws.com/charts/:splat                                              200
+
+# proxy rules to keep master manifests accessible
+
+/master/manifests/*                                               https://calico-master.netlify.app/master/manifests/:splat                                         200
+/master/security/tutorials/*                                      https://calico-master.netlify.app/master/security/tutorials/:splat                                200
+/master/getting-started/kubernetes/installation/*                 https://calico-master.netlify.app/master/getting-started/kubernetes/installation/:splat           200
+
+# proxy rules to keep root level manifests accessible, point them to latest manifest on new production site
+
+/manifests/*                                                      https://calico-tigera.netlify.app/manifests/:splat                                         200
+/security/tutorials/*                                             https://calico-tigera.netlify.app/security/tutorials/:splat                                200
+/getting-started/kubernetes/installation/*                        https://calico-tigera.netlify.app/getting-started/kubernetes/installation/:splat           200
+
+# proxy rules to keep manifest files accessible for versions v3.21 and below, all new version manifests will be accessible through https://projectcalico.docs.tigera.io
+
+/v3.21/manifests/*                                                https://calico-v3-21.netlify.app/archive/v3.21/manifests/:splat                                   200
+/v3.21/security/tutorials/*                                       https://calico-v3-21.netlify.app/archive/v3.21/security/tutorials/:splat                          200
+/v3.21/getting-started/kubernetes/installation/*                  https://calico-v3-21.netlify.app/archive/v3.21/getting-started/kubernetes/installation/:splat     200
+/archive/v3.21/manifests/*                                        https://calico-v3-21.netlify.app/archive/v3.21/manifests/:splat                                   200
+/archive/v3.21/security/tutorials/*                               https://calico-v3-21.netlify.app/archive/v3.21/security/tutorials/:splat                          200
+/archive/v3.21/getting-started/kubernetes/installation/*          https://calico-v3-21.netlify.app/archive/v3.21/getting-started/kubernetes/installation/:splat     200
+
+/v3.20/manifests/*                                                https://calico-v3-20.netlify.app/archive/v3.20/manifests/:splat                                   200
+/v3.20/security/tutorials/*                                       https://calico-v3-20.netlify.app/archive/v3.20/security/tutorials/:splat                          200
+/v3.20/getting-started/kubernetes/installation/*                  https://calico-v3-20.netlify.app/archive/v3.20/getting-started/kubernetes/installation/:splat     200
+/archive/v3.20/manifests/*                                        https://calico-v3-20.netlify.app/archive/v3.20/manifests/:splat                                   200
+/archive/v3.20/security/tutorials/*                               https://calico-v3-20.netlify.app/archive/v3.20/security/tutorials/:splat                          200
+/archive/v3.20/getting-started/kubernetes/installation/*          https://calico-v3-20.netlify.app/archive/v3.20/getting-started/kubernetes/installation/:splat     200
+
+/v3.19/manifests/*                                                https://calico-v3-19.netlify.app/archive/v3.19/manifests/:splat                                   200
+/v3.19/security/tutorials/*                                       https://calico-v3-19.netlify.app/archive/v3.19/security/tutorials/:splat                          200
+/v3.19/getting-started/kubernetes/installation/*                  https://calico-v3-19.netlify.app/archive/v3.19/getting-started/kubernetes/installation/:splat     200
+/archive/v3.19/manifests/*                                        https://calico-v3-19.netlify.app/archive/v3.19/manifests/:splat                                   200
+/archive/v3.19/security/tutorials/*                               https://calico-v3-19.netlify.app/archive/v3.19/security/tutorials/:splat                          200
+/archive/v3.19/getting-started/kubernetes/installation/*          https://calico-v3-19.netlify.app/archive/v3.19/getting-started/kubernetes/installation/:splat     200
+
+/v3.18/manifests/*                                                https://calico-v3-18.netlify.app/archive/v3.18/manifests/:splat                                   200
+/v3.18/security/tutorials/*                                       https://calico-v3-18.netlify.app/archive/v3.18/security/tutorials/:splat                          200
+/v3.18/getting-started/kubernetes/installation/*                  https://calico-v3-18.netlify.app/archive/v3.18/getting-started/kubernetes/installation/:splat     200
+/archive/v3.18/manifests/*                                        https://calico-v3-18.netlify.app/archive/v3.18/manifests/:splat                                   200
+/archive/v3.18/security/tutorials/*                               https://calico-v3-18.netlify.app/archive/v3.18/security/tutorials/:splat                          200
+/archive/v3.18/getting-started/kubernetes/installation/*          https://calico-v3-18.netlify.app/archive/v3.18/getting-started/kubernetes/installation/:splat     200
+
+/v3.17/manifests/*                                                https://calico-v3-17.netlify.app/archive/v3.17/manifests/:splat                                   200
+/v3.17/security/tutorials/*                                       https://calico-v3-17.netlify.app/archive/v3.17/security/tutorials/:splat                          200
+/v3.17/getting-started/kubernetes/installation/*                  https://calico-v3-17.netlify.app/archive/v3.17/getting-started/kubernetes/installation/:splat     200
+/archive/v3.17/manifests/*                                        https://calico-v3-17.netlify.app/archive/v3.17/manifests/:splat                                   200
+/archive/v3.17/security/tutorials/*                               https://calico-v3-17.netlify.app/archive/v3.17/security/tutorials/:splat                          200
+/archive/v3.17/getting-started/kubernetes/installation/*          https://calico-v3-17.netlify.app/archive/v3.17/getting-started/kubernetes/installation/:splat     200
+
+/v3.16/manifests/*                                                https://calico-v3-16.netlify.app/archive/v3.16/manifests/:splat                                   200
+/v3.16/security/tutorials/*                                       https://calico-v3-16.netlify.app/archive/v3.16/security/tutorials/:splat                          200
+/v3.16/getting-started/kubernetes/installation/*                  https://calico-v3-16.netlify.app/archive/v3.16/getting-started/kubernetes/installation/:splat     200
+/archive/v3.16/manifests/*                                        https://calico-v3-16.netlify.app/archive/v3.16/manifests/:splat                                   200
+/archive/v3.16/security/tutorials/*                               https://calico-v3-16.netlify.app/archive/v3.16/security/tutorials/:splat                          200
+/archive/v3.16/getting-started/kubernetes/installation/*          https://calico-v3-16.netlify.app/archive/v3.16/getting-started/kubernetes/installation/:splat     200
+
+/v3.15/manifests/*                                                https://calico-v3-15.netlify.app/archive/v3.15/manifests/:splat                                   200
+/v3.15/security/tutorials/*                                       https://calico-v3-15.netlify.app/archive/v3.15/security/tutorials/:splat                          200
+/v3.15/getting-started/kubernetes/installation/*                  https://calico-v3-15.netlify.app/archive/v3.15/getting-started/kubernetes/installation/:splat     200
+/archive/v3.15/manifests/*                                        https://calico-v3-15.netlify.app/archive/v3.15/manifests/:splat                                   200
+/archive/v3.15/security/tutorials/*                               https://calico-v3-15.netlify.app/archive/v3.15/security/tutorials/:splat                          200
+/archive/v3.15/getting-started/kubernetes/installation/*          https://calico-v3-15.netlify.app/archive/v3.15/getting-started/kubernetes/installation/:splat     200
+
+/v3.14/manifests/*                                                https://calico-v3-14.netlify.app/archive/v3.14/manifests/:splat                                   200
+/v3.14/security/tutorials/*                                       https://calico-v3-14.netlify.app/archive/v3.14/security/tutorials/:splat                          200
+/v3.14/getting-started/kubernetes/installation/*                  https://calico-v3-14.netlify.app/archive/v3.14/getting-started/kubernetes/installation/:splat     200
+/archive/v3.14/manifests/*                                        https://calico-v3-14.netlify.app/archive/v3.14/manifests/:splat                                   200
+/archive/v3.14/security/tutorials/*                               https://calico-v3-14.netlify.app/archive/v3.14/security/tutorials/:splat                          200
+/archive/v3.14/getting-started/kubernetes/installation/*          https://calico-v3-14.netlify.app/archive/v3.14/getting-started/kubernetes/installation/:splat     200
+
+/v3.13/manifests/*                                                https://calico-v3-13.netlify.app/archive/v3.13/manifests/:splat                                   200
+/v3.13/security/tutorials/*                                       https://calico-v3-13.netlify.app/archive/v3.13/security/tutorials/:splat                          200
+/v3.13/getting-started/kubernetes/installation/*                  https://calico-v3-13.netlify.app/archive/v3.13/getting-started/kubernetes/installation/:splat     200
+/archive/v3.13/manifests/*                                        https://calico-v3-13.netlify.app/archive/v3.13/manifests/:splat                                   200
+/archive/v3.13/security/tutorials/*                               https://calico-v3-13.netlify.app/archive/v3.13/security/tutorials/:splat                          200
+/archive/v3.13/getting-started/kubernetes/installation/*          https://calico-v3-13.netlify.app/archive/v3.13/getting-started/kubernetes/installation/:splat     200
+
+/v3.12/manifests/*                                                https://calico-v3-12.netlify.app/archive/v3.12/manifests/:splat                                   200
+/v3.12/security/tutorials/*                                       https://calico-v3-12.netlify.app/archive/v3.12/security/tutorials/:splat                          200
+/v3.12/getting-started/kubernetes/installation/*                  https://calico-v3-12.netlify.app/archive/v3.12/getting-started/kubernetes/installation/:splat     200
+/archive/v3.12/manifests/*                                        https://calico-v3-12.netlify.app/archive/v3.12/manifests/:splat                                   200
+/archive/v3.12/security/tutorials/*                               https://calico-v3-12.netlify.app/archive/v3.12/security/tutorials/:splat                          200
+/archive/v3.12/getting-started/kubernetes/installation/*          https://calico-v3-12.netlify.app/archive/v3.12/getting-started/kubernetes/installation/:splat     200
+
+/v3.11/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.11/manifests/:splat                                  200
+/v3.11/security/tutorials/*                                       https://calico-legacy.netlify.app/archive/v3.11/security/tutorials/:splat                         200
+/v3.11/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.11/getting-started/kubernetes/installation/:splat    200
+/archive/v3.11/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.11/manifests/:splat                                  200
+/archive/v3.11/security/tutorials/*                               https://calico-legacy.netlify.app/archive/v3.11/security/tutorials/:splat                         200
+/archive/v3.11/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.11/getting-started/kubernetes/installation/:splat    200
+
+/v3.10/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.10/manifests/:splat                                  200
+/v3.10/security/tutorials/*                                       https://calico-legacy.netlify.app/archive/v3.10/security/tutorials/:splat                         200
+/v3.10/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.10/getting-started/kubernetes/installation/:splat    200
+/archive/v3.10/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.10/manifests/:splat                                  200
+/archive/v3.10/security/tutorials/*                               https://calico-legacy.netlify.app/archive/v3.10/security/tutorials/:splat                         200
+/archive/v3.10/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.10/getting-started/kubernetes/installation/:splat    200
+
+/v3.9/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.9/manifests/:splat                                    200
+/v3.9/security/tutorials/*                                       https://calico-legacy.netlify.app/archive/v3.9/security/tutorials/:splat                           200
+/v3.9/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.9/getting-started/kubernetes/installation/:splat      200
+/archive/v3.9/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.9/manifests/:splat                                    200
+/archive/v3.9/security/tutorials/*                               https://calico-legacy.netlify.app/archive/v3.9/security/tutorials/:splat                           200
+/archive/v3.9/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.9/getting-started/kubernetes/installation/:splat      200
+
+/v3.8/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.8/manifests/:splat                                    200
+/v3.8/security/app-layer-policy/*                                https://calico-legacy.netlify.app/archive/v3.8/security/app-layer-policy/:splat                    200
+/v3.8/security/stars-policy/*                                    https://calico-legacy.netlify.app/archive/v3.8/security/stars-policy/:splat                        200
+/v3.8/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.8/getting-started/kubernetes/installation/:splat      200
+/archive/v3.8/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.8/manifests/:splat                                    200
+/archive/v3.8/security/app-layer-policy/*                        https://calico-legacy.netlify.app/archive/v3.8/security/app-layer-policy/:splat                    200
+/archive/v3.8/security/stars-policy/*                            https://calico-legacy.netlify.app/archive/v3.8/security/stars-policy/:splat                        200
+/archive/v3.8/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.8/getting-started/kubernetes/installation/:splat      200
+
+/v3.7/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.7/manifests/:splat                                    200
+/v3.7/security/app-layer-policy/*                                https://calico-legacy.netlify.app/archive/v3.7/security/app-layer-policy/:splat                    200
+/v3.7/security/stars-policy/*                                    https://calico-legacy.netlify.app/archive/v3.7/security/stars-policy/:splat                        200
+/v3.7/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.7/getting-started/kubernetes/installation/:splat      200
+/archive/v3.7/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.7/manifests/:splat                                    200
+/archive/v3.7/security/app-layer-policy/*                        https://calico-legacy.netlify.app/archive/v3.7/security/app-layer-policy/:splat                    200
+/archive/v3.7/security/stars-policy/*                            https://calico-legacy.netlify.app/archive/v3.7/security/stars-policy/:splat                        200
+/archive/v3.7/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.7/getting-started/kubernetes/installation/:splat      200
+
+/v3.6/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.6/manifests/:splat                                    200
+/v3.6/security/app-layer-policy/*                                https://calico-legacy.netlify.app/archive/v3.6/security/app-layer-policy/:splat                    200
+/v3.6/security/stars-policy/*                                    https://calico-legacy.netlify.app/archive/v3.6/security/stars-policy/:splat                        200
+/v3.6/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.6/getting-started/kubernetes/installation/:splat      200
+/archive/v3.6/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.6/manifests/:splat                                    200
+/archive/v3.6/security/app-layer-policy/*                        https://calico-legacy.netlify.app/archive/v3.6/security/app-layer-policy/:splat                    200
+/archive/v3.6/security/stars-policy/*                            https://calico-legacy.netlify.app/archive/v3.6/security/stars-policy/:splat                        200
+/archive/v3.6/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.6/getting-started/kubernetes/installation/:splat      200
+
+/v3.5/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.5/manifests/:splat                                    200
+/v3.5/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.5/getting-started/kubernetes/installation/:splat      200
+/v3.5/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.5/getting-started/kubernetes/tutorials/:splat         200
+/archive/v3.5/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.5/manifests/:splat                                    200
+/archive/v3.5/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.5/getting-started/kubernetes/installation/:splat      200
+/v3.5/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.5/getting-started/kubernetes/tutorials/:splat         200
+
+/v3.4/manifests/*                                                https://calico-legacy.netlify.app/archive/v3.4/manifests/:splat                                    200
+/v3.4/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.4/getting-started/kubernetes/installation/:splat      200
+/v3.4/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.4/getting-started/kubernetes/tutorials/:splat         200
+/archive/v3.4/manifests/*                                        https://calico-legacy.netlify.app/archive/v3.4/manifests/:splat                                    200
+/archive/v3.4/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.4/getting-started/kubernetes/installation/:splat      200
+/v3.4/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.4/getting-started/kubernetes/tutorials/:splat         200
+
+/v3.3/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.3/getting-started/kubernetes/installation/:splat      200
+/v3.3/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.3/getting-started/kubernetes/tutorials/:splat         200
+/archive/v3.3/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.3/getting-started/kubernetes/installation/:splat      200
+/v3.3/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.3/getting-started/kubernetes/tutorials/:splat         200
+
+/v3.2/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.2/getting-started/kubernetes/installation/:splat      200
+/v3.2/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.2/getting-started/kubernetes/tutorials/:splat         200
+/archive/v3.2/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.2/getting-started/kubernetes/installation/:splat      200
+/v3.2/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.2/getting-started/kubernetes/tutorials/:splat         200
+
+/v3.1/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.1/getting-started/kubernetes/installation/:splat      200
+/v3.1/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.1/getting-started/kubernetes/tutorials/:splat         200
+/archive/v3.1/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.1/getting-started/kubernetes/installation/:splat      200
+/v3.1/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.1/getting-started/kubernetes/tutorials/:splat         200
+
+/v3.0/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v3.0/getting-started/kubernetes/installation/:splat      200
+/v3.0/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.0/getting-started/kubernetes/tutorials/:splat         200
+/archive/v3.0/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v3.0/getting-started/kubernetes/installation/:splat      200
+/v3.0/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v3.0/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.6/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/installation/:splat      200
+/v2.6/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.6/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/installation/:splat      200
+/v2.6/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.6/getting-started/rkt/installation/*                         https://calico-legacy.netlify.app/archive/v2.6/getting-started/rkt/installation/:splat             200
+/v2.6/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/installation/:splat      200
+/v2.6/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.6/getting-started/rkt/installation/*                 https://calico-legacy.netlify.app/archive/v2.6/getting-started/rkt/installation/:splat             200
+/archive/v2.6/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/installation/:splat      200
+/archive/v2.6/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v2.6/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.5/getting-started/rkt/installation/*                         https://calico-legacy.netlify.app/archive/v2.5/getting-started/rkt/installation/:splat             200
+/v2.5/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.5/getting-started/kubernetes/installation/:splat      200
+/v2.5/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.5/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.5/getting-started/rkt/installation/*                 https://calico-legacy.netlify.app/archive/v2.5/getting-started/rkt/installation/:splat             200
+/archive/v2.5/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.5/getting-started/kubernetes/installation/:splat      200
+/archive/v2.5/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v2.5/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.4/getting-started/rkt/installation/*                         https://calico-legacy.netlify.app/archive/v2.4/getting-started/rkt/installation/:splat             200
+/v2.4/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.4/getting-started/kubernetes/installation/:splat      200
+/v2.4/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.4/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.4/getting-started/rkt/installation/*                 https://calico-legacy.netlify.app/archive/v2.4/getting-started/rkt/installation/:splat             200
+/archive/v2.4/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.4/getting-started/kubernetes/installation/:splat      200
+/archive/v2.4/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v2.4/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.3/getting-started/rkt/installation/*                         https://calico-legacy.netlify.app/archive/v2.3/getting-started/rkt/installation/:splat             200
+/v2.3/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.3/getting-started/kubernetes/installation/:splat      200
+/v2.3/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.3/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.3/getting-started/rkt/installation/*                 https://calico-legacy.netlify.app/archive/v2.3/getting-started/rkt/installation/:splat             200
+/archive/v2.3/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.3/getting-started/kubernetes/installation/:splat      200
+/archive/v2.3/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v2.3/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.2/getting-started/rkt/installation/*                         https://calico-legacy.netlify.app/archive/v2.2/getting-started/rkt/installation/:splat             200
+/v2.2/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.2/getting-started/kubernetes/installation/:splat      200
+/v2.2/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.2/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.2/getting-started/rkt/installation/*                 https://calico-legacy.netlify.app/archive/v2.2/getting-started/rkt/installation/:splat             200
+/archive/v2.2/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.2/getting-started/kubernetes/installation/:splat      200
+/archive/v2.2/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v2.2/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.1/getting-started/rkt/installation/*                         https://calico-legacy.netlify.app/archive/v2.1/getting-started/rkt/installation/:splat             200
+/v2.1/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.1/getting-started/kubernetes/installation/:splat      200
+/v2.1/getting-started/kubernetes/cloud-config/*                  https://calico-legacy.netlify.app/archive/v2.1/getting-started/kubernetes/cloud-config/:splat      200
+/v2.1/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.1/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.1/getting-started/rkt/installation/*                 https://calico-legacy.netlify.app/archive/v2.1/getting-started/rkt/installation/:splat             200
+/archive/v2.1/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.1/getting-started/kubernetes/installation/:splat      200
+/archive/v2.1/getting-started/kubernetes/cloud-config/*          https://calico-legacy.netlify.app/archive/v2.1/getting-started/kubernetes/cloud-config/:splat      200
+/archive/v2.1/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v2.1/getting-started/kubernetes/tutorials/:splat         200
+
+/v2.0/getting-started/rkt/installation/*                         https://calico-legacy.netlify.app/archive/v2.0/getting-started/rkt/installation/:splat             200
+/v2.0/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v2.0/getting-started/kubernetes/installation/:splat      200
+/v2.0/getting-started/kubernetes/cloud-config/*                  https://calico-legacy.netlify.app/archive/v2.0/getting-started/kubernetes/cloud-config/:splat      200
+/v2.0/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v2.0/getting-started/kubernetes/tutorials/:splat         200
+/archive/v2.0/getting-started/rkt/installation/*                 https://calico-legacy.netlify.app/archive/v2.0/getting-started/rkt/installation/:splat             200
+/archive/v2.0/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v2.0/getting-started/kubernetes/installation/:splat      200
+/archive/v2.0/getting-started/kubernetes/cloud-config/*          https://calico-legacy.netlify.app/archive/v2.0/getting-started/kubernetes/cloud-config/:splat      200
+/archive/v2.0/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v2.0/getting-started/kubernetes/tutorials/:splat         200
+
+/v1.6/getting-started/rkt/vagrant/cloud-config//*                https://calico-legacy.netlify.app/archive/v1.6/getting-started/rkt/vagrant/cloud-config/:splat     200
+/v1.6/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v1.6/getting-started/kubernetes/installation/:splat      200
+/v1.6/getting-started/kubernetes/cloud-config/*                  https://calico-legacy.netlify.app/archive/v1.6/getting-started/kubernetes/cloud-config/:splat      200
+/v1.6/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v1.6/getting-started/kubernetes/tutorials/:splat         200
+/archive/v1.6/getting-started/rkt/vagrant/cloud-config/*         https://calico-legacy.netlify.app/archive/v1.6/getting-started/rkt/vagrant/cloud-config/:splat     200
+/archive/v1.6/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v1.6/getting-started/kubernetes/installation/:splat      200
+/archive/v1.6/getting-started/kubernetes/cloud-config/*          https://calico-legacy.netlify.app/archive/v1.6/getting-started/kubernetes/cloud-config/:splat      200
+/archive/v1.6/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v1.6/getting-started/kubernetes/tutorials/:splat         200
+
+/v1.5/getting-started/rkt/vagrant/cloud-config//*                https://calico-legacy.netlify.app/archive/v1.5/getting-started/rkt/vagrant/cloud-config/:splat     200
+/v1.5/getting-started/kubernetes/installation/*                  https://calico-legacy.netlify.app/archive/v1.5/getting-started/kubernetes/installation/:splat      200
+/v1.5/getting-started/kubernetes/cloud-config/*                  https://calico-legacy.netlify.app/archive/v1.5/getting-started/kubernetes/cloud-config/:splat      200
+/v1.5/getting-started/kubernetes/tutorials/*                     https://calico-legacy.netlify.app/archive/v1.5/getting-started/kubernetes/tutorials/:splat         200
+/archive/v1.5/getting-started/rkt/vagrant/cloud-config/*         https://calico-legacy.netlify.app/archive/v1.5/getting-started/rkt/vagrant/cloud-config/:splat     200
+/archive/v1.5/getting-started/kubernetes/installation/*          https://calico-legacy.netlify.app/archive/v1.5/getting-started/kubernetes/installation/:splat      200
+/archive/v1.5/getting-started/kubernetes/cloud-config/*          https://calico-legacy.netlify.app/archive/v1.5/getting-started/kubernetes/cloud-config/:splat      200
+/archive/v1.5/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v1.5/getting-started/kubernetes/tutorials/:splat         200
+
+# blanket forced redirect for content
+/*                                                               https://projectcalico.docs.tigera.io/:splat                                                        301!


### PR DESCRIPTION
## Description

As a part of consolidating online assets under tigera.io domain, from
now on we host projectcalico docs at projectcalico.docs.tigera.io. This
commit adds 301 redirect for all the content for docs.projectcalico.org
site except for manifests and helm charts, which will still be accesible
under previous domain.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
