### PR TITLE
Introducing bindMode in BGPConfiguration

### DIFF
--- a/api/pkg/apis/projectcalico/v3/bgpconfig.go
+++ b/api/pkg/apis/projectcalico/v3/bgpconfig.go
@@ -25,6 +25,13 @@ const (
 	KindBGPConfigurationList = "BGPConfigurationList"
 )
 
+type BindMode string
+
+const (
+	BindModeNone   BindMode = "None"
+	BindModeNodeIP BindMode = "NodeIP"
+)
+
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -91,6 +98,12 @@ type BGPConfigurationSpec struct {
 	// This field can only be set on the default BGPConfiguration instance and requires that NodeMesh is enabled
 	// +optional
 	NodeMeshMaxRestartTime *metav1.Duration `json:"nodeMeshMaxRestartTime,omitempty" confignamev1:"node_mesh_restart_time"`
+
+	// BindMode indicates whether to listen for BGP connections on all addresses (None)
+	// or only on the node's canonical IP address Node.Spec.BGP.IPvXAddress (NodeIP).
+	// Default behaviour is to listen for BGP connections on all addresses.
+	// +optional
+	BindMode *BindMode `json:"bindMode,omitempty"`
 }
 
 // ServiceLoadBalancerIPBlock represents a single allowed LoadBalancer IP CIDR block.

--- a/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -140,6 +140,11 @@ func (in *BGPConfigurationSpec) DeepCopyInto(out *BGPConfigurationSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.BindMode != nil {
+		in, out := &in.BindMode, &out.BindMode
+		*out = new(BindMode)
+		**out = **in
+	}
 	return
 }
 

--- a/api/pkg/openapi/openapi_generated.go
+++ b/api/pkg/openapi/openapi_generated.go
@@ -613,6 +613,13 @@ func schema_pkg_apis_projectcalico_v3_BGPConfigurationSpec(ref common.ReferenceC
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"bindMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "BindMode indicates whether to listen for BGP connections on all addresses (None) or only on the node's canonical IP address Node.Spec.BGP.IPvXAddress (NodeIP). Default behaviour is to listen for BGP connections on all addresses.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/calico/reference/resources/bgpconfig.md
+++ b/calico/reference/resources/bgpconfig.md
@@ -24,6 +24,7 @@ spec:
   - cidr: 104.244.42.129/32
   - cidr: 172.217.3.0/24
   listenPort: 178
+  bindMode: NodeIP
   communities:
   - name: bgp-large-community
     value: 63400:300:100
@@ -56,6 +57,7 @@ spec:
 | serviceExternalIPs | The CIDR blocks for Kubernetes Service External IPs to be advertised over BGP. Kubernetes Service External IPs will only be advertised if they are within one of these blocks. Only valid on the global `default` BGPConfiguration: will be ignored otherwise. | A list of valid IPv4 or IPv6 CIDR blocks. | List of `cidr: <ip>/<prefix length>` values. | Empty List |
 | serviceLoadBalancerIPs | The CIDR blocks for Kubernetes Service status.LoadBalancer IPs to be advertised over BGP. Kubernetes LoadBalancer IPs will only be advertised if they are within one of these blocks. Only valid on the global `default` BGPConfiguration: will be ignored otherwise. | A list of valid IPv4 or IPv6 CIDR blocks. | List of `cidr: <ip>/<prefix length>` values. | Empty List |
 | listenPort | The port where BGP protocol should listen.| A valid port number. | integer | 179 |
+| bindMode | Indicates whether to listen for BGP connections on all addresses (None) or only on the node's canonical IP address Node.Spec.BGP.IPvXAddress (NodeIP). If this field is changed when calico-node is already running, the change will not take effect until calico-node is manually restarted.| None, NodeIP. | string | None |
 | communities | List of BGP community names and their values, communities are not advertised unless they are used in [prefixAdvertisements](#prefixadvertisements). || List of [communities](#communities) |
 | prefixAdvertisements | List of per-prefix advertisement properties, like BGP communities.|| List of [prefixAdvertisements](#prefixadvertisements) |
 | nodeMeshPassword   | BGP password for the all the peerings in a full mesh configuration. |  | [BGPPassword](bgppeer#bgppassword) | `nil` (no password) |

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -42,13 +42,30 @@ router id {{if eq "hash" ($router_id) -}}
 	{{if ne "" ($router_id)}}{{$router_id}}{{else}}{{$node_ip}}{{end}};
 {{- end}}
 
+{{- $listen_address := ""}}
+{{- $bind_mode := ""}}
+{{- $host_bind_mode_key := printf "/host/%s/bind_mode" (getenv "NODENAME")}}
+{{- if exists $host_bind_mode_key }}
+{{- $bind_mode = getv $host_bind_mode_key}}
+{{- else if exists "/global/bind_mode" }}
+{{- $bind_mode = getv "/global/bind_mode"}}
+{{- end}}
+{{- if and (eq $bind_mode "NodeIP") (ne $node_ip "")}}
+{{- $listen_address = print " address " $node_ip}}
+{{- end}}
+
+{{- $listen_port := ""}}
 {{- $node_listen_port_key := printf "/host/%s/listen_port" (getenv "NODENAME")}}
 {{- if exists $node_listen_port_key}}
 # Set node listen_port
-listen bgp port {{getv $node_listen_port_key}};
+{{- $listen_port = print " port " (getv $node_listen_port_key)}}
 {{- else if exists "/global/listen_port" }}
 # Set global listen_port
-listen bgp port {{getv "/global/listen_port"}};
+{{- $listen_port = print " port " (getv "/global/listen_port")}}
+{{- end}}
+
+{{- if or (ne $listen_address "") (ne $listen_port "")}}
+listen bgp{{$listen_address}}{{$listen_port}};
 {{- end}}
 
 {{- define "LOGGING"}}

--- a/confd/etc/calico/confd/templates/bird6.cfg.template
+++ b/confd/etc/calico/confd/templates/bird6.cfg.template
@@ -43,13 +43,30 @@ router id {{if eq "hash" ($router_id) -}}
 	{{if ne "" ($router_id)}}{{$router_id}}{{else}}{{$node_ip}}{{end}};  # Use IPv4 address since router id is 4 octets, even in MP-BGP
 {{- end}}
 
+{{- $listen_address := ""}}
+{{- $bind_mode := ""}}
+{{- $host_bind_mode_key := printf "/host/%s/bind_mode" (getenv "NODENAME")}}
+{{- if exists $host_bind_mode_key }}
+{{- $bind_mode = getv $host_bind_mode_key}}
+{{- else if exists "/global/bind_mode" }}
+{{- $bind_mode = getv "/global/bind_mode"}}
+{{- end}}
+{{- if and (eq $bind_mode "NodeIP") (ne $node_ip6 "")}}
+{{- $listen_address = print " address " $node_ip6}}
+{{- end}}
+
+{{- $listen_port := ""}}
 {{- $node_listen_port_key := printf "/host/%s/listen_port" (getenv "NODENAME")}}
 {{- if exists $node_listen_port_key}}
 # Set node listen_port
-listen bgp port {{getv $node_listen_port_key}};
+{{- $listen_port = print " port " (getv $node_listen_port_key)}}
 {{- else if exists "/global/listen_port" }}
 # Set global listen_port
-listen bgp port {{getv "/global/listen_port"}};
+{{- $listen_port = print " port " (getv "/global/listen_port")}}
+{{- end}}
+
+{{- if or (ne $listen_address "") (ne $listen_port "")}}
+listen bgp{{$listen_address}}{{$listen_port}};
 {{- end}}
 
 {{- define "LOGGING"}}

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1016,6 +1016,7 @@ func (c *client) updateBGPConfigCache(resName string, v3res *apiv3.BGPConfigurat
 	if resName == globalConfigName {
 		c.getPrefixAdvertisementsKVPair(v3res, model.GlobalBGPConfigKey{})
 		c.getListenPortKVPair(v3res, model.GlobalBGPConfigKey{}, updatePeersV1, updateReasons)
+		c.getBindModeKVPair(v3res, model.GlobalBGPConfigKey{}, updatePeersV1, updateReasons)
 		c.getASNumberKVPair(v3res, model.GlobalBGPConfigKey{}, updatePeersV1, updateReasons)
 		c.getServiceExternalIPsKVPair(v3res, model.GlobalBGPConfigKey{}, svcAdvertisement)
 		c.getServiceClusterIPsKVPair(v3res, model.GlobalBGPConfigKey{}, svcAdvertisement)
@@ -1144,6 +1145,18 @@ func (c *client) getListenPortKVPair(v3res *apiv3.BGPConfiguration, key interfac
 		}
 		*updateReasons = append(*updateReasons, "listenPort deleted.")
 		c.updateCache(api.UpdateTypeKVDeleted, getKVPair(listenPortKey))
+	}
+	*updatePeersV1 = true
+}
+
+func (c *client) getBindModeKVPair(v3res *apiv3.BGPConfiguration, key interface{}, updatePeersV1 *bool, updateReasons *[]string) {
+	bindMode := getBGPConfigKey("bind_mode", key)
+	if v3res != nil && v3res.Spec.BindMode != nil {
+		*updateReasons = append(*updateReasons, "bindMode updated.")
+		c.updateCache(api.UpdateTypeKVUpdated, getKVPair(bindMode, string(*v3res.Spec.BindMode)))
+	} else {
+		*updateReasons = append(*updateReasons, "bindMode deleted.")
+		c.updateCache(api.UpdateTypeKVDeleted, getKVPair(bindMode))
 	}
 	*updatePeersV1 = true
 }

--- a/confd/tests/compiled_templates/explicit_peering/global/bird.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global/bird.cfg
@@ -8,7 +8,7 @@ include "bird_ipam.cfg";
 
 router id 10.192.0.2;
 # Set global listen_port
-listen bgp port 150;
+listen bgp address 10.192.0.2 port 150;
 
 # Configure synchronization between routing tables and kernel.
 protocol kernel {

--- a/confd/tests/mock_data/calicoctl/explicit_peering/global/input.yaml
+++ b/confd/tests/mock_data/calicoctl/explicit_peering/global/input.yaml
@@ -7,6 +7,7 @@ spec:
   logSeverityScreen: Debug
   asNumber: 64567
   listenPort: 150
+  bindMode: NodeIP
 
 ---
 

--- a/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_bgpconfigurations.yaml
@@ -36,6 +36,12 @@ spec:
                   64512]'
                 format: int32
                 type: integer
+              bindMode:
+                description: BindMode indicates whether to listen for BGP connections
+                  on all addresses (None) or only on the node's canonical IP address
+                  Node.Spec.BGP.IPvXAddress (NodeIP). Default behaviour is to listen
+                  for BGP connections on all addresses.
+                type: string
               communities:
                 description: Communities is a list of BGP community values and their
                   arbitrary names for tagging routes.


### PR DESCRIPTION
## Description

Introducing new config parameter `bindMode` in `BGPConfiguration` to let user choose whether to use 0.0.0.0 as bind address or calico's Node.Spec.BGP.IPvXAddress.

## Related issues

https://github.com/projectcalico/calico/issues/4974

```release-note
Allow configuration of bind mode via the BGPConfiguration API
```