### PR TITLE
Automated cherry pick of #5550: Switch to Centos stream 8 for build container.

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -25,7 +25,7 @@ FROM ${BIRD_IMAGE} as bird
 # Use this build stage to build iptables rpm and runit binaries.
 # We need to rebuild the iptables rpm because the prepackaged rpm does not have legacy iptables binaries.
 # We need to build runit because there aren't any rpms for it in CentOS or ubi repositories.
-FROM centos:8 as centos
+FROM quay.io/centos/centos:stream8 as centos
 
 ARG ARCH
 ARG IPTABLES_VER


### PR DESCRIPTION
Cherry pick of #5550 on release-v3.21.

#5550: Switch to Centos stream 8 for build container.

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Centos (pre-stream) 8 seams to have rotted.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Switch to centos stream8
```