### PR TITLE
Automated cherry pick of #5515: Build pod2daemon binary statically

### DIFF
--- a/pod2daemon/Dockerfile.amd64
+++ b/pod2daemon/Dockerfile.amd64
@@ -43,6 +43,8 @@ LABEL name="Calico FlexVolume driver installer" \
 
 COPY --from=ubi /licenses /licenses
 COPY --from=ubi /bin /bin
+COPY --from=ubi /lib64 /lib64
+COPY --from=ubi /usr/lib64 /usr/lib64
 COPY --from=ubi /usr/bin /usr/bin
 COPY --from=ubi /usr/local/bin/flexvol.sh /usr/local/bin/flexvol.sh
 

--- a/pod2daemon/Dockerfile.amd64
+++ b/pod2daemon/Dockerfile.amd64
@@ -43,8 +43,6 @@ LABEL name="Calico FlexVolume driver installer" \
 
 COPY --from=ubi /licenses /licenses
 COPY --from=ubi /bin /bin
-COPY --from=ubi /lib64 /lib64
-COPY --from=ubi /usr/lib64 /usr/lib64
 COPY --from=ubi /usr/bin /usr/bin
 COPY --from=ubi /usr/local/bin/flexvol.sh /usr/local/bin/flexvol.sh
 

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -15,12 +15,9 @@ include ../lib.Makefile
 
 ###############################################################################
 
-# We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.
-ifeq ($(ARCH), $(filter $(ARCH),amd64))
-CGO_ENABLED=1
-else
+# We need CGO to leverage Boring SSL.  However, pod2daemon doesn't perform any crypto,
+# so we can disable it across the board.
 CGO_ENABLED=0
-endif
 
 SRC_FILES=$(shell find -name '*.go')
 

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -40,8 +40,6 @@ endif
 ###############################################################################
 # Building the binary
 ###############################################################################
-LDFLAGS=-ldflags "-linkmode=external -extldflags=-static"
-
 .PHONY: build-all
 ## Build the binaries for all architectures and platforms
 build-all: $(addprefix bin/flexvol-,$(VALIDARCHES))
@@ -56,7 +54,7 @@ bin/flexvol-armv7: ARCH=armv7
 bin/flexvol-ppc64le: ARCH=ppc64le
 bin/flexvol-s390x: ARCH=s390x
 bin/flexvol-%: $(SRC_FILES)
-	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) go build -tags osusergo,netgo -v -o bin/flexvol-$(ARCH) $(LDFLAGS) flexvol/flexvoldriver.go
+	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) go build -v -o bin/flexvol-$(ARCH) flexvol/flexvoldriver.go
 
 ###############################################################################
 # Building the image

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -43,6 +43,8 @@ endif
 ###############################################################################
 # Building the binary
 ###############################################################################
+LDFLAGS=-ldflags "-linkmode=external -extldflags=-static"
+
 .PHONY: build-all
 ## Build the binaries for all architectures and platforms
 build-all: $(addprefix bin/flexvol-,$(VALIDARCHES))
@@ -57,7 +59,7 @@ bin/flexvol-armv7: ARCH=armv7
 bin/flexvol-ppc64le: ARCH=ppc64le
 bin/flexvol-s390x: ARCH=s390x
 bin/flexvol-%: $(SRC_FILES)
-	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) go build -v -o bin/flexvol-$(ARCH) flexvol/flexvoldriver.go
+	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) go build -tags osusergo,netgo -v -o bin/flexvol-$(ARCH) $(LDFLAGS) flexvol/flexvoldriver.go
 
 ###############################################################################
 # Building the image


### PR DESCRIPTION
Cherry pick of #5515 on release-v3.22.

#5515: Build pod2daemon binary statically

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes #5356

I think we could probably disable CGO entirely for pod2daemon since it doesn't actually import any crypto code, which is the only reason we do compile with CGO (to use BoringSSL)

I'm keeping CGO_ENABLED=1 anyway and compiling statically just in case we do include SSL in the future we don't accidentally ship a non-fips-compliant build. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix dynamic build of pod2daemon which resulted in cryptic "no such file or directory" errors
```