### PR TITLE
Copy ownerefs and finalizers directly over into CRD

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -139,6 +139,9 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	romCopy.ResourceVersion = ""
 	romCopy.Labels = nil
 	romCopy.Annotations = nil
+	romCopy.OwnerReferences = nil
+	romCopy.Finalizers = nil
+	romCopy.UID = ""
 
 	// Marshal the data and store the json representation in the annotations.
 	metadataBytes, err := json.Marshal(romCopy)
@@ -160,6 +163,8 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
 	meta.UID = rom.GetUID()
+	meta.Finalizers = rom.GetFinalizers()
+	meta.OwnerReferences = rom.GetOwnerReferences()
 
 	resOut := resIn.DeepCopyObject().(Resource)
 	romOut := resOut.GetObjectMeta()
@@ -203,6 +208,8 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.Labels = rom.GetLabels()
 	meta.Annotations = annotations
 	meta.UID = rom.GetUID()
+	meta.Finalizers = rom.GetFinalizers()
+	meta.OwnerReferences = rom.GetOwnerReferences()
 
 	// Overwrite the K8s metadata with the Calico metadata.
 	meta.DeepCopyInto(rom.(*metav1.ObjectMeta))

--- a/libcalico-go/lib/testutils/resources.go
+++ b/libcalico-go/lib/testutils/resources.go
@@ -208,7 +208,7 @@ func (t *testResourceWatcher) expectEvents(kind string, anyOrder bool, expectedE
 	// events, so protect against that scenario - we'll check later once we've
 	// constructed useful diagnostics.
 	var actualEvents []watch.Event
-	log.Infof("Received %s events, expected %d", len(t.events), len(expectedEvents))
+	log.Infof("Received %d events, expected %d", len(t.events), len(expectedEvents))
 	if len(t.events) != len(expectedEvents) {
 		// Log out the events we received before failing the test.
 		log.Errorf("Number of received events does not match expected.")


### PR DESCRIPTION
## Description
Alternative fix for #5532

This copies the owner ref and finalizers into the underlying CRDs. This ensures garbage collection of our aggregated API server resources are garbage collected through garbage collection of the CRDs.  Currently GC is broken due to the non-uniqueness of the UIDs for the v3 and CRD resource types.

The way this is implemented I'm completely ignoring the annotation values of finalizer and owner ref. Easy enough to include them as a backup (so use the annotation by default and then copy across the ones in the CRD is specified) - but the GC won't work in this case because of the UUID issue - resource would need to be re-applied to get the owner ref and finalizer copied to the CRD.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
