### PR TITLE
windows: fix the install zip file version

### DIFF
--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -20,8 +20,8 @@
 #>
 
 Param(
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/v3.22.0/",
-    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-v3.22.0.zip",
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/v3.22.1/",
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-v3.22.1.zip",
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $DownloadOnly="no",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",


### PR DESCRIPTION


## Description
This is a temporary fix for the current release version and anyone
installing calico for windows from our docs site.

This addresses #5749 partly; I'll put up a follow-up PR to fix how the windows install script is handled during the release process. As I commented in #5749, we should consider rolling back  [these](https://github.com/projectcalico/calico/commit/eab88ada71021d5abb4675f3789fd09f83e28af3) install script changes.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
