### PR TITLE
[v3.22] Fix post-NAT IP port on SYN without NAT

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -271,6 +271,9 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 				/* Set DNAT info for policy */
 				ctx.state->post_nat_ip_dst = ctx.state->ct_result.nat_ip;
 				ctx.state->post_nat_dport = ctx.state->ct_result.nat_port;
+			} else {
+				ctx.state->post_nat_ip_dst = ctx.state->ip_dst;
+				ctx.state->post_nat_dport = ctx.state->dport;
 			}
 			goto syn_force_policy;
 		}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Backports #5768

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF mode: Fix that policy would see 0.0.0.0:0 as the post-nat destination for SYN packets that had a conntrack hit.
```
