### PR TITLE
Prevent GC when IPAM datstore migrate lock

### DIFF
--- a/kube-controllers/pkg/controllers/node/syncer.go
+++ b/kube-controllers/pkg/controllers/node/syncer.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	apiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/watchersyncer"
@@ -33,7 +35,10 @@ func NewDataFeed(c client.Interface) *DataFeed {
 	// Kinds to register with on the syncer API.
 	resourceTypes := []watchersyncer.ResourceType{
 		{
-			ListInterface: model.ResourceListOptions{Kind: apiv3.KindNode},
+			ListInterface: model.ResourceListOptions{Kind: libapiv3.KindNode},
+		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv3.KindClusterInformation},
 		},
 		{
 			ListInterface: model.BlockListOptions{},


### PR DESCRIPTION
## Description
I noticed that calico-kube-controllers still exec GC when we use lock the datastore. 

But I'm a little confused with the Lock Description : ` Lock the datastore to prepare it for migration. This prevents any new
  Calico resources from affecting the cluster but does not prevent updating
  or creating new Calico resources.`
  
  So, what is the situation that we could update or create new Calico resources?
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Prevent IPAM GC when datastore is locked
```
