### PR TITLE
fix wireguard pkg files' build flags (#5746)

### DIFF
--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
+
 package wireguard
 
 import (

--- a/felix/wireguard/metrics_linux.go
+++ b/felix/wireguard/metrics_linux.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
+
 package wireguard
 
 import (

--- a/felix/wireguard/metrics_windows.go
+++ b/felix/wireguard/metrics_windows.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package wireguard
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+var _ prometheus.Collector = (*Metrics)(nil)
+
+type Metrics struct {
+}
+
+func (collector *Metrics) Describe(_ chan<- *prometheus.Desc) {
+}
+
+func (collector *Metrics) Collect(_ chan<- prometheus.Metric) {
+}
+
+func MustNewWireguardMetrics() *Metrics {
+	wg, err := NewWireguardMetrics()
+	if err != nil {
+		logrus.Panic(err)
+	}
+	return wg
+}
+
+func NewWireguardMetrics() (*Metrics, error) {
+	return &Metrics{}, nil
+}

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
+
 package wireguard
 
 import (


### PR DESCRIPTION
* fix wireguard pkg build flags
- also resolve differences between OSS <-> ent

* remove extra +build tags

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

cherry pick: https://github.com/projectcalico/calico/pull/5746

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
