### PR TITLE
Add internalIPs from node.Spec.Addresses to expectedIPs in autoHostEndpoint

### DIFF
--- a/kube-controllers/tests/fv/node_auto_hep_test.go
+++ b/kube-controllers/tests/fv/node_auto_hep_test.go
@@ -179,6 +179,25 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
 
+		// Add an internal IP and an external IP to the Addresses in the node spec.
+		// Also add a duplicate IP and make sure it is not added.
+		Expect(testutils.UpdateCalicoNode(c, cn.Name, func(cn *libapi.Node) {
+			cn.Spec.Addresses = []libapi.NodeAddress{
+				{Address: "192.168.200.1",
+					Type: libapi.InternalIP},
+				{Address: "192.168.200.2",
+					Type: libapi.ExternalIP},
+				{Address: "172.100.2.3",
+					Type: libapi.InternalIP},
+			}
+		})).NotTo(HaveOccurred())
+
+		// Expect the HEP to include the internal IP from Addresses.
+		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "192.168.100.1", "192.168.200.1"}
+		Eventually(func() error {
+			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles)
+		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
+
 		// Delete the Kubernetes node.
 		err = k8sClient.CoreV1().Nodes().Delete(context.Background(), kNodeName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Product changes are in kube-controllers/pkg/controllers/node/hostendpoints.go,
and test coverage was expanded in kube-controllers/tests/fv/node_auto_hep_test.go
(tested with `GINKGO_ARGS=-ginkgo.focus="Auto Hostendpoint" make fv`)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Automatic host endpoints now detect internal IPs from all interfaces on the node.
```
