### PR TITLE
Dikastes: use gRPC graceful shutdown to exit cleanly after getting signal

### DIFF
--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -130,6 +130,7 @@ func runServer(arguments map[string]interface{}) {
 
 	// Block until a signal is received.
 	log.Infof("Got signal: %v", <-c)
+	gs.GracefulStop()
 }
 
 func runClient(arguments map[string]interface{}) {


### PR DESCRIPTION
I've come across an issue when using Dikastes sidecar in a kubernetes job.

I needed to manually send `SIGTERM` to the process otherwise my pod would never be marked as `Completed` (all containers inside the pod need to be terminated). This worked but dikastes usually returned non-zero exit code due to the gRPC server terminating abruptly. Calling the `GracefulStop` library function fixed it for me and I believe it is a good practice to use it anyway.