### PR TITLE
Fix version errors while uploading helm charts and a release tagging bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CALICO_DIR=$(shell git rev-parse --show-toplevel)
 GIT_HASH=$(shell git rev-parse --short=9 HEAD)
+GIT_UPSTREAM=$(shell git remote -v | grep projectcalico.*\(push\) | awk '{print $$1}')
 VERSIONS_FILE?=$(CALICO_DIR)/_data/versions.yml
 IMAGES_FILE=
 JEKYLL_VERSION=pages
@@ -83,7 +84,7 @@ _includes/charts/%/values.yaml: _plugins/values.rb _plugins/helm.rb _data/versio
 # Note that helm requires strict semantic versioning, so we use v0.0 to represent 'master'.
 ifdef RELEASE_CHART
 # the presence of RELEASE_CHART indicates we're trying to cut an official chart release.
-chartVersion:=$(CALICO_VER)
+chartVersion:=$(CALICO_VER)-$(CHART_RELEASE)
 appVersion:=$(CALICO_VER)
 else
 # otherwise, it's a nightly build.
@@ -382,7 +383,7 @@ export RELEASE_BODY
 ## Pushes a github release and release artifacts produced by `make release-build`.
 release-publish: release-prereqs $(UPLOAD_DIR)
 	# Push the git tag.
-	git push origin $(CALICO_VER)
+	git push $(GIT_UPSTREAM) $(CALICO_VER)
 
 	cp $(RELEASE_HELM_CHART) $(RELEASE_DIR).tgz $(RELEASE_WINDOWS_ZIP) $(UPLOAD_DIR)
 
@@ -427,6 +428,9 @@ endif
 release-prereqs: charts
 	@if [ $(CALICO_VER) != $(NODE_VER) ]; then \
 		echo "Expected CALICO_VER $(CALICO_VER) to equal NODE_VER $(NODE_VER)"; \
+		exit 1; \
+	elif [ -z $(GIT_UPSTREAM) ]; then \
+		echo "At least one git remote must reference the projectcalico repo"; \
 		exit 1; fi
 ifeq (, $(shell which ghr))
 	$(error Unable to find `ghr` in PATH, run this: go get -u github.com/tcnksm/ghr)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -329,8 +329,9 @@ This will cause `docs.projectcalico.org` to be updated (after a few minutes). Va
 
 1. Push your branch and open a pull request. Get it reviewed and wait for it to pass CI.
 
-1. Once reviewed and CI is passing, run the following on your local branch in order to build and publish the release
-   at the newly created commit.
+1. Once reviewed and CI is passing, merge your pull request. This will cause the live docs site to be
+   updated (after a few minutes). After your pull request has merged, run the following on the release
+   branch in order to build and publish the release at the newly created commit.
 
    ```
    make release
@@ -341,7 +342,6 @@ This will cause `docs.projectcalico.org` to be updated (after a few minutes). Va
    ```
    make release-publish
    ```
-1. Merge the PR. This will cause the live docs site to be updated (after a few minutes).
 
 # Release notes
 

--- a/getting-started/kubernetes/helm.md
+++ b/getting-started/kubernetes/helm.md
@@ -49,7 +49,7 @@ echo '{installation.kubernetesProvider: EKS}' > values.yaml
 ```
 1. Add any other customizations you require to `values.yaml`.  You might like to refer to the [helm docs](https://helm.sh/docs/) or run 
    ```
-   helm show values projectcalico/tigera-operator --version {{site.data.versions[0].title}}
+   helm show values projectcalico/tigera-operator --version {{site.data.versions[0].title}}-{{site.data.versions[0].chart.version}}
    ``` 
    to see the values that can be customized in the chart.
 
@@ -58,11 +58,11 @@ echo '{installation.kubernetesProvider: EKS}' > values.yaml
 1. Install the Tigera {{site.prodname}} operator and custom resource definitions using the Helm chart:
 
    ```
-   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}}
+   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}}-{{site.data.versions[0].chart.version}}
    ```
    or if you created a `values.yaml` above:
    ```
-   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}} -f values.yaml
+   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}}-{{site.data.versions[0].chart.version}} -f values.yaml
    ```
 
 1. Confirm that all of the pods are running with the following command.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This fixes 2 issues:
1. There was an issue uploading helm charts since our build process expected them to be in the format `v3.20.3-1` but instead they were created in the format `v3.20.3`. These changes make it so that the helm version of the charts are properly reflected in both the helm index and by the scripts when uploading.
2. The `release-publish` target would push the tags against the publisher's `origin` git remote (which was usually a fork of the actual repo) which placed the release tags in the wrong place when publishing the actual release on github. Now the script should detect what the local git remote is for the `projectcalico/calico` repo and push correctly to that repo.

cherry-pick of https://github.com/projectcalico/calico/pull/5140

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
