### PR TITLE
Fix: IPAMBlock GC breaks flannel migration

### DIFF
--- a/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
@@ -56,9 +56,9 @@ var (
 	// nodeNetworkFlannel is a map value indicates a node is still part of Flannel vxlan network.
 	// This is used both as a nodeSelector for Flannel daemonset and a label for a node.
 	nodeNetworkFlannel = map[string]string{migrationNodeSelectorKey: "flannel"}
-	// nodeNetworkCalico is a map value indicates a node is becoming part of Calico vxlan network.
+	// NodeNetworkCalico is a map value indicates a node is becoming part of Calico vxlan network.
 	// This is used both as a nodeSelector for Calico daemonset and a label for a node.
-	nodeNetworkCalico = map[string]string{migrationNodeSelectorKey: "calico"}
+	NodeNetworkCalico = map[string]string{migrationNodeSelectorKey: "calico"}
 	// nodeNetworkNone is a map value indicates there should be neither Flannel nor Calico running on the node.
 	nodeNetworkNone = map[string]string{migrationNodeSelectorKey: "none"}
 	// nodeMigrationInProgress is a map value indicates a node is running network migration.
@@ -240,7 +240,7 @@ func (c *flannelMigrationController) processNewNode(node *v1.Node) {
 	}
 
 	n := k8snode(node.Name)
-	err = n.addNodeLabels(c.k8sClientset, nodeNetworkCalico)
+	err = n.addNodeLabels(c.k8sClientset, NodeNetworkCalico)
 	if err != nil {
 		log.WithError(err).Fatalf("Error adding node label to enable Calico network for new node %s.", node.Name)
 		return
@@ -511,7 +511,7 @@ func (c *flannelMigrationController) completeMigration() error {
 	// Remove nodeSelector for Calico Daemonet.
 	d = daemonset(c.config.CalicoDaemonsetName)
 	log.Infof("Remove node selector for daemonset %s.", c.config.CalicoDaemonsetName)
-	err = d.RemoveNodeSelector(c.k8sClientset, namespaceKubeSystem, nodeNetworkCalico)
+	err = d.RemoveNodeSelector(c.k8sClientset, namespaceKubeSystem, NodeNetworkCalico)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to remove node selector for daemonset %s.", c.config.CalicoDaemonsetName)
 		return err

--- a/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
@@ -181,7 +181,7 @@ func (m *networkMigrator) setupCalicoNetworkForNode(node *v1.Node) error {
 	// This will install Calico CNI configuration file.
 	// It will take the preference over Flannel CNI config or Canal CNI config.
 	log.Infof("Setting node label to enable Calico daemonset pod on %s.", node.Name)
-	err = n.addNodeLabels(m.k8sClientset, nodeNetworkCalico)
+	err = n.addNodeLabels(m.k8sClientset, NodeNetworkCalico)
 	if err != nil {
 		log.WithError(err).Errorf("Error adding node label to enable Calico network for node %s.", node.Name)
 		return err

--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -82,7 +82,7 @@ func NewNodeController(ctx context.Context,
 	nodeDeletionFuncs := []func(){}
 
 	// Create the IPAM controller.
-	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset)
+	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset, nodeInformer)
 	nc.ipamCtrl.RegisterWith(nc.dataFeed)
 	nodeDeletionFuncs = append(nodeDeletionFuncs, nc.ipamCtrl.OnKubernetesNodeDeleted)
 

--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -82,7 +82,7 @@ func NewNodeController(ctx context.Context,
 	nodeDeletionFuncs := []func(){}
 
 	// Create the IPAM controller.
-	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset, nodeInformer)
+	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset, nodeInformer.GetIndexer())
 	nc.ipamCtrl.RegisterWith(nc.dataFeed)
 	nodeDeletionFuncs = append(nodeDeletionFuncs, nc.ipamCtrl.OnKubernetesNodeDeleted)
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -17,11 +17,13 @@ package node
 import (
 	"context"
 	"fmt"
-	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/flannelmigration"
-	"k8s.io/client-go/tools/cache"
 	"net"
 	"strings"
 	"time"
+
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/flannelmigration"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -577,7 +577,7 @@ func (c *ipamController) checkEmptyBlocks() error {
 		// During a Flannel migration, we can only migrate blocks affined to nodes that have already undergone the migration
 		migrating, err := c.nodeIsBeingMigrated(node)
 		if err != nil {
-			logc.Warn("Couldn't find node affined to empty block, skipping affinity release")
+			logc.WithError(err).Warn("Failed to check if node is being migrated from Flannel, skipping affinity release")
 			continue
 		}
 		if migrating {

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -988,11 +988,12 @@ func (c *ipamController) nodeExists(knode string) bool {
 func (c *ipamController) nodeIsBeingMigrated(name string) (bool, error) {
 	// Get node to inspect labels
 	obj, ok, err := c.nodeIndexer.GetByKey(name)
+	if !ok {
+		// Node doesn't exist, so isn't being migrated.
+		return false, nil
+	}
 	if err != nil {
 		return false, fmt.Errorf("failed to check node for migration status: %w", err)
-	}
-	if !ok {
-		return false, fmt.Errorf("failed to check node for migration status: node not found")
 	}
 	node, ok := obj.(v1.Node)
 	if !ok {

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -984,10 +984,16 @@ func (c *ipamController) nodeExists(knode string) bool {
 	return true
 }
 
-// nodeIsBeingMigrated looks up a node and checks, if it is marked by the flannel-migration controller to undergo migration.
+// nodeIsBeingMigrated looks up a Kubernetes node for a Calico node and checks,
+// if it is marked by the flannel-migration controller to undergo migration.
 func (c *ipamController) nodeIsBeingMigrated(name string) (bool, error) {
+	// Find the Kubernetes node referenced by the Calico node
+	kname, err := c.kubernetesNodeForCalico(name)
+	if err != nil {
+		return false, err
+	}
 	// Get node to inspect labels
-	obj, ok, err := c.nodeIndexer.GetByKey(name)
+	obj, ok, err := c.nodeIndexer.GetByKey(kname)
 	if !ok {
 		// Node doesn't exist, so isn't being migrated.
 		return false, nil

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -995,7 +995,7 @@ func (c *ipamController) nodeIsBeingMigrated(name string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to check node for migration status: %w", err)
 	}
-	node, ok := obj.(v1.Node)
+	node, ok := obj.(*v1.Node)
 	if !ok {
 		return false, fmt.Errorf("failed to check node for migration status: unexpected error: object is not a node")
 	}


### PR DESCRIPTION
## Description

This fixes a regression in the kube-controllers ipam code that breaks the flannel migration.

The empty block garbage collection breaks the flannel migration, because it cleans up blocks with IPs that are in use only by unmigrated Flannel nodes. This deletes the routes on Calico nodes to IPs in those blocks.

The kube-controllers already sometimes skips releasing blocks, e.g. when it's the node's only affined block.
I just add another check that gets the node currently affined to the block and check if it has labels that exist only on nodes that haven't been migrated yet.

I have successfully tested the migration on a cluster running 1.21.5 and flannel 0.11.0.
I believe there aren't any automated tests for the migration. Otherwise the regression would've been caught in the first place.

The new code needs access to the labels the migration controller uses. I chose to export that variable in favour of copy-pasting. That's a personal choice. I'm fine with either one. One could also have an exported var and a non-exported var. That would reduce the diff of this MR, but also be "dirty".

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/5349

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Fix garbage collection of empty blocks during flannel migration
```
