### PR TITLE
Clearer Wording for WireGuard Configuration

### DIFF
--- a/calico/security/encrypt-cluster-pod-traffic.md
+++ b/calico/security/encrypt-cluster-pod-traffic.md
@@ -49,7 +49,7 @@ WireGuard is included in Linux 5.6+ kernels, and has been backported to earlier 
 
 Install WireGuard on cluster nodes using {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}. Note that you may need to reboot your nodes after installing WireGuard to make the kernel modules available on your system.
 
-Use the following instructions for these platforms that are not listed on the WireGuard installation page.
+Use the following instructions for these platforms that are not listed on the WireGuard installation page, before proceeding to [enabling WireGuard](#Enable-WireGuard-for-a-cluster).
 
 {% tabs %}
 <label:EKS,active:true>

--- a/calico/security/encrypt-cluster-pod-traffic.md
+++ b/calico/security/encrypt-cluster-pod-traffic.md
@@ -49,7 +49,7 @@ WireGuard is included in Linux 5.6+ kernels, and has been backported to earlier 
 
 Install WireGuard on cluster nodes using {% include open-new-window.html text='instructions for your operating system' url='https://www.wireguard.com/install/' %}. Note that you may need to reboot your nodes after installing WireGuard to make the kernel modules available on your system.
 
-Use the following instructions for these platforms that are not listed on the WireGuard installation page, before proceeding to [enabling WireGuard](#Enable-WireGuard-for-a-cluster).
+Use the following instructions for these platforms that are not listed on the WireGuard installation page, before proceeding to [enabling WireGuard](#enable-wireguard-for-a-cluster).
 
 {% tabs %}
 <label:EKS,active:true>


### PR DESCRIPTION
## Description

This section of the WireGuard docs has proven slightly unclear (whether `wireguardHostEncryptionEnabled` and `wireguardEnabled`  both need setting when installing on AKS/EKS).

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
