### PR TITLE
Fix bugs in calicoctl k8s->calico NetworkPolicy conversion

### DIFF
--- a/calicoctl/calicoctl/commands/convert.go
+++ b/calicoctl/calicoctl/commands/convert.go
@@ -254,24 +254,17 @@ func getTypeConverter(resKind string) (converters.Converter, error) {
 
 func unpackResourceLists(convRes []unversioned.Resource) ([]unversioned.Resource, error) {
 	var unpackedConvRes []unversioned.Resource
-	for i, convResource := range convRes {
+	for _, convResource := range convRes {
 		if strings.EqualFold(convResource.GetTypeMetadata().Kind, resourceloader.KindK8sListV1) && strings.EqualFold(convResource.GetTypeMetadata().APIVersion, resourceloader.VersionK8sListV1) {
-			// Remove list from convRes
-			convRes[i] = convRes[len(convRes)-1]
-			convRes = convRes[:len(convRes)-1]
-
 			k8sNPList, ok := convResource.(*resourceloader.K8sNetworkPolicyList)
 			if !ok {
 				return nil, fmt.Errorf("failed to convert resource to K8sNetworkPolicyList")
 			}
 
-			var listResources []unversioned.Resource
 			for _, item := range k8sNPList.Items {
-				listResources = append(listResources, &item)
+				// Append the items from the list to unpackedConvRes
+				unpackedConvRes = append(unpackedConvRes, &item)
 			}
-
-			// Append the items from the list to convRes
-			unpackedConvRes = append(unpackedConvRes, listResources...)
 		} else {
 			unpackedConvRes = append(unpackedConvRes, convResource)
 		}

--- a/calicoctl/calicoctl/commands/convert.go
+++ b/calicoctl/calicoctl/commands/convert.go
@@ -97,7 +97,13 @@ Description:
 	// of resources for easier handling.
 	convRes, err := resourceloader.CreateResourcesFromFile(filename)
 	if err != nil {
-		return fmt.Errorf("Failed to execute command: %v", err)
+		return fmt.Errorf("Failed to create resources from file: %w", err)
+	}
+
+	// Unpack list resources (if any) into the slice
+	convRes, err = unpackResourceLists(convRes)
+	if err != nil {
+		return fmt.Errorf("Failed to unpack lists: %w", err)
 	}
 
 	var results []runtime.Object
@@ -105,12 +111,11 @@ Description:
 	for _, convResource := range convRes {
 		v3Resource, err := convertResource(convResource)
 		if err != nil {
-			return fmt.Errorf("Failed to execute command: %w", err)
+			return fmt.Errorf("Failed to convert resource: %w", err)
 		}
 
 		// Remove any extra metadata the object might have.
 		rom := v3Resource.(v1.ObjectMetaAccessor).GetObjectMeta()
-		rom.SetNamespace("")
 		rom.SetUID("")
 		rom.SetResourceVersion("")
 		rom.SetCreationTimestamp(v1.Time{})
@@ -131,9 +136,16 @@ Description:
 
 	log.Infof("results: %+v", results)
 
+	if len(results) > 1 {
+		results, err = createV1List(results)
+		if err != nil {
+			return fmt.Errorf("Failed to create v1.List: %w", err)
+		}
+	}
+
 	err = rp.Print(nil, results)
 	if err != nil {
-		return fmt.Errorf("Failed to execute command: %v", err)
+		return fmt.Errorf("Failed to print results: %w", err)
 	}
 
 	return nil
@@ -238,4 +250,57 @@ func getTypeConverter(resKind string) (converters.Converter, error) {
 	default:
 		return nil, fmt.Errorf("conversion for the resource type '%s' is not supported", resKind)
 	}
+}
+
+func unpackResourceLists(convRes []unversioned.Resource) ([]unversioned.Resource, error) {
+	var unpackedConvRes []unversioned.Resource
+	for i, convResource := range convRes {
+		if strings.EqualFold(convResource.GetTypeMetadata().Kind, resourceloader.KindK8sListV1) && strings.EqualFold(convResource.GetTypeMetadata().APIVersion, resourceloader.VersionK8sListV1) {
+			// Remove list from convRes
+			convRes[i] = convRes[len(convRes)-1]
+			convRes = convRes[:len(convRes)-1]
+
+			k8sNPList, ok := convResource.(*resourceloader.K8sNetworkPolicyList)
+			if !ok {
+				return nil, fmt.Errorf("failed to convert resource to K8sNetworkPolicyList")
+			}
+
+			var listResources []unversioned.Resource
+			for _, item := range k8sNPList.Items {
+				listResources = append(listResources, &item)
+			}
+
+			// Append the items from the list to convRes
+			unpackedConvRes = append(unpackedConvRes, listResources...)
+		} else {
+			unpackedConvRes = append(unpackedConvRes, convResource)
+		}
+	}
+
+	return unpackedConvRes, nil
+}
+
+func createV1List(results []runtime.Object) ([]runtime.Object, error) {
+	list := v1.List{
+		TypeMeta: v1.TypeMeta{
+			Kind:       resourceloader.KindK8sListV1,
+			APIVersion: resourceloader.VersionK8sListV1,
+		},
+	}
+
+	for _, item := range results {
+		var rawExt runtime.RawExtension
+
+		err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&item, &rawExt, nil)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convert runtime.Object to runtime.RawExtension: %w", err)
+		}
+
+		list.Items = append(list.Items, rawExt)
+	}
+
+	var obj []runtime.Object
+	obj = append(obj, &list)
+
+	return obj, nil
 }

--- a/calicoctl/calicoctl/commands/resourceloader/resourceloader.go
+++ b/calicoctl/calicoctl/commands/resourceloader/resourceloader.go
@@ -32,6 +32,8 @@ import (
 	v1validator "github.com/projectcalico/calico/libcalico-go/lib/validator/v1"
 )
 
+var KindK8sListV1 = "List"
+var VersionK8sListV1 = "v1"
 var VersionK8sNetworkingV1 = "networking.k8s.io/v1"
 
 // Store a resourceHelper for each resource unversioned.TypeMetadata.
@@ -53,6 +55,7 @@ func populateResourceTypes() {
 		apiv1.NewProfile(),
 		apiv1.NewWorkloadEndpoint(),
 		NewK8sNetworkPolicy(),
+		NewK8sNetworkPolicyList(),
 	}
 
 	for _, rt := range resTypes {
@@ -218,6 +221,29 @@ func NewK8sNetworkPolicy() *K8sNetworkPolicy {
 		TypeMetadata: unversioned.TypeMetadata{
 			Kind:       "NetworkPolicy",
 			APIVersion: VersionK8sNetworkingV1,
+		},
+	}
+}
+
+type K8sListMetadata struct {
+	ResourceVersion string `json:"resourceVersion"`
+	SelfLink        string `json:"selfLink"`
+}
+
+// K8sNetworkPolicyList contains a list of resources.
+type K8sNetworkPolicyList struct {
+	unversioned.TypeMetadata
+	Metadata K8sListMetadata    `json:"metadata"`
+	Items    []K8sNetworkPolicy `json:"items" validate:"dive"`
+}
+
+// NewK8sNetworkPolicyList creates a new (zeroed) K8sNetworkPolicyList struct with the
+// TypeMetadata initialised to the current version.
+func NewK8sNetworkPolicyList() *K8sNetworkPolicyList {
+	return &K8sNetworkPolicyList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       KindK8sListV1,
+			APIVersion: VersionK8sListV1,
 		},
 	}
 }

--- a/calicoctl/test-data/convert/input/k8s/k8s-networkpolicy-multiple-list.yaml
+++ b/calicoctl/test-data/convert/input/k8s/k8s-networkpolicy-multiple-list.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+items:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-all-egress
+    namespace: default
+  spec:
+    egress:
+    - {}
+    podSelector: {}
+    policyTypes:
+    - Egress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: default-deny-ingress
+    namespace: default
+  spec:
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: test-network-policy1
+    namespace: test-ns
+  spec:
+    egress:
+    - ports:
+      - port: 5978
+        protocol: TCP
+      to:
+      - ipBlock:
+          cidr: 10.0.0.0/24
+    ingress:
+    - from:
+      - ipBlock:
+          cidr: 172.17.0.0/16
+          except:
+          - 172.17.1.0/24
+      - namespaceSelector:
+          matchLabels:
+            project: myproject
+      - podSelector:
+          matchLabels:
+            role: frontend
+      ports:
+      - port: 6379
+        protocol: TCP
+    podSelector:
+      matchLabels:
+        role: db
+    policyTypes:
+    - Ingress
+    - Egress
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/calicoctl/test-data/convert/input/k8s/k8s-networkpolicy-multiple.yaml
+++ b/calicoctl/test-data/convert/input/k8s/k8s-networkpolicy-multiple.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: test-network-policy1
-  namespace: default
+  namespace: test-ns
 spec:
   podSelector:
     matchLabels:

--- a/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple-list.json
+++ b/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple-list.json
@@ -1,0 +1,235 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "NetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "test-network-policy1",
+        "namespace": "test-ns",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "order": 1000,
+        "ingress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "nets": [
+                "172.17.0.0/16"
+              ],
+              "notNets": [
+                "172.17.1.0/24"
+              ]
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s'",
+              "namespaceSelector": "project == 'myproject'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'frontend'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          }
+        ],
+        "egress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {},
+            "destination": {
+              "nets": [
+                "10.0.0.0/24"
+              ],
+              "ports": [
+                5978
+              ]
+            }
+          }
+        ],
+        "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'db'",
+        "types": [
+          "Ingress",
+          "Egress"
+        ]
+      }
+    },
+    {
+      "kind": "NetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "test-network-policy1",
+        "namespace": "test-ns",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "order": 1000,
+        "ingress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "nets": [
+                "172.17.0.0/16"
+              ],
+              "notNets": [
+                "172.17.1.0/24"
+              ]
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s'",
+              "namespaceSelector": "project == 'myproject'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'frontend'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          }
+        ],
+        "egress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {},
+            "destination": {
+              "nets": [
+                "10.0.0.0/24"
+              ],
+              "ports": [
+                5978
+              ]
+            }
+          }
+        ],
+        "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'db'",
+        "types": [
+          "Ingress",
+          "Egress"
+        ]
+      }
+    },
+    {
+      "kind": "NetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "test-network-policy1",
+        "namespace": "test-ns",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "order": 1000,
+        "ingress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "nets": [
+                "172.17.0.0/16"
+              ],
+              "notNets": [
+                "172.17.1.0/24"
+              ]
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s'",
+              "namespaceSelector": "project == 'myproject'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'frontend'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          }
+        ],
+        "egress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {},
+            "destination": {
+              "nets": [
+                "10.0.0.0/24"
+              ],
+              "ports": [
+                5978
+              ]
+            }
+          }
+        ],
+        "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'db'",
+        "types": [
+          "Ingress",
+          "Egress"
+        ]
+      }
+    }
+  ]
+}

--- a/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple-list.yaml
+++ b/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple-list.yaml
@@ -1,0 +1,145 @@
+apiVersion: v1
+items:
+- apiVersion: projectcalico.org/v3
+  kind: NetworkPolicy
+  metadata:
+    creationTimestamp: null
+    name: test-network-policy1
+    namespace: test-ns
+  spec:
+    egress:
+    - action: Allow
+      destination:
+        nets:
+        - 10.0.0.0/24
+        ports:
+        - 5978
+      protocol: TCP
+      source: {}
+    ingress:
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        nets:
+        - 172.17.0.0/16
+        notNets:
+        - 172.17.1.0/24
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        namespaceSelector: project == 'myproject'
+        selector: projectcalico.org/orchestrator == 'k8s'
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        selector: projectcalico.org/orchestrator == 'k8s' && role == 'frontend'
+    order: 1000
+    selector: projectcalico.org/orchestrator == 'k8s' && role == 'db'
+    types:
+    - Ingress
+    - Egress
+- apiVersion: projectcalico.org/v3
+  kind: NetworkPolicy
+  metadata:
+    creationTimestamp: null
+    name: test-network-policy1
+    namespace: test-ns
+  spec:
+    egress:
+    - action: Allow
+      destination:
+        nets:
+        - 10.0.0.0/24
+        ports:
+        - 5978
+      protocol: TCP
+      source: {}
+    ingress:
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        nets:
+        - 172.17.0.0/16
+        notNets:
+        - 172.17.1.0/24
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        namespaceSelector: project == 'myproject'
+        selector: projectcalico.org/orchestrator == 'k8s'
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        selector: projectcalico.org/orchestrator == 'k8s' && role == 'frontend'
+    order: 1000
+    selector: projectcalico.org/orchestrator == 'k8s' && role == 'db'
+    types:
+    - Ingress
+    - Egress
+- apiVersion: projectcalico.org/v3
+  kind: NetworkPolicy
+  metadata:
+    creationTimestamp: null
+    name: test-network-policy1
+    namespace: test-ns
+  spec:
+    egress:
+    - action: Allow
+      destination:
+        nets:
+        - 10.0.0.0/24
+        ports:
+        - 5978
+      protocol: TCP
+      source: {}
+    ingress:
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        nets:
+        - 172.17.0.0/16
+        notNets:
+        - 172.17.1.0/24
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        namespaceSelector: project == 'myproject'
+        selector: projectcalico.org/orchestrator == 'k8s'
+    - action: Allow
+      destination:
+        ports:
+        - 6379
+      protocol: TCP
+      source:
+        selector: projectcalico.org/orchestrator == 'k8s' && role == 'frontend'
+    order: 1000
+    selector: projectcalico.org/orchestrator == 'k8s' && role == 'db'
+    types:
+    - Ingress
+    - Egress
+kind: List
+metadata: {}

--- a/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple.json
+++ b/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple.json
@@ -1,114 +1,120 @@
-[
-  {
-    "kind": "NetworkPolicy",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "test-network-policy1",
-      "creationTimestamp": null
-    },
-    "spec": {
-      "order": 1000,
-      "ingress": [
-        {
-          "action": "Allow",
-          "protocol": "TCP",
-          "source": {
-            "nets": [
-              "172.17.0.0/16"
-            ],
-            "notNets": [
-              "172.17.1.0/24"
-            ]
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "NetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "test-network-policy1",
+        "namespace": "test-ns",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "order": 1000,
+        "ingress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "nets": [
+                "172.17.0.0/16"
+              ],
+              "notNets": [
+                "172.17.1.0/24"
+              ]
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
           },
-          "destination": {
-            "ports": [
-              6379
-            ]
-          }
-        },
-        {
-          "action": "Allow",
-          "protocol": "TCP",
-          "source": {
-            "selector": "projectcalico.org/orchestrator == 'k8s'",
-            "namespaceSelector": "project == 'myproject'"
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s'",
+              "namespaceSelector": "project == 'myproject'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
           },
-          "destination": {
-            "ports": [
-              6379
-            ]
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'frontend'"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
           }
-        },
-        {
-          "action": "Allow",
-          "protocol": "TCP",
-          "source": {
-            "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'frontend'"
-          },
-          "destination": {
-            "ports": [
-              6379
-            ]
+        ],
+        "egress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {},
+            "destination": {
+              "nets": [
+                "10.0.0.0/24"
+              ],
+              "ports": [
+                5978
+              ]
+            }
           }
-        }
-      ],
-      "egress": [
-        {
-          "action": "Allow",
-          "protocol": "TCP",
-          "source": {},
-          "destination": {
-            "nets": [
-              "10.0.0.0/24"
-            ],
-            "ports": [
-              5978
-            ]
-          }
-        }
-      ],
-      "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'db'",
-      "types": [
-        "Ingress",
-        "Egress"
-      ]
-    }
-  },
-  {
-    "kind": "NetworkPolicy",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "default-deny-ingress",
-      "creationTimestamp": null
+        ],
+        "selector": "projectcalico.org/orchestrator == 'k8s' \u0026\u0026 role == 'db'",
+        "types": [
+          "Ingress",
+          "Egress"
+        ]
+      }
     },
-    "spec": {
-      "order": 1000,
-      "selector": "projectcalico.org/orchestrator == 'k8s'",
-      "types": [
-        "Ingress"
-      ]
-    }
-  },
-  {
-    "kind": "NetworkPolicy",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "allow-all-egress",
-      "creationTimestamp": null
+    {
+      "kind": "NetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "default-deny-ingress",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "order": 1000,
+        "selector": "projectcalico.org/orchestrator == 'k8s'",
+        "types": [
+          "Ingress"
+        ]
+      }
     },
-    "spec": {
-      "order": 1000,
-      "egress": [
-        {
-          "action": "Allow",
-          "source": {},
-          "destination": {}
-        }
-      ],
-      "selector": "projectcalico.org/orchestrator == 'k8s'",
-      "types": [
-        "Egress"
-      ]
+    {
+      "kind": "NetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "allow-all-egress",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "order": 1000,
+        "egress": [
+          {
+            "action": "Allow",
+            "source": {},
+            "destination": {}
+          }
+        ],
+        "selector": "projectcalico.org/orchestrator == 'k8s'",
+        "types": [
+          "Egress"
+        ]
+      }
     }
-  }
-]
+  ]
+}

--- a/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple.yaml
+++ b/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy-multiple.yaml
@@ -1,8 +1,11 @@
+apiVersion: v1
+items:
 - apiVersion: projectcalico.org/v3
   kind: NetworkPolicy
   metadata:
     creationTimestamp: null
     name: test-network-policy1
+    namespace: test-ns
   spec:
     egress:
     - action: Allow
@@ -68,3 +71,5 @@
     selector: projectcalico.org/orchestrator == 'k8s'
     types:
     - Egress
+kind: List
+metadata: {}

--- a/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy.json
+++ b/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy.json
@@ -3,6 +3,7 @@
   "apiVersion": "projectcalico.org/v3",
   "metadata": {
     "name": "test-network-policy",
+    "namespace": "default",
     "creationTimestamp": null
   },
   "spec": {

--- a/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy.yaml
+++ b/calicoctl/test-data/convert/output/k8s/k8s-networkpolicy.yaml
@@ -3,6 +3,7 @@ kind: NetworkPolicy
 metadata:
   creationTimestamp: null
   name: test-network-policy
+  namespace: default
 spec:
   egress:
   - action: Allow

--- a/calicoctl/test-data/convert/output/v1/migration/policy.json
+++ b/calicoctl/test-data/convert/output/v1/migration/policy.json
@@ -1,139 +1,144 @@
-[
-  {
-    "kind": "GlobalNetworkPolicy",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "allow-tcp-6379",
-      "creationTimestamp": null,
-      "annotations": {
-        "aname": "avalue"
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "GlobalNetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "allow-tcp-6379",
+        "creationTimestamp": null,
+        "annotations": {
+          "aname": "avalue"
+        }
+      },
+      "spec": {
+        "order": 1234,
+        "ingress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "notProtocol": "UDPLite",
+            "source": {
+              "selector": "role == 'frontend' \u0026\u0026 thing not in {'three', 'four'}",
+              "notSelector": "role != 'something' \u0026\u0026 thing in {'one', 'two'}"
+            },
+            "destination": {
+              "ports": [
+                6379
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "notSelector": "role != 'something' \u0026\u0026 thing in {'one', 'two'}"
+            },
+            "destination": {}
+          },
+          {
+            "action": "Deny",
+            "protocol": "TCP",
+            "source": {},
+            "destination": {
+              "ports": [
+                22,
+                443
+              ],
+              "notPorts": [
+                80
+              ]
+            }
+          },
+          {
+            "action": "Allow",
+            "source": {
+              "nets": [
+                "172.18.18.200/32",
+                "172.18.19.0/24"
+              ]
+            },
+            "destination": {}
+          },
+          {
+            "action": "Allow",
+            "source": {
+              "nets": [
+                "172.18.18.100/32"
+              ]
+            },
+            "destination": {}
+          },
+          {
+            "action": "Deny",
+            "source": {
+              "notNets": [
+                "172.19.19.100/32"
+              ]
+            },
+            "destination": {}
+          },
+          {
+            "action": "Deny",
+            "source": {
+              "notNets": [
+                "172.18.0.0/16"
+              ]
+            },
+            "destination": {}
+          }
+        ],
+        "egress": [
+          {
+            "action": "Allow",
+            "protocol": "ICMP",
+            "icmp": {
+              "type": 25,
+              "code": 25
+            },
+            "source": {},
+            "destination": {}
+          }
+        ],
+        "selector": "role == 'database' \u0026\u0026 !has(demo)",
+        "types": [
+          "Ingress",
+          "Egress"
+        ]
       }
     },
-    "spec": {
-      "order": 1234,
-      "ingress": [
-        {
-          "action": "Allow",
-          "protocol": "TCP",
-          "notProtocol": "UDPLite",
-          "source": {
-            "selector": "role == 'frontend' \u0026\u0026 thing not in {'three', 'four'}",
-            "notSelector": "role != 'something' \u0026\u0026 thing in {'one', 'two'}"
-          },
-          "destination": {
-            "ports": [
-              6379
-            ]
+    {
+      "kind": "GlobalNetworkPolicy",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "allow-tcp-555-donottrack",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "order": 1230,
+        "ingress": [
+          {
+            "action": "Allow",
+            "protocol": "TCP",
+            "source": {
+              "selector": "role == 'cache'"
+            },
+            "destination": {
+              "ports": [
+                555
+              ]
+            }
           }
-        },
-        {
-          "action": "Allow",
-          "protocol": "TCP",
-          "source": {
-            "notSelector": "role != 'something' \u0026\u0026 thing in {'one', 'two'}"
-          },
-          "destination": {}
-        },
-        {
-          "action": "Deny",
-          "protocol": "TCP",
-          "source": {},
-          "destination": {
-            "ports": [
-              22,
-              443
-            ],
-            "notPorts": [
-              80
-            ]
-          }
-        },
-        {
-          "action": "Allow",
-          "source": {
-            "nets": [
-              "172.18.18.200/32",
-              "172.18.19.0/24"
-            ]
-          },
-          "destination": {}
-        },
-        {
-          "action": "Allow",
-          "source": {
-            "nets": [
-              "172.18.18.100/32"
-            ]
-          },
-          "destination": {}
-        },
-        {
-          "action": "Deny",
-          "source": {
-            "notNets": [
-              "172.19.19.100/32"
-            ]
-          },
-          "destination": {}
-        },
-        {
-          "action": "Deny",
-          "source": {
-            "notNets": [
-              "172.18.0.0/16"
-            ]
-          },
-          "destination": {}
-        }
-      ],
-      "egress": [
-        {
-          "action": "Allow",
-          "protocol": "ICMP",
-          "icmp": {
-            "type": 25,
-            "code": 25
-          },
-          "source": {},
-          "destination": {}
-        }
-      ],
-      "selector": "role == 'database' \u0026\u0026 !has(demo)",
-      "types": [
-        "Ingress",
-        "Egress"
-      ]
+        ],
+        "selector": "role == 'database'",
+        "types": [
+          "Ingress"
+        ],
+        "doNotTrack": true,
+        "applyOnForward": true
+      }
     }
-  },
-  {
-    "kind": "GlobalNetworkPolicy",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "allow-tcp-555-donottrack",
-      "creationTimestamp": null
-    },
-    "spec": {
-      "order": 1230,
-      "ingress": [
-        {
-          "action": "Allow",
-          "protocol": "TCP",
-          "source": {
-            "selector": "role == 'cache'"
-          },
-          "destination": {
-            "ports": [
-              555
-            ]
-          }
-        }
-      ],
-      "selector": "role == 'database'",
-      "types": [
-        "Ingress"
-      ],
-      "doNotTrack": true,
-      "applyOnForward": true
-    }
-  }
-]
+  ]
+}

--- a/calicoctl/test-data/convert/output/v1/migration/policy.yaml
+++ b/calicoctl/test-data/convert/output/v1/migration/policy.yaml
@@ -1,3 +1,5 @@
+apiVersion: v1
+items:
 - apiVersion: projectcalico.org/v3
   kind: GlobalNetworkPolicy
   metadata:
@@ -84,3 +86,5 @@
     selector: role == 'database'
     types:
     - Ingress
+kind: List
+metadata: {}

--- a/calicoctl/test-data/convert/output/v1/migration/workloadendpoint.json
+++ b/calicoctl/test-data/convert/output/v1/migration/workloadendpoint.json
@@ -3,6 +3,7 @@
   "apiVersion": "projectcalico.org/v3",
   "metadata": {
     "name": "rack1--host1-k8s-frontend--5gs43-eth0",
+    "namespace": "default",
     "creationTimestamp": null,
     "labels": {
       "app": "frontend",

--- a/calicoctl/test-data/convert/output/v1/migration/workloadendpoint.yaml
+++ b/calicoctl/test-data/convert/output/v1/migration/workloadendpoint.yaml
@@ -6,6 +6,7 @@ metadata:
     app: frontend
     projectcalico.org/namespace: default
   name: rack1--host1-k8s-frontend--5gs43-eth0
+  namespace: default
 spec:
   endpoint: eth0
   interfaceName: cali0ef24ba

--- a/calicoctl/test-data/convert/output/v1/multi-resource.json
+++ b/calicoctl/test-data/convert/output/v1/multi-resource.json
@@ -1,78 +1,83 @@
-[
-  {
-    "kind": "BGPPeer",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "node1.00aa-00bb-0000-0000-0000-0000-0000-00ff",
-      "creationTimestamp": null
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "BGPPeer",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "node1.00aa-00bb-0000-0000-0000-0000-0000-00ff",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "node": "node1",
+        "peerIP": "aa:bb::ff",
+        "asNumber": 64514
+      }
     },
-    "spec": {
-      "node": "node1",
-      "peerIP": "aa:bb::ff",
-      "asNumber": 64514
-    }
-  },
-  {
-    "kind": "BGPPeer",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "node2.1-2-3-4",
-      "creationTimestamp": null
+    {
+      "kind": "BGPPeer",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "node2.1-2-3-4",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "node": "node2",
+        "peerIP": "1.2.3.4",
+        "asNumber": 6455
+      }
     },
-    "spec": {
-      "node": "node2",
-      "peerIP": "1.2.3.4",
-      "asNumber": 6455
-    }
-  },
-  {
-    "kind": "BGPPeer",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "192-20-30-40",
-      "creationTimestamp": null
+    {
+      "kind": "BGPPeer",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "192-20-30-40",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "peerIP": "192.20.30.40",
+        "asNumber": 64567
+      }
     },
-    "spec": {
-      "peerIP": "192.20.30.40",
-      "asNumber": 64567
-    }
-  },
-  {
-    "kind": "IPPool",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "192-168-0-0-16",
-      "creationTimestamp": null
+    {
+      "kind": "IPPool",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "192-168-0-0-16",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "cidr": "192.168.0.0/16",
+        "vxlanMode": "Never",
+        "ipipMode": "Always",
+        "blockSize": 26,
+        "nodeSelector": "all()",
+        "allowedUses": [
+          "Workload",
+          "Tunnel"
+        ]
+      }
     },
-    "spec": {
-      "cidr": "192.168.0.0/16",
-      "vxlanMode": "Never",
-      "ipipMode": "Always",
-      "blockSize": 26,
-      "nodeSelector": "all()",
-      "allowedUses": [
-        "Workload",
-        "Tunnel"
-      ]
+    {
+      "kind": "IPPool",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "2001---120",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "cidr": "2001::/120",
+        "vxlanMode": "Never",
+        "ipipMode": "Never",
+        "blockSize": 122,
+        "nodeSelector": "all()",
+        "allowedUses": [
+          "Workload",
+          "Tunnel"
+        ]
+      }
     }
-  },
-  {
-    "kind": "IPPool",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "2001---120",
-      "creationTimestamp": null
-    },
-    "spec": {
-      "cidr": "2001::/120",
-      "vxlanMode": "Never",
-      "ipipMode": "Never",
-      "blockSize": 122,
-      "nodeSelector": "all()",
-      "allowedUses": [
-        "Workload",
-        "Tunnel"
-      ]
-    }
-  }
-]
+  ]
+}

--- a/calicoctl/test-data/convert/output/v1/multi-resource.yaml
+++ b/calicoctl/test-data/convert/output/v1/multi-resource.yaml
@@ -1,3 +1,5 @@
+apiVersion: v1
+items:
 - apiVersion: projectcalico.org/v3
   kind: BGPPeer
   metadata:
@@ -52,3 +54,5 @@
     ipipMode: Never
     nodeSelector: all()
     vxlanMode: Never
+kind: List
+metadata: {}

--- a/calicoctl/test-data/convert/output/v1/node.json
+++ b/calicoctl/test-data/convert/output/v1/node.json
@@ -1,28 +1,33 @@
-[
-  {
-    "kind": "Node",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "node1",
-      "creationTimestamp": null
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Node",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "node1",
+        "creationTimestamp": null
+      },
+      "spec": {},
+      "status": {}
     },
-    "spec": {},
-    "status": {}
-  },
-  {
-    "kind": "Node",
-    "apiVersion": "projectcalico.org/v3",
-    "metadata": {
-      "name": "node2",
-      "creationTimestamp": null
-    },
-    "spec": {
-      "bgp": {
-        "asNumber": 12345,
-        "ipv4Address": "1.2.3.4/24",
-        "ipv6Address": "aa::ff/128"
-      }
-    },
-    "status": {}
-  }
-]
+    {
+      "kind": "Node",
+      "apiVersion": "projectcalico.org/v3",
+      "metadata": {
+        "name": "node2",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "bgp": {
+          "asNumber": 12345,
+          "ipv4Address": "1.2.3.4/24",
+          "ipv6Address": "aa::ff/128"
+        }
+      },
+      "status": {}
+    }
+  ]
+}

--- a/calicoctl/test-data/convert/output/v1/node.yaml
+++ b/calicoctl/test-data/convert/output/v1/node.yaml
@@ -1,3 +1,5 @@
+apiVersion: v1
+items:
 - apiVersion: projectcalico.org/v3
   kind: Node
   metadata:
@@ -16,3 +18,5 @@
       ipv4Address: 1.2.3.4/24
       ipv6Address: aa::ff/128
   status: {}
+kind: List
+metadata: {}

--- a/calicoctl/tests/st/calicoctl/test_convert.py
+++ b/calicoctl/tests/st/calicoctl/test_convert.py
@@ -25,24 +25,28 @@ from tests.st.utils.data import *
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 logger = logging.getLogger(__name__)
 
+# TODO: applySuccess param relates to 'calicoctl apply' not working correctly
+# with a resource of "Kind: List". Once that is fixed, we should be able to
+# remove this arg (and consistently check for 'calicoctl apply' success).
 convert_files = [
-        ("test-data/convert/input/v1/bgppeer-global.yaml",),
-        ("test-data/convert/input/v1/bgppeer-node.yaml",),
-        ("test-data/convert/input/v1/bgppeer-node2.yaml",),
-        ("test-data/convert/input/v1/multi-resource.yaml",),
-        ("test-data/convert/input/v1/node.yaml",),
-        ("test-data/convert/input/v1/test3.yaml",),
-        ("test-data/convert/input/v1/migration/bgppeer.yaml",),
-        ("test-data/convert/input/v1/migration/hostendpoint.yaml",),
-        ("test-data/convert/input/v1/migration/ippool.yaml",),
-        ("test-data/convert/input/v1/migration/node.yaml",),
-        ("test-data/convert/input/v1/migration/policy.yaml",),
-        ("test-data/convert/input/v1/migration/profile.yaml",),
-        ("test-data/convert/input/v1/migration/workloadendpoint.yaml",),
-        ("test-data/convert/input/k8s/k8s-networkpolicy.yaml",),
-        ("test-data/convert/input/k8s/k8s-networkpolicy-invalid.yaml",),
-        ("test-data/convert/input/k8s/k8s-networkpolicy-multiple.yaml",),
-        ("test-data/convert/input/k8s/k8s-networkpolicy-multiple-invalid.yaml",),
+        ("test-data/convert/input/v1/bgppeer-global.yaml", True,),
+        ("test-data/convert/input/v1/bgppeer-node.yaml", True,),
+        ("test-data/convert/input/v1/bgppeer-node2.yaml", True,),
+        ("test-data/convert/input/v1/multi-resource.yaml", False,),
+        ("test-data/convert/input/v1/node.yaml", False,),
+        ("test-data/convert/input/v1/test3.yaml", True,),
+        ("test-data/convert/input/v1/migration/bgppeer.yaml", True,),
+        ("test-data/convert/input/v1/migration/hostendpoint.yaml", True,),
+        ("test-data/convert/input/v1/migration/ippool.yaml", True,),
+        ("test-data/convert/input/v1/migration/node.yaml", True,),
+        ("test-data/convert/input/v1/migration/policy.yaml", False,),
+        ("test-data/convert/input/v1/migration/profile.yaml", True,),
+        ("test-data/convert/input/v1/migration/workloadendpoint.yaml", True,),
+        ("test-data/convert/input/k8s/k8s-networkpolicy.yaml", True,),
+        ("test-data/convert/input/k8s/k8s-networkpolicy-invalid.yaml", True,),
+        ("test-data/convert/input/k8s/k8s-networkpolicy-multiple.yaml", False,),
+        ("test-data/convert/input/k8s/k8s-networkpolicy-multiple-list.yaml", False,),
+        ("test-data/convert/input/k8s/k8s-networkpolicy-multiple-invalid.yaml", False,),
     ]
 
 class TestCalicoctlConvert(TestBase):
@@ -50,7 +54,7 @@ class TestCalicoctlConvert(TestBase):
     Test calicoctl convert
     """
 
-    def _test_convert(self, filename, format="yaml"):
+    def _test_convert(self, filename, applySuccess, format="yaml"):
         """
         Test convert successfully
         """
@@ -76,20 +80,23 @@ class TestCalicoctlConvert(TestBase):
 
             # Load the converted data
             rc = calicoctl("apply -f /tmp/converted")
-            rc.assert_no_error()
+            if applySuccess:
+                rc.assert_no_error()
+            else:
+                rc.assert_error()
         else:
             rc.assert_error()
 
     @parameterized.expand(convert_files)
-    def test_convert_successful_yaml(self, filename):
+    def test_convert_yaml(self, filename, applySuccess):
         """
         Test convert with yaml output.
         """
-        self._test_convert(filename, format="yaml")
+        self._test_convert(filename, applySuccess, format="yaml")
 
     @parameterized.expand(convert_files)
-    def test_convert_successful_json(self, filename):
+    def test_convert_json(self, filename, applySuccess):
         """
         Test convert with json output.
         """
-        self._test_convert(filename, format="json")
+        self._test_convert(filename, applySuccess, format="json")

--- a/calicoctl/tests/st/calicoctl/test_upgrade.py
+++ b/calicoctl/tests/st/calicoctl/test_upgrade.py
@@ -98,7 +98,7 @@ def _test_converter(testname, fail_expected, error_text=None, format="yaml"):
         cleaned_output = yaml.safe_dump(
             clean_calico_data(
                 yaml.safe_load(rc.output),
-                extra_keys_to_remove=['projectcalico.org/orchestrator', 'namespace']
+                extra_keys_to_remove=['projectcalico.org/orchestrator']
             )
         )
         original_resource.assert_data(cleaned_output, format=format)


### PR DESCRIPTION
Fix CORE-7365, CORE-7366 and CORE-7367. Namely:

- Make 'calicoctl convert' accept list types as input (tested with k8s
  resource of 'Kind: List').
- Make 'calicoctl convert' no longer clear the namespace of converted
  resources.
- Make 'calicoctl convert' output a valid list (k8s resource of 'Kind: List')
  which can be applied with 'kubectl apply -f' ('calicoctl apply -f'
  fails, which was already happening, but we weren't testing for it. Will
  file a bug to look into that).

Also adjust tests for the new output, the namespace change and add an
arg to test_convert.py st to skip 'calicoctl apply -f' when dealing with
'Kind: List' resources.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
