### PR TITLE
Pool-based IPAM Metrics

### DIFF
--- a/calico/_includes/charts/calico/templates/calico-kube-controllers-rbac.yaml
+++ b/calico/_includes/charts/calico/templates/calico-kube-controllers-rbac.yaml
@@ -64,14 +64,12 @@ rules:
       - get
       - list
       - watch
-  # IPAM resources are manipulated when nodes are deleted.
+  # IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - ippools
       - ipreservations
     verbs:
       - list
-      - watch
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities
@@ -83,6 +81,13 @@ rules:
       - create
       - update
       - delete
+      - watch
+  # Pools are watched to maintain a mapping of blocks to IP pools.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
       - watch
   # kube-controllers manages hostendpoints.
   - apiGroups: ["crd.projectcalico.org"]

--- a/calico/_includes/charts/calico/templates/calico-kube-controllers-rbac.yaml
+++ b/calico/_includes/charts/calico/templates/calico-kube-controllers-rbac.yaml
@@ -71,6 +71,7 @@ rules:
       - ipreservations
     verbs:
       - list
+      - watch
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities

--- a/calico/maintenance/monitor/monitor-component-metrics.md
+++ b/calico/maintenance/monitor/monitor-component-metrics.md
@@ -538,7 +538,7 @@ kubectl port-forward pod/prometheus-pod 9090:9090 -n calico-monitoring
 
 Browse to [http://localhost:9090](http://localhost:9090){: data-proofer-ignore=""} you should be able to see prometheus dashboard. Type **felix_active_local_endpoints** in the Expression input textbox then hit the execute button. Console table should be populated with all your nodes and quantity of endpoints in each of them.
 
-> **Note**: A comprehensive list of metrics can be [found at this link]({{ site.baseurl }}/reference/felix/prometheus).
+> **Note**: A list of Felix metrics can be [found at this link]({{ site.baseurl }}/reference/felix/prometheus). Similar lists can be found for [kube-controllers]({{ site.baseurl }}/reference/kube-controllers/prometheus) and [Typha]({{ site.baseurl }}/reference/typha/prometheus).
    {: .alert .alert-info}
 
 Push the `Add Graph` button, You should be able to see the metric plotted on a Graph.

--- a/calico/reference/kube-controllers/prometheus.md
+++ b/calico/reference/kube-controllers/prometheus.md
@@ -28,11 +28,11 @@ existing metrics.
 | `ipam_allocations_per_node` | node    | Number of Calico IP allocations, indexed by node on which the allocation was made. Prefer `ipam_allocations_in_use` for new integrations. |
 | `ipam_allocations_borrowed_per_node` | node    | Number of Calico IP allocations borrowed from a non-affine block, indexed by node on which the allocation was made. Prefer `ipam_allocations_borrowed` for new integrations. |
 
-Labels can be interpreted as follows
+Labels can be interpreted as follows:
 
 | Label Name | Description |
 |------------|-------------|
-| `node`     | For allocation metrics, the node on which the allocation was made. For block metrics, the node for which the block has affinity - if the block has no affinity, value will be `no_affinity` |
+| `node`     | For allocation metrics, the node on which the allocation was made. For block metrics, the node for which the block has affinity. If the block has no affinity, value will be `no_affinity` |
 | `ippool`   | The IP Pool that the IPAM block occupies. If there is no IP Pool which matches the block, value will be `no_pool` |
 
 Prometheus metrics are self-documenting, with metrics turned on, `curl` can be used to list the

--- a/calico/reference/kube-controllers/prometheus.md
+++ b/calico/reference/kube-controllers/prometheus.md
@@ -16,11 +16,24 @@ may be tied to particular implementation choices inside kube-controllers we can'
 metrics will persist across releases.  However, we aim not to make any spurious changes to
 existing metrics.
 
-| Name          | Description     |
-| ------------- | --------------- |
-| `ipam_blocks_per_node` | Number of IPAM blocks, indexed by the node to which they have affinity. |
-| `ipam_allocations_per_node` | Number of Calico IP allocations, indexed by node on which the allocation was made. |
-| `ipam_allocations_borrowed_per_node` | Number of Calico IP allocations borrowed from a non-affine block, indexed by node on which the allocation was made. |
+| Metric Name  | Labels  | Description |
+|--------------|---------|-------------|
+| `ipam_allocations_in_use` | ippool, node | Number of Calico IP allocations currently in use by a workload or interface. |
+| `ipam_allocations_borrowed` | ippool, node | Number of Calico IP allocations currently in use where the allocation was borrowed from a block affine to another node. |
+| `ipam_allocations_gc_candidates` | ippool, node | Number of Calico IP allocations currently marked by the GC as potential leaks. This metric returns to zero under normal GC operation. |
+| `ipam_allocations_gc_reclamations` | ippool, node | Count of Calico IP allocations that have been reclaimed by the GC. The counter increments when the candidates gauge goes to zero under normal operation. |
+| `ipam_blocks` | ippool, node | Number of IPAM blocks. |
+| `ipam_pool_size` | ippool  | Number of IP addresses in the IP Pool CIDR. |
+| `ipam_blocks_per_node` | no      | Number of IPAM blocks, indexed by the node to which they have affinity. Prefer `ipam_blocks` for new integrations. |
+| `ipam_allocations_per_node` | node    | Number of Calico IP allocations, indexed by node on which the allocation was made. Prefer `ipam_allocations_in_use` for new integrations. |
+| `ipam_allocations_borrowed_per_node` | node    | Number of Calico IP allocations borrowed from a non-affine block, indexed by node on which the allocation was made. Prefer `ipam_allocations_borrowed` for new integrations. |
+
+Labels can be interpreted as follows
+
+| Label Name | Description |
+|------------|-------------|
+| `node`     | For allocation metrics, the node on which the allocation was made. For block metrics, the node for which the block has affinity - if the block has no affinity, value will be `no_affinity` |
+| `ippool`   | The IP Pool that the IPAM block occupies. If there is no IP Pool which matches the block, value will be `no_pool` |
 
 Prometheus metrics are self-documenting, with metrics turned on, `curl` can be used to list the
 metrics along with their help text and type information.

--- a/calico/reference/kube-controllers/prometheus.md
+++ b/calico/reference/kube-controllers/prometheus.md
@@ -23,8 +23,8 @@ existing metrics.
 | `ipam_allocations_gc_candidates` | ippool, node | Number of Calico IP allocations currently marked by the GC as potential leaks. This metric returns to zero under normal GC operation. |
 | `ipam_allocations_gc_reclamations` | ippool, node | Count of Calico IP allocations that have been reclaimed by the GC. The counter increments when the candidates gauge goes to zero under normal operation. |
 | `ipam_blocks` | ippool, node | Number of IPAM blocks. |
-| `ipam_pool_size` | ippool  | Number of IP addresses in the IP Pool CIDR. |
-| `ipam_blocks_per_node` | no      | Number of IPAM blocks, indexed by the node to which they have affinity. Prefer `ipam_blocks` for new integrations. |
+| `ipam_ippool_size` | ippool  | Number of IP addresses in the IP Pool CIDR. |
+| `ipam_blocks_per_node` | node    | Number of IPAM blocks, indexed by the node to which they have affinity. Prefer `ipam_blocks` for new integrations. |
 | `ipam_allocations_per_node` | node    | Number of Calico IP allocations, indexed by node on which the allocation was made. Prefer `ipam_allocations_in_use` for new integrations. |
 | `ipam_allocations_borrowed_per_node` | node    | Number of Calico IP allocations borrowed from a non-affine block, indexed by node on which the allocation was made. Prefer `ipam_allocations_borrowed` for new integrations. |
 
@@ -32,8 +32,8 @@ Labels can be interpreted as follows:
 
 | Label Name | Description |
 |------------|-------------|
-| `node`     | For allocation metrics, the node on which the allocation was made. For block metrics, the node for which the block has affinity. If the block has no affinity, value will be `no_affinity` |
-| `ippool`   | The IP Pool that the IPAM block occupies. If there is no IP Pool which matches the block, value will be `no_pool` |
+| `node`     | For allocation metrics, the node on which the allocation was made. For block metrics, the node for which the block has affinity. If the block has no affinity, value will be `no_affinity`. |
+| `ippool`   | The IP Pool that the IPAM block occupies. If there is no IP Pool which matches the block, value will be `no_ippool`. |
 
 Prometheus metrics are self-documenting, with metrics turned on, `curl` can be used to list the
 metrics along with their help text and type information.

--- a/calico/reference/kube-controllers/prometheus.md
+++ b/calico/reference/kube-controllers/prometheus.md
@@ -21,7 +21,7 @@ existing metrics.
 | `ipam_allocations_in_use` | ippool, node | Number of Calico IP allocations currently in use by a workload or interface. |
 | `ipam_allocations_borrowed` | ippool, node | Number of Calico IP allocations currently in use where the allocation was borrowed from a block affine to another node. |
 | `ipam_allocations_gc_candidates` | ippool, node | Number of Calico IP allocations currently marked by the GC as potential leaks. This metric returns to zero under normal GC operation. |
-| `ipam_allocations_gc_reclamations` | ippool, node | Count of Calico IP allocations that have been reclaimed by the GC. The counter increments when the candidates gauge goes to zero under normal operation. |
+| `ipam_allocations_gc_reclamations` | ippool, node | Count of Calico IP allocations that have been reclaimed by the GC. Increase of this counter corresponds with a decrease of the candidates gauge under normal operation. |
 | `ipam_blocks` | ippool, node | Number of IPAM blocks. |
 | `ipam_ippool_size` | ippool  | Number of IP addresses in the IP Pool CIDR. |
 | `ipam_blocks_per_node` | node    | Number of IPAM blocks, indexed by the node to which they have affinity. Prefer `ipam_blocks` for new integrations. |

--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -175,7 +175,11 @@ func NewNodeController(ctx context.Context,
 func getK8sNodeName(calicoNode api.Node) (string, error) {
 	for _, orchRef := range calicoNode.Spec.OrchRefs {
 		if orchRef.Orchestrator == "k8s" {
-			return orchRef.NodeName, nil
+			if orchRef.NodeName == "" {
+				return "", &ErrorNotKubernetes{calicoNode.Name}
+			} else {
+				return orchRef.NodeName, nil
+			}
 		}
 	}
 	return "", &ErrorNotKubernetes{calicoNode.Name}

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -362,19 +362,16 @@ func (c *ipamController) handleNodeUpdate(kvp model.KVPair) {
 	if kvp.Value != nil {
 		n := kvp.Value.(*libapiv3.Node)
 		kn, err := getK8sNodeName(*n)
-
 		if err != nil {
 			log.WithError(err).Info("Unable to get corresponding k8s node name")
 		}
 
 		// Maintain mapping of Calico node to Kubernetes node. Ensure all Calico nodes have an entry in the map by
-		// assigning a value of "" for nodes that are not orchestrated by Kubernetes (1) or have a Kubernetes name of "" (2).
-		// Expects getK8sNodeName to return "", err for (1) and "", nil for (2).
+		// assigning a value of "" for nodes that are not orchestrated by Kubernetes.
 		if current, ok := c.kubernetesNodesByCalicoName[n.Name]; !ok {
 			log.Debugf("Add mapping calico node -> k8s node. %s -> %s", n.Name, kn)
 			c.kubernetesNodesByCalicoName[n.Name] = kn
-		} else if current != kn && !(err == nil && kn == "") {
-			// Update mapping if the value has changed, and the change is not a loss of Kubernetes name.
+		} else if current != kn {
 			log.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
 			c.kubernetesNodesByCalicoName[n.Name] = kn
 		}

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -586,9 +586,9 @@ func (c *ipamController) updateMetrics() {
 	// Iterate blocks to determine the correct metric values.
 	for poolName, poolBlocks := range c.poolManager.blocksByPool {
 		// These counts track pool-based gauges by node for the current pool.
-		inUseAllocationsByNode := c.createZeroedMapForNodeValues()
-		borrowedAllocationsByNode := c.createZeroedMapForNodeValues()
-		gcCandidatesByNode := c.createZeroedMapForNodeValues()
+		inUseAllocationsByNode := c.createZeroedMapForNodeValues(poolName)
+		borrowedAllocationsByNode := c.createZeroedMapForNodeValues(poolName)
+		gcCandidatesByNode := c.createZeroedMapForNodeValues(poolName)
 		blocksByNode := map[string]int{}
 
 		for blockCIDR := range poolBlocks {
@@ -1255,12 +1255,16 @@ func unregisterMetricVectorsForPool(poolName string) {
 
 // Creates map used to index gauge values by node, and seeds with zeroes to create explicit zero values rather than
 // absence of data for a node. This enables users to construct utilization expressions that return 0 when the numerator
-// is zero, rather than no data.
-func (c *ipamController) createZeroedMapForNodeValues() map[string]int {
+// is zero, rather than no data. If the pool is the 'unknown' pool, the map is not seeded.
+func (c *ipamController) createZeroedMapForNodeValues(poolName string) map[string]int {
 	valuesByNode := map[string]int{}
-	for cnode := range c.kubernetesNodesByCalicoName {
-		valuesByNode[cnode] = 0
+
+	if poolName != unknownPoolLabel {
+		for cnode := range c.kubernetesNodesByCalicoName {
+			valuesByNode[cnode] = 0
+		}
 	}
+
 	return valuesByNode
 }
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -22,13 +22,10 @@ import (
 	"strings"
 	"time"
 
-	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
-
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/flannelmigration"
 
-	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -36,6 +33,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
+
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/config"
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
@@ -679,7 +678,7 @@ func (c *ipamController) updateMetrics() {
 		blocksForPoolByNode := map[string]int{}
 		gcCandidatesForPoolByNode := map[string]int{}
 
-		for blockCIDR, _ := range poolBlocks {
+		for blockCIDR := range poolBlocks {
 			b := c.allBlocks[blockCIDR].Value.(*model.AllocationBlock)
 
 			affineNode := "no_affinity"

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -27,7 +27,6 @@ import (
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -181,7 +180,7 @@ func (c *ipamController) onUpdate(update bapi.Update) {
 	case model.BlockKey:
 		c.syncerUpdates <- update.KVPair
 	default:
-		logrus.Warnf("Unexpected kind received over syncer: %s", update.KVPair.Key)
+		log.Warnf("Unexpected kind received over syncer: %s", update.KVPair.Key)
 	}
 }
 
@@ -331,15 +330,15 @@ func (c *ipamController) handleNodeUpdate(kvp model.KVPair) {
 			// It's possible that a previous version of this node had an orchRef and so was added to the
 			// map. If so, we need to remove it.
 			if current, ok := c.kubernetesNodesByCalicoName[n.Name]; ok {
-				logrus.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
+				log.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
 				delete(c.kubernetesNodesByCalicoName, n.Name)
 			}
 		} else if kn != "" {
 			if current, ok := c.kubernetesNodesByCalicoName[n.Name]; !ok {
-				logrus.Debugf("Add mapping calico node -> k8s node. %s -> %s", n.Name, kn)
+				log.Debugf("Add mapping calico node -> k8s node. %s -> %s", n.Name, kn)
 				c.kubernetesNodesByCalicoName[n.Name] = kn
 			} else if current != kn {
-				logrus.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
+				log.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
 				c.kubernetesNodesByCalicoName[n.Name] = kn
 			}
 			// No change.
@@ -347,7 +346,7 @@ func (c *ipamController) handleNodeUpdate(kvp model.KVPair) {
 	} else {
 		cnode := kvp.Key.(model.ResourceKey).Name
 		if _, ok := c.kubernetesNodesByCalicoName[cnode]; ok {
-			logrus.Debugf("Remove mapping for calico node %s", cnode)
+			log.Debugf("Remove mapping for calico node %s", cnode)
 			delete(c.kubernetesNodesByCalicoName, cnode)
 		}
 	}
@@ -1062,10 +1061,10 @@ func (c *ipamController) kubernetesNodeForCalico(cnode string) (string, error) {
 	calicoNode, err := c.client.Nodes().Get(context.TODO(), cnode, options.GetOptions{})
 	if err != nil {
 		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
-			logrus.WithError(err).Info("Calico Node referenced in IPAM data does not exist")
+			log.WithError(err).Info("Calico Node referenced in IPAM data does not exist")
 			return "", nil
 		}
-		logrus.WithError(err).Warn("failed to query Calico Node referenced in IPAM data")
+		log.WithError(err).Warn("failed to query Calico Node referenced in IPAM data")
 		return "", err
 	}
 

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -362,24 +362,21 @@ func (c *ipamController) handleNodeUpdate(kvp model.KVPair) {
 	if kvp.Value != nil {
 		n := kvp.Value.(*libapiv3.Node)
 		kn, err := getK8sNodeName(*n)
-		if err != nil {
-			log.WithError(err).Info("Unable to get corresponding k8s node name, skipping")
 
-			// It's possible that a previous version of this node had an orchRef and so was added to the
-			// map. If so, we need to remove it.
-			if current, ok := c.kubernetesNodesByCalicoName[n.Name]; ok {
-				log.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
-				delete(c.kubernetesNodesByCalicoName, n.Name)
-			}
-		} else if kn != "" {
-			if current, ok := c.kubernetesNodesByCalicoName[n.Name]; !ok {
-				log.Debugf("Add mapping calico node -> k8s node. %s -> %s", n.Name, kn)
-				c.kubernetesNodesByCalicoName[n.Name] = kn
-			} else if current != kn {
-				log.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
-				c.kubernetesNodesByCalicoName[n.Name] = kn
-			}
-			// No change.
+		if err != nil {
+			log.WithError(err).Info("Unable to get corresponding k8s node name")
+		}
+
+		// Maintain mapping of Calico node to Kubernetes node. Ensure all Calico nodes have an entry in the map by
+		// assigning a value of "" for nodes that are not orchestrated by Kubernetes (1) or have a Kubernetes name of "" (2).
+		// Expects getK8sNodeName to return "", err for (1) and "", nil for (2).
+		if current, ok := c.kubernetesNodesByCalicoName[n.Name]; !ok {
+			log.Debugf("Add mapping calico node -> k8s node. %s -> %s", n.Name, kn)
+			c.kubernetesNodesByCalicoName[n.Name] = kn
+		} else if current != kn && !(err == nil && kn == "") {
+			// Update mapping if the value has changed, and the change is not a loss of Kubernetes name.
+			log.Warnf("Update mapping calico node -> k8s node. %s -> %s (previously %s)", n.Name, kn, current)
+			c.kubernetesNodesByCalicoName[n.Name] = kn
 		}
 	} else {
 		cnode := kvp.Key.(model.ResourceKey).Name
@@ -1147,7 +1144,7 @@ func (c *ipamController) nodeIsBeingMigrated(name string) (bool, error) {
 // Returns ErrorNotKubernetes if the given Calico node is not a Kubernetes node.
 func (c *ipamController) kubernetesNodeForCalico(cnode string) (string, error) {
 	// Check if we have the node name cached.
-	if kn, ok := c.kubernetesNodesByCalicoName[cnode]; ok {
+	if kn, ok := c.kubernetesNodesByCalicoName[cnode]; ok && kn != "" {
 		return kn, nil
 	}
 	log.WithField("cnode", cnode).Debug("Node not in cache, look it up in the API")
@@ -1172,16 +1169,15 @@ func (c *ipamController) kubernetesNodeForCalico(cnode string) (string, error) {
 
 func (c *ipamController) incrementReclamationMetric(block string, node string) {
 	pool := c.poolManager.poolsByBlock[block]
-	metricNode := node
-	if metricNode == "" {
-		metricNode = unknownNodeLabel
+	if node == "" {
+		node = unknownNodeLabel
 	}
 	gcReclamationsCounter := gcReclamationCounters[pool]
 	if gcReclamationsCounter == nil {
 		log.Warnf("Reclamation count metric vector used for pool %s was not created, skipping publishing", pool)
 		return
 	}
-	gcReclamationsCounter.With(prometheus.Labels{"node": metricNode}).Inc()
+	gcReclamationsCounter.With(prometheus.Labels{"node": node}).Inc()
 }
 
 func registerMetricVectorsForPool(poolName string) {

--- a/kube-controllers/pkg/controllers/node/ipam_allocation.go
+++ b/kube-controllers/pkg/controllers/node/ipam_allocation.go
@@ -72,6 +72,7 @@ type allocation struct {
 	handle         string
 	attrs          map[string]string
 	sequenceNumber uint64
+	block          string
 
 	// The Kubernetes node name hosting this allocation.
 	knode string

--- a/kube-controllers/pkg/controllers/node/ipam_allocation.go
+++ b/kube-controllers/pkg/controllers/node/ipam_allocation.go
@@ -164,6 +164,10 @@ func (a *allocation) isConfirmedLeak() bool {
 	return a.confirmedLeak
 }
 
+func (a *allocation) isCandidateLeak() bool {
+	return a.leakedAt != nil && !a.confirmedLeak
+}
+
 func (a *allocation) isPodIP() bool {
 	ns := a.attrs[ipam.AttributeNamespace]
 	pod := a.attrs[ipam.AttributePod]

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -238,6 +238,7 @@ var _ = Describe("IPAM controller UTs", func() {
 			ip:     "10.0.0.0",
 			handle: handle,
 			attrs:  b.Attributes[0].AttrSecondary,
+			block:  "10.0.0.0/30",
 		}
 
 		// Unique ID we expect for this allocation.

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -325,6 +325,190 @@ var _ = Describe("IPAM controller UTs", func() {
 		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
 	})
 
+	It("should maintain pool and block mappings", func() {
+		// Start the controller.
+		c.Start(stopChan)
+
+		// Add first block with no pools established.
+		firstBlockCIDR := net.MustParseCIDR("192.168.0.0/30")
+		firstBlockAff := "host:cnode"
+		firstBlockKey := model.BlockKey{CIDR: firstBlockCIDR}
+		firstBlock := model.AllocationBlock{
+			CIDR:        firstBlockCIDR,
+			Affinity:    &firstBlockAff,
+			Allocations: []*int{nil, nil, nil, nil},
+			Unallocated: []int{0, 1, 2, 3},
+			Attributes:  []model.AllocationAttribute{},
+		}
+		firstBlockKvp := model.KVPair{
+			Key:   firstBlockKey,
+			Value: &firstBlock,
+		}
+		firstBlockUpdate := bapi.Update{KVPair: firstBlockKvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(firstBlockUpdate)
+
+		// Expect new entries in the pool manager maps under unknown pool.
+		Eventually(func() string {
+			done := c.pause()
+			defer done()
+			return c.poolManager.poolsByBlock[firstBlockCIDR.String()]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(unknownPoolLabel))
+		Eventually(func() map[string]bool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.blocksByPool[unknownPoolLabel]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(map[string]bool{firstBlockCIDR.String(): true}))
+		Eventually(func() map[string]*apiv3.IPPool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.allPools
+		}, 1*time.Second, 100*time.Millisecond).Should(BeEmpty())
+
+		// Establish first pool for the first block.
+		firstIPPoolName := "ippool-1"
+		firstIPPoolKey := model.ResourceKey{Name: firstIPPoolName, Kind: apiv3.KindIPPool}
+		firstIPPool := apiv3.IPPool{}
+		firstIPPool.Name = firstIPPoolName
+		firstIPPool.Spec.CIDR = "192.168.0.0/24"
+		firstIPPool.Spec.BlockSize = 30
+		firstIPPool.Spec.NodeSelector = "all()"
+		firstIPPool.Spec.Disabled = false
+		firstPoolKvp := model.KVPair{
+			Key:   firstIPPoolKey,
+			Value: &firstIPPool,
+		}
+		firstPoolUpdate := bapi.Update{
+			KVPair:     firstPoolKvp,
+			UpdateType: bapi.UpdateTypeKVNew,
+		}
+		c.onUpdate(firstPoolUpdate)
+
+		// Expect first block to be associated with first pool.
+		Eventually(func() string {
+			done := c.pause()
+			defer done()
+			return c.poolManager.poolsByBlock[firstBlockCIDR.String()]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(firstIPPoolName))
+		Eventually(func() map[string]bool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.blocksByPool[firstIPPoolName]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(map[string]bool{firstBlockCIDR.String(): true}))
+		Eventually(func() *apiv3.IPPool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.allPools[firstIPPoolName]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(&firstIPPool))
+
+		// Create a second pool and a second block immediately associated to it.
+		secondIPPoolName := "ippool-2"
+		secondIPPoolKey := model.ResourceKey{Name: secondIPPoolName, Kind: apiv3.KindIPPool}
+		secondIPPool := apiv3.IPPool{}
+		secondIPPool.Name = secondIPPoolName
+		secondIPPool.Spec.CIDR = "10.16.0.0/24"
+		secondIPPool.Spec.BlockSize = 30
+		secondIPPool.Spec.NodeSelector = "all()"
+		secondIPPool.Spec.Disabled = false
+		secondIPPoolKvp := model.KVPair{
+			Key:   secondIPPoolKey,
+			Value: &secondIPPool,
+		}
+		secondPoolUpdate := bapi.Update{
+			KVPair:     secondIPPoolKvp,
+			UpdateType: bapi.UpdateTypeKVNew,
+		}
+		c.onUpdate(secondPoolUpdate)
+
+		secondBlockCIDR := net.MustParseCIDR("10.16.0.0/30")
+		secondBlockAff := "host:cnode"
+		secondBlockKey := model.BlockKey{CIDR: secondBlockCIDR}
+		secondBlock := model.AllocationBlock{
+			CIDR:        secondBlockCIDR,
+			Affinity:    &secondBlockAff,
+			Allocations: []*int{nil, nil, nil, nil},
+			Unallocated: []int{0, 1, 2, 3},
+			Attributes:  []model.AllocationAttribute{},
+		}
+		secondBlockKvp := model.KVPair{
+			Key:   secondBlockKey,
+			Value: &secondBlock,
+		}
+		secondBlockUpdate := bapi.Update{KVPair: secondBlockKvp, UpdateType: bapi.UpdateTypeKVNew}
+		c.onUpdate(secondBlockUpdate)
+
+		// Expect second block to be associated with second pool.
+		Eventually(func() string {
+			done := c.pause()
+			defer done()
+			return c.poolManager.poolsByBlock[secondBlockCIDR.String()]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(secondIPPoolName))
+		Eventually(func() map[string]bool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.blocksByPool[secondIPPoolName]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(map[string]bool{secondBlockCIDR.String(): true}))
+		Eventually(func() *apiv3.IPPool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.allPools[secondIPPoolName]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(&secondIPPool))
+
+		// Delete second block (associated with second pool). Expect block to be removed from pool maps.
+		secondBlockUpdate.KVPair.Value = nil
+		c.onUpdate(secondBlockUpdate)
+		Eventually(func() string {
+			done := c.pause()
+			defer done()
+			return c.poolManager.poolsByBlock[secondBlockCIDR.String()]
+		}, 1*time.Second, 100*time.Millisecond).Should(BeEmpty())
+		Eventually(func() map[string]bool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.blocksByPool[secondIPPoolName]
+		}, 1*time.Second, 100*time.Millisecond).Should(BeEmpty())
+
+		// Delete first pool. Expect first block to be associated with unknown pool, and pool removed from pool cache.
+		firstPoolUpdate.KVPair.Value = nil
+		c.onUpdate(firstPoolUpdate)
+		Eventually(func() string {
+			done := c.pause()
+			defer done()
+			return c.poolManager.poolsByBlock[firstBlockCIDR.String()]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(unknownPoolLabel))
+		Eventually(func() map[string]bool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.blocksByPool[unknownPoolLabel]
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(map[string]bool{firstBlockCIDR.String(): true}))
+		Eventually(func() *apiv3.IPPool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.allPools[firstIPPoolName]
+		}, 1*time.Second, 100*time.Millisecond).Should(BeNil())
+
+		// Delete first block (unassociated with a pool). Expect block to be removed from pool maps.
+		firstBlockUpdate.KVPair.Value = nil
+		c.onUpdate(firstBlockUpdate)
+		Eventually(func() string {
+			done := c.pause()
+			defer done()
+			return c.poolManager.poolsByBlock[firstBlockCIDR.String()]
+		}, 1*time.Second, 100*time.Millisecond).Should(BeEmpty())
+		Eventually(func() map[string]bool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.blocksByPool[firstIPPoolName]
+		}, 1*time.Second, 100*time.Millisecond).Should(BeEmpty())
+
+		// The unknown pool has no more blocks, it should be removed from the blocksByPool map.
+		// The second pool has no more blocks, it should remain from the blocksByPool map since it is an active pool.
+		Eventually(func() map[string]map[string]bool {
+			done := c.pause()
+			defer done()
+			return c.poolManager.blocksByPool
+		}, 1*time.Second, 100*time.Millisecond).Should(Equal(map[string]map[string]bool{"ippool-2": {}}))
+	})
+
 	It("should handle node deletion properly", func() {
 		// Start the controller.
 		c.Start(stopChan)

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -84,6 +84,15 @@ func assertConsistentState(c *ipamController) {
 		ExpectWithOffset(1, c.blocksByNode[n][cidr]).To(BeTrue(), fmt.Sprintf("Block %s not present in blocksByNode", cidr))
 	}
 
+	// Make sure blocksByAllocation and allocationsByBlock are consistent.
+	for cidr, allocations := range c.allocationsByBlock {
+		for allocation := range allocations {
+			ExpectWithOffset(1, c.blocksByAllocation[allocation]).To(Equal(cidr), fmt.Sprintf("Allocation %s on wrong block", allocation))
+		}
+	}
+	for allocation, cidr := range c.blocksByAllocation {
+		ExpectWithOffset(1, c.allocationsByBlock[cidr][allocation]).To(Not(BeNil()), fmt.Sprintf("Allocation %s not present in allocationsByBlock", allocation))
+	}
 }
 
 var _ = Describe("IPAM controller UTs", func() {

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -83,16 +83,6 @@ func assertConsistentState(c *ipamController) {
 	for cidr, n := range c.nodesByBlock {
 		ExpectWithOffset(1, c.blocksByNode[n][cidr]).To(BeTrue(), fmt.Sprintf("Block %s not present in blocksByNode", cidr))
 	}
-
-	// Make sure blocksByAllocation and allocationsByBlock are consistent.
-	for cidr, allocations := range c.allocationsByBlock {
-		for allocation := range allocations {
-			ExpectWithOffset(1, c.blocksByAllocation[allocation]).To(Equal(cidr), fmt.Sprintf("Allocation %s on wrong block", allocation))
-		}
-	}
-	for allocation, cidr := range c.blocksByAllocation {
-		ExpectWithOffset(1, c.allocationsByBlock[cidr][allocation]).To(Not(BeNil()), fmt.Sprintf("Allocation %s not present in allocationsByBlock", allocation))
-	}
 }
 
 var _ = Describe("IPAM controller UTs", func() {

--- a/kube-controllers/pkg/controllers/node/pool_manager.go
+++ b/kube-controllers/pkg/controllers/node/pool_manager.go
@@ -1,0 +1,130 @@
+package node
+
+import (
+	"net"
+
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
+
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
+)
+
+// Maintains a mapping of blocks to pools, based on whether the block CIDR occupies the pool CIDR.
+// Blocks can have a known pool association (handled, occupies a pool), unknown pool association (handled,
+// does not occupy a pool), or nil association (not yet handled).
+type poolManager struct {
+	blocksByPool map[string]map[string]bool
+	poolsByBlock map[string]string
+	allPools     map[string]*v3.IPPool
+}
+
+func newPoolManager() *poolManager {
+	return &poolManager{
+		blocksByPool: make(map[string]map[string]bool),
+		poolsByBlock: make(map[string]string),
+		allPools:     make(map[string]*v3.IPPool),
+	}
+}
+
+const (
+	// "no_ippool" is a special pool label that represents when a block has no matching IP pool.
+	unknownPoolLabel = "no_ippool"
+)
+
+func (p *poolManager) onPoolUpdated(pool *v3.IPPool) {
+	_, poolNet, err := cnet.ParseCIDR(pool.Spec.CIDR)
+	if err != nil {
+		log.WithError(err).Warnf("Unable to parse CIDR for IP Pool %s", pool.Name)
+		return
+	}
+
+	// Blocks may not have a known association to an IP Pool. This can happen when a Pool gets deleted, or if block
+	// updates appear before their associated pool updates. Blocks lacking association to an IP Pool are grouped under
+	// "no_ippool", and we check for transitions from unknown to known pool association on pool update.
+	for block := range p.blocksByPool[unknownPoolLabel] {
+		_, blockNet, err := net.ParseCIDR(block)
+		if err != nil {
+			log.WithError(err).Warnf("Unable to parse block %s to determine if it matches pool %s", block, pool.Name)
+			continue
+		}
+
+		if blockOccupiesPool(blockNet, poolNet) {
+			p.updatePoolForBlock(block, pool.Name)
+		}
+	}
+
+	p.allPools[pool.Name] = pool
+}
+
+func (p *poolManager) onPoolDeleted(poolName string) {
+	// When an IP Pool is deleted, its association transitions from known to unknown.
+	for block := range p.blocksByPool[poolName] {
+		p.updatePoolForBlock(block, unknownPoolLabel)
+	}
+
+	delete(p.blocksByPool, poolName)
+	delete(p.allPools, poolName)
+}
+
+func (p *poolManager) onBlockUpdated(blockCIDR string) {
+	// We only update pool association if current association is nil, since block update can only trigger transitions of
+	// association from nil to known pool or nil to unknown pool. Transitions from known to nil or unknown to nil
+	// occur due to block delete, transitions from known to unknown occur due to pool delete, and transitions from
+	// unknown to known occur due to pool update.
+	if p.poolsByBlock[blockCIDR] == "" {
+		pool := p.getPoolForBlock(blockCIDR)
+		p.updatePoolForBlock(blockCIDR, pool)
+	}
+}
+
+func (p *poolManager) onBlockDeleted(blockCIDR string) {
+	// Transition from known or unknown pool association to nil.
+	pool := p.poolsByBlock[blockCIDR]
+	delete(p.blocksByPool[pool], blockCIDR)
+	delete(p.poolsByBlock, blockCIDR)
+}
+
+// Resolve the IP Pool that the Block occupies.
+func (p *poolManager) getPoolForBlock(blockCIDR string) string {
+	_, blockNet, err := net.ParseCIDR(blockCIDR)
+	if err != nil {
+		log.WithError(err).Warnf("Unable to parse block %s for pool determination", blockCIDR)
+		return unknownPoolLabel
+	}
+
+	for poolName, pool := range p.allPools {
+		_, poolNet, err := cnet.ParseCIDR(pool.Spec.CIDR)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to parse CIDR for IP Pool %s", poolName)
+			continue
+		}
+		if blockOccupiesPool(blockNet, poolNet) {
+			return poolName
+		}
+	}
+
+	return unknownPoolLabel
+}
+
+func (p *poolManager) updatePoolForBlock(blockCIDR string, newPool string) {
+	previousPool := p.poolsByBlock[blockCIDR]
+	if previousPool == newPool {
+		return
+	}
+
+	// Update pools by block
+	p.poolsByBlock[blockCIDR] = newPool
+
+	// Update blocks by pool
+	if previousPoolBlocks, ok := p.blocksByPool[previousPool]; ok {
+		delete(previousPoolBlocks, blockCIDR)
+	}
+	if p.blocksByPool[newPool] == nil {
+		p.blocksByPool[newPool] = map[string]bool{}
+	}
+	p.blocksByPool[newPool][blockCIDR] = true
+}
+
+func blockOccupiesPool(blockNet *net.IPNet, poolNet *cnet.IPNet) bool {
+	return poolNet.Covers(*blockNet)
+}

--- a/kube-controllers/pkg/controllers/node/syncer.go
+++ b/kube-controllers/pkg/controllers/node/syncer.go
@@ -43,6 +43,9 @@ func NewDataFeed(c client.Interface) *DataFeed {
 		{
 			ListInterface: model.BlockListOptions{},
 		},
+		{
+			ListInterface: model.ResourceListOptions{Kind: apiv3.KindIPPool},
+		},
 	}
 	type accessor interface {
 		Backend() bapi.Client

--- a/kube-controllers/tests/fv/metrics_test.go
+++ b/kube-controllers/tests/fv/metrics_test.go
@@ -105,15 +105,10 @@ var _ = Describe("kube-controllers metrics tests", func() {
 		// Run controller manager.
 		controllerManager = testutils.RunK8sControllerManager(apiserver.IP)
 
-		// Create an IP pool with room for 4 blocks.
-		p := api.NewIPPool()
-		p.Name = "test-ippool"
-		p.Spec.CIDR = "192.168.0.0/24"
-		p.Spec.BlockSize = 26
-		p.Spec.NodeSelector = "all()"
-		p.Spec.Disabled = false
-		_, err = calicoClient.IPPools().Create(context.Background(), p, options.SetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		// Ensure the metrics endpoint is online.
+		Eventually(func() (string, error) {
+			return getMetrics(fmt.Sprintf("http://%s:9094/metrics", kubeControllers.IP))
+		}, 10*time.Second, 1*time.Second).ShouldNot(BeNil())
 	})
 
 	AfterEach(func() {
@@ -124,171 +119,189 @@ var _ = Describe("kube-controllers metrics tests", func() {
 	})
 
 	It("should export metrics for IPAM state", func() {
+		// Create an IP pool with room for 4 blocks.
+		createIPPool("test-ippool", "192.168.0.0/24", calicoClient)
+		createIPPool("test-ippool-2", "172.16.0.0/16", calicoClient)
+		createIPPool("test-ippool-3", "10.16.0.0/24", calicoClient)
+
 		// Create nodes in the Kubernetes API.
 		nodeA := "node-a"
 		nodeB := "node-b"
 		nodeC := "node-c"
-		_, err := k8sClient.CoreV1().Nodes().Create(context.Background(),
-			&v1.Node{
-				TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{Name: nodeA},
-				Spec:       v1.NodeSpec{},
-			},
-			metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		_, err = k8sClient.CoreV1().Nodes().Create(context.Background(),
-			&v1.Node{
-				TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{Name: nodeB},
-				Spec:       v1.NodeSpec{},
-			},
-			metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		_, err = k8sClient.CoreV1().Nodes().Create(context.Background(),
-			&v1.Node{
-				TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{Name: nodeC},
-				Spec:       v1.NodeSpec{},
-			},
-			metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		createNode(nodeA, k8sClient)
+		createNode(nodeB, k8sClient)
+		createNode(nodeC, k8sClient)
 
-		// Assert no IPAM metrics reported yet.
-		var out string
-		Eventually(func() error {
-			out, err = getMetrics(fmt.Sprintf("http://%s:9094/metrics", kubeControllers.IP))
-			return err
-		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-		Expect(out).NotTo(ContainSubstring("ipam_"))
+		// Assert only pool size IPAM metrics are reported at this point.
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_pool_size{ippool="test-ippool"} 256`,
+				`ipam_pool_size{ippool="test-ippool-2"} 65536`,
+				`ipam_pool_size{ippool="test-ippool-3"} 256`,
+			},
+			[]string{
+				`ipam_allocations_`,
+				`ipam_blocks_`,
+			},
+			kubeControllers.IP,
+			10*time.Second, 1*time.Second,
+		)
 
-		// Allocate a pod IP address and thus a block and affinity to NodeA.
+		// Allocate pod IP addresses from pool 1 and 2, and thus blocks and affinities to NodeA.
 		handleA := "handleA"
-		attrs := map[string]string{"node": nodeA, "pod": "pod-a", "namespace": "default"}
-		err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.1"), HandleID: &handleA, Attrs: attrs, Hostname: nodeA,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		handleA2 := "handleA2"
+		allocatePodIpWithHandle("192.168.0.1", handleA, nodeA, "pod-a", calicoClient)
+		allocatePodIpWithHandle("172.16.0.1", handleA2, nodeA, "pod-a2", calicoClient)
 
 		// Allocate an IPIP, VXLAN and WG address to NodeA as well.
 		handleAIPIP := "handleAIPIP"
-		attrs = map[string]string{"node": nodeA, "type": "ipipTunnelAddress"}
-		err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.2"), HandleID: &handleAIPIP, Attrs: attrs, Hostname: nodeA,
-		})
-		Expect(err).NotTo(HaveOccurred())
-
 		handleAVXLAN := "handleAVXLAN"
-		attrs = map[string]string{"node": nodeA, "type": "vxlanTunnelAddress"}
-		err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.3"), HandleID: &handleAVXLAN, Attrs: attrs, Hostname: nodeA,
-		})
-		Expect(err).NotTo(HaveOccurred())
-
 		handleAWG := "handleAWireguard"
-		attrs = map[string]string{"node": nodeA, "type": "wireguardTunnelAddress"}
-		err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.4"), HandleID: &handleAWG, Attrs: attrs, Hostname: nodeA,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		allocateInterfaceIpWithHandle("192.168.0.2", handleAIPIP, nodeA, "ipipTunnelAddress", calicoClient)
+		allocateInterfaceIpWithHandle("192.168.0.3", handleAVXLAN, nodeA, "vxlanTunnelAddress", calicoClient)
+		allocateInterfaceIpWithHandle("192.168.0.4", handleAWG, nodeA, "wireguardTunnelAddress", calicoClient)
 
-		// Allocate a pod IP address and thus a block and affinity to NodeB.
+		// Allocate pod IP addresses from pool 1 and 3, and thus blocks and affinities to NodeB.
 		handleB := "handleB"
-		attrs = map[string]string{"node": nodeB, "pod": "pod-b", "namespace": "default"}
-		err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.65"), HandleID: &handleB, Attrs: attrs, Hostname: nodeB,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		handleB2 := "handleB2"
+		allocatePodIpWithHandle("192.168.0.65", handleB, nodeB, "pod-b", calicoClient)
+		allocatePodIpWithHandle("10.16.0.1", handleB2, nodeB, "pod-b2", calicoClient)
 
-		// Allocate a pod IP address and thus a block and affinity to NodeC.
+		// Allocate a pod IP address from pool 1 and thus a block and affinity to NodeC.
 		handleC := "handleC"
-		attrs = map[string]string{"node": nodeC, "pod": "pod-c", "namespace": "default"}
-		err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.129"), HandleID: &handleC, Attrs: attrs, Hostname: nodeC,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		allocatePodIpWithHandle("192.168.0.129", handleC, nodeC, "pod-c", calicoClient)
 
 		// Assert that IPAM metrics have been updated to include the blocks and allocations from above.
-		expectedMetrics := []string{
-			`ipam_allocations_per_node{node="node-a"} 4`,
-			`ipam_allocations_per_node{node="node-b"} 1`,
-			`ipam_blocks_per_node{node="node-a"} 1`,
-			`ipam_blocks_per_node{node="node-b"} 1`,
-			`ipam_blocks_per_node{node="node-c"} 1`,
-		}
-		Eventually(func() error {
-			out, err = getMetrics(fmt.Sprintf("http://%s:9094/metrics", kubeControllers.IP))
-			Expect(err).NotTo(HaveOccurred())
-			for _, s := range expectedMetrics {
-				if !strings.Contains(out, s) {
-					return fmt.Errorf("Expected:\n%s\nTo contain metric:\n  %s\n", out, s)
-				}
-			}
-			return nil
-		}, 5*time.Second).ShouldNot(HaveOccurred())
+		// Assert that IPAM metrics have been updated to include the blocks and allocations from above.
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-a"} 4`,
+				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-a"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-b"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-b"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-c"} 1`,
+				`ipam_allocations_per_node{node="node-a"} 5`,
+				`ipam_allocations_per_node{node="node-b"} 2`,
+				`ipam_allocations_per_node{node="node-c"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="node-a"} 1`,
+				`ipam_blocks{ippool="test-ippool-2",node="node-a"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="node-b"} 1`,
+				`ipam_blocks{ippool="test-ippool-3",node="node-b"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="node-c"} 1`,
+				`ipam_blocks_per_node{node="node-a"} 2`,
+				`ipam_blocks_per_node{node="node-b"} 2`,
+				`ipam_blocks_per_node{node="node-c"} 1`,
+			},
+			[]string{},
+			kubeControllers.IP,
+			5*time.Second,
+		)
 
 		// Release the affinity for node-C's block, creating an IP address in a non-affine block.
-		err = calicoClient.IPAM().ReleaseHostAffinities(context.Background(), nodeC, false)
+		err := calicoClient.IPAM().ReleaseHostAffinities(context.Background(), nodeC, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Assert that IPAM metrics have been updated. It should now show a block with no affinity,
 		// and an IP address that is "borrowed" from the empty block on node C.
-		expectedMetrics = []string{
-			`ipam_allocations_per_node{node="node-a"} 4`,
-			`ipam_allocations_per_node{node="node-b"} 1`,
-			`ipam_allocations_per_node{node="node-c"} 1`,
-			`ipam_blocks_per_node{node="node-a"} 1`,
-			`ipam_blocks_per_node{node="node-b"} 1`,
-			`ipam_blocks_per_node{node="no_affinity"} 1`,
-			`ipam_allocations_borrowed_per_node{node="node-c"} 1`,
-		}
-		Eventually(func() error {
-			out, err = getMetrics(fmt.Sprintf("http://%s:9094/metrics", kubeControllers.IP))
-			Expect(err).NotTo(HaveOccurred())
-			for _, s := range expectedMetrics {
-				if !strings.Contains(out, s) {
-					return fmt.Errorf("Expected:\n%s\nTo contain metric:\n  %s\n", out, s)
-				}
-			}
-			return nil
-		}, 5*time.Second).ShouldNot(HaveOccurred())
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-a"} 4`,
+				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-a"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-b"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-b"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-c"} 1`,
+				`ipam_allocations_per_node{node="node-a"} 5`,
+				`ipam_allocations_per_node{node="node-b"} 2`,
+				`ipam_allocations_per_node{node="node-c"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="node-a"} 1`,
+				`ipam_blocks{ippool="test-ippool-2",node="node-a"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="node-b"} 1`,
+				`ipam_blocks{ippool="test-ippool-3",node="node-b"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="no_affinity"} 1`,
+				`ipam_blocks_per_node{node="node-a"} 2`,
+				`ipam_blocks_per_node{node="node-b"} 2`,
+				`ipam_blocks_per_node{node="no_affinity"} 1`,
+				`ipam_allocations_borrowed{ippool="test-ippool",node="node-c"} 1`,
+				`ipam_allocations_borrowed_per_node{node="node-c"} 1`,
+			}, []string{
+				`ipam_blocks{ippool="test-ippool",node="node-c"}`,
+				`ipam_blocks_per_node{node="node-c"}`,
+			},
+			kubeControllers.IP,
+			5*time.Second,
+		)
 
 		// Also allocate an IP address on NodeC within NodeB's block, to simulate a "borrowed" address.
 		handleC2 := "handleC2"
-		attrs = map[string]string{"node": nodeC, "pod": "pod-c2", "namespace": "default"}
-		err = calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-			IP: net.MustParseIP("192.168.0.66"), HandleID: &handleC2, Attrs: attrs, Hostname: nodeC,
-		})
-		Expect(err).NotTo(HaveOccurred())
+		allocatePodIpWithHandle("192.168.0.66", handleC2, nodeC, "pod-c2", calicoClient)
 
 		// Assert that IPAM metrics for node-c have been updated.
-		expectedMetrics = []string{
-			`ipam_allocations_per_node{node="node-c"} 2`,
-			`ipam_allocations_borrowed_per_node{node="node-c"} 2`,
-		}
-		Eventually(func() error {
-			out, err = getMetrics(fmt.Sprintf("http://%s:9094/metrics", kubeControllers.IP))
-			Expect(err).NotTo(HaveOccurred())
-			for _, s := range expectedMetrics {
-				if !strings.Contains(out, s) {
-					return fmt.Errorf("Expected:\n%s\nTo contain metric:\n  %s\n", out, s)
-				}
-			}
-			return nil
-		}, 5*time.Second).ShouldNot(HaveOccurred())
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-c"} 2`,
+				`ipam_allocations_per_node{node="node-c"} 2`,
+				`ipam_allocations_borrowed{ippool="test-ippool",node="node-c"} 2`,
+				`ipam_allocations_borrowed_per_node{node="node-c"} 2`,
+			},
+			[]string{},
+			kubeControllers.IP,
+			5*time.Second,
+		)
 
 		// Expect the correct blocks to exist as a result of the IPAM allocations above.
 		blocks, err := bc.List(context.Background(), model.BlockListOptions{}, "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(blocks.KVPairs)).To(Equal(3))
+		Expect(len(blocks.KVPairs)).To(Equal(5))
 		affs, err := bc.List(context.Background(), model.BlockAffinityListOptions{Host: nodeA}, "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(affs.KVPairs)).To(Equal(1))
+		Expect(len(affs.KVPairs)).To(Equal(2))
 		affs, err = bc.List(context.Background(), model.BlockAffinityListOptions{Host: nodeB}, "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(affs.KVPairs)).To(Equal(1))
+		Expect(len(affs.KVPairs)).To(Equal(2))
 		affs, err = bc.List(context.Background(), model.BlockAffinityListOptions{Host: nodeC}, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(affs.KVPairs)).To(Equal(0))
+
+		// Delete Pools 2 and 3 to trigger the change of pool associations
+		_, err = calicoClient.IPPools().Delete(context.Background(), "test-ippool-2", options.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		_, err = calicoClient.IPPools().Delete(context.Background(), "test-ippool-3", options.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Assert that associated pools are labelled as no_pool, and block affinities as no_affinity.
+		// Blocks lose affinity when their pool is deleted.
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_pool_size{ippool="test-ippool"} 256`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-a"} 4`,
+				`ipam_allocations_in_use{ippool="no_pool",node="node-a"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-b"} 1`,
+				`ipam_allocations_in_use{ippool="no_pool",node="node-b"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-c"} 2`,
+				`ipam_allocations_per_node{node="node-a"} 5`,
+				`ipam_allocations_per_node{node="node-b"} 2`,
+				`ipam_allocations_per_node{node="node-c"} 2`,
+				`ipam_blocks{ippool="test-ippool",node="node-a"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="node-b"} 1`,
+				`ipam_blocks{ippool="no_pool",node="no_affinity"} 2`, // Blocks from pools 2 and 3 lose affinity and pool.
+				`ipam_blocks{ippool="test-ippool",node="no_affinity"} 1`,
+				`ipam_blocks_per_node{node="node-a"} 1`,
+				`ipam_blocks_per_node{node="node-b"} 1`,
+				`ipam_blocks_per_node{node="no_affinity"} 3`,
+				`ipam_allocations_borrowed{ippool="test-ippool",node="node-c"} 2`,
+				`ipam_allocations_borrowed_per_node{node="node-c"} 2`,
+			},
+			[]string{
+				`ipam_pool_size{ippool="test-ippool-2"}`,
+				`ipam_pool_size{ippool="test-ippool-3"}`,
+				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-a"}`,
+				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-b"}`,
+				`ipam_blocks{ippool="test-ippool-2",node="node-a"}`,
+				`ipam_blocks{ippool="test-ippool-3",node="node-b"}`,
+			},
+			kubeControllers.IP,
+			5*time.Second,
+		)
 
 		// Deleting NodeB should clean up the allocations associated with the node, as well as the
 		// affinity, but should leave the block intact since there are still allocations from another
@@ -299,17 +312,23 @@ var _ = Describe("kube-controllers metrics tests", func() {
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleA, 1); err != nil {
 				return err
 			}
+			if err := assertIPsWithHandle(calicoClient.IPAM(), handleA2, 1); err != nil {
+				return err
+			}
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleAIPIP, 1); err != nil {
 				return err
 			}
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleB, 0); err != nil {
 				return err
 			}
+			if err := assertIPsWithHandle(calicoClient.IPAM(), handleB2, 0); err != nil {
+				return err
+			}
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleC, 1); err != nil {
 				return err
 			}
 
-			if err := assertNumBlocks(bc, 3); err != nil {
+			if err := assertNumBlocks(bc, 4); err != nil {
 				return err
 			}
 			return nil
@@ -318,33 +337,31 @@ var _ = Describe("kube-controllers metrics tests", func() {
 		// Assert that IPAM metrics have been updated. We should no longer have any allocations on NodeB, however
 		// the block should still exist. Since we don't release affinity until the block is empty, the block should
 		// still be affine to node-b.
-		notExpectedMetrics := []string{
-			`ipam_allocations_per_node{node="node-b"}`,
-			`ipam_blocks_per_node{node="node-c"}`,
-		}
-		expectedMetrics = []string{
-			`ipam_allocations_per_node{node="node-a"} 4`,
-			`ipam_allocations_per_node{node="node-c"} 2`,
-			`ipam_blocks_per_node{node="node-a"} 1`,
-			`ipam_blocks_per_node{node="node-b"} 1`,
-			`ipam_blocks_per_node{node="no_affinity"} 1`,
-			`ipam_allocations_borrowed_per_node{node="node-c"} 2`,
-		}
-		Eventually(func() error {
-			out, err = getMetrics(fmt.Sprintf("http://%s:9094/metrics", kubeControllers.IP))
-			Expect(err).NotTo(HaveOccurred())
-			for _, s := range expectedMetrics {
-				if !strings.Contains(out, s) {
-					return fmt.Errorf("Expected:\n%s\nTo contain metric:\n  %s\n", out, s)
-				}
-			}
-			for _, s := range notExpectedMetrics {
-				if strings.Contains(out, s) {
-					return fmt.Errorf("Expected:\n%s\nNOT to contain metric:\n  %s\n", out, s)
-				}
-			}
-			return nil
-		}, 5*time.Second).ShouldNot(HaveOccurred())
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-a"} 4`,
+				`ipam_allocations_in_use{ippool="no_pool",node="node-a"} 1`,
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-c"} 2`,
+				`ipam_allocations_per_node{node="node-a"} 5`,
+				`ipam_allocations_per_node{node="node-c"} 2`,
+				`ipam_blocks{ippool="test-ippool",node="node-a"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="node-b"} 1`,
+				`ipam_blocks{ippool="no_pool",node="no_affinity"} 1`,
+				`ipam_blocks{ippool="test-ippool",node="no_affinity"} 1`,
+				`ipam_blocks_per_node{node="node-a"} 1`,
+				`ipam_blocks_per_node{node="node-b"} 1`,
+				`ipam_blocks_per_node{node="no_affinity"} 2`,
+				`ipam_allocations_borrowed{ippool="test-ippool",node="node-c"} 2`,
+				`ipam_allocations_borrowed_per_node{node="node-c"} 2`,
+			},
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-b"}`,
+				`ipam_allocations_in_use{ippool="no_pool",node="node-b"}`,
+				`ipam_allocations_per_node{node="node-b"}`,
+			},
+			kubeControllers.IP,
+			5*time.Second,
+		)
 
 		// Deleting NodeC should clean up the second and third blocks since both node B and C
 		// are now gone.
@@ -357,7 +374,7 @@ var _ = Describe("kube-controllers metrics tests", func() {
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleC2, 0); err != nil {
 				return err
 			}
-			if err := assertNumBlocks(bc, 1); err != nil {
+			if err := assertNumBlocks(bc, 2); err != nil {
 				return err
 			}
 			return nil
@@ -365,39 +382,76 @@ var _ = Describe("kube-controllers metrics tests", func() {
 
 		// Assert that IPAM metrics have been updated. Both blocks should now be released, and all that should be
 		// left is the block and allocations for node A.
-		notExpectedMetrics = []string{
-			`ipam_allocations_per_node{node="node-c"}`,
-			`ipam_allocations_per_node{node="node-b"}`,
-			`ipam_blocks_per_node{node="node-b"}`,
-			`ipam_blocks_per_node{node="node-c"}`,
-			`ipam_blocks_per_node{node="no_affinity"}`,
-			`ipam_allocations_borrowed_per_node{node="node-c"}`,
-		}
-		expectedMetrics = []string{
-			`ipam_allocations_per_node{node="node-a"} 4`,
-			`ipam_blocks_per_node{node="node-a"} 1`,
-		}
-		Eventually(func() error {
-			out, err = getMetrics(fmt.Sprintf("http://%s:9094/metrics", kubeControllers.IP))
-			Expect(err).NotTo(HaveOccurred())
-			for _, s := range expectedMetrics {
-				if !strings.Contains(out, s) {
-					return fmt.Errorf("Expected:\n%s\nTo contain metric:\n  %s\n", out, s)
-				}
-			}
-			for _, s := range notExpectedMetrics {
-				if strings.Contains(out, s) {
-					return fmt.Errorf("Expected:\n%s\nNOT to contain metric:\n  %s\n", out, s)
-				}
-			}
-			return nil
-		}, 5*time.Second).ShouldNot(HaveOccurred())
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-a"} 4`,
+				`ipam_allocations_in_use{ippool="no_pool",node="node-a"} 1`,
+				`ipam_allocations_per_node{node="node-a"} 5`,
+				`ipam_blocks{ippool="test-ippool",node="node-a"} 1`,
+				`ipam_blocks{ippool="no_pool",node="no_affinity"} 1`,
+				`ipam_blocks_per_node{node="node-a"} 1`,
+				`ipam_blocks_per_node{node="no_affinity"} 1`,
+			},
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-c"}`,
+				`ipam_allocations_per_node{node="node-c"}`,
+				`ipam_blocks{ippool="test-ippool",node="node-b"}`,
+				`ipam_blocks{ippool="test-ippool",node="no_affinity"}`,
+				`ipam_blocks_per_node{node="node-b"}`,
+				`ipam_allocations_borrowed{ippool="test-ippool",node="node-c"}`,
+				`ipam_allocations_borrowed_per_node{node="node-c"}`,
+			},
+			kubeControllers.IP,
+			5*time.Second,
+		)
+
+		// Create an IP Pool that is analogous to the deleted pool 2.
+		createIPPool("test-ippool-2-analogue", "172.16.0.0/16", calicoClient)
+
+		// Validate that blocks and allocations are labelled with the analogue.
+		// Pool labels represent the pool occupied by the block and allocations.
+		validateExpectedAndUnexpectedMetrics(
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-a"} 4`,
+				`ipam_allocations_in_use{ippool="test-ippool-2-analogue",node="node-a"} 1`,
+				`ipam_allocations_per_node{node="node-a"} 5`,
+				`ipam_blocks{ippool="test-ippool",node="node-a"} 1`,
+				`ipam_blocks{ippool="test-ippool-2-analogue",node="no_affinity"} 1`,
+				`ipam_blocks_per_node{node="node-a"} 1`,
+				`ipam_blocks_per_node{node="no_affinity"} 1`,
+			},
+			[]string{
+				`ipam_allocations_in_use{ippool="no_pool",node="node-a"} 1`,
+				`ipam_blocks{ippool="no_pool",node="no_affinity"} 1`,
+			},
+			kubeControllers.IP,
+			5*time.Second,
+		)
 
 		// Deleting NodeA should clean up the final block and the remaining allocations within.
 		err = k8sClient.CoreV1().Nodes().Delete(context.Background(), nodeA, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		validateExpectedAndUnexpectedMetrics(
+			[]string{},
+			[]string{
+				`ipam_allocations_in_use{ippool="test-ippool",node="node-a"}`,
+				`ipam_allocations_in_use{ippool="test-ippool-2-analogue",node="node-a"}`,
+				`ipam_allocations_per_node{node="node-a"}`,
+				`ipam_blocks{ippool="test-ippool",node="node-a"}`,
+				`ipam_blocks{ippool="test-ippool-2-analogue",node="no_affinity"}`,
+				`ipam_blocks_per_node{node="node-a"}`,
+				`ipam_blocks_per_node{node="no_affinity"}`,
+			},
+			kubeControllers.IP,
+			5*time.Second,
+		)
+
 		Eventually(func() error {
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleA, 0); err != nil {
+				return err
+			}
+			if err := assertIPsWithHandle(calicoClient.IPAM(), handleA2, 0); err != nil {
 				return err
 			}
 			if err := assertIPsWithHandle(calicoClient.IPAM(), handleAIPIP, 0); err != nil {
@@ -447,4 +501,60 @@ func getMetrics(metricsURL string) (string, error) {
 		return "", err
 	}
 	return string(body), nil
+}
+
+func createNode(node string, k8sClient *kubernetes.Clientset) {
+	_, err := k8sClient.CoreV1().Nodes().Create(context.Background(),
+		&v1.Node{
+			TypeMeta:   metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: node},
+			Spec:       v1.NodeSpec{},
+		},
+		metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createIPPool(name string, cidr string, calicoClient client.Interface) {
+	p := api.NewIPPool()
+	p.Name = name
+	p.Spec.CIDR = cidr
+	p.Spec.BlockSize = 26
+	p.Spec.NodeSelector = "all()"
+	p.Spec.Disabled = false
+	_, err := calicoClient.IPPools().Create(context.Background(), p, options.SetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func allocatePodIpWithHandle(ip string, handle string, node string, pod string, calicoClient client.Interface) {
+	attrs := map[string]string{"node": node, "pod": pod, "namespace": "default"}
+	err := calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+		IP: net.MustParseIP(ip), HandleID: &handle, Attrs: attrs, Hostname: node,
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func allocateInterfaceIpWithHandle(ip string, handle string, node string, itype string, calicoClient client.Interface) {
+	attrs := map[string]string{"node": node, "type": itype}
+	err := calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+		IP: net.MustParseIP(ip), HandleID: &handle, Attrs: attrs, Hostname: node,
+	})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func validateExpectedAndUnexpectedMetrics(expectedMetrics []string, notExpectedMetrics []string, host string, intervals ...interface{}) {
+	Eventually(func() error {
+		out, err := getMetrics(fmt.Sprintf("http://%s:9094/metrics", host))
+		Expect(err).NotTo(HaveOccurred())
+		for _, s := range expectedMetrics {
+			if !strings.Contains(out, s) {
+				return fmt.Errorf("Expected:\n%s\nTo contain metric:\n  %s\n", out, s)
+			}
+		}
+		for _, s := range notExpectedMetrics {
+			if strings.Contains(out, s) {
+				return fmt.Errorf("Expected:\n%s\nNOT to contain metric:\n  %s\n", out, s)
+			}
+		}
+		return nil
+	}, intervals...).ShouldNot(HaveOccurred())
 }

--- a/kube-controllers/tests/fv/metrics_test.go
+++ b/kube-controllers/tests/fv/metrics_test.go
@@ -151,17 +151,46 @@ var _ = Describe("kube-controllers metrics tests", func() {
 		createNode(nodeB, k8sClient)
 		createNode(nodeC, k8sClient)
 
-		// Assert only pool size IPAM metrics are reported at this point.
+		// Metrics for pool size should be present, along with explicit zero values on allocation gauges for pool,node pairs
 		validateExpectedAndUnexpectedMetrics(
 			[]string{
 				`ipam_ippool_size{ippool="test-ippool-1"} 256`,
 				`ipam_ippool_size{ippool="test-ippool-2"} 65536`,
 				`ipam_ippool_size{ippool="test-ippool-3"} 256`,
+				`ipam_allocations_in_use{ippool="test-ippool-1",node="node-a"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-1",node="node-b"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-1",node="node-c"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-a"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-b"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-c"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-a"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-b"} 0`,
+				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-c"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-1",node="node-a"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-1",node="node-b"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-1",node="node-c"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-2",node="node-a"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-2",node="node-b"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-2",node="node-c"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-3",node="node-a"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-3",node="node-b"} 0`,
+				`ipam_allocations_borrowed{ippool="test-ippool-3",node="node-c"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-1",node="node-a"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-1",node="node-b"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-1",node="node-c"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-2",node="node-a"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-2",node="node-b"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-2",node="node-c"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-3",node="node-a"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-3",node="node-b"} 0`,
+				`ipam_allocations_gc_candidates{ippool="test-ippool-3",node="node-c"} 0`,
 			},
 			[]string{
-				`ipam_allocations_`,
+				// Block gauges, GC reclamation count, and legacy allocation gauges should be absent.
 				`ipam_blocks_`,
-				`ipam_gc_`,
+				`ipam_allocations_gc_reclamations`,
+				`ipam_allocations_per_node`,
+				`ipam_allocations_borrowed_per_node`,
 			},
 			kubeControllers.IP,
 			10*time.Second, 1*time.Second,
@@ -210,30 +239,6 @@ var _ = Describe("kube-controllers metrics tests", func() {
 				`ipam_blocks_per_node{node="node-a"} 2`,
 				`ipam_blocks_per_node{node="node-b"} 2`,
 				`ipam_blocks_per_node{node="node-c"} 1`,
-
-				// Pool-based allocation gauges explicitly return zero for ippool,node pairs
-				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-a"} 0`,
-				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-b"} 0`,
-				`ipam_allocations_in_use{ippool="test-ippool-2",node="node-c"} 0`,
-				`ipam_allocations_in_use{ippool="test-ippool-3",node="node-c"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-1",node="node-a"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-1",node="node-b"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-1",node="node-c"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-2",node="node-a"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-2",node="node-b"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-2",node="node-c"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-3",node="node-a"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-3",node="node-b"} 0`,
-				`ipam_allocations_borrowed{ippool="test-ippool-3",node="node-c"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-1",node="node-a"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-1",node="node-b"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-1",node="node-c"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-2",node="node-a"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-2",node="node-b"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-2",node="node-c"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-3",node="node-a"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-3",node="node-b"} 0`,
-				`ipam_allocations_gc_candidates{ippool="test-ippool-3",node="node-c"} 0`,
 			},
 			[]string{
 				`ipam_allocations_gc_reclamations`,
@@ -367,6 +372,7 @@ var _ = Describe("kube-controllers metrics tests", func() {
 				`ipam_allocations_borrowed_per_node{node="node-c"} 2`,
 			},
 			[]string{
+				// Ensure all pool gauges are no longer using the deleted pool labels
 				`ipam_ippool_size{ippool="test-ippool-2"}`,
 				`ipam_ippool_size{ippool="test-ippool-3"}`,
 				`ipam_allocations_in_use{ippool="test-ippool-2"`,
@@ -379,7 +385,15 @@ var _ = Describe("kube-controllers metrics tests", func() {
 				`ipam_allocations_gc_candidates{ippool="test-ippool-3"`,
 				`ipam_allocations_gc_reclamations{ippool="test-ippool-2"`,
 				`ipam_allocations_gc_reclamations{ippool="test-ippool-3"`,
+
+				// Counter clears rather than lose association
 				`ipam_allocations_gc_reclamations{ippool="no_ippool",node="node-a"}`,
+
+				// There should be no explicit zero values for the no_ippool label. This behaviour only makes
+				// sense for active IP pools.
+				`{ippool="no_ippool",node="node-a"} 0`,
+				`{ippool="no_ippool",node="node-b"} 0`,
+				`{ippool="no_ippool",node="node-c"} 0`,
 			},
 			kubeControllers.IP,
 			5*time.Second,

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -78,10 +78,10 @@ rules:
       - get
       - list
       - watch
-  # IPAM resources are manipulated when nodes are deleted.
+  # IPAM resources are manipulated in response to node and block updates, as well as periodic triggers.
   - apiGroups: ["crd.projectcalico.org"]
     resources:
-      - ippools
+      - ipreservations
     verbs:
       - list
   - apiGroups: ["crd.projectcalico.org"]
@@ -95,6 +95,13 @@ rules:
       - create
       - update
       - delete
+      - watch
+  # Pools are watched to maintain a mapping of blocks to IP pools.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
       - watch
   # kube-controllers manages hostendpoints.
   - apiGroups: ["crd.projectcalico.org"]


### PR DESCRIPTION
## Description
Implements new IPAM metrics within kube-controllers that enable tracking of allocations and garbage collection candidates by pool.

New metrics are tagged with pool and node where appropriate. Previous `*_per_node` allocation metrics remain in place for backwards compatibility.

Feature has been broken down into granular commits for review.

### Limitations
Currently, no metric tracks IPs that are not in use, yet not usable (e.g. reserved IPs in a block, IPs from a block with released affinity). We could consider adding an additional metric here to enable the most accurate calculations of 'free' IPs.

## Related issues/PRs
Fixes #5430.


## Todos

- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note
```release-note
```
