### PR TITLE
[RFC] Exact match for index

### DIFF
--- a/libcalico-go/lib/selector/parser/parser_test.go
+++ b/libcalico-go/lib/selector/parser/parser_test.go
@@ -341,3 +341,35 @@ var _ = Describe("Visitor", func() {
 		),
 	)
 })
+
+var exactMatchTests = []struct {
+	sel           string
+	exactMatch    map[string]string
+} {
+	{`a == 'a1' && b == 'b1'`, map[string]string{"a": "a1", "b": "b1"}},
+	{`a == 'a1'`, map[string]string{"a": "a1"}},
+	{`a == 'a1' && b in {'b1'}`, map[string]string{"a": "a1", "b": "b1"}},
+	{`a == 'a1' && b in {'b1', 'b2'}`, map[string]string{"a": "a1"}},
+	{`a == 'a1' || b == 'b1'`, map[string]string{}},
+	{`a == 'a1' && (b == 'b1' || c == 'c1')`, map[string]string{"a": "a1"}},
+}
+
+var _ = Describe("exactMatch", func() {
+	for _, test := range exactMatchTests {
+		var test = test // Take copy of variable for the closure.
+		Context(fmt.Sprintf("selector %#v", test.sel), func() {
+			var sel parser.Selector
+			var err error
+			BeforeEach(func() {
+				sel, err = parser.Parse(test.sel)
+				Expect(err).To(BeNil())
+			})
+			It("should match the exact Match", func() {
+				em := sel.GetExactMatch()
+
+				Expect(em).To(Equal(test.exactMatch))
+			})
+		})
+	}
+
+})

--- a/libcalico-go/lib/selector/selector.go
+++ b/libcalico-go/lib/selector/selector.go
@@ -30,6 +30,15 @@ type Selector interface {
 
 	// UniqueID returns the unique ID that represents this selector.
 	UniqueID() string
+
+
+	/*
+	Get exact match, returning the label and value. For selector 'a=a1 && b in "b1, "b2"',
+	 (a, a1) is the exact match. For selector 'a=a1 && b in "b1"', both (a, a1) and (b, b1) are
+	exact matches. For selector 'a=a1 || b in "b1"', there is no exact matches.
+	*/
+	GetExactMatch() map[string]string
+
 }
 
 // Parse a string representation of a selector expression into a Selector.


### PR DESCRIPTION
When a selector is used to choose the resource, some match operartor
will decide the maxiumum scope of the resource.

For example, considering followed selector:
a=='a1' && b in {'b1', 'b2'}

All the result is sure to meet a=='a1' requirement. If we index all the
resource through the value for label 'a', the the flow will be:
1. Use the index to find all the resource that meet a=='a1' through O(1)
search,
2. Evaluate all the result from step 1 with  `b in {'b1', 'b2'}`

Such search is sure to be much faster than the current full scan.

This patch includes:
1. Create an index for selector and an index for endpoint. Please
notice that if the value is not found, then an empty value is used.

2. When matching a selector to a endpoint, check if any exact match is
specified in the selector. If yes, get the value and use that value as
index to figure out all the endpoint with the corresponding label/value
pair.

3. When matching an endpoint to a selector, check if any exact match is
specified in the endpoint's labels. If yes, get the value and use the
value to find out all the selector. Please notice that we will search
both selector with the corresponding value, or selector wit empty value,
i.e. selector does not specify this label. This can be enhanced in
future but let's keep it simple, since this matching is not the heaviest
one.

On a LNP environment with 200k neteworkset and 200k networkpolicies, 60M
extra memory added on the node on top of 2G.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
