### PR TITLE
cast empty-interface to correct type for each option

### DIFF
--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
@@ -74,12 +74,17 @@ var routeTableRangesToString = func(value interface{}) interface{} {
 	ranges := value.(apiv3.RouteTableRanges)
 	rangesStr := make([]string, 0)
 	for _, r := range ranges {
-		rangesStr = append(rangesStr, routeTableRangeToString(r).(string))
+		rangesStr = append(rangesStr, routeTableIDRangeToString(r).(string))
 	}
 	return strings.Join(rangesStr, ",")
 }
 
-var routeTableRangeToString = func(value interface{}) interface{} {
+var routeTableIDRangeToString = func(value interface{}) interface{} {
 	r := value.(apiv3.RouteTableIDRange)
+	return fmt.Sprintf("%d-%d", r.Min, r.Max)
+}
+
+var routeTableRangeToString = func(value interface{}) interface{} {
+	r := value.(apiv3.RouteTableRange)
 	return fmt.Sprintf("%d-%d", r.Min, r.Max)
 }


### PR DESCRIPTION
## Description
Currently options `routeTableRange` and `routeTableRanges` cannot be parsed by `libcalico-go` due to a bad typecast. This issue is also present in CaliEnt so this fix will need picking.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
