### PR TITLE
Jump to tc accepted entry program instead of in-lining the calico_tc_skb_accepted function.

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include <linux/types.h>
@@ -320,6 +320,7 @@ syn_force_policy:
 		 * seen by another program since it must have come in via another interface.
 		 */
 		CALI_DEBUG("Packet is from the host: ACCEPT\n");
+		ctx.state->pol_rc = CALI_POL_ALLOW;
 		goto skip_policy;
 	}
 
@@ -406,6 +407,7 @@ syn_force_policy:
 		CALI_DEBUG("Post-NAT dest IP is local host.\n");
 		if (CALI_F_FROM_HEP && is_failsafe_in(ctx.state->ip_proto, ctx.state->post_nat_dport, ctx.state->ip_src)) {
 			CALI_DEBUG("Inbound failsafe port: %d. Skip policy.\n", ctx.state->post_nat_dport);
+			ctx.state->pol_rc = CALI_POL_ALLOW;
 			goto skip_policy;
 		}
 		ctx.state->flags |= CALI_ST_DEST_IS_HOST;
@@ -414,6 +416,7 @@ syn_force_policy:
 		CALI_DEBUG("Source IP is local host.\n");
 		if (CALI_F_TO_HEP && is_failsafe_out(ctx.state->ip_proto, ctx.state->post_nat_dport, ctx.state->post_nat_ip_dst)) {
 			CALI_DEBUG("Outbound failsafe port: %d. Skip policy.\n", ctx.state->post_nat_dport);
+			ctx.state->pol_rc = CALI_POL_ALLOW;
 			goto skip_policy;
 		}
 		ctx.state->flags |= CALI_ST_SRC_IS_HOST;
@@ -423,6 +426,7 @@ syn_force_policy:
 	bpf_tail_call(skb, &cali_jump, PROG_INDEX_POLICY);
 	if (CALI_F_HEP) {
 		CALI_DEBUG("HEP with no policy, allow.\n");
+		ctx.state->pol_rc = CALI_POL_ALLOW;
 		goto skip_policy;
 	} else {
 		/* should not reach here */
@@ -436,7 +440,7 @@ icmp_send_reply:
 	goto deny;
 
 skip_policy:
-	ctx.state->pol_rc = CALI_POL_ALLOW;
+	//ctx.state->pol_rc = CALI_POL_ALLOW;
 	bpf_tail_call(skb, &cali_jump, PROG_INDEX_ALLOWED);
 	/* should not reach here */
 	goto deny;

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -468,10 +468,12 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 		CALI_DEBUG("State map lookup failed: DROP\n");
 		return TC_ACT_SHOT;
 	}
-	if (!(ctx.state->flags & CALI_ST_SKIP_POLICY) && (ctx.state->flags & CALI_ST_SUPPRESS_CT_STATE)) {
-		// See comment above where CALI_ST_SUPPRESS_CT_STATE is set.
-		CALI_DEBUG("Egress HEP should drop packet with no CT state\n");
-		return TC_ACT_SHOT;
+	if (CALI_F_HEP) {
+		if (!(ctx.state->flags & CALI_ST_SKIP_POLICY) && (ctx.state->flags & CALI_ST_SUPPRESS_CT_STATE)) {
+			// See comment above where CALI_ST_SUPPRESS_CT_STATE is set.
+			CALI_DEBUG("Egress HEP should drop packet with no CT state\n");
+			return TC_ACT_SHOT;
+		}
 	}
 
 	if (skb_refresh_validate_ptrs(&ctx, UDP_SIZE)) {

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -90,6 +90,8 @@ enum cali_state_flags {
 	CALI_ST_SRC_IS_HOST	  = 0x08,
 	/* CALI_ST_SUPPRESS_CT_STATE prevents the creation of any new CT state. */
 	CALI_ST_SUPPRESS_CT_STATE = 0x10,
+	/* CALI_ST_SKIP_POLICY is set when the policy program is skipped for example for mid-flow packets. */
+	CALI_ST_SKIP_POLICY = 0x20,
 };
 
 struct fwd {

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -90,7 +90,7 @@ enum cali_state_flags {
 	CALI_ST_SRC_IS_HOST	  = 0x08,
 	/* CALI_ST_SUPPRESS_CT_STATE prevents the creation of any new CT state. */
 	CALI_ST_SUPPRESS_CT_STATE = 0x10,
-	/* CALI_ST_SKIP_POLICY is set when the policy program is skipped for example for mid-flow packets. */
+	/* CALI_ST_SKIP_POLICY is set when the policy program is skipped. */
 	CALI_ST_SKIP_POLICY = 0x20,
 };
 


### PR DESCRIPTION
## Description
The tc program is getting large, and small changes usually make the verifier exceed the 1M limit of visited instructions when exploring every possible execution path. To reduce the size of the main program we tail call to `calico_tc_skb_accepted_entrypoint` from `calico_tc` when we have a CT hit and we skip policy, rather than in-lining `calico_tc_skb_accepted` into the same `calico_tc` program.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
