### PR TITLE
windows: replace install-calico-windows.ps1 template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ CHART_RELEASE := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '[0].chart.ve
 # The Calico for Windows installation script. This is generated from the node
 # repo.
 INSTALL_CALICO_WINDOWS_SCRIPT=./scripts/install-calico-windows.ps1
-# This variable controls the branch/tag of node checked out to build the
-# install-calico-windows.ps1 script.
-NODE_BRANCH_FOR_SCRIPT?=$(RELEASE_STREAM)
 
+# This variable controls the branch or tag of node checked out to build the
+# install-calico-windows.ps1 script for a release.
+NODE_VERSION_FOR_SCRIPT?=$(RELEASE_STREAM)
 
 CONTAINERIZED_VALUES?=docker run --rm \
 	  -v $$PWD:/calico \
@@ -421,11 +421,11 @@ release-prereqs: charts
 		exit 1; fi
 	# Ensure that install-calico-windows.ps1 is the same version as the release
 	# version in node.
-	$(MAKE) update-install-calico-windows-script NODE_BRANCH_FOR_SCRIPT=$(NODE_VER)
+	$(MAKE) update-install-calico-windows-script NODE_VERSION_FOR_SCRIPT=$(NODE_VER)
 	@if ! git diff --quiet $(INSTALL_CALICO_WINDOWS_SCRIPT); then \
 		echo "Expected scripts/install-calico-windows.ps1 to equal the version at node@$(NODE_VER)"; \
 		echo "Check output of 'git diff $(INSTALL_CALICO_WINDOWS_SCRIPT)'"; \
-		echo "Run 'make update-install-calico-windows-script NODE_BRANCH_FOR_SCRIPT=$(NODE_VER)' to update the script"; \
+		echo "Run 'make update-install-calico-windows-script NODE_VERSION_FOR_SCRIPT=$(NODE_VER)' to update the script"; \
 		exit 1; fi
 ifeq (, $(shell which ghr))
 	$(error Unable to find `ghr` in PATH, run this: go get -u github.com/tcnksm/ghr)
@@ -633,13 +633,17 @@ build-operator-reference:
 
 .PHONY: update-install-calico-windows-script
 ## Update install-calico-windows.ps1 from the node repo. By default, it builds the script using branch name of this current branch.
-#  To update the script for release, override the NODE_BRANCH_FOR_SCRIPT variable:
 #
-#  make update-install-calico-windows-script NODE_BRANCH_FOR_SCRIPT=vX.Y.Z
+#  To update the script for release:
 #
+#    make update-install-calico-windows-script NODE_VERSION_FOR_SCRIPT=vX.Y.Z
+#
+#  To update the script for a release branch:
+#
+#    make update-install-calico-windows-script NODE_VERSION_FOR_SCRIPT=release-vX.Y
 update-install-calico-windows-script:
 	rm -rf ./bin/install-calico-windows
 	mkdir -p ./bin/install-calico-windows
-	git clone --depth=1 -b $(NODE_BRANCH_FOR_SCRIPT) https://github.com/projectcalico/node ./bin/install-calico-windows/node
+	git clone --depth=1 -b $(NODE_VERSION_FOR_SCRIPT) https://github.com/projectcalico/node ./bin/install-calico-windows/node
 	make -C ./bin/install-calico-windows/node install-calico-windows-script
 	cp ./bin/install-calico-windows/node/dist/install-calico-windows.ps1 $(INSTALL_CALICO_WINDOWS_SCRIPT)

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ CHART_RELEASE := $(shell cat $(VERSIONS_FILE) | $(YAML_CMD) read - '[0].chart.ve
 
 ##############################################################################
 
+# The Calico for Windows installation script. This is generated from the node
+# repo.
+INSTALL_CALICO_WINDOWS_SCRIPT=./scripts/install-calico-windows.ps1
+# This variable controls the branch/tag of node checked out to build the
+# install-calico-windows.ps1 script.
+NODE_BRANCH_FOR_SCRIPT?=$(RELEASE_STREAM)
 
 
 CONTAINERIZED_VALUES?=docker run --rm \
@@ -413,6 +419,14 @@ release-prereqs: charts
 	@if [ $(CALICO_VER) != $(NODE_VER) ]; then \
 		echo "Expected CALICO_VER $(CALICO_VER) to equal NODE_VER $(NODE_VER)"; \
 		exit 1; fi
+	# Ensure that install-calico-windows.ps1 is the same version as the release
+	# version in node.
+	$(MAKE) update-install-calico-windows-script NODE_BRANCH_FOR_SCRIPT=$(NODE_VER)
+	@if ! git diff --quiet $(INSTALL_CALICO_WINDOWS_SCRIPT); then \
+		echo "Expected scripts/install-calico-windows.ps1 to equal the version at node@$(NODE_VER)"; \
+		echo "Check output of 'git diff $(INSTALL_CALICO_WINDOWS_SCRIPT)'"; \
+		echo "Run 'make update-install-calico-windows-script NODE_BRANCH_FOR_SCRIPT=$(NODE_VER)' to update the script"; \
+		exit 1; fi
 ifeq (, $(shell which ghr))
 	$(error Unable to find `ghr` in PATH, run this: go get -u github.com/tcnksm/ghr)
 endif
@@ -616,3 +630,16 @@ build-operator-reference:
 	           go mod download && go build && \
 	           ./gen-crd-api-reference-docs -config /go/src/$(PACKAGE_NAME)/reference/installation/config.json \
 	                   -api-dir github.com/tigera/operator/api -out-file /go/src/$(PACKAGE_NAME)/reference/installation/_api.html'
+
+.PHONY: update-install-calico-windows-script
+## Update install-calico-windows.ps1 from the node repo. By default, it builds the script using branch name of this current branch.
+#  To update the script for release, override the NODE_BRANCH_FOR_SCRIPT variable:
+#
+#  make update-install-calico-windows-script NODE_BRANCH_FOR_SCRIPT=vX.Y.Z
+#
+update-install-calico-windows-script:
+	rm -rf ./bin/install-calico-windows
+	mkdir -p ./bin/install-calico-windows
+	git clone --depth=1 -b $(NODE_BRANCH_FOR_SCRIPT) https://github.com/projectcalico/node ./bin/install-calico-windows/node
+	make -C ./bin/install-calico-windows/node install-calico-windows-script
+	cp ./bin/install-calico-windows/node/dist/install-calico-windows.ps1 $(INSTALL_CALICO_WINDOWS_SCRIPT)

--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -20,8 +20,10 @@
 #>
 
 Param(
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/a0e0bcc9b518/",
-    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-a0e0bcc9b518.zip",
+    # Note: we don't publish a release artifact for the "master" branch. To test
+    # against master, build calico-windows.zip from projectcalico/node.
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/master/",
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-master.zip",
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $DownloadOnly="no",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",

--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -1,7 +1,4 @@
----
-layout: null
----
-# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+# Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,30 +12,16 @@ layout: null
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{%- if site.prodname == "Calico" %}
-{%- assign installName = "Calico for Windows" %}
-{%- assign rootDir = "CalicoWindows" %}
-{%- assign zipFileName = "calico-windows.zip" %}
-{%- else %}
-{%- assign installName = "Tigera Calico for Windows" %}
-{%- assign rootDir = "TigeraCalico" %}
-{%- assign zipFileName = "tigera-calico-windows.zip" %}
-{%- endif %}
-
 <#
 .DESCRIPTION
-    This script installs and starts {{site.prodname}} services on a Windows node.
+    This script installs and starts Calico services on a Windows node.
 
     Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 #>
 
 Param(
-{%- if site.url == "https://docs.projectcalico.org" %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
-{%- else %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
-{%- endif %}
-    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/a0e0bcc9b518/",
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-a0e0bcc9b518.zip",
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $DownloadOnly="no",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",
@@ -153,7 +136,7 @@ function GetBackendType()
     if ($Datastore -EQ "kubernetes") {
         $encap=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}' -n $CalicoNamespace
         if ($encap -EQ "true") {
-            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+            throw "Calico on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
         }
 
         $encap=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}' -n $CalicoNamespace
@@ -299,18 +282,18 @@ function SetAKSCalicoStaticRules {
 
 function StartCalico()
 {
-    Write-Host "`nStart {{installName}}...`n"
+    Write-Host "`nStart Calico for Windows...`n"
 
     pushd
     cd $RootDir
     .\install-calico.ps1
     popd
-    Write-Host "`n{{installName}} Started`n"
+    Write-Host "`nCalico for Windows Started`n"
 }
 
 $BaseDir="c:\k"
-$RootDir="c:\{{rootDir}}"
-$CalicoZip="c:\{{zipFileName}}"
+$RootDir="c:\CalicoWindows"
+$CalicoZip="c:\calico-windows.zip"
 
 # Must load the helper modules before doing anything else.
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -330,14 +313,8 @@ ipmo -force $helperv2
 
 if (!(Test-Path $CalicoZip))
 {
-{%- if site.prodname == "Calico Enterprise" %}
-    throw "Cannot find {{installName}} zip file $CalicoZip."
-{%- else if site.prodname == "Calico" %}
-    Write-Host "$CalicoZip not found, downloading {{installName}} release..."
+    Write-Host "$CalicoZip not found, downloading Calico for Windows release..."
     DownloadFile -Url $ReleaseBaseURL/$ReleaseFile -Destination c:\calico-windows.zip
-{%- else %}
-    throw "Invalid product name - did prodname in _config.yml change?"
-{%- endif %}
 }
 
 $platform=GetPlatformType
@@ -352,7 +329,7 @@ Exit
 }
 
 Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
-Write-Host "Unzip {{installName}} release..."
+Write-Host "Unzip Calico for Windows release..."
 Expand-Archive -Force $CalicoZip c:\
 
 Write-Host "Setup Calico for Windows..."
@@ -438,7 +415,7 @@ if ($platform -EQ "bare-metal") {
 }
 
 if ($DownloadOnly -EQ "yes") {
-    Write-Host "Dowloaded Calico for Windows. Update c:\CalicoWindows\config.ps1 and run c:\CalicoWindows\install-calico.ps1"
+    Write-Host "Downloaded Calico for Windows. Update c:\CalicoWindows\config.ps1 and run c:\CalicoWindows\install-calico.ps1"
     Exit
 }
 


### PR DESCRIPTION
## Description

As of see [node #1366](https://github.com/projectcalico/node/pull/1366), the node repo is now the source for the Calico
for Windows installation script.

This PR:
- Adds make targets to update the install-calico-windows.ps1 script and to check that we have
the release version of the script checked in for release.
- Replaces the install-calico-windows.ps1 template with the latest version of the script from node master.

Here is how I think making changes to `install-calico-windows.ps1` in the branch release-vX.Y will work:
- Merge changes to `install-calico-windows.ps1` in node repo in the branch release-vX.Y
- The changes are tested in a dev release of Calico for release-vX.Y
    - When building an internal dev release of Calico for testing, we generate the `install-calico-windows.ps1` script from the node repo and copy that over to the resulting calico site (just like how we generate and copy over the Calico for Windows installation zip file to the dev docs site today).
    - The changes are not added to the release-vX.Y branch of the calico repo yet (because that would publish that version of the script immediately on our docs site).
- When we cut the next Calico release from release-vX.Y, we install the just released version of the `install-calico-windows.ps1` script from node with the `update-install-calico-windows-script` target.
  - The `release-prereqs` target has a new check to ensure we do this.

Not sure yet how we can keep the this repo's `master` version of `install-calico-windows.ps1` up-to-date. I don't think it's critical since for dev releases from master we follow the same procedure above to test master releases.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
