### PR TITLE
etcdv3: we handle watch errors, so don't log them at Error level

### DIFF
--- a/libcalico-go/lib/backend/etcdv3/watcher.go
+++ b/libcalico-go/lib/backend/etcdv3/watcher.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,7 +125,7 @@ func (wc *watcher) watchLoop() {
 		if wres.Err() != nil {
 			// A watch channel error is a terminating event, so exit the loop.
 			err := wres.Err()
-			log.WithError(err).Error("Watch channel error")
+			log.WithError(err).Warning("Watch channel error")
 			wc.sendError(err)
 			return
 		}


### PR DESCRIPTION
One of our customers sees these ERROR logs periodically because of
compaction:

    <date> [ERROR][427981] felix/watcher.go 128: Watch channel error error=etcdserver: mvcc: required revision has been compacted

To be precise, about 2 times per week.  But they investigate any ERROR
logs, and as these are actually benign and expected, they should be
downgraded.

## Release Note

```release-note
Downgrade a benign ERROR log that occurs when etcdv3 datastore is compacted.
```
