### PR TITLE
Update Node Dockerfile to install ipset 7.11

### DIFF
--- a/metadata.mk
+++ b/metadata.mk
@@ -6,8 +6,8 @@
 GO_BUILD_VER = v0.65
 
 # Version of Kubernetes to use for tests.
-K8S_VERSION     = v1.22.1
-KUBECTL_VERSION = v1.22.1
+K8S_VERSION     = v1.23.0
+KUBECTL_VERSION = v1.23.0
 
 # Version of various tools used in the build and tests.
 COREDNS_VERSION=1.5.2

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -15,6 +15,7 @@ ARG ARCH=x86_64
 ARG GIT_VERSION=unknown
 ARG IPTABLES_VER=1.8.4-17
 ARG LIBNFTNL_VER=1.1.5-4
+ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
 ARG BIRD_IMAGE=calico/bird:latest
 
@@ -30,10 +31,13 @@ FROM centos:8 as centos
 ARG ARCH
 ARG IPTABLES_VER
 ARG LIBNFTNL_VER
+ARG IPSET_VER
 ARG RUNIT_VER
 ARG CENTOS_MIRROR_BASE_URL=https://vault.centos.org/8.4.2105
 ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/libnftnl-${LIBNFTNL_VER}.el8.src.rpm
 ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/iptables-${IPTABLES_VER}.el8.src.rpm
+ARG STREAM9_MIRROR_BASE_URL=https://iad.mirror.rackspace.com/centos-stream/9-stream
+ARG IPSET_SOURCERPM_URL=${STREAM9_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.
 RUN dnf install -y 'dnf-command(config-manager)' && \
@@ -87,6 +91,11 @@ RUN sed -i '/%files$/a \
 # Finally rebuild iptables.
 RUN rpmbuild -bb /root/rpmbuild/SPECS/iptables.spec
 
+# Install source RPM for ipset and install its build dependencies.
+RUN rpm -i ${IPSET_SOURCERPM_URL} && \
+    yum-builddep -y --spec /root/rpmbuild/SPECS/ipset.spec && \
+    rpmbuild -bb /root/rpmbuild/SPECS/ipset.spec
+
 # runit is not available in ubi or CentOS repos so build it.
 # get it from the debian repos as the official website doesn't support https
 RUN wget -P /tmp https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz && \
@@ -100,6 +109,7 @@ ARG ARCH
 ARG GIT_VERSION
 ARG IPTABLES_VER
 ARG LIBNFTNL_VER
+ARG IPSET_VER
 ARG RUNIT_VER
 
 # Update base packages to pick up security updates.  Must do this before adding the centos repo.
@@ -125,7 +135,6 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     --setopt=tsflags=nodocs \
     # Needed for iptables
     libpcap libmnl libnfnetlink libnetfilter_conntrack \
-    ipset \
     iputils \
     # Need arp
     net-tools \
@@ -149,6 +158,9 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     # Install compatible libnftnl version with selected iptables version
     rpm --force -i /tmp/rpms/libnftnl-${LIBNFTNL_VER}.el8.${ARCH}.rpm && \
     rpm -i /tmp/rpms/iptables-${IPTABLES_VER}.el8.${ARCH}.rpm && \
+    # Install ipset version
+    rpm --force -i /tmp/rpms/ipset-libs-${IPSET_VER}.el8.x86_64.rpm && \
+    rpm -i /tmp/rpms/ipset-${IPSET_VER}.el8.x86_64.rpm && \
     # Set alternatives
     alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-legacy 1 && \
     alternatives --install /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-legacy 1


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR fixes https://github.com/projectcalico/calico/issues/5011 by bumping up ipset package from version 7.1 to version 7.11

Since we haven't got a ubi:9 image to install ipset 7.11 from the official repo, the workaround is to download the source rpm with all the dependencies and get it built from ubi:8.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
