### PR TITLE
Return rule conversion errors from K8sNetworkPolicyToCalico()

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/conversion.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
@@ -262,12 +263,16 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 	// This order might change in future.
 	order := float64(1000.0)
 
+	errorTracker := cerrors.ErrorPolicyConversion{PolicyName: np.Name}
+
 	// Generate the ingress rules list.
 	var ingressRules []apiv3.Rule
 	for _, r := range np.Spec.Ingress {
 		rules, err := c.k8sRuleToCalico(r.From, r.Ports, np.Namespace, true)
 		if err != nil {
 			log.WithError(err).Warn("dropping k8s rule that couldn't be converted.")
+			// Add rule to conversion error slice
+			errorTracker.BadIngressRule(&r, fmt.Sprintf("k8s rule couldn't be converted: %s", err))
 		} else {
 			ingressRules = append(ingressRules, rules...)
 		}
@@ -279,6 +284,8 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		rules, err := c.k8sRuleToCalico(r.To, r.Ports, np.Namespace, false)
 		if err != nil {
 			log.WithError(err).Warn("dropping k8s rule that couldn't be converted")
+			// Add rule to conversion error slice
+			errorTracker.BadEgressRule(&r, fmt.Sprintf("k8s rule couldn't be converted: %s", err))
 		} else {
 			egressRules = append(egressRules, rules...)
 		}
@@ -332,8 +339,8 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		Types:    types,
 	}
 
-	// Build and return the KVPair.
-	return &model.KVPair{
+	// Build the KVPair.
+	kvp := &model.KVPair{
 		Key: model.ResourceKey{
 			Name:      policyName,
 			Namespace: np.Namespace,
@@ -341,7 +348,10 @@ func (c converter) K8sNetworkPolicyToCalico(np *networkingv1.NetworkPolicy) (*mo
 		},
 		Value:    policy,
 		Revision: np.ResourceVersion,
-	}, nil
+	}
+
+	// Return the KVPair with conversion errors if applicable
+	return kvp, errorTracker.GetError()
 }
 
 // k8sSelectorToCalico takes a namespaced k8s label selector and returns the Calico

--- a/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
@@ -27,6 +27,7 @@ import (
 
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 
 	kapiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -1296,8 +1297,9 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 	It("should drop rules with invalid ports in a k8s NetworkPolicy", func() {
 		port80 := intstr.FromInt(80)
 		portFoo := intstr.FromString("foo")
-		portBad := intstr.FromString("-50:-1")
-		np := networkingv1.NetworkPolicy{
+		portBad1 := intstr.FromString("-50:-1")
+		portBad2 := intstr.FromString("-22:-3")
+		np1 := networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test.policy",
 				Namespace: "default",
@@ -1329,7 +1331,7 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 					{
 						Ports: []networkingv1.NetworkPolicyPort{
 							{Port: &port80},
-							{Port: &portBad},
+							{Port: &portBad1},
 						},
 						From: []networkingv1.NetworkPolicyPeer{
 							{
@@ -1346,17 +1348,50 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 			},
 		}
+		expectedErr1 := cerrors.ErrorPolicyConversion{
+			PolicyName: "test.policy",
+			Rules: []cerrors.ErrorPolicyConversionRule{
+				{
+					EgressRule: nil,
+					IngressRule: &networkingv1.NetworkPolicyIngressRule{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: nil,
+								Port:     &intstr.IntOrString{Type: 0, IntVal: 80, StrVal: ""},
+								EndPort:  nil,
+							},
+							{
+								Protocol: nil,
+								Port:     &intstr.IntOrString{Type: 1, IntVal: 0, StrVal: "-50:-1"},
+								EndPort:  nil,
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels:      map[string]string{"k2": "v2", "k": "v"},
+									MatchExpressions: nil,
+								},
+								NamespaceSelector: nil,
+								IPBlock:           nil,
+							},
+						},
+					},
+					Reason: "k8s rule couldn't be converted: failed to parse k8s port: invalid port -50:-1: invalid name for named port (-50:-1)",
+				},
+			},
+		}
 
 		// Parse the policy.
-		pol, err := c.K8sNetworkPolicyToCalico(&np)
-		Expect(err).NotTo(HaveOccurred())
+		pol1, err := c.K8sNetworkPolicyToCalico(&np1)
+		Expect(err).To(Equal(expectedErr1))
 
 		protoTCP := numorstring.ProtocolFromString("TCP")
 
 		// Only the two valid ports should exist. The third should have been dropped.
-		Expect(len(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
+		Expect(len(pol1.Value.(*apiv3.NetworkPolicy).Spec.Ingress)).To(Equal(1))
 
-		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Ingress).To(ConsistOf(
+		Expect(pol1.Value.(*apiv3.NetworkPolicy).Spec.Ingress).To(ConsistOf(
 			apiv3.Rule{
 				Action:   "Allow",
 				Protocol: &protoTCP, // Defaulted to TCP.
@@ -1365,6 +1400,151 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 				},
 				Destination: apiv3.EntityRule{
 					Ports: []numorstring.Port{numorstring.SinglePort(80), numorstring.NamedPort("foo")},
+				},
+			},
+		))
+		np2 := networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test.policy",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"label":  "value",
+						"label2": "value2",
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Port: &port80},
+							{Port: &portFoo},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k":  "v",
+										"k2": "v2",
+									},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Port: &port80},
+							{Port: &portBad1},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k":  "v",
+										"k2": "v2",
+									},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Port: &port80},
+							{Port: &portBad2},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"k":  "v",
+										"k2": "v2",
+									},
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			},
+		}
+		expectedErr2 := cerrors.ErrorPolicyConversion{
+			PolicyName: "test.policy",
+			Rules: []cerrors.ErrorPolicyConversionRule{
+				{
+					IngressRule: nil,
+					EgressRule: &networkingv1.NetworkPolicyEgressRule{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: nil,
+								Port:     &intstr.IntOrString{Type: 0, IntVal: 80, StrVal: ""},
+								EndPort:  nil,
+							},
+							{
+								Protocol: nil,
+								Port:     &intstr.IntOrString{Type: 1, IntVal: 0, StrVal: "-50:-1"},
+								EndPort:  nil,
+							},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels:      map[string]string{"k2": "v2", "k": "v"},
+									MatchExpressions: nil,
+								},
+								NamespaceSelector: nil,
+								IPBlock:           nil,
+							},
+						},
+					},
+					Reason: "k8s rule couldn't be converted: failed to parse k8s port: invalid port -50:-1: invalid name for named port (-50:-1)",
+				},
+				{
+					IngressRule: nil,
+					EgressRule: &networkingv1.NetworkPolicyEgressRule{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: nil,
+								Port:     &intstr.IntOrString{Type: 0, IntVal: 80, StrVal: ""},
+								EndPort:  nil,
+							},
+							{
+								Protocol: nil,
+								Port:     &intstr.IntOrString{Type: 1, IntVal: 0, StrVal: "-22:-3"},
+								EndPort:  nil,
+							},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels:      map[string]string{"k2": "v2", "k": "v"},
+									MatchExpressions: nil,
+								},
+								NamespaceSelector: nil,
+								IPBlock:           nil,
+							},
+						},
+					},
+					Reason: "k8s rule couldn't be converted: failed to parse k8s port: invalid port -22:-3: invalid name for named port (-22:-3)",
+				},
+			},
+		}
+
+		// Parse the policy.
+		pol2, err := c.K8sNetworkPolicyToCalico(&np2)
+		Expect(err).To(Equal(expectedErr2))
+
+		// Only the two valid ports should exist. The invalid ones should have been dropped.
+		Expect(len(pol2.Value.(*apiv3.NetworkPolicy).Spec.Egress)).To(Equal(1))
+
+		Expect(pol2.Value.(*apiv3.NetworkPolicy).Spec.Egress).To(ConsistOf(
+			apiv3.Rule{
+				Action:   "Allow",
+				Protocol: &protoTCP, // Defaulted to TCP.
+				Source:   apiv3.EntityRule{},
+				Destination: apiv3.EntityRule{
+					Ports:    []numorstring.Port{numorstring.SinglePort(80), numorstring.NamedPort("foo")},
+					Selector: "projectcalico.org/orchestrator == 'k8s' && k == 'v' && k2 == 'v2'",
 				},
 			},
 		))

--- a/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubenetworkpolicy.go
@@ -100,7 +100,11 @@ func (c *networkPolicyClient) List(ctx context.Context, list model.ListInterface
 	convertFunc := func(r Resource) ([]*model.KVPair, error) {
 		p := r.(*networkingv1.NetworkPolicy)
 		kvp, err := c.K8sNetworkPolicyToCalico(p)
-		if err != nil {
+		// Silently ignore rule conversion errors. We don't expect any conversion errors
+		// since the data given to us here is validated by the Kubernetes API. The conversion
+		// code ignores any rules that it cannot parse, and we will pass the valid ones to Felix.
+		var e *cerrors.ErrorPolicyConversion
+		if err != nil && !errors.As(err, &e) {
 			return nil, err
 		}
 		return []*model.KVPair{kvp}, nil


### PR DESCRIPTION
Add ErrorPolicyConversion which contains a slice of ErrorPolicyConversionRules,
so that K8sNetworkPolicyToCalico() in libcalico-go/lib/backend/k8s/conversion/conversion.go
returns all rules that it could not convert (this will be used to implement a policy
conversion tool in calicoctl).

Make current uses of K8sNetworkPolicyToCalico() ignore the error if it is
ErrorPolicyConversion (as they were currently functioning without having these returned anyway).