### PR TITLE
Use protobuf for Kubernetes client

### DIFF
--- a/libcalico-go/lib/backend/k8s/k8s.go
+++ b/libcalico-go/lib/backend/k8s/k8s.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -316,6 +317,9 @@ func CreateKubernetesClientset(ca *apiconfig.CalicoAPIConfigSpec) (*rest.Config,
 	if err != nil {
 		return nil, nil, resources.K8sErrorToCalico(err, nil)
 	}
+
+	config.AcceptContentTypes = strings.Join([]string{runtime.ContentTypeProtobuf, runtime.ContentTypeJSON}, ",")
+	config.ContentType = runtime.ContentTypeProtobuf
 
 	// Overwrite the QPS if provided. Default QPS is 5.
 	if ca.K8sClientQPS != float32(0) {


### PR DESCRIPTION
## Description

Use protobuf as the default proto in k8s client, improve kube-api performance at large scale.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Switch to protobuf for Kubernetes API calls
```
