### PR TITLE
felix/bpf: include RPF and wg chains again.

### DIFF
--- a/felix/rules/rule_defs.go
+++ b/felix/rules/rule_defs.go
@@ -167,7 +167,7 @@ type RuleRenderer interface {
 	StaticNATTableChains(ipVersion uint8) []*iptables.Chain
 	StaticNATPostroutingChains(ipVersion uint8) []*iptables.Chain
 	StaticRawTableChains(ipVersion uint8) []*iptables.Chain
-	StaticBPFModeRawChains(ipVersion uint8, tcBypassMark uint32) []*iptables.Chain
+	StaticBPFModeRawOutputChains(ipVersion uint8, tcBypassMark uint32) []*iptables.Chain
 	StaticMangleTableChains(ipVersion uint8) []*iptables.Chain
 	StaticFilterForwardAppendRules() []iptables.Rule
 

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -986,36 +986,8 @@ func (r *DefaultRuleRenderer) StaticRawTableChains(ipVersion uint8) []*Chain {
 	}
 }
 
-func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8, tcBypassMark uint32) []*Chain {
-	rawPreroutingChain := &Chain{
-		Name: ChainRawPrerouting,
-		Rules: []Rule{
-			Rule{
-				// Return, i.e. no-op, if bypass mark is not set.
-				Match:  Match().NotMarkMatchesWithMask(tcBypassMark, 0xffffffff),
-				Action: ReturnAction{},
-			},
-			// At this point we know bypass mark is set, which means that the packet has
-			// been explicitly allowed by untracked ingress policy (XDP).  We should
-			// clear the mark so as not to affect any FROM_HOST processing.  (There
-			// shouldn't be any FROM_HOST processing, because untracked policy is only
-			// intended for traffic to/from the host.  But if the traffic is in fact
-			// forwarded and goes to or through another endpoint, it's better to enforce
-			// that endpoint's policy than to accidentally skip it because of the BYPASS
-			// mark.  Note that we can clear the mark without stomping on anyone else's
-			// logic because no one else's iptables should have had a chance to execute
-			// yet.
-			Rule{
-				Action: SetMarkAction{Mark: 0},
-			},
-			// Now ensure that the packet is not tracked.
-			Rule{
-				Action: NoTrackAction{},
-			},
-		},
-	}
+func (r *DefaultRuleRenderer) StaticBPFModeRawOutputChains(ipVersion uint8, tcBypassMark uint32) []*Chain {
 	return []*Chain{
-		rawPreroutingChain,
 		r.failsafeOutChain("raw", ipVersion),
 		r.StaticRawOutputChain(tcBypassMark),
 	}


### PR DESCRIPTION
Since commit
https://github.com/projectcalico/calico/commit/cabb7c129bd476e9fc339bd02d285e457ed2993f
the prerouting raw chain does not include the RPF and wg chains as those
are removed by the chains generated by StaticBPFModeRawChains(). Hence
we do not enforce RPF when RPF is disabled or set to lose.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
