### PR TITLE
Automated cherry pick of #5550: Switch to Centos stream 8 for build container.

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -25,7 +25,7 @@ FROM ${BIRD_IMAGE} as bird
 # Use this build stage to build iptables rpm and runit binaries.
 # We need to rebuild the iptables rpm because the prepackaged rpm does not have legacy iptables binaries.
 # We need to build runit because there aren't any rpms for it in CentOS or ubi repositories.
-FROM centos:8 as centos
+FROM quay.io/centos/centos:stream8 as centos
 
 ARG ARCH
 ARG IPTABLES_VER

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -173,17 +173,17 @@ COPY --from=bird /bird* /bin/
 RUN chmod u+s /bin/bird
 RUN chmod u+s /bin/bird6
 
-# Copy in the filesystem - this contains felix, calico-bgp-daemon, licenses, etc...
-COPY filesystem/ /
+# Copy in the filesystem - this contains licenses, etc...
+COPY filesystem/etc/ /etc
+COPY filesystem/included-source/ /included-source
+COPY filesystem/licenses/ /licenses
+COPY filesystem/usr/ /usr
+COPY filesystem/sbin/* /usr/sbin/
 
 # Change permissions to make confd templates and output available in /etc/calico
 # to all container users.
 RUN chgrp -R 0 /etc/calico && \
     chmod -R g=u /etc/calico
-
-# On UBI, /sbin/ is a symlink so the above copy clobbers it; restore /sbin as symlinks (some binaries and
-# scripts hard-code /sbin/xyz, for example.
-RUN ln -s /usr/sbin/* /sbin/
 
 COPY --from=bpftool /bpftool /bin
 

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -16,7 +16,7 @@ ARG GIT_VERSION=unknown
 ARG IPTABLES_VER=1.8.4-17
 ARG LIBNFTNL_VER=1.1.5-4
 ARG RUNIT_VER=2.1.2
-ARG QEMU_IMAGE=calico/go-build:v0.55-arm64
+ARG QEMU_IMAGE
 ARG BIRD_IMAGE=calico/bird:latest
 ARG UBI_IMAGE
 
@@ -24,7 +24,7 @@ FROM calico/bpftool:v5.0-arm64 as bpftool
 FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 
-FROM arm64v8/centos:8 as centos
+FROM quay.io/centos/centos:stream8 as centos
 
 MAINTAINER Reza Ramezanpour <reza@projectcalico.org>
 # Enable non-native builds of this image on an amd64 hosts.
@@ -180,12 +180,12 @@ RUN systemctl disable systemd-resolved
 # Copy our bird binaries in
 COPY --from=bird /bird* /bin/
 
-# Copy in the filesystem - this contains felix, calico-bgp-daemon, licenses, etc...
-COPY filesystem/ /
-
-# On UBI, /sbin/ is a symlink so the above copy clobbers it; restore /sbin as symlinks (some binaries and
-# scripts hard-code /sbin/xyz, for example.
-RUN ln -s /usr/sbin/* /sbin/
+# Copy in the filesystem - this contains licenses, etc...
+COPY filesystem/etc/ /etc
+COPY filesystem/included-source/ /included-source
+COPY filesystem/licenses/ /licenses
+COPY filesystem/usr/ /usr
+COPY filesystem/sbin/* /usr/sbin/
 
 COPY --from=bpftool /bpftool /bin
 

--- a/node/Dockerfile.ppc64le
+++ b/node/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2016,2021 Tigera, Inc. All rights reserved.
 # Copyright IBM Corp. 2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/node/Makefile
+++ b/node/Makefile
@@ -26,12 +26,17 @@ LOCAL_CHECKS=check-boring-ssl
 ###############################################################################
 include ../lib.Makefile
 
-# Required for eBPF support in ARM64
+# Set the platform correctly for building docker images.
+TARGET_PLATFORM=--platform=linux/$(ARCH)
 ifeq ($(ARCH),arm64)
 # Forces ARM64 build image to be used in a crosscompilation run.
 CALICO_BUILD:=$(CALICO_BUILD)-$(ARCH)
 # Prevents docker from tagging the output image incorrectly as amd64.
 TARGET_PLATFORM=--platform=linux/arm64/v8
+endif
+
+ifeq ($(ARCH),armv7)
+TARGET_PLATFORM=--platform=linux/arm/v7
 endif
 
 ###############################################################################
@@ -284,7 +289,12 @@ clean-sub-image-%:
 
 $(NODE_IMAGE): $(NODE_CONTAINER_CREATED)
 $(NODE_CONTAINER_CREATED): register ./Dockerfile.$(ARCH) $(NODE_CONTAINER_FILES) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) remote-deps
-	docker build --pull -t $(NODE_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) . --build-arg BIRD_IMAGE=$(BIRD_IMAGE) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg UBI_IMAGE=$(UBI_IMAGE) --build-arg GIT_VERSION=$(GIT_VERSION) -f ./Dockerfile.$(ARCH)
+	docker buildx build $(TARGET_PLATFORM) -t $(NODE_IMAGE):latest-$(ARCH) \
+		--build-arg BIRD_IMAGE=$(BIRD_IMAGE) \
+		--build-arg QEMU_IMAGE=$(CALICO_BUILD) \
+		--build-arg UBI_IMAGE=$(UBI_IMAGE) \
+		--build-arg GIT_VERSION=$(GIT_VERSION) \
+		-f ./Dockerfile.$(ARCH) . --load
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 


### PR DESCRIPTION
Cherry pick of #5550 on release-v3.22.

#5550: Switch to Centos stream 8 for build container.

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Centos (pre-stream) 8 seams to have rotted.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Switch to centos stream8
```