### PR TITLE
Centralize + update ubi version to 8.5

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -127,7 +127,7 @@ sub-image-%:
 
 $(API_SERVER_IMAGE): register $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): docker-image/Dockerfile.$(ARCH) $(BINDIR)/apiserver-$(ARCH) $(BINDIR)/filecheck-$(ARCH)
-	docker build --no-cache --pull -t $(API_SERVER_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-image/Dockerfile.$(ARCH) .
+	docker build --no-cache --pull -t $(API_SERVER_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-image/Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/apiserver/docker-image/Dockerfile.amd64
+++ b/apiserver/docker-image/Dockerfile.amd64
@@ -1,4 +1,7 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as ubi
+ARG UBI_IMAGE
+
+FROM ${UBI_IMAGE} as ubi
+
 RUN microdnf update
 
 # At runtime, apiserver generate certificates in /code directory

--- a/apiserver/docker-image/Dockerfile.arm64
+++ b/apiserver/docker-image/Dockerfile.arm64
@@ -1,7 +1,10 @@
 ARG QEMU_IMAGE
+ARG UBI_IMAGE
+
 FROM ${QEMU_IMAGE} as qemu
 
-FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.5 as ubi
+FROM --platform=linux/arm64 ${UBI_IMAGE} as ubi
+
 COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
 RUN microdnf update

--- a/app-policy/Dockerfile.amd64
+++ b/app-policy/Dockerfile.amd64
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 ARG GIT_VERSION=unknown
+ARG UBI_IMAGE
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as build
+FROM ${UBI_IMAGE} as ubi
+
 RUN mkdir -p /tmp/dikastes
 RUN chmod 0777 /tmp/dikastes
 
@@ -32,13 +34,13 @@ LABEL name="Calico Dikastes" \
       description="Calico Dikastes enables Application Layer Policy" \
       maintainer="Laurence Man<laurence@tigera.io>"
 
-COPY --from=build /licenses /licenses
+COPY --from=ubi /licenses /licenses
 ADD bin/dikastes-amd64 /dikastes
 ADD bin/healthz-amd64 /healthz
 
 # Include libraries from UBI for dynamic linking.
-COPY --from=build /lib64 /lib64
-COPY --from=build /lib /lib
+COPY --from=ubi /lib64 /lib64
+COPY --from=ubi /lib /lib
 
 # Typical Linux systems start numbering human users at 1000, reserving 1-999
 # for services, so we pick 999 to be least likely to overlap.  It's not a big
@@ -47,7 +49,7 @@ COPY --from=build /lib /lib
 #
 # Precreate the /var/run/dikastes directory so that we don't need any elevated
 # permission to create the directory at runtime.
-COPY --chown=999 --from=build /tmp/dikastes /var/run/dikastes
+COPY --chown=999 --from=ubi /tmp/dikastes /var/run/dikastes
 USER 999
 ENTRYPOINT ["/dikastes"]
 CMD ["server"]

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -130,7 +130,7 @@ sub-image-%:
 
 $(DIKASTES_IMAGE): $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): Dockerfile.$(ARCH) bin/dikastes-$(ARCH) bin/healthz-$(ARCH)
-	docker build -t $(DIKASTES_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	docker build -t $(DIKASTES_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/calicoctl/Dockerfile.amd64
+++ b/calicoctl/Dockerfile.amd64
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as ubi
+ARG UBI_IMAGE
+
+FROM ${UBI_IMAGE} as ubi
 
 RUN mkdir /licenses
 COPY LICENSE /licenses

--- a/calicoctl/Dockerfile.arm64
+++ b/calicoctl/Dockerfile.arm64
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG QEMU_IMAGE=calico/go-build:v0.55
+ARG UBI_IMAGE
+
 FROM ${QEMU_IMAGE} as qemu
 
-FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.5 as ubi
+FROM --platform=linux/arm64 ${UBI_IMAGE} as ubi
+
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/

--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -96,7 +96,7 @@ gen-crds:
 image: $(CALICOCTL_IMAGE)
 $(CALICOCTL_IMAGE): $(CTL_CONTAINER_CREATED)
 $(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH) register
-	docker buildx build --pull -t $(CALICOCTL_IMAGE):latest-$(ARCH) --platform=linux/$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) . --load
+	docker buildx build --pull -t $(CALICOCTL_IMAGE):latest-$(ARCH) --platform=linux/$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) . --load
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/cni-plugin/Dockerfile.amd64
+++ b/cni-plugin/Dockerfile.amd64
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as base
+ARG UBI_IMAGE
+
+FROM ${UBI_IMAGE} as ubi
 
 FROM scratch
 
@@ -30,8 +32,8 @@ ADD licenses/ /licenses
 ADD LICENSE /licenses/
 
 # Include libraries from UBI for dynamic linking.
-COPY --from=base /lib64 /lib64
-COPY --from=base /lib /lib
+COPY --from=ubi /lib64 /lib64
+COPY --from=ubi /lib /lib
 
 ADD bin/amd64/ /opt/cni/bin/
 

--- a/cni-plugin/Dockerfile.s390x
+++ b/cni-plugin/Dockerfile.s390x
@@ -8,8 +8,8 @@ RUN mkdir -p /opt/cni/bin
 
 FROM scratch
 
-COPY --from=base /licenses /licenses
-COPY --from=base /opt/cni/bin /opt/cni/bin
+COPY --from=ubi /licenses /licenses
+COPY --from=ubi /opt/cni/bin /opt/cni/bin
 
 ADD bin/s390x/ /opt/cni/bin/
 

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -104,7 +104,7 @@ sub-image-%:
 	$(MAKE) image ARCH=$*
 
 $(DEPLOY_CONTAINER_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
-	docker build -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	docker build -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/kube-controllers/Dockerfile.amd64
+++ b/kube-controllers/Dockerfile.amd64
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 ARG GIT_VERSION=unknown
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as base
+ARG UBI_IMAGE
+
+FROM ${UBI_IMAGE} as ubi
 
 # Add in top-level license file
 RUN mkdir /licenses
@@ -35,13 +37,13 @@ LABEL name="Calico Kubernetes controllers" \
       description="Calico Kubernetes controllers monitor the Kubernetes API and perform actions based on cluster state" \
       maintainer="Casey Davenport <casey@tigera.io>"
 
-COPY --from=base /licenses /licenses
-COPY --from=base /profiles /profiles
-COPY --from=base /status /status
+COPY --from=ubi /licenses /licenses
+COPY --from=ubi /profiles /profiles
+COPY --from=ubi /status /status
 
-COPY --from=base /usr/include /usr/include
-COPY --from=base /lib64 /lib64
-COPY --from=base /lib /lib
+COPY --from=ubi /usr/include /usr/include
+COPY --from=ubi /lib64 /lib64
+COPY --from=ubi /lib /lib
 
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ADD bin/check-status-linux-amd64 /usr/bin/check-status

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -83,8 +83,8 @@ sub-image-%:
 	$(MAKE) image ARCH=$*
 
 image.created-$(ARCH): bin/kube-controllers-linux-$(ARCH) bin/check-status-linux-$(ARCH) bin/kubectl-$(ARCH)
-	docker build -t $(KUBE_CONTROLLERS_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
-	docker build -t $(FLANNEL_MIGRATION_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-images/flannel-migration/Dockerfile.$(ARCH) .
+	docker build -t $(KUBE_CONTROLLERS_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	docker build -t $(FLANNEL_MIGRATION_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f docker-images/flannel-migration/Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/kube-controllers/docker-images/flannel-migration/Dockerfile.amd64
+++ b/kube-controllers/docker-images/flannel-migration/Dockerfile.amd64
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 ARG GIT_VERSION=unknown
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as base
+ARG UBI_IMAGE
+
+FROM ${UBI_IMAGE} as ubi
 
 # Add in top-level license file
 RUN mkdir /licenses
@@ -32,11 +34,11 @@ LABEL name="Calico Flannel migration controller" \
       description="Calico Flannel migration controller updates a flannel cluster to Calico" \
       maintainer="Song Jiang <song@tigera.io>"
 
-COPY --from=base /licenses /licenses
-COPY --from=base /status /status
-COPY --from=base /usr/include /usr/include
-COPY --from=base /lib64 /lib64
-COPY --from=base /lib /lib
+COPY --from=ubi /licenses /licenses
+COPY --from=ubi /status /status
+COPY --from=ubi /usr/include /usr/include
+COPY --from=ubi /lib64 /lib64
+COPY --from=ubi /lib /lib
 
 ADD bin/kubectl-amd64 /usr/bin/kubectl
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -156,6 +156,7 @@ ifeq ($(BUILDARCH),amd64)
 	# *-amd64 tagged images for etcd are not available until v3.5.0
 	ETCD_IMAGE = quay.io/coreos/etcd:$(ETCD_VERSION)
 endif
+UBI_IMAGE ?= registry.access.redhat.com/ubi8/ubi-minimal:$(UBI_VERSION)
 
 ifeq ($(GIT_USE_SSH),true)
 	GIT_CONFIG_SSH ?= git config --global url."ssh://git@github.com/".insteadOf "https://github.com/";

--- a/metadata.mk
+++ b/metadata.mk
@@ -13,6 +13,7 @@ KUBECTL_VERSION = v1.22.1
 COREDNS_VERSION=1.5.2
 ETCD_VERSION=v3.3.7
 PROTOC_VER=v0.1
+UBI_VERSION=8.5
 
 # Configuration for Semaphore integration.
 ORGANIZATION = projectcalico

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -17,7 +17,7 @@ ARG IPTABLES_VER=1.8.4-17
 ARG LIBNFTNL_VER=1.1.5-4
 ARG RUNIT_VER=2.1.2
 ARG BIRD_IMAGE=calico/bird:latest
-
+ARG UBI_IMAGE
 
 FROM calico/bpftool:v5.3-amd64 as bpftool
 FROM ${BIRD_IMAGE} as bird
@@ -95,7 +95,8 @@ RUN wget -P /tmp https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_V
     cd /tmp/admin/runit-${RUNIT_VER}/ && \
     package/install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 as ubi
+FROM ${UBI_IMAGE} as ubi
+
 ARG ARCH
 ARG GIT_VERSION
 ARG IPTABLES_VER

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -18,6 +18,7 @@ ARG LIBNFTNL_VER=1.1.5-4
 ARG RUNIT_VER=2.1.2
 ARG QEMU_IMAGE=calico/go-build:v0.55-arm64
 ARG BIRD_IMAGE=calico/bird:latest
+ARG UBI_IMAGE
 
 FROM calico/bpftool:v5.0-arm64 as bpftool
 FROM ${QEMU_IMAGE} as qemu
@@ -105,7 +106,9 @@ RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
     package/install
 
 ARG UBI_DIGEST
-FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.4 as ubi
+
+FROM --platform=linux/arm64 ${UBI_IMAGE} as ubi
+
 ARG ARCH
 ARG GIT_VERSION
 ARG IPTABLES_VER

--- a/node/Makefile
+++ b/node/Makefile
@@ -284,7 +284,7 @@ clean-sub-image-%:
 
 $(NODE_IMAGE): $(NODE_CONTAINER_CREATED)
 $(NODE_CONTAINER_CREATED): register ./Dockerfile.$(ARCH) $(NODE_CONTAINER_FILES) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) remote-deps
-	docker build --pull -t $(NODE_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
+	docker build --pull -t $(NODE_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
@@ -428,7 +428,7 @@ busybox.tar:
 	docker save --output busybox.tar $(ARCH)/busybox:latest
 
 workload.tar:
-	cd workload && docker build -t workload --build-arg QEMU_IMAGE=$(CALICO_BUILD) -f Dockerfile.$(ARCH) .
+	cd workload && docker build -t workload --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) -f Dockerfile.$(ARCH) .
 	docker save --output workload.tar workload
 
 stop-etcd:
@@ -439,7 +439,7 @@ IPT_ALLOW_ETCD:=-A INPUT -i docker0 -p tcp --dport 2379 -m comment --comment "ca
 # Create the calico/test image
 test_image: calico_test.created
 calico_test.created: $(TEST_CONTAINER_FILES)
-	cd calico_test && docker build --build-arg QEMU_IMAGE=$(CALICO_BUILD) -f Dockerfile.$(ARCH).calico_test -t $(TEST_CONTAINER_NAME) .
+	cd calico_test && docker build --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) -f Dockerfile.$(ARCH).calico_test -t $(TEST_CONTAINER_NAME) .
 	touch calico_test.created
 
 calico-node.tar: $(NODE_CONTAINER_CREATED)

--- a/pod2daemon/Dockerfile.amd64
+++ b/pod2daemon/Dockerfile.amd64
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2-301 AS base
+ARG UBI_IMAGE
+
+FROM ${UBI_IMAGE} as ubi
 
 ADD flexvol/docker/clean.sh /usr/local/bin/clean.sh
 ADD flexvol/docker/flexvol.sh /usr/local/bin/flexvol.sh
@@ -39,12 +41,12 @@ LABEL name="Calico FlexVolume driver installer" \
       description="Calico FlexVolume driver installer to setup secure connections from Kubernetes pods to local daemons" \
       maintainer="Laurence Man <laurence@tigera.io>"
 
-COPY --from=base /licenses /licenses
-COPY --from=base /bin /bin
-COPY --from=base /lib64 /lib64
-COPY --from=base /usr/lib64 /usr/lib64
-COPY --from=base /usr/bin /usr/bin
-COPY --from=base /usr/local/bin/flexvol.sh /usr/local/bin/flexvol.sh
+COPY --from=ubi /licenses /licenses
+COPY --from=ubi /bin /bin
+COPY --from=ubi /lib64 /lib64
+COPY --from=ubi /usr/lib64 /usr/lib64
+COPY --from=ubi /usr/bin /usr/bin
+COPY --from=ubi /usr/local/bin/flexvol.sh /usr/local/bin/flexvol.sh
 
 ADD bin/flexvol-amd64 /usr/local/bin/flexvol
 

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -71,7 +71,7 @@ sub-image-%:
 
 $(FLEXVOL_IMAGE): $(CONTAINER_CREATED)
 $(CONTAINER_CREATED): Dockerfile.$(ARCH) bin/flexvol-$(ARCH)
-	docker build -t $(FLEXVOL_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+	docker build -t $(FLEXVOL_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -103,7 +103,7 @@ $(TYPHA_IMAGE): bin/calico-typha-$(ARCH) register
 	mkdir -p docker-image/bin
 	cp bin/calico-typha-$(ARCH) docker-image/bin/
 	cp LICENSE docker-image/
-	docker buildx build --platform linux/$(ARCH) -t $(TYPHA_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) --file ./docker-image/Dockerfile.$(ARCH) docker-image --load
+	docker buildx build --platform linux/$(ARCH) -t $(TYPHA_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) --file ./docker-image/Dockerfile.$(ARCH) docker-image --load
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 
 ###############################################################################

--- a/typha/docker-image/Dockerfile.amd64
+++ b/typha/docker-image/Dockerfile.amd64
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 ARG GIT_VERSION=unknown
+ARG UBI_IMAGE
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as base
+FROM ${UBI_IMAGE} as ubi
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
 ENV TINI_VERSION v0.18.0
@@ -36,12 +37,12 @@ LABEL name="Calico Typha" \
       description="Calico Typha is a fan-out datastore proxy" \
       maintainer="Shaun Crampton <shaun@tigera.io>"
 
-COPY --from=base /sbin/tini /sbin/tini
-COPY --from=base /licenses /licenses
+COPY --from=ubi /sbin/tini /sbin/tini
+COPY --from=ubi /licenses /licenses
 
-COPY --from=base /usr/include /usr/include
-COPY --from=base /lib64 /lib64
-COPY --from=base /lib /lib
+COPY --from=ubi /usr/include /usr/include
+COPY --from=ubi /lib64 /lib64
+COPY --from=ubi /lib /lib
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.


### PR DESCRIPTION
Use lib.Makefile + metadata.mk + Dockerfile ARG to centralize ubi image and version across all dirs.

Pin the version in metadata.mk to 8.5-218 (latest as of now).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Bump UBI base image to 8.5 for all images
```
