### PR TITLE
Add memory / cpu profiling for kube-controllers

### DIFF
--- a/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
+++ b/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
@@ -63,9 +63,9 @@ type KubeControllersConfigurationSpec struct {
 	// Controllers enables and configures individual Kubernetes controllers
 	Controllers ControllersConfig `json:"controllers"`
 
-	// DebugMemoryProfilePort configures the port to serve memory profiles on. If not specified, memory profiling
+	// DebugProfilePort configures the port to serve memory and cpu profiles on. If not specified, profiling
 	// is disabled.
-	DebugMemoryProfilePort *int32 `json:"debugMemoryProfilePort,omitempty"`
+	DebugProfilePort *int32 `json:"debugProfilePort,omitempty"`
 }
 
 // ControllersConfig enables and configures individual Kubernetes controllers

--- a/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
+++ b/api/pkg/apis/projectcalico/v3/kubecontrollersconfig.go
@@ -62,6 +62,10 @@ type KubeControllersConfigurationSpec struct {
 
 	// Controllers enables and configures individual Kubernetes controllers
 	Controllers ControllersConfig `json:"controllers"`
+
+	// DebugMemoryProfilePort configures the port to serve memory profiles on. If not specified, memory profiling
+	// is disabled.
+	DebugMemoryProfilePort *int32 `json:"debugMemoryProfilePort,omitempty"`
 }
 
 // ControllersConfig enables and configures individual Kubernetes controllers

--- a/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1717,8 +1717,8 @@ func (in *KubeControllersConfigurationSpec) DeepCopyInto(out *KubeControllersCon
 		**out = **in
 	}
 	in.Controllers.DeepCopyInto(&out.Controllers)
-	if in.DebugMemoryProfilePort != nil {
-		in, out := &in.DebugMemoryProfilePort, &out.DebugMemoryProfilePort
+	if in.DebugProfilePort != nil {
+		in, out := &in.DebugProfilePort, &out.DebugProfilePort
 		*out = new(int32)
 		**out = **in
 	}

--- a/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/api/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1717,6 +1717,11 @@ func (in *KubeControllersConfigurationSpec) DeepCopyInto(out *KubeControllersCon
 		**out = **in
 	}
 	in.Controllers.DeepCopyInto(&out.Controllers)
+	if in.DebugMemoryProfilePort != nil {
+		in, out := &in.DebugMemoryProfilePort, &out.DebugMemoryProfilePort
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/api/pkg/openapi/openapi_generated.go
+++ b/api/pkg/openapi/openapi_generated.go
@@ -3446,6 +3446,13 @@ func schema_pkg_apis_projectcalico_v3_KubeControllersConfigurationSpec(ref commo
 							Ref:         ref("github.com/projectcalico/api/pkg/apis/projectcalico/v3.ControllersConfig"),
 						},
 					},
+					"debugMemoryProfilePort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DebugMemoryProfilePort configures the port to serve memory profiles on. If not specified, memory profiling is disabled.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"controllers"},
 			},

--- a/api/pkg/openapi/openapi_generated.go
+++ b/api/pkg/openapi/openapi_generated.go
@@ -3446,9 +3446,9 @@ func schema_pkg_apis_projectcalico_v3_KubeControllersConfigurationSpec(ref commo
 							Ref:         ref("github.com/projectcalico/api/pkg/apis/projectcalico/v3.ControllersConfig"),
 						},
 					},
-					"debugMemoryProfilePort": {
+					"debugProfilePort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DebugMemoryProfilePort configures the port to serve memory profiles on. If not specified, memory profiling is disabled.",
+							Description: "DebugProfilePort configures the port to serve memory and cpu profiles on. If not specified, profiling is disabled.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/osrg/gobgp v0.0.0-20170802061517-bbd1d99396fe
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/pkg/profile v1.6.0
 	github.com/projectcalico/api v0.0.0-20211102181812-edfaf495a5c8
 	github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba
 	github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54

--- a/go.sum
+++ b/go.sum
@@ -802,6 +802,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
+github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/kube-controllers/Dockerfile.amd64
+++ b/kube-controllers/Dockerfile.amd64
@@ -19,9 +19,10 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as base
 RUN mkdir /licenses
 COPY LICENSE /licenses
 
-# Make sure the status file is owned by our user.
-RUN mkdir /status
+# Make sure the status and pprof files are owned by our user.
+RUN mkdir /status /profiles
 RUN touch /status/status.json && chown 999 /status/status.json
+RUN touch /profiles/mem.pprof && chown 999 /profiles/mem.pprof
 
 FROM scratch
 ARG GIT_VERSION
@@ -34,6 +35,7 @@ LABEL name="Calico Kubernetes controllers" \
       maintainer="Casey Davenport <casey@tigera.io>"
 
 COPY --from=base /licenses /licenses
+COPY --from=base /profiles /profiles
 COPY --from=base /status /status
 
 COPY --from=base /usr/include /usr/include

--- a/kube-controllers/Dockerfile.amd64
+++ b/kube-controllers/Dockerfile.amd64
@@ -23,6 +23,7 @@ COPY LICENSE /licenses
 RUN mkdir /status /profiles
 RUN touch /status/status.json && chown 999 /status/status.json
 RUN touch /profiles/mem.pprof && chown 999 /profiles/mem.pprof
+RUN touch /profiles/cpu.pprof && chown 999 /profiles/cpu.pprof
 
 FROM scratch
 ARG GIT_VERSION

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -195,12 +195,12 @@ func main() {
 		}()
 	}
 
-	if runCfg.DebugMemoryProfilePort != 0 {
+	if runCfg.DebugProfilePort != 0 {
 		// Run a webserver to expose memory profiling.
 		setPathOption := profile.ProfilePath("/profiles")
-		defer profile.Start(profile.MemProfile, setPathOption).Stop()
+		defer profile.Start(profile.CPUProfile, profile.MemProfile, setPathOption).Stop()
 		go func() {
-			http.ListenAndServe(fmt.Sprintf(":%d", runCfg.DebugMemoryProfilePort), nil)
+			http.ListenAndServe(fmt.Sprintf(":%d", runCfg.DebugProfilePort), nil)
 		}()
 	}
 

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -200,7 +200,10 @@ func main() {
 		setPathOption := profile.ProfilePath("/profiles")
 		defer profile.Start(profile.CPUProfile, profile.MemProfile, setPathOption).Stop()
 		go func() {
-			http.ListenAndServe(fmt.Sprintf(":%d", runCfg.DebugProfilePort), nil)
+			err := http.ListenAndServe(fmt.Sprintf(":%d", runCfg.DebugProfilePort), nil)
+			if err != nil {
+				log.WithError(err).Fatal("Failed to start debug profiling")
+			}
 		}()
 	}
 

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 	"time"
 
+	_ "net/http/pprof"
+
+	"github.com/pkg/profile"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	log "github.com/sirupsen/logrus"
@@ -189,6 +192,15 @@ func main() {
 			if err != nil {
 				log.WithError(err).Fatal("Failed to serve prometheus metrics")
 			}
+		}()
+	}
+
+	if runCfg.DebugMemoryProfilePort != 0 {
+		// Run a webserver to expose memory profiling.
+		setPathOption := profile.ProfilePath("/profiles")
+		defer profile.Start(profile.MemProfile, setPathOption).Stop()
+		go func() {
+			http.ListenAndServe(fmt.Sprintf(":%d", runCfg.DebugMemoryProfilePort), nil)
 		}()
 	}
 

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -77,6 +77,7 @@ type RunConfig struct {
 	EtcdV3CompactionPeriod time.Duration
 	HealthEnabled          bool
 	PrometheusPort         int
+	DebugMemoryProfilePort int32
 }
 
 type ControllersConfig struct {
@@ -314,6 +315,9 @@ func mergeConfig(envVars map[string]string, envCfg Config, apiCfg v3.KubeControl
 	// Merge prometheus information.
 	if apiCfg.PrometheusMetricsPort != nil {
 		rCfg.PrometheusPort = *apiCfg.PrometheusMetricsPort
+	}
+	if apiCfg.DebugMemoryProfilePort != nil {
+		rCfg.DebugMemoryProfilePort = *apiCfg.DebugMemoryProfilePort
 	}
 
 	// Don't bother looking at this unless the node controller is enabled.

--- a/kube-controllers/pkg/config/runconfig.go
+++ b/kube-controllers/pkg/config/runconfig.go
@@ -77,7 +77,7 @@ type RunConfig struct {
 	EtcdV3CompactionPeriod time.Duration
 	HealthEnabled          bool
 	PrometheusPort         int
-	DebugMemoryProfilePort int32
+	DebugProfilePort       int32
 }
 
 type ControllersConfig struct {
@@ -316,8 +316,8 @@ func mergeConfig(envVars map[string]string, envCfg Config, apiCfg v3.KubeControl
 	if apiCfg.PrometheusMetricsPort != nil {
 		rCfg.PrometheusPort = *apiCfg.PrometheusMetricsPort
 	}
-	if apiCfg.DebugMemoryProfilePort != nil {
-		rCfg.DebugMemoryProfilePort = *apiCfg.DebugMemoryProfilePort
+	if apiCfg.DebugProfilePort != nil {
+		rCfg.DebugProfilePort = *apiCfg.DebugProfilePort
 	}
 
 	// Don't bother looking at this unless the node controller is enabled.

--- a/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -101,9 +101,9 @@ spec:
                         type: string
                     type: object
                 type: object
-              debugMemoryProfilePort:
-                description: DebugMemoryProfilePort configures the port to serve memory
-                  profiles on. If not specified, memory profiling is disabled.
+              debugProfilePort:
+                description: DebugProfilePort configures the port to serve memory
+                  and cpu profiles on. If not specified, profiling is disabled.
                 format: int32
                 type: integer
               etcdV3CompactionPeriod:
@@ -216,9 +216,9 @@ spec:
                             type: string
                         type: object
                     type: object
-                  debugMemoryProfilePort:
-                    description: DebugMemoryProfilePort configures the port to serve
-                      memory profiles on. If not specified, memory profiling is disabled.
+                  debugProfilePort:
+                    description: DebugProfilePort configures the port to serve memory
+                      and cpu profiles on. If not specified, profiling is disabled.
                     format: int32
                     type: integer
                   etcdV3CompactionPeriod:

--- a/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -101,6 +101,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              debugMemoryProfilePort:
+                description: DebugMemoryProfilePort configures the port to serve memory
+                  profiles on. If not specified, memory profiling is disabled.
+                format: int32
+                type: integer
               etcdV3CompactionPeriod:
                 description: 'EtcdV3CompactionPeriod is the period between etcdv3
                   compaction requests. Set to 0 to disable. [Default: 10m]'
@@ -211,6 +216,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  debugMemoryProfilePort:
+                    description: DebugMemoryProfilePort configures the port to serve
+                      memory profiles on. If not specified, memory profiling is disabled.
+                    format: int32
+                    type: integer
                   etcdV3CompactionPeriod:
                     description: 'EtcdV3CompactionPeriod is the period between etcdv3
                       compaction requests. Set to 0 to disable. [Default: 10m]'


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds configuration for memory profile generation via
KubeControllersConfiguration.

When enabled, a debug pprof file can be downloaded by curling the pod at
the specified port at `/debug/pprof/heap`.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add debug memory profiling capabilities to kube-controllers
```