### PR TITLE
Fix bug with DSR enablement for kube-proxy

### DIFF
--- a/scripts/install-calico-windows.ps1
+++ b/scripts/install-calico-windows.ps1
@@ -228,7 +228,7 @@ function EnableWinDsrForEKS()
         Write-Host "WinDsr is enabled by default."
     } else {
         $UpdatedPath = $Path + " --enable-dsr=true --feature-gates=WinDSR=true"
-        Get-CimInstance win32_service -filter 'Name="kube-proxy"' | Invoke-CimMethod -Name Change -ArgumentList @($null,$null,$null,$null,$null,$UpdatedPath)
+        Get-CimInstance win32_service -filter 'Name="kube-proxy"' | Invoke-CimMethod -Name Change -Arguments @{PathName=$UpdatedPath}
         Restart-Service -name "kube-proxy"
         Write-Host "WinDsr has been enabled for kube-proxy."
     }


### PR DESCRIPTION
## Description

```-ArgumentList``` parameter is invalid for ```Invoke-CimMethod``` and generates an error during install, resulting in ```--enable-dsr=true --feature-gates=WinDSR=true``` flags not being passed to kube-proxy service if the node does in fact support DSR.

Switch to use working ```-Arguments``` parameter as per Microsoft docs: https://docs.microsoft.com/en-us/powershell/module/cimcmdlets/invoke-cimmethod?view=powershell-7.1

## Release Note


```release-note
None required
```
