### PR TITLE
Fix Conversion of Felix RouteTableRange config to string 

### DIFF
--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
@@ -70,16 +70,20 @@ var protoPortSliceToString = func(value interface{}) interface{} {
 	return strings.Join(parts, ",")
 }
 
+// Converts multiple route table ranges to its string config representation.
+// e.g. RouteTableRanges{{Min: 0, Max: 250}, {Min: 255, Max: 3000}} => "0-250,255-3000"
 var routeTableRangesToString = func(value interface{}) interface{} {
 	ranges := value.(apiv3.RouteTableRanges)
 	rangesStr := make([]string, 0)
 	for _, r := range ranges {
-		rangesStr = append(rangesStr, routeTableRangeToString(r).(string))
+		rangesStr = append(rangesStr, fmt.Sprintf("%d-%d", r.Min, r.Max))
 	}
 	return strings.Join(rangesStr, ",")
 }
 
+// Converts a route table range to its string config representation.
+// e.g. RouteTableRange{Min: 0, Max: 250} => "0-250"
 var routeTableRangeToString = func(value interface{}) interface{} {
-	r := value.(apiv3.RouteTableIDRange)
+	r := value.(apiv3.RouteTableRange)
 	return fmt.Sprintf("%d-%d", r.Min, r.Max)
 }

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixconfigprocessor.go
@@ -40,7 +40,7 @@ func NewFelixConfigUpdateProcessor() watchersyncer.SyncerUpdateProcessor {
 			"FailsafeInboundHostPorts":  protoPortSliceToString,
 			"FailsafeOutboundHostPorts": protoPortSliceToString,
 			"RouteTableRange":           routeTableRangeToString,
-			"RouteTableRanges":          routeTableRangesToString,
+			"RouteTableRanges":          routeTableRangeListToString,
 		},
 	)
 }
@@ -72,7 +72,7 @@ var protoPortSliceToString = func(value interface{}) interface{} {
 
 // Converts multiple route table ranges to its string config representation.
 // e.g. RouteTableRanges{{Min: 0, Max: 250}, {Min: 255, Max: 3000}} => "0-250,255-3000"
-var routeTableRangesToString = func(value interface{}) interface{} {
+var routeTableRangeListToString = func(value interface{}) interface{} {
 	ranges := value.(apiv3.RouteTableRanges)
 	rangesStr := make([]string, 0)
 	for _, r := range ranges {


### PR DESCRIPTION
## Description

Currently options `routeTableRange` and `routeTableRanges` cannot be parsed by libcalico-go due to a bad typecast. This issue is also present in CaliEnt so this fix will need picking.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
