### PR TITLE
bpf: always enforce policy on SYN packets and rewrite closed CT entries with the same tuple

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -788,7 +788,13 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 		result.ifindex_fwd = dst_to_src->ifindex;
 	}
 
-	CALI_CT_DEBUG("result: %d\n", result.rc);
+	if (syn) {
+		CALI_CT_DEBUG("packet is SYN\n");
+		ct_result_set_flag(result.rc, CALI_CT_SYN);
+	}
+
+
+	CALI_CT_DEBUG("result: 0x%x\n", result.rc);
 
 	if (related) {
 		ct_result_set_flag(result.rc, CALI_CT_RELATED);

--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -374,6 +374,19 @@ static CALI_BPF_INLINE void ct_tcp_entry_update(struct tcphdr *tcp_header,
 	}
 }
 
+static CALI_BPF_INLINE bool tcp_recycled(bool syn, struct calico_ct_value *v)
+{
+	struct calico_ct_leg *a, *b;
+
+	a = &v->a_to_b;
+	b = &v->b_to_a;
+
+	/* When we see a SYN for a connection that has seen FIN or RST in both direction,
+	 * a new connection with the same tuple is trying to recycle this entry.
+	 */
+	return syn && (a->fin_seen || a->rst_seen) && (b->fin_seen || b->rst_seen);
+}
+
 static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_tc_ctx *tc_ctx)
 {
 	// TODO: refactor the conntrack code to simply use the tc_ctx instead of its own.  This
@@ -544,6 +557,10 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			CALI_CT_DEBUG("Miss when looking for secondary entry.\n");
 			goto out_lookup_fail;
 		}
+		if (tcp_recycled(syn, tracking_v)) {
+			CALI_CT_DEBUG("TCP SYN recycles entry, NEW flow.\n");
+			goto out_lookup_fail;
+		}
 		result.nat_sport = v->nat_sport ? : sport;
 		// Record timestamp.
 		tracking_v->last_seen = now;
@@ -588,6 +605,10 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 
 		break;
 	case CALI_CT_TYPE_NAT_REV:
+		if (tcp_recycled(syn, v)) {
+			CALI_CT_DEBUG("TCP SYN recycles entry, NEW flow.\n");
+			goto out_lookup_fail;
+		}
 		if (srcLTDest) {
 			CALI_VERB("CT-ALL REV src_to_dst A->B\n");
 			src_to_dst = &v->a_to_b;
@@ -641,6 +662,10 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 
 	case CALI_CT_TYPE_NORMAL:
 		CALI_CT_DEBUG("Hit! NORMAL entry.\n");
+		if (tcp_recycled(syn, v)) {
+			CALI_CT_DEBUG("TCP SYN recycles entry, NEW flow.\n");
+			goto out_lookup_fail;
+		}
 		CALI_CT_VERB("Created: %llu.\n", v->created);
 		if (tcp_header) {
 			CALI_CT_VERB("Last seen: %llu.\n", v->last_seen);

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -156,6 +156,7 @@ enum calico_ct_result_type {
 #define CALI_CT_RELATED         0x100
 #define CALI_CT_RPF_FAILED      0x200
 #define CALI_CT_TUN_SRC_CHANGED 0x400
+#define CALI_CT_SYN		0x800
 
 #define ct_result_rc(rc)		((rc) & 0xff)
 #define ct_result_flags(rc)		((rc) & ~0xff)
@@ -165,6 +166,7 @@ enum calico_ct_result_type {
 #define ct_result_is_related(rc)	((rc) & CALI_CT_RELATED)
 #define ct_result_rpf_failed(rc)	((rc) & CALI_CT_RPF_FAILED)
 #define ct_result_tun_src_changed(rc)	((rc) & CALI_CT_TUN_SRC_CHANGED)
+#define ct_result_is_syn(rc)		((rc) & CALI_CT_SYN)
 
 struct calico_ct_result {
 	__s16 rc;

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -263,6 +263,11 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			ctx.state->flags |= CALI_ST_SKIP_FIB;
 		}
 		CALI_DEBUG("CT Hit\n");
+
+		if (ctx.state->ip_proto == IPPROTO_TCP && ct_result_is_syn(ctx.state->ct_result.rc)) {
+			CALI_DEBUG("Forcing policy on SYN\n");
+			goto syn_force_policy;
+		}
 		goto skip_policy;
 	}
 
@@ -388,6 +393,8 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			ctx.state->pre_nat_dport = ctx_port_to_host(revnat->port);
 		}
 	}
+
+syn_force_policy:
 
 	if (rt_addr_is_local_host(ctx.state->post_nat_ip_dst)) {
 		CALI_DEBUG("Post-NAT dest IP is local host.\n");
@@ -974,7 +981,9 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		goto allow;
 
 	case CALI_CT_ESTABLISHED_BYPASS:
-		seen_mark = CALI_SKB_MARK_BYPASS;
+		if (!ct_result_is_syn(state->ct_result.rc)) {
+			seen_mark = CALI_SKB_MARK_BYPASS;
+		}
 		// fall through
 	case CALI_CT_ESTABLISHED:
 		goto allow;

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -540,20 +540,32 @@ func (p *Builder) writeRule(r Rule, actionLabel string, destLeg matchLeg) {
 	}
 
 	if len(rule.SrcPorts) > 0 || len(rule.SrcNamedPortIpSetIds) > 0 {
-		log.WithField("ports", rule.SrcPorts).Debugf("SrcPorts match")
+		log.WithFields(log.Fields{
+			"ports":   rule.SrcPorts,
+			"set ids": rule.SrcNamedPortIpSetIds,
+		}).Debugf("SrcPorts match")
 		p.writePortsMatch(false, legSource, rule.SrcPorts, rule.SrcNamedPortIpSetIds)
 	}
 	if len(rule.NotSrcPorts) > 0 || len(rule.NotSrcNamedPortIpSetIds) > 0 {
-		log.WithField("ports", rule.NotSrcPorts).Debugf("NotSrcPorts match")
+		log.WithFields(log.Fields{
+			"ports":   rule.NotSrcPorts,
+			"set ids": rule.NotSrcNamedPortIpSetIds,
+		}).Debugf("NotSrcPorts match")
 		p.writePortsMatch(true, legSource, rule.NotSrcPorts, rule.NotSrcNamedPortIpSetIds)
 	}
 
 	if len(rule.DstPorts) > 0 || len(rule.DstNamedPortIpSetIds) > 0 {
-		log.WithField("ports", rule.DstPorts).Debugf("DstPorts match")
+		log.WithFields(log.Fields{
+			"ports":   rule.DstPorts,
+			"set ids": rule.DstNamedPortIpSetIds,
+		}).Debugf("DstPorts match")
 		p.writePortsMatch(false, destLeg, rule.DstPorts, rule.DstNamedPortIpSetIds)
 	}
 	if len(rule.NotDstPorts) > 0 || len(rule.NotDstNamedPortIpSetIds) > 0 {
-		log.WithField("ports", rule.NotDstPorts).Debugf("NotDstPorts match")
+		log.WithFields(log.Fields{
+			"ports":   rule.NotDstPorts,
+			"set ids": rule.NotDstNamedPortIpSetIds,
+		}).Debugf("NotDstPorts match")
 		p.writePortsMatch(true, destLeg, rule.NotDstPorts, rule.NotDstNamedPortIpSetIds)
 	}
 

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -29,8 +29,10 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/nat"
+	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	"github.com/projectcalico/calico/felix/ip"
+	"github.com/projectcalico/calico/felix/proto"
 )
 
 func TestNATPodPodXNode(t *testing.T) {
@@ -1404,9 +1406,11 @@ func TestNATSYNRetryGoesToSameBackend(t *testing.T) {
 	err = rtMap.Update(rtKey, rtVal)
 	Expect(err).NotTo(HaveOccurred())
 
+	origTCPSrcPort := tcpSyn.SrcPort
+	var firstIP net.IP
+
 	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		// Part 1: if we resend the same SYN, then it should get conntracked to the same backend.
-		var firstIP net.IP
 		for attempt := 0; attempt < 10; attempt++ {
 			res, err := bpfrun(synPkt)
 			Expect(err).NotTo(HaveOccurred())
@@ -1439,6 +1443,36 @@ func TestNATSYNRetryGoesToSameBackend(t *testing.T) {
 			}
 		}
 		Expect(seenOtherIP).To(BeTrue(), "SYNs from varying source ports all went to same backend")
+	})
+
+	// Change back to the
+	tcpSyn.SrcPort = origTCPSrcPort
+	_, _, _, _, synPkt, err = testPacket(nil, nil, tcpSyn, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	bpfIfaceName = "SYNP"
+	changedToDeny := &polprog.Rules{
+		Tiers: []polprog.Tier{{
+			Name: "base tier",
+			Policies: []polprog.Policy{{
+				Name: "allow->deny",
+				Rules: []polprog.Rule{{
+					Rule: &proto.Rule{
+						Action:      "Allow",
+						NotDstPorts: []*proto.PortRange{{First: 666, Last: 666}},
+						NotDstNet:   []string{firstIP.String()}, // We should hit the same backend as before
+					}}},
+			}},
+		}},
+	}
+
+	// Make sure that when the policy changes, it is applied to correctly to the next SYN
+	runBpfTest(t, "calico_from_workload_ep", changedToDeny, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
 	})
 }
 

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -1445,7 +1445,8 @@ func TestNATSYNRetryGoesToSameBackend(t *testing.T) {
 		Expect(seenOtherIP).To(BeTrue(), "SYNs from varying source ports all went to same backend")
 	})
 
-	// Change back to the
+	// Change back to the original SYN packet so that we can test the new policy
+	// with an existing CT entry.
 	tcpSyn.SrcPort = origTCPSrcPort
 	_, _, _, _, synPkt, err = testPacket(nil, nil, tcpSyn, nil)
 	Expect(err).NotTo(HaveOccurred())

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -616,7 +616,7 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 					"Will retry if it shows up.")
 			return set.RemoveItem
 		}
-		log.WithError(err).Warn("Failed to apply policy to interface, will retry")
+		log.WithField("iface", iface).WithError(err).Warn("Failed to apply policy to interface, will retry")
 		return nil
 	})
 }

--- a/felix/fv/named_ports_test.go
+++ b/felix/fv/named_ports_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/projectcalico/calico/felix/fv/connectivity"
@@ -216,17 +215,6 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 		applyAtOthers
 	)
 
-	bpfEnabled := false
-	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
-		bpfEnabled = true
-	}
-
-	cleanConntrack := func() {
-		if bpfEnabled {
-			felix.Exec("calico-bpf", "conntrack", "clean")
-		}
-	}
-
 	// Baseline test with no named ports policy.
 	Context("with no named port policy", func() {
 		It("should give full connectivity to and from workload 0", func() {
@@ -248,7 +236,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectSome(w[1], w[0].Port(4000))
 			cc.ExpectSome(w[2], w[0].Port(4000))
 
-			cc.CheckConnectivity(connectivity.CheckWithBeforeRetry(cleanConntrack))
+			cc.CheckConnectivity()
 		})
 	})
 
@@ -390,7 +378,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectSome(w[0], w[1].Port(w1Port))
 			cc.ExpectSome(w[0], w[2].Port(w2Port))
 
-			cc.CheckConnectivity(dumpResource(pol), connectivity.CheckWithBeforeRetry(cleanConntrack))
+			cc.CheckConnectivity(dumpResource(pol))
 		},
 
 		// Non-negated named port match.  The rule will allow traffic to the named port.
@@ -489,7 +477,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectSome(w[3], w[0].Port(4000))       // Numeric port in list.
 			cc.ExpectNone(w[2], w[0].Port(3000))       // Numeric port not in list.
 
-			cc.CheckConnectivity(dumpResource(policy), connectivity.CheckWithBeforeRetry(cleanConntrack))
+			cc.CheckConnectivity(dumpResource(policy))
 		}
 		It("should have expected connectivity", expectBaselineConnectivity)
 
@@ -514,7 +502,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 				cc.ExpectSome(w[3], w[0].Port(4000))       // No change.
 				cc.ExpectNone(w[2], w[0].Port(3000))       // No change.
 
-				cc.CheckConnectivity(dumpResource(policy), connectivity.CheckWithBeforeRetry(cleanConntrack))
+				cc.CheckConnectivity(dumpResource(policy))
 			})
 		})
 
@@ -542,7 +530,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 				cc.ExpectSome(w[3], w[0].Port(4000))       // No change.
 				cc.ExpectNone(w[2], w[0].Port(3000))       // No change.
 
-				cc.CheckConnectivity(dumpResource(policy), connectivity.CheckWithBeforeRetry(cleanConntrack))
+				cc.CheckConnectivity(dumpResource(policy))
 			})
 		})
 
@@ -559,7 +547,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 			cc.ExpectNone(w[2], w[0].Port(4000))
 			cc.ExpectNone(w[2], w[0].Port(3000))
 
-			cc.CheckConnectivity(dumpResource(policy), connectivity.CheckWithBeforeRetry(cleanConntrack))
+			cc.CheckConnectivity(dumpResource(policy))
 		}
 
 		Describe("with "+oppositeDir+" selectors, removing w[2] and w[3]", func() {
@@ -682,7 +670,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 					cc.ExpectSome(w[3], w[0].Port(4000))       // No change.
 					cc.ExpectNone(w[2], w[0].Port(3000))       // No change.
 
-					cc.CheckConnectivity(dumpResource(policy), connectivity.CheckWithBeforeRetry(cleanConntrack))
+					cc.CheckConnectivity(dumpResource(policy))
 				})
 			})
 		})
@@ -713,7 +701,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 				cc.ExpectNone(w[3], w[0].Port(4000))       // Numeric port in NotPorts list.
 				cc.ExpectNone(w[2], w[0].Port(3000))       // No change
 
-				cc.CheckConnectivity(dumpResource(policy), connectivity.CheckWithBeforeRetry(cleanConntrack))
+				cc.CheckConnectivity(dumpResource(policy))
 			})
 		})
 	})

--- a/felix/fv/named_ports_test.go
+++ b/felix/fv/named_ports_test.go
@@ -222,7 +222,7 @@ func describeNamedPortTests(testSourcePorts bool, protocol string) {
 	}
 
 	cleanConntrack := func() {
-		if bpfEnabled {
+		if bpfEnabled && protocol == "udp" {
 			felix.Exec("calico-bpf", "conntrack", "clean")
 		}
 	}


### PR DESCRIPTION
## Description

    bpf: TCP SYN recycles CT entry if it looks closed
    
    If a SYN matches a CT entry and the entry has seen FIN or RST in both
    directions, it is clearly a new unrelated connection with the same
    tuple and the entry is not clean up yet. Then recycle the entry, report,
    that the flow is new and the entry will be over written by a fresh one.
    
    That also forces the new connection through policy rather than reusing
    the decision made on the old one.

    bpf: enforce policy on SYN packets
    
    In case policy has changed and there is an existing conntrack entry for
    previously allowed connection, a new connection with the same tuple
    would hit the CT entry and would be let through even if the current
    policy does not let it anymore.
    
    This is a corner case, but a client can enforce its source port as our
    named ports FV tests do.

    Unlike NAT lookup, CT lookup does not set the DNAT in state, which is
    fixed only after policy. Therefore we need to set it properly if we want
    to enforce policy correctly.
    
    Adds a test that changes the policy and checks that the policy is
    enforce on a retransmitted SYN - equal to a fresh new SYN hitting an
    existing CT from previous connection.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
BPF mode: improve handling of connections that reuse the same TCP source/dest tuple.  Detect reuse and treat as new connection.
```
