### PR TITLE
Introduce patchMode for pod annotations

### DIFF
--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -38,6 +38,7 @@ import (
 
 	libapi "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	k8sconversion "github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
+	k8sresources "github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
 	calicoclient "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
@@ -476,7 +477,11 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	}
 
 	// Write the endpoint object (either the newly created one, or the updated one)
-	if _, err := utils.CreateOrUpdate(ctx, calicoClient, endpoint); err != nil {
+	// Pass special-case flag through to KDD to let it know what kind of patch to apply to the underlying
+	// Pod resource. Felix also modifies the pod through a patch and setting this avoids patching the
+	// same fields as Felix so that we can't clobber Felix's updates.
+	ctxPatchCNI := k8sresources.ContextWithPatchMode(ctx, k8sresources.PatchModeCNI)
+	if _, err := utils.CreateOrUpdate(ctxPatchCNI, calicoClient, endpoint); err != nil {
 		logger.WithError(err).Error("Error creating/updating endpoint in datastore.")
 		releaseIPAM()
 		return nil, err

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/resources"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -1614,7 +1616,8 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			wep, err := c.Get(ctx, model.ResourceKey{Name: wepName, Namespace: "default", Kind: libapiv3.KindWorkloadEndpoint}, "")
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Printf("Updating Wep %+v\n", wep.Value.(*libapiv3.WorkloadEndpoint).Spec)
-			_, err = c.Update(ctx, wep)
+			ctxCNI := resources.ContextWithPatchMode(ctx, resources.PatchModeCNI)
+			_, err = c.Update(ctxCNI, wep)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -1750,7 +1753,8 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 					// Recreate the WEP (this puts the annotations back again).
 					wepKV.Revision = ""
 					wepKV.UID = nil
-					_, err = c.Create(ctx, wepKV)
+					ctxCNI := resources.ContextWithPatchMode(ctx, resources.PatchModeCNI)
+					_, err = c.Create(ctxCNI, wepKV)
 					Expect(err).NotTo(HaveOccurred())
 					return
 				}
@@ -1867,7 +1871,8 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			Expect(err).NotTo(HaveOccurred())
 			wep.Value.(*libapiv3.WorkloadEndpoint).Spec.IPNetworks = []string{"192.168.1.1"}
 			fmt.Printf("Updating Wep %+v\n", wep.Value.(*libapiv3.WorkloadEndpoint).Spec)
-			_, err = c.Update(ctx, wep)
+			ctxCNI := resources.ContextWithPatchMode(ctx, resources.PatchModeCNI)
+			_, err = c.Update(ctxCNI, wep)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get the pod through the k8s API to check the annotation has appeared.

--- a/libcalico-go/lib/backend/k8s/resources/patchmode.go
+++ b/libcalico-go/lib/backend/k8s/resources/patchmode.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+)
+
+type patchModeKey struct{}
+type PatchMode string
+
+const (
+	PatchModeCNI         PatchMode = "patchModeCNI"
+	PatchModeUnspecified PatchMode = "patchModeUnspecified"
+)
+
+func ContextWithPatchMode(ctx context.Context, mode PatchMode) context.Context {
+	if mode == PatchModeCNI {
+		return context.WithValue(ctx, patchModeKey{}, mode)
+	}
+	return ctx
+}
+
+func PatchModeOf(ctx context.Context) PatchMode {
+	v := ctx.Value(patchModeKey{})
+	if v != nil {
+		return v.(PatchMode)
+	}
+	return PatchModeUnspecified
+}

--- a/libcalico-go/lib/backend/k8s/resources/patchmode_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/patchmode_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PatchMode", func() {
+	Context("PatchMode", func() {
+
+		It("patchMode round-trips", func() {
+			ctx := ContextWithPatchMode(context.Background(), PatchModeCNI)
+			patchMode := PatchModeOf(ctx)
+			Expect(patchMode).To(Equal(PatchModeCNI))
+		})
+
+		It("patchMode handles unspecified value", func() {
+			ctx := context.Background()
+			patchMode := PatchModeOf(ctx)
+			Expect(patchMode).To(Equal(PatchModeUnspecified))
+		})
+
+		It("patchMode handles unexpected value", func() {
+			ctx := ContextWithPatchMode(context.Background(), "patchModeSomething")
+			patchMode := PatchModeOf(ctx)
+			Expect(patchMode).To(Equal(PatchModeUnspecified))
+		})
+	})
+})

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
@@ -53,26 +53,6 @@ type WorkloadEndpointClient struct {
 	converter conversion.Converter
 }
 
-type patchModeKey struct{}
-type PatchMode string
-
-const (
-	PatchModeCNI         PatchMode = "patchModeCNI"
-	PatchModeUnspecified PatchMode = "patchModeUnspecified"
-)
-
-func ContextWithPatchMode(ctx context.Context, mode PatchMode) context.Context {
-	return context.WithValue(ctx, patchModeKey{}, mode)
-}
-
-func PatchModeOf(ctx context.Context) PatchMode {
-	v := ctx.Value(patchModeKey{})
-	if v != nil {
-		return v.(PatchMode)
-	}
-	return PatchModeUnspecified
-}
-
 func (c *WorkloadEndpointClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
 	log.Debug("Received Create request on WorkloadEndpoint type")
 	// As a special case for the CNI plugin, try to patch the Pod with the IP that we've calculated.

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
@@ -53,6 +53,27 @@ type WorkloadEndpointClient struct {
 	converter conversion.Converter
 }
 
+type patchModeKey struct{}
+type PatchMode string
+
+const (
+	PatchModeCNI           PatchMode = "patchCNI"
+	PatchModeEgressGateway PatchMode = "patchEgressGateway"
+	PatchModeUnspecified   PatchMode = "patchUnspecified"
+)
+
+func ContextWithPatchMode(ctx context.Context, mode PatchMode) context.Context {
+	return context.WithValue(ctx, patchModeKey{}, mode)
+}
+
+func PatchModeOf(ctx context.Context) PatchMode {
+	v := ctx.Value(patchModeKey{})
+	if v != nil {
+		return v.(PatchMode)
+	}
+	return PatchModeUnspecified
+}
+
 func (c *WorkloadEndpointClient) Create(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
 	log.Debug("Received Create request on WorkloadEndpoint type")
 	// As a special case for the CNI plugin, try to patch the Pod with the IP that we've calculated.
@@ -62,7 +83,7 @@ func (c *WorkloadEndpointClient) Create(ctx context.Context, kvp *model.KVPair) 
 	// Note: it's a bit odd to do this in the Create, but the CNI plugin uses CreateOrUpdate().  Doing it
 	// here makes sure that, if the update fails: we retry here, and, we don't report success without
 	// making the patch.
-	return c.patchInAnnotations(ctx, kvp)
+	return c.patchInAnnotations(ctx, kvp, "Create")
 }
 
 func (c *WorkloadEndpointClient) Update(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -70,7 +91,7 @@ func (c *WorkloadEndpointClient) Update(ctx context.Context, kvp *model.KVPair) 
 	// As a special case for the CNI plugin, try to patch the Pod with the IP that we've calculated.
 	// This works around a bug in kubelet that causes it to delay writing the Pod IP for a long time:
 	// https://github.com/kubernetes/kubernetes/issues/39113.
-	return c.patchInAnnotations(ctx, kvp)
+	return c.patchInAnnotations(ctx, kvp, "Update")
 }
 
 func (c *WorkloadEndpointClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
@@ -87,32 +108,67 @@ func (c *WorkloadEndpointClient) Delete(ctx context.Context, key model.Key, revi
 //
 // We store the IP addresses in annotations because patching the PodStatus directly races with changes that
 // kubelet makes so kubelet can undo our changes.
-func (c *WorkloadEndpointClient) patchInAnnotations(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
+func (c *WorkloadEndpointClient) patchInAnnotations(ctx context.Context, kvp *model.KVPair, operation string) (*model.KVPair, error) {
+	var annotations map[string]string
+	var revision string
+	patchMode := PatchModeOf(ctx)
+	switch patchMode {
+	case PatchModeCNI:
+		annotations = c.calcCniAnnotations(kvp)
+		// Note: we drop the revision here because the CNI plugin can't handle a retry right now (and the kubelet
+		// ensures that only one CNI ADD for a given UID can be in progress).
+		revision = ""
+	default:
+		log.Errorf("no WorkloadEndpoint patching will be performed, unrecognised PatchMode passed to patchInAnnotations: %s.", patchMode)
+		return nil, cerrors.ErrorOperationNotSupported{
+			Identifier: kvp.Key,
+			Operation:  operation,
+			Reason:     fmt.Sprintf("unsupported PatchMode: %s", patchMode),
+		}
+	}
+	return c.patchPodAnnotations(ctx, kvp.Key, revision, kvp.UID, annotations)
+}
+
+func (c *WorkloadEndpointClient) calcCniAnnotations(kvp *model.KVPair) map[string]string {
+	annotations := make(map[string]string)
 	wep := kvp.Value.(*libapiv3.WorkloadEndpoint)
 	ips := wep.Spec.IPNetworks
 	if len(ips) == 0 {
-		return kvp, nil
+		return annotations
 	}
-
 	log.Debugf("PATCHing pod with IPs: %v", ips)
-	key := kvp.Key
 
-	// Note: we drop the revision here because the CNI plugin can't handle a retry right now (and the kubelet
-	// ensures that only one CNI ADD for a given UID can be in progress).
-	return c.patchPodAnnotations(ctx, key, "", kvp.UID, wep.Spec.ContainerID, ips)
+	// Write the IP addresses into annotations.  This generates an event more quickly than
+	// waiting for kubelet to update the PodStatus PodIP and PodIPs fields.
+	firstIP := ""
+	if len(ips) > 0 {
+		firstIP = ips[0]
+	}
+	annotations[conversion.AnnotationPodIP] = firstIP
+	annotations[conversion.AnnotationPodIPs] = strings.Join(ips, ",")
+
+	containerID := wep.Spec.ContainerID
+	if containerID != "" {
+		log.WithField("containerID", containerID).Debug("Container ID specified, including in patch")
+		annotations[conversion.AnnotationContainerID] = containerID
+	}
+	return annotations
 }
 
 // patchOutAnnotations sets our pod IP annotations to empty strings; this is used to signal that the IP has been removed
 // from the pod at teardown.
 func (c *WorkloadEndpointClient) patchOutAnnotations(ctx context.Context, key model.Key, revision string, uid *types.UID) (*model.KVPair, error) {
-	// Passing "" for containerID means "don't touch".  Passing nil for IPs will result in all annotations being
-	// explicitly set to the empty string.  Setting the podIPs to empty string is used to signal that the CNI DEL
-	// has removed the IP from the Pod.  We leave the container ID in place to allow any repeat invocations of the
-	// CNI DEL to tell which instance of a Pod they are seeing.
-	return c.patchPodAnnotations(ctx, key, revision, uid, "", nil)
+	// Passing nil for annotations will result in all annotations being explicitly set to the empty string.
+	// Setting the podIPs to empty string is used to signal that the CNI DEL has removed the IP from the Pod.
+	// We leave the container ID in place to allow any repeat invocations of the CNI DEL to tell which instance of a Pod they are seeing.
+	annotations := map[string]string{
+		conversion.AnnotationPodIP:  "",
+		conversion.AnnotationPodIPs: "",
+	}
+	return c.patchPodAnnotations(ctx, key, revision, uid, annotations)
 }
 
-func (c *WorkloadEndpointClient) patchPodAnnotations(ctx context.Context, key model.Key, revision string, uid *types.UID, containerID string, ips []string) (*model.KVPair, error) {
+func (c *WorkloadEndpointClient) patchPodAnnotations(ctx context.Context, key model.Key, revision string, uid *types.UID, annotations map[string]string) (*model.KVPair, error) {
 	wepID, err := c.converter.ParseWorkloadEndpointName(key.(model.ResourceKey).Name)
 	if err != nil {
 		return nil, err
@@ -120,21 +176,7 @@ func (c *WorkloadEndpointClient) patchPodAnnotations(ctx context.Context, key mo
 	if wepID.Pod == "" {
 		return nil, cerrors.ErrorInsufficientIdentifiers{Name: key.(model.ResourceKey).Name}
 	}
-	// Write the IP addresses into annotations.  This generates an event more quickly than
-	// waiting for kubelet to update the PodStatus PodIP and PodIPs fields.
 	ns := key.(model.ResourceKey).Namespace
-	firstIP := ""
-	if len(ips) > 0 {
-		firstIP = ips[0]
-	}
-	annotations := map[string]string{
-		conversion.AnnotationPodIP:  firstIP,
-		conversion.AnnotationPodIPs: strings.Join(ips, ","),
-	}
-	if containerID != "" {
-		log.WithField("containerID", containerID).Debug("Container ID specified, including in patch")
-		annotations[conversion.AnnotationContainerID] = containerID
-	}
 	patch, err := calculateAnnotationPatch(revision, uid, annotations)
 	if err != nil {
 		log.WithError(err).Error("failed to calculate Pod patch.")
@@ -159,7 +201,9 @@ func calculateAnnotationPatch(revision string, uid *types.UID, annotations map[s
 	patch := map[string]interface{}{}
 	metadata := map[string]interface{}{}
 	patch["metadata"] = metadata
-	metadata["annotations"] = annotations
+	if len(annotations) > 0 {
+		metadata["annotations"] = annotations
+	}
 
 	if revision != "" {
 		// We have a revision.  Since the revision is immutable, if our patch revision doesn't match then the

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
@@ -57,9 +57,8 @@ type patchModeKey struct{}
 type PatchMode string
 
 const (
-	PatchModeCNI           PatchMode = "patchCNI"
-	PatchModeEgressGateway PatchMode = "patchEgressGateway"
-	PatchModeUnspecified   PatchMode = "patchUnspecified"
+	PatchModeCNI         PatchMode = "patchModeCNI"
+	PatchModeUnspecified PatchMode = "patchModeUnspecified"
 )
 
 func ContextWithPatchMode(ctx context.Context, mode PatchMode) context.Context {
@@ -114,12 +113,11 @@ func (c *WorkloadEndpointClient) patchInAnnotations(ctx context.Context, kvp *mo
 	patchMode := PatchModeOf(ctx)
 	switch patchMode {
 	case PatchModeCNI:
-		annotations = c.calcCniAnnotations(kvp)
+		annotations = c.calcCNIAnnotations(kvp)
 		// Note: we drop the revision here because the CNI plugin can't handle a retry right now (and the kubelet
 		// ensures that only one CNI ADD for a given UID can be in progress).
 		revision = ""
 	default:
-		log.Errorf("no WorkloadEndpoint patching will be performed, unrecognised PatchMode passed to patchInAnnotations: %s.", patchMode)
 		return nil, cerrors.ErrorOperationNotSupported{
 			Identifier: kvp.Key,
 			Operation:  operation,
@@ -129,7 +127,7 @@ func (c *WorkloadEndpointClient) patchInAnnotations(ctx context.Context, kvp *mo
 	return c.patchPodAnnotations(ctx, kvp.Key, revision, kvp.UID, annotations)
 }
 
-func (c *WorkloadEndpointClient) calcCniAnnotations(kvp *model.KVPair) map[string]string {
+func (c *WorkloadEndpointClient) calcCNIAnnotations(kvp *model.KVPair) map[string]string {
 	annotations := make(map[string]string)
 	wep := kvp.Value.(*libapiv3.WorkloadEndpoint)
 	ips := wep.Spec.IPNetworks

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint_test.go
@@ -89,7 +89,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 					Value: wep,
 				}
 
-				_, err = wepClient.Create(context.Background(), kvp)
+				ctxCNI := resources.ContextWithPatchMode(context.Background(), resources.PatchModeCNI)
+				_, err = wepClient.Create(ctxCNI, kvp)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
@@ -139,7 +140,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 					Value: wep,
 				}
 
-				_, err = wepClient.Create(context.Background(), kvp)
+				ctxCNI := resources.ContextWithPatchMode(context.Background(), resources.PatchModeCNI)
+				_, err = wepClient.Create(ctxCNI, kvp)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
@@ -194,7 +196,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 					Value: wep,
 				}
 
-				_, err = wepClient.Update(context.Background(), kvp)
+				ctxCNI := resources.ContextWithPatchMode(context.Background(), resources.PatchModeCNI)
+				_, err = wepClient.Update(ctxCNI, kvp)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})
@@ -244,7 +247,8 @@ var _ = Describe("WorkloadEndpointClient", func() {
 					Value: wep,
 				}
 
-				_, err = wepClient.Update(context.Background(), kvp)
+				ctxCNI := resources.ContextWithPatchMode(context.Background(), resources.PatchModeCNI)
+				_, err = wepClient.Update(ctxCNI, kvp)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pod, err := k8sClient.CoreV1().Pods("testNamespace").Get(ctx, "simplePod", metav1.GetOptions{})


### PR DESCRIPTION
## Description

When patching pod annotations, some clients desire different behaviour. The CNI Plugin wishes to patch only the CNI annotations, and since it does not currently retry the `CreateOrUpdate` operation, it requires the revision to be set to `""`.
Other clients wish to patch different annotations, and to set the revision properly and handle retries.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
