### PR TITLE
Set correct VPP branch

### DIFF
--- a/calico/_config.yml
+++ b/calico/_config.yml
@@ -72,8 +72,8 @@ defaults:
       show_title: true
       show_read_time: true
       show_toc: true
-      version: v3.21 
-      vppbranch: master  # The branch in vpp repo that these docs should point to for manifests, etc
+      version: v3.21
+      vppbranch: v0.18.1-calicov3.21.2  # The branch in vpp repo that these docs should point to for manifests, etc
       sitemap: true
       registry:
       # A lookup map for imageNames based on component names.


### PR DESCRIPTION
## Description
Looks like the instructions for VPP install are broken in:
https://projectcalico.docs.tigera.io/getting-started/kubernetes/vpp/getting-started

This is because they link to manifests in https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/generated/

They use {{page.vppbranch}} in their URL, but it seems that this var didn't get set at release time.  This PR fixes that.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
