### PR TITLE
Choose a more resilient way to create container ID from netns path

### DIFF
--- a/cni-plugin/internal/pkg/testutils/utils_linux.go
+++ b/cni-plugin/internal/pkg/testutils/utils_linux.go
@@ -16,13 +16,14 @@ package testutils
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 	"syscall"
 
@@ -152,8 +153,7 @@ func CreateContainerNamespace() (containerNs ns.NetNS, containerId string, err e
 		return nil, "", err
 	}
 
-	netnsname := path.Base(containerNs.Path())
-	containerId = netnsname[:10]
+	containerId =  netnsToContainerID(containerNs.Path())
 
 	err = containerNs.Do(func(_ ns.NetNS) error {
 		lo, err := netlink.LinkByName("lo")
@@ -368,8 +368,7 @@ func DeleteContainerWithId(netconf, netnspath, podName, podNamespace, containerI
 }
 
 func DeleteContainerWithIdAndIfaceName(netconf, netnspath, podName, podNamespace, containerId, ifaceName string) (exitCode int, err error) {
-	netnsname := path.Base(netnspath)
-	container_id := netnsname[:10]
+	container_id :=  netnsToContainerID(netnspath)
 	if containerId != "" {
 		container_id = containerId
 	}
@@ -467,4 +466,15 @@ func CheckSysctlValue(sysctlPath, value string) error {
 	}
 
 	return nil
+}
+
+// Convert the netns name to a container ID.
+func netnsToContainerID(netns string) string {
+	hasher := sha256.New()
+	_, err := hasher.Write([]byte(netns))
+	if err != nil {
+		log.WithError(err).Panic("Failed to write netns to hash.")
+	}
+	hash := base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
+	return hash[0:10]
 }


### PR DESCRIPTION
## Description

I think this should fix flakes related to host-local IPAM of the type:

```
Unexpected error:
      <*types.Error | 0xc002c539b0>: {
          Code: 999,
          Msg: "failed to allocate for range 0: 10.0.0.4 has been allocated to cnitest-90, duplicate allocation is not allowed",
          Details: "",
      }
      failed to allocate for range 0: 10.0.0.4 has been allocated to cnitest-90, duplicate allocation is not allowed
  occurred[0m
```

This error message occurs when the container specified by the ID already has a IP associated with it.

Problem is the container ID is simply the shortened netns file name - I think this is potentially non-unique and causing clashes.

I suspect we are also not tidying up some containers somewhere - but this should at least stop the flakes.



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
