### PR TITLE
[WIP] Fix UID for v3 resources in KDD mode

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/customresource.go
+++ b/libcalico-go/lib/backend/k8s/resources/customresource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019,2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019,2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -175,7 +175,10 @@ func (c *customK8sResourceClient) Delete(ctx context.Context, k model.Key, revis
 
 	opts := &metav1.DeleteOptions{}
 	if uid != nil {
-		opts.Preconditions = &metav1.Preconditions{UID: uid}
+		// The UID of the underlying CRD is reversed (see ReverseUID, ConvertK8sResourceToCalicoResource and
+		// ConvertCalicoResourceToK8sResource for details)
+		ruid := ReverseUID(*uid)
+		opts.Preconditions = &metav1.Preconditions{UID: &ruid}
 	}
 
 	// Delete the resource using the name.

--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@ package resources
 
 import (
 	"encoding/json"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
@@ -139,6 +141,7 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	romCopy.ResourceVersion = ""
 	romCopy.Labels = nil
 	romCopy.Annotations = nil
+	romCopy.UID = ""
 
 	// Marshal the data and store the json representation in the annotations.
 	metadataBytes, err := json.Marshal(romCopy)
@@ -159,7 +162,10 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	meta.Namespace = rom.GetNamespace()
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
-	meta.UID = rom.GetUID()
+
+	// Do not use the same UID as the underlying CRD as this breaks garbage collection. We reverse the underlying
+	// UID so that it can be reversed back again when applying to the CRD.
+	meta.UID = ReverseUID(rom.GetUID())
 
 	resOut := resIn.DeepCopyObject().(Resource)
 	romOut := resOut.GetObjectMeta()
@@ -202,10 +208,36 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
 	meta.Annotations = annotations
-	meta.UID = rom.GetUID()
 
+	// Do not use the same UID as the underlying CRD as this breaks garbage collection. We reverse the underlying
+	// UID so that it can be reversed back again when applying to the CRD.
+	meta.UID = ReverseUID(rom.GetUID())
+	
 	// Overwrite the K8s metadata with the Calico metadata.
 	meta.DeepCopyInto(rom.(*metav1.ObjectMeta))
 
 	return nil
+}
+
+// ReverseUID reverses the segments of a UID to create another UID.
+//
+// We use this to map between the CRD and v3 resource types. It is not possible to use the same UID as this breaks
+// garbage collection of the v3 resource types. We need to be able to deterministically map between the v3 and CRD
+// UID and this seems like a reasonable approach. We could potentially store in the annotation (so both CRD and v3
+// have this annotation and we switch annotation w/ the metadata UID) - however that doesn't work for deletes where
+// the metadata is unavailable, but a UID may have been supplied to handle atomicity.
+func ReverseUID(uid types.UID) types.UID {
+	parts := strings.Split(string(uid), "-")
+	for ii := range parts {
+		parts[ii] = ReverseString(parts[ii])
+	}
+	return types.UID(strings.Join(parts, "-"))
+}
+
+func ReverseString(s string) string {
+	r := []rune(s)
+	for ii, jj := 0, len(r)-1; ii < len(r)/2; ii, jj = ii+1, jj-1 {
+		r[ii], r[jj] = r[jj], r[ii]
+	}
+	return string(r)
 }


### PR DESCRIPTION
## Description
It seems that using the same UID for the v3 resource and the CRD breaks garbage collection.

Propose we simply reverse the UID sections to create mapped UID between v3 and CRD.  This would allow us to handle delete w/ UID where we don't have annotations as a way to store the mapping.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
