### PR TITLE
windows: use upstream k8s pause image

### DIFF
--- a/calico/getting-started/windows-calico/openshift/installation.md
+++ b/calico/getting-started/windows-calico/openshift/installation.md
@@ -256,14 +256,6 @@ cp c:\k\config c:\k\kubeconfig
 c:\wmcb.exe configure-cni --cni-dir c:\k\cni --cni-config c:\k\cni\config\10-calico.conf
 ```
 
-Then, we need to override the pod infra image used by kubelet. This is to ensure
-the pod infrastructure image used is using the same base Windows Server OS as
-the node. (For more details, see this {% include open-new-window.html text='upstream issue' url='https://github.com/kubernetes/kubernetes/issues/87339' %}.) 
-
-```powershell
-docker tag kubeletwin/pause mcr.microsoft.com/k8s/core/pause:1.2.0
-```
-
 Finally, clean up the additional files created on the Windows node:
 
 ```powershell

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -57,6 +57,24 @@ function PrepareKubernetes()
     DownloadFiles
     ipmo C:\k\hns.psm1
     InstallK8sBinaries
+
+    # Prepull and tag the pause image for docker
+    if (-not (Get-IsContainerdRunning)) {
+        # If containerd is not running we assume the installation should be
+        # configured for docker. But in this case, docker has to be running.
+        $svc = Get-Service | where Name -EQ 'docker'
+        if ($svc -EQ $null) {
+            Write-Host "Docker service is not installed. Cannot prepare kubernetes pause image."
+            exit 1
+        }
+        if ($svc.Status -NE 'Running') {
+            Write-Host "Docker service is not running. Cannot prepare kubernetes pause image. Run 'Start-Service docker' and try again."
+            exit 1
+        }
+        $pause = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
+        docker pull $pause
+        docker tag $pause kubeletwin/pause
+    }
 }
 
 function InstallK8sBinaries()
@@ -305,10 +323,6 @@ if (!(Test-Path $CalicoZip))
 
 $platform=GetPlatformType
 
-if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
-    PrepareKubernetes
-}
-
 if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
 Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
 Exit
@@ -318,6 +332,11 @@ Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
 Write-Host "Unzip Calico for Windows release..."
 Expand-Archive -Force $CalicoZip c:\
 ipmo $RootDir\libs\calico\calico.psm1
+
+# This comes after we import calico.psm1
+if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
+    PrepareKubernetes
+}
 
 Write-Host "Setup Calico for Windows..."
 SetConfigParameters -OldString '<your datastore type>' -NewString $Datastore

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -49,35 +49,13 @@ function DownloadFiles()
     md $BaseDir\cni\config -ErrorAction Ignore
 
     Write-Host "Downloading Windows Kubernetes scripts"
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -Destination $BaseDir\InstallImages.ps1
     DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
-}
-
-function PrepareDockerFile()
-{
-    # Update Dockerfile for windows
-    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
-    $OSNumber = $OSInfo.WindowsVersion
-    $ExistOSNumber = cat c:\k\Dockerfile | findstr.exe $OSNumber
-    if (!$ExistOSNumber)
-    {
-        Write-Host "Update dockerfile for $OSNumber"
-
-        $ImageWithOSNumber = "nanoserver:" + $OSNumber
-        (get-content c:\k\Dockerfile) | foreach-object {$_ -replace "nanoserver", "$ImageWithOSNumber"} | set-content c:\k\Dockerfile
-    }
 }
 
 function PrepareKubernetes()
 {
     DownloadFiles
-    PrepareDockerFile
     ipmo C:\k\hns.psm1
-
-    # Prepare POD infra Images
-    c:\k\InstallImages.ps1
-
     InstallK8sBinaries
 }
 

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -49,7 +49,7 @@ function DownloadFiles()
     md $BaseDir\cni\config -ErrorAction Ignore
 
     Write-Host "Downloading Windows Kubernetes scripts"
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
 }
 
 function PrepareKubernetes()

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -65,7 +65,7 @@ else
     $argList += "--cni-bin-dir=""c:\k\cni"""
     $argList += "--cni-conf-dir=""c:\k\cni\config"""
     $argList += "--network-plugin=cni"
-    $argList += "--pod-infra-container-image=mcr.microsoft.com/oss/kubernetes/pause:3.6"
+    $argList += "--pod-infra-container-image=kubeletwin/pause"
     $argList += "--image-pull-progress-deadline=20m"
 }
 

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -65,7 +65,7 @@ else
     $argList += "--cni-bin-dir=""c:\k\cni"""
     $argList += "--cni-conf-dir=""c:\k\cni\config"""
     $argList += "--network-plugin=cni"
-    $argList += "--pod-infra-container-image=k8s.gcr.io/pause:3.6"
+    $argList += "--pod-infra-container-image=mcr.microsoft.com/oss/kubernetes/pause:3.6"
     $argList += "--image-pull-progress-deadline=20m"
 }
 

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -65,7 +65,7 @@ else
     $argList += "--cni-bin-dir=""c:\k\cni"""
     $argList += "--cni-conf-dir=""c:\k\cni\config"""
     $argList += "--network-plugin=cni"
-    $argList += "--pod-infra-container-image=kubeletwin/pause"
+    $argList += "--pod-infra-container-image=k8s.gcr.io/pause:3.6"
     $argList += "--image-pull-progress-deadline=20m"
 }
 


### PR DESCRIPTION
## Description

Our Calico for Windows install includes building a pause image using an older version of the pause image Dockerfile. This particular version of the pause image doesn't include wincat.exe which is required for kubectl proxy.

With this change, when a new Windows version comes up we will need to bump our pause image to the latest k8s pause image that supports that version.

`mcr.microsoft.com/oss/kubernetes/pause:3.6` is the latest upstream pause image and appears to support pretty much all windows versions from 1809 onwards (EOL and current).

```
$ crane manifest mcr.microsoft.com/oss/kubernetes/pause:3.6 | grep os\.version
2022/03/04 16:16:44 No matching credentials were found for "mcr.microsoft.com/oss/kubernetes/pause", falling back on anonymous
            "os.version": "10.0.17763.2300"
            "os.version": "10.0.18362.1256"
            "os.version": "10.0.18363.1556"
            "os.version": "10.0.19041.1348"
            "os.version": "10.0.19042.1348"
            "os.version": "10.0.20348.350"
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
