### PR TITLE
Report health detail

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -226,7 +226,7 @@ blocks:
       - export KEYPAIR_NAME=${CLUSTER_NAME}
       - echo CLUSTER_NAME=${CLUSTER_NAME}
       - sudo apt-get install -y putty-tools
-      - git clone git@github.com:tigera/process.git ~/process
+      - git clone -b winfv-verbose git@github.com:tigera/process.git ~/process
       - cd felix
       - make bin/calico-felix.exe fv/win-fv.exe
     epilogue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -226,7 +226,7 @@ blocks:
       - export KEYPAIR_NAME=${CLUSTER_NAME}
       - echo CLUSTER_NAME=${CLUSTER_NAME}
       - sudo apt-get install -y putty-tools
-      - git clone -b winfv-verbose git@github.com:tigera/process.git ~/process
+      - git clone git@github.com:tigera/process.git ~/process
       - cd felix
       - make bin/calico-felix.exe fv/win-fv.exe
     epilogue:

--- a/felix/fv/health_test.go
+++ b/felix/fv/health_test.go
@@ -37,6 +37,7 @@ package fv_test
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"time"
@@ -465,7 +466,8 @@ func getHealthStatus(ip, port, endpoint string) func() int {
 			return statusErr
 		}
 		defer resp.Body.Close()
-		log.WithField("resp", resp).Info("Health response")
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.WithField("resp", resp).Infof("Health response:\n%v\n", string(body))
 		return resp.StatusCode
 	}
 }

--- a/felix/fv/winfv/policy_test.go
+++ b/felix/fv/winfv/policy_test.go
@@ -70,6 +70,7 @@ func kubectlExec(command string) error {
 		log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).WithError(err).Error("Error running kubectl command")
 		return err
 	}
+	log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).Info("kubectl command succeeded")
 	return nil
 }
 

--- a/felix/fv/winfv/policy_test.go
+++ b/felix/fv/winfv/policy_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -72,9 +71,9 @@ func kubectlExec(command string) error {
 		log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).WithError(err).Error("Error running kubectl command")
 		return err
 	}
-	if strings.Contains(stderr, "timed out") {
-		log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).WithError(err).Error("kubectl stderr indicates timeout")
-		return errors.New("timed out")
+	if stderr != "" {
+		log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).WithError(err).Error("kubectl stderr indicates error")
+		return errors.New("non-empty stderr")
 	}
 	log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).Info("kubectl command succeeded")
 	return nil

--- a/felix/fv/winfv/policy_test.go
+++ b/felix/fv/winfv/policy_test.go
@@ -16,8 +16,10 @@ package winfv_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -69,6 +71,10 @@ func kubectlExec(command string) error {
 	if err != nil {
 		log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).WithError(err).Error("Error running kubectl command")
 		return err
+	}
+	if strings.Contains(stderr, "timed out") {
+		log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).WithError(err).Error("kubectl stderr indicates timeout")
+		return errors.New("timed out")
 	}
 	log.WithFields(log.Fields{"stderr": stderr, "stdout": stdout}).Info("kubectl command succeeded")
 	return nil

--- a/libcalico-go/lib/health/health.go
+++ b/libcalico-go/lib/health/health.go
@@ -147,20 +147,6 @@ func NewHealthAggregator() *HealthAggregator {
 		reporters:    map[string]*reporterState{},
 		httpServeMux: http.NewServeMux(),
 	}
-	genResponse := func(rsp http.ResponseWriter, quality string, state bool, detail string) {
-		status := StatusBad
-		if state {
-			log.Debug("Health: " + quality)
-			status = StatusGood
-			if len(detail) == 0 {
-				status = StatusGoodNoContent
-			}
-		} else {
-			log.Warn("Health: not " + quality)
-		}
-		rsp.WriteHeader(status)
-		rsp.Write([]byte(detail))
-	}
 	aggregator.httpServeMux.HandleFunc("/readiness", func(rsp http.ResponseWriter, req *http.Request) {
 		log.Debug("GET /readiness")
 		summary := aggregator.Summary()
@@ -172,6 +158,21 @@ func NewHealthAggregator() *HealthAggregator {
 		genResponse(rsp, "live", summary.Live, summary.Detail)
 	})
 	return aggregator
+}
+
+func genResponse(rsp http.ResponseWriter, quality string, state bool, detail string) {
+	status := StatusBad
+	if state {
+		log.Debug("Health: " + quality)
+		status = StatusGood
+		if len(detail) == 0 {
+			status = StatusGoodNoContent
+		}
+	} else {
+		log.Warn("Health: not " + quality)
+	}
+	rsp.WriteHeader(status)
+	rsp.Write([]byte(detail))
 }
 
 // Summary calculates the current overall health for a HealthAggregator.

--- a/libcalico-go/lib/health/health.go
+++ b/libcalico-go/lib/health/health.go
@@ -15,19 +15,23 @@
 package health
 
 import (
+	"bytes"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 )
 
 // The HealthReport struct has slots for the levels of health that we monitor and aggregate.
 type HealthReport struct {
-	Live  bool
-	Ready bool
+	Live   bool
+	Ready  bool
+	Detail string
 }
 
 type reporterState struct {
@@ -144,27 +148,29 @@ func NewHealthAggregator() *HealthAggregator {
 		reporters:    map[string]*reporterState{},
 		httpServeMux: http.NewServeMux(),
 	}
-	aggregator.httpServeMux.HandleFunc("/readiness", func(rsp http.ResponseWriter, req *http.Request) {
-		log.Debug("GET /readiness")
+	genResponse := func(rsp http.ResponseWriter, quality string, state bool, detail string) {
 		status := StatusBad
-		if aggregator.Summary().Ready {
-			log.Debug("Health: ready")
+		if state {
+			log.Debug("Health: " + quality)
 			status = StatusGood
+			if len(detail) == 0 {
+				status = StatusGoodNoContent
+			}
 		} else {
-			log.Warn("Health: not ready")
+			log.Warn("Health: not " + quality)
 		}
 		rsp.WriteHeader(status)
+		rsp.Write([]byte(detail))
+	}
+	aggregator.httpServeMux.HandleFunc("/readiness", func(rsp http.ResponseWriter, req *http.Request) {
+		log.Debug("GET /readiness")
+		summary := aggregator.Summary()
+		genResponse(rsp, "ready", summary.Ready, summary.Detail)
 	})
 	aggregator.httpServeMux.HandleFunc("/liveness", func(rsp http.ResponseWriter, req *http.Request) {
 		log.Debug("GET /liveness")
-		status := StatusBad
-		if aggregator.Summary().Live {
-			log.Debug("Health: live")
-			status = StatusGood
-		} else {
-			log.Warn("Health: not live")
-		}
-		rsp.WriteHeader(status)
+		summary := aggregator.Summary()
+		genResponse(rsp, "live", summary.Live, summary.Detail)
 	})
 	return aggregator
 }
@@ -177,18 +183,49 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 	// In the absence of any reporters, default to indicating that we are both live and ready.
 	summary := &HealthReport{Live: true, Ready: true}
 
+	// Prepare a table to report detail.
+	var buf bytes.Buffer
+	table := tablewriter.NewWriter(&buf)
+	table.SetHeader([]string{"COMPONENT", "TIMEOUT", "LIVENESS", "READINESS", "DETAIL"})
+
 	// Now for each reporter...
 	for _, reporter := range aggregator.reporters {
 		log.WithField("reporter", reporter).Debug("Checking state of reporter")
+		livenessStr := "-"
 		if reporter.HasLivenessProblem() {
 			log.WithField("name", reporter.name).Warn("Reporter is not live.")
 			summary.Live = false
+			if reporter.TimedOut() {
+				livenessStr = "timed out"
+			} else {
+				livenessStr = "reporting non-live"
+			}
+		} else if reporter.reports.Live {
+			livenessStr = "reporting live"
 		}
+		readinessStr := "-"
 		if reporter.HasReadinessProblem() {
 			log.WithField("name", reporter.name).Warn("Reporter is not ready.")
 			summary.Ready = false
+			if reporter.TimedOut() {
+				readinessStr = "timed out"
+			} else {
+				readinessStr = "reporting non-ready"
+			}
+		} else if reporter.reports.Ready {
+			readinessStr = "reporting ready"
 		}
+		table.Append([]string{
+			reporter.name,
+			reporter.timeout.String(),
+			livenessStr,
+			readinessStr,
+			reporter.latest.Detail,
+		})
 	}
+
+	table.Render()
+	summary.Detail = strings.TrimSpace(buf.String())
 
 	// Summary status has changed so update previous status and log.
 	if aggregator.lastReport == nil || *summary != *aggregator.lastReport {
@@ -202,10 +239,14 @@ func (aggregator *HealthAggregator) Summary() *HealthReport {
 }
 
 const (
-	// The HTTP status that we use for 'ready' or 'live'.  204 means "No Content: The server
-	// successfully processed the request and is not returning any content."  (Kubernetes
+	// The HTTP status that we use for 'ready' or 'live', with detail content.  (Kubernetes
 	// interprets any 200<=status<400 as 'good'.)
-	StatusGood = 204
+	StatusGood = 200
+
+	// The HTTP status that we use for 'ready' or 'live', without any detail content.  204 means
+	// "No Content: The server successfully processed the request and is not returning any
+	// content."  (Kubernetes interprets any 200<=status<400 as 'good'.)
+	StatusGoodNoContent = 204
 
 	// The HTTP status that we use for 'not ready' or 'not live'.  503 means "Service
 	// Unavailable: The server is currently unavailable (because it is overloaded or down for

--- a/libcalico-go/lib/health/health.go
+++ b/libcalico-go/lib/health/health.go
@@ -132,7 +132,6 @@ func (aggregator *HealthAggregator) Report(name string, report *HealthReport) {
 		"lastReport": reporter.latest,
 	})
 
-	logCxt.Debug("New health report")
 	if reporter.latest != *report {
 		logCxt.Info("Health of component changed")
 		reporter.latest = *report


### PR DESCRIPTION
This change surfaces more detail about the internal components, within a given process such as
Felix, that contribute to that process's overall liveness and readiness state.  If a process is
reporting non-live, or non-ready, and it isn't immediately obvious why, this extra detail should
indicate where the problem is.

Here's an example for Felix during startup, when it hasn't yet managed to connect to the datastore:
```
+---------------+---------+----------------+---------------------+--------+
|   COMPONENT   | TIMEOUT |    LIVENESS    |      READINESS      | DETAIL |
+---------------+---------+----------------+---------------------+--------+
| felix-startup | 0s      | reporting live | reporting non-ready |        |
| int_dataplane | 20s     | reporting live | reporting non-ready |        |
+---------------+---------+----------------+---------------------+--------+
```

On the internal health API, this is provided as the `Detail` field of the report returned by
`HealthAggregator.Summary()`.  It's also now possible for individual health reporters to fill in
`Detail` when they make a report, and that would be shown in the "DETAIL" column.  (But no existing
coding sets any per-reporter `Detail` yet, as this commit has only just created the `Detail` field.)

On the HTTP endpoints `/liveness` and `/readiness`, this detail is provided as the body of the HTTP response.