### PR TITLE
Add DSR loopback support for windows

### DIFF
--- a/cni-plugin/pkg/dataplane/windows/dataplane_windows.go
+++ b/cni-plugin/pkg/dataplane/windows/dataplane_windows.go
@@ -757,6 +757,25 @@ func (d *windowsDataplane) createAndAttachContainerEP(args *skel.CmdArgs,
 		v2pols = append(v2pols, hcnPol)
 	}
 
+	// if supported add loopback DSR
+	if err := hcn.DSRSupported(); err == nil {
+		// v1
+		v1pols = append(v1pols, []json.RawMessage{
+			[]byte(fmt.Sprintf(`{"Type":"OutBoundNAT","Destinations":["%s"]}`, epIP.String())),
+		}...)
+
+		// v2
+		loopBackPol := hcn.EndpointPolicy{
+			Type: hcn.OutBoundNAT,
+			Settings: json.RawMessage(
+				fmt.Sprintf(`{"Destinations":["%s"]}`, epIP.String()),
+			),
+		}
+		v2pols = append(v2pols, loopBackPol)
+	} else {
+		d.logger.Info("DSR not supported")
+	}
+
 	isDockerV1 := cri.IsDockershimV1(args.Netns)
 	attempts := 3
 	for {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

With this change an outbound nat policy is added which allows for traffic to return to the same pod it originated. This is required for DSR loopback support.

Since DSR is required for Calico I've enabled it in all scenarios, instead of adding a flag to the cni config.  

I didn't find tests for other polices in the windows test dir: https://github.com/projectcalico/calico/tree/master/cni-plugin/win_tests but happy to look into how to do this and any pointers on how it is normally tested would be helpful.

## Related issues/PRs
Fixes: #5522

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add Windows DSR Loopback support
```
