### PR TITLE
Docs-move-alias-content

### DIFF
--- a/calico/reference/calicoctl/overview.md
+++ b/calico/reference/calicoctl/overview.md
@@ -93,3 +93,24 @@ In order to update low-level Felix or BGP settings (`FelixConfiguration` and `BG
 1. Update the resource using `apply` or `replace` command: `calicoctl replace -f config.yaml`.
 
 See [Configuring Felix]({{ site.baseurl }}/reference/felix/configuration) for more details.
+
+## Supported resource definition aliases
+
+The following table lists supported aliases for {{site.prodname}} resources when using `calicoctl`. Note that all aliases
+are **case insensitive**.
+
+| Resource definition                  | Supported calicoctl aliases                                  |
+| :----------------------------------- | :----------------------------------------------------------- |
+| BGP configuration                    | `bgpconfig`, `bgpconfigurations`, `bgpconfigs`               |
+| BGP peer                             | `bgppeer`, `bgppeers`, `bgpp`, `bgpps`, `bp`, `bps`          |
+| Felix configuration                  | `felixconfiguration`, `felixconfig`, `felixconfigurations`, `felixconfigs` |
+| Global network policy                | `globalnetworkpolicy`, `globalnetworkpolicies`, `gnp`, `gnps` |
+| Global network set                   | `globalnetworkset`, `globalnetworksets`                      |
+| Host endpoint                        | `hostendpoint`, `hostendpoints`, `hep`, `heps`               |
+| IP pool                              | `ippool`, `ippools`, `ipp`, `ipps`, `pool`, `pools`          |
+| IP reservation                       | `ipreservation`, `ipreservations`, `reservation`, `reservations` |
+| Kubernetes controllers configuration | `kubecontrollersconfiguration`, `kubecontrollersconfig`      |
+| Network policy                       | `networkpolicy`, `networkpolicies`, `policy`, `np`, `policies`, `pol`, `pols` |
+| Node                                 | `node`, `nodes`, `no`, `nos`                                 |
+| Profiles                             | `profile`, `profiles`, `pro`, `pros`                         |
+| Workload endpoint                    | `workloadendpoint`, `workloadendpoints`, `wep`, `weps`       |

--- a/calico/reference/resources/bgpconfig.md
+++ b/calico/reference/resources/bgpconfig.md
@@ -7,9 +7,6 @@ canonical_url: '/reference/resources/bgpconfig'
 A BGP configuration resource (`BGPConfiguration`) represents BGP specific configuration options for the cluster or a
 specific node.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `bgpconfiguration`, `bgpconfig`, `bgpconfigurations`, `bgpconfigs`.
-
 ### Sample YAML
 
 ```yaml

--- a/calico/reference/resources/bgppeer.md
+++ b/calico/reference/resources/bgppeer.md
@@ -11,9 +11,6 @@ with your datacenter fabric (e.g. ToR). For more
 information on cluster layouts, see {{site.prodname}}'s documentation on
 [{{site.prodname}} over IP fabrics]({{ site.baseurl }}/reference/architecture/design/l3-interconnect-fabric).
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `bgppeer`, `bgppeers`, `bgpp`, `bgpps`, `bp`, `bps`.
-
 ### Sample YAML
 
 ```yaml

--- a/calico/reference/resources/felixconfig.md
+++ b/calico/reference/resources/felixconfig.md
@@ -6,9 +6,6 @@ canonical_url: '/reference/resources/felixconfig'
 
 A [Felix]({{ site.baseurl }}/reference/architecture/overview#felix) configuration resource (`FelixConfiguration`) represents Felix configuration options for the cluster.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `felixconfiguration`, `felixconfig`, `felixconfigurations`, `felixconfigs`.
-
 See [Configuring Felix]({{ site.baseurl }}/reference/felix/configuration) for more details.
 
 ### Sample YAML

--- a/calico/reference/resources/globalnetworkpolicy.md
+++ b/calico/reference/resources/globalnetworkpolicy.md
@@ -16,9 +16,6 @@ See [network policy resource]({{ site.baseurl }}/reference/resources/networkpoli
 `GlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{site.prodname}} endpoints and host endpoints, and
 take precedence over [Profile resources]({{ site.baseurl }}/reference/resources/profile) if any are defined.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `globalnetworkpolicy`, `globalnetworkpolicies`, `gnp`, `gnps`.
-
 ### Sample YAML
 
 This sample policy allows TCP traffic from `frontend` endpoints to port 6379 on

--- a/calico/reference/resources/globalnetworkset.md
+++ b/calico/reference/resources/globalnetworkset.md
@@ -20,8 +20,6 @@ the CIDRs from any network sets that match the selector.
 > policy will see the kube-proxy's host's IP as the source instead of the real source.
 {: .alert .alert-danger}
 
-For `calicoctl` commands that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `globalnetworkset`, `globalnetworksets`.
 
 ### Sample YAML
 

--- a/calico/reference/resources/hostendpoint.md
+++ b/calico/reference/resources/hostendpoint.md
@@ -21,9 +21,6 @@ will use to apply
 [policy]({{ site.baseurl }}/reference/resources/networkpolicy)
 to the interface.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `hostendpoint`, `hostendpoints`, `hep`, `heps`.
-
 **Default behavior of external traffic to/from host**
 
 If a host endpoint is created and network policy is not in place, the {{site.prodname}} default is to deny traffic to/from that endpoint (except for traffic allowed by failsafe rules).

--- a/calico/reference/resources/ippool.md
+++ b/calico/reference/resources/ippool.md
@@ -7,9 +7,6 @@ canonical_url: '/reference/resources/ippool'
 An IP pool resource (`IPPool`) represents a collection of IP addresses from which {{site.prodname}} expects
 endpoint IPs to be assigned.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `ippool`, `ippools`, `ipp`, `ipps`, `pool`, `pools`.
-
 ### Sample YAML
 
 ```yaml

--- a/calico/reference/resources/ipreservation.md
+++ b/calico/reference/resources/ipreservation.md
@@ -7,10 +7,6 @@ canonical_url: '/reference/resources/ipreservation'
 An IP reservation resource (`IPReservation`) represents a collection of IP addresses that {{site.prodname}} should 
 not use when automatically assigning new IP addresses.  It only applies when {{site.prodname}} IPAM is in use.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, 
-the following aliases are supported (all case insensitive): `ipreservation`, `ipreservations`, `reservation`, 
-`reservations`.
-
 ### Sample YAML
 
 ```yaml

--- a/calico/reference/resources/kubecontrollersconfig.md
+++ b/calico/reference/resources/kubecontrollersconfig.md
@@ -6,9 +6,6 @@ canonical_url: '/reference/resources/kubecontrollersconfig'
 
 A {{site.prodname}} [Kubernetes controllers]({{ site.baseurl }}/reference/kube-controllers/configuration) configuration resource (`KubeControllersConfiguration`) represents configuration options for the {{site.prodname}} Kubernetes controllers.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `kubecontrollersconfiguration`, `kubecontrollersconfig`.
-
 ### Sample YAML
 
 ```yaml

--- a/calico/reference/resources/networkpolicy.md
+++ b/calico/reference/resources/networkpolicy.md
@@ -16,9 +16,6 @@ See [global network policy resource]({{ site.baseurl }}/reference/resources/glob
 `NetworkPolicy` resources can be used to define network connectivity rules between groups of {{site.prodname}} endpoints and host endpoints, and
 take precedence over [profile resources]({{ site.baseurl }}/reference/resources/profile) if any are defined.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `networkpolicy`, `networkpolicies`, `policy`, `np`, `policies`, `pol`, `pols`.
-
 ### Sample YAML
 
 This sample policy allows TCP traffic from `frontend` endpoints to port 6379 on

--- a/calico/reference/resources/node.md
+++ b/calico/reference/resources/node.md
@@ -14,10 +14,6 @@ match the name configured in the Node resource.
 By default, starting a `{{site.nodecontainer}}` instance will automatically create a node resource
 using the `hostname` of the compute host.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that
-specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `node`, `nodes`, `no`, `nos`.
-
 ### Sample YAML
 
 ```yaml

--- a/calico/reference/resources/profile.md
+++ b/calico/reference/resources/profile.md
@@ -11,9 +11,6 @@ flexible [NetworkPolicy]({{ site.baseurl }}/reference/resources/networkpolicy) a
 
 Each {{site.prodname}} endpoint or host endpoint can be assigned to zero or more profiles.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview) that specify a resource type on the CLI, the following
-aliases are supported (all case insensitive): `profile`, `profiles`, `pro`, `pros`.
-
 ### Sample YAML
 
 The following sample profile allows all traffic from endpoints that

--- a/calico/reference/resources/workloadendpoint.md
+++ b/calico/reference/resources/workloadendpoint.md
@@ -16,10 +16,6 @@ in a specific namespace only applies to the WorkloadEndpoint in that namespace.
 Two resources are in the same namespace if the namespace value is set the same
 on both.
 
-For `calicoctl` [commands]({{ site.baseurl }}/reference/calicoctl/overview)
-that specify a resource type on the CLI, the following aliases are supported (all case
-insensitive): `workloadendpoint`, `workloadendpoints`, `wep`, `weps`.
-
 > **Note**: While `calicoctl` allows the user to fully manage Workload Endpoint resources,
 > the lifecycle of these resources is generally handled by an orchestrator-specific
 > plugin such as the {{site.prodname}} CNI plugin, the {{site.prodname}} Docker network plugin,


### PR DESCRIPTION
### Move calicoctl alias content to Overview to allow better sharing with Calico Cloud docs

- Merge and cherrypick to latest
- Merge to CE docs