### PR TITLE
Fix flake with multiple concurrent calls to map

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/projectcalico/calico/felix/ifacemonitor"
 
@@ -1957,6 +1958,7 @@ var _ = Describe("EndpointManager IPv4", endpointManagerTests(4))
 var _ = Describe("EndpointManager IPv6", endpointManagerTests(6))
 
 type testProcSys struct {
+	lock           sync.Mutex
 	state          map[string]string
 	pathsThatExist map[string]bool
 	Fail           bool
@@ -1967,6 +1969,8 @@ var (
 )
 
 func (t *testProcSys) write(path, value string) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
 	log.WithFields(log.Fields{
 		"path":  path,
 		"value": value,
@@ -1979,6 +1983,8 @@ func (t *testProcSys) write(path, value string) error {
 }
 
 func (t *testProcSys) stat(path string) (os.FileInfo, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
 	exists := t.pathsThatExist[path]
 	if exists {
 		return nil, nil
@@ -1988,6 +1994,8 @@ func (t *testProcSys) stat(path string) (os.FileInfo, error) {
 }
 
 func (t *testProcSys) checkState(expected map[string]string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
 	Expect(t.state).To(Equal(expected))
 }
 


### PR DESCRIPTION
## Description

Spotted concurrent map write in test code.   Just adding a lock around the accessor methods.  Some of the tests still access the data directly, but the data should be fixed by that point, otherwise the test is wrong.

```
goroutine 183 [running]: 06:28
20792runtime.throw({0x2ec7087, 0x58cdc0}) 06:28
20793	/usr/local/go-cgo/src/runtime/panic.go:1198 +0x71 fp=0xc001ac5750 sp=0xc001ac5720 pc=0x443f11 06:28
20794runtime.mapassign_faststr(0xc001d31260, 0xc000000004, {0xc001906690, 0x2e}) 06:28
20795	/usr/local/go-cgo/src/runtime/map_faststr.go:211 +0x39c fp=0xc001ac57b8 sp=0xc001ac5750 pc=0x42141c 06:28
20796github.com/projectcalico/calico/felix/dataplane/linux.(*testProcSys).write(0xc0027ed440, {0xc001906690, 0x2e}, {0x2fc1c18, 0x1}) 06:28
20797	/go/src/github.com/projectcalico/calico/felix/dataplane/linux/endpoint_mgr_test.go:2399 +0x1e7 fp=0xc001ac5950 sp=0xc001ac57b8 pc=0x2567507 06:28
20798github.com/projectcalico/calico/felix/dataplane/linux.(*testProcSys).write-fm({0xc001906690, 0x24}, {0x2fc1c18, 0x1}) 06:28
20799	/go/src/github.com/projectcalico/calico/felix/dataplane/linux/endpoint_mgr_test.go:2391 +0x3f fp=0xc001ac5988 sp=0xc001ac5950 pc=0x25ccd5f 06:28
20800github.com/projectcalico/calico/felix/dataplane/linux.(*vxlanManager).configureVXLANDevice(0xc000f8e800, 0x578, 0xc00295a440, 0x0) 06:28
20801	/go/src/github.com/projectcalico/calico/felix/dataplane/linux/vxlan_mgr.go:604 +0xcf0 fp=0xc001ac5d78 sp=0xc001ac5988 pc=0x2528f70 06:28
20802github.com/projectcalico/calico/felix/dataplane/linux.(*vxlanManager).KeepVXLANDeviceInSync(0xc000f8e800, 0x24e10e0, 0x0, 0xc00051dfb8) 06:28
20803	/go/src/github.com/projectcalico/calico/felix/dataplane/linux/vxlan_mgr.go:466 +0x43b fp=0xc001ac5fb0 sp=0xc001ac5d78 pc=0x2527dbb 06:28
20804github.com/projectcalico/calico/felix/dataplane/linux.glob..func15.3·dwrap·48() 06:28
20805	/go/src/github.com/projectcalico/calico/felix/dataplane/linux/vxlan_mgr_test.go:208 +0x32 fp=0xc001ac5fe0 sp=0xc001ac5fb0 pc=0x25a9f92 06:28
20806runtime.goexit() 06:28
20807	/usr/local/go-cgo/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc001ac5fe8 sp=0xc001ac5fe0 pc=0x477aa1 06:28
20808created by github.com/projectcalico/calico/felix/dataplane/linux.glob..func15.3 06:28
20809	/go/src/github.com/projectcalico/calico/felix/dataplane/linux/vxlan_mgr_test.go:208 +0xa5
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
