### PR TITLE
Reinstate streaming of v1 ProfileLabels (alongside v3 Profile)

### DIFF
--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -446,6 +446,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
+			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 		})
 
 		By("Deleting the namespace", func() {
@@ -455,6 +456,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are no longer in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
+			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 		})
 	})
 
@@ -494,6 +496,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
+			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeTrue())
 		})
 
 		By("deleting a namespace", func() {
@@ -503,6 +506,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 		By("Checking the correct entries are in no longer in our cache", func() {
 			expectedName := "kns.test-syncer-namespace-no-default-deny"
 			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileRulesKey{ProfileKey: model.ProfileKey{expectedName}}), slowCheck...).Should(BeFalse())
+			Eventually(cb.GetSyncerValuePresentFunc(model.ProfileLabelsKey{ProfileKey: model.ProfileKey{expectedName}})).Should(BeFalse())
 		})
 	})
 

--- a/libcalico-go/lib/backend/model/keys.go
+++ b/libcalico-go/lib/backend/model/keys.go
@@ -247,6 +247,9 @@ func KeyFromDefaultPath(path string) Key {
 		case "rules":
 			log.Debugf("Profile rules")
 			return ProfileRulesKey{ProfileKey: pk}
+		case "labels":
+			log.Debugf("Profile labels")
+			return ProfileLabelsKey{ProfileKey: pk}
 		}
 		return nil
 	} else if m := matchHostIp.FindStringSubmatch(path); m != nil {

--- a/libcalico-go/lib/backend/model/keys_test.go
+++ b/libcalico-go/lib/backend/model/keys_test.go
@@ -137,6 +137,12 @@ var _ = DescribeTable(
 		false,
 	),
 	Entry(
+		"profile labels with a /",
+		"/calico/v1/policy/profile/foo%2fbar/labels",
+		ProfileLabelsKey{ProfileKey: ProfileKey{Name: "foo/bar"}},
+		false,
+	),
+	Entry(
 		"policy with a /",
 		"/calico/v1/policy/tier/default/policy/biff%2fbop",
 		PolicyKey{Name: "biff/bop"},

--- a/libcalico-go/lib/backend/model/profile.go
+++ b/libcalico-go/lib/backend/model/profile.go
@@ -81,6 +81,24 @@ func (key ProfileRulesKey) String() string {
 	return fmt.Sprintf("ProfileRules(name=%s)", key.Name)
 }
 
+// ProfileLabelsKey implements the KeyInterface for the profile labels
+type ProfileLabelsKey struct {
+	ProfileKey
+}
+
+func (key ProfileLabelsKey) defaultPath() (string, error) {
+	e, err := key.ProfileKey.defaultPath()
+	return e + "/labels", err
+}
+
+func (key ProfileLabelsKey) valueType() (reflect.Type, error) {
+	return reflect.TypeOf(map[string]string{}), nil
+}
+
+func (key ProfileLabelsKey) String() string {
+	return fmt.Sprintf("ProfileLabels(name=%s)", key.Name)
+}
+
 type ProfileListOptions struct {
 	Name string
 }
@@ -109,6 +127,8 @@ func (options ProfileListOptions) KeyFromDefaultPath(path string) Key {
 	}
 	pk := ProfileKey{Name: name}
 	switch kind {
+	case "labels":
+		return ProfileLabelsKey{ProfileKey: pk}
 	case "rules":
 		return ProfileRulesKey{ProfileKey: pk}
 	}
@@ -135,6 +155,8 @@ func (_ *ProfileListOptions) ListConvert(ds []*KVPair) []*KVPair {
 	var name string
 	for _, d := range ds {
 		switch t := d.Key.(type) {
+		case ProfileLabelsKey:
+			name = t.Name
 		case ProfileRulesKey:
 			name = t.Name
 		default:

--- a/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
+++ b/libcalico-go/lib/backend/syncersv1/felixsyncer/felixsyncer_e2e_test.go
@@ -114,9 +114,18 @@ func calculateDefaultFelixSyncerEntries(cs kubernetes.Interface, dt apiconfig.Da
 				},
 			})
 
-			// And expect a v3 profile for each namespace. The labels should include the name
+			// Expect profile labels for each namespace as well. The labels should include the name
 			// of the namespace. As of Kubernetes v1.21, k8s also includes a label for the namespace name
 			// that will be inherited by the profile.
+			expected = append(expected, model.KVPair{
+				Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
+				Value: map[string]string{
+					"pcns.projectcalico.org/name":      ns.Name,
+					"pcns.kubernetes.io/metadata.name": ns.Name,
+				},
+			})
+
+			// And expect a v3 profile for each namespace.
 			prof := apiv3.Profile{
 				TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
 				ObjectMeta: metav1.ObjectMeta{Name: name, UID: ns.UID, CreationTimestamp: ns.CreationTimestamp},
@@ -148,8 +157,16 @@ func calculateDefaultFelixSyncerEntries(cs kubernetes.Interface, dt apiconfig.Da
 					},
 				})
 
-				//  We also expect one v3 Profile to be present for each ServiceAccount. The labels should include the name
+				// Expect profile labels for each default serviceaccount as well. The labels should include the name
 				// of the service account.
+				expected = append(expected, model.KVPair{
+					Key: model.ProfileLabelsKey{ProfileKey: model.ProfileKey{Name: name}},
+					Value: map[string]string{
+						"pcsa.projectcalico.org/name": sa.Name,
+					},
+				})
+
+				//  We also expect one v3 Profile to be present for each ServiceAccount.
 				prof := apiv3.Profile{
 					TypeMeta:   metav1.TypeMeta{Kind: "Profile", APIVersion: "projectcalico.org/v3"},
 					ObjectMeta: metav1.ObjectMeta{Name: name, UID: sa.UID, CreationTimestamp: sa.CreationTimestamp},

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/profileprocessor_test.go
@@ -59,8 +59,13 @@ var _ = Describe("Test the Profile update processor", func() {
 			Revision: "abcde",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(kvps).To(HaveLen(2))
+		Expect(kvps).To(HaveLen(3))
 		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key:      model.ProfileLabelsKey{v1ProfileKey1},
+			Value:    map[string]string{"testLabel": "label"},
+			Revision: "abcde",
+		}))
+		Expect(kvps[1]).To(Equal(&model.KVPair{
 			Key:      model.ProfileRulesKey{v1ProfileKey1},
 			Value:    nilRules,
 			Revision: "abcde",
@@ -158,8 +163,13 @@ var _ = Describe("Test the Profile update processor", func() {
 
 		v1irule := updateprocessors.RuleAPIV2ToBackend(irule, "")
 		v1erule := updateprocessors.RuleAPIV2ToBackend(erule, "")
-		Expect(kvps).To(HaveLen(2))
+		Expect(kvps).To(HaveLen(3))
 		Expect(kvps[0]).To(Equal(&model.KVPair{
+			Key:      model.ProfileLabelsKey{v1ProfileKey2},
+			Value:    map[string]string{"testLabel": "label2"},
+			Revision: "1234",
+		}))
+		Expect(kvps[1]).To(Equal(&model.KVPair{
 			Key: model.ProfileRulesKey{v1ProfileKey2},
 			Value: &model.ProfileRules{
 				InboundRules:  []model.Rule{v1irule},
@@ -175,6 +185,10 @@ var _ = Describe("Test the Profile update processor", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   model.ProfileLabelsKey{v1ProfileKey1},
+				Value: nil,
+			},
 			{
 				Key:   model.ProfileRulesKey{v1ProfileKey1},
 				Value: nil,
@@ -211,6 +225,10 @@ var _ = Describe("Test the Profile update processor", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(kvps).To(Equal([]*model.KVPair{
+			{
+				Key:   model.ProfileLabelsKey{v1ProfileKey1},
+				Value: nil,
+			},
 			{
 				Key:   model.ProfileRulesKey{v1ProfileKey1},
 				Value: nil,


### PR DESCRIPTION
We need to keep this for a few release cycles to support upgrade from Calico OSS <=v3.22 and Calico
Enterprise <=v3.12.  Otherwise, in such an upgrade, if any of the Typha instances are upgraded
before some of the calico-nodes, we could have:

- up-level Typha no longer streams v1 ProfileLabels

- but down-level Felix (in calico-node) is still looking for v1 ProfileLabels to get profile labels.
