### PR TITLE
felix/bpf: fix pod-service-self without CTLB

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -183,6 +183,9 @@ enum calico_skb_mark {
 	 * do SNAT for this flow.  Subsequent packets will also be allowed to fall through to the host
 	 * netns. */
 	CALI_SKB_MARK_NAT_OUT                = CALI_SKB_MARK_BYPASS  | 0x00800000,
+	/* CALI_SKB_MARK_MASQ enforces MASQ on the connection.
+	 */
+	CALI_SKB_MARK_MASQ                   = CALI_SKB_MARK_BYPASS  | 0x00600000,
 
 	/* CT_ESTABLISHED is used by iptables to tell the BPF programs that the packet is part of an
 	 * established Linux conntrack flow. This allows the BPF program to let through pre-existing

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1073,6 +1073,12 @@ nat_encap:
 	}
 
 allow:
+	if (CALI_F_FROM_WEP && state->ip_src == state->ip_dst) {
+		CALI_DEBUG("Loopback SNAT\n");
+		seen_mark |=  CALI_SKB_MARK_MASQ;
+		fib = false; /* Disable FIB because we want to drop to iptables */
+	}
+
 	{
 		struct fwd fwd = {
 			.res = rc,

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -27,6 +27,8 @@ const (
 	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0x00f00000
 	MarkSeenNATOutgoing              = MarkSeenBypass | 0x00800000
 	MarkSeenNATOutgoingMask          = MarkSeenBypassMask | MarkSeenNATOutgoing
+	MarkSeenMASQ                     = MarkSeenBypass | 0x00600000
+	MarkSeenMASQMask                 = MarkSeenBypassMask | MarkSeenMASQ
 
 	MarkLinuxConntrackEstablished     = 0x08000000
 	MarkLinuxConntrackEstablishedMask = 0x08000000

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -19,6 +19,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 	. "github.com/projectcalico/calico/felix/iptables"
 	"github.com/projectcalico/calico/felix/proto"
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
@@ -771,6 +772,17 @@ func (r *DefaultRuleRenderer) StaticNATPostroutingChains(ipVersion uint8) []*Cha
 		{
 			Action: JumpAction{Target: ChainNATOutgoing},
 		},
+	}
+
+	if r.BPFEnabled {
+		// Prepend a BPF SNAT rule.
+		rules = append([]Rule{
+			{
+				Comment: []string{"BPF loopback SNAT"},
+				Match:   Match().MarkMatchesWithMask(tcdefs.MarkSeenMASQ, tcdefs.MarkSeenMASQMask),
+				Action:  MasqAction{},
+			},
+		}, rules...)
 	}
 
 	var tunnelIfaces []string


### PR DESCRIPTION
Host namespace must do SNAT like what kube-proxy does.

fixes #5060

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
