### PR TITLE
Use void pointer for ip_header in bpf context

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -280,7 +280,7 @@ static CALI_BPF_INLINE bool skb_icmp_err_unpack(struct cali_tc_ctx *ctx, struct 
 	}
 
 	struct iphdr *ip_inner;
-	ip_inner = (struct iphdr *)(tc_icmphdr(ctx) + 1); /* skip to inner ip */
+	ip_inner = (struct iphdr *)(icmphdr(ctx) + 1); /* skip to inner ip */
 	CALI_DEBUG("CT-ICMP: proto %d\n", ip_inner->protocol);
 
 	ct_ctx->proto = ip_inner->protocol;
@@ -416,7 +416,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			CALI_DEBUG("Too short\n");
 			bpf_exit(TC_ACT_SHOT);
 		}
-		ct_lookup_ctx.tcp = tc_tcphdr(tc_ctx);
+		ct_lookup_ctx.tcp = tcphdr(tc_ctx);
 	}
 
 	__u8 proto_orig = ct_ctx->proto;
@@ -482,10 +482,10 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			goto out_lookup_fail;
 		}
 
-		if (!icmp_type_is_err(tc_icmphdr(tc_ctx)->type)) {
+		if (!icmp_type_is_err(icmphdr(tc_ctx)->type)) {
 			// ICMP but not an error response packet.
 			CALI_DEBUG("CT-ICMP: type %d not an error\n",
-					tc_icmphdr(tc_ctx)->type);
+					icmphdr(tc_ctx)->type);
 			goto out_lookup_fail;
 		}
 

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -146,7 +146,7 @@ skip_redir_ifindex:
 			 * IP stack handle it. It was approved by policy, so it
 			 * is safe.
 			 */
-			if ip_ttl_exceeded(ctx->ip_header) {
+			if ip_ttl_exceeded(ipv4hdr(ctx)) {
 				rc = TC_ACT_UNSPEC;
 				goto cancel_fib;
 			}
@@ -161,7 +161,7 @@ skip_redir_ifindex:
 			rc = bpf_redirect(fib_params.ifindex, 0);
 			/* now we know we will bypass IP stack and ip->ttl > 1, decrement it! */
 			if (rc == TC_ACT_REDIRECT) {
-				ip_dec_ttl(ctx->ip_header);
+				ip_dec_ttl(ipv4hdr(ctx));
 			}
 		} else if (rc < 0) {
 			CALI_DEBUG("FIB lookup failed (bad input): %d.\n", rc);

--- a/felix/bpf-gpl/icmp.h
+++ b/felix/bpf-gpl/icmp.h
@@ -100,10 +100,10 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 	ipv4hdr(ctx)->saddr = INTF_IP;
 	ipv4hdr(ctx)->daddr = ip_orig.saddr;
 
-	tc_icmphdr(ctx)->type = type;
-	tc_icmphdr(ctx)->code = code;
-	*((__be32 *)&tc_icmphdr(ctx)->un) = un;
-	tc_icmphdr(ctx)->checksum = 0;
+	icmphdr(ctx)->type = type;
+	icmphdr(ctx)->code = code;
+	*((__be32 *)&icmphdr(ctx)->un) = un;
+	icmphdr(ctx)->checksum = 0;
 
 	__wsum ip_csum = bpf_csum_diff(0, 0, ctx->ip_header, IPv4_SIZE, 0);
 	__wsum icmp_csum = bpf_csum_diff(0, 0, ctx->nh,

--- a/felix/bpf-gpl/icmp.h
+++ b/felix/bpf-gpl/icmp.h
@@ -26,9 +26,9 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 		return -1;
 	}
 
-	struct iphdr ip_orig = *ctx->ip_header;
-	CALI_DEBUG("ip->ihl: %d\n", ctx->ip_header->ihl);
-	if (ctx->ip_header->ihl > 5) {
+	struct iphdr ip_orig = *ipv4hdr(ctx);
+	CALI_DEBUG("ip->ihl: %d\n", ipv4hdr(ctx)->ihl);
+	if (ipv4hdr(ctx)->ihl > 5) {
 		CALI_DEBUG("ICMP v4 reply: IP options\n");
 		return -1;
 	}
@@ -37,7 +37,7 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 	 * part-way through the UDP/TCP header.
 	 */
 	__u32 len = skb_iphdr_offset() + sizeof(struct iphdr) + 64;
-	switch (ctx->ip_header->protocol) {
+	switch (ipv4hdr(ctx)->protocol) {
 	case IPPROTO_TCP:
 		len += sizeof(struct tcphdr);
 		break;
@@ -78,13 +78,13 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 	/* we do not touch ethhdr, we rely on linux to rewrite it after routing
 	 * XXX we might want to swap MACs and bounce it back from the same device
 	 */
-	ctx->ip_header->version = 4;
-	ctx->ip_header->ihl = 5;
-	ctx->ip_header->tos = 0;
-	ctx->ip_header->ttl = 64; /* good default */
-	ctx->ip_header->protocol = IPPROTO_ICMP;
-	ctx->ip_header->check = 0;
-	ctx->ip_header->tot_len = bpf_htons(len - sizeof(struct ethhdr));
+	ipv4hdr(ctx)->version = 4;
+	ipv4hdr(ctx)->ihl = 5;
+	ipv4hdr(ctx)->tos = 0;
+	ipv4hdr(ctx)->ttl = 64; /* good default */
+	ipv4hdr(ctx)->protocol = IPPROTO_ICMP;
+	ipv4hdr(ctx)->check = 0;
+	ipv4hdr(ctx)->tot_len = bpf_htons(len - sizeof(struct ethhdr));
 
 #ifdef CALI_PARANOID
 	/* XXX verify that ip_orig.daddr is always the node's IP
@@ -97,17 +97,17 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 #endif
 
 	/* use the host IP of the program that handles the packet */
-	ctx->ip_header->saddr = INTF_IP;
-	ctx->ip_header->daddr = ip_orig.saddr;
+	ipv4hdr(ctx)->saddr = INTF_IP;
+	ipv4hdr(ctx)->daddr = ip_orig.saddr;
 
 	tc_icmphdr(ctx)->type = type;
 	tc_icmphdr(ctx)->code = code;
 	*((__be32 *)&tc_icmphdr(ctx)->un) = un;
 	tc_icmphdr(ctx)->checksum = 0;
 
-	__wsum ip_csum = bpf_csum_diff(0, 0, (void *)ctx->ip_header, sizeof(*ctx->ip_header), 0);
+	__wsum ip_csum = bpf_csum_diff(0, 0, ctx->ip_header, IPv4_SIZE, 0);
 	__wsum icmp_csum = bpf_csum_diff(0, 0, ctx->nh,
-		len - sizeof(struct iphdr) - skb_iphdr_offset(), 0);
+		len - IPv4_SIZE - skb_iphdr_offset(), 0);
 
 	ret = bpf_l3_csum_replace(ctx->skb,
 			skb_iphdr_offset() + offsetof(struct iphdr, check), 0, ip_csum, 0);
@@ -123,7 +123,6 @@ static CALI_BPF_INLINE int icmp_v4_reply(struct cali_tc_ctx *ctx,
 	}
 
 	CALI_DEBUG("ICMP v4 reply creation succeeded\n");
-
 	return 0;
 }
 

--- a/felix/bpf-gpl/metadata.h
+++ b/felix/bpf-gpl/metadata.h
@@ -53,9 +53,9 @@ static CALI_BPF_INLINE int xdp2tc_set_metadata(struct xdp_md *xdp, __u32 flags) 
 		goto error;
 	}
 
-	CALI_DEBUG("IP TOS: %d\n", ctx.ip_header->tos);
-	ctx.ip_header->tos |= CALI_META_ACCEPTED_BY_XDP;
-	CALI_DEBUG("Set IP TOS: %d\n", ctx.ip_header->tos);
+	CALI_DEBUG("IP TOS: %d\n", ipv4hdr(&ctx)->tos);
+	ipv4hdr(&ctx)->tos |= CALI_META_ACCEPTED_BY_XDP;
+	CALI_DEBUG("Set IP TOS: %d\n", ipv4hdr(&ctx)->tos);
 	goto metadata_ok;
 #endif
 	} else {
@@ -93,12 +93,12 @@ static CALI_BPF_INLINE __u32 xdp2tc_get_metadata(struct __sk_buff *skb) {
 		goto no_metadata;
 	}
 
-	CALI_DEBUG("IP TOS: %d\n", ctx.ip_header->tos);
+	CALI_DEBUG("IP TOS: %d\n", ipv4hdr(&ctx)->tos);
 	struct cali_metadata unittest_metadata = {};
-	unittest_metadata.flags = ctx.ip_header->tos;
+	unittest_metadata.flags = ipv4hdr(&ctx)->tos;
 	metadata = &unittest_metadata;
-	ctx.ip_header->tos &= (~CALI_META_ACCEPTED_BY_XDP);
-	CALI_DEBUG("Set IP TOS: %d\n", ctx.ip_header->tos);
+	ipv4hdr(&ctx)->tos &= (~CALI_META_ACCEPTED_BY_XDP);
+	CALI_DEBUG("Set IP TOS: %d\n", ipv4hdr(&ctx)->tos);
 	goto metadata_ok;
 #endif /* UNITTEST */
 	} else {

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -92,20 +92,20 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	/* Copy the original IP header. Since it is already DNATed, the dest IP is
 	 * already set. All we need to do is to change the source IP
 	 */
-	*ctx->ip_header = *ip_inner;
+	*ipv4hdr(ctx) = *ip_inner;
 
 	/* decrement TTL for the inner IP header. TTL must be > 1 to get here */
 	ip_dec_ttl(ip_inner);
 
-	ctx->ip_header->saddr = ip_src;
-	ctx->ip_header->daddr = ip_dst;
-	ctx->ip_header->tot_len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) + new_hdrsz);
-	ctx->ip_header->ihl = 5; /* in case there were options in ip_inner */
-	ctx->ip_header->check = 0;
-	ctx->ip_header->protocol = IPPROTO_UDP;
+	ipv4hdr(ctx)->saddr = ip_src;
+	ipv4hdr(ctx)->daddr = ip_dst;
+	ipv4hdr(ctx)->tot_len = bpf_htons(bpf_ntohs(ipv4hdr(ctx)->tot_len) + new_hdrsz);
+	ipv4hdr(ctx)->ihl = 5; /* in case there were options in ip_inner */
+	ipv4hdr(ctx)->check = 0;
+	ipv4hdr(ctx)->protocol = IPPROTO_UDP;
 
 	tc_udphdr(ctx)->source = tc_udphdr(ctx)->dest = bpf_htons(VXLAN_PORT);
-	tc_udphdr(ctx)->len = bpf_htons(bpf_ntohs(ctx->ip_header->tot_len) - sizeof(struct iphdr));
+	tc_udphdr(ctx)->len = bpf_htons(bpf_ntohs(ipv4hdr(ctx)->tot_len) - IPv4_SIZE);
 
 	*((__u8*)&vxlan->flags) = 1 << 3; /* set the I flag to make the VNI valid */
 	vxlan->vni = bpf_htonl(CALI_VXLAN_VNI) >> 8; /* it is actually 24-bit, last 8 reserved */
@@ -113,11 +113,11 @@ static CALI_BPF_INLINE int vxlan_v4_encap(struct cali_tc_ctx *ctx,  __be32 ip_sr
 	/* keep eth_inner MACs zeroed, it is useless after decap */
 	eth_inner->h_proto = tc_ethhdr(ctx)->h_proto;
 
-	CALI_DEBUG("vxlan encap %x : %x\n", bpf_ntohl(ctx->ip_header->saddr), bpf_ntohl(ctx->ip_header->daddr));
+	CALI_DEBUG("vxlan encap %x : %x\n", bpf_ntohl(ipv4hdr(ctx)->saddr), bpf_ntohl(ipv4hdr(ctx)->daddr));
 
 	/* change the checksums last to avoid pointer access revalidation */
 
-	csum = bpf_csum_diff(0, 0, (void *)ctx->ip_header, sizeof(struct iphdr), 0);
+	csum = bpf_csum_diff(0, 0, ctx->ip_header, IPv4_SIZE, 0);
 	ret = bpf_l3_csum_replace(ctx->skb, ((long) ctx->ip_header) - ((long) skb_start_ptr(ctx->skb)) +
 				  offsetof(struct iphdr, check), 0, csum, 0);
 
@@ -197,10 +197,10 @@ static CALI_BPF_INLINE bool vxlan_v4_encap_too_big(struct cali_tc_ctx *ctx)
 static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 	/* decap on host ep only if directly for the node */
 	CALI_DEBUG("VXLAN tunnel packet to %x (host IP=%x)\n",
-		bpf_ntohl(ctx->ip_header->daddr),
+		bpf_ntohl(ipv4hdr(ctx)->daddr),
 		bpf_ntohl(HOST_IP));
 
-	if (!rt_addr_is_local_host(ctx->ip_header->daddr)) {
+	if (!rt_addr_is_local_host(ipv4hdr(ctx)->daddr)) {
 		goto fall_through;
 	}
 	if (!vxlan_size_ok(ctx)) {
@@ -211,14 +211,14 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 		goto fall_through;
 	}
 	if (vxlan_vni(ctx) != CALI_VXLAN_VNI) {
-		if (rt_addr_is_remote_host(ctx->ip_header->saddr)) {
+		if (rt_addr_is_remote_host(ipv4hdr(ctx)->saddr)) {
 			/* Not BPF-generated VXLAN packet but it was from a Calico host to this node. */
 			goto auto_allow;
 		}
 		/* Not our VNI, not from Calico host. Fall through to policy. */
 		goto fall_through;
 	}
-	if (!rt_addr_is_remote_host(ctx->ip_header->saddr)) {
+	if (!rt_addr_is_remote_host(ipv4hdr(ctx)->saddr)) {
 		CALI_DEBUG("VXLAN with our VNI from unexpected source.\n");
 		ctx->fwd.reason = CALI_REASON_UNAUTH_SOURCE;
 		goto deny;
@@ -230,7 +230,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 		goto deny;
 	}
 
-	ctx->arpk.ip = ctx->ip_header->saddr;
+	ctx->arpk.ip = ipv4hdr(ctx)->saddr;
 	ctx->arpk.ifindex = ctx->skb->ifindex;
 
 	/* We update the map straight with the packet data, eth header is
@@ -240,7 +240,7 @@ static CALI_BPF_INLINE int vxlan_attempt_decap(struct cali_tc_ctx *ctx) {
 	cali_v4_arp_update_elem(&ctx->arpk, tc_ethhdr(ctx), 0);
 	CALI_DEBUG("ARP update for ifindex %d ip %x\n", ctx->arpk.ifindex, bpf_ntohl(ctx->arpk.ip));
 
-	ctx->state->tun_ip = ctx->ip_header->saddr;
+	ctx->state->tun_ip = ipv4hdr(ctx)->saddr;
 	CALI_DEBUG("vxlan decap\n");
 	if (vxlan_v4_decap(ctx->skb)) {
 		ctx->fwd.reason = CALI_REASON_DECAP_FAIL;

--- a/felix/bpf-gpl/parsing.h
+++ b/felix/bpf-gpl/parsing.h
@@ -27,7 +27,7 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 			CALI_DEBUG("Too short\n");
 			goto deny;
 		}
-		protocol = bpf_ntohs(tc_ethhdr(ctx)->h_proto);
+		protocol = bpf_ntohs(ethhdr(ctx)->h_proto);
 	} else {
 		protocol = bpf_ntohs(ctx->skb->protocol);
 	}
@@ -125,14 +125,14 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx)
 			CALI_DEBUG("Too short\n");
 			goto deny;
 		}
-		ctx->state->sport = bpf_ntohs(tc_tcphdr(ctx)->source);
-		ctx->state->dport = bpf_ntohs(tc_tcphdr(ctx)->dest);
+		ctx->state->sport = bpf_ntohs(tcphdr(ctx)->source);
+		ctx->state->dport = bpf_ntohs(tcphdr(ctx)->dest);
 		ctx->state->pre_nat_dport = ctx->state->dport;
 		CALI_DEBUG("TCP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
 		break;
 	case IPPROTO_UDP:
-		ctx->state->sport = bpf_ntohs(tc_udphdr(ctx)->source);
-		ctx->state->dport = bpf_ntohs(tc_udphdr(ctx)->dest);
+		ctx->state->sport = bpf_ntohs(udphdr(ctx)->source);
+		ctx->state->dport = bpf_ntohs(udphdr(ctx)->dest);
 		ctx->state->pre_nat_dport = ctx->state->dport;
 		CALI_DEBUG("UDP; ports: s=%d d=%d\n", ctx->state->sport, ctx->state->dport);
 		if (ctx->state->dport == VXLAN_PORT) {
@@ -152,11 +152,11 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx)
 		}
 		break;
 	case IPPROTO_ICMP:
-		ctx->state->icmp_type = tc_icmphdr(ctx)->type;
-		ctx->state->icmp_code = tc_icmphdr(ctx)->code;
+		ctx->state->icmp_type = icmphdr(ctx)->type;
+		ctx->state->icmp_code = icmphdr(ctx)->code;
 
 		CALI_DEBUG("ICMP; type=%d code=%d\n",
-				tc_icmphdr(ctx)->type, tc_icmphdr(ctx)->code);
+				icmphdr(ctx)->type, icmphdr(ctx)->code);
 		break;
 	case IPPROTO_IPIP:
 		if (CALI_F_TUNNEL | CALI_F_WIREGUARD) {

--- a/felix/bpf-gpl/parsing.h
+++ b/felix/bpf-gpl/parsing.h
@@ -74,15 +74,15 @@ static CALI_BPF_INLINE int parse_packet_ip(struct cali_tc_ctx *ctx) {
 	}
 
 	// Drop malformed IP packets
-	if (ctx->ip_header->ihl < 5) {
+	if (ipv4hdr(ctx)->ihl < 5) {
 		ctx->fwd.reason = CALI_REASON_IP_MALFORMED;
 		CALI_DEBUG("Drop malformed IP packets\n");
 		goto deny;
-	} else if (ctx->ip_header->ihl > 5) {
+	} else if (ipv4hdr(ctx)->ihl > 5) {
 		/* Drop packets with IP options from/to WEP.
 		 * Also drop packets with IP options if the dest IP is not host IP
 		 */
-		if (CALI_F_WEP || (CALI_F_FROM_HEP && !rt_addr_is_local_host(ctx->ip_header->daddr))) {
+		if (CALI_F_WEP || (CALI_F_FROM_HEP && !rt_addr_is_local_host(ipv4hdr(ctx)->daddr))) {
 			ctx->fwd.reason = CALI_REASON_IP_OPTIONS;
 			CALI_DEBUG("Drop packets with IP options\n");
 			goto deny;
@@ -106,11 +106,11 @@ deny:
 
 static CALI_BPF_INLINE void tc_state_fill_from_iphdr(struct cali_tc_ctx *ctx)
 {
-	ctx->state->ip_src = ctx->ip_header->saddr;
-	ctx->state->ip_dst = ctx->ip_header->daddr;
-	ctx->state->pre_nat_ip_dst = ctx->ip_header->daddr;
-	ctx->state->ip_proto = ctx->ip_header->protocol;
-	ctx->state->ip_size = ctx->ip_header->tot_len;
+	ctx->state->ip_src = ipv4hdr(ctx)->saddr;
+	ctx->state->ip_dst = ipv4hdr(ctx)->daddr;
+	ctx->state->pre_nat_ip_dst = ipv4hdr(ctx)->daddr;
+	ctx->state->ip_proto = ipv4hdr(ctx)->protocol;
+	ctx->state->ip_size = ipv4hdr(ctx)->tot_len;
 }
 
 /* Continue parsing packet based on the IP protocol and fill in relevant fields

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -636,7 +636,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 			 * WARNING: this modifies the ip_header pointer in the main context; need to
 			 * be careful in later code to avoid overwriting that. */
 			l3_csum_off += IPv4_SIZE + sizeof(struct icmphdr);
-			ctx->ip_header = (tc_icmphdr(ctx) + 1); /* skip to inner ip */
+			ctx->ip_header = (icmphdr(ctx) + 1); /* skip to inner ip */
 			if (ipv4hdr(ctx)->ihl != 5) {
 				CALI_INFO("ICMP inner IP header has options; unsupported\n");
 				ctx->fwd.reason = CALI_REASON_IP_OPTIONS;
@@ -732,7 +732,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				CALI_DEBUG("Too short for TCP: DROP\n");
 				goto deny;
 			}
-			ct_ctx_nat.tcp = tc_tcphdr(ctx);
+			ct_ctx_nat.tcp = tcphdr(ctx);
 		}
 
 		// If we get here, we've passed policy.
@@ -862,18 +862,18 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		case IPPROTO_TCP:
 			if (state->ct_result.nat_sport) {
 				CALI_DEBUG("Fixing TCP source port from %d to %d\n",
-						bpf_ntohs(tc_tcphdr(ctx)->source), state->ct_result.nat_sport);
-				tc_tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_sport);
+						bpf_ntohs(tcphdr(ctx)->source), state->ct_result.nat_sport);
+				tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_sport);
 			}
-			tc_tcphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
+			tcphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
 			break;
 		case IPPROTO_UDP:
 			if (state->ct_result.nat_sport) {
 				CALI_DEBUG("Fixing UDP source port from %d to %d\n",
-						bpf_ntohs(tc_udphdr(ctx)->source), state->ct_result.nat_sport);
-				tc_udphdr(ctx)->source = bpf_htons(state->ct_result.nat_sport);
+						bpf_ntohs(udphdr(ctx)->source), state->ct_result.nat_sport);
+				udphdr(ctx)->source = bpf_htons(state->ct_result.nat_sport);
 			}
-			tc_udphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
+			udphdr(ctx)->dest = bpf_htons(state->post_nat_dport);
 			break;
 		}
 
@@ -956,19 +956,19 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 
 		switch (ipv4hdr(ctx)->protocol) {
 		case IPPROTO_TCP:
-			tc_tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
+			tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
 			if (state->ct_result.nat_sport) {
 				CALI_DEBUG("Fixing TCP dest port from %d to %d\n",
-						bpf_ntohs(tc_tcphdr(ctx)->dest), state->ct_result.nat_sport);
-				tc_tcphdr(ctx)->dest = bpf_htons(state->ct_result.nat_sport);
+						bpf_ntohs(tcphdr(ctx)->dest), state->ct_result.nat_sport);
+				tcphdr(ctx)->dest = bpf_htons(state->ct_result.nat_sport);
 			}
 			break;
 		case IPPROTO_UDP:
-			tc_udphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
+			udphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
 			if (state->ct_result.nat_sport) {
 				CALI_DEBUG("Fixing UDP dest port from %d to %d\n",
-						bpf_ntohs(tc_tcphdr(ctx)->dest), state->ct_result.nat_sport);
-				tc_udphdr(ctx)->dest = bpf_htons(state->ct_result.nat_sport);
+						bpf_ntohs(tcphdr(ctx)->dest), state->ct_result.nat_sport);
+				udphdr(ctx)->dest = bpf_htons(state->ct_result.nat_sport);
 			}
 			break;
 		}
@@ -1091,7 +1091,7 @@ nat_encap:
 				reason = CALI_REASON_SHORT;
 				goto deny;
 			}
-			__builtin_memcpy(&tc_ethhdr(ctx)->h_dest, arpv->mac_dst, ETH_ALEN);
+			__builtin_memcpy(&ethhdr(ctx)->h_dest, arpv->mac_dst, ETH_ALEN);
 			if (state->ct_result.ifindex_fwd == skb->ifindex) {
 				/* No need to change src MAC, if we are at the right device */
 			} else {

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -119,7 +119,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 				goto deny;
 			}
 
-			__be32 ip_src = ctx.ip_header->saddr;
+			__be32 ip_src = ipv4hdr(&ctx)->saddr;
 			if (ip_src == HOST_IP) {
 				CALI_DEBUG("src ip fixup not needed %x\n", bpf_ntohl(ip_src));
 				goto allow;
@@ -128,7 +128,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			}
 
 			/* XXX do a proper CT lookup to find this */
-			ctx.ip_header->saddr = HOST_IP;
+			ipv4hdr(&ctx)->saddr = HOST_IP;
 			int l3_csum_off = skb_iphdr_offset() + offsetof(struct iphdr, check);
 
 			int res = bpf_l3_csum_replace(skb, l3_csum_off, ip_src, HOST_IP, 4);
@@ -188,7 +188,7 @@ static CALI_BPF_INLINE int pre_policy_processing(struct cali_tc_ctx *ctx)
 	/* Now we've got as far as the UDP header, check if this is one of our VXLAN packets, which we
 	 * use to forward traffic for node ports. */
 	if (dnat_should_decap() /* Compile time: is this a BPF program that should decap packets? */ &&
-			is_vxlan_tunnel(ctx->ip_header) /* Is this a VXLAN packet? */ ) {
+			is_vxlan_tunnel(ipv4hdr(ctx)) /* Is this a VXLAN packet? */ ) {
 		/* Decap it; vxlan_attempt_decap will revalidate the packet if needed. */
 		switch (vxlan_attempt_decap(ctx)) {
 		case -1:
@@ -581,8 +581,8 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	/* We check the ttl here to avoid needing complicated handling of
 	 * related traffic back from the host if we let the host to handle it.
 	 */
-	CALI_DEBUG("ip->ttl %d\n", ctx->ip_header->ttl);
-	if (ip_ttl_exceeded(ctx->ip_header)) {
+	CALI_DEBUG("ip->ttl %d\n", ipv4hdr(ctx)->ttl);
+	if (ip_ttl_exceeded(ipv4hdr(ctx))) {
 		switch (ct_rc){
 		case CALI_CT_NEW:
 			if (nat_dest) {
@@ -598,7 +598,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	l3_csum_off = skb_iphdr_offset() +  offsetof(struct iphdr, check);
 
 	if (ct_related) {
-		if (ctx->ip_header->protocol == IPPROTO_ICMP) {
+		if (ipv4hdr(ctx)->protocol == IPPROTO_ICMP) {
 			bool outer_ip_snat;
 
 			/* if we do SNAT ... */
@@ -614,7 +614,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 
 			/* ... then fix the outer header IP first */
 			if (outer_ip_snat) {
-				ctx->ip_header->saddr = state->ct_result.nat_ip;
+				ipv4hdr(ctx)->saddr = state->ct_result.nat_ip;
 				int res = bpf_l3_csum_replace(skb, l3_csum_off,
 						state->ip_src, state->ct_result.nat_ip, 4);
 				if (res) {
@@ -635,15 +635,15 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 			/* Skip past the ICMP header and check the inner IP header.
 			 * WARNING: this modifies the ip_header pointer in the main context; need to
 			 * be careful in later code to avoid overwriting that. */
-			l3_csum_off += sizeof(*ctx->ip_header) + sizeof(struct icmphdr);
-			ctx->ip_header = (struct iphdr *)(tc_icmphdr(ctx) + 1); /* skip to inner ip */
-			if (ctx->ip_header->ihl != 5) {
+			l3_csum_off += IPv4_SIZE + sizeof(struct icmphdr);
+			ctx->ip_header = (tc_icmphdr(ctx) + 1); /* skip to inner ip */
+			if (ipv4hdr(ctx)->ihl != 5) {
 				CALI_INFO("ICMP inner IP header has options; unsupported\n");
 				ctx->fwd.reason = CALI_REASON_IP_OPTIONS;
 				ctx->fwd.res = TC_ACT_SHOT;
 				goto deny;
 			}
-			ctx->nh = (void*)(ctx->ip_header+1);
+			ctx->nh = (ctx->ip_header + IPv4_SIZE);
 
 			/* Flip the direction, we need to reverse the original packet. */
 			switch (ct_rc) {
@@ -671,7 +671,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		}
 	}
 
-	__u8 ihl = ctx->ip_header->ihl * 4;
+	__u8 ihl = ipv4hdr(ctx)->ihl * 4;
 
 	int res = 0;
 	bool encap_needed = false;
@@ -679,7 +679,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	if (state->ip_proto == IPPROTO_ICMP && ct_related) {
 		/* do not fix up embedded L4 checksum for related ICMP */
 	} else {
-		switch (ctx->ip_header->protocol) {
+		switch (ipv4hdr(ctx)->protocol) {
 		case IPPROTO_TCP:
 			l4_csum_off = skb_l4hdr_offset(skb, ihl) + offsetof(struct tcphdr, check);
 			break;
@@ -843,7 +843,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		}
 		if (encap_needed) {
 			if (!(state->ip_proto == IPPROTO_TCP && skb_is_gso(skb)) &&
-					ip_is_dnf(ctx->ip_header) && vxlan_v4_encap_too_big(ctx)) {
+					ip_is_dnf(ipv4hdr(ctx)) && vxlan_v4_encap_too_big(ctx)) {
 				CALI_DEBUG("Request packet with DNF set is too big\n");
 				goto icmp_too_big;
 			}
@@ -856,9 +856,9 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 			goto nat_encap;
 		}
 
-		ctx->ip_header->daddr = state->post_nat_ip_dst;
+		ipv4hdr(ctx)->daddr = state->post_nat_ip_dst;
 
-		switch (ctx->ip_header->protocol) {
+		switch (ipv4hdr(ctx)->protocol) {
 		case IPPROTO_TCP:
 			if (state->ct_result.nat_sport) {
 				CALI_DEBUG("Fixing TCP source port from %d to %d\n",
@@ -886,7 +886,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 					bpf_htons(state->post_nat_dport),
 					bpf_htons(state->sport),
 					bpf_htons(state->ct_result.nat_sport ? : state->sport),
-					ctx->ip_header->protocol == IPPROTO_UDP ? BPF_F_MARK_MANGLED_0 : 0);
+					ipv4hdr(ctx)->protocol == IPPROTO_UDP ? BPF_F_MARK_MANGLED_0 : 0);
 		}
 
 		res |= bpf_l3_csum_replace(skb, l3_csum_off, state->ip_dst, state->post_nat_ip_dst, 4);
@@ -945,16 +945,16 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 			}
 
 			if (!(state->ip_proto == IPPROTO_TCP && skb_is_gso(skb)) &&
-					ip_is_dnf(ctx->ip_header) && vxlan_v4_encap_too_big(ctx)) {
+					ip_is_dnf(ipv4hdr(ctx)) && vxlan_v4_encap_too_big(ctx)) {
 				CALI_DEBUG("Return ICMP mtu is too big\n");
 				goto icmp_too_big;
 			}
 		}
 
 		// Actually do the NAT.
-		ctx->ip_header->saddr = state->ct_result.nat_ip;
+		ipv4hdr(ctx)->saddr = state->ct_result.nat_ip;
 
-		switch (ctx->ip_header->protocol) {
+		switch (ipv4hdr(ctx)->protocol) {
 		case IPPROTO_TCP:
 			tc_tcphdr(ctx)->source = bpf_htons(state->ct_result.nat_port);
 			if (state->ct_result.nat_sport) {
@@ -980,7 +980,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				state->ip_src, state->ct_result.nat_ip,
 				bpf_htons(state->dport), bpf_htons(state->ct_result.nat_sport ? : state->dport),
 				bpf_htons(state->sport), bpf_htons(state->ct_result.nat_port),
-				ctx->ip_header->protocol == IPPROTO_UDP ? BPF_F_MARK_MANGLED_0 : 0);
+				ipv4hdr(ctx)->protocol == IPPROTO_UDP ? BPF_F_MARK_MANGLED_0 : 0);
 		}
 
 		CALI_VERB("L3 checksum update (csum is at %d) port from %x to %x\n",
@@ -1042,7 +1042,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	goto deny;
 
 icmp_ttl_exceeded:
-	if (ip_frag_no(ctx->ip_header)) {
+	if (ip_frag_no(ipv4hdr(ctx))) {
 		goto deny;
 	}
 	state->icmp_type = ICMP_TIME_EXCEEDED;

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -111,7 +111,7 @@ struct cali_tc_ctx {
   /* Our single copies of the data start/end pointers loaded from the skb. */
   void *data_start;
   void *data_end;
-  struct iphdr *ip_header;
+  void *ip_header;
   void *nh;
 
   struct cali_tc_state *state;
@@ -119,6 +119,11 @@ struct cali_tc_ctx {
   struct arp_key arpk;
   struct fwd fwd;
 };
+
+static CALI_BPF_INLINE struct iphdr* ipv4hdr(struct cali_tc_ctx *ctx)
+{
+	return (struct iphdr *)ctx->ip_header;
+}
 
 static CALI_BPF_INLINE struct ethhdr* tc_ethhdr(struct cali_tc_ctx *ctx)
 {

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -125,22 +125,22 @@ static CALI_BPF_INLINE struct iphdr* ipv4hdr(struct cali_tc_ctx *ctx)
 	return (struct iphdr *)ctx->ip_header;
 }
 
-static CALI_BPF_INLINE struct ethhdr* tc_ethhdr(struct cali_tc_ctx *ctx)
+static CALI_BPF_INLINE struct ethhdr* ethhdr(struct cali_tc_ctx *ctx)
 {
 	return (struct ethhdr *)ctx->data_start;
 }
 
-static CALI_BPF_INLINE struct tcphdr* tc_tcphdr(struct cali_tc_ctx *ctx)
+static CALI_BPF_INLINE struct tcphdr* tcphdr(struct cali_tc_ctx *ctx)
 {
 	return (struct tcphdr *)ctx->nh;
 }
 
-static CALI_BPF_INLINE struct udphdr* tc_udphdr(struct cali_tc_ctx *ctx)
+static CALI_BPF_INLINE struct udphdr* udphdr(struct cali_tc_ctx *ctx)
 {
 	return (struct udphdr *)ctx->nh;
 }
 
-static CALI_BPF_INLINE struct icmphdr* tc_icmphdr(struct cali_tc_ctx *ctx)
+static CALI_BPF_INLINE struct icmphdr* icmphdr(struct cali_tc_ctx *ctx)
 {
 	return (struct icmphdr *)ctx->nh;
 }

--- a/felix/bpf-gpl/ut/ip_dec_ttl.c
+++ b/felix/bpf-gpl/ut/ip_dec_ttl.c
@@ -18,7 +18,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 		return -1;
 	}
 
-	ip_dec_ttl(ctx.ip_header);
+	ip_dec_ttl(ipv4hdr(&ctx));
 
 	return 0;
 }


### PR DESCRIPTION
## Description
This PR changes `ip_header` type in `cali_tc_ctx` struct to `void *`, so the same field can be used also for IPv6. Also a function called `ipv4hdr()` is introduced to allow use the field for IPv4 packets.

We have been using similar approach for `eth`, `tcp`, `udp`, and `icmp`. However, to align and shorten function names `tc_` prefix is removed from the helper functions for those fields.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
