### PR TITLE
Update helm.md

### DIFF
--- a/calico/getting-started/kubernetes/helm.md
+++ b/calico/getting-started/kubernetes/helm.md
@@ -17,7 +17,7 @@ Helm charts are a way to package up an application for Kubernetes (similar to `a
 
 - Install Helm 3
 - Kubernetes cluster meets these requirements:
-  - Kubernetes is installed *without* a CNI plugin **OR** cluster is running a compatible CNI for {{site.prodname}} to run in policy-only mode 
+  - Kubernetes is installed *without* a CNI plugin **OR** cluster is running a compatible CNI for {{site.prodname}} to run in policy-only mode
   - x86-64, arm64, ppc64le, or s390x processors
   - RedHat Enterprise Linux 7.x+, CentOS 7.x+, Ubuntu 16.04+, or Debian 9.x+
 - `kubeconfig` is configured to work with your cluster (check by running `kubectl get nodes`)
@@ -45,12 +45,12 @@ If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubern
 
 1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api#operator.tigera.io/v1.Provider).  For example:
 ```
-echo '{installation.kubernetesProvider: EKS}' > values.yaml
+echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml
 ```
-1. Add any other customizations you require to `values.yaml`.  You might like to refer to the [helm docs](https://helm.sh/docs/) or run 
+1. Add any other customizations you require to `values.yaml`.  You might like to refer to the [helm docs](https://helm.sh/docs/) or run
    ```
    helm show values projectcalico/tigera-operator --version {{site.data.versions[0].title}}
-   ``` 
+   ```
    to see the values that can be customized in the chart.
 
 #### Install {{site.prodname}}


### PR DESCRIPTION
The chart index no longer includes the chart-version in the version, so the docs are wrong.

```
lance@lwr20:~/scratch$ helm install calico projectcalico/tigera-operator --version v3.21.2-0
Error: INSTALLATION FAILED: failed to download "projectcalico/tigera-operator" at version "v3.21.2-0"

lance@lwr20:~/scratch$ helm install calico projectcalico/tigera-operator --version v3.21.2
W1207 09:47:20.273337  129294 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1207 09:47:20.353424  129294 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME: calico
LAST DEPLOYED: Tue Dec  7 09:47:20 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
