### PR TITLE
felix/bpf: when reusing TCP entries, delete them first

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -576,6 +576,8 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 		}
 		if (tcp_recycled(syn, tracking_v)) {
 			CALI_CT_DEBUG("TCP SYN recycles entry, NEW flow.\n");
+			cali_v4_ct_delete_elem(&k);
+			cali_v4_ct_delete_elem(&v->nat_rev_key);
 			goto out_lookup_fail;
 		}
 		result.nat_sport = v->nat_sport ? : sport;
@@ -622,10 +624,8 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 
 		break;
 	case CALI_CT_TYPE_NAT_REV:
-		if (tcp_recycled(syn, v)) {
-			CALI_CT_DEBUG("TCP SYN recycles entry, NEW flow.\n");
-			goto out_lookup_fail;
-		}
+		// N.B. we do not check for tcp_recycled because this cannot be the first
+		// SYN that is opening a new connection. This must be returning traffic.
 		if (srcLTDest) {
 			CALI_VERB("CT-ALL REV src_to_dst A->B\n");
 			src_to_dst = &v->a_to_b;
@@ -681,6 +681,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 		CALI_CT_DEBUG("Hit! NORMAL entry.\n");
 		if (tcp_recycled(syn, v)) {
 			CALI_CT_DEBUG("TCP SYN recycles entry, NEW flow.\n");
+			cali_v4_ct_delete_elem(&k);
 			goto out_lookup_fail;
 		}
 		CALI_CT_VERB("Created: %llu.\n", v->created);

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1198,12 +1198,16 @@ deny:
 SEC("classifier/tc/drop")
 int calico_tc_skb_drop(struct __sk_buff *skb)
 {
-	CALI_DEBUG("Entering calico_tc_skb_drop\n");
+	CALI_DEBUG("Entering calico_tc_skb_drop - DENY\n");
 
-	struct cali_tc_state *state = state_get();
-	if (!state) {
-		CALI_DEBUG("State map lookup failed: no event generated\n");
-		goto drop;
+	struct cali_tc_state *state;
+
+	if (CALI_LOG_LEVEL >= CALI_LOG_LEVEL_DEBUG) {
+		state = state_get();
+		if (!state) {
+			CALI_DEBUG("State map lookup failed: no event generated\n");
+			return TC_ACT_SHOT;
+		}
 	}
 
 	CALI_DEBUG("proto=%d\n", state->ip_proto);
@@ -1216,7 +1220,6 @@ int calico_tc_skb_drop(struct __sk_buff *skb)
 	CALI_DEBUG("flags=0x%x\n", state->flags);
 	CALI_DEBUG("ct_rc=%d\n", state->ct_result.rc);
 
-drop:
 	return TC_ACT_SHOT;
 }
 

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -175,6 +175,14 @@ func (e Value) AsBytes() []byte {
 	return e[:]
 }
 
+func (e *Value) SetLegA2B(leg Leg) {
+	copy(e[24:36], leg.AsBytes())
+}
+
+func (e *Value) SetLegB2A(leg Leg) {
+	copy(e[36:48], leg.AsBytes())
+}
+
 func initValue(v *Value, created, lastSeen time.Duration, typ, flags uint8) {
 	binary.LittleEndian.PutUint64(v[:8], uint64(created))
 	binary.LittleEndian.PutUint64(v[8:16], uint64(lastSeen))
@@ -188,8 +196,8 @@ func NewValueNormal(created, lastSeen time.Duration, flags uint8, legA, legB Leg
 
 	initValue(&v, created, lastSeen, TypeNormal, flags)
 
-	copy(v[24:36], legA.AsBytes())
-	copy(v[36:48], legA.AsBytes())
+	v.SetLegA2B(legA)
+	v.SetLegB2A(legB)
 
 	return v
 }
@@ -214,8 +222,8 @@ func NewValueNATReverse(created, lastSeen time.Duration, flags uint8, legA, legB
 
 	initValue(&v, created, lastSeen, TypeNATReverse, flags)
 
-	copy(v[24:36], legA.AsBytes())
-	copy(v[36:48], legA.AsBytes())
+	v.SetLegA2B(legA)
+	v.SetLegB2A(legB)
 
 	copy(v[48:52], origIP.To4())
 	binary.LittleEndian.PutUint16(v[52:54], origPort)

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1063,6 +1063,8 @@ func resetBPFMaps() {
 	resetCTMap(ctMap)
 	resetRTMap(rtMap)
 	resetMap(fsafeMap)
+	resetMap(natMap)
+	resetMap(natBEMap)
 }
 
 func TestMapIterWithDelete(t *testing.T) {

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -1358,6 +1358,7 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 func TestNormalSYNRetryForcePolicy(t *testing.T) {
 	RegisterTestingT(t)
 
+	defer func() { bpfIfaceName = "" }()
 	bpfIfaceName = "SYN1"
 
 	tcpSyn := &layers.TCP{

--- a/felix/bpf/ut/tcp_test.go
+++ b/felix/bpf/ut/tcp_test.go
@@ -34,6 +34,8 @@ func TestTCPRecycleClosedConn(t *testing.T) {
 	defer func() { bpfIfaceName = "" }()
 	bpfIfaceName = "REC1"
 
+	resetCTMap(ctMap) // ensure it is clean
+
 	tcpSyn := &layers.TCP{
 		SrcPort:    54321,
 		DstPort:    7890,
@@ -113,6 +115,8 @@ func TestTCPRecycleClosedConnNAT(t *testing.T) {
 
 	defer func() { bpfIfaceName = "" }()
 	bpfIfaceName = "Rec1"
+
+	resetCTMap(ctMap) // ensure it is clean
 
 	tcpSyn := &layers.TCP{
 		SrcPort:    54321,

--- a/felix/bpf/ut/tcp_test.go
+++ b/felix/bpf/ut/tcp_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ut_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/nat"
+	"github.com/projectcalico/calico/felix/bpf/routes"
+)
+
+func TestTCPRecycleClosedConn(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer func() { bpfIfaceName = "" }()
+	bpfIfaceName = "REC1"
+
+	tcpSyn := &layers.TCP{
+		SrcPort:    54321,
+		DstPort:    7890,
+		SYN:        true,
+		DataOffset: 5,
+	}
+
+	_, _, _, _, synPkt, err := testPacket(nil, nil, tcpSyn, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Insert a reverse route for the source workload.
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload, 1).AsBytes()
+	defer resetRTMap(rtMap)
+	err = rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+	})
+
+	ct, err := conntrack.LoadMapMem(ctMap)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ct).To(HaveLen(1))
+
+	var (
+		ctKey conntrack.Key
+		ctVal conntrack.Value
+	)
+
+	for ctKey, ctVal = range ct {
+		// Get the only k,v in the map
+	}
+
+	v := ctVal.Data()
+	v.A2B.FinSeen = true
+	v.A2B.AckSeen = true
+	v.A2B.Opener = true
+	ctVal.SetLegA2B(v.A2B)
+	v.B2A.FinSeen = true
+	v.B2A.AckSeen = true
+	v.B2A.Opener = true
+	ctVal.SetLegB2A(v.B2A)
+
+	fmt.Printf("ctVal = %+v\n", ctVal)
+
+	_ = ctMap.Update(ctKey.AsBytes(), ctVal.AsBytes())
+
+	bpfIfaceName = "REC2"
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+	})
+
+	ct, err = conntrack.LoadMapMem(ctMap)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ct).To(HaveLen(1))
+
+	for ctKey, ctVal = range ct {
+		// Get the only k,v in the map
+	}
+
+	v = ctVal.Data()
+	Expect(v.A2B.FinSeen).To(BeFalse())
+	Expect(v.B2A.FinSeen).To(BeFalse())
+}
+
+func TestTCPRecycleClosedConnNAT(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer func() { bpfIfaceName = "" }()
+	bpfIfaceName = "Rec1"
+
+	tcpSyn := &layers.TCP{
+		SrcPort:    54321,
+		DstPort:    7890,
+		SYN:        true,
+		DataOffset: 5,
+	}
+
+	_, ipv4, l4, _, synPkt, err := testPacket(nil, nil, tcpSyn, nil)
+	Expect(err).NotTo(HaveOccurred())
+	tcp := l4.(*layers.TCP)
+
+	err = natMap.Update(
+		nat.NewNATKey(ipv4.DstIP, uint16(tcp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
+		nat.NewNATValue(0, 1, 0, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	natIP := net.IPv4(8, 8, 8, 8)
+	natPort := uint16(666)
+
+	err = natBEMap.Update(
+		nat.NewNATBackendKey(0, 0).AsBytes(),
+		nat.NewNATBackendValue(natIP, natPort).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Insert a reverse route for the source workload.
+	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
+	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload, 1).AsBytes()
+	defer resetRTMap(rtMap)
+	err = rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+	})
+
+	ct, err := conntrack.LoadMapMem(ctMap)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ct).To(HaveLen(2))
+
+	var (
+		ctKey conntrack.Key
+		ctVal conntrack.Value
+	)
+
+	for ctKey, ctVal = range ct {
+		if ctVal.Type() == conntrack.TypeNATReverse {
+			break
+		}
+	}
+
+	v := ctVal.Data()
+	v.A2B.FinSeen = true
+	v.A2B.AckSeen = true
+	v.A2B.Opener = true
+	ctVal.SetLegA2B(v.A2B)
+	v.B2A.FinSeen = true
+	v.B2A.AckSeen = true
+	v.B2A.Opener = true
+	ctVal.SetLegB2A(v.B2A)
+
+	fmt.Printf("ctVal = %+v\n", ctVal)
+
+	_ = ctMap.Update(ctKey.AsBytes(), ctVal.AsBytes())
+
+	bpfIfaceName = "Rec2"
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(synPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+	})
+
+	ct, err = conntrack.LoadMapMem(ctMap)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ct).To(HaveLen(2))
+
+	for ctKey, ctVal = range ct {
+		if ctVal.Type() == conntrack.TypeNATReverse {
+			break
+		}
+	}
+
+	v = ctVal.Data()
+	Expect(v.A2B.FinSeen).To(BeFalse())
+	Expect(v.B2A.FinSeen).To(BeFalse())
+}

--- a/felix/bpf/ut/to_host_allowed_test.go
+++ b/felix/bpf/ut/to_host_allowed_test.go
@@ -33,6 +33,8 @@ import (
 func TestToHostAllowedCTFull(t *testing.T) {
 	RegisterTestingT(t)
 
+	resetBPFMaps()
+
 	hostIP := net.IPv4(1, 1, 1, 1)
 	hostPort := uint16(666)
 


### PR DESCRIPTION
## Description

    felix/bpf: when reusing TCP entries, delete them first
    
    UT and completion of 7280fbb06028db7b6788c03512274f14aba57e2d
    
    If entries are not deleted or if we do not enforce overwrite, we may hit
    all sorts of issues like resolving source port collision or rejecting
    the packet because of unexpected ct entry.

    felix/bpf: make drop program report DENY for easier grep


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
relates to https://github.com/projectcalico/calico/pull/5308
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
