### PR TITLE
Added build steps for darwin-arm64

### DIFF
--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -55,7 +55,7 @@ endif
 ###############################################################################
 .PHONY: build-all
 ## Build the binaries for all architectures and platforms
-build-all: $(addprefix bin/calicoctl-linux-,$(VALIDARCHES)) bin/calicoctl-windows-amd64.exe bin/calicoctl-darwin-amd64
+build-all: $(addprefix bin/calicoctl-linux-,$(VALIDARCHES)) bin/calicoctl-windows-amd64.exe bin/calicoctl-darwin-amd64 bin/calicoctl-darwin-arm64
 .PHONY: build
 ## Build the binary for the current architecture and platform
 build: bin/calicoctl-$(BUILDOS)-$(ARCH)
@@ -65,7 +65,8 @@ bin/calicoctl-%-armv7: ARCH=armv7
 bin/calicoctl-%-arm64: ARCH=arm64
 bin/calicoctl-%-ppc64le: ARCH=ppc64le
 bin/calicoctl-%-s390x: ARCH=s390x
-bin/calicoctl-darwin-amd64: BUILDOS=darwin
+bin/calicoctl-darwin-amd64: BUILDOS=darwin ARCH=amd64
+bin/calicoctl-darwin-arm64: BUILDOS=darwin ARCH=arm64
 bin/calicoctl-windows-amd64: BUILDOS=windows
 bin/calicoctl-linux-%: BUILDOS=linux
 # We reinvoke make here to re-evaluate BUILDOS and ARCH so the correct values

--- a/calicoctl/README.md
+++ b/calicoctl/README.md
@@ -42,16 +42,17 @@ the need for any dependencies in your host developer environment, using the foll
 make build
 ```
 
-The binary will be put in `./dist/` and named `calicoctl-<os>-<arch>`, e.g.:
+The binary will be put in `./bin/` and named `calicoctl-<os>-<arch>`, e.g.:
 
 ```
-$ ls -1 ./dist/
+$ ls -1 ./bin/
 calicoctl-linux-amd64
 calicoctl-linux-arm64
 calicoctl-linux-armv7
 calicoctl-linux-ppc64le
 calicoctl-linux-s390x
 calicoctl-darwin-amd64
+calicoctl-darwin-arm64
 calicoctl-windows-amd64.exe
 ```
 


### PR DESCRIPTION
## Description

- This change features a release for Apple M1 (darwin-arm64) devices. 
- No specific testing has been done other than executing the resulting binary and checking its filetype.

## Related issues/PRs

No related issues/PRs.

## Todos

- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
calicoctl can now be used on Apple M1 devices
```
