### PR TITLE
fix the panic of SetupRoutes in csi-plugin

### DIFF
--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -352,7 +352,7 @@ func SetupRoutes(hostVeth netlink.Link, result *cniv1.Result) error {
 				var conflict string
 
 				for _, r := range routes {
-					if r.Dst.IP.Equal(route.Dst.IP) {
+					if r.Dst != nil && r.Dst.IP.Equal(route.Dst.IP) {
 						linkName := "unknown"
 						if link, err := netlink.LinkByIndex(r.LinkIndex); err == nil {
 							linkName = link.Attrs().Name


### PR DESCRIPTION
## Description
When the IP allocation conflicts, and the network card name occupying the IP is inconsistent with the network card name of the Pod, it will cause panic.

The setupRoutes function will get all the routes and configure the IP. Default route does not have dst information(dst = nil), and referencing dst.IP directly will panic.

## Related issues/PRs
ISSUE LINK: (https://github.com/projectcalico/calico/issues/5779)

```release-note
Fix potential panic in CNI plugin due to conflicting host routes
```