### PR TITLE
Automated cherry pick of #5119: Add missing calico/apiserver to imageset

### DIFF
--- a/calico/maintenance/image-options/imageset.md
+++ b/calico/maintenance/image-options/imageset.md
@@ -85,6 +85,8 @@ metadata:
   name: calico-{{site.data.versions.first.title}}
 spec:
   images:
+  - image: "calico/apiserver"
+    digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   - image: "calico/cni"
     digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   - image: "calico/kube-controllers"
@@ -94,6 +96,8 @@ spec:
   - image: "calico/typha"
     digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   - image: "calico/pod2daemon-flexvol"
+    digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  - image: "calico/windows-upgrade"
     digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   - image: "tigera/operator"
     digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -144,7 +148,7 @@ Copy the following script into a file, make it executable, and run the script. T
 ```
 #!/bin/bash -e
 
-images=(calico/cni calico/kube-controllers calico/node calico/typha calico/pod2daemon-flexvol tigera/key-cert-provisioner tigera/operator)
+images=(calico/apiserver calico/cni calico/kube-controllers calico/node calico/typha calico/pod2daemon-flexvol calico/windows-upgrade tigera/key-cert-provisioner tigera/operator)
 
 OPERATOR_IMAGE={{ operator.registry }}/{{ operator.image }}:{{ operator.version }}
 echo "Pulling $OPERATOR_IMAGE"
@@ -167,12 +171,7 @@ EOF
 for x in "${imagelist[@]}"; do
   for y in ${images[*]}; do
     if [[ $x =~ $y: ]]; then
-      echo "Pulling $x"
-      docker pull $x -q > /dev/null
-      {% raw %}digests=$(docker inspect $x -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'){% endraw %}
-      name=$(echo $x | sed -e 's|docker.io/||' -e 's|:.*$||')
-      imgdigest=$(echo -e $digests | grep $name)
-      digest=$(echo -e $imgdigest | sed -e 's|^.*@||')
+      digest=$(docker run --rm gcr.io/go-containerregistry/crane:v0.7.0 digest ${x})
       echo "Adding digest for $x"
       echo 
       echo "  - image: \"$(echo $x | sed -e 's|^.*/\([^/]*/[^/]*\):.*$|\1|')\"" >> ./imageset.yaml


### PR DESCRIPTION
Cherry pick of #5119 on release-v3.21.

#5119: Add missing calico/apiserver to imageset

Fixes https://github.com/tigera/operator/issues/1655