### PR TITLE
Automated cherry pick of #5368: Use medium size build machines for typha

### DIFF
--- a/.semaphore/push-images/typha.yml
+++ b/.semaphore/push-images/typha.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish typha images
 agent:
   machine:
-    type: e1-standard-2
+    type: e1-standard-4
     os_image: ubuntu1804
 
 execution_time_limit:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -112,7 +112,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-8
+        type: e1-standard-4
         os_image: ubuntu1804
     jobs:
     - name: "Typha: UT and FV tests"


### PR DESCRIPTION
Cherry pick of #5368 on release-v3.21.

#5368: Use medium size build machines for typha

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Typha image builds seem to be stalling - I think it's because the
machiens are running out of resources.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```