### PR TITLE
WireGuard Startup Bootstrapping (fix hostencryption deadlocking)

### DIFF
--- a/felix/daemon/bootstrap_linux.go
+++ b/felix/daemon/bootstrap_linux.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"github.com/projectcalico/calico/felix/config"
+	"github.com/projectcalico/calico/felix/netlinkshim"
+	"github.com/projectcalico/calico/felix/wireguard"
+	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func bootstrapWireguard(configParams *config.Config, v3Client clientv3.Interface) error {
+	log.Debug("bootstrapping wireguard host connectivity")
+	return wireguard.BootstrapHostConnectivity(
+		configParams,
+		netlinkshim.NewRealWireguard,
+		v3Client,
+	)
+}

--- a/felix/daemon/bootstrap_windows.go
+++ b/felix/daemon/bootstrap_windows.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package daemon
+
+import (
+	"github.com/projectcalico/calico/felix/config"
+	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+)
+
+func bootstrapWireguard(_ *config.Config, _ clientv3.Interface) error {
+	return nil
+} // no-op

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -57,7 +57,6 @@ import (
 	"github.com/projectcalico/calico/felix/buildinfo"
 	"github.com/projectcalico/calico/felix/calc"
 	"github.com/projectcalico/calico/felix/config"
-	_ "github.com/projectcalico/calico/felix/config"
 	dp "github.com/projectcalico/calico/felix/dataplane"
 	"github.com/projectcalico/calico/felix/jitter"
 	"github.com/projectcalico/calico/felix/logutils"
@@ -367,6 +366,15 @@ configRetry:
 	if configParams.DebugSimulateDataRace {
 		log.Warn("DebugSimulateDataRace is set, will start some racing goroutines!")
 		simulateDataRace()
+	}
+
+	// We may need to temporarily disable encrypted traffic to this node in order to connect to Typha
+	if configParams.WireguardEnabled {
+		err := bootstrapWireguard(configParams, v3Client)
+		if err != nil {
+			time.Sleep(2 * time.Second) // avoid a tight restart loop
+			log.WithError(err).Fatal("Couldn't bootstrap WireGuard host connectivity")
+		}
 	}
 
 	// Start up the dataplane driver.  This may be the internal go-based driver or an external

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -28,12 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"github.com/onsi/gomega/types"
 	log "github.com/sirupsen/logrus"
-
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
@@ -79,6 +75,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 		dmesgCmd     *exec.Cmd
 		dmesgBuf     bytes.Buffer
 		dmesgKill    func()
+
+		wgBootstrapEvents chan struct{}
 	)
 
 	BeforeEach(func() {
@@ -101,7 +99,13 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 		log.Info("Started dmesg log capture")
 
 		infra = getInfra()
-		topologyOptions := wireguardTopologyOptions("CalicoIPAM", true)
+		topologyOptions := wireguardTopologyOptions(
+			"CalicoIPAM", true,
+			map[string]string{
+				"FELIX_DebugDisableLogDropping":        "true",
+				"FELIX_WireguardHostEncryptionEnabled": "true",
+			},
+		)
 		felixes, client = infrastructure.StartNNodeTopology(nodeCount, topologyOptions, infra)
 
 		// To allow all ingress and egress, in absence of any Policy.
@@ -119,6 +123,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 			// Prepare route entry.
 			routeEntries[i] = fmt.Sprintf("10.65.%d.0/26 dev %s scope link", i, wireguardInterfaceNameDefault)
 
+			wgBootstrapEvents = felixes[i].WatchStdoutFor(
+				regexp.MustCompile(".*Cleared WireGuard public key from datastore.+"),
+			)
 			felixes[i].TriggerDelayedStart()
 		}
 		// Swap route entry to match between workloads.
@@ -178,6 +185,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 					return fmt.Errorf("felix %d has no Wireguard device", i)
 				}, "10s", "100ms").ShouldNot(HaveOccurred())
 			}
+		})
+
+		It("should have called bootstrap", func() {
+			Eventually(wgBootstrapEvents, "5s", "100ms").Should(BeClosed())
 		})
 
 		It("the Wireguard routing rule should exist", func() {
@@ -993,7 +1004,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 		}
 
 		// initialise host-networked pods
-		for i, _ := range hostNetworkedWls {
+		for i := range hostNetworkedWls {
 			hostNetworkedWls[i] = createHostNetworkedWorkload(fmt.Sprintf("wl-f%d-hn-0", i), felixes[i])
 		}
 
@@ -1039,9 +1050,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 
 		// Ping other felix nodes from each node to trigger Wireguard handshakes.
 		for i, felix := range felixes {
-			for j, _ := range felixes {
+			for j := range felixes {
 				if i != j {
-					felix.ExecMayFail("ping", "-c", "1", "-W", "1", "-s", "1", felixes[j].IP)
+					if err := felix.ExecMayFail("ping", "-c", "1", "-W", "1", "-s", "1", felixes[j].IP); err != nil {
+						log.WithError(err).Warning("felix.ExecMayFail returned err")
+					}
 				}
 			}
 		}
@@ -1049,7 +1062,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 		// Check felix nodes have performed Wireguard handshakes.
 		for i, felix := range felixes {
 			var matchers []types.GomegaMatcher
-			for j, _ := range felixes {
+			for j := range felixes {
 				if i != j {
 					matchers = append(matchers, BeNumerically(">", 0))
 				}
@@ -1130,7 +1143,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 		}
 
 		By("Checking the routing table entries exist")
-		for i, _ := range wlsByHost {
+		for i := range wlsByHost {
 			var matchers []types.GomegaMatcher
 			for j, wls := range wlsByHost {
 				if i != j {
@@ -1166,7 +1179,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 		}
 
 		By("Checking wireguard allowed ips")
-		for i, _ := range wlsByHost {
+		for i := range wlsByHost {
 			var matchers []types.GomegaMatcher
 			for j, wls := range wlsByHost {
 				if i != j {
@@ -1213,15 +1226,15 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 		}
 
 		By("checking different node pod-to-pod connectivity")
-		for i, _ := range wlsByHost {
-			for j, _ := range wlsByHost {
+		for i := range wlsByHost {
+			for j := range wlsByHost {
 				cc.ExpectSome(wlsByHost[i][0], wlsByHost[j][0])
 			}
 		}
 
 		By("checking host-networked pod to regular pod connectivity")
 		for _, wl := range hostNetworkedWls {
-			for j, _ := range wlsByHost {
+			for j := range wlsByHost {
 				cc.ExpectSome(wl, wlsByHost[j][0])
 			}
 		}
@@ -1250,7 +1263,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 
 // Setup cluster topology options.
 // mainly, enable Wireguard with delayed start option.
-func wireguardTopologyOptions(routeSource string, ipipEnabled bool) infrastructure.TopologyOptions {
+func wireguardTopologyOptions(routeSource string, ipipEnabled bool, extraEnvs ...map[string]string) infrastructure.TopologyOptions {
 	topologyOptions := infrastructure.DefaultTopologyOptions()
 
 	// Waiting for calico-node to be ready.
@@ -1272,6 +1285,12 @@ func wireguardTopologyOptions(routeSource string, ipipEnabled bool) infrastructu
 	// With Wireguard and BPF mode the default IptablesMarkMask of 0xffff0000 isn't enough.
 	topologyOptions.ExtraEnvVars["FELIX_IPTABLESMARKMASK"] = "4294934528" // 0xffff8000
 
+	for _, envs := range extraEnvs {
+		for k, v := range envs {
+			topologyOptions.ExtraEnvVars[k] = v
+		}
+	}
+
 	// Enable Wireguard.
 	felixConfig := api.NewFelixConfiguration()
 	felixConfig.SetName("default")
@@ -1281,7 +1300,7 @@ func wireguardTopologyOptions(routeSource string, ipipEnabled bool) infrastructu
 
 	// Debugging.
 	//topologyOptions.ExtraEnvVars["FELIX_DebugUseShortPollIntervals"] = "true"
-	//topologyOptions.FelixLogSeverity = "debug"
+	topologyOptions.FelixLogSeverity = "debug"
 
 	return topologyOptions
 }
@@ -1365,38 +1384,4 @@ func createWorkloadWithAssignedIP(
 
 func createHostNetworkedWorkload(wlName string, felix *infrastructure.Felix) *workload.Workload {
 	return workload.RunWithMTU(felix, wlName, "default", felix.IP, defaultWorkloadPort, "tcp", wireguardMTUDefault)
-}
-
-func k8sServiceWireguard(name, clusterIP string, w *workload.Workload, port,
-	tgtPort int, nodePort int32, protocol string) *v1.Service {
-	k8sProto := v1.ProtocolTCP
-	if protocol == "udp" {
-		k8sProto = v1.ProtocolUDP
-	}
-
-	svcType := v1.ServiceTypeClusterIP
-	if nodePort != 0 {
-		svcType = v1.ServiceTypeNodePort
-	}
-
-	return &v1.Service{
-		TypeMeta:   typeMetaV1("Service"),
-		ObjectMeta: objectMetaV1(name),
-		Spec: v1.ServiceSpec{
-			ClusterIP: clusterIP,
-			Type:      svcType,
-			Selector: map[string]string{
-				"name": w.Name,
-			},
-			Ports: []v1.ServicePort{
-				{
-					Protocol:   k8sProto,
-					Port:       int32(port),
-					NodePort:   nodePort,
-					Name:       fmt.Sprintf("port-%d", tgtPort),
-					TargetPort: intstr.FromInt(tgtPort),
-				},
-			},
-		},
-	}
 }

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -102,8 +102,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 		topologyOptions := wireguardTopologyOptions(
 			"CalicoIPAM", true,
 			map[string]string{
-				"FELIX_DebugDisableLogDropping":        "true",
-				"FELIX_WireguardHostEncryptionEnabled": "true",
+				"FELIX_DebugDisableLogDropping": "true",
+				"FELIX_DBG_WGBOOTSTRAP":         "true",
 			},
 		)
 		felixes, client = infrastructure.StartNNodeTopology(nodeCount, topologyOptions, infra)

--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -17,6 +17,7 @@ package wireguard
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -38,7 +39,9 @@ func BootstrapHostConnectivity(configParams *config.Config, getWireguardHandle f
 	wgDeviceName := configParams.WireguardInterfaceName
 	nodeName := configParams.FelixHostname
 
-	if !configParams.WireguardHostEncryptionEnabled {
+	_, dbgBootstrap := os.LookupEnv("FELIX_DBG_WGBOOTSTRAP")
+
+	if !configParams.WireguardHostEncryptionEnabled && !dbgBootstrap {
 		return nil
 	}
 

--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wireguard
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/projectcalico/calico/felix/config"
+	"github.com/projectcalico/calico/felix/netlinkshim"
+	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+// BootstrapHostConnectivity forces WireGuard peers with hostencryption enabled to communicate with this node unencrypted.
+// This ensures connectivity in scenarios where we have lost our WireGuard config, but will be sent WireGuard traffic
+// e.g. after a node restart, during felix startup, when we need to fetch config from Typha (calico/issues/5125)
+func BootstrapHostConnectivity(configParams *config.Config, getWireguardHandle func() (netlinkshim.Wireguard, error), calicoClient clientv3.Interface) error {
+	wgDeviceName := configParams.WireguardInterfaceName
+	nodeName := configParams.FelixHostname
+
+	if !configParams.WireguardHostEncryptionEnabled {
+		return nil
+	}
+
+	logCtx := log.WithFields(log.Fields{
+		"iface":    wgDeviceName,
+		"hostName": nodeName,
+		"ref":      "wgBootstrap",
+	})
+
+	logCtx.Debug("Bootstrapping wireguard")
+
+	var storedPublicKey string
+	var kernelPublicKey string
+	const (
+		backoffDuration  = 2 * time.Second
+		backoffExpFactor = 2
+		backoffMax       = 32 * time.Second
+		jitter           = 0.2
+	)
+	maxRetries := 3
+	expBackoffMgr := wait.NewExponentialBackoffManager(
+		backoffDuration, backoffMax, time.Minute, backoffExpFactor, jitter, clock.RealClock{})
+	defer expBackoffMgr.Backoff().Stop()
+
+	wg, err := getWireguardHandle()
+	if err != nil {
+		logCtx.Info("Couldn't acquire WireGuard handle, treating public key as unset")
+	} else {
+		kernelPublicKey = getPublicKey(logCtx, wgDeviceName, wg).String()
+		defer wg.Close()
+	}
+
+	// make a few attempts to read our publickey from the datastore, compare, and update if required
+	for r := 0; r < maxRetries; r++ {
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		thisNode, err := calicoClient.Nodes().Get(ctx, nodeName, options.GetOptions{})
+		cancel()
+		if err != nil {
+			logCtx.WithError(err).Warn("Couldn't fetch node config from datastore, retrying")
+			<-expBackoffMgr.Backoff().C() // safe to block here as we're not dependent on other threads
+			continue
+		}
+
+		// if there is any config mismatch, wipe the datastore's publickey (forces peers to send unencrypted traffic)
+		storedPublicKey = thisNode.Status.WireguardPublicKey
+		if storedPublicKey != kernelPublicKey {
+			logCtx.Info("Found mismatch between kernel and datastore WireGuard keys. Clearing stale key from datastore")
+			thisNode.Status.WireguardPublicKey = ""
+			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+			_, err := calicoClient.Nodes().Update(ctx, thisNode, options.SetOptions{})
+			cancel()
+			if err != nil {
+				switch err.(type) {
+				case cerrors.ErrorResourceUpdateConflict:
+					logCtx.Infof("Conflict while clearing WireGuard config, retrying update (%v)", err)
+
+				default:
+					logCtx.Errorf("Failed to clear WireGuard config: %v", err)
+				}
+				<-expBackoffMgr.Backoff().C()
+				continue
+			}
+			logCtx.Info("Cleared WireGuard public key from datastore")
+		}
+		return nil
+	}
+
+	return fmt.Errorf("couldn't bootstrap host connecivity after %d retries", maxRetries)
+}
+
+// getPublicKey attempts to fetch a wireguard key from the kernel statelessly
+// this is intended for use during startup; an error may simply mean wireguard is not configured
+func getPublicKey(log *log.Entry, wgIfaceName string, wg netlinkshim.Wireguard) wgtypes.Key {
+	dev, err := wg.DeviceByName(wgIfaceName)
+	if err != nil {
+		log.WithError(err).Debugf("Couldn't find WireGuard device '%s', reporting unset key", wgIfaceName)
+		return zeroKey
+	}
+
+	return dev.PublicKey
+}


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Currently on AKS/EKS (or any host-encryption-enabled cluster) with Typha, restarting a node which doesnt have a Typha pod will lead to its `calico-node` hanging in an unready state indefinitely.
This happens because the restart clears all wireguard config from the host, and new WireGuard config cannot be shared due to remote Typha instances expecting WireGuard traffic.

This PR attempts to fix this by clearing any stale wireguard config from the datastore directly, before Felix is connected to Typha. Connecting directly to the datastore will not deadlock as controlplane traffic is assumed to never be encrypted.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
fixes https://github.com/projectcalico/calico/issues/5125


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
