### PR TITLE
CNI install to non-writeable directory fix

### DIFF
--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -187,11 +187,14 @@ func Install() error {
 
 	// Place the new binaries if the directory is writeable.
 	dirs := []string{"/host/opt/cni/bin", "/host/secondary-bin-dir"}
+	binsWritten := false
 	for _, d := range dirs {
 		if err := fileutil.IsDirWriteable(d); err != nil {
 			logrus.Infof("%s is not writeable, skipping", d)
 			continue
 		}
+		// Binaries were placed into at least one directory
+		binsWritten = true
 
 		// Iterate through each binary we might want to install.
 		files, err := ioutil.ReadDir("/opt/cni/bin/")
@@ -226,6 +229,11 @@ func Install() error {
 			logrus.WithError(err).Warnf("Failed getting CNI plugin version")
 		}
 		logrus.Infof("CNI plugin version: %s", out.String())
+	}
+
+	// If binaries were not placed, exit
+	if !binsWritten {
+		logrus.WithError(err).Fatalf("found no writeable directory, exiting")
 	}
 
 	if kubecfg != nil {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Hi,

I am proposing a change to fix issue #5763. The approach to fix the issue was to introduce a `-force` flag to the install command which will preserve current install cni behaviour (continues ignoring the error). The default behaviour (without setting the `-force` flag) is now different and install command fails if it detects that the directory is not writeable. The edge case when the directory does not exist preserves previous behaviour (continues ignoring the error).

The cases that I have described are also backed with appropriate tests and the signature of the `runCniContainer` function was therefore changed.

Let me know what you think.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
fixes https://github.com/projectcalico/calico/issues/5763

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico's install-cni command now fails in case the directory is not writeable.
```
