### PR TITLE
Add dual-stack support in Canal

### DIFF
--- a/cni-plugin/internal/pkg/utils/utils.go
+++ b/cni-plugin/internal/pkg/utils/utils.go
@@ -202,16 +202,18 @@ func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) er
 		// We need to replace "usePodCidr" with a valid, but dummy podCidr string with "host-local" IPAM.
 		// host-local IPAM releases the IP by ContainerID, so podCidr isn't really used to release the IP.
 		// It just needs a valid CIDR, but it doesn't have to be the CIDR associated with the host.
-		const dummyPodCidr = "0.0.0.0/0"
+		dummyPodCidrv4 := "0.0.0.0/0"
+		dummyPodCidrv6 := "::/0"
 		var stdinData map[string]interface{}
 		err := json.Unmarshal(args.StdinData, &stdinData)
 		if err != nil {
 			return err
 		}
 
-		logger.WithField("podCidr", dummyPodCidr).Info("Using a dummy podCidr to release the IP")
-		getDummyPodCIDR := func() (string, error) {
-			return dummyPodCidr, nil
+		logger.WithFields(logrus.Fields{"podCidrv4": dummyPodCidrv4,
+			"podCidrv6": dummyPodCidrv6}).Info("Using dummy podCidrs to release the IPs")
+		getDummyPodCIDR := func() (string, string, error) {
+			return dummyPodCidrv4, dummyPodCidrv6, nil
 		}
 		err = ReplaceHostLocalIPAMPodCIDRs(logger, stdinData, getDummyPodCIDR)
 		if err != nil {
@@ -286,13 +288,13 @@ func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) er
 //      }
 //      ...
 //    }
-func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]interface{}, getPodCIDR func() (string, error)) error {
+func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]interface{}, getPodCIDRs func() (string, string, error)) error {
 	ipamData, ok := stdinData["ipam"].(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("failed to parse host-local IPAM data; was expecting a dict, not: %v", stdinData["ipam"])
 	}
 	// Older versions of host-local IPAM store a single subnet in the top-level IPAM dict.
-	err := replaceHostLocalIPAMPodCIDR(logger, ipamData, getPodCIDR)
+	err := replaceHostLocalIPAMPodCIDR(logger, ipamData, getPodCIDRs)
 	if err != nil {
 		return err
 	}
@@ -310,7 +312,7 @@ func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]int
 				return fmt.Errorf("failed to parse host-local IPAM range set; was expecting a list, not: %v", rs)
 			}
 			for _, r := range rs {
-				err := replaceHostLocalIPAMPodCIDR(logger, r, getPodCIDR)
+				err := replaceHostLocalIPAMPodCIDR(logger, r, getPodCIDRs)
 				if err != nil {
 					return err
 				}
@@ -320,29 +322,47 @@ func ReplaceHostLocalIPAMPodCIDRs(logger *logrus.Entry, stdinData map[string]int
 	return nil
 }
 
-func replaceHostLocalIPAMPodCIDR(logger *logrus.Entry, rawIpamData interface{}, getPodCidr func() (string, error)) error {
+func replaceHostLocalIPAMPodCIDR(logger *logrus.Entry, rawIpamData interface{}, getPodCidrs func() (string, string, error)) error {
 	logrus.WithField("ipamData", rawIpamData).Debug("Examining IPAM data for usePodCidr")
 	ipamData, ok := rawIpamData.(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("failed to parse host-local IPAM data; was expecting a dict, not: %v", rawIpamData)
 	}
 	subnet, _ := ipamData["subnet"].(string)
+
 	if strings.EqualFold(subnet, "usePodCidr") {
-		logger.Info("Calico CNI fetching podCidr from Kubernetes")
-		podCidr, err := getPodCidr()
+		ipv4Cidr, _, err := getPodCidrs()
 		if err != nil {
-			logger.Info("Failed to getPodCidr")
+			logger.Errorf("Failed to getPodCidrs")
 			return err
 		}
-		logger.WithField("podCidr", podCidr).Info("Fetched podCidr")
-		ipamData["subnet"] = podCidr
-		subnet = podCidr
-		logger.Infof("Calico CNI passing podCidr to host-local IPAM: %s", podCidr)
+		if ipv4Cidr == "" {
+			return errors.New("usePodCidr found but there is no IPv4 CIDR configured")
+		}
+
+		ipamData["subnet"] = ipv4Cidr
+		subnet = ipv4Cidr
+		logger.Infof("Calico CNI passing podCidr to host-local IPAM: %s", ipv4Cidr)
+
+		// updateHostLocalIPAMDataForOS is only required for Windows and only ipv4 is supported
+		err = updateHostLocalIPAMDataForOS(subnet, ipamData)
+		if err != nil {
+			return err
+		}
 	}
 
-	err := updateHostLocalIPAMDataForOS(subnet, ipamData)
-	if err != nil {
-		return err
+	if strings.EqualFold(subnet, "usePodCidrIPv6") {
+		_, ipv6Cidr, err := getPodCidrs()
+		if err != nil {
+			logger.Errorf("Failed to ipv6 getPodCidrs")
+			return err
+		}
+		if ipv6Cidr == "" {
+			return errors.New("usePodCidrIPv6 found but there is no IPv6 CIDR configured")
+		}
+
+		ipamData["subnet"] = ipv6Cidr
+		logger.Infof("Calico CNI passing podCidrv6 to host-local IPAM: %s", ipv6Cidr)
 	}
 
 	return nil
@@ -360,6 +380,7 @@ func UpdateHostLocalIPAMDataForWindows(subnet string, ipamData map[string]interf
 		return err
 	}
 	//process only if we have ipv4 subnet
+	//VXLAN networks on Windows do not support dual-stack https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#ipv6-networking
 	if ip.To4() != nil {
 		//get Expected start and end range for given CIDR
 		expStartRange, expEndRange := getIPRanges(ip, ipnet)


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR provides dual-stack support for canal. It requires three changes in the canal config/manifest:

### Change 1

The ipam section of the cni_network_config for dual-stack must be defined like this:
```
          "ipam": {
              "type": "host-local",
              "ranges": [
                  [
                      {
                          "subnet": "usePodCidr"
                      }
                  ],
                  [
                      {
                          "subnet": "usePodCidrIPv6"
                      }
                  ]
             ]
          },
```
The effective changes are:
a) the ` "subnet": "usePodCidr"` moves inside the ranges slice
b) we define a new subnet called `usePodCidrIPv6`

This PR does not break the current way of deploying canal for ipv4 single-stack. If you want dual-stack, you'll need to apply this config change. If not, you are fine with the current config.

### Change 2

The flannel image of the `kube-flannel` container, must move to, at least, version 0.15 which support dual-stack. For example:
`image: quay.io/coreos/flannel:v0.15.1`

### Change 3

We must activate the dual-stack feature in flannel. To do so, in the flannel `net-conf.json`, we must add the following fields:
```
"IPv6Network": "2001:dada:42:0::/56",
"EnableIPv6": true,
```
The IPv6Network can be anything. We will anyway read the CIDR assigned to the node

In the code, the essential change is that we are now asking for `node.Spec.PodCIDRs` instead of `node.Spec.PodCIDR`. As a consequence, we will receive a slice of strings, which will have length=1 in the single-stack case and length=2 in the dual-stack case. There is a new function `getIPsByFamily` that reads the podCidrs and returns the ipv4 and the ipv6 cidr. The former substitutes `"subnet": "usePodCidr"` in the host-local ipam config. The latter substitutes `"subnet": "usePodCidrIPv6"` in the host-local ipam config.

Moreover, we use a dummy ipv4 and ipv6 address to release the host-local IP and a test is included with `usePodCidrIPv6`

I did not change anything in `UpdateHostLocalIPAMDataForWindows` because dual-stack is not supported in k8s for vxlan scenarios in Windows: https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#ipv6-networking (added a comment about this)

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes https://github.com/projectcalico/cni-plugin/issues/1177

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [X] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
