### PR TITLE
felix/bpf: use correct affinity key for unconnected udp

### DIFF
--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -132,7 +132,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup(__be32 ip_sr
 		return NULL;
 	}
 
-	if (nat_lv1_val->affinity_timeo == 0) {
+	if (nat_lv1_val->affinity_timeo == 0 && !affinity_always_timeo) {
 		goto skip_affinity;
 	}
 
@@ -144,7 +144,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup(__be32 ip_sr
 	affkey.nat_key = nat_data;
 	affkey.client_ip = ip_src;
 
-	CALI_DEBUG("NAT: backend affinity %d seconds\n", nat_lv1_val->affinity_timeo);
+	CALI_DEBUG("NAT: backend affinity %d seconds\n", nat_lv1_val->affinity_timeo ? : affinity_always_timeo);
 
 	struct calico_nat_v4_affinity_val *affval;
 

--- a/felix/bpf/nat/maps.go
+++ b/felix/bpf/nat/maps.go
@@ -416,6 +416,10 @@ type AffinityKey [affinityKeySize]byte
 
 type FrontEndAffinityKey [frontendAffKeySize]byte
 
+func (k FrontEndAffinityKey) AsBytes() []byte {
+	return k[:]
+}
+
 // NewAffinityKey create a new AffinityKey from a clientIP and FrontendKey
 func NewAffinityKey(clientIP net.IP, fEndKey FrontendKey) AffinityKey {
 	var k AffinityKey


### PR DESCRIPTION
We enforce affinity on unconnected udp when we use ctlb because
otherwise we would make a NAT decision for every packet, possibly
spraying them all over the backends even for a single client.

We were incorrectly initializing the affinity key so that the key was
zeroed and we are not making the actuall lookup.

FV tests that the new key is expected and that the values are consistent.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
