### PR TITLE
felix/bpf: backwards compatible 16bit ct flags

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -120,8 +120,8 @@ create:
 		.orig_port = orig_dport,
 	};
 
-	ct_value.flags = ct_ctx->flags;
-	CALI_DEBUG("CT-ALL tracking entry flags 0x%x\n", ct_value.flags);
+	ct_value_set_flags(&ct_value, ct_ctx->flags);
+	CALI_DEBUG("CT-ALL tracking entry flags 0x%x\n", ct_value_get_flags(&ct_value));
 
 	if (ct_ctx->type == CALI_CT_TYPE_NAT_REV && ct_ctx->tun_ip) {
 		if (ct_ctx->flags & CALI_CT_FLAG_NP_FWD) {
@@ -552,7 +552,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 	__u64 now = bpf_ktime_get_ns();
 	v->last_seen = now;
 
-	result.flags = v->flags;
+	result.flags = ct_value_get_flags(v);
 
 	// Return the if_index where the CT state was created.
 	if (v->a_to_b.opener) {
@@ -600,7 +600,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 		result.tun_ip = tracking_v->tun_ip;
 		CALI_CT_DEBUG("fwd tun_ip:%x\n", bpf_ntohl(tracking_v->tun_ip));
 		// flags are in the tracking entry
-		result.flags = tracking_v->flags;
+		result.flags = ct_value_get_flags(tracking_v);
 
 		if (ct_ctx->proto == IPPROTO_ICMP) {
 			result.rc =	CALI_CT_ESTABLISHED_DNAT;
@@ -639,7 +639,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 		result.tun_ip = v->tun_ip;
 		CALI_CT_DEBUG("tun_ip:%x\n", bpf_ntohl(v->tun_ip));
 
-		result.flags = v->flags;
+		result.flags = ct_value_get_flags(v);
 
 		if (ct_ctx->proto == IPPROTO_ICMP || (related && proto_orig == IPPROTO_ICMP)) {
 			result.rc =	CALI_CT_ESTABLISHED_SNAT;

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -61,7 +61,8 @@ struct calico_ct_value {
 	// not to zero the padding bytes, which upsets the verifier.  Worse than
 	// that, debug logging often prevents such optimisation resulting in
 	// failures when debug logging is compiled out only :-).
-	__u8 pad0[6];
+	__u8 pad0[5];
+	__u8 flags2;
 	union {
 		// CALI_CT_TYPE_NORMAL and CALI_CT_TYPE_NAT_REV.
 		struct {
@@ -84,6 +85,17 @@ struct calico_ct_value {
 		};
 	};
 };
+
+#define ct_value_set_flags(v, f) do {		\
+	(v)->flags |= ((f) & 0xff);		\
+	(v)->flags2 |= (((f) >> 8) & 0xff);	\
+} while(0)
+
+#define ct_value_get_flags(v) ({			\
+	__u16 ret = (v)->flags | ((v)->flags2 << 8);	\
+							\
+	ret;						\
+})
 
 struct ct_lookup_ctx {
 	__u8 proto;
@@ -108,7 +120,7 @@ struct ct_create_ctx {
 	__be32 tun_ip; /* is set when the packet arrive through the NP tunnel.
 			* It is also set on the first node when we create the
 			* initial CT entry for the tunneled traffic. */
-	__u8 flags;
+	__u16 flags;
 	enum cali_ct_type type;
 	bool allow_return;
 };

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -86,7 +86,8 @@ func NewKey(proto uint8, ipA net.IP, portA uint16, ipB net.IP, portB uint16) Key
 //  // not to zero the padding bytes, which upsets the verifier.  Worse than
 //  // that, debug logging often prevents such optimisation resulting in
 //  // failures when debug logging is compiled out only :-).
-//  __u8 pad0[6];
+//  __u8 pad0[5];
+//  __u8 flags2;
 //  union {
 //    // CALI_CT_TYPE_NORMAL and CALI_CT_TYPE_NAT_REV.
 //    struct {
@@ -122,8 +123,8 @@ func (e Value) Type() uint8 {
 	return e[16]
 }
 
-func (e Value) Flags() uint8 {
-	return e[17]
+func (e Value) Flags() uint16 {
+	return uint16(e[17]) | (uint16(e[23]) << 8)
 }
 
 // OrigIP returns the original destination IP, valid only if Type() is TypeNormal or TypeNATReverse
@@ -152,13 +153,14 @@ const (
 	TypeNATForward
 	TypeNATReverse
 
-	FlagNATOut    uint8 = (1 << 0)
-	FlagNATFwdDsr uint8 = (1 << 1)
-	FlagNATNPFwd  uint8 = (1 << 2)
-	FlagSkipFIB   uint8 = (1 << 3)
-	FlagReserved4 uint8 = (1 << 4)
-	FlagReserved5 uint8 = (1 << 5)
-	FlagExtLocal  uint8 = (1 << 6)
+	FlagNATOut    uint16 = (1 << 0)
+	FlagNATFwdDsr uint16 = (1 << 1)
+	FlagNATNPFwd  uint16 = (1 << 2)
+	FlagSkipFIB   uint16 = (1 << 3)
+	FlagReserved4 uint16 = (1 << 4)
+	FlagReserved5 uint16 = (1 << 5)
+	FlagExtLocal  uint16 = (1 << 6)
+	FlagViaNATIf  uint16 = (1 << 7)
 )
 
 func (e Value) ReverseNATKey() Key {
@@ -183,15 +185,16 @@ func (e *Value) SetLegB2A(leg Leg) {
 	copy(e[36:48], leg.AsBytes())
 }
 
-func initValue(v *Value, created, lastSeen time.Duration, typ, flags uint8) {
+func initValue(v *Value, created, lastSeen time.Duration, typ uint8, flags uint16) {
 	binary.LittleEndian.PutUint64(v[:8], uint64(created))
 	binary.LittleEndian.PutUint64(v[8:16], uint64(lastSeen))
 	v[16] = typ
-	v[17] = flags
+	v[17] = byte(flags & 0xff)
+	v[23] = byte((flags >> 8) & 0xff)
 }
 
 // NewValueNormal creates a new Value of type TypeNormal based on the given parameters
-func NewValueNormal(created, lastSeen time.Duration, flags uint8, legA, legB Leg) Value {
+func NewValueNormal(created, lastSeen time.Duration, flags uint16, legA, legB Leg) Value {
 	v := Value{}
 
 	initValue(&v, created, lastSeen, TypeNormal, flags)
@@ -204,7 +207,7 @@ func NewValueNormal(created, lastSeen time.Duration, flags uint8, legA, legB Leg
 
 // NewValueNATForward creates a new Value of type TypeNATForward for the given
 // arguments and the reverse key
-func NewValueNATForward(created, lastSeen time.Duration, flags uint8, revKey Key) Value {
+func NewValueNATForward(created, lastSeen time.Duration, flags uint16, revKey Key) Value {
 	v := Value{}
 
 	initValue(&v, created, lastSeen, TypeNATForward, flags)
@@ -216,7 +219,7 @@ func NewValueNATForward(created, lastSeen time.Duration, flags uint8, revKey Key
 
 // NewValueNATReverse creates a new Value of type TypeNATReverse for the given
 // arguments and reverse parameters
-func NewValueNATReverse(created, lastSeen time.Duration, flags uint8, legA, legB Leg,
+func NewValueNATReverse(created, lastSeen time.Duration, flags uint16, legA, legB Leg,
 	tunnelIP, origIP net.IP, origPort uint16) Value {
 	v := Value{}
 
@@ -356,6 +359,7 @@ func (e Value) String() string {
 	if flags == 0 {
 		flagsStr = " <none>"
 	} else {
+		flagsStr = fmt.Sprintf(" 0x%x", flags)
 		if flags&FlagNATOut != 0 {
 			flagsStr += " nat-out"
 		}

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -152,7 +152,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	Expect(ok).To(BeTrue())
 	// No NATing, service already resolved
 	Expect(v.Type()).To(Equal(conntrack.TypeNormal))
-	Expect(v.Flags()).To(Equal(uint8(0)))
+	Expect(v.Flags()).To(Equal(uint16(0)))
 
 	// Arriving at workload at node 2
 	skbMark = tcdefs.MarkSeen // CALI_SKB_MARK_SEEN

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,7 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -1416,6 +1417,7 @@ k8s.io/csi-translation-lib v0.23.3 h1:mXRFj3b1fGECCXojva+xJ2dKVx5jVY0y1wTXe9qOVL
 k8s.io/csi-translation-lib v0.23.3/go.mod h1:8J7hpeqMoCJWofd1lCs4vZrEshdbVYrqurFeB6GZ/+E=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c h1:GohjlNKauSai7gN4wsJkeZ3WAJx4Sh+oT/b5IYn5suA=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog v0.3.0 h1:0VPpR+sizsiivjIfIAQH/rl8tan6jvWkS7lU+0di3lE=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=


### PR DESCRIPTION
We use a formerly unused field for another set of 8 flags, that we treat
externally as a single 16bit field.

This provide extra space for marking connections.

The API allows for a non-compatible but faster implementation in the
future.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
