### PR TITLE
docs: operator based installation for the VPP dataplane

### DIFF
--- a/calico/_includes/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
+++ b/calico/_includes/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: apiservers.operator.tigera.io
   annotations:
-    helm.sh/hook: crd-install
+    controller-gen.kubebuilder.io/version: v0.3.0
+  name: apiservers.operator.tigera.io
 spec:
   group: operator.tigera.io
   names:
@@ -22,12 +22,12 @@ spec:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -46,3 +46,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/calico/_includes/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
+++ b/calico/_includes/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
@@ -46,9 +46,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/calico/_includes/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
+++ b/calico/_includes/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
@@ -114,6 +114,7 @@ spec:
                     enum:
                     - Iptables
                     - BPF
+                    - VPP
                     type: string
                   mtu:
                     description: MTU specifies the maximum transmission unit to use
@@ -155,6 +156,12 @@ spec:
                         description: Interface enables IP auto-detection based on
                           interfaces that match the given regex.
                         type: string
+                      kubernetes:
+                        description: Kubernetes configures Calico to detect node addresses
+                          based on the Kubernetes API.
+                        enum:
+                        - NodeInternalIP
+                        type: string
                       skipInterface:
                         description: SkipInterface enables IP auto-detection based
                           on interfaces that do not match the given regex.
@@ -184,6 +191,12 @@ spec:
                       interface:
                         description: Interface enables IP auto-detection based on
                           interfaces that match the given regex.
+                        type: string
+                      kubernetes:
+                        description: Kubernetes configures Calico to detect node addresses
+                          based on the Kubernetes API.
+                        enum:
+                        - NodeInternalIP
                         type: string
                       skipInterface:
                         description: SkipInterface enables IP auto-detection based
@@ -313,7 +326,7 @@ spec:
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -326,7 +339,7 @@ spec:
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
                             otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                   required:
@@ -401,7 +414,7 @@ spec:
                   the image path for each image. If not specified or empty, the default
                   for each image will be used. A special case value, UseDefault, is
                   supported to explicitly specify the default image path will be used
-                  for each image. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<imagePath>` portion of the
                   above format."
                 type: string
@@ -411,7 +424,7 @@ spec:
                   a prefix on each image. If not specified or empty, no prefix will
                   be used. A special case value, UseDefault, is supported to explicitly
                   specify the default image prefix will be used for each image. \n
-                  Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<imagePrefix>` portion of
                   the above format."
                 type: string
@@ -463,6 +476,34 @@ spec:
                       for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
                       See https://github.com/kubernetes/kubernetes/issues/35345'
                     properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of nodes with an existing
+                          available DaemonSet pod that can have an updated DaemonSet
+                          pod during during an update. Value can be an absolute number
+                          (ex: 5) or a percentage of desired pods (ex: 10%). This
+                          can not be 0 if MaxUnavailable is 0. Absolute number is
+                          calculated from percentage by rounding up to a minimum of
+                          1. Default value is 0. Example: when this is set to 30%,
+                          at most 30% of the total number of nodes that should be
+                          running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their a new pod created before the old pod is marked
+                          as deleted. The update starts by launching new pods on 30%
+                          of nodes. Once an updated pod is available (Ready for at
+                          least minReadySeconds) the old DaemonSet pod on that node
+                          is marked deleted. If the old pod becomes unavailable for
+                          any reason (Ready transitions to false, is evicted, or is
+                          drained) an updated pod is immediatedly created on that
+                          node without considering surge limits. Allowing surge implies
+                          the possibility that the resources consumed by the daemonset
+                          on any given node can double if the readiness check fails,
+                          and so resource intensive daemonsets should take into account
+                          that they may cause evictions during disruption. This is
+                          an alpha field and requires enabling DaemonSetUpdateSurge
+                          feature gate.'
+                        x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
@@ -471,17 +512,18 @@ spec:
                           be unavailable during the update. Value can be an absolute
                           number (ex: 5) or a percentage of total number of DaemonSet
                           pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This cannot
-                          be 0. Default value is 1. Example: when this is set to 30%,
-                          at most 30% of the total number of nodes that should be
-                          running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their pods stopped for an update at any given time.
-                          The update starts by stopping at most 30% of those DaemonSet
-                          pods and then brings up new DaemonSet pods in their place.
-                          Once the new pods are available, it then proceeds onto other
-                          DaemonSet pods, thus ensuring that at least 70% of original
-                          number of DaemonSet pods are available at all times during
-                          the update.'
+                          is calculated from percentage by rounding down to a minimum
+                          of one. This cannot be 0 if MaxSurge is 0 Default value
+                          is 1. Example: when this is set to 30%, at most 30% of the
+                          total number of nodes that should be running the daemon
+                          pod (i.e. status.desiredNumberScheduled) can have their
+                          pods stopped for an update at any given time. The update
+                          starts by stopping at most 30% of those DaemonSet pods and
+                          then brings up new DaemonSet pods in their place. Once the
+                          new pods are available, it then proceeds onto other DaemonSet
+                          pods, thus ensuring that at least 70% of original number
+                          of DaemonSet pods are available at all times during the
+                          update.'
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
@@ -495,10 +537,11 @@ spec:
                 type: string
               registry:
                 description: "Registry is the default Docker registry used for component
-                  Docker images. If specified, all images will be pulled from this
-                  registry. If not specified then the default registries will be used.
-                  A special case value, UseDefault, is supported to explicitly specify
-                  the default registries will be used. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                  Docker images. If specified then the given value must end with a
+                  slash character (`/`) and all images will be pulled from this registry.
+                  If not specified then the default registries will be used. A special
+                  case value, UseDefault, is supported to explicitly specify the default
+                  registries will be used. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                   \n This option allows configuring the `<registry>` portion of the
                   above format."
                 type: string
@@ -814,6 +857,7 @@ spec:
                         enum:
                         - Iptables
                         - BPF
+                        - VPP
                         type: string
                       mtu:
                         description: MTU specifies the maximum transmission unit to
@@ -856,6 +900,12 @@ spec:
                             description: Interface enables IP auto-detection based
                               on interfaces that match the given regex.
                             type: string
+                          kubernetes:
+                            description: Kubernetes configures Calico to detect node
+                              addresses based on the Kubernetes API.
+                            enum:
+                            - NodeInternalIP
+                            type: string
                           skipInterface:
                             description: SkipInterface enables IP auto-detection based
                               on interfaces that do not match the given regex.
@@ -886,6 +936,12 @@ spec:
                           interface:
                             description: Interface enables IP auto-detection based
                               on interfaces that match the given regex.
+                            type: string
+                          kubernetes:
+                            description: Kubernetes configures Calico to detect node
+                              addresses based on the Kubernetes API.
+                            enum:
+                            - NodeInternalIP
                             type: string
                           skipInterface:
                             description: SkipInterface enables IP auto-detection based
@@ -1019,7 +1075,7 @@ spec:
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                               description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                             requests:
                               additionalProperties:
@@ -1032,7 +1088,7 @@ spec:
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
                       required:
@@ -1108,7 +1164,7 @@ spec:
                       used as the image path for each image. If not specified or empty,
                       the default for each image will be used. A special case value,
                       UseDefault, is supported to explicitly specify the default image
-                      path will be used for each image. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      path will be used for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<imagePath>` portion
                       of the above format."
                     type: string
@@ -1118,7 +1174,7 @@ spec:
                       as a prefix on each image. If not specified or empty, no prefix
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default image prefix will be used
-                      for each image. \n Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<imagePrefix>` portion
                       of the above format."
                     type: string
@@ -1170,6 +1226,35 @@ spec:
                           our convention for oneOf, whatever we decide it to be. Same
                           as Deployment `strategy.rollingUpdate`. See https://github.com/kubernetes/kubernetes/issues/35345'
                         properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'The maximum number of nodes with an existing
+                              available DaemonSet pod that can have an updated DaemonSet
+                              pod during during an update. Value can be an absolute
+                              number (ex: 5) or a percentage of desired pods (ex:
+                              10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                              number is calculated from percentage by rounding up
+                              to a minimum of 1. Default value is 0. Example: when
+                              this is set to 30%, at most 30% of the total number
+                              of nodes that should be running the daemon pod (i.e.
+                              status.desiredNumberScheduled) can have their a new
+                              pod created before the old pod is marked as deleted.
+                              The update starts by launching new pods on 30% of nodes.
+                              Once an updated pod is available (Ready for at least
+                              minReadySeconds) the old DaemonSet pod on that node
+                              is marked deleted. If the old pod becomes unavailable
+                              for any reason (Ready transitions to false, is evicted,
+                              or is drained) an updated pod is immediatedly created
+                              on that node without considering surge limits. Allowing
+                              surge implies the possibility that the resources consumed
+                              by the daemonset on any given node can double if the
+                              readiness check fails, and so resource intensive daemonsets
+                              should take into account that they may cause evictions
+                              during disruption. This is an alpha field and requires
+                              enabling DaemonSetUpdateSurge feature gate.'
+                            x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
                             - type: integer
@@ -1179,17 +1264,17 @@ spec:
                               absolute number (ex: 5) or a percentage of total number
                               of DaemonSet pods at the start of the update (ex: 10%).
                               Absolute number is calculated from percentage by rounding
-                              up. This cannot be 0. Default value is 1. Example: when
-                              this is set to 30%, at most 30% of the total number
-                              of nodes that should be running the daemon pod (i.e.
-                              status.desiredNumberScheduled) can have their pods stopped
-                              for an update at any given time. The update starts by
-                              stopping at most 30% of those DaemonSet pods and then
-                              brings up new DaemonSet pods in their place. Once the
-                              new pods are available, it then proceeds onto other
-                              DaemonSet pods, thus ensuring that at least 70% of original
-                              number of DaemonSet pods are available at all times
-                              during the update.'
+                              down to a minimum of one. This cannot be 0 if MaxSurge
+                              is 0 Default value is 1. Example: when this is set to
+                              30%, at most 30% of the total number of nodes that should
+                              be running the daemon pod (i.e. status.desiredNumberScheduled)
+                              can have their pods stopped for an update at any given
+                              time. The update starts by stopping at most 30% of those
+                              DaemonSet pods and then brings up new DaemonSet pods
+                              in their place. Once the new pods are available, it
+                              then proceeds onto other DaemonSet pods, thus ensuring
+                              that at least 70% of original number of DaemonSet pods
+                              are available at all times during the update.'
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
@@ -1203,11 +1288,12 @@ spec:
                     type: string
                   registry:
                     description: "Registry is the default Docker registry used for
-                      component Docker images. If specified, all images will be pulled
+                      component Docker images. If specified then the given value must
+                      end with a slash character (`/`) and all images will be pulled
                       from this registry. If not specified then the default registries
                       will be used. A special case value, UseDefault, is supported
                       to explicitly specify the default registries will be used. \n
-                      Image format:    `<registry>/<imagePath>/<imagePrefix><imageName>:<image-tag>`
+                      Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>`
                       \n This option allows configuring the `<registry>` portion of
                       the above format."
                     type: string

--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -162,6 +162,9 @@ DPDK provides better performance compared to the standard install but it require
    SSH_ALLOW_CIDR="0.0.0.0/0"              # source IP from which ssh access is allowed when KEYNAME is specified
    INSTANCE_TYPE=m5.large                  # EC2 instance type
    INSTANCE_NUM=2                          # Number of instances in cluster
+   ## Calico installation spec for the operator; could be url or local file
+   CALICO_INSTALLATION_YAML=https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/calico/installation-eks.yaml
+   #CALICO_INSTALLATION_YAML=./calico_installation.yaml
    ## Calico/VPP deployment yaml; could be url or local file
    CALICO_VPP_YAML=https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/generated/calico-vpp-eks-dpdk.yaml
    #CALICO_VPP_YAML=<full path>/calico-vpp-eks-dpdk.yaml
@@ -175,7 +178,7 @@ DPDK provides better performance compared to the standard install but it require
 
 
    ```bash
-   bash create_eks_cluster.sh <cluster name> -r <region-name> [-k <keyname>] [-t <instance type>] [-n <number of instances>] [-f <calico/vpp config yaml file>]
+   bash create_eks_cluster.sh <cluster name> -r <region-name> [-k <keyname>] [-t <instance type>] [-n <number of instances>] [-f <calico/vpp config yaml file>] [-i <installation yaml>]
    ```
 
    `CLUSTER_NAME` and `REGION` are MANDATORY.  Note that command-line options override the `CONFIG PARAMS` options. In case you want to enable ssh access to the EKS worker instances specify the name of an existing SSH key in EC2 in the `KEYNAME` option. For details on ssh access refer to {% include open-new-window.html text='Amazon EC2 key pairs and  Linux  instances' url='https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html' %}

--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -223,15 +223,16 @@ The VPP dataplane has the following requirements:
 **Optional**
 For some hardware, the following hugepages configuration may enable VPP to use more efficient drivers:
 
-- At least 128 x 2MB-hugepages are available (`cat /proc/meminfo | grep HugePages_Free`)
+- At least 256 x 2MB-hugepages are available (`grep HugePages_Free /proc/meminfo`)
 - The `vfio-pci` (`vfio_pci` on centos) or `uio_pci_generic` kernel module is loaded. For example:
 
    ````bash
    echo "vfio-pci" > /etc/modules-load.d/95-vpp.conf
    modprobe vfio-pci
-   echo "vm.nr_hugepages = 128" >> /etc/sysctl.conf
+   echo "vm.nr_hugepages = 256" >> /etc/sysctl.conf
    sysctl -p
-   # restart kubelet to take the changes into account, you may need to use a different command depending on how kubelet was installed
+   # restart kubelet to take the changes into account
+   # you may need to use a different command depending on how kubelet was installed
    systemctl restart kubelet
    ````
 

--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -24,7 +24,7 @@ The VPP dataplane mode has several advantages over standard Linux networking pip
 
 The VPP dataplane is entirely compatible with the other {{site.prodname}} dataplanes, meaning you can have a cluster with VPP-enabled nodes along with regular nodes. This makes it possible to migrate a cluster from Linux or eBPF networking to VPP networking.
 
-In the addition, the VPP dataplane offers some specific features for network-intensive applications, such as providing `memif` userspace packet interfaces to the pods (instead of regular Linux network devices), or exposing the VPP Host Stack to run optimized L4+ applications in the pods.
+In addition, the VPP dataplane offers some specific features for network-intensive applications, such as providing `memif` userspace packet interfaces to the pods (instead of regular Linux network devices), or exposing the VPP Host Stack to run optimized L4+ applications in the pods.
 
 Trying out the tech preview will give you a taste of these benefits and an opportunity to give feedback to the VPP dataplane team.
 

--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -9,7 +9,7 @@ canonical_url: '/getting-started/kubernetes/vpp/getting-started'
 
 Install {{site.prodname}} and enable the tech preview of the VPP dataplane.
 
-> **Warning!** The VPP dataplane is a tech preview and should not be used in production clusters. It has had limited testing and it will contain bugs (please report these on the [Calico Users slack](https://calicousers.slack.com/archives/C017220EXU1) or [Github](https://github.com/projectcalico/vpp-dataplane/issues)).  In addition, it does not support all the features of {{site.prodname}} and it is currently missing some security features such as Host Endpoint policies.
+> **Warning!** The VPP dataplane is a tech preview and should not be used in production clusters. It has had limited testing and it will contain bugs (please report these on the [Calico Users slack](https://calicousers.slack.com/archives/C017220EXU1) or [Github](https://github.com/projectcalico/vpp-dataplane/issues)).  In addition, it does not support all the features of {{site.prodname}} and it is currently missing some security features such as Application Layer Policy.
 {: .alert .alert-danger }
 
 ### Value
@@ -22,9 +22,9 @@ The VPP dataplane mode has several advantages over standard Linux networking pip
   * Reduces first-packet latency for packets to services
   * Preserves external client source IP addresses all the way to the pod
 
-The VPP dataplane is entirely compatible with the other {{site.prodname}} dataplanes, meaning you can have a cluster with VPP-enabled nodes along with regular nodes. This makes it easy to migrate a cluster from Linux or eBPF networking to VPP networking.
+The VPP dataplane is entirely compatible with the other {{site.prodname}} dataplanes, meaning you can have a cluster with VPP-enabled nodes along with regular nodes. This makes it possible to migrate a cluster from Linux or eBPF networking to VPP networking.
 
-In the future, the VPP dataplane will offer additional features for network-intensive applications, such as providing `memif` userspace packet interfaces to the pods (instead of regular Linux network devices).
+In the addition, the VPP dataplane offers some specific features for network-intensive applications, such as providing `memif` userspace packet interfaces to the pods (instead of regular Linux network devices), or exposing the VPP Host Stack to run optimized L4+ applications in the pods.
 
 Trying out the tech preview will give you a taste of these benefits and an opportunity to give feedback to the VPP dataplane team.
 
@@ -40,7 +40,14 @@ This how-to guide uses the following {{site.prodname}} features:
 
 #### VPP
 
-The Vector Packet Processor (VPP) is a high-performance, open-source userspace network dataplane written in C, developed under the [fd.io](https://fd.io) umbrella. It supports many standard networking features (L2, L3 routing, NAT, encapsulations), and is easily extensible using plugins. The VPP dataplane uses plugins to efficiently implement Kubernetes services load balancing and {{site.prodname}} policies.
+The Vector Packet Processor (VPP) is a high-performance, open-source userspace network dataplane written in C, developed under the [fd.io](https://fd.io) umbrella. It supports many standard networking features (L2 switching, L3 routing, NAT, encapsulations), and is easily extensible using plugins. The VPP dataplane uses plugins to efficiently implement Kubernetes services load balancing and {{site.prodname}} policies.
+
+#### Operator based installation
+
+This guide uses the Tigera operator to install {{site.prodname}}. The operator provides lifecycle management for {{site.prodname}}
+exposed via the Kubernetes API defined as a custom resource definition. While it is also technically possible to install {{site.prodname}}
+and configure it for VPP using manifests directly, only operator based installations are supported at this stage.
+
 
 ### How to
 
@@ -67,7 +74,7 @@ For these instructions, we will use `eksctl` to provision the cluster. However, 
 
 Before you get started, make sure you have downloaded and configured the {% include open-new-window.html text='necessary prerequisites' url='https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html#eksctl-prereqs' %}
 
-#### Provision and configure the cluster
+#### Provision the cluster
 
 1. First, create an Amazon EKS cluster without any nodes.
 
@@ -75,13 +82,32 @@ Before you get started, make sure you have downloaded and configured the {% incl
    eksctl create cluster --name my-calico-cluster --without-nodegroup
    ```
 
-1. Since this cluster will use {{site.prodname}} for networking, you must delete the `aws-node` daemon set to disable AWS VPC networking for pods.
+1. Since this cluster will use {{site.prodname}} for networking, you must delete the `aws-node` DaemonSet to disable the default AWS VPC networking for the pods.
 
    ```bash
    kubectl delete daemonset -n kube-system aws-node
    ```
 
-1. Now that you have a cluster configured, you can install {{site.prodname}}.
+
+#### Install and configure Calico with the VPP dataplane
+
+1. Now that you have an empty cluster configured, you can install the Tigera operator. 
+
+   ```bash
+   kubectl apply -f {{ "/manifests/tigera-operator.yaml" | absolute_url }}
+   ```
+
+1. Then, you need to configure the {{site.prodname}} installation for the VPP dataplane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference]({{site.baseurl}}/reference/installation/api).
+
+   > **Note**: Before applying this manifest, read its contents and make sure its settings are correct for your environment. For example,
+   > you may need to specify the default IP pool CIDR to match your desired pod network CIDR.
+   {: .alert .alert-info}
+
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/calico/installation-eks.yaml
+   ```
+
+1. Now is time to install the VPP dataplane components.
 
    ```bash
    kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/generated/calico-vpp-eks.yaml
@@ -90,7 +116,7 @@ Before you get started, make sure you have downloaded and configured the {% incl
 1. Finally, add nodes to the cluster.
 
    ```bash
-   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --node-ami auto --max-pods-per-node 100
+   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --node-ami auto --max-pods-per-node 50
    ```
 
    > **Tip**: The --max-pods-per-node option above, ensures that EKS does not limit the {% include open-new-window.html text='number of pods based on node-type' url='https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt' %}. For the full set of node group options, see `eksctl create nodegroup --help`.
@@ -206,9 +232,27 @@ For some hardware, the following hugepages configuration may enable VPP to use m
    systemctl restart kubelet
    ````
 
-#### Configure nodes for VPP
+#### Install Calico and configure it for VPP
 
-Start by getting the appropriate yaml manifest for the {{ site.prodname }} VPP dataplane:
+1. Start by installing the Tigera operator on your cluster. 
+
+   ```bash
+   kubectl apply -f {{ "/manifests/tigera-operator.yaml" | absolute_url }}
+   ```
+
+1. Then, you need to configure the {{site.prodname}} installation for the VPP dataplane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the installation reference]({{site.baseurl}}/reference/installation/api).
+
+   > **Note**: Before applying this manifest, read its contents and make sure its settings are correct for your environment. For example,
+   > you may need to specify the default IP pool CIDR to match your desired pod network CIDR.
+   {: .alert .alert-info}
+
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/calico/installation.yaml
+   ```
+
+#### Install the VPP dataplane components
+
+Start by getting the appropriate yaml manifest for the VPP dataplane resources:
 ```bash
 # If you have configured hugepages on your machines
 curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/generated/calico-vpp.yaml
@@ -218,11 +262,11 @@ curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-data
 curl -o calico-vpp.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/generated/calico-vpp-nohuge.yaml
 ```
 
-Then configure these parameters in the `calico-vpp-config` ConfigMap in the yaml manifest.
+Then locate the `calico-vpp-config` ConfigMap in this yaml manifest and configure it as follows.
 
 **Required**
 
-* `vpp_dataplane_interface` is the primary interface that VPP will use. It must be the name of a Linux interface, configured with an address. The address configured on this interface must be the node address in Kubernetes (`kubectl get nodes -o wide`).
+* `vpp_dataplane_interface` is the primary interface that VPP will use. It must be the name of a Linux interface, up and configured with an address. The address configured on this interface **must** be the node address in Kubernetes (`kubectl get nodes -o wide`).
 * `service_prefix` is the Kubernetes service CIDR. You can retrieve it by running:
 ````bash
 kubectl cluster-info dump | grep -m 1 service-cluster-ip-range
@@ -231,12 +275,15 @@ If this command doesn't return anything, you can leave the default value of `10.
 
 **Optional**
 
-* `vpp_uplink_driver` configures how VPP grabs the physical interface, available values are:
-  * `""` : will automatically select and try drivers based on available resources, starting with the fastest
-  * `avf` : use the native AVF driver
-  * `virtio` : use the native virtio driver (requires hugepages)
+* `vpp_uplink_driver` configures how VPP drives the physical interface. The supported values will depend on the interface type. Available values are:
+  * `""` : will automatically select and try drivers based on interface type and available resources, starting with the fastest
   * `af_xdp` : use an AF_XDP socket to drive the interface (requires kernel 5.4 or newer)
-  * `af_packet` : use an AF_PACKET socket to drive the interface (slow but works everywhere)
+  * `af_packet` : use an AF_PACKET socket to drive the interface (not optimized but works everywhere)
+  * `avf` : use the VPP native driver for Intel 700-Series and 800-Series interfaces (requires hugepages)
+  * `vmxnet3` : use the VPP native driver for VMware virtual interfaces (requires hugepages)
+  * `virtio` : use the VPP native driver for Virtio virtual interfaces  (requires hugepages)
+  * `rdma` : use the VPP native driver for Mellanox CX-4 and CX-5 interfaces (requires hugepages)
+  * `dpdk` : use the DPDK interface drivers with VPP (requires hugepages, works with most interfaces)
   * `none` : do not configure connectivity automatically. This can be used when [configuring the interface manually]({{ site.baseurl }}/reference/vpp/uplink-configuration)
 
 **Example**
@@ -254,8 +301,6 @@ data:
   ...
 ````
 
-**Note** {{ site.prodname }} uses `192.168.0.0/16` as the IP range for the pods by default. If this IP range is used somewhere else in your environment, you should further [customize the manifest]({{ site.baseurl }}/getting-started/kubernetes/installation/config-options) to change it.
-
 #### Apply the configuration
 
 To apply the configuration, run:
@@ -263,7 +308,7 @@ To apply the configuration, run:
 kubectl apply -f calico-vpp.yaml
 ````
 
-This will create all the resources necessary to connect your pods through VPP and configure Calico on the nodes.
+This will install all the resources required by the VPP dataplane in your cluster.
 
 %>
 {% endtabs %}

--- a/calico/maintenance/troubleshoot/vpp.md
+++ b/calico/maintenance/troubleshoot/vpp.md
@@ -6,7 +6,7 @@ canonical_url: '/maintenance/troubleshoot/vpp'
 
 ### Big picture
 
-This page describes the troubleshooting steps for the VPP dataplane. If you did not configure the VPP dataplane, this page is not for you!
+This page describes the troubleshooting steps for the [VPP dataplane]({{ site.baseurl }}/getting-started/kubernetes/vpp/getting-started). If you did not configure the VPP dataplane, this page is not for you!
 
 If you're encountering issues with the VPP dataplane, feel free to reach out to us either on the [#vpp channel](https://calicousers.slack.com/archives/C017220EXU1) on the {{ site.prodname }} slack, or by opening a new issue in [Github](https://github.com/projectcalico/vpp-dataplane/issues)).
 

--- a/calico/manifests/tigera-operator.yaml
+++ b/calico/manifests/tigera-operator.yaml
@@ -4,4 +4,6 @@ layout: null
 {% helm tigera-operator %}
 installation:
   enabled: false
+apiServer:
+  enabled: false
 {% endhelm %}


### PR DESCRIPTION
## Description

This PR updates the Installation and APIServer CRD definitions from the current operator master.

## Related issues/PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
VPP dataplane instructions now use operator-based install
```
