### PR TITLE
felix/bpf: ICMP conntrack fix

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -533,6 +533,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	// dport to hold icmp type and code
 	if (state->ip_proto == IPPROTO_ICMP) {
 		state->dport = 0;
+		state->post_nat_dport = 0;
 	}
 
 	if (CALI_F_FROM_WEP && (state->flags & CALI_ST_NAT_OUTGOING)) {

--- a/felix/bpf/ut/icmp_test.go
+++ b/felix/bpf/ut/icmp_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+)
+
+func TestICMPCTPlain(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer resetBPFMaps()
+
+	bpfIfaceName = "ICCT"
+
+	icmpEcho := makeICMPEcho(node1ip, srcIP, 8 /* Echo Request*/) // ping
+
+	// Workload route for RPF check
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload, 1).AsBytes()
+	defer resetRTMap(rtMap)
+	err := rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+	dumpRTMap(rtMap)
+
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(icmpEcho)
+		Expect(err).NotTo(HaveOccurred())
+		// there is no normal CT record yet, must be denied
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		dumpCTMap(ctMap)
+
+		ct, err := conntrack.LoadMapMem(ctMap)
+		Expect(err).NotTo(HaveOccurred())
+		for k := range ct {
+			Expect(k.PortA()).To(Equal(uint16(0)))
+			Expect(k.PortB()).To(Equal(uint16(0)))
+		}
+	})
+
+	icmpEcho = makeICMPEcho(srcIP, node1ip, 0 /* Echo Reply */) // pong
+
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(icmpEcho)
+		Expect(err).NotTo(HaveOccurred())
+		// there is no normal CT record yet, must be denied
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		dumpCTMap(ctMap)
+
+		ct, err := conntrack.LoadMapMem(ctMap)
+		Expect(err).NotTo(HaveOccurred())
+		for k := range ct {
+			Expect(k.PortA()).To(Equal(uint16(0)))
+			Expect(k.PortB()).To(Equal(uint16(0)))
+		}
+	})
+}
+
+func makeICMPEcho(src, dst net.IP, icmpType uint8) []byte {
+	payload := make([]byte, 64)
+
+	eth := &layers.Ethernet{
+		SrcMAC:       []byte{0xee, 0, 0, 0, 0, 1},
+		DstMAC:       []byte{0xfe, 0, 0, 0, 0, 2},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+
+	ipv4 := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		Flags:    layers.IPv4DontFragment,
+		SrcIP:    src,
+		DstIP:    dst,
+		Protocol: layers.IPProtocolICMPv4,
+		Length:   uint16(20 + 8 + len(payload)),
+	}
+
+	icmp := &layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(icmpType, 0),
+	}
+
+	pkt := gopacket.NewSerializeBuffer()
+	err := gopacket.SerializeLayers(pkt, gopacket.SerializeOptions{ComputeChecksums: true},
+		eth, ipv4, icmp, gopacket.Payload(payload))
+	Expect(err).NotTo(HaveOccurred())
+
+	return pkt.Bytes()
+}


### PR DESCRIPTION
state->dport is overloaded and used as ICMP type/code for policy and
must be zeroed before it is used in conntrack lookup. The value gets
propagated into post_nat_dport and thus also this has to be zeroed.

## Description

fixes https://github.com/projectcalico/calico/issues/5358

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
