### PR TITLE
Update Calico v3.22.1 to use operator v1.25.3

### DIFF
--- a/calico/_data/versions.yml
+++ b/calico/_data/versions.yml
@@ -2,7 +2,7 @@
   tigera-operator:
    image: tigera/operator
    registry: quay.io
-   version: v1.25.2
+   version: v1.25.3
   components:
      typha:
       version: v3.22.1


### PR DESCRIPTION
## Description
This PR bumps the operator release for Calico v3.22.1
See release notes: https://github.com/tigera/operator/releases/tag/v1.25.3

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
