### PR TITLE
Fix ipam_allocations_borrowed_per_node name in doc

### DIFF
--- a/calico/reference/kube-controllers/prometheus.md
+++ b/calico/reference/kube-controllers/prometheus.md
@@ -20,7 +20,7 @@ existing metrics.
 | ------------- | --------------- |
 | `ipam_blocks_per_node` | Number of IPAM blocks, indexed by the node to which they have affinity. |
 | `ipam_allocations_per_node` | Number of Calico IP allocations, indexed by node on which the allocation was made. |
-| `ipam_borrowed_allocations_per_node` | Number of Calico IP allocations borrowed from a non-affine block, indexed by node on which the allocation was made. |
+| `ipam_allocations_borrowed_per_node` | Number of Calico IP allocations borrowed from a non-affine block, indexed by node on which the allocation was made. |
 
 Prometheus metrics are self-documenting, with metrics turned on, `curl` can be used to list the
 metrics along with their help text and type information.


### PR DESCRIPTION
## Description

The following Prometheus metric exists for kube-controllers
```
grep -lir ipam_allocations_borrowed_per_node *
kube-controllers/tests/fv/metrics_test.go
kube-controllers/pkg/controllers/node/ipam.go
```
but:
```
grep -lir ipam_borrowed_allocations_per_node *
calico/reference/kube-controllers/prometheus.md
```
This leads me to think that the naming in the docs is incorrect. I thought I would quickly check this on a real cluster, but oddly I don't see it with either name, but I **think** that's a red herring:
```
docker@cluster-a-m02:~$ curl -s http://10.200.2.2:9094/metrics | grep -i ipam_blocks_per_node | wc -l
4
docker@cluster-a-m02:~$ curl -s http://10.200.2.2:9094/metrics | grep -i ipam_allocations_per_node | wc -l
4
docker@cluster-a-m02:~$ curl -s http://10.200.2.2:9094/metrics | grep -i borrowed | wc -l
0
```

## Related issues/PRs

None - discovered during other work.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
