### PR TITLE
Fix endpoint ipsets not updated for labels with empty values

### DIFF
--- a/felix/labelindex/named_port_index.go
+++ b/felix/labelindex/named_port_index.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019,2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2019,2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -170,7 +170,8 @@ func (d *endpointData) Equals(other *endpointData) bool {
 	}
 
 	for k, v := range d.labels {
-		if other.labels[k] != v {
+		otherLabel, exists := other.labels[k]
+		if !exists || otherLabel != v {
 			return false
 		}
 	}

--- a/felix/labelindex/named_port_index_test.go
+++ b/felix/labelindex/named_port_index_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,6 +107,45 @@ var _ = Describe("SelectorAndNamedPortIndex", func() {
 			set, ok := recorder.ipsets["scoobydoobydoo"]
 			Expect(ok).To(BeTrue())
 			Expect(set).To(HaveLen(1))
+		})
+	})
+	Describe("HostEndpoint CIDRs", func() {
+		It("should update IP sets for labels with empty values", func() {
+			hep := &model.HostEndpoint{
+				Name:              "eth0",
+				ExpectedIPv4Addrs: []calinet.IP{calinet.MustParseIP("1.2.3.4")},
+				ExpectedIPv6Addrs: []calinet.IP{calinet.MustParseIP("aa:bb::cc:dd")},
+				Labels: map[string]string{
+					"label2": "",
+				},
+				ProfileIDs: []string{"profile1"},
+			}
+			hepKVP := model.KVPair{
+				Key:   model.HostEndpointKey{Hostname: "127.0.0.1", EndpointID: "hosta.eth0-a"},
+				Value: hep,
+			}
+			uut.OnUpdate(api.Update{KVPair: hepKVP})
+			s, err := selector.Parse("has(label2)")
+			Expect(err).ToNot(HaveOccurred())
+
+			// The new ipset should have 2 IPs.
+			uut.UpdateIPSet("heptest", s, ProtocolNone, "")
+			set, ok := recorder.ipsets["heptest"]
+			Expect(ok).To(BeTrue())
+			Expect(set).To(HaveLen(2))
+
+			// Update the hostendpoint labels so they are not matched by the
+			// selector.
+			hep.Labels = map[string]string{
+				"label1": "value1",
+			}
+			uut.OnUpdate(api.Update{KVPair: hepKVP})
+
+			// Expect the ipset to be empty (OnMemberRemoved will have been
+			// called twice.)
+			set, ok = recorder.ipsets["heptest"]
+			Expect(ok).To(BeFalse())
+			Expect(set).To(HaveLen(0))
 		})
 	})
 })


### PR DESCRIPTION
## Description

Fix endpoint not updating its related ipsets if an endpoint update was only to labels with empty values. In this specific case, the endpoint update would mean ipset contribution updates for that endpoint would be skipped.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
