### PR TITLE
VPP Getting Started doc fixes

### DIFF
--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -223,13 +223,13 @@ The VPP dataplane has the following requirements:
 **Optional**
 For some hardware, the following hugepages configuration may enable VPP to use more efficient drivers:
 
-- At least 256 x 2MB-hugepages are available (`grep HugePages_Free /proc/meminfo`)
+- At least 512 x 2MB-hugepages are available (`grep HugePages_Free /proc/meminfo`)
 - The `vfio-pci` (`vfio_pci` on centos) or `uio_pci_generic` kernel module is loaded. For example:
 
    ````bash
    echo "vfio-pci" > /etc/modules-load.d/95-vpp.conf
    modprobe vfio-pci
-   echo "vm.nr_hugepages = 256" >> /etc/sysctl.conf
+   echo "vm.nr_hugepages = 512" >> /etc/sysctl.conf
    sysctl -p
    # restart kubelet to take the changes into account
    # you may need to use a different command depending on how kubelet was installed

--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -251,7 +251,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
    {: .alert .alert-info}
 
    ```bash
-   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/calico/installation.yaml
+   kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/calico/installation-default.yaml
    ```
 
 #### Install the VPP dataplane components


### PR DESCRIPTION
## Description

The VPP Getting Started doc (https://projectcalico.docs.tigera.io/master/getting-started/kubernetes/vpp/getting-started) has the wrong value for the hugepages requirement, ie, 256 MB, when it should say 512 MB, and it points to a non-existent installation yaml:

```
kubectl apply -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/yaml/calico/installation.yaml
```

Correcting them.

## Related issues/PRs

This is a cherry-pick of https://github.com/projectcalico/calico/pull/5496 and https://github.com/projectcalico/calico/pull/5486.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
