### PR TITLE
Fix that second call to shutdown hook would block.

### DIFF
--- a/felix/fv/config_update_test.go
+++ b/felix/fv/config_update_test.go
@@ -185,7 +185,7 @@ var _ = Context("Config update tests, after starting felix", func() {
 	})
 
 	Context("after switching kube-proxy mode that should trigger a restart", func() {
-		// This test simulate kube-proxy switching between iptables to ipvs mode by adding/removing
+		// This test simulates kube-proxy switching between iptables to ipvs mode by adding/removing
 		// kube-ipvs0 dummy interface.
 		var proxy *kubeProxy
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Continue draining the channel after starting shut down. This prevents deadlock between
threads that are doing graceful shutdown and the main loop.  The deadlock was
handled with a timeout but the end result was to extend the normal 2s timeout to 30s,
which causes flakes in the FV tests.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Issue was exposed by #5776 since the kube-proxy IPVS logic can trigger twice after that change.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
