### PR TITLE
fixed install command for linux kubectl plugin

### DIFF
--- a/calico/maintenance/clis/calicoctl/install.md
+++ b/calico/maintenance/clis/calicoctl/install.md
@@ -209,7 +209,7 @@ you want to install the binary.
 1. Use the following command to download the `calicoctl` binary.
 
    ```bash
-   curl -L {{ url }}/calicoctl-linux-arm64 -o kubectl-calico
+   curl -L {{ url }}/calicoctl-linux-amd64 -o kubectl-calico
    ```
 
 1. Set the file to be executable.


### PR DESCRIPTION
## Description

fixed install command for linux kubectl plugin in documentation
https://projectcalico.docs.tigera.io/maintenance/clis/calicoctl/install#install-calicoctl-as-a-kubectl-plugin-on-a-single-host

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note
