### PR TITLE
[release-v3.22] Pick of #5653: Revert "windows: set kube-proxy IPv6DualStack=false for VXLAN

### DIFF
--- a/node/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
@@ -86,10 +86,6 @@ if ($network.Type -EQ "Overlay") {
     $sourceVip = (Get-HnsEndpoint | ? Name -EQ "Calico_ep").IpAddress
     $argList += "--source-vip=$sourceVip"
     $extraFeatures += "WinOverlay=true"
-
-    # VXLAN on Windows doesn't support dualstack so disable explicitly. From k8s
-    # 1.21 onwards IPv6DualStack defaults to true
-    $extraFeatures += "IPv6DualStack=false"
 }
 
 if ($extraFeatures.Length -GT 0) {


### PR DESCRIPTION
Cherry pick of #5653 on release-v3.22.

#5653: Revert "windows: set kube-proxy IPv6DualStack=false for VXLAN

```release-note
Fix windows kube-proxy config incompatible with k8s 1.23
```