### PR TITLE
FIX: hack directory now lives inside calico subdirectory

### DIFF
--- a/calico/hack/remove-calico-policy/override-policy.md
+++ b/calico/hack/remove-calico-policy/override-policy.md
@@ -24,13 +24,13 @@ Create a policy-override resource by running the following command:
 For Calico `v2.5.x` or higher:
 
 ```
-kubectl create -f=https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/global-network-policy-override.yaml
+kubectl create -f=https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/global-network-policy-override.yaml
 ```
 
 For Calico `v2.3.x` and `v2.4.x`:
 
 ```
-kubectl create -f=https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/system-network-policy-override.yaml
+kubectl create -f=https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/system-network-policy-override.yaml
 ```
 
 #### Revert override to enable Calico policy
@@ -41,11 +41,11 @@ responsible for the override by running the following command:
 For Calico `v2.5.x` or higher:
 
 ```
-kubectl delete -f=https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/global-network-policy-override.yaml
+kubectl delete -f=https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/global-network-policy-override.yaml
 ```
 
 For Calico `v2.3.x` and `v2.4.x`:
 
 ```
-kubectl delete -f=https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/system-network-policy-override.yaml
+kubectl delete -f=https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/system-network-policy-override.yaml
 ```

--- a/calico/hack/remove-calico-policy/remove-policy.md
+++ b/calico/hack/remove-calico-policy/remove-policy.md
@@ -19,7 +19,7 @@ Calico policy can be disabled and removed for troubleshooting purposes or in eme
 To build the `calico/iptables-remover` Docker image used by the DaemonSet:
 
 ```
-curl https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/Dockerfile -o Dockerfile
+curl https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/Dockerfile -o Dockerfile
 docker build -t calico/iptables-remover .
 ```
 
@@ -57,14 +57,14 @@ The DaemonSet relies on a ConfigMap containing [the script to execute](remove-ca
 directory. First, create the ConfigMap:
 
 ```
-curl https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/remove-calico-policy.sh -o remove-calico-policy.sh
+curl https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/remove-calico-policy.sh -o remove-calico-policy.sh
 kubectl create configmap remove-calico-policy-config -n=kube-system --from-file=./remove-calico-policy.sh
 ```
 
 Then, deploy the DaemonSet:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/iptables-remover-ds.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/iptables-remover-ds.yaml
 ```
 
 #### Revert: Re-enabling Calico Policy
@@ -76,7 +76,7 @@ To revert the disabling and removal of Calico policy, follow the steps below.
 Remove the policy-removal Daemonset and the ConfigMap:
 
 ```
-kubectl delete -f https://raw.githubusercontent.com/projectcalico/calico/master/hack/remove-calico-policy/iptables-remover-ds.yaml
+kubectl delete -f https://raw.githubusercontent.com/projectcalico/calico/master/calico/hack/remove-calico-policy/iptables-remover-ds.yaml
 kubectl delete configmap remove-calico-policy-config -n=kube-system
 ```
 

--- a/calico/reference/etcd-rbac/certificate-generation.md
+++ b/calico/reference/etcd-rbac/certificate-generation.md
@@ -11,7 +11,7 @@ Authority (CA), Certificates and Keys that can be used to authenticate a
 specific user with etcd. There are many different tools that can be used to
 generate these files. This tutorial tries to layout the unique or specific
 details that are needed for each of the different certificates but uses the
-[hack/tls-setup tool from the etcd repo](https://github.com/coreos/etcd/tree/master/hack/tls-setup){:target="_blank"},
+[hack/tls-setup tool from the etcd repo](https://github.com/coreos/etcd/tree/master/calico/hack/tls-setup){:target="_blank"},
 to make certificate generation easy.
 
 The etcd server links a certificate to a specific user by using the Common

--- a/calico/reference/etcd-rbac/certificate-generation.md
+++ b/calico/reference/etcd-rbac/certificate-generation.md
@@ -11,7 +11,7 @@ Authority (CA), Certificates and Keys that can be used to authenticate a
 specific user with etcd. There are many different tools that can be used to
 generate these files. This tutorial tries to layout the unique or specific
 details that are needed for each of the different certificates but uses the
-[hack/tls-setup tool from the etcd repo](https://github.com/coreos/etcd/tree/master/calico/hack/tls-setup){:target="_blank"},
+[hack/tls-setup tool from the etcd repo](https://github.com/coreos/etcd/tree/master/calico/tls-setup){:target="_blank"},
 to make certificate generation easy.
 
 The etcd server links a certificate to a specific user by using the Common

--- a/calico/reference/etcd-rbac/certificate-generation.md
+++ b/calico/reference/etcd-rbac/certificate-generation.md
@@ -11,7 +11,7 @@ Authority (CA), Certificates and Keys that can be used to authenticate a
 specific user with etcd. There are many different tools that can be used to
 generate these files. This tutorial tries to layout the unique or specific
 details that are needed for each of the different certificates but uses the
-[hack/tls-setup tool from the etcd repo](https://github.com/coreos/etcd/tree/master/calico/tls-setup){:target="_blank"},
+[hack/tls-setup tool from the etcd repo](https://github.com/coreos/etcd/tree/master/hack/tls-setup){:target="_blank"},
 to make certificate generation easy.
 
 The etcd server links a certificate to a specific user by using the Common


### PR DESCRIPTION
## Description

Several links in docs refer to the hack directory, which changed locations in the repo from `./hack` to `calico/hack`

## Todos

~- [ ] Tests~
~- [ ] Documentation~
~- [ ] Release note~

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
