### PR TITLE
[WIP] Remove wireguard configuration when unable to connect to Typha

### DIFF
--- a/felix/daemon/bootstrap_linux.go
+++ b/felix/daemon/bootstrap_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,17 @@ func bootstrapWireguard(configParams *config.Config, v3Client clientv3.Interface
 	log.Debug("bootstrapping wireguard host connectivity")
 	return wireguard.BootstrapHostConnectivity(
 		configParams,
+		netlinkshim.NewRealNetlink,
 		netlinkshim.NewRealWireguard,
+		v3Client,
+	)
+}
+
+func bootstrapRemoveWireguard(configParams *config.Config, v3Client clientv3.Interface) error {
+	log.Debug("bootstrapping wireguard host connectivity by removing wireguard config")
+	return wireguard.RemoveWireguardForHostEncryptionBootstrapping(
+		configParams,
+		netlinkshim.NewRealNetlink,
 		v3Client,
 	)
 }

--- a/felix/daemon/bootstrap_windows.go
+++ b/felix/daemon/bootstrap_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,5 +20,9 @@ import (
 )
 
 func bootstrapWireguard(_ *config.Config, _ clientv3.Interface) error {
+	return nil
+} // no-op
+
+func bootstrapRemoveWireguard(_ *config.Config, _ clientv3.Interface) error {
 	return nil
 } // no-op

--- a/felix/daemon/bootstrap_windows.go
+++ b/felix/daemon/bootstrap_windows.go
@@ -23,6 +23,10 @@ func bootstrapWireguard(_ *config.Config, _ clientv3.Interface) error {
 	return nil
 } // no-op
 
+func bootstrapRemoveWireguardIfTyphaNotProgrammed(typhaNodeName string, configParams *config.Config, v3Client clientv3.Interface) (bool, error) {
+	return true, nil
+} //no-op
+
 func bootstrapRemoveWireguard(_ *config.Config, _ clientv3.Interface) error {
 	return nil
 } // no-op

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -170,7 +170,7 @@ func Run(configFile string, gitVersion string, buildDate string, gitRevision str
 	var v3Client client.Interface
 	var datastoreConfig apiconfig.CalicoAPIConfig
 	var configParams *config.Config
-	var typhaAddr string
+	var typha discovery.Typha
 	var numClientsCreated int
 	var k8sClientSet *kubernetes.Clientset
 	var kubernetesVersion string
@@ -317,7 +317,7 @@ configRetry:
 		}
 
 		// If we're configured to discover Typha, do that now so we can retry if we fail.
-		typhaAddr, err = discoverTyphaAddr(configParams, k8sClientSet)
+		typha, err = discoverTyphaAddr(configParams, k8sClientSet)
 		if err != nil {
 			log.WithError(err).Error("Typha discovery enabled but discovery failed.")
 			time.Sleep(1 * time.Second)
@@ -455,11 +455,11 @@ configRetry:
 	var syncer Startable
 	var typhaConnection *syncclient.SyncerClient
 	syncerToValidator := calc.NewSyncerCallbacksDecoupler()
-	if typhaAddr != "" {
+	if typha.Addr != "" {
 		// Use a remote Syncer, via the Typha server.
-		log.WithField("addr", typhaAddr).Info("Connecting to Typha.")
+		log.WithField("addr", typha.Addr).Info("Connecting to Typha.")
 		typhaConnection = syncclient.New(
-			typhaAddr,
+			typha.Addr,
 			buildinfo.GitVersion,
 			configParams.FelixHostname,
 			fmt.Sprintf("Revision: %s; Build date: %s",
@@ -494,7 +494,7 @@ configRetry:
 		if err != nil {
 			log.WithError(err).Error("Failed to connect to Typha. Retrying...")
 			startTime := time.Now()
-			var deleteWireguardCalled bool
+			var wireguardDeleted bool
 			for err != nil && time.Since(startTime) < 30*time.Second {
 				// Set Ready to false and Live to true when unable to connect to typha
 				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: false})
@@ -504,16 +504,19 @@ configRetry:
 				}
 				log.WithError(err).Debug("Retrying Typha connection")
 
-				if !deleteWireguardCalled {
-					if err = bootstrapRemoveWireguard(configParams, v3Client); err != nil {
+				if !wireguardDeleted && typha.NodeName != nil {
+					if wireguardDeleted, err = bootstrapRemoveWireguardIfTyphaNotProgrammed(*typha.NodeName, configParams, v3Client); err != nil {
 						log.WithError(err).Warn("Unable remove wireguard configuration")
-					} else {
-						deleteWireguardCalled = true
 					}
 				}
 				time.Sleep(1 * time.Second)
 			}
 			if err != nil {
+				if !wireguardDeleted {
+					if err = bootstrapRemoveWireguard(configParams, v3Client); err != nil {
+						log.WithError(err).Warn("Unable remove wireguard configuration")
+					}
+				}
 				log.WithError(err).Fatal("Failed to connect to Typha")
 			} else {
 				log.Info("Connected to Typha after retries.")
@@ -1208,7 +1211,7 @@ func (fc *DataplaneConnector) Start() {
 	go fc.handleWireguardStatUpdateFromDataplane()
 }
 
-func discoverTyphaAddr(configParams *config.Config, k8sClientSet kubernetes.Interface) (string, error) {
+func discoverTyphaAddr(configParams *config.Config, k8sClientSet kubernetes.Interface) (discovery.Typha, error) {
 	typhaDiscoveryOpts := configParams.TyphaDiscoveryOpts()
 	typhaDiscoveryOpts = append(typhaDiscoveryOpts, discovery.WithKubeClient(k8sClientSet))
 	return discovery.DiscoverTyphaAddr(typhaDiscoveryOpts...)

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -368,13 +368,11 @@ configRetry:
 		simulateDataRace()
 	}
 
-	// We may need to temporarily disable encrypted traffic to this node in order to connect to Typha
-	if configParams.WireguardEnabled {
-		err := bootstrapWireguard(configParams, v3Client)
-		if err != nil {
-			time.Sleep(2 * time.Second) // avoid a tight restart loop
-			log.WithError(err).Fatal("Couldn't bootstrap WireGuard host connectivity")
-		}
+	// We may need to remove out-of-date wireguard configuration to allow us to connect to Typha.
+	err := bootstrapWireguard(configParams, v3Client)
+	if err != nil {
+		time.Sleep(2 * time.Second) // avoid a tight restart loop
+		log.WithError(err).Fatal("Couldn't bootstrap WireGuard host connectivity")
 	}
 
 	// Start up the dataplane driver.  This may be the internal go-based driver or an external
@@ -496,6 +494,7 @@ configRetry:
 		if err != nil {
 			log.WithError(err).Error("Failed to connect to Typha. Retrying...")
 			startTime := time.Now()
+			var deleteWireguardCalled bool
 			for err != nil && time.Since(startTime) < 30*time.Second {
 				// Set Ready to false and Live to true when unable to connect to typha
 				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: false})
@@ -504,6 +503,14 @@ configRetry:
 					break
 				}
 				log.WithError(err).Debug("Retrying Typha connection")
+
+				if !deleteWireguardCalled {
+					if err = bootstrapRemoveWireguard(configParams, v3Client); err != nil {
+						log.WithError(err).Warn("Unable remove wireguard configuration")
+					} else {
+						deleteWireguardCalled = true
+					}
+				}
 				time.Sleep(1 * time.Second)
 			}
 			if err != nil {

--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package wireguard
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -27,23 +26,31 @@ import (
 
 	"github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/felix/netlinkshim"
+	apiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
+const (
+	bootstrapBackoffDuration  = 200 * time.Millisecond
+	bootstrapBackoffExpFactor = 2
+	bootstrapBackoffMax       = 2 * time.Second
+	bootstrapJitter           = 0.2
+	bootstrapMaxRetries       = 5
+)
+
 // BootstrapHostConnectivity forces WireGuard peers with hostencryption enabled to communicate with this node unencrypted.
 // This ensures connectivity in scenarios where we have lost our WireGuard config, but will be sent WireGuard traffic
 // e.g. after a node restart, during felix startup, when we need to fetch config from Typha (calico/issues/5125)
-func BootstrapHostConnectivity(configParams *config.Config, getWireguardHandle func() (netlinkshim.Wireguard, error), calicoClient clientv3.Interface) error {
+func BootstrapHostConnectivity(
+	configParams *config.Config,
+	getNetlinkHandle func() (netlinkshim.Interface, error),
+	getWireguardHandle func() (netlinkshim.Wireguard, error),
+	calicoClient clientv3.Interface,
+) error {
 	wgDeviceName := configParams.WireguardInterfaceName
 	nodeName := configParams.FelixHostname
-
-	_, dbgBootstrap := os.LookupEnv("FELIX_DBG_WGBOOTSTRAP")
-
-	if !configParams.WireguardHostEncryptionEnabled && !dbgBootstrap {
-		return nil
-	}
 
 	logCtx := log.WithFields(log.Fields{
 		"iface":    wgDeviceName,
@@ -51,32 +58,48 @@ func BootstrapHostConnectivity(configParams *config.Config, getWireguardHandle f
 		"ref":      "wgBootstrap",
 	})
 
+	if !configParams.WireguardHostEncryptionEnabled {
+		// HostEncryption is currently enabled in environments by operator rather than through FelixConfiguration.
+		// This should not change for a given deployment. We only need to handle bootstrapping for clusters where
+		// host encryption is enabled.
+		logCtx.Debug("Host encryption is not enabled - no wireguard bootstrapping required")
+	}
+
 	logCtx.Debug("Bootstrapping wireguard")
 
-	var storedPublicKey string
-	var kernelPublicKey string
-	const (
-		backoffDuration  = 2 * time.Second
-		backoffExpFactor = 2
-		backoffMax       = 32 * time.Second
-		jitter           = 0.2
-	)
-	maxRetries := 3
-	expBackoffMgr := wait.NewExponentialBackoffManager(
-		backoffDuration, backoffMax, time.Minute, backoffExpFactor, jitter, clock.RealClock{})
-	defer expBackoffMgr.Backoff().Stop()
+	if !configParams.WireguardEnabled || configParams.WireguardInterfaceName == "" {
+		logCtx.Info("Wireguard is not enabled - ensure no wireguard config")
+		return RemoveWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+	}
 
 	wg, err := getWireguardHandle()
 	if err != nil {
-		logCtx.Info("Couldn't acquire WireGuard handle, treating public key as unset")
-	} else {
-		kernelPublicKey = getPublicKey(logCtx, wgDeviceName, wg).String()
-		defer wg.Close()
+		logCtx.Info("Couldn't acquire wireguard handle, remove configuration")
+		return RemoveWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
 	}
+	defer func() {
+		err = wg.Close()
+		logCtx.WithError(err).Info("Couldn't close wireguard handle")
+	}()
 
-	// make a few attempts to read our publickey from the datastore, compare, and update if required
-	for r := 0; r < maxRetries; r++ {
+	var storedPublicKey string
+	var kernelPublicKey string
+	expBackoffMgr := wait.NewExponentialBackoffManager(
+		bootstrapBackoffDuration,
+		bootstrapBackoffMax,
+		time.Minute,
+		bootstrapBackoffExpFactor,
+		bootstrapJitter,
+		clock.RealClock{},
+	)
+	defer expBackoffMgr.Backoff().Stop()
 
+	// Get the public key currently programmed in the kernel.
+	kernelPublicKey = getPublicKey(logCtx, wgDeviceName, wg).String()
+
+	// Make a few attempts to read our publickey from the datastore, compare. If different, remove all wireguard
+	// configuration.
+	for r := 0; r < bootstrapMaxRetries; r++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		thisNode, err := calicoClient.Nodes().Get(ctx, nodeName, options.GetOptions{})
 		cancel()
@@ -86,31 +109,167 @@ func BootstrapHostConnectivity(configParams *config.Config, getWireguardHandle f
 			continue
 		}
 
-		// if there is any config mismatch, wipe the datastore's publickey (forces peers to send unencrypted traffic)
+		// If there is any config mismatch, wipe the datastore's publickey (forces peers to send unencrypted traffic).
+		// Once connected and sync'd the key will be regenerated and propagated.
 		storedPublicKey = thisNode.Status.WireguardPublicKey
 		if storedPublicKey != kernelPublicKey {
-			logCtx.Info("Found mismatch between kernel and datastore WireGuard keys. Clearing stale key from datastore")
-			thisNode.Status.WireguardPublicKey = ""
-			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
-			_, err := calicoClient.Nodes().Update(ctx, thisNode, options.SetOptions{})
-			cancel()
-			if err != nil {
-				switch err.(type) {
-				case cerrors.ErrorResourceUpdateConflict:
-					logCtx.Infof("Conflict while clearing WireGuard config, retrying update (%v)", err)
-
-				default:
-					logCtx.Errorf("Failed to clear WireGuard config: %v", err)
-				}
-				<-expBackoffMgr.Backoff().C()
-				continue
-			}
-			logCtx.Info("Cleared WireGuard public key from datastore")
+			logCtx.Info("Found mismatch between kernel and datastore wireguard keys - removing wireguard configuration")
+			return RemoveWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
 		}
 		return nil
 	}
 
-	return fmt.Errorf("couldn't bootstrap host connecivity after %d retries", maxRetries)
+	// Couldn't determine the current wireguard configuration.
+	return fmt.Errorf("couldn't determine current wireguard configuration after %d retries", bootstrapMaxRetries)
+}
+
+// RemoveWireguardForHostEncryptionBootstrapping removes all wireguard configuration. This includes:
+// - The wireguard public key
+// - The wireguard device (which in turn will delete all wireguard routing rules).
+func RemoveWireguardForHostEncryptionBootstrapping(
+	configParams *config.Config,
+	getNetlinkHandle func() (netlinkshim.Interface, error),
+	calicoClient clientv3.Interface,
+) error {
+	wgDeviceName := configParams.WireguardInterfaceName
+	nodeName := configParams.FelixHostname
+
+	logCtx := log.WithFields(log.Fields{
+		"iface":    wgDeviceName,
+		"hostName": nodeName,
+	})
+
+	if !configParams.WireguardHostEncryptionEnabled {
+		// HostEncryption is currently enabled in environments by operator rather than through FelixConfiguration.
+		// This should not change for a given deployment. We only need to handle bootstrapping for clusters where
+		// host encryption is enabled.
+		logCtx.Debug("Host encryption is not enabled - no wireguard bootstrapping required")
+	}
+
+	// Remove all wireguard configuration that we can.
+	err1 := removeWireguardDevice(configParams, getNetlinkHandle)
+	err2 := removeWireguardPublicKey(configParams, calicoClient)
+
+	if err1 != nil {
+		return err1
+	} else if err2 != nil {
+		return err2
+	}
+	return nil
+}
+
+// removeWireguardDevice removes the wireguard device
+func removeWireguardDevice(
+	configParams *config.Config,
+	getNetlinkHandle func() (netlinkshim.Interface, error),
+) error {
+	wgDeviceName := configParams.WireguardInterfaceName
+	nodeName := configParams.FelixHostname
+
+	logCtx := log.WithFields(log.Fields{
+		"iface":    wgDeviceName,
+		"hostName": nodeName,
+	})
+
+	if wgDeviceName == "" {
+		logCtx.Debug("No wireguard device specified")
+		return nil
+	}
+
+	logCtx.Debug("Removing wireguard device")
+
+	expBackoffMgr := wait.NewExponentialBackoffManager(
+		bootstrapBackoffDuration,
+		bootstrapBackoffMax,
+		time.Minute,
+		bootstrapBackoffExpFactor,
+		bootstrapJitter,
+		clock.RealClock{},
+	)
+	defer expBackoffMgr.Backoff().Stop()
+
+	// Make a few attempts to delete the wireguard device.
+	var err error
+	var handle netlinkshim.Interface
+	for r := 0; r < bootstrapMaxRetries; r++ {
+		if handle == nil {
+			if handle, err = getNetlinkHandle(); err != nil {
+				<-expBackoffMgr.Backoff().C()
+				continue
+			}
+			defer handle.Delete()
+		}
+		if err = removeLink(wgDeviceName, handle); err != nil {
+			<-expBackoffMgr.Backoff().C()
+			continue
+		}
+		return nil
+	}
+
+	return fmt.Errorf("couldn't remove wireguard device after %d retries: %v", bootstrapMaxRetries, err)
+}
+
+// removeWireguardPublicKey removes the public key from the node.
+func removeWireguardPublicKey(
+	configParams *config.Config,
+	calicoClient clientv3.Interface,
+) error {
+	nodeName := configParams.FelixHostname
+
+	logCtx := log.WithFields(log.Fields{
+		"hostName": nodeName,
+	})
+
+	logCtx.Debug("Removing wireguard public key")
+
+	expBackoffMgr := wait.NewExponentialBackoffManager(
+		bootstrapBackoffDuration,
+		bootstrapBackoffMax,
+		time.Minute,
+		bootstrapBackoffExpFactor,
+		bootstrapJitter,
+		clock.RealClock{},
+	)
+	defer expBackoffMgr.Backoff().Stop()
+
+	// Make a few attempts to remove the public key from the datastore.
+	var err error
+	var thisNode *apiv3.Node
+	for r := 0; r < bootstrapMaxRetries; r++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		thisNode, err = calicoClient.Nodes().Get(ctx, nodeName, options.GetOptions{})
+		cancel()
+		if err != nil {
+			logCtx.WithError(err).Warn("Couldn't fetch node config from datastore, retrying")
+			<-expBackoffMgr.Backoff().C() // safe to block here as we're not dependent on other threads
+			continue
+		}
+
+		// if there is any config mismatch, wipe the datastore's publickey (forces peers to send unencrypted traffic)
+		if thisNode.Status.WireguardPublicKey != "" {
+			logCtx.Info("Wireguard key set on node - removing")
+			thisNode.Status.WireguardPublicKey = ""
+			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+			_, err = calicoClient.Nodes().Update(ctx, thisNode, options.SetOptions{})
+			cancel()
+			if err != nil {
+				switch err.(type) {
+				case cerrors.ErrorResourceUpdateConflict:
+					logCtx.Infof("Conflict while clearing wireguard config, retrying update (%v)", err)
+				default:
+					logCtx.Errorf("Failed to clear wireguard config: %v", err)
+				}
+				<-expBackoffMgr.Backoff().C()
+				continue
+			}
+			logCtx.Info("Cleared wireguard public key from datastore")
+		} else {
+			logCtx.Info("Wireguard public key not set in datastore")
+		}
+		return nil
+	}
+
+	return fmt.Errorf("couldn't delete wireguard public key after %d retries: %v", bootstrapMaxRetries, err)
 }
 
 // getPublicKey attempts to fetch a wireguard key from the kernel statelessly
@@ -118,9 +277,28 @@ func BootstrapHostConnectivity(configParams *config.Config, getWireguardHandle f
 func getPublicKey(log *log.Entry, wgIfaceName string, wg netlinkshim.Wireguard) wgtypes.Key {
 	dev, err := wg.DeviceByName(wgIfaceName)
 	if err != nil {
-		log.WithError(err).Debugf("Couldn't find WireGuard device '%s', reporting unset key", wgIfaceName)
+		log.WithError(err).Debugf("Couldn't find wireguard device '%s', reporting unset key", wgIfaceName)
 		return zeroKey
 	}
-
 	return dev.PublicKey
+}
+
+// removeLink removes the named link.
+func removeLink(name string, netlinkClient netlinkshim.Interface) error {
+	logCxt := log.WithField("ifaceName", name)
+	link, err := netlinkClient.LinkByName(name)
+	if err == nil {
+		logCxt.Info("Deleting device")
+		if err := netlinkClient.LinkDel(link); err != nil {
+			log.WithError(err).Error("Error deleting wireguard type link")
+			return err
+		}
+		logCxt.Info("Deleted device")
+	} else if netlinkshim.IsNotExist(err) {
+		logCxt.Debug("Device does not exist")
+	} else if err != nil {
+		logCxt.WithError(err).Error("Unable to determine if device exists")
+		return err
+	}
+	return nil
 }

--- a/felix/wireguard/config.go
+++ b/felix/wireguard/config.go
@@ -1,3 +1,16 @@
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package wireguard
 
 type Config struct {

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/wireguard/wireguard_suite_test.go
+++ b/felix/wireguard/wireguard_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/typha/pkg/syncclientutils/startsyncerclient.go
+++ b/typha/pkg/syncclientutils/startsyncerclient.go
@@ -39,7 +39,7 @@ func MustStartSyncerClientIfTyphaConfigured(
 	myVersion, myHostname, myInfo string,
 	cbs api.SyncerCallbacks,
 ) bool {
-	typhaAddr, err := discovery.DiscoverTyphaAddr(
+	typha, err := discovery.DiscoverTyphaAddr(
 		discovery.WithAddrOverride(typhaConfig.Addr),
 		discovery.WithInClusterKubeClient(), /* defer creation of a client until its needed. */
 		discovery.WithKubeService(typhaConfig.K8sNamespace, typhaConfig.K8sServiceName),
@@ -47,15 +47,15 @@ func MustStartSyncerClientIfTyphaConfigured(
 	if err != nil {
 		log.WithError(err).Fatal("Typha discovery enabled but discovery failed.")
 	}
-	if typhaAddr == "" {
+	if typha.Addr == "" {
 		log.Debug("Typha is not configured")
 		return false
 	}
 
 	// Use a remote Syncer, via the Typha server.
-	log.WithField("addr", typhaAddr).Info("Connecting to Typha.")
+	log.WithField("addr", typha.Addr).Info("Connecting to Typha.")
 	typhaConnection := syncclient.New(
-		typhaAddr,
+		typha.Addr,
 		myVersion, myHostname, myInfo,
 		cbs,
 		&syncclient.Options{


### PR DESCRIPTION
## Description

This PR extends the original wireguard bootstrapping.
-  On startup it attempts wireguard bootstrap (1)
- On failing to connect to typha (twice) if attempts wireguard deletion for bootstrapping (2)

(1)  If wireguard device does not exist, or wireguard public key does not match that configured in the node then delete wireguard config.

(2) deletion of wireguard config now includes both the public key and the wg link - deleting the link should also remove any associated routes.

I've removed the felix debug option for determining when we bootstrap and we just always do the bootstrapping when there is host encryption enabled (even if wireguard is not actually enabled).


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
