### PR TITLE
Add sources to chart so the source of the chart is known

### DIFF
--- a/calico/_includes/charts/tigera-operator/Chart.yaml
+++ b/calico/_includes/charts/tigera-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tigera-operator
 description: Installs the Tigera operator for Calico
 home: https://www.tigera.io/
-icon: https://tigera.io/wp-content/uploads/2021/05/cropped-tigera-icon-1.png
+icon: https://projectcalico.docs.tigera.io/images/felix_icon.png
 sources:
   - https://github.com/projectcalico/calico/tree/master/calico/_includes/charts/tigera-operator
   - https://github.com/tigera/operator

--- a/calico/_includes/charts/tigera-operator/Chart.yaml
+++ b/calico/_includes/charts/tigera-operator/Chart.yaml
@@ -1,6 +1,12 @@
 apiVersion: v2
 name: tigera-operator
 description: Installs the Tigera operator for Calico
-
+home: https://www.tigera.io/
+icon: https://tigera.io/wp-content/uploads/2021/05/cropped-tigera-icon-1.png
+sources:
+  - https://github.com/projectcalico/calico/tree/master/calico/_includes/charts/tigera-operator
+  - https://github.com/tigera/operator
+  - https://github.com/projectcalico/calico
+ 
 # version will be overridden at chart compilation time via args, but still must exist in chart.yaml
 version: v0.0

--- a/calico/_includes/charts/tigera-operator/Chart.yaml
+++ b/calico/_includes/charts/tigera-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tigera-operator
 description: Installs the Tigera operator for Calico
-home: https://www.tigera.io/
+home: https://projectcalico.docs.tigera.io/about/about-calico
 icon: https://projectcalico.docs.tigera.io/images/felix_icon.png
 sources:
   - https://github.com/projectcalico/calico/tree/master/calico/_includes/charts/tigera-operator


### PR DESCRIPTION
## Description

It is always hard to understand an chart without it's source, especially this chart since the values are hardly document (the entire space)
So it is useful to understand where the source code is, which is fairly hard to find right now (i had to ask in slack myself to be pointed here).

I would love to improve this for others to find it an easier way on https://artifacthub.io/packages/helm/projectcalico/tigera-operator and others. Thoughts?

## Related issues/PRs

https://calicousers.slack.com/archives/CPTH1KS00/p1642115657039500

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
None required
```
