### PR TITLE
felix/bpf: legacy attaching to cgroup

### DIFF
--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -218,7 +218,12 @@ func (o *Obj) AttachCGroup(cgroup, progName string) (*Link, error) {
 
 	link, err := C.bpf_program_attach_cgroup(o.obj, C.int(fd), cProgName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to attach %s to cgroup %s: %w", progName, cgroup, err)
+		link = nil
+		_, err2 := C.bpf_program_attach_cgroup_legacy(o.obj, C.int(fd), cProgName)
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to attach %s to cgroup %s (legacy try %s): %w",
+				progName, cgroup, err2, err)
+		}
 	}
 
 	return &Link{link: link}, nil

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -149,6 +149,31 @@ out:
 	return link;
 }
 
+int bpf_program_attach_cgroup_legacy(struct bpf_object *obj, int cgroup_fd, char *name)
+{
+	int err = 0, prog_fd;
+	struct bpf_program *prog;
+	enum bpf_attach_type attach_type;
+
+	if (!(prog = bpf_object__find_program_by_name(obj, name))) {
+		err = ENOENT;
+		goto out;
+	}
+
+	prog_fd = bpf_program__fd(prog);
+	if (prog_fd < 0) {
+		err = EINVAL;
+		goto out;
+	}
+
+	attach_type = bpf_program__get_expected_attach_type(prog);
+	err = bpf_prog_attach(prog_fd, cgroup_fd, attach_type, 0);
+
+out:
+	set_errno(err);
+	return err;
+}
+
 void bpf_ctlb_set_globals(struct bpf_map *map, uint udp_not_seen_timeo)
 {
 	struct cali_ctlb_globals data = {


### PR DESCRIPTION
Kernels older than 5.7 do not support BPF_LINK_CREATE so we first try
the new way of attaching programs and if that fails we try a legacy way
that does not return a link. We do not use the link anyway.

We fail if both methods fail.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
