### PR TITLE
[v3.22] Fix Typha expected number of connections calculation.

### DIFF
--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -419,7 +419,7 @@ func (t *TyphaDaemon) Start(cxt context.Context) {
 		ticker := jitter.NewTicker(
 			t.ConfigParams.K8sServicePollIntervalSecs,
 			t.ConfigParams.K8sServicePollIntervalSecs/10)
-		go k8s.PollK8sForConnectionLimit(cxt, t.ConfigParams, ticker.C, k8sAPI, t.Server)
+		go k8s.PollK8sForConnectionLimit(cxt, t.ConfigParams, ticker.C, k8sAPI, t.Server, len(t.CachesBySyncerType))
 	}
 	log.Info("Started the datastore Syncer/cache layer/server.")
 

--- a/typha/pkg/k8s/rebalance_test.go
+++ b/typha/pkg/k8s/rebalance_test.go
@@ -35,7 +35,7 @@ var _ = DescribeTable("CalculateMaxConnLimit tests",
 			MaxConnectionsLowerLimit: 11,
 			MaxConnectionsUpperLimit: 101,
 		}
-		num, reason := CalculateMaxConnLimit(configParams, numTyphas, numNodes)
+		num, reason := CalculateMaxConnLimit(configParams, numTyphas, numNodes, 3)
 		Expect(num).To(Equal(expectedNumber))
 		Expect(reason).To(Equal(expectedReason))
 	},
@@ -69,7 +69,7 @@ var _ = Describe("Poll loop tests", func() {
 		server = &dummyServer{}
 		go func() {
 			defer GinkgoRecover()
-			PollK8sForConnectionLimit(cxt, configParams, tickerC, k8sAPI, server)
+			PollK8sForConnectionLimit(cxt, configParams, tickerC, k8sAPI, server, 3)
 		}()
 	})
 


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Do a once-and-for-all fix by passing the actual number of syncers.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Fixes https://github.com/projectcalico/calico/issues/5629
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Typha would periodically disconnect clients in clusters with more than 100 nodes per Typha due to miscalculating the expected number of connections.
```
