### PR TITLE
Fix empty LOCAL_IP_ENV in libcalico-go

### DIFF
--- a/libcalico-go/Makefile
+++ b/libcalico-go/Makefile
@@ -15,6 +15,8 @@ include ../lib.Makefile
 
 BINDIR?=bin
 
+LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
+
 # Create a list of files upon which the generated file depends, skip the generated file itself
 UPGRADE_SRCS := $(filter-out ./lib/upgrade/migrator/clients/v1/k8s/custom/zz_generated.deepcopy.go, \
                              $(wildcard ./lib/upgrade/migrator/clients/v1/k8s/custom/*.go))


### PR DESCRIPTION
## Description
`LOCAL_IP_ENV` in `libcalico-go/Makefile` was not defined, which will cause the fv test to hang indefinitely.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
