### PR TITLE
Rework interface monitor to fix various issues

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -373,7 +373,7 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
 
-	if update.State == ifacemonitor.StateUnknown {
+	if update.State == ifacemonitor.StateNotPresent {
 		if err := bpf.ForgetIfaceAttachedProg(update.Name); err != nil {
 			log.WithError(err).Errorf("Error in removing interface %s json file. err=%v", update.Name, err)
 		}

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -467,6 +467,17 @@ var _ = Describe("BPF Endpoint Manager", func() {
 					}]).NotTo(HaveKey("eth0"))
 				})
 			})
+			Context("with eth0 deleted", func() {
+				JustBeforeEach(genIfaceUpdate("eth0", ifacemonitor.StateNotPresent, 10))
+
+				It("clears host endpoint for eth0", func() {
+					Expect(bpfEpMgr.hostIfaceToEpMap).To(BeEmpty())
+					Expect(bpfEpMgr.policiesToWorkloads[proto.PolicyID{
+						Tier: "default",
+						Name: "mypolicy",
+					}]).NotTo(HaveKey("eth0"))
+				})
+			})
 		})
 	})
 })

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1002,16 +1002,17 @@ type ifaceUpdate struct {
 	Index int
 }
 
-// Check if current felix ipvs config is correct when felix gets an kube-ipvs0 interface update.
+// Check if current felix ipvs config is correct when felix gets a kube-ipvs0 interface update.
 // If KubeIPVSInterface is UP and felix ipvs support is disabled (kube-proxy switched from iptables to ipvs mode),
 // or if KubeIPVSInterface is DOWN and felix ipvs support is enabled (kube-proxy switched from ipvs to iptables mode),
 // restart felix to pick up correct ipvs support mode.
 func (d *InternalDataplane) checkIPVSConfigOnStateUpdate(state ifacemonitor.State) {
-	if (!d.config.RulesConfig.KubeIPVSSupportEnabled && state == ifacemonitor.StateUp) ||
-		(d.config.RulesConfig.KubeIPVSSupportEnabled && state == ifacemonitor.StateDown) {
+	ipvsIfacePresent := state != ifacemonitor.StateNotPresent
+	ipvsSupportEnabled := d.config.RulesConfig.KubeIPVSSupportEnabled
+	if ipvsSupportEnabled != ipvsIfacePresent {
 		log.WithFields(log.Fields{
 			"ipvsIfaceState": state,
-			"ipvsSupport":    d.config.RulesConfig.KubeIPVSSupportEnabled,
+			"ipvsSupport":    ipvsSupportEnabled,
 		}).Info("kube-proxy mode changed. Restart felix.")
 		d.config.ConfigChangedRestartCallback()
 	}

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -262,7 +262,7 @@ func (w *Wireguard) OnIfaceStateChanged(ifaceName string, state ifacemonitor.Sta
 			w.ifaceUp = true
 			w.inSyncWireguard = false
 		}
-	case ifacemonitor.StateDown:
+	default: /* StateDown or StateNotPresent */
 		logCxt.Debug("Interface down")
 		w.ifaceUp = false
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Previously, the iface monitor used "down" to mean two things:

- Interface was previously signalled as "up" and now it has gone  "oper down".
- Interface was previously signalled as "up" and now it has been  deleted.

It never signalled "down" interfaces that had never previously been "up".

This was confusing and resulted in mismatched expectations in the (Enterprise) AWS IP manager, which was expecting "down" interfaces to be signalled (so that it could bring them "up").

Standardise on signalling:

- "up" for present, "oper up" interfaces.
- "down" for present, "oper down" interfaces.
- "" for deleted interfaces.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

https://tigera.atlassian.net/browse/BPF-1749

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Rework Felix's interface monitoring logic.  Fixes a couple of bugs where interface state changes wouldn't be noticed: kube-proxy being switched ti IPVS mode could go unnoticed; BPF mode would sometimes fail to clean up status tracking files when an interface was removed.
```
