### PR TITLE
[windows] Revert "windows: set kube-proxy IPv6DualStack=false for VXLAN (#1018)"

### DIFF
--- a/node/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
@@ -75,10 +75,6 @@ if ($network.Type -EQ "Overlay") {
     $sourceVip = (Get-HnsEndpoint | ? Name -EQ "Calico_ep").IpAddress
     $argList += "--source-vip=$sourceVip"
     $extraFeatures += "WinOverlay=true"
-
-    # VXLAN on Windows doesn't support dualstack so disable explicitly. From k8s
-    # 1.21 onwards IPv6DualStack defaults to true
-    $extraFeatures += "IPv6DualStack=false"
 }
 
 if ($extraFeatures.Length -GT 0) {


### PR DESCRIPTION
## Description

This reverts commit bc1af6aa2970d7287bb59d9c5ec6af3ca7729af6.
This commit is no longer needed as of k8s 1.21.6. For more context, see this comment: https://github.com/projectcalico/calico/issues/5539#issuecomment-1045652710

Furthermore, this commit breaks kube-proxy in k8s 1.23 onwards since the feature flag is
incompatible with dual-stack GA.

This will fix the main issue in #5539
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix windows kube-proxy config incompatible with k8s 1.23
```
