### PR TITLE
Added Calico printer for CalicoNodeStatus to apiserver

### DIFF
--- a/apiserver/pkg/printers/projectcalico/printers.go
+++ b/apiserver/pkg/printers/projectcalico/printers.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectcalico
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/kubernetes/pkg/printers"
+
+	calico "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+)
+
+// AddHandlers adds print handlers for projectcalico types.
+func AddHandlers(h printers.PrintHandler) {
+	calicoNodeStatusColumnDefinitions := []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+		{Name: "Node", Type: "string", Priority: 0, Description: "The node name identifies the Calico node instance for node status."},
+		{Name: "Classes", Type: "string", Description: "Types of information to monitor for this calico/node."},
+		{Name: "Update Interval", Type: "string", Description: "Period in seconds at which CalicoNodeStatus should be updated."},
+		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
+		{Name: "last Updated", Type: "string", Description: "Last time the status has been updated"},
+		{Name: "Agent State", Type: "string", Priority: 1, Description: "The state of the BGP Daemon."},
+		{Name: "BGP Peers", Type: "string", Priority: 1, Description: "Number of BGP Peers in the format of total/established/non-established."},
+		{Name: "BGP Routes", Type: "string", Priority: 1, Description: "Number of routes learned from BGP peers."},
+	}
+	h.TableHandler(calicoNodeStatusColumnDefinitions, printCalicoNodeStatusList)
+	h.TableHandler(calicoNodeStatusColumnDefinitions, printCalicoNodeStatus)
+}
+
+func printCalicoNodeStatusList(statusList *calico.CalicoNodeStatusList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	rows := make([]metav1.TableRow, 0, len(statusList.Items))
+	for i := range statusList.Items {
+		r, err := printCalicoNodeStatus(&statusList.Items[i], options)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+
+func printCalicoNodeStatus(status *calico.CalicoNodeStatus, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+	row := metav1.TableRow{
+		Object: runtime.RawExtension{Object: status},
+	}
+
+	// Define a function return true if the status contains information about a class.
+	hasClass := func(c calico.NodeStatusClassType) bool {
+		for _, class := range status.Spec.Classes {
+			if class == c {
+				return true
+			}
+		}
+		return false
+	}
+
+	var classes string
+	for _, class := range status.Spec.Classes {
+		classes += fmt.Sprintf("%s,", class)
+	}
+	classesStr := fmt.Sprintf("[%s]", strings.TrimSuffix(classes, ","))
+
+	var lastUpdatedStr string
+	lastUpdatedDate := status.Status.LastUpdated
+	if !lastUpdatedDate.IsZero() {
+		lastUpdatedStr = fmt.Sprintf("%s ago", translateTimestampSince(lastUpdatedDate))
+	}
+
+	row.Cells = append(row.Cells,
+		status.Name,
+		status.Spec.Node,
+		classesStr,
+		fmt.Sprintf("%ds", *status.Spec.UpdatePeriodSeconds),
+		translateTimestampSince(status.CreationTimestamp),
+		lastUpdatedStr)
+
+	if options.Wide {
+		var agentStateStr string
+		if hasClass(calico.NodeStatusClassTypeAgent) {
+			agent := status.Status.Agent
+			if !reflect.ValueOf(agent.BIRDV4).IsZero() {
+				agentStateStr = fmt.Sprintf("v4(%s) ", agent.BIRDV4.State)
+			}
+			if !reflect.ValueOf(agent.BIRDV6).IsZero() {
+				agentStateStr += fmt.Sprintf("v6(%s)", agent.BIRDV6.State)
+			}
+		}
+
+		var peersStr string
+		if hasClass(calico.NodeStatusClassTypeBGP) {
+			bgp := status.Status.BGP
+			if !reflect.ValueOf(bgp.PeersV4).IsZero() {
+				peersStr = fmt.Sprintf("v4(%d/%d/%d) ",
+					len(bgp.PeersV4), bgp.NumberEstablishedV4, bgp.NumberNotEstablishedV4)
+			}
+			if !reflect.ValueOf(bgp.PeersV6).IsZero() {
+				peersStr += fmt.Sprintf("v6(%d/%d/%d) ",
+					len(bgp.PeersV6), bgp.NumberEstablishedV6, bgp.NumberNotEstablishedV6)
+			}
+		}
+
+		getNumberOfBGPRoutes := func(routes []calico.CalicoNodeRoute) int {
+			n := 0
+			for _, r := range routes {
+				if (r.LearnedFrom.SourceType == calico.RouteSourceTypeBGPPeer) ||
+					(r.LearnedFrom.SourceType == calico.RouteSourceTypeNodeMesh) {
+					n++
+				}
+			}
+			return n
+		}
+
+		var routesStr string
+		if hasClass(calico.NodeStatusClassTypeRoutes) {
+			routes := status.Status.Routes
+			if !reflect.ValueOf(routes.RoutesV4).IsZero() {
+				routesStr = fmt.Sprintf("v4(%d) ", getNumberOfBGPRoutes(routes.RoutesV4))
+			}
+			if !reflect.ValueOf(routes.RoutesV6).IsZero() {
+				routesStr += fmt.Sprintf("v6(%d)", getNumberOfBGPRoutes(routes.RoutesV6))
+			}
+		}
+
+		row.Cells = append(row.Cells, agentStateStr, peersStr, routesStr)
+	}
+
+	return []metav1.TableRow{row}, nil
+}
+
+// The followings are helper functions copied from k8s.io/kubernetes
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// translateTimestampUntil returns the elapsed time until timestamp in
+// human-readable approximation.
+func translateTimestampUntil(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Until(timestamp.Time))
+}

--- a/apiserver/pkg/printers/projectcalico/utils.go
+++ b/apiserver/pkg/printers/projectcalico/utils.go
@@ -1,0 +1,44 @@
+// Copyright 2017 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectcalico
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+// The followings are helper functions copied from k8s.io/kubernetes
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// translateTimestampUntil returns the elapsed time until timestamp in
+// human-readable approximation.
+func translateTimestampUntil(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Until(timestamp.Time))
+}

--- a/apiserver/pkg/registry/projectcalico/caliconodestatus/storage.go
+++ b/apiserver/pkg/registry/projectcalico/caliconodestatus/storage.go
@@ -9,7 +9,10 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/kubernetes/pkg/printers"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
+	calicoprinter "github.com/projectcalico/calico/apiserver/pkg/printers/projectcalico"
 	"github.com/projectcalico/calico/apiserver/pkg/registry/projectcalico/server"
 )
 
@@ -85,6 +88,8 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 
 		Storage:     storageInterface,
 		DestroyFunc: dFunc,
+
+		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(calicoprinter.AddHandlers)},
 	}
 
 	return &REST{store, opts.ShortNames}, nil

--- a/apiserver/pkg/registry/projectcalico/caliconodestatus/storage.go
+++ b/apiserver/pkg/registry/projectcalico/caliconodestatus/storage.go
@@ -89,7 +89,7 @@ func NewREST(scheme *runtime.Scheme, opts server.Options) (*REST, error) {
 		Storage:     storageInterface,
 		DestroyFunc: dFunc,
 
-		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(calicoprinter.AddHandlers)},
+		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(calicoprinter.CalicoNodeStatusAddHandlers)},
 	}
 
 	return &REST{store, opts.ShortNames}, nil


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR added code to support `kubectl get caliconodestatus -o wide`.

Sample output:
```
song@song-dev6:~$ kubectl get caliconodestatus 
NAME         NODE           CLASSES              UPDATE INTERVAL   AGE     LAST UPDATED
elm          kind-worker    [Agent,BGP]          30s               3h30m   3h30m ago
withroutes   kind-worker2   [Agent,BGP,Routes]   10s               6m51s   1s ago
song@song-dev6:~$ kubectl get caliconodestatus -o wide
NAME         NODE           CLASSES              UPDATE INTERVAL   AGE     LAST UPDATED   AGENT STATE           BGP PEERS              BGP ROUTES
elm          kind-worker    [Agent,BGP]          30s               3h30m   3h30m ago      v4(Ready) v6(Ready)   v4(3/3/0) v6(3/3/0)    
withroutes   kind-worker2   [Agent,BGP,Routes]   10s               6m54s   4s ago         v4(Ready) v6(Ready)   v4(3/3/0) v6(3/3/0)    v4(3) v6(3)
```


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [X] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
