### PR TITLE
fix a typo in installation doc

### DIFF
--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -251,7 +251,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
    {: .alert .alert-info}
 
    ```bash
-   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/calico/installation.yaml
+   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/calico/installation-default.yaml
    ```
 
 #### Install the VPP dataplane components


### PR DESCRIPTION
## Description

The VPP Getting Started doc (https://projectcalico.docs.tigera.io/master/getting-started/kubernetes/vpp/getting-started) points to a non-existent installation yaml:

```
kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/calico/installation.yaml
```

Fixing the typo.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note


## Related issues/PRs

## Release Note

```
None required
```
