### PR TITLE
APIServer: Update allowed TLS ciphers

### DIFF
--- a/apiserver/cmd/apiserver/server/options.go
+++ b/apiserver/cmd/apiserver/server/options.go
@@ -110,18 +110,16 @@ func (o *CalicoServerOptions) Config() (*apiserver.Config, error) {
 		return nil, err
 	}
 
-	//Explicitly setting cipher suites in order to remove deprecated ones:
-	//- TLS_RSA --- lack perfect forward secrecy
-	//- 3DES --- widely considered to be too weak
-	//Order matters as indicates preference for the cipher in the selection algorithm. Also, some suites (TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
-	//for instance, for full list refer to golang.org/x/net/http2) are blacklisted by HTTP/2 spec and MUST be placed after the HTTP/2-approved
-	//cipher suites. Not doing that might cause client to be given an unapproved suite and reject the connection.
+	// Explicitly setting cipher suites in order to remove deprecated ones
+	// The list is taken from https://github.com/golang/go/blob/dev.boringcrypto.go1.13/src/crypto/tls/boring.go#L54
 	cipherSuites := []uint16{
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA}
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	}
 	serverConfig.SecureServing.CipherSuites = cipherSuites
 
 	if o.PrintSwagger {


### PR DESCRIPTION
## Description
Fixes https://github.com/projectcalico/calico/issues/5447

Enhancement to disable insecure and deprecated TLS ciphersuites in the Calico APIServer
Took the same ciphersuites that are enabled in typha from
https://github.com/projectcalico/calico/blob/79b442a53adb7d7f1fd62927d9322daf87dce9de/typha/pkg/syncserver/sync_server.go#L495-L504

Only manual testing, i.e. kubectl edit FelixConfiguration.
Verified no log lines in APIServer logs

Manual scan with this enhancement
```bash
# nmap --script ssl-enum-ciphers -p 443 calico-api.calico-apiserver.svc.cluster.local
Starting Nmap 7.92 ( https://nmap.org ) at 2022-01-15 12:07 UTC
Nmap scan report for calico-api.calico-apiserver.svc.cluster.local (10.96.99.195)
Host is up (0.000095s latency).

PORT    STATE SERVICE
443/tcp open  https
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
|     compressors: 
|       NULL
|     cipher preference: server
|   TLSv1.3: 
|     ciphers: 
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|     cipher preference: server
|_  least strength: A
```

## Related issues/PRs


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

APIServer disable deprecated and insecure ciphersuites

```release-note
None required
```
