### PR TITLE
Remove v1 profile labels

### DIFF
--- a/felix/calc/active_rules_calculator.go
+++ b/felix/calc/active_rules_calculator.go
@@ -113,7 +113,7 @@ func (arc *ActiveRulesCalculator) RegisterWith(localEndpointDispatcher, allUpdDi
 	// ...as well as all the policies and profiles.
 	allUpdDispatcher.Register(model.PolicyKey{}, arc.OnUpdate)
 	allUpdDispatcher.Register(model.ProfileRulesKey{}, arc.OnUpdate)
-	allUpdDispatcher.Register(model.ProfileLabelsKey{}, arc.OnUpdate)
+	allUpdDispatcher.Register(model.ResourceKey{}, arc.OnUpdate)
 	allUpdDispatcher.RegisterStatusHandler(arc.OnStatusUpdate)
 }
 
@@ -142,7 +142,7 @@ func (arc *ActiveRulesCalculator) OnUpdate(update api.Update) (_ bool) {
 			arc.updateEndpointProfileIDs(key, []string{})
 		}
 		arc.labelIndex.OnUpdate(update)
-	case model.ProfileLabelsKey:
+	case model.ResourceKey:
 		arc.labelIndex.OnUpdate(update)
 	case model.ProfileRulesKey:
 		if update.Value != nil {

--- a/felix/calc/profile_decoder_test.go
+++ b/felix/calc/profile_decoder_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018,2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018,2020-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ var _ = Describe("profileDecoder", func() {
 			uut.RegisterWith(disp)
 		})
 
-		It("should Register for ProfileLabels only", func() {
+		It("should Register for Profile only", func() {
 			disp.OnUpdate(api.Update{
 				KVPair:     model.KVPair{Key: model.HostEndpointKey{}},
 				UpdateType: api.UpdateTypeKVNew,
@@ -182,11 +182,18 @@ func (p *passthruCallbackRecorder) OnGlobalBGPConfigUpdate(*v3.BGPConfiguration)
 	Fail("OnGlobalBGPConfigUpdate received")
 }
 
-func labelsKV(name string, labels interface{}) model.KVPair {
+func labelsKV(name string, labels map[string]string) model.KVPair {
+	var value interface{}
+	if labels != nil {
+		value = &v3.Profile{
+			Spec: v3.ProfileSpec{
+				LabelsToApply: labels,
+			},
+		}
+	}
 	return model.KVPair{
-		Key: model.ProfileLabelsKey{
-			ProfileKey: model.ProfileKey{Name: name}},
-		Value: labels,
+		Key:   model.ResourceKey{Name: name, Kind: v3.KindProfile},
+		Value: value,
 	}
 }
 

--- a/felix/calc/resources_for_test.go
+++ b/felix/calc/resources_for_test.go
@@ -22,6 +22,7 @@ import (
 	discovery "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/encap"
@@ -535,18 +536,46 @@ var profileRules1NegatedTagSelUpdate = ProfileRules{
 	},
 }
 
-var profileLabels1Tag1 = map[string]string{
-	"profile": "prof-1",
-	"tag-1":   "",
+var profileLabels1Tag1 = &v3.Profile{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "prof-1",
+	},
+	Spec: v3.ProfileSpec{
+		LabelsToApply: map[string]string{
+			"profile": "prof-1",
+			"tag-1":   "",
+		},
+	},
 }
-var profileLabels1 = map[string]string{
-	"profile": "prof-1",
+var profileLabels1 = &v3.Profile{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "prof-1",
+	},
+	Spec: v3.ProfileSpec{
+		LabelsToApply: map[string]string{
+			"profile": "prof-1",
+		},
+	},
 }
-var profileLabels2 = map[string]string{
-	"profile": "prof-2",
+var profileLabels2 = &v3.Profile{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "prof-2",
+	},
+	Spec: v3.ProfileSpec{
+		LabelsToApply: map[string]string{
+			"profile": "prof-2",
+		},
+	},
 }
-var profileLabelsTag1 = map[string]string{
-	"tag-1": "foobar",
+var profileLabelsTag1 = &v3.Profile{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "prof-1",
+	},
+	Spec: v3.ProfileSpec{
+		LabelsToApply: map[string]string{
+			"tag-1": "foobar",
+		},
+	},
 }
 
 var tag1LabelID = ipSetIDForTag("tag-1")

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -20,6 +20,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	apiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	. "github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 
@@ -600,7 +601,7 @@ var localEpsWithOverlappingIPsAndInheritedLabels = empty.withKVUpdates(
 	// Two local endpoints with overlapping IPs.
 	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
 	KVPair{Key: localWlEpKey2, Value: &localWlEp2},
-	KVPair{Key: ProfileLabelsKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: profileLabels1},
+	KVPair{Key: ResourceKey{Kind: v3.KindProfile, Name: "prof-1"}, Value: profileLabels1},
 ).withEndpoint(
 	localWlEp1Id,
 	[]mock.TierInfo{},
@@ -647,7 +648,7 @@ var localEpsAndNamedPortPolicyMatchingInheritedLabelOnEP1 = localEpsWithOverlapp
 
 // Add a second profile with the same labels so that both endpoints now match.
 var localEpsAndNamedPortPolicyMatchingInheritedLabelBothEPs = localEpsAndNamedPortPolicyMatchingInheritedLabelOnEP1.withKVUpdates(
-	KVPair{Key: ProfileLabelsKey{ProfileKey: ProfileKey{Name: "prof-2"}}, Value: profileLabels1},
+	KVPair{Key: ResourceKey{Kind: v3.KindProfile, Name: "prof-2"}, Value: profileLabels1},
 ).withIPSet(namedPortInheritIPSetID, []string{
 	"10.0.0.1,tcp:8080", // ep1
 	"fc00:fe11::1,tcp:8080",
@@ -681,7 +682,7 @@ var localEpsAndNamedPortPolicyDuplicatePorts = localEpsAndNamedPortPolicyMatchin
 
 // Then, change the label on EP2 so it no-longer matches.
 var localEpsAndNamedPortPolicyNoLongerMatchingInheritedLabelOnEP2 = localEpsAndNamedPortPolicyMatchingInheritedLabelBothEPs.withKVUpdates(
-	KVPair{Key: ProfileLabelsKey{ProfileKey: ProfileKey{Name: "prof-2"}}, Value: profileLabels2},
+	KVPair{Key: ResourceKey{Kind: v3.KindProfile, Name: "prof-2"}, Value: profileLabels2},
 ).withIPSet(namedPortInheritIPSetID, []string{
 	"10.0.0.1,tcp:8080", // ep1
 	"fc00:fe11::1,tcp:8080",
@@ -692,7 +693,7 @@ var localEpsAndNamedPortPolicyNoLongerMatchingInheritedLabelOnEP2 = localEpsAndN
 
 // Then, change the label on EP1 so it no-longer matches.
 var localEpsAndNamedPortPolicyNoLongerMatchingInheritedLabelOnEP1 = localEpsAndNamedPortPolicyNoLongerMatchingInheritedLabelOnEP2.withKVUpdates(
-	KVPair{Key: ProfileLabelsKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: profileLabels2},
+	KVPair{Key: ResourceKey{Kind: v3.KindProfile, Name: "prof-1"}, Value: profileLabels2},
 ).withIPSet(namedPortInheritIPSetID, []string{
 	// No longer any matches.
 }).withName("2 local WEPs with policy not matching inherited labels")
@@ -766,7 +767,7 @@ var localEpsWithPolicyUpdatedIPs = localEpsWithPolicy.withKVUpdates(
 // withProfile adds a profile to the initialised state.
 var withProfile = initialisedStore.withKVUpdates(
 	KVPair{Key: ProfileRulesKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: &profileRules1},
-	KVPair{Key: ProfileLabelsKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: profileLabels1Tag1},
+	KVPair{Key: ResourceKey{Kind: v3.KindProfile, Name: "prof-1"}, Value: profileLabels1Tag1},
 ).withName("profile")
 
 // localEpsWithProfile contains a pair of overlapping IP endpoints and a profile
@@ -855,7 +856,7 @@ var localEpsWithUpdatedProfileNegatedTags = localEpsWithUpdatedProfile.withKVUpd
 // tags as labels.  I.e. a tag of name foo should be equivalent to label foo=""
 var withProfileTagInherit = initialisedStore.withKVUpdates(
 	KVPair{Key: ProfileRulesKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: &profileRulesWithTagInherit},
-	KVPair{Key: ProfileLabelsKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: profileLabels1Tag1},
+	KVPair{Key: ResourceKey{Kind: v3.KindProfile, Name: "prof-1"}, Value: profileLabels1Tag1},
 ).withName("profile")
 
 var localEpsWithTagInheritProfile = withProfileTagInherit.withKVUpdates(
@@ -887,7 +888,7 @@ var localEpsWithTagInheritProfile = withProfileTagInherit.withKVUpdates(
 
 var withProfileTagOverriden = initialisedStore.withKVUpdates(
 	KVPair{Key: ProfileRulesKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: &profileRulesWithTagInherit},
-	KVPair{Key: ProfileLabelsKey{ProfileKey: ProfileKey{Name: "prof-1"}}, Value: profileLabelsTag1},
+	KVPair{Key: ResourceKey{Kind: v3.KindProfile, Name: "prof-1"}, Value: profileLabelsTag1},
 ).withName("profile")
 
 // localEpsWithTagOverriddenProfile Checks that tags-inherited labels can be

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	apiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	. "github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 

--- a/felix/labelindex/label_inheritance_index.go
+++ b/felix/labelindex/label_inheritance_index.go
@@ -48,6 +48,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/selector"
@@ -148,10 +149,13 @@ func (l *InheritIndex) OnUpdate(update api.Update) (_ bool) {
 			log.Debugf("Deleting host endpoint %v from InheritIndex", key)
 			l.DeleteLabels(key)
 		}
-	case model.ProfileLabelsKey:
+	case model.ResourceKey:
+		if key.Kind != v3.KindProfile {
+			return
+		}
 		if update.Value != nil {
 			log.Debugf("Updating InheritIndex for profile labels %v", key)
-			labels := update.Value.(map[string]string)
+			labels := update.Value.(*v3.Profile).Spec.LabelsToApply
 			l.UpdateParentLabels(key.Name, labels)
 		} else {
 			log.Debugf("Removing profile labels %v from InheritIndex", key)

--- a/felix/labelindex/label_inheritance_index.go
+++ b/felix/labelindex/label_inheritance_index.go
@@ -49,6 +49,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/selector"

--- a/felix/labelindex/named_port_bench_test.go
+++ b/felix/labelindex/named_port_bench_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	. "github.com/projectcalico/calico/felix/labelindex"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"

--- a/felix/labelindex/named_port_bench_test.go
+++ b/felix/labelindex/named_port_bench_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	. "github.com/projectcalico/calico/felix/labelindex"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
@@ -157,18 +158,18 @@ func benchmarkParentUpdates(b *testing.B, numSels, numEndpoints int) {
 	updates = nil
 	for n := 0; n < b.N; n++ {
 		name := fmt.Sprintf("namespace-%d", n%b.N)
-		key := model.ProfileLabelsKey{
-			ProfileKey: model.ProfileKey{
-				Name: name,
-			},
-		}
+		key := model.ResourceKey{Kind: v3.KindProfile, Name: name}
 		updates = append(updates, api.Update{
 			KVPair: model.KVPair{
 				Key: key,
-				Value: map[string]string{
-					"projectcalico.org/name": name,
-					"update-idx":             fmt.Sprint(n),
-					"something-shared":       "foo",
+				Value: &v3.Profile{
+					Spec: v3.ProfileSpec{
+						LabelsToApply: map[string]string{
+							"projectcalico.org/name": name,
+							"update-idx":             fmt.Sprint(n),
+							"something-shared":       "foo",
+						},
+					},
 				},
 			},
 		})

--- a/felix/labelindex/named_port_index.go
+++ b/felix/labelindex/named_port_index.go
@@ -21,6 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/felix/dispatcher"
@@ -252,7 +253,7 @@ func NewSelectorAndNamedPortIndex() *SelectorAndNamedPortIndex {
 }
 
 func (idx *SelectorAndNamedPortIndex) RegisterWith(allUpdDispatcher *dispatcher.Dispatcher) {
-	allUpdDispatcher.Register(model.ProfileLabelsKey{}, idx.OnUpdate)
+	allUpdDispatcher.Register(model.ResourceKey{}, idx.OnUpdate)
 	allUpdDispatcher.Register(model.WorkloadEndpointKey{}, idx.OnUpdate)
 	allUpdDispatcher.Register(model.HostEndpointKey{}, idx.OnUpdate)
 	allUpdDispatcher.Register(model.NetworkSetKey{}, idx.OnUpdate)
@@ -309,10 +310,13 @@ func (idx *SelectorAndNamedPortIndex) OnUpdate(update api.Update) (_ bool) {
 			log.Debugf("Deleting network set %v from NamedPortIndex", key)
 			idx.DeleteEndpoint(key)
 		}
-	case model.ProfileLabelsKey:
+	case model.ResourceKey:
+		if key.Kind != v3.KindProfile {
+			return
+		}
 		if update.Value != nil {
 			log.Debugf("Updating NamedPortIndex for profile labels %v", key)
-			labels := update.Value.(map[string]string)
+			labels := update.Value.(*v3.Profile).Spec.LabelsToApply
 			idx.UpdateParentLabels(key.Name, labels)
 		} else {
 			log.Debugf("Removing profile labels %v from NamedPortIndex", key)

--- a/felix/labelindex/named_port_index_test.go
+++ b/felix/labelindex/named_port_index_test.go
@@ -16,6 +16,7 @@ package labelindex_test
 
 import (
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	. "github.com/projectcalico/calico/felix/labelindex"
 
 	. "github.com/onsi/ginkgo"

--- a/felix/labelindex/named_port_index_test.go
+++ b/felix/labelindex/named_port_index_test.go
@@ -15,6 +15,7 @@
 package labelindex_test
 
 import (
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	. "github.com/projectcalico/calico/felix/labelindex"
 
 	. "github.com/onsi/ginkgo"
@@ -82,8 +83,12 @@ var _ = Describe("SelectorAndNamedPortIndex", func() {
 		It("should inherit labels from profiles", func() {
 			uut.OnUpdate(api.Update{
 				KVPair: model.KVPair{
-					Key:   model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: "doo"}},
-					Value: map[string]string{"superhero": "scooby"},
+					Key: model.ResourceKey{Kind: v3.KindProfile, Name: "doo"},
+					Value: &v3.Profile{
+						Spec: v3.ProfileSpec{
+							LabelsToApply: map[string]string{"superhero": "scooby"},
+						},
+					},
 				},
 			})
 			uut.OnUpdate(api.Update{

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -446,7 +446,6 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
-			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 		})
 
 		By("Deleting the namespace", func() {
@@ -456,7 +455,6 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are no longer in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
-			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 		})
 	})
 
@@ -496,7 +494,6 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
-			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 		})
 
 		By("deleting a namespace", func() {
@@ -506,7 +503,6 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are in no longer in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
-			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 		})
 	})
 

--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -247,9 +247,6 @@ func KeyFromDefaultPath(path string) Key {
 		case "rules":
 			log.Debugf("Profile rules")
 			return ProfileRulesKey{ProfileKey: pk}
-		case "labels":
-			log.Debugf("Profile labels")
-			return ProfileLabelsKey{ProfileKey: pk}
 		}
 		return nil
 	} else if m := matchHostIp.FindStringSubmatch(path); m != nil {

--- a/libcalico-go/lib/backend/model/keys_test.go
+++ b/libcalico-go/lib/backend/model/keys_test.go
@@ -137,12 +137,6 @@ var _ = DescribeTable(
 		false,
 	),
 	Entry(
-		"profile labels with a /",
-		"/calico/v1/policy/profile/foo%2fbar/labels",
-		ProfileLabelsKey{ProfileKey: ProfileKey{Name: "foo/bar"}},
-		false,
-	),
-	Entry(
 		"policy with a /",
 		"/calico/v1/policy/tier/default/policy/biff%2fbop",
 		PolicyKey{Name: "biff/bop"},

--- a/libcalico-go/lib/backend/model/profile.go
+++ b/libcalico-go/lib/backend/model/profile.go
@@ -81,24 +81,6 @@ func (key ProfileRulesKey) String() string {
 	return fmt.Sprintf("ProfileRules(name=%s)", key.Name)
 }
 
-// ProfileLabelsKey implements the KeyInterface for the profile labels
-type ProfileLabelsKey struct {
-	ProfileKey
-}
-
-func (key ProfileLabelsKey) defaultPath() (string, error) {
-	e, err := key.ProfileKey.defaultPath()
-	return e + "/labels", err
-}
-
-func (key ProfileLabelsKey) valueType() (reflect.Type, error) {
-	return reflect.TypeOf(map[string]string{}), nil
-}
-
-func (key ProfileLabelsKey) String() string {
-	return fmt.Sprintf("ProfileLabels(name=%s)", key.Name)
-}
-
 type ProfileListOptions struct {
 	Name string
 }
@@ -127,8 +109,6 @@ func (options ProfileListOptions) KeyFromDefaultPath(path string) Key {
 	}
 	pk := ProfileKey{Name: name}
 	switch kind {
-	case "labels":
-		return ProfileLabelsKey{ProfileKey: pk}
 	case "rules":
 		return ProfileRulesKey{ProfileKey: pk}
 	}
@@ -155,8 +135,6 @@ func (_ *ProfileListOptions) ListConvert(ds []*KVPair) []*KVPair {
 	var name string
 	for _, d := range ds {
 		switch t := d.Key.(type) {
-		case ProfileLabelsKey:
-			name = t.Name
 		case ProfileRulesKey:
 			name = t.Name
 		default:

--- a/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -114,18 +114,9 @@ func calculateDefaultFelixSyncerEntries(cs kubernetes.Interface, dt apiconfig.Da
 				},
 			})
 
-			// Expect profile labels for each namespace as well. The labels should include the name
+			// And expect a v3 profile for each namespace. The labels should include the name
 			// of the namespace. As of Kubernetes v1.21, k8s also includes a label for the namespace name
 			// that will be inherited by the profile.
-			expected = append(expected, model.KVPair{
-				Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
-				Value: map[string]string{
-					"pcns.projectcalico.org/name":      ns.Name,
-					"pcns.kubernetes.io/metadata.name": ns.Name,
-				},
-			})
-
-			// And expect a v3 profile for each namespace.
 			prof := apiv3.Profile{
 				TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
 				ObjectMeta: metav1.ObjectMeta{Name: name, UID: ns.UID, CreationTimestamp: ns.CreationTimestamp},
@@ -157,16 +148,8 @@ func calculateDefaultFelixSyncerEntries(cs kubernetes.Interface, dt apiconfig.Da
 					},
 				})
 
-				// Expect profile labels for each default serviceaccount as well. The labels should include the name
+				//  We also expect one v3 Profile to be present for each ServiceAccount. The labels should include the name
 				// of the service account.
-				expected = append(expected, model.KVPair{
-					Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
-					Value: map[string]string{
-						"pcsa.projectcalico.org/name": sa.Name,
-					},
-				})
-
-				//  We also expect one v3 Profile to be present for each ServiceAccount.
 				prof := apiv3.Profile{
 					TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
 					ObjectMeta: metav1.ObjectMeta{Name: name, UID: sa.UID, CreationTimestamp: sa.CreationTimestamp},

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor.go
@@ -61,7 +61,6 @@ func (pup *profileUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 		Name: v3key.Name,
 	}
 
-	v1labelsKey := model.ProfileLabelsKey{pk}
 	v1rulesKey := model.ProfileRulesKey{pk}
 	v3kvp := *kvp
 
@@ -77,25 +76,18 @@ func (pup *profileUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 		}
 	}
 
-	labelskvp := &model.KVPair{
-		Key: v1labelsKey,
-	}
 	ruleskvp := &model.KVPair{
 		Key: v1rulesKey,
 	}
 
 	if v1profile != nil {
-		if len(v1profile.Labels) > 0 {
-			labelskvp.Value = v1profile.Labels
-			labelskvp.Revision = kvp.Revision
-		}
 		ruleskvp.Value = &v1profile.Rules
 		ruleskvp.Revision = kvp.Revision
 	}
 
 	// Stream the whole v3 Profile resource, as well as the v1 pieces that legacy Felix code
 	// expects.
-	return []*model.KVPair{labelskvp, ruleskvp, &v3kvp}, nil
+	return []*model.KVPair{ruleskvp, &v3kvp}, nil
 }
 
 func (pup *profileUpdateProcessor) OnSyncerStarting() {
@@ -124,8 +116,7 @@ func convertProfileV2ToV1Value(val interface{}) (*model.Profile, error) {
 	}
 
 	v1value := &model.Profile{
-		Rules:  rules,
-		Labels: v3res.Spec.LabelsToApply,
+		Rules: rules,
 	}
 
 	return v1value, nil

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
@@ -59,13 +59,8 @@ var _ = Describe("Test the Profile update processor", func() {
 			Revision: "abcde",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(kvps).To(HaveLen(3))
+		Expect(kvps).To(HaveLen(2))
 		Expect(kvps[0]).To(Equal(&model.KVPair{
-			Key:      model.ProfileLabelsKey{v1ProfileKey1},
-			Value:    map[string]string{"testLabel": "label"},
-			Revision: "abcde",
-		}))
-		Expect(kvps[1]).To(Equal(&model.KVPair{
 			Key:      model.ProfileRulesKey{v1ProfileKey1},
 			Value:    nilRules,
 			Revision: "abcde",
@@ -163,13 +158,8 @@ var _ = Describe("Test the Profile update processor", func() {
 
 		v1irule := updateprocessors.RuleAPIV2ToBackend(irule, "")
 		v1erule := updateprocessors.RuleAPIV2ToBackend(erule, "")
-		Expect(kvps).To(HaveLen(3))
+		Expect(kvps).To(HaveLen(2))
 		Expect(kvps[0]).To(Equal(&model.KVPair{
-			Key:      model.ProfileLabelsKey{v1ProfileKey2},
-			Value:    map[string]string{"testLabel": "label2"},
-			Revision: "1234",
-		}))
-		Expect(kvps[1]).To(Equal(&model.KVPair{
 			Key: model.ProfileRulesKey{v1ProfileKey2},
 			Value: &model.ProfileRules{
 				InboundRules:  []model.Rule{v1irule},
@@ -185,10 +175,6 @@ var _ = Describe("Test the Profile update processor", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvps).To(Equal([]*model.KVPair{
-			{
-				Key:   model.ProfileLabelsKey{v1ProfileKey1},
-				Value: nil,
-			},
 			{
 				Key:   model.ProfileRulesKey{v1ProfileKey1},
 				Value: nil,
@@ -225,10 +211,6 @@ var _ = Describe("Test the Profile update processor", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvps).To(Equal([]*model.KVPair{
-			{
-				Key:   model.ProfileLabelsKey{v1ProfileKey1},
-				Value: nil,
-			},
 			{
 				Key:   model.ProfileRulesKey{v1ProfileKey1},
 				Value: nil,


### PR DESCRIPTION
1. Felix Calculation Graph: use v3 Profile instead of v1 ProfileLabels
2. Felix Syncer: stop sending v1 profile labels, as no longer needed
3. Remove ProfileLabelsKey infrastructure, which is now unused
