### PR TITLE
Changed calicoctl version command per issue #5260

### DIFF
--- a/calicoctl/calicoctl/commands/version.go
+++ b/calicoctl/calicoctl/commands/version.go
@@ -25,6 +25,9 @@ import (
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/argutils"
@@ -87,6 +90,11 @@ Description:
 	cf := parsedArgs["--config"].(string)
 	client, err := clientmgr.NewClient(cf)
 	if err != nil {
+		if derr, ok := err.(errors.ErrorDatastoreError); ok {
+			log.Debugf("Client config error: %s", derr.Error())
+			fmt.Println("Unable to detect installed Calico version")
+			return nil
+		}
 		return err
 	}
 	ctx := context.Background()


### PR DESCRIPTION
Print calicoctl version with exit success when no config is present

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Hi all,

I have changed the implementation of the `calico version` command as requested in issue #5260.

The error happens because the underlying implementation tries to [fallback to loading the config from environment](https://github.com/projectcalico/calico/blob/79b442a53adb7d7f1fd62927d9322daf87dce9de/libcalico-go/lib/apiconfig/load.go#L38) and ends up [defaulting to kubernetes datastore](https://github.com/projectcalico/calico/blob/79b442a53adb7d7f1fd62927d9322daf87dce9de/libcalico-go/lib/apiconfig/load.go#L101) when detecting it. Because of this, k8s backend tries to build a client and [returns errors.ErrorDatastoreError](https://github.com/projectcalico/calico/blob/0c189f7e024d8a2b0c7f5073cddc63ffd5553d0c/libcalico-go/lib/backend/k8s/resources/errors.go#L98). Therefore, the approach was to check the error type and print a message when this error occurs. Since no one can guarantee that other states will not give the same error, a `log.Debugf` call with the error message was added for easier debugging in the future if needed. 

This change should not affect any other component other than `calicoctl version` and I tried to cover only the case which was described in the linked issue. The change was tested manually and seems to work well. No corresponding unit tests for this change were added.

This is how `calicoctl version` looks without config:
```
$ ./calicoctl-linux-amd64 version
Client Version:    v3.22.0-0.dev-24946-gca67e1513bf2
Git commit:        ca67e1513
Unable to detect installed Calico version

$ ./calicoctl-linux-amd64 -l debug version
INFO[0000] Log level set to debug                       
Client Version:    v3.22.0-0.dev-24946-gca67e1513bf2
Git commit:        ca67e1513
INFO[0000] Config file: /etc/calico/calicoctl.cfg cannot be read - reading config from environment 
DEBU[0000] Datastore type isn't set, trying to detect it 
DEBU[0000] No EtcdEndpoints specified, defaulting to kubernetes. 
DEBU[0000] No kubeconfig file at default path, leaving blank. 
INFO[0000] Loaded client config: apiconfig.CalicoAPIConfigSpec{DatastoreType:"kubernetes", EtcdConfig:apiconfig.EtcdConfig{EtcdEndpoints:"", EtcdDiscoverySrv:"", EtcdUsername:"", EtcdPassword:"", EtcdKeyFile:"", EtcdCertFile:"", EtcdCACertFile:"", EtcdKey:"", EtcdCert:"", EtcdCACert:""}, KubeConfig:apiconfig.KubeConfig{Kubeconfig:"", K8sAPIEndpoint:"", K8sKeyFile:"", K8sCertFile:"", K8sCAFile:"", K8sAPIToken:"", K8sInsecureSkipTLSVerify:false, K8sDisableNodePoll:false, K8sUsePodCIDR:false, KubeconfigInline:"", K8sClientQPS:0, K8sCurrentContext:""}} 
DEBU[0000] Using datastore type 'kubernetes'            
DEBU[0000] Client config error: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable 
Unable to detect installed Calico version
```

Let me know what you think.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Issue #5260 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Handle client creation errors in `calicoctl version`, and print appropriate message
```
