### PR TITLE
Pin client-go to version with fix for #5173

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ replace (
 	k8s.io/apimachinery => k8s.io/apimachinery v0.21.8
 	k8s.io/apiserver => k8s.io/apiserver v0.21.8
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.21.8
-	k8s.io/client-go => k8s.io/client-go v0.21.8
+	k8s.io/client-go => github.com/fasaxc/client-go v0.21.8-fix-match-rev
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.21.8
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.21.8
 	k8s.io/code-generator => k8s.io/code-generator v0.21.8

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch/v5 v5.2.0 h1:8ozOH5xxoMYDt5/u+yMTsVXydVCbTORFnOOoq2lumco=
 github.com/evanphx/json-patch/v5 v5.2.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/fasaxc/client-go v0.21.8-fix-match-rev h1:QL3vW7+rL1MZhMMfmvLOHIUer0xSTqvDtj/Ds2WCjWQ=
+github.com/fasaxc/client-go v0.21.8-fix-match-rev/go.mod h1:FcrKJITUrWtQSX3SCmqswlETK8AcVDTTA5PxDPxNtcg=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -1427,8 +1429,6 @@ k8s.io/apimachinery v0.21.8/go.mod h1:VdCLtKQwpSUQEWDaRsWR5ESDRqqhY2NeVzo9KCQ9uy
 k8s.io/apiserver v0.21.8 h1:JeBpbz0Hf4/zDCn8X6bZ5d2WOgIVHm84ImaA4SNfJzw=
 k8s.io/apiserver v0.21.8/go.mod h1:nnC0gG8nSTQW7Mig4ymKZBMSLzbNqmzPAXQyr1nYuOU=
 k8s.io/cli-runtime v0.21.8/go.mod h1:eWa1ebMMB2cRnXnwd5oS18bgjCyD0cgCj8dOq43JgC8=
-k8s.io/client-go v0.21.8 h1:okz2KT8eM2VrRRXQMqS205hulPOfGE112HdFFvwgy+E=
-k8s.io/client-go v0.21.8/go.mod h1:FcrKJITUrWtQSX3SCmqswlETK8AcVDTTA5PxDPxNtcg=
 k8s.io/cloud-provider v0.21.8/go.mod h1:PVbg45dslB/EvvELseKG/OivAfXbVEfJ3s/pACTIHWU=
 k8s.io/cluster-bootstrap v0.21.8/go.mod h1:tG9xoDw4m8HawkMsgBrEArJok87tyJH9kmd7do0ctE8=
 k8s.io/code-generator v0.21.8 h1:ajS/EvClGPP9svtZbXFK5n2kdakaWHJZOcpzF8jh8MM=

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -2449,6 +2449,15 @@ var _ = testutils.E2eDatastoreDescribe("Test Watch support", testutils.Datastore
 			Expect(err).NotTo(HaveOccurred())
 			watch.Stop()
 		})
+		It("should handle a list for many network policies with a revision", func() {
+			for i := 3; i < 1000; i++ {
+				createTestNetworkPolicy(fmt.Sprintf("test-net-policy-%d", i))
+			}
+			kvs, err := c.List(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, "")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = c.List(ctx, model.ResourceListOptions{Kind: model.KindKubernetesNetworkPolicy}, kvs.Revision)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Describe("watching NetworkPolicies (calico)", func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

When KDD does a paginated list with a revision, it sets
ResourceVersionMatch as well as ResourceVersion.  The client-go
pager was sendign the ResourceVersionMatch parameter on continuation
pages resulting in an error.  This caused the watcher to consistently
fail after hitting that condition.

Pin to a version of client-go that unsets ResourceVersionMatch
on continuation pages.

I added a test that failed before making the fix but now succeeds.

## Related issues/PRs

Fixes #5173 

## Todos

- [x] Tests
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix a serious regression introduced in v3.21 where the datastore watcher could get stuck and report stale information in clusters with >500 policies/pods/etc.  The bug was triggered by needing to do a resync (for example after an etcd compaction) when there were enough resources to trigger the list pager.
```
