### PR TITLE
Cherry-pick wireguard fix to v3.21

### DIFF
--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -115,10 +115,12 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
 		subDir := "globals"
 		if m.Type() == libbpf.MapTypeProgrArray && strings.Contains(m.Name(), "cali_jump") {
+			// Remove period in the interface name if any
+			ifName := strings.ReplaceAll(ap.Iface, ".", "")
 			if ap.Hook == HookIngress {
-				subDir = ap.Iface + "_igr/"
+				subDir = ifName + "_igr/"
 			} else {
-				subDir = ap.Iface + "_egr/"
+				subDir = ifName + "_egr/"
 			}
 		}
 		pinPath := path.Join(baseDir, subDir, m.Name())


### PR DESCRIPTION
## Description

If the interface name has period, creating directories for jump maps with period will fail. This happens with wireguard, vxlan.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
