### PR TITLE
[RFC] Check active policy only for policy resolver

### DIFF
--- a/felix/calc/policy_sorter.go
+++ b/felix/calc/policy_sorter.go
@@ -76,6 +76,29 @@ func (poc *PolicySorter) OnUpdate(update api.Update) (dirty bool) {
 	return
 }
 
+
+func (poc *PolicySorter) UpdatePolicy(key model.PolicyKey, newPolicy *model.Policy) (dirty bool) {
+		oldPolicy := poc.tier.Policies[key]
+		if newPolicy != nil {
+			if oldPolicy == nil ||
+				oldPolicy.Order != newPolicy.Order ||
+				oldPolicy.DoNotTrack != newPolicy.DoNotTrack ||
+				oldPolicy.PreDNAT != newPolicy.PreDNAT ||
+				oldPolicy.ApplyOnForward != newPolicy.ApplyOnForward ||
+				!policyTypesEqual(oldPolicy, newPolicy) {
+				dirty = true
+			}
+			poc.tier.Policies[key] = newPolicy
+		} else {
+			if oldPolicy != nil {
+				delete(poc.tier.Policies, key)
+				dirty = true
+			}
+		}
+	return
+}
+
+
 func (poc *PolicySorter) Sorted() *tierInfo {
 	tierInfo := poc.tier
 	tierInfo.OrderedPolicies = make([]PolKV, 0, len(tierInfo.Policies))


### PR DESCRIPTION
Currently the policy resolver put all the policies into the policySorter
and scan it when a policy becomes matched or mismatched.

However, we need only put the active policy into the policy sorter and
when a policy match change happens, we don't need scan all the policies,
but only the active one. This should reduce a lot of effort.

A new field is added to keep all the policies.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
