### PR TITLE
Fix some test flakes - use unique name for workloads in STs

### DIFF
--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -2545,8 +2545,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			clientset := getKubernetesClient()
 
-			// Now create a K8s pod.
-			name := "mypod-1"
+			// Create two k8s pods - for this test we want to ensure that the names for the pods
+			// look alike so make sure we handle pods with very similar names.
+			name2 := fmt.Sprintf("pod-%d", rand.Uint32())
+			name := fmt.Sprintf("%s1", name2)
 
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
 				&v1.Pod{
@@ -2633,8 +2635,6 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Now we create another pod with a very similar name.
-			name2 := "mypod"
-
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -3036,7 +3036,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			clientset := getKubernetesClient()
 
 			// Now create a K8s pod.
-			name := "mypod-1"
+			name := fmt.Sprintf("pod-%d", rand.Uint32())
 
 			ensureNamespace(clientset, testutils.K8S_TEST_NS)
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
@@ -3105,7 +3105,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			clientset := getKubernetesClient()
 
 			// Now create a K8s pod.
-			name := "mypod-1"
+			name := fmt.Sprintf("pod-%d", rand.Uint32())
 
 			ensureNamespace(clientset, testutils.K8S_TEST_NS)
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,

--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -88,7 +88,8 @@ func ensurePodDeleted(clientset *kubernetes.Clientset, ns string, podName string
 		podName,
 		metav1.DeleteOptions{
 			PropagationPolicy:  &fg,
-			GracePeriodSeconds: &zero})
+			GracePeriodSeconds: &zero,
+		})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for pod to disappear.
@@ -120,7 +121,8 @@ func ensureNodeDeleted(clientset *kubernetes.Clientset, nodeName string) {
 		nodeName,
 		metav1.DeleteOptions{
 			PropagationPolicy:  &fg,
-			GracePeriodSeconds: &zero})
+			GracePeriodSeconds: &zero,
+		})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Wait for node to disappear.
@@ -1113,9 +1115,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 		var nc types.NetConf
 		var netconf string
 		var pool1CIDR, pool2CIDR *net.IPNet
-		var pool1 = "50.60.0.0/28"
-		var pool2 = "60.70.0.0/28"
-		var numAddrsInPool = 16
+		pool1 := "50.60.0.0/28"
+		pool2 := "60.70.0.0/28"
+		numAddrsInPool := 16
 		var clientset *kubernetes.Clientset
 		var name string
 		var testNS string
@@ -1354,14 +1356,13 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			err = calicoClient.IPAM().ReleaseByHandle(context.Background(), handle)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-
 	})
 
 	Context("using calico-ipam with Namespace annotation and pod annotation", func() {
 		var nc types.NetConf
 		var netconf string
 		var ipPoolCIDR *net.IPNet
-		var pool1 = "50.70.0.0/16"
+		pool1 := "50.70.0.0/16"
 		var clientset *kubernetes.Clientset
 		var name string
 		var testNS string
@@ -1447,8 +1448,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 	Context("using calico-ipam specifying IP pools via pod annotation", func() {
 		var nc types.NetConf
 		var netconf string
-		var pool1 = "172.16.0.0/16"
-		var pool2 = "172.17.0.0/16"
+		pool1 := "172.16.0.0/16"
+		pool2 := "172.17.0.0/16"
 		var pool1CIDR, pool2CIDR *net.IPNet
 		var pool2Name string
 		var clientset *kubernetes.Clientset
@@ -1554,7 +1555,6 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-
 	})
 
 	Context("using floatingIPs annotation to assign a DNAT", func() {
@@ -2138,6 +2138,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			ncb, err := json.Marshal(nc)
 			Expect(err).NotTo(HaveOccurred())
 			netconf = string(ncb)
+
+			// Make sure the namespace exists.
+			ensureNamespace(clientset, testutils.K8S_TEST_NS)
 
 			// Create a new ipPool.
 			testutils.MustCreateNewIPPool(calicoClient, ipPool, false, false, true)
@@ -2768,7 +2771,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					saName,
 					metav1.DeleteOptions{
 						PropagationPolicy:  &fg,
-						GracePeriodSeconds: &zero})
+						GracePeriodSeconds: &zero,
+					})
 				Expect(err).NotTo(HaveOccurred())
 			}()
 
@@ -2921,8 +2925,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			name = fmt.Sprintf("run%d", rand.Uint32())
 			generateName := "test-gen-name"
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: name,
-					GenerateName: generateName},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         name,
+					GenerateName: generateName,
+				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
 						Name:  fmt.Sprintf("container-%s", name),
@@ -3128,7 +3134,6 @@ var _ = Describe("Kubernetes CNI tests", func() {
 	})
 
 	Describe("testConnection tests", func() {
-
 		It("successfully connects to the datastore", func(done Done) {
 			netconf := fmt.Sprintf(`
 			{
@@ -3198,9 +3203,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).To(HaveOccurred())
 			close(done)
 		}, 10)
-
 	})
-
 })
 
 func checkPodIPAnnotations(clientset *kubernetes.Clientset, ns, name, expectedIP, expectedIPs string) {

--- a/node/tests/st/utils/docker_host.py
+++ b/node/tests/st/utils/docker_host.py
@@ -15,6 +15,8 @@ import logging
 import json
 import os
 import re
+import random
+import string
 import tempfile
 import uuid
 import yaml
@@ -537,12 +539,14 @@ class DockerHost(object):
         """
         assert self._cleaned
 
-    def create_workload(self, name,
+    def create_workload(self, base_name,
                         image="busybox", network="bridge",
                         ip=None, labels=[], namespace=None):
         """
         Create a workload container inside this host container.
         """
+        name = base_name + "_" + \
+            ''.join([random.choice(string.ascii_letters) for ii in range(6)]).lower()
         workload = Workload(self, name, image=image, network=network,
                             ip=ip, labels=labels, namespace=namespace)
         self.workloads.add(workload)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This is a hopeful fix for a number of test flakes seen recently with the symptom "pod does not exist" appearing unexpectedly.

The cause is that re-use of the pod name causes race conditions where the same pod, created by a previous test, can still exist in the API at the time that the next test starts (i.e., when the test checks if it needs to create the pod), but be deleted by the time that the test actually goes to query the pod.

By using different names for each test, we remove the possibility that the pod resources will be shared across tests and thus resolve the issue with test ordering. 

An alternative fix might be to wait for pods to be deleted before continuing on to the next test, but that adds unnecessary wait time and inter-test dependency where there need not be any. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```