### PR TITLE
Fix read back of XDP mode when using "driver" mode

### DIFF
--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -1228,15 +1228,18 @@ func (b *BPFLib) GetXDPMode(ifName string) (XDPMode, error) {
 	}
 
 	s := strings.Fields(string(output))
-	allModes := map[string]XDPMode{
-		"xdp":        XDPDriver, // We write "xdpdrv" but read back "xdp"
-		"xdpoffload": XDPOffload,
-		"xdpgeneric": XDPGeneric,
-	}
-	for _, mode := range []string{"xdpgeneric", "xdpoffload", "xdp"} {
+	// Note: using a slice (rather than a map[string]XDPMode) here to ensure deterministic ordering.
+	for _, modeMapping := range []struct {
+		String string
+		Mode   XDPMode
+	}{
+		{"xdpgeneric", XDPGeneric},
+		{"xdpoffload", XDPOffload},
+		{"xdp", XDPDriver}, // We write "xdpdrv" but read back "xdp"
+	} {
 		for _, f := range s {
-			if f == mode {
-				return allModes[f], nil
+			if f == modeMapping.String {
+				return modeMapping.Mode, nil
 			}
 		}
 	}

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -1229,13 +1229,15 @@ func (b *BPFLib) GetXDPMode(ifName string) (XDPMode, error) {
 
 	s := strings.Fields(string(output))
 	allModes := map[string]XDPMode{
-		XDPDriver.String():  XDPDriver,
-		XDPOffload.String(): XDPOffload,
-		XDPGeneric.String(): XDPGeneric,
+		"xdp":        XDPDriver, // We write "xdpdrv" but read back "xdp"
+		"xdpoffload": XDPOffload,
+		"xdpgeneric": XDPGeneric,
 	}
-	for i := range s {
-		if mode, ok := allModes[s[i]]; ok {
-			return mode, nil
+	for _, mode := range []string{"xdpgeneric", "xdpoffload", "xdp"} {
+		for _, f := range s {
+			if f == mode {
+				return allModes[f], nil
+			}
 		}
 	}
 

--- a/felix/dataplane/linux/xdp_state.go
+++ b/felix/dataplane/linux/xdp_state.go
@@ -468,10 +468,27 @@ func (s *xdpIPState) newXDPResyncState(bpfLib bpf.BPFDataplane, ipsSource ipsets
 	for _, iface := range xdpIfaces {
 		tag, tagErr := bpfLib.GetXDPTag(iface)
 		mode, modeErr := bpfLib.GetXDPMode(iface)
-		// error can happen when the program was not pinned in the bpf filesystem, so we say it's bogus anyway
-		bogus := tagErr != nil || tag != programTag || modeErr != nil || !isValidMode(mode, xpdModes)
+
+		var bogosityReasons []string
+		if tagErr != nil {
+			bogosityReasons = append(bogosityReasons, fmt.Sprintf("error getting tag: %s", tagErr.Error()))
+		} else if tag != programTag {
+			bogosityReasons = append(bogosityReasons, "loaded program doesn't match expected tag")
+		}
+		if modeErr != nil {
+			bogosityReasons = append(bogosityReasons, fmt.Sprintf("error getting mode: %s", modeErr.Error()))
+		} else if !isValidMode(mode, xpdModes) {
+			bogosityReasons = append(bogosityReasons, fmt.Sprintf("installed program uses disallowed mode: %v", mode))
+		}
+		if len(bogosityReasons) > 0 {
+			log.WithFields(log.Fields{
+				"reasons": bogosityReasons,
+				"iface":   iface,
+			}).Info("Program on interface is bogus in some way.  Will need to reapply it.")
+		}
+
 		ifacesWithProgs[iface] = progInfo{
-			bogus: bogus,
+			bogus: len(bogosityReasons) > 0,
 		}
 	}
 	ifacesWithPinnedMaps, err := bpfLib.ListCIDRMaps(s.getBpfIPFamily())
@@ -1720,11 +1737,11 @@ func (s *xdpSystemState) Copy() *xdpSystemState {
 
 type xdpPendingDiffState struct {
 	NewIfaceNameToHostEpID map[string]proto.HostEndpointID
-	IfaceNamesToDrop       set.Set //<string>
+	IfaceNamesToDrop       set.Set // <string>
 	IfaceEpIDChange        map[string]proto.HostEndpointID
-	UpdatedHostEndpoints   set.Set //<proto.HostEndpointID>
-	RemovedHostEndpoints   set.Set //<proto.HostEndpointID>
-	PoliciesToRemove       set.Set //<PolicyID>
+	UpdatedHostEndpoints   set.Set // <proto.HostEndpointID>
+	RemovedHostEndpoints   set.Set // <proto.HostEndpointID>
+	PoliciesToRemove       set.Set // <PolicyID>
 	PoliciesToUpdate       map[proto.PolicyID]*xdpRules
 }
 
@@ -1743,10 +1760,10 @@ func newXDPPendingDiffState() *xdpPendingDiffState {
 type xdpBPFActions struct {
 	// sets of interface names, for which a bpf map should be
 	// created
-	CreateMap set.Set //<string>
+	CreateMap set.Set // <string>
 	// sets of interface names, for which a bpf map should be
 	// dropped (or emptied in some cases)
-	RemoveMap set.Set //<string>
+	RemoveMap set.Set // <string>
 
 	// The fields below are normalized, so for a given interface a
 	// set ID will appear either in AddToMap or RemoveFromMap,
@@ -1760,10 +1777,10 @@ type xdpBPFActions struct {
 
 	// sets of interface names, where XDP program should be
 	// loaded/attached
-	InstallXDP set.Set //<string>
+	InstallXDP set.Set // <string>
 	// sets of interface names, where XDP program should be
 	// unloaded/detached
-	UninstallXDP set.Set //<string>
+	UninstallXDP set.Set // <string>
 
 	// Resync fallout
 	// keys are interface names, values are maps, where keys are
@@ -2120,7 +2137,7 @@ func processMemberDeletions(memberCache *xdpMemberCache, iface string, mi member
 
 type xdpIfaceData struct {
 	EpID             proto.HostEndpointID
-	PoliciesToSetIDs map[proto.PolicyID]set.Set //<string>
+	PoliciesToSetIDs map[proto.PolicyID]set.Set // <string>
 }
 
 func (data xdpIfaceData) Copy() xdpIfaceData {

--- a/felix/dataplane/linux/xdp_state.go
+++ b/felix/dataplane/linux/xdp_state.go
@@ -458,7 +458,7 @@ func (s *xdpIPState) getBpfIPFamily() bpf.IPFamily {
 }
 
 // newXDPResyncState creates the xdpResyncState object, returning an error on failure.
-func (s *xdpIPState) newXDPResyncState(bpfLib bpf.BPFDataplane, ipsSource ipsetsSource, programTag string, xpdModes []bpf.XDPMode) (*xdpResyncState, error) {
+func (s *xdpIPState) newXDPResyncState(bpfLib bpf.BPFDataplane, ipsSource ipsetsSource, programTag string, xdpModes []bpf.XDPMode) (*xdpResyncState, error) {
 	xdpIfaces, err := bpfLib.GetXDPIfaces()
 	if err != nil {
 		return nil, err
@@ -473,11 +473,12 @@ func (s *xdpIPState) newXDPResyncState(bpfLib bpf.BPFDataplane, ipsSource ipsets
 		if tagErr != nil {
 			bogosityReasons = append(bogosityReasons, fmt.Sprintf("error getting tag: %s", tagErr.Error()))
 		} else if tag != programTag {
-			bogosityReasons = append(bogosityReasons, "loaded program doesn't match expected tag")
+			bogosityReasons = append(bogosityReasons, fmt.Sprintf("loaded program's tag (%s) doesn't match expected tag (%s)",
+				tag, programTag))
 		}
 		if modeErr != nil {
 			bogosityReasons = append(bogosityReasons, fmt.Sprintf("error getting mode: %s", modeErr.Error()))
-		} else if !isValidMode(mode, xpdModes) {
+		} else if !isValidMode(mode, xdpModes) {
 			bogosityReasons = append(bogosityReasons, fmt.Sprintf("installed program uses disallowed mode: %v", mode))
 		}
 		if len(bogosityReasons) > 0 {

--- a/felix/fv/xdp_test.go
+++ b/felix/fv/xdp_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/calico/felix/fv/connectivity"
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"

--- a/felix/fv/xdp_test.go
+++ b/felix/fv/xdp_test.go
@@ -17,13 +17,13 @@ package fv
 import (
 	"fmt"
 	"os"
-	"strings"
+	"regexp"
+	"strconv"
 	"time"
-
-	"github.com/projectcalico/calico/felix/fv/connectivity"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/projectcalico/calico/felix/fv/connectivity"
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -192,14 +192,29 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ XDP tests with initialized 
 		expectNoConnectivity(ccTCP)
 	})
 
-	xdpProgramAttached := func(felix *infrastructure.Felix, iface string) bool {
+	xdpProgramID := func(felix *infrastructure.Felix, iface string) int {
 		out, err := felix.ExecCombinedOutput("ip", "link", "show", "dev", iface)
 		Expect(err).NotTo(HaveOccurred())
-		return strings.Contains(out, "prog/xdp id")
+		r := regexp.MustCompile(`prog/xdp id (\d+)`)
+		matches := r.FindStringSubmatch(out)
+		if len(matches) == 0 {
+			return 0
+		}
+		id, err := strconv.Atoi(matches[1])
+		Expect(err).NotTo(HaveOccurred())
+		return id
+	}
+
+	xdpProgramAttached := func(felix *infrastructure.Felix, iface string) bool {
+		return xdpProgramID(felix, iface) != 0
 	}
 
 	xdpProgramAttached_felix1_eth0 := func() bool {
 		return xdpProgramAttached(felixes[1], "eth0")
+	}
+
+	xdpProgramID_felix1_eth0 := func() int {
+		return xdpProgramID(felixes[1], "eth0")
 	}
 
 	Context("with no untracked policy", func() {
@@ -277,7 +292,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ XDP tests with initialized 
 
 		It("should have XDP program attached", func() {
 			Eventually(xdpProgramAttached_felix1_eth0, "10s", "1s").Should(BeTrue())
-			Consistently(xdpProgramAttached_felix1_eth0, "2s", "1s").Should(BeTrue())
+			id := xdpProgramID(felixes[1], "eth0")
+			Consistently(xdpProgramID_felix1_eth0(), "2s", "100ms").Should(Equal(id))
 		})
 
 		Context("with untracked policies deleted again", func() {


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We write xdpdrv but ip link returns "xdp" when we read it back.

think the bug was exposed by kernels being updated so that now xdpdrv mode is supported on veths.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix application of the iptables-mode XDP DoS protection program on devices that support driver mode.
```
