### PR TITLE
Automated cherry pick of #5453: proxy_delay setting failure should not be a critical error

### DIFF
--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -392,7 +392,7 @@ func (d *linuxDataplane) configureSysctls(hostVethName string, hasIPv4, hasIPv6 
 		// Normally, the kernel has a delay before responding to proxy ARP but we know
 		// that's not needed in a Calico network so we disable it.
 		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/neigh/%s/proxy_delay", hostVethName), "0"); err != nil {
-			return fmt.Errorf("failed to set net.ipv4.neigh.%s.proxy_delay=0: %s", hostVethName, err)
+			d.logger.Warnf("failed to set net.ipv4.neigh.%s.proxy_delay=0: %s", hostVethName, err)
 		}
 
 		// Enable proxy ARP, this makes the host respond to all ARP requests with its own

--- a/felix/dataplane/linux/endpoint_mgr.go
+++ b/felix/dataplane/linux/endpoint_mgr.go
@@ -1192,7 +1192,7 @@ func (m *endpointManager) configureInterface(name string) error {
 		// that's not needed in a Calico network so we disable it.
 		err = m.writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/neigh/%s/proxy_delay", name), "0")
 		if err != nil {
-			return err
+			log.Warnf("failed to set net.ipv4.neigh.%s.proxy_delay=0: %s", name, err)
 		}
 		// Enable proxy ARP, this makes the host respond to all ARP requests with its own
 		// MAC.  This has a couple of advantages:


### PR DESCRIPTION
Cherry pick of #5453 on release-v3.22.

#5453: proxy_delay setting failure should not be a critical error

# Original PR Body below

Signed-off-by: cyclinder <qifeng.guo@daocloud.io>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
https://github.com/projectcalico/calico/issues/5341

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
proxy_delay setting failure should not be a critical error
```