### PR TITLE
calicoctl: remove reference for transfer.sh

### DIFF
--- a/calicoctl/calicoctl/commands/node/diags.go
+++ b/calicoctl/calicoctl/commands/node/diags.go
@@ -56,10 +56,6 @@ Description:
   This is usually used when trying to diagnose an issue that may be related to
   your Calico network.
 
-  The output of the command explains how to automatically upload the
-  diagnostics to http://transfer.sh for easy sharing of the data. Note that the
-  uploaded files will be deleted after 14 days.
-
   This command must be run on the specific Calico node that you are gathering
   diagnostics for.
 `
@@ -176,11 +172,7 @@ func runDiags(logDir string) error {
 	tarFilePath := filepath.Join(tmpDir, tarFile)
 
 	fmt.Printf("\nDiags saved to %s\n", tarFilePath)
-	fmt.Printf(`If required, you can upload the diagnostics bundle to a file sharing service
-such as transfer.sh using curl or similar.  For example:
-
-    curl --upload-file %s https://transfer.sh/%s`, tarFilePath, tarFilePath)
-	fmt.Println()
+	fmt.Println("If required, you can upload the diagnostics bundle to a file sharing service.")
 
 	return nil
 }


### PR DESCRIPTION
## Description

transfer.sh online file sharing service is offline and no
longer accepts uploading files.
Remove the reference of transfer.sh from node diag cmdline.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
