### PR TITLE
Add terraform logic for building a release VM

### DIFF
--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -40,5 +40,5 @@ blocks:
         - name: VAR_FILE
           value: /home/semaphore/secrets/release.tfvars
         commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release release; fi
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release release-publish; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release release; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release release-publish; fi

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish official release
 agent:
   machine:
-    type: e1-standard-8
+    type: e1-standard-4
     os_image: ubuntu1804
 
 execution_time_limit:
@@ -34,12 +34,11 @@ blocks:
         # Log in to container registries needed for release.
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - cat ~/secrets/gcr-credentials.json | docker login -u _json_key --password-stdin https://gcr.io
-        - cat ~/secrets/gcr-credentials.json | docker login -u _json_key --password-stdin https://us.gcr.io
-        - cat ~/secrets/gcr-credentials.json | docker login -u _json_key --password-stdin https://eu.gcr.io
-        - cat ~/secrets/gcr-credentials.json | docker login -u _json_key --password-stdin https://asia.gcr.io
       jobs:
-      - name: "Release"
+      - name: "Release on GCP VM"
+        env_vars:
+        - name: VAR_FILE
+          value: /home/semaphore/secrets/release.tfvars
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release release; fi
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release release-publish; fi

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -41,5 +41,5 @@ blocks:
       jobs:
       - name: "Release"
         commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make release; fi
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make release-publish; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release release; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release release-publish; fi

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -34,6 +34,9 @@ blocks:
         # Log in to container registries needed for release.
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+        # Credentials for accessing gcloud, needed to create a GCP VM.
+        - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
+        - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
       jobs:
       - name: "Release on GCP VM"
         env_vars:

--- a/hack/release/.gitignore
+++ b/hack/release/.gitignore
@@ -6,3 +6,5 @@ ssh_key.pub
 terraform.tfstate
 terraform.tfstate.backup
 .terraform.lock.hcl
+bin/
+.terraform.init

--- a/hack/release/.gitignore
+++ b/hack/release/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+terraform.tfvars
+.terraform.tfstate.lock.info
+ssh_key
+ssh_key.pub
+terraform.tfstate
+terraform.tfstate.backup

--- a/hack/release/.gitignore
+++ b/hack/release/.gitignore
@@ -5,3 +5,4 @@ ssh_key
 ssh_key.pub
 terraform.tfstate
 terraform.tfstate.backup
+.terraform.lock.hcl

--- a/hack/release/Makefile
+++ b/hack/release/Makefile
@@ -1,11 +1,22 @@
+include ../../metadata.mk
+include ../../lib.Makefile
+
+# Build a release from the currently checked out commit.
+# Uses SSH to run commands on the remote builder.
+release: .vm.created
+	$(./bin/terraform output connect_command) -- cd calico && git fetch && checkout $(GIT_VERSION)
+	$(./bin/terraform output connect_command) -- cd calico && make release
+
 # Create a VM using the given vars.
 VAR_FILE ?= terraform.tfvars
-apply: .terraform.init
+apply:  .vm.created
+.vm.created: .terraform.init
 	./bin/terraform apply --auto-approve -var-file=$(VAR_FILE)
 
 # Destroy the VM.
 destroy:
 	./bin/terraform destroy --auto-approve -var-file=$(VAR_FILE)
+	rm -f .vm.created
 
 # Tear down any existing VM, and create a new one.
 rebuild:
@@ -19,5 +30,5 @@ rebuild:
 bin/terraform: bin/terraform.zip
 	unzip bin/terraform.zip -d bin && touch $@
 bin/terraform.zip:
-	mkdir bin
+	mkdir -p bin
 	wget https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_amd64.zip -O $@

--- a/hack/release/Makefile
+++ b/hack/release/Makefile
@@ -4,14 +4,18 @@ include ../../lib.Makefile
 # Build a release from the currently checked out commit.
 # Uses SSH to run commands on the remote builder.
 release: .vm.created
-	$(./bin/terraform output connect_command) -- cd calico && git fetch && checkout $(GIT_VERSION)
-	$(./bin/terraform output connect_command) -- cd calico && make release
+	./remote-execute.sh "cd calico && git fetch && git checkout $(GIT_VERSION)"
+	./remote-execute.sh "cd calico && make release"
+
+# Expects that a release has already been created on the remote VM via the "release" target.
+release-publish: .vm.created
+	./remote-execute.sh "cd calico && make release-publish"
 
 # Create a VM using the given vars.
 VAR_FILE ?= terraform.tfvars
 apply:  .vm.created
 .vm.created: .terraform.init
-	./bin/terraform apply --auto-approve -var-file=$(VAR_FILE)
+	./bin/terraform apply --auto-approve -var-file=$(VAR_FILE) && touch $@
 
 # Destroy the VM.
 destroy:

--- a/hack/release/Makefile
+++ b/hack/release/Makefile
@@ -1,10 +1,13 @@
 include ../../metadata.mk
 include ../../lib.Makefile
 
+# We only ever release from the tip of a release branch.
+GIT_BRANCH?=$(git rev-parse HEAD)
+
 # Build a release from the currently checked out commit.
 # Uses SSH to run commands on the remote builder.
 release: .vm.created
-	./remote-execute.sh "cd calico && git fetch && git checkout $(GIT_VERSION)"
+	./remote-execute.sh "cd calico && git fetch --tags && git checkout $(GIT_BRANCH)"
 	./remote-execute.sh "cd calico && make release"
 
 # Expects that a release has already been created on the remote VM via the "release" target.

--- a/hack/release/Makefile
+++ b/hack/release/Makefile
@@ -1,0 +1,23 @@
+# Create a VM using the given vars.
+VAR_FILE ?= terraform.tfvars
+apply: .terraform.init
+	./bin/terraform apply --auto-approve -var-file=$(VAR_FILE)
+
+# Destroy the VM.
+destroy:
+	./bin/terraform destroy --auto-approve -var-file=$(VAR_FILE)
+
+# Tear down any existing VM, and create a new one.
+rebuild:
+	$(MAKE) destroy apply
+
+# Initialize the terraform install.
+.terraform.init: bin/terraform
+	./bin/terraform init && touch $@
+
+# Install the terraform binary.
+bin/terraform: bin/terraform.zip
+	unzip bin/terraform.zip -d bin && touch $@
+bin/terraform.zip:
+	mkdir bin
+	wget https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_amd64.zip -O $@

--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -395,7 +395,7 @@ Attached to this release are the following artifacts:
 		ver,
 		r.uploadDir(ver),
 	}
-	_, err = r.runner.Run("ghr", args, nil)
+	_, err = r.runner.Run("./hack/release/ghr", args, nil)
 	return err
 }
 

--- a/hack/release/remote-execute.sh
+++ b/hack/release/remote-execute.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Get the SSH command, and use eval to remove the quotes from it.
+ssh=$(./bin/terraform output connect_command)
+ssh=$(eval echo $ssh)
+eval "${ssh} -- '$1'"

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -1,0 +1,131 @@
+provider "google" {
+  project = var.google_project
+  region  = var.google_region
+  zone    = var.google_zone
+}
+
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "${var.prefix}-calico-release-executor"
+  machine_type = var.machine_type
+  zone         = var.google_zone
+
+  service_account {
+    scopes = ["storage-ro", "cloud-platform", "compute-rw", "logging-write", "monitoring", "service-control", "service-management"]
+  }
+
+  tags = ["calico-release"]
+
+  metadata = {
+    ssh-keys = "ubuntu:${tls_private_key.ssh.public_key_openssh}"
+  }
+
+  connection {
+    user        = "ubuntu"
+    agent       = false
+    private_key = tls_private_key.ssh.private_key_pem
+    host        = self.network_interface.0.access_config.0.nat_ip
+  }
+
+  boot_disk {
+    initialize_params {
+      image = var.image
+      type  = var.disk_type
+      size  = var.disk_size
+    }
+  }
+
+  network_interface {
+    network = var.google_network
+
+    access_config {
+      // This empty field requests an Ephemeral IP
+    }
+  }
+}
+
+resource "null_resource" "configure_vm" {
+  connection {
+    user        = "ubuntu"
+    agent       = false
+    private_key = tls_private_key.ssh.private_key_pem
+    host        = google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip
+  }
+
+  // Install the necessary environment for release.
+  provisioner "remote-exec" {
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get install -y git make ca-certificates curl gnupg lsb-release",
+      "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg",
+      "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu bionic stable' | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null",
+      "sudo apt-get update",
+      "sudo apt-get install -y docker-ce docker-ce-cli containerd.io",
+      "sudo usermod -aG docker ubuntu"
+    ]
+  }
+
+  // Authenticate the docker daemon with GCR.
+  // TODO: Also handle quay and dockerhub.
+  provisioner "file" {
+    source      = var.gcr_auth_path
+    destination = "/tmp/gcr-credentials.json"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://gcr.io",
+      "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://eu.gcr.io",
+      "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://asia.gcr.io",
+      "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://us.gcr.io",
+    ]
+  }
+
+  // Set GITHUB_TOKEN in the environment.
+  provisioner "remote-exec" {
+    inline = [
+      "sudo sh -c 'echo GITHUB_TOKEN=${var.github_token} >> /etc/environment'",
+    ]
+  }
+
+  // Clone the Calico repository.
+  provisioner "remote-exec" {
+    inline = [
+      "git clone https://github.com/projectcalico/calico /home/ubuntu/calico",
+    ]
+  }
+}
+
+resource "local_file" "local_ssh_key" {
+  content  = tls_private_key.ssh.private_key_pem
+  filename = "${path.root}/ssh_key"
+
+  provisioner "local-exec" {
+    command = "chmod 600 ${path.root}/ssh_key"
+  }
+}
+
+resource "local_file" "local_ssh_key_pub" {
+  content  = tls_private_key.ssh.public_key_openssh
+  filename = "${path.root}/ssh_key.pub"
+
+  provisioner "local-exec" {
+    command = "chmod 644 ${path.root}/ssh_key.pub"
+  }
+}
+
+output "instance_ip" {
+  value = google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip
+}
+
+output "instance_ssh_key" {
+  value      = "${abspath(path.root)}/ssh_key"
+  depends_on = [tls_private_key.ssh]
+}
+
+output "connect_command" {
+  value      = "ssh -i ${abspath(path.root)}/ssh_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@${google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip}"
+  depends_on = [tls_private_key.ssh]
+}

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -80,7 +80,7 @@ resource "null_resource" "configure_vm" {
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://asia.gcr.io",
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://us.gcr.io",
       "echo ${var.dockerhub_token} | docker login --username ${var.dockerhub_user} --password-stdin",
-      "echo ${var.quay_token} | docker login --username ${var.quay_user} --password-stdin",
+      "echo ${var.quay_token} | docker login --username ${var.quay_user} --password-stdin quay.io",
     ]
   }
 

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -79,8 +79,8 @@ resource "null_resource" "configure_vm" {
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://eu.gcr.io",
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://asia.gcr.io",
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://us.gcr.io",
-      "echo ${var.dockerhub_token} | docker login --username ${var.dockerhub_user} --password-stdin"
-      "echo ${var.quay_token} | docker login --username ${var.quay_user} --password-stdin"
+      "echo ${var.dockerhub_token} | docker login --username ${var.dockerhub_user} --password-stdin",
+      "echo ${var.quay_token} | docker login --username ${var.quay_user} --password-stdin",
     ]
   }
 

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -59,7 +59,7 @@ resource "null_resource" "configure_vm" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt-get update",
-      "sudo apt-get install -y git make ca-certificates curl gnupg lsb-release",
+      "sudo apt-get install -y git make zip unzip ca-certificates curl gnupg lsb-release",
       "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg",
       "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu bionic stable' | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null",
       "sudo apt-get update",
@@ -68,8 +68,7 @@ resource "null_resource" "configure_vm" {
     ]
   }
 
-  // Authenticate the docker daemon with GCR.
-  // TODO: Also handle quay and dockerhub.
+  // Authenticate the docker daemon with GCR, dockerhub, and quay.
   provisioner "file" {
     source      = var.gcr_auth_path
     destination = "/tmp/gcr-credentials.json"
@@ -80,6 +79,8 @@ resource "null_resource" "configure_vm" {
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://eu.gcr.io",
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://asia.gcr.io",
       "cat /tmp/gcr-credentials.json | docker login -u _json_key --password-stdin https://us.gcr.io",
+      "echo ${var.dockerhub_token} | docker login --username ${var.dockerhub_user} --password-stdin"
+      "echo ${var.quay_token} | docker login --username ${var.quay_user} --password-stdin"
     ]
   }
 

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -127,6 +127,6 @@ output "instance_ssh_key" {
 }
 
 output "connect_command" {
-  value      = "ssh -i ${abspath(path.root)}/ssh_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@${google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip}"
+  value      = "ssh -A -i ${abspath(path.root)}/ssh_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@${google_compute_instance.vm_instance.network_interface.0.access_config.0.nat_ip}"
   depends_on = [tls_private_key.ssh]
 }

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -58,12 +58,13 @@ resource "null_resource" "configure_vm" {
   // Install the necessary environment for release.
   provisioner "remote-exec" {
     inline = [
-      "sudo apt-get update",
-      "sudo apt-get install -y git make zip unzip ca-certificates curl gnupg lsb-release",
+      "sudo apt update",
+      "sudo apt install -y ca-certificates curl",
       "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg",
       "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu bionic stable' | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null",
-      "sudo apt-get update",
-      "sudo apt-get install -y docker-ce docker-ce-cli containerd.io",
+      "sudo apt update",
+      "sudo apt install -y docker-ce docker-ce-cli containerd.io",
+      "sudo apt install -y git make zip unzip",
       "sudo usermod -aG docker ubuntu"
     ]
   }
@@ -91,10 +92,14 @@ resource "null_resource" "configure_vm" {
     ]
   }
 
-  // Clone the Calico repository.
+  // Clone the Calico repository. We do this via HTTPS to clone initially, but change the remote to SSH
+  // to work around the fact that Terraform doesn't seem to forward SSH.
   provisioner "remote-exec" {
     inline = [
       "git clone https://github.com/projectcalico/calico /home/ubuntu/calico",
+      "cd /home/ubuntu/calico",
+      "git remote remove origin",
+      "git remote add origin git@github.com:projectcalico/calico.git",
     ]
   }
 }

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -100,6 +100,7 @@ resource "null_resource" "configure_vm" {
       "cd /home/ubuntu/calico",
       "git remote remove origin",
       "git remote add origin git@github.com:projectcalico/calico.git",
+      "ssh-keyscan -H github.com >> ~/.ssh/known_hosts",
     ]
   }
 }

--- a/hack/release/variables.tf
+++ b/hack/release/variables.tf
@@ -1,0 +1,56 @@
+variable "google_project" {
+  type = string
+}
+variable "google_region" {
+  type = string
+}
+variable "google_zone" {
+  type = string
+}
+variable "prefix" {
+  type = string
+}
+
+variable "machine_type" {
+  type    = string
+  default = "n2-standard-32"
+}
+
+variable "disk_size" {
+  type    = number
+  default = 100
+}
+
+variable "disk_type" {
+  type    = string
+  default = "pd-ssd"
+}
+
+variable "image" {
+  type        = string
+  description = "Select which image family to use."
+  default     = "ubuntu-1804-lts"
+}
+
+variable "google_network" {
+  type        = string
+  default     = "default"
+  description = "The name of the network to bring instances up on."
+}
+
+variable "gcr_auth_path" {
+  type        = string
+  description = "Path to docker authentication file. Needed to publish images to dockerhub, quay, and GCR."
+  validation {
+    condition     = fileexists(pathexpand(var.gcr_auth_path))
+    error_message = "Invalid docker auth file."
+  }
+}
+
+variable "github_token" {
+  type        = string
+  validation {
+    condition     = var.github_token != ""
+    error_message = "Must specify a Github token."
+  }
+}

--- a/hack/release/variables.tf
+++ b/hack/release/variables.tf
@@ -38,19 +38,31 @@ variable "google_network" {
   description = "The name of the network to bring instances up on."
 }
 
+variable "github_token" {
+  type        = string
+}
+
 variable "gcr_auth_path" {
   type        = string
-  description = "Path to docker authentication file. Needed to publish images to dockerhub, quay, and GCR."
+  description = "Path to docker authentication file for GCR."
   validation {
     condition     = fileexists(pathexpand(var.gcr_auth_path))
     error_message = "Invalid docker auth file."
   }
 }
 
-variable "github_token" {
+variable "dockerhub_token" {
   type        = string
-  validation {
-    condition     = var.github_token != ""
-    error_message = "Must specify a Github token."
-  }
+}
+
+variable "dockerhub_user" {
+  type        = string
+}
+
+variable "quay_token" {
+  type        = string
+}
+
+variable "quay_user" {
+  type        = string
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds simple terraform to manage a build-machine for releasing Calico.

Deploys a build-machine with:

- Prerequisites installed
- Calico repo checked out 
- Docker daemon authenticated using provided credentials
- GH access via user provided token in environment


To use, simply provide the necessary variables and run `terraform apply`.

You can then SSH to the machine to run build commands. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```