### PR TITLE
Create srmsg and ctnats map upfront to avoid races

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -651,6 +651,18 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			log.WithError(err).Panic("Failed to create conntrack BPF map.")
 		}
 
+		srMsgMap := nat.SendRecvMsgMap(bpfMapContext)
+		err = srMsgMap.EnsureExists()
+		if err != nil {
+			log.WithError(err).Panic("Failed to create send recv msg map.")
+		}
+
+		ctNatsMap := nat.AllNATsMsgMap(bpfMapContext)
+		err = ctNatsMap.EnsureExists()
+		if err != nil {
+			log.WithError(err).Panic("Failed to create ct nats map.")
+		}
+
 		conntrackScanner := conntrack.NewScanner(ctMap,
 			conntrack.NewLivenessScanner(config.BPFConntrackTimeouts, config.BPFNodePortDSREnabled))
 

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -405,7 +405,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					BeforeEach(func() {
 						Eventually(func() int {
 							return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
-						}, "5s", "200ms").Should(Equal(len(felixes) - 1))
+						}, "10s", "200ms").Should(Equal(len(felixes) - 1))
 
 						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 						defer cancel()


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed race when creating bpf maps that prevented loading bpf programs.
```
