### PR TITLE
routerule prio fix

### DIFF
--- a/felix/routerule/route_rule.go
+++ b/felix/routerule/route_rule.go
@@ -141,6 +141,11 @@ func (r *RouteRules) getActiveRule(rule *Rule, f RulesMatchFunc) *Rule {
 
 // Set a Rule. Add to activeRules if it does not already exist based on matchForUpdate function.
 func (r *RouteRules) SetRule(rule *Rule) {
+
+	if r.netlinkFamily != rule.nlRule.Family {
+		log.WithField("rule", rule).Warnf("Rule does not match family %d, ignoring.", r.netlinkFamily)
+	}
+
 	if !r.tableIndexSet.Contains(rule.nlRule.Table) {
 		log.WithField("tableindex", rule.nlRule.Table).Panic("Unknown Table Index")
 	}
@@ -153,6 +158,11 @@ func (r *RouteRules) SetRule(rule *Rule) {
 
 // Remove a Rule. Do nothing if Rule not exists depends based on matchForRemove function.
 func (r *RouteRules) RemoveRule(rule *Rule) {
+
+	if r.netlinkFamily != rule.nlRule.Family {
+		log.WithField("rule", rule).Warnf("Rule does not match family %d, ignoring.", r.netlinkFamily)
+	}
+
 	if p := r.getActiveRule(rule, r.matchForRemove); p != nil {
 		r.activeRules.Discard(p)
 		r.inSync = false

--- a/felix/routerule/route_rule.go
+++ b/felix/routerule/route_rule.go
@@ -41,13 +41,12 @@ var (
 	TableIndexFailed = errors.New("no table index specified")
 )
 
-// RouteRules represents set of routing rules with same ip family and priority.
+// RouteRules represents set of routing rules with same ip family.
 // The target of those rules are set of routing tables.
 type RouteRules struct {
 	logCxt *log.Entry
 
 	IPVersion int
-	Priority  int
 
 	// Routing table indexes which is exclusively managed by us.
 	tableIndexSet set.Set
@@ -83,7 +82,6 @@ type RouteRules struct {
 
 func New(
 	ipVersion int,
-	priority int,
 	tableIndexSet set.Set,
 	updateFunc RulesMatchFunc,
 	removeFunc RulesMatchFunc,
@@ -114,7 +112,6 @@ func New(
 			"ipVersion": ipVersion,
 		}),
 		IPVersion:        ipVersion,
-		Priority:         priority,
 		matchForUpdate:   updateFunc,
 		matchForRemove:   removeFunc,
 		tableIndexSet:    tableIndexSet,

--- a/felix/routerule/route_rule_test.go
+++ b/felix/routerule/route_rule_test.go
@@ -53,7 +53,6 @@ var _ = Describe("RouteRules Construct", func() {
 		tableIndexSet := set.New()
 		_, err := New(
 			4,
-			100,
 			tableIndexSet,
 			RulesMatchSrcFWMarkTable,
 			RulesMatchSrcFWMark,
@@ -70,7 +69,6 @@ var _ = Describe("RouteRules Construct", func() {
 		tableIndexSet.Add(10)
 		_, err := New(
 			4,
-			100,
 			tableIndexSet,
 			RulesMatchSrcFWMarkTable,
 			RulesMatchSrcFWMark,
@@ -84,7 +82,6 @@ var _ = Describe("RouteRules Construct", func() {
 		tableIndexSet.Add(252)
 		_, err = New(
 			4,
-			100,
 			tableIndexSet,
 			RulesMatchSrcFWMarkTable,
 			RulesMatchSrcFWMark,
@@ -102,7 +99,6 @@ var _ = Describe("RouteRules Construct", func() {
 		tableIndexSet.Add(250)
 		_, err := New(
 			4,
-			100,
 			tableIndexSet,
 			RulesMatchSrcFWMarkTable,
 			RulesMatchSrcFWMark,
@@ -133,7 +129,6 @@ var _ = Describe("RouteRules", func() {
 		var err error
 		rrs, err = New(
 			4,
-			100,
 			tableIndexSet,
 			RulesMatchSrcFWMarkTable,
 			RulesMatchSrcFWMark,

--- a/felix/routerule/rule_lib_test.go
+++ b/felix/routerule/rule_lib_test.go
@@ -49,6 +49,9 @@ var _ = Describe("RouteRule Rule build cases", func() {
 		Expect(NewRule(4, 100).Not().NetLinkRule().Invert).To(Equal(true))
 		Expect(NewRule(4, 100).GoToTable(10).NetLinkRule().Table).To(Equal(10))
 		Expect(NewRule(4, 100).MatchSrcAddress(*ip).NetLinkRule().Src.String()).To(Equal("10.0.1.0/26"))
+		ipv6 := mustParseCIDR("2002::1234:abcd:ffff:c0a8:101/128")
+		Expect(NewRule(6, 100).MatchSrcAddress(*ipv6).NetLinkRule().Src.String()).
+			To(Equal("2002::1234:abcd:ffff:c0a8:101/128"))
 		Expect(NewRule(4, 100).Not().
 			MatchFWMark(0x400).
 			MatchSrcAddress(*ip).
@@ -66,6 +69,10 @@ var _ = Describe("RouteRule Rule build cases", func() {
 				SuppressIfgroup:   -1,
 				SuppressPrefixlen: -1,
 			}))
+	})
+	It("should ignore wrong values", func() {
+		ipv6 := mustParseCIDR("2002::1234:abcd:ffff:c0a8:101/64")
+		Expect(NewRule(4, 100).MatchSrcAddress(*ipv6).NetLinkRule().Src).To(BeNil())
 	})
 })
 

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -214,7 +214,6 @@ func NewWithShims(
 	// Create routerule.
 	rr, err := routerule.New(
 		ipVersion,
-		config.RoutingRulePriority,
 		set.From(config.RoutingTableIndex),
 		routerule.RulesMatchSrcFWMarkTable,
 		routerule.RulesMatchSrcFWMarkTable,


### PR DESCRIPTION
## Description

    felix/routerule: warn about incorect values and ignore them
    
    RouteRules should manage rules of a given family only and rule's IPs
    should match the family.

    felix/routerule: remove priority from the manager
    
    The priority is not used in any way and is specified per-rule.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
