### PR TITLE
Fix for performance drop with BPF dataplane

### DIFF
--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -114,7 +114,7 @@ skip_redir_ifindex:
 
 		struct bpf_fib_lookup fib_params = {
 			.family = 2, /* AF_INET */
-			.tot_len = bpf_ntohs(ctx->ip_header->tot_len),
+			.tot_len = 0,
 			.ifindex = ctx->skb->ingress_ifindex,
 			.l4_protocol = state->ip_proto,
 			.sport = bpf_htons(state->sport),

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -68,6 +68,7 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 			sizeof(struct udphdr) + sizeof(struct vxlanhdr);
 
 	ret = bpf_skb_adjust_room(ctx->skb, new_hdrsz, BPF_ADJ_ROOM_MAC,
+						  BPF_F_ADJ_ROOM_FIXED_GSO |
 						  BPF_F_ADJ_ROOM_ENCAP_L4_UDP |
 						  BPF_F_ADJ_ROOM_ENCAP_L3_IPV4 |
 						  BPF_F_ADJ_ROOM_ENCAP_L2(sizeof(struct ethhdr)));

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -68,7 +68,6 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 			sizeof(struct udphdr) + sizeof(struct vxlanhdr);
 
 	ret = bpf_skb_adjust_room(ctx->skb, new_hdrsz, BPF_ADJ_ROOM_MAC,
-						  BPF_F_ADJ_ROOM_FIXED_GSO |
 						  BPF_F_ADJ_ROOM_ENCAP_L4_UDP |
 						  BPF_F_ADJ_ROOM_ENCAP_L3_IPV4 |
 						  BPF_F_ADJ_ROOM_ENCAP_L2(sizeof(struct ethhdr)));

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -134,7 +134,7 @@ static CALI_BPF_INLINE int vxlan_v4_decap(struct __sk_buff *skb)
 	extra_hdrsz = sizeof(struct ethhdr) + sizeof(struct iphdr) +
 		sizeof(struct udphdr) + sizeof(struct vxlanhdr);
 
-	ret = bpf_skb_adjust_room(skb, -extra_hdrsz, BPF_ADJ_ROOM_MAC, 0);
+	ret = bpf_skb_adjust_room(skb, -extra_hdrsz, BPF_ADJ_ROOM_MAC | BPF_F_ADJ_ROOM_FIXED_GSO, 0);
 
 	return ret;
 }

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -160,6 +160,6 @@ static CALI_BPF_INLINE __u32 skb_ingress_ifindex(struct __sk_buff *skb)
 #endif
 }
 
-#define skb_is_gso(skb) ((skb)->gso_segs > 1)
+#define skb_is_gso(skb) ((skb)->gso_segs > 0)
 
 #endif /* __SKB_H__ */

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -160,6 +160,6 @@ static CALI_BPF_INLINE __u32 skb_ingress_ifindex(struct __sk_buff *skb)
 #endif
 }
 
-#define skb_is_gso(skb) ((skb)->gso_segs > 0)
+#define skb_is_gso(skb) ((skb)->gso_segs > 1)
 
 #endif /* __SKB_H__ */


### PR DESCRIPTION
## Description
This PR fixes some nodeports and tunnel MTU related issues: 

1) Pass tot_len as 0 during fib_lookup. If the tot_len is > 0, fib_lookup does MTU check and the kernel returns ICMP in the case of tunnelling.
2) Use BPF_F_ADJ_ROOM_FIXED_GSO during decap. This is to preserve the gso status of the skb. 

## Related issues/PRs
https://github.com/projectcalico/calico/issues/5575

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
