### PR TITLE
Automated cherry pick of #5360: Clean up DEV_REGSITRIES / RELEASE_REGISTRIES

### DIFF
--- a/.semaphore/push-images/alp.yml
+++ b/.semaphore/push-images/alp.yml
@@ -30,6 +30,9 @@ blocks:
       - name: docker
       jobs:
       - name: "ALP"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C pod2daemon image-all cd CONFIRM=true; fi
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C app-policy image-all cd CONFIRM=true; fi

--- a/.semaphore/push-images/apiserver.yml
+++ b/.semaphore/push-images/apiserver.yml
@@ -30,5 +30,8 @@ blocks:
       - name: docker
       jobs:
       - name: "apiserver"
-        commands:
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
+       commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C apiserver image-all cd CONFIRM=true; fi

--- a/.semaphore/push-images/calicoctl.yml
+++ b/.semaphore/push-images/calicoctl.yml
@@ -30,5 +30,8 @@ blocks:
       - name: docker
       jobs:
       - name: "calicoctl"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C calicoctl image-all cd CONFIRM=true; fi

--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -30,5 +30,8 @@ blocks:
       - name: docker
       jobs:
       - name: "cni-plugin"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin image-all cd CONFIRM=true; fi

--- a/.semaphore/push-images/kube-controllers.yml
+++ b/.semaphore/push-images/kube-controllers.yml
@@ -30,5 +30,8 @@ blocks:
       - name: docker
       jobs:
       - name: "kube-controllers"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C kube-controllers image-all cd CONFIRM=true; fi

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -32,9 +32,15 @@ blocks:
       # The node build takes a long time due to some architectures, so we split it up.
       # TODO: Add support for other architectures
       - name: "Linux amd64"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make VALIDARCHES=amd64 -C node image-all cd-common CONFIRM=true; fi
 
       - name: "windows-upgrade"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node build-windows-upgrade-archive image-tar-windows-all cd-windows-upgrade CONFIRM=true; fi

--- a/.semaphore/push-images/typha.yml
+++ b/.semaphore/push-images/typha.yml
@@ -30,5 +30,8 @@ blocks:
       - name: docker
       jobs:
       - name: "typha"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C typha image-all cd CONFIRM=true; fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -119,12 +119,10 @@ blocks:
       commands:
       - cd typha
       - make ci EXCEPT=k8sfv-test
-    - name: "Typha: felix k8s-st tests with updated typha image"
+    - name: "Typha: felix k8s-st tests"
       commands:
-      - cd typha
-      - make image
-      - cd ../felix
-      - JUST_A_MINUTE=true USE_TYPHA=true FV_TYPHAIMAGE=calico/typha:latest TYPHA_VERSION=latest make k8sfv-test
+      - cd felix
+      - JUST_A_MINUTE=true USE_TYPHA=true make k8sfv-test
     epilogue:
       always:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -122,7 +122,7 @@ blocks:
     - name: "Typha: felix k8s-st tests with updated typha image"
       commands:
       - cd typha
-      - make calico/typha
+      - make image
       - cd ../felix
       - JUST_A_MINUTE=true USE_TYPHA=true FV_TYPHAIMAGE=calico/typha:latest TYPHA_VERSION=latest make k8sfv-test
     epilogue:

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -121,7 +121,7 @@ sub-image-%:
 	$(MAKE) image ARCH=$*
 
 $(API_SERVER_IMAGE): $(CONTAINER_CREATED)
-$(CONTAINER_CREATED): docker-image/Dockerfile.$(ARCH) $(BINDIR)/apiserver
+$(CONTAINER_CREATED): docker-image/Dockerfile.$(ARCH) $(BINDIR)/apiserver $(BINDIR)/filecheck
 	docker build -t $(API_SERVER_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-image/Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -6,12 +6,10 @@ LOCAL_CHECKS     = lint-cache-dir goimports check-copyright check-boring-ssl
 # Used so semaphore commits generated files when pins are updated
 EXTRA_FILES_TO_COMMIT=*_generated.go *_generated.*.go
 
-API_SERVER_IMAGE      ?=calico/apiserver
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
+API_SERVER_IMAGE      ?=apiserver
 BUILD_IMAGES          ?=$(API_SERVER_IMAGE)
-DEV_REGISTRIES        ?=quay.io docker.io
-RELEASE_REGISTRIES    ?=$(DEV_REGISTRIES)
-RELEASE_BRANCH_PREFIX ?=release
-DEV_TAG_SUFFIX        ?=0.dev
 
 EXTRA_DOCKER_ARGS += -e GOLANGCI_LINT_CACHE=/lint-cache -v $(CURDIR)/.lint-cache:/lint-cache:rw \
 				 -v $(CURDIR)/hack/boilerplate:/go/src/k8s.io/kubernetes/hack/boilerplate:rw
@@ -80,7 +78,7 @@ LINT_ARGS := --disable gosimple,govet,structcheck,errcheck,goimports,unused,inef
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: clean static-checks calico/apiserver fv ut
+ci: clean static-checks image fv ut
 
 ## Deploys images to registry
 cd: image-all cd-common
@@ -125,19 +123,8 @@ sub-image-%:
 $(API_SERVER_IMAGE): $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): docker-image/Dockerfile.$(ARCH) $(BINDIR)/apiserver
 	docker build -t $(API_SERVER_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-image/Dockerfile.$(ARCH) .
-ifeq ($(ARCH),amd64)
-	docker tag $(API_SERVER_IMAGE):latest-$(ARCH) $(API_SERVER_IMAGE):latest
-endif
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
-
-# Build the calico/apiserver docker image.
-.PHONY: calico/apiserver
-calico/apiserver: $(BINDIR)/apiserver $(BINDIR)/filecheck
-	rm -rf docker-image/bin
-	mkdir -p docker-image/bin
-	cp $(BINDIR)/apiserver docker-image/bin/
-	cp $(BINDIR)/filecheck docker-image/bin/
-	docker build --pull -t calico/apiserver --file ./docker-image/Dockerfile.$(ARCH) docker-image
 
 .PHONY: lint-cache-dir
 lint-cache-dir:
@@ -296,11 +283,8 @@ fv-kdd: run-kubernetes-server hack-lib
 		sh -c 'DATASTORE_TYPE="kubernetes" test/integration.sh'
 
 .PHONY: clean
-clean: clean-bin clean-build-image clean-hack-lib
+clean: clean-bin clean-hack-lib
 	rm -rf .lint-cache
-
-clean-build-image:
-	docker rmi -f calico/apiserver > /dev/null 2>&1 || true
 
 clean-bin:
 	rm -rf $(BINDIR) \

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -4,9 +4,6 @@ PACKAGE_NAME = github.com/projectcalico/calico/app-policy
 
 ###############################################################################
 
-PROTOC_VER?=v0.1
-PROTOC_CONTAINER?=calico/protoc:$(PROTOC_VER)-$(BUILDARCH)
-
 # Figure out the users UID/GID.  These are needed to run docker containers
 # as the current user and ensure that files built inside containers are
 # owned by the current user.

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -133,9 +133,6 @@ $(DIKASTES_IMAGE): $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): Dockerfile.$(ARCH) bin/dikastes-$(ARCH) bin/healthz-$(ARCH)
 	docker build -t $(DIKASTES_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-ifeq ($(ARCH),amd64)
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-endif
 	touch $@
 
 ###############################################################################

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -7,11 +7,6 @@ PACKAGE_NAME = github.com/projectcalico/calico/app-policy
 PROTOC_VER?=v0.1
 PROTOC_CONTAINER?=calico/protoc:$(PROTOC_VER)-$(BUILDARCH)
 
-DIKASTES_GIT_VERSION?=$(shell git describe --tags --dirty --always --abbrev=12)
-
-# Get version from git - used for releases.
-GIT_VERSION?=$(shell git describe --tags --dirty --always --abbrev=12)
-
 # Figure out the users UID/GID.  These are needed to run docker containers
 # as the current user and ensure that files built inside containers are
 # owned by the current user.
@@ -21,20 +16,10 @@ MY_GID:=$(shell id -g)
 GENERATED_FILES=proto/felixbackend.pb.go proto/healthz.pb.go
 SRC_FILES=$(shell find . -name '*.go' |grep -v vendor) $(GENERATED_FILES)
 
-RELEASE_REGISTRIES ?=gcr.io/projectcalico-org eu.gcr.io/projectcalico-org asia.gcr.io/projectcalico-org us.gcr.io/projectcalico-org
-
-# If this is a release, also tag and push additional images.
-ifeq ($(RELEASE),true)
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
 DIKASTES_IMAGE ?=dikastes
-DEV_REGISTRIES ?=quay.io/calico calico $(RELEASE_REGISTRIES)
-else
-DIKASTES_IMAGE ?=calico/dikastes
-DEV_REGISTRIES ?=quay.io docker.io
-endif
-
 BUILD_IMAGES ?= $(DIKASTES_IMAGE)
-
-GIT_USE_SSH?=true
 
 ##############################################################################
 # Download and include ../lib.Makefile before anything else
@@ -147,8 +132,9 @@ sub-image-%:
 $(DIKASTES_IMAGE): $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): Dockerfile.$(ARCH) bin/dikastes-$(ARCH) bin/healthz-$(ARCH)
 	docker build -t $(DIKASTES_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 ifeq ($(ARCH),amd64)
-	docker tag $(DIKASTES_IMAGE):latest-$(ARCH) $(DIKASTES_IMAGE):latest
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 endif
 	touch $@
 

--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -177,12 +177,15 @@ st: bin/calicoctl-linux-amd64 version-helper
 
 .PHONY: run-etcd-host
 run-etcd-host:
+	# TODO: We shouldn't need to enable the v2 API, but some of our test code 
+	# still relies on it. 
 	@-docker rm -f calico-etcd
 	docker run --detach \
 	--net=host \
 	--name calico-etcd \
 	$(ETCD_IMAGE) \
 	etcd \
+	--enable-v2 \
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379" \
 	--listen-client-urls "http://0.0.0.0:2379"
 

--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -175,24 +175,13 @@ st: bin/calicoctl-linux-amd64 version-helper
 	$(MAKE) stop-etcd
 	$(MAKE) stop-kubernetes-master
 
-## Etcd is used by the STs
-# NOTE: https://quay.io/repository/coreos/etcd is available *only* for the following archs with the following tags:
-# amd64: 3.3.7
-# arm64: 3.3.7-arm64
-# ppc64le: 3.3.7-ppc64le
-# s390x is not available
-# armv7 is not available
-COREOS_ETCD?=quay.io/coreos/etcd:$(ETCD_VERSION)-$(ARCH)
-ifeq ($(ARCH),amd64)
-COREOS_ETCD=quay.io/coreos/etcd:$(ETCD_VERSION)
-endif
 .PHONY: run-etcd-host
 run-etcd-host:
 	@-docker rm -f calico-etcd
 	docker run --detach \
 	--net=host \
 	--name calico-etcd \
-	$(COREOS_ETCD) \
+	$(ETCD_IMAGE) \
 	etcd \
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379" \
 	--listen-client-urls "http://0.0.0.0:2379"

--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -5,13 +5,12 @@ PACKAGE_NAME = github.com/projectcalico/calico/calicoctl
 KUBE_APISERVER_PORT?=6443
 KUBE_MOCK_NODE_MANIFEST?=mock-node.yaml
 
-CALICOCTL_IMAGE       ?=calico/ctl
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
+CALICOCTL_IMAGE       ?=ctl
 BUILD_IMAGES          ?=$(CALICOCTL_IMAGE)
-DEV_REGISTRIES        ?=quay.io docker.io
-RELEASE_REGISTRIES    ?= $(DEV_REGISTRIES)
 RELEASE_BRANCH_PREFIX ?= release
 DEV_TAG_SUFFIX        ?= 0.dev
-
 
 # Remove any excluded architectures since for calicoctl we want to build everything.
 EXCLUDEARCH?=
@@ -96,9 +95,7 @@ image: $(CALICOCTL_IMAGE)
 $(CALICOCTL_IMAGE): $(CTL_CONTAINER_CREATED)
 $(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH) register
 	docker buildx build --pull -t $(CALICOCTL_IMAGE):latest-$(ARCH) --platform=linux/$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) . --load
-ifeq ($(ARCH),amd64)
-	docker tag $(CALICOCTL_IMAGE):latest-$(ARCH) $(CALICOCTL_IMAGE):latest
-endif
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
 # by default, build the image for the target architecture

--- a/calicoctl/tests/st/utils/utils.py
+++ b/calicoctl/tests/st/utils/utils.py
@@ -464,6 +464,7 @@ def curl_etcd(path, options=None, recursive=True, ip=None):
             % (ip, path, str(recursive).lower(), " ".join(options)),
             shell=True)
 
+    logger.info("etcd RC: %s" % rc.strip())
     return json.loads(rc.strip())
 
 def wipe_etcd(ip):

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -268,7 +268,7 @@ pkg/install/install.test: pkg/install/*.go
 .PHONY: test-install-cni
 ## Test the install
 test-install-cni: image pkg/install/install.test
-	cd pkg/install && CONTAINER_NAME=$(CNI_PLUGIN_IMAGE) ./install.test
+	cd pkg/install && CONTAINER_NAME=$(CNI_PLUGIN_IMAGE)-$(ARCH) ./install.test
 
 ###############################################################################
 # CI/CD

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -110,9 +110,6 @@ sub-image-%:
 $(DEPLOY_CONTAINER_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
 	docker build -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-ifeq ($(ARCH),amd64)
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-endif
 	touch $@
 
 .PHONY: fetch-cni-bins

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -5,19 +5,9 @@ PACKAGE_NAME = github.com/projectcalico/calico/cni-plugin
 # Add in local static-checks
 LOCAL_CHECKS=check-boring-ssl
 
-RELEASE_REGISTRIES    ?= gcr.io/projectcalico-org eu.gcr.io/projectcalico-org asia.gcr.io/projectcalico-org us.gcr.io/projectcalico-org
-RELEASE_BRANCH_PREFIX ?= release
-DEV_TAG_SUFFIX        ?= 0.dev
-
-# If this is a release, also tag and push additional images.
-ifeq ($(RELEASE),true)
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
 CNI_PLUGIN_IMAGE ?=cni
-DEV_REGISTRIES   ?=quay.io/calico calico $(RELEASE_REGISTRIES)
-else
-CNI_PLUGIN_IMAGE ?=calico/cni
-DEV_REGISTRIES   ?=quay.io docker.io
-endif
-
 BUILD_IMAGES   ?=$(CNI_PLUGIN_IMAGE)
 
 ###############################################################################
@@ -118,10 +108,10 @@ sub-image-%:
 	$(MAKE) image ARCH=$*
 
 $(DEPLOY_CONTAINER_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
-	GO111MODULE=on docker build -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	docker build -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 ifeq ($(ARCH),amd64)
-	# Need amd64 builds tagged as :latest because Semaphore depends on that
-	docker tag $(CNI_PLUGIN_IMAGE):latest-$(ARCH) $(CNI_PLUGIN_IMAGE):latest
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 endif
 	touch $@
 

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -258,7 +258,7 @@ pkg/install/install.test: pkg/install/*.go
 .PHONY: test-install-cni
 ## Test the install
 test-install-cni: image pkg/install/install.test
-	cd pkg/install && CONTAINER_NAME=$(CNI_PLUGIN_IMAGE)-$(ARCH) ./install.test
+	cd pkg/install && CONTAINER_NAME=$(CNI_PLUGIN_IMAGE):latest-$(ARCH) ./install.test
 
 ###############################################################################
 # CI/CD

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -34,13 +34,6 @@ CNI_SPEC_VERSION?=0.3.1
 
 DEPLOY_CONTAINER_MARKER=cni_deploy_container-$(ARCH).created
 
-
-ETCD_CONTAINER ?= quay.io/coreos/etcd:$(ETCD_VERSION)-$(BUILDARCH)
-# If building on amd64 omit the arch in the container name.
-ifeq ($(BUILDARCH),amd64)
-	ETCD_CONTAINER=quay.io/coreos/etcd:$(ETCD_VERSION)
-endif
-
 # We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.
 ifeq ($(ARCH), $(filter $(ARCH),amd64))
 CGO_ENABLED=1
@@ -243,7 +236,7 @@ stop-k8s-controller:
 run-etcd: stop-etcd
 	docker run --detach \
 	  -p 2379:2379 \
-	  --name calico-etcd $(ETCD_CONTAINER) \
+	  --name calico-etcd $(ETCD_IMAGE) \
 	  etcd \
 	  --advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379,http://$(LOCAL_IP_ENV):4001,http://127.0.0.1:4001" \
 	  --listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"

--- a/confd/Makefile
+++ b/confd/Makefile
@@ -110,21 +110,12 @@ test-etcd: bin/confd bin/etcdctl bin/bird bin/bird6 bin/calico-node bin/kubectl 
 ut:
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r .'
 
-## Etcd is used by the kubernetes
-# NOTE: https://quay.io/repository/coreos/etcd is available *only* for the following archs with the following tags:
-# amd64: 3.2.5
-# arm64: 3.2.5-arm64
-# ppc64le: 3.2.5-ppc64le
-# s390x is not available
-COREOS_ETCD ?= quay.io/coreos/etcd:$(ETCD_VERSION)-$(ARCH)
-ifeq ($(ARCH),amd64)
-COREOS_ETCD = quay.io/coreos/etcd:$(ETCD_VERSION)
-endif
+
 run-etcd: stop-etcd
 	docker run --detach \
 	-e GO111MODULE=on \
 	--net=host \
-	--name calico-etcd $(COREOS_ETCD) \
+	--name calico-etcd $(ETCD_IMAGE) \
 	etcd \
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379,http://$(LOCAL_IP_ENV):4001,http://127.0.0.1:4001" \
 	--listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -59,16 +59,10 @@ MAKE_REPO?=https://raw.githubusercontent.com/projectcalico/go-build/$(MAKE_BRANC
 
 include ../lib.Makefile
 
-FV_ETCDIMAGE?=quay.io/coreos/etcd:$(ETCD_VERSION)-$(BUILDARCH)
+FV_ETCDIMAGE?=$(ETCD_IMAGE)
 FV_TYPHAIMAGE?=felix-test/typha:latest-$(BUILDARCH)
 FV_K8SIMAGE=calico/go-build:$(GO_BUILD_VER)
 FV_FELIXIMAGE?=$(FELIX_IMAGE)-test:latest-$(BUILDARCH)
-
-# If building on amd64 omit the arch in the container name.  Fixme!
-ifeq ($(BUILDARCH),amd64)
-	FV_ETCDIMAGE=quay.io/coreos/etcd:$(ETCD_VERSION)
-	FV_TYPHAIMAGE=felix-test/typha:latest
-endif
 
 # Total number of batches to split the tests into.  In CI we set this to say 5 batches,
 # and run a single batch on each test VM.

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -60,14 +60,14 @@ MAKE_REPO?=https://raw.githubusercontent.com/projectcalico/go-build/$(MAKE_BRANC
 include ../lib.Makefile
 
 FV_ETCDIMAGE?=quay.io/coreos/etcd:$(ETCD_VERSION)-$(BUILDARCH)
-FV_TYPHAIMAGE?=calico/typha:latest-$(BUILDARCH)
+FV_TYPHAIMAGE?=felix-test/typha:latest-$(BUILDARCH)
 FV_K8SIMAGE=calico/go-build:$(GO_BUILD_VER)
 FV_FELIXIMAGE?=$(FELIX_IMAGE)-test:latest-$(BUILDARCH)
 
 # If building on amd64 omit the arch in the container name.  Fixme!
 ifeq ($(BUILDARCH),amd64)
 	FV_ETCDIMAGE=quay.io/coreos/etcd:$(ETCD_VERSION)
-	FV_TYPHAIMAGE=calico/typha:latest
+	FV_TYPHAIMAGE=felix-test/typha:latest
 endif
 
 # Total number of batches to split the tests into.  In CI we set this to say 5 batches,
@@ -273,7 +273,7 @@ fv/infrastructure/crds:
 	cp -r ../libcalico-go/config/crd fv/infrastructure/crds; chmod +w fv/infrastructure/crds/
 
 build-typha:
-	make -C ../typha image
+	make -C ../typha image DEV_REGISTRIES=felix-test
 
 .PHONY: fv
 # runs all of the fv tests
@@ -349,7 +349,7 @@ K8SFV_GO_FILES:=$(shell find ./$(K8SFV_DIR) -name prometheus -prune -o -type f -
 # e.g.
 #       $(MAKE) k8sfv-test JUST_A_MINUTE=true USE_TYPHA=true
 #       $(MAKE) k8sfv-test JUST_A_MINUTE=true USE_TYPHA=false
-k8sfv-test: image-test  k8sfv-test-existing-felix
+k8sfv-test: image-test k8sfv-test-existing-felix
 # Run k8sfv test with whatever is the existing 'calico/felix:latest'
 # container image.  To use some existing Felix version other than
 # 'latest', do 'FELIX_VERSION=<...> make k8sfv-test-existing-felix'.

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -31,9 +31,11 @@ include ../metadata.mk
 ###############################################################################
 PACKAGE_NAME = github.com/projectcalico/calico/felix
 
-FELIX_IMAGE    ?=calico/felix
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
+FELIX_IMAGE    ?=felix
 BUILD_IMAGES   ?=$(FELIX_IMAGE)
-DEV_REGISTRIES ?=$(DOCKERHUB_REGISTRY) quay.io
+
 LIBBPF_PATH=bpf-gpl/include/libbpf/src
 LIBBPF_CONTAINER_PATH=/go/src/github.com/projectcalico/calico/felix/$(LIBBPF_PATH)
 BPFGPL_PATH=/go/src/github.com/projectcalico/calico/felix/bpf-gpl
@@ -230,8 +232,9 @@ $(FELIX_IMAGE)-$(ARCH): bin/calico-felix-$(ARCH) \
 	# Copy only the files we're explicitly expecting (in case we have left overs after switching branch).
 	cp $(ALL_BPF_PROGS) docker-image/bpf/bin
 	docker build --pull -t $(FELIX_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --file ./docker-image/Dockerfile.$(ARCH) docker-image;
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 ifeq ($(ARCH),amd64)
-	docker tag $(FELIX_IMAGE):latest-$(ARCH) $(FELIX_IMAGE):latest
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 endif
 
 ifeq ($(FV_RACE_DETECTOR_ENABLED),true)
@@ -242,14 +245,16 @@ endif
 
 image-test: image fv/Dockerfile.test.amd64 bin/pktgen bin/test-workload bin/test-connection bin/$(FV_BINARY) image-wgtool
 	docker build -t $(FELIX_IMAGE)-test:latest-$(ARCH) --build-arg FV_BINARY=$(FV_BINARY) --file ./fv/Dockerfile.test.$(ARCH) bin;
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-test
 ifeq ($(ARCH),amd64)
-	docker tag $(FELIX_IMAGE)-test:latest-$(ARCH) $(FELIX_IMAGE)-test:latest
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-test
 endif
 
 image-wgtool: fv/Dockerfile.wgtool.amd64
 	docker build -t $(FELIX_IMAGE)-wgtool:latest-$(ARCH) --file ./fv/Dockerfile.wgtool.$(ARCH) fv;
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-wgtool
 ifeq ($(ARCH),amd64)
-	docker tag $(FELIX_IMAGE)-wgtool:latest-$(ARCH) $(FELIX_IMAGE)-wgtool:latest
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-wgtool
 endif
 
 ###############################################################################

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -233,9 +233,6 @@ $(FELIX_IMAGE)-$(ARCH): bin/calico-felix-$(ARCH) \
 	cp $(ALL_BPF_PROGS) docker-image/bpf/bin
 	docker build --pull -t $(FELIX_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --file ./docker-image/Dockerfile.$(ARCH) docker-image;
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-ifeq ($(ARCH),amd64)
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-endif
 
 ifeq ($(FV_RACE_DETECTOR_ENABLED),true)
 FV_BINARY=calico-felix-race-amd64
@@ -246,16 +243,10 @@ endif
 image-test: image fv/Dockerfile.test.amd64 bin/pktgen bin/test-workload bin/test-connection bin/$(FV_BINARY) image-wgtool
 	docker build -t $(FELIX_IMAGE)-test:latest-$(ARCH) --build-arg FV_BINARY=$(FV_BINARY) --file ./fv/Dockerfile.test.$(ARCH) bin;
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-test
-ifeq ($(ARCH),amd64)
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-test
-endif
 
 image-wgtool: fv/Dockerfile.wgtool.amd64
 	docker build -t $(FELIX_IMAGE)-wgtool:latest-$(ARCH) --file ./fv/Dockerfile.wgtool.$(ARCH) fv;
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-wgtool
-ifeq ($(ARCH),amd64)
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest BUILD_IMAGES=$(FELIX_IMAGE)-wgtool
-endif
 
 ###############################################################################
 # Unit Tests

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -22,12 +22,6 @@ MAKE_REPO?=https://raw.githubusercontent.com/projectcalico/go-build/$(MAKE_BRANC
 
 include ../lib.Makefile
 
-ETCD_IMAGE?=quay.io/coreos/etcd:$(ETCD_VERSION)-$(BUILDARCH)
-# If building on amd64 omit the arch in the container name.
-ifeq ($(BUILDARCH),amd64)
-	ETCD_IMAGE=quay.io/coreos/etcd:$(ETCD_VERSION)
-endif
-
 SRC_FILES=cmd/kube-controllers/main.go $(shell find pkg -name '*.go')
 
 # We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -2,11 +2,12 @@ include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/kube-controllers
 
-# Makefile configuration options
-KUBE_CONTROLLERS_IMAGE  ?=calico/kube-controllers
-FLANNEL_MIGRATION_IMAGE ?=calico/flannel-migration-controller
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
+KUBE_CONTROLLERS_IMAGE  ?=kube-controllers
+FLANNEL_MIGRATION_IMAGE ?=flannel-migration-controller
+
 BUILD_IMAGES            ?=$(KUBE_CONTROLLERS_IMAGE) $(FLANNEL_MIGRATION_IMAGE)
-DEV_REGISTRIES          ?=docker.io quay.io
 
 # Add in local static-checks
 LOCAL_CHECKS=check-boring-ssl
@@ -85,14 +86,11 @@ sub-image-%:
 	$(MAKE) image ARCH=$*
 
 image.created-$(ARCH): bin/kube-controllers-linux-$(ARCH) bin/check-status-linux-$(ARCH) bin/kubectl-$(ARCH)
-	# Build the docker image for the policy controller.
 	docker build -t $(KUBE_CONTROLLERS_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
-	# Build the docker image for the flannel migration controller.
 	docker build -t $(FLANNEL_MIGRATION_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-images/flannel-migration/Dockerfile.$(ARCH) .
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 ifeq ($(ARCH),amd64)
-	# Need amd64 builds tagged as :latest because Semaphore depends on that
-	docker tag $(KUBE_CONTROLLERS_IMAGE):latest-$(ARCH) $(KUBE_CONTROLLERS_IMAGE):latest
-	docker tag $(FLANNEL_MIGRATION_IMAGE):latest-$(ARCH) $(FLANNEL_MIGRATION_IMAGE):latest
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 endif
 	touch $@
 

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -89,9 +89,6 @@ image.created-$(ARCH): bin/kube-controllers-linux-$(ARCH) bin/check-status-linux
 	docker build -t $(KUBE_CONTROLLERS_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 	docker build -t $(FLANNEL_MIGRATION_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-images/flannel-migration/Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-ifeq ($(ARCH),amd64)
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-endif
 	touch $@
 
 .PHONY: remote-deps

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -149,11 +149,12 @@ endif
 # we do not need to use the arch since go-build:v0.15 now is multi-arch manifest
 GO_BUILD_IMAGE ?= calico/go-build
 CALICO_BUILD    = $(GO_BUILD_IMAGE):$(GO_BUILD_VER)
-
-COREDNS_VERSION=1.5.2
-ETCD_VERSION=v3.3.7
-PROTOC_VER=v0.1
 PROTOC_CONTAINER=calico/protoc:$(PROTOC_VER)-$(BUILDARCH)
+
+# NOTE: https://quay.io/repository/coreos/etcd is available *only* for the following archs with the following tags:
+# amd64, arm64, ppc64le
+# s390x is not available
+ETCD_IMAGE ?= quay.io/coreos/etcd:$(ETCD_VERSION)-$(ARCH)
 
 ifeq ($(GIT_USE_SSH),true)
 	GIT_CONFIG_SSH ?= git config --global url."ssh://git@github.com/".insteadOf "https://github.com/";

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -149,11 +149,9 @@ endif
 # we do not need to use the arch since go-build:v0.15 now is multi-arch manifest
 GO_BUILD_IMAGE ?= calico/go-build
 CALICO_BUILD    = $(GO_BUILD_IMAGE):$(GO_BUILD_VER)
-PROTOC_CONTAINER=calico/protoc:$(PROTOC_VER)-$(BUILDARCH)
 
-# NOTE: https://quay.io/repository/coreos/etcd is available *only* for the following archs with the following tags:
-# amd64, arm64, ppc64le
-# s390x is not available
+# Images used in build / test across multiple directories.
+PROTOC_CONTAINER=calico/protoc:$(PROTOC_VER)-$(BUILDARCH)
 ETCD_IMAGE ?= quay.io/coreos/etcd:$(ETCD_VERSION)-$(ARCH)
 
 ifeq ($(GIT_USE_SSH),true)

--- a/libcalico-go/Makefile
+++ b/libcalico-go/Makefile
@@ -151,7 +151,7 @@ run-etcd-tls: stop-etcd-tls
 		-v `pwd`/$(TEST_CERT_PATH):/root/etcd-certificates/ \
 		--net=host \
 		--entrypoint=/usr/local/bin/etcd \
-		--name calico-etcd-tls quay.io/coreos/etcd:$(ETCD_VERSION)  \
+		--name calico-etcd-tls $(ETCD_IMAGE)  \
 		--listen-peer-urls https://127.0.0.1:5008 \
 		--peer-cert-file=/root/etcd-certificates/server.crt \
 		--peer-key-file=/root/etcd-certificates/server.key \
@@ -172,7 +172,7 @@ run-etcd: stop-etcd
 	docker run --detach \
 	--net=host \
 	--entrypoint=/usr/local/bin/etcd \
-	--name calico-etcd quay.io/coreos/etcd:$(ETCD_VERSION) \
+	--name calico-etcd $(ETCD_IMAGE) \
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379,http://$(LOCAL_IP_ENV):4001,http://127.0.0.1:4001" \
 	--listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
 

--- a/metadata.mk
+++ b/metadata.mk
@@ -9,6 +9,11 @@ GO_BUILD_VER = v0.65
 K8S_VERSION     = v1.22.1
 KUBECTL_VERSION = v1.22.1
 
+# Version of various tools used in the build and tests.
+COREDNS_VERSION=1.5.2
+ETCD_VERSION=v3.5.0
+PROTOC_VER=v0.1
+
 # Configuration for Semaphore integration.
 ORGANIZATION = projectcalico
 

--- a/metadata.mk
+++ b/metadata.mk
@@ -18,12 +18,11 @@ GIT_USE_SSH = true
 # The version of BIRD to use for calico/node builds and confd tests.
 BIRD_VERSION=v0.3.3-184-g202a2186
 
-# TODO: Update Makefiles to pull registry configuration from here.
-# DEV_REGISTRIES configures the container image registries which are published to as part of 
-# this branches CI/CD pipeline.
-#DEV_REGISTRIES = quay.io docker.io
+# DEV_REGISTRIES configures the container image registries which are built from this
+# repository. By default, just build images with calico/. CI/CD will override this
+# variable to quay.io/calico and docker.io/calico
+DEV_REGISTRIES = calico
 
-# TODO: Update Makefiles to pull registry configuration from here.
 # RELEASE_REGISTIRES configures the container images registries which are published to 
 # as part of an official release.
-#RELEASE_REGISTRIES = $(DEV_REGISTRIES)
+RELEASE_REGISTRIES = quay.io/calico docker.io/calico gcr.io/projectcalico-org eu.gcr.io/projectcalico-org asia.gcr.io/projectcalico-org us.gcr.io/projectcalico-org

--- a/node/Makefile
+++ b/node/Makefile
@@ -2,20 +2,13 @@ include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/node
 
-RELEASE_REGISTRIES    ?=gcr.io/projectcalico-org eu.gcr.io/projectcalico-org asia.gcr.io/projectcalico-org us.gcr.io/projectcalico-org
 RELEASE_BRANCH_PREFIX ?=release
 DEV_TAG_SUFFIX        ?=0.dev
 
-# If this is a release, also tag and push additional images.
-ifeq ($(RELEASE),true)
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
 NODE_IMAGE            ?=node
 WINDOWS_UPGRADE_IMAGE ?=windows-upgrade
-DEV_REGISTRIES        ?=quay.io/calico calico $(RELEASE_REGISTRIES)
-else
-NODE_IMAGE            ?=calico/node
-WINDOWS_UPGRADE_IMAGE ?=calico/windows-upgrade
-DEV_REGISTRIES        ?=quay.io docker.io
-endif
 
 WINDOWS_VERSIONS?=1809 2004 20H2 ltsc2022
 BUILD_IMAGES ?=$(NODE_IMAGE)
@@ -282,14 +275,8 @@ clean-sub-image-%:
 
 $(NODE_IMAGE): $(NODE_CONTAINER_CREATED)
 $(NODE_CONTAINER_CREATED): register ./Dockerfile.$(ARCH) $(NODE_CONTAINER_FILES) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) remote-deps
-	# Check versions of the binaries that we're going to use to build the image.
-	# Since the binaries are built for Linux, run them in a container to allow the
-	# make target to be run on different platforms (e.g. MacOS).
-	docker run --rm -v $(CURDIR)/dist/bin:/go/bin:rw $(CALICO_BUILD) /bin/sh -c "\
-	  echo; echo calico-node-$(ARCH) -v;	 /go/bin/calico-node-$(ARCH) -v; \
-	"
-## TARGET_PLATFORM fixes an issue where `FROM SCRATCH` in the Dockerfile share the same architecture as the host.
 	docker build --pull -t $(NODE_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
 # download BIRD source to include in image.

--- a/node/Makefile
+++ b/node/Makefile
@@ -341,11 +341,14 @@ $(BINDIR)/kubectl:
 # etcd is used by the STs
 .PHONY: run-etcd
 run-etcd:
+	# TODO: We shouldn't need to enable the v2 API, but some of our test code 
+	# still relies on it. 
 	@-docker rm -f calico-etcd
 	docker run --detach \
 	--net=host \
 	--name calico-etcd $(ETCD_IMAGE) \
 	etcd \
+	--enable-v2 \
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:2379" \
 	--listen-client-urls "http://0.0.0.0:2379"
 

--- a/node/Makefile
+++ b/node/Makefile
@@ -48,11 +48,6 @@ CNI_VER?=master
 TEST_CONTAINER_NAME_VER?=latest
 CTL_CONTAINER_NAME?=calico/ctl:$(CALICOCTL_VER)-$(ARCH)
 TEST_CONTAINER_NAME?=calico/test:$(TEST_CONTAINER_NAME_VER)-$(ARCH)
-# If building on amd64 omit the arch in the container name.  Fixme!
-ETCD_IMAGE?=quay.io/coreos/etcd:$(ETCD_VERSION)
-ifneq ($(BUILDARCH),amd64)
-	ETCD_IMAGE=$(ETCD_IMAGE)-$(ARCH)
-endif
 
 # TODO: Update this to use newer version of Kubernetes.
 HYPERKUBE_IMAGE?=gcr.io/google_containers/hyperkube-$(ARCH):v1.17.0

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -2,19 +2,9 @@ include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/pod2daemon
 
-RELEASE_REGISTRIES    ?= gcr.io/projectcalico-org eu.gcr.io/projectcalico-org asia.gcr.io/projectcalico-org us.gcr.io/projectcalico-org
-RELEASE_BRANCH_PREFIX ?= release
-DEV_TAG_SUFFIX        ?= 0.dev
-
-# If this is a release, also tag and push additional images.
-ifeq ($(RELEASE),true)
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
 FLEXVOL_IMAGE  ?=pod2daemon-flexvol
-DEV_REGISTRIES ?=quay.io/calico calico $(RELEASE_REGISTRIES)
-else
-FLEXVOL_IMAGE  ?=calico/pod2daemon-flexvol
-DEV_REGISTRIES ?=quay.io docker.io
-endif
-
 BUILD_IMAGES ?=$(FLEXVOL_IMAGE)
 
 ###############################################################################
@@ -80,8 +70,9 @@ sub-image-%:
 $(FLEXVOL_IMAGE): $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): Dockerfile.$(ARCH) bin/flexvol-$(ARCH)
 	docker build -t $(FLEXVOL_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 ifeq ($(ARCH),amd64)
-	docker tag $(FLEXVOL_IMAGE):latest-$(ARCH) $(FLEXVOL_IMAGE):latest
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 endif
 	touch $@
 

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -71,9 +71,6 @@ $(FLEXVOL_IMAGE): $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): Dockerfile.$(ARCH) bin/flexvol-$(ARCH)
 	docker build -t $(FLEXVOL_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-ifeq ($(ARCH),amd64)
-	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
-endif
 	touch $@
 
 ###############################################################################

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -2,19 +2,9 @@ include ../metadata.mk
 
 PACKAGE_NAME = github.com/projectcalico/calico/typha
 
-RELEASE_REGISTRIES    ?= gcr.io/projectcalico-org eu.gcr.io/projectcalico-org asia.gcr.io/projectcalico-org us.gcr.io/projectcalico-org
-RELEASE_BRANCH_PREFIX ?= release
-DEV_TAG_SUFFIX        ?= 0.dev
-
-# If this is a release, also tag and push additional images.
-ifeq ($(RELEASE),true)
+# Name of the images.
+# e.g., <registry>/<name>:<tag>
 TYPHA_IMAGE    ?=typha
-DEV_REGISTRIES ?=quay.io/calico calico $(RELEASE_REGISTRIES)
-else
-TYPHA_IMAGE    ?=calico/typha
-DEV_REGISTRIES ?=quay.io docker.io
-endif
-
 BUILD_IMAGES   ?=$(TYPHA_IMAGE)
 
 # We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.
@@ -111,9 +101,7 @@ $(TYPHA_IMAGE): bin/calico-typha-$(ARCH) register
 	cp bin/calico-typha-$(ARCH) docker-image/bin/
 	cp LICENSE docker-image/
 	docker buildx build --platform linux/$(ARCH) -t $(TYPHA_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) --file ./docker-image/Dockerfile.$(ARCH) docker-image --load
-ifeq ($(ARCH),amd64)
-	docker tag $(TYPHA_IMAGE):latest-$(ARCH) $(TYPHA_IMAGE):latest
-endif
+	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 
 ###############################################################################
 # Unit Tests


### PR DESCRIPTION
Cherry pick of #5360 on release-v3.21.

#5360: Clean up DEV_REGSITRIES / RELEASE_REGISTRIES

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fundamental semantic change for DEV_REGISTRIES - this is now an argument passed to the build system by the developer / CI/CD pipeline / release process / etc that allows configuring the prefix stuck on to each image. Previously, DEV_REGISTRIES and BUILD_IMAGE had different semantics based on whether or not a release was being performed - this is no longer the case.

Produced images are now always of the form `<REGISTRY>/<IMAGE>:<TAG>`. 

Main changes:

- DEV_REGISTRIES now specified in metadata.mk
- DEV_REGISTIRES defaults to calico/, overridden in semaphore config for CI/CD so that we push do dockerhub and quay
- Felix k8s-test builds Typha with DEV_REGISTRY=ci to make sure we use locally built typha, and don't accidentally pull from dockerhub. 
- Refactor how images are tagged as part of the build to use common lib.Makefile tagging functions

Other relevant points:

- Release tooling will override DEV_REGISTRIES with those needed for release.
- Another PR to make IMAGETAG configurable is probably appropriate. 
- Allows developers to build their own set of images easily - e.g., `make DEV_REGISTRIES=caseydavenport image` will produce `caseydavenport/node:latest` instead of the previous behavior -  `caseydavenport/calico/node:latest`

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```