### PR TITLE
Automated cherry pick of #5136: Removed form from footer navbar

### DIFF
--- a/_includes/open_source_navbar.html
+++ b/_includes/open_source_navbar.html
@@ -190,15 +190,6 @@
 					<ul class="dropdown-menu dropdown-menu-left" aria-labelledby="nav-version-dropdown" style="margin:0"></ul>
 				</li>
 			</ul>
-			<form class="navbar-form visible-xs">
-				<ul class="nav navbar-nav navbar-right">
-					{% for navbar in navbars %}
-						<li {% if this_pages_navbar == navbar %} class="active"{% endif %}>
-							<a href="{{site.baseurl}}{{navbar.path}}">{{ navbar.title }}</a>
-						</li>
-					{% endfor %}
-				</ul>
-			</form>
 		</div>
 	</div>
 </nav>


### PR DESCRIPTION
Cherry pick of #5136 on release-v3.21.

#5136: Removed form from footer navbar