### PR TITLE
Change Typha discovery from random to local-first-if-available.

### DIFF
--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -170,7 +170,7 @@ func Run(configFile string, gitVersion string, buildDate string, gitRevision str
 	var v3Client client.Interface
 	var datastoreConfig apiconfig.CalicoAPIConfig
 	var configParams *config.Config
-	var typhaAddr string
+	var typhaAddresses []discovery.Typha
 	var numClientsCreated int
 	var k8sClientSet *kubernetes.Clientset
 	var kubernetesVersion string
@@ -317,7 +317,7 @@ configRetry:
 		}
 
 		// If we're configured to discover Typha, do that now so we can retry if we fail.
-		typhaAddr, err = discoverTyphaAddr(configParams, k8sClientSet)
+		typhaAddresses, err = discoverTyphaAddr(configParams, k8sClientSet)
 		if err != nil {
 			log.WithError(err).Error("Typha discovery enabled but discovery failed.")
 			time.Sleep(1 * time.Second)
@@ -457,11 +457,12 @@ configRetry:
 	var syncer Startable
 	var typhaConnection *syncclient.SyncerClient
 	syncerToValidator := calc.NewSyncerCallbacksDecoupler()
-	if typhaAddr != "" {
+
+	if len(typhaAddresses) > 0 {
 		// Use a remote Syncer, via the Typha server.
-		log.WithField("addr", typhaAddr).Info("Connecting to Typha.")
+		log.WithField("addresses", typhaAddresses).Info("Connecting to Typha.")
 		typhaConnection = syncclient.New(
-			typhaAddr,
+			typhaAddresses,
 			buildinfo.GitVersion,
 			configParams.FelixHostname,
 			fmt.Sprintf("Revision: %s; Build date: %s",
@@ -1201,8 +1202,15 @@ func (fc *DataplaneConnector) Start() {
 	go fc.handleWireguardStatUpdateFromDataplane()
 }
 
-func discoverTyphaAddr(configParams *config.Config, k8sClientSet kubernetes.Interface) (string, error) {
+func discoverTyphaAddr(configParams *config.Config, k8sClientSet kubernetes.Interface) ([]discovery.Typha, error) {
 	typhaDiscoveryOpts := configParams.TyphaDiscoveryOpts()
-	typhaDiscoveryOpts = append(typhaDiscoveryOpts, discovery.WithKubeClient(k8sClientSet))
-	return discovery.DiscoverTyphaAddr(typhaDiscoveryOpts...)
+	typhaDiscoveryOpts = append(typhaDiscoveryOpts,
+		discovery.WithKubeClient(k8sClientSet),
+		discovery.WithNodeAffinity(configParams.FelixHostname),
+	)
+	res, err := discovery.DiscoverTyphaAddr(typhaDiscoveryOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }

--- a/felix/daemon/daemon_test.go
+++ b/felix/daemon/daemon_test.go
@@ -15,15 +15,12 @@
 package daemon
 
 import (
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/projectcalico/calico/libcalico-go/lib/set"
-
 	"github.com/projectcalico/calico/felix/config"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -88,20 +85,22 @@ var _ = Describe("Typha address discovery", func() {
 		configParams.TyphaAddr = "10.0.0.1:8080"
 		typhaAddr, err := discoverTyphaAddr(configParams, nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("10.0.0.1:8080"))
+		Expect(typhaAddr).To(Equal([]discovery.Typha{{Addr: "10.0.0.1:8080"}}))
 	})
 
 	It("should return nothing if no service name", func() {
 		configParams.TyphaK8sServiceName = ""
 		typhaAddr, err := discoverTyphaAddr(configParams, nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal(""))
+		Expect(typhaAddr).To(BeNil())
 	})
 
 	It("should return IP from endpoints", func() {
 		typhaAddr, err := discoverTyphaAddr(configParams, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("10.0.0.2:8156"))
+		Expect(typhaAddr).To(ConsistOf(
+			discovery.Typha{Addr: "10.0.0.2:8156", IP: "10.0.0.2"},
+		))
 	})
 
 	It("should bracket an IPv6 Typha address", func() {
@@ -109,7 +108,9 @@ var _ = Describe("Typha address discovery", func() {
 		refreshClient()
 		typhaAddr, err := discoverTyphaAddr(configParams, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("[fd5f:65af::2]:8156"))
+		Expect(typhaAddr).To(ConsistOf(
+			discovery.Typha{Addr: "[fd5f:65af::2]:8156", IP: "fd5f:65af::2"},
+		))
 	})
 
 	It("should error if no Typhas", func() {
@@ -120,19 +121,17 @@ var _ = Describe("Typha address discovery", func() {
 	})
 
 	It("should choose random Typhas", func() {
-		seenAddresses := set.New()
-		expected := set.From("10.0.0.2:8156", "10.0.0.6:8156")
+		// Skip("skip random test")
 		endpoints.Subsets[1].Addresses = append(endpoints.Subsets[1].Addresses, v1.EndpointAddress{IP: "10.0.0.6"})
 		refreshClient()
 
-		for i := 0; i < 32; i++ {
-			addr, err := discoverTyphaAddr(configParams, k8sClient)
-			Expect(err).NotTo(HaveOccurred())
-			seenAddresses.Add(addr)
-			if seenAddresses.ContainsAll(expected) {
-				return
-			}
-		}
-		Fail(fmt.Sprintf("Didn't get expected values; got %v", seenAddresses))
+		addr, err := discoverTyphaAddr(configParams, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addr).To(
+			ContainElements(
+				discovery.Typha{Addr: "10.0.0.2:8156", IP: "10.0.0.2"},
+				discovery.Typha{Addr: "10.0.0.6:8156", IP: "10.0.0.6"},
+			),
+		)
 	})
 })

--- a/typha/cmd/typha-client/typha-client.go
+++ b/typha/cmd/typha-client/typha-client.go
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	hostname, _ := os.Hostname()
-	client := syncclient.New(addr, buildinfo.GitVersion, hostname, "typha command-line client", callbacks, options)
+	client := syncclient.New([]string{addr}, buildinfo.GitVersion, hostname, "typha command-line client", callbacks, options)
 	err = client.Start(context.Background())
 	if err != nil {
 		log.WithError(err).Panic("Client failed")

--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -45,6 +45,7 @@ import (
 	calinet "github.com/projectcalico/calico/libcalico-go/lib/net"
 	. "github.com/projectcalico/calico/typha/fv-tests"
 	"github.com/projectcalico/calico/typha/pkg/calc"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 	"github.com/projectcalico/calico/typha/pkg/snapcache"
 	"github.com/projectcalico/calico/typha/pkg/syncclient"
 	"github.com/projectcalico/calico/typha/pkg/syncproto"
@@ -186,8 +187,9 @@ var _ = Describe("With an in-process Server", func() {
 	createClient := func(id interface{}, syncType syncproto.SyncerType) clientState {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
+		serverAddr := fmt.Sprintf("127.0.0.1:%d", server.Port())
 		client := syncclient.New(
-			fmt.Sprintf("127.0.0.1:%d", server.Port()),
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			fmt.Sprintf("test-host-%v", id),
 			"test-info",
@@ -690,7 +692,7 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
 		client := syncclient.New(
-			serverAddr,
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host",
 			"test-info",
@@ -724,7 +726,7 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 		recorder := NewRecorder()
 
 		client := syncclient.New(
-			serverAddr,
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host",
 			"test-info",
@@ -945,7 +947,7 @@ var _ = Describe("With an in-process Server with long ping interval", func() {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
 		client := syncclient.New(
-			serverAddr,
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host",
 			"test-info",
@@ -1090,7 +1092,7 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			recorder.BlockAfterNUpdates(1, 2500*time.Millisecond)
 
 			client := syncclient.New(
-				serverAddr,
+				[]discovery.Typha{{Addr: serverAddr}},
 				"test-version",
 				"test-host",
 				"test-info",
@@ -1139,7 +1141,7 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			recorder.BlockAfterNUpdates(initialSnapshotSize+1, 2500*time.Millisecond)
 
 			client := syncclient.New(
-				serverAddr,
+				[]discovery.Typha{{Addr: serverAddr}},
 				"test-version",
 				"test-host",
 				"test-info",
@@ -1323,8 +1325,9 @@ var _ = Describe("with server requiring TLS", func() {
 	createClient := func(options *syncclient.Options) clientState {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
+		serverAddr := fmt.Sprintf("127.0.0.1:%d", server.Port())
 		client := syncclient.New(
-			fmt.Sprintf("127.0.0.1:%d", server.Port()),
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host-1",
 			"test-info",

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/projectcalico/calico/typha/pkg/daemon"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 
 	"context"
 	"fmt"
@@ -163,9 +164,10 @@ var _ = Describe("Daemon", func() {
 
 				// Get the chosen port then start a real client in a context we can cancel.
 				port := d.Server.Port()
+				addr := fmt.Sprintf("127.0.0.1:%d", port)
 				cbs := fvtests.NewRecorder()
 				client := syncclient.New(
-					fmt.Sprintf("127.0.0.1:%d", port),
+					[]discovery.Typha{{Addr: addr}},
 					"",
 					"",
 					"",

--- a/typha/pkg/discovery/discovery_test.go
+++ b/typha/pkg/discovery/discovery_test.go
@@ -15,7 +15,6 @@
 package discovery
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -24,14 +23,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
 var _ = Describe("Typha address discovery", func() {
 	var (
-		endpoints *v1.Endpoints
-		k8sClient *fake.Clientset
+		endpoints                     *v1.Endpoints
+		k8sClient                     *fake.Clientset
+		localNodeName, remoteNodeName string
+		noTyphas                      []string
 	)
 
 	refreshClient := func() {
@@ -39,6 +38,9 @@ var _ = Describe("Typha address discovery", func() {
 	}
 
 	BeforeEach(func() {
+		localNodeName = "felix-local"
+		remoteNodeName = "felix-remote"
+
 		rand.Seed(time.Now().UTC().UnixNano())
 		endpoints = &v1.Endpoints{
 			TypeMeta: metav1.TypeMeta{
@@ -52,7 +54,7 @@ var _ = Describe("Typha address discovery", func() {
 			Subsets: []v1.EndpointSubset{
 				{
 					Addresses: []v1.EndpointAddress{
-						{IP: "10.0.0.4"},
+						{IP: "10.0.0.4", NodeName: &localNodeName},
 					},
 					NotReadyAddresses: []v1.EndpointAddress{},
 					Ports: []v1.EndpointPort{
@@ -61,10 +63,10 @@ var _ = Describe("Typha address discovery", func() {
 				},
 				{
 					Addresses: []v1.EndpointAddress{
-						{IP: "10.0.0.2"},
+						{IP: "10.0.0.2", NodeName: &remoteNodeName},
 					},
 					NotReadyAddresses: []v1.EndpointAddress{
-						{IP: "10.0.0.5"},
+						{IP: "10.0.0.5", NodeName: &remoteNodeName},
 					},
 					Ports: []v1.EndpointPort{
 						{Name: "calico-typha-v2", Port: 8157, Protocol: v1.ProtocolUDP},
@@ -80,19 +82,19 @@ var _ = Describe("Typha address discovery", func() {
 	It("should return address if configured", func() {
 		typhaAddr, err := DiscoverTyphaAddr(WithAddrOverride("10.0.0.1:8080"))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("10.0.0.1:8080"))
+		Expect(typhaAddr).To(Equal([]Typha{{Addr: "10.0.0.1:8080"}}))
 	})
 
 	It("should return nothing if no service name and no client", func() {
 		typhaAddr, err := DiscoverTyphaAddr()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal(""))
+		Expect(typhaAddr).To(Equal(noTyphas))
 	})
 
 	It("should return nothing if no service name with client", func() {
 		typhaAddr, err := DiscoverTyphaAddr(WithKubeClient(k8sClient))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal(""))
+		Expect(typhaAddr).To(Equal(noTyphas))
 	})
 
 	It("should return IP from endpoints", func() {
@@ -101,17 +103,23 @@ var _ = Describe("Typha address discovery", func() {
 			WithKubeClient(k8sClient),
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("10.0.0.2:8156"))
+		Expect(typhaAddr).To(Equal([]Typha{
+			{Addr: "10.0.0.2:8156", NodeName: &localNodeName},
+		}))
 	})
 
-	It("should return v2 IP from endpoints if port name override is used", func() {
+	It("should return v2 IP from endpoints if port name override is used, ordered with local endpoint first", func() {
 		typhaAddr, err := DiscoverTyphaAddr(
 			WithKubeService("kube-system", "calico-typha-service"),
 			WithKubeClient(k8sClient),
 			WithKubeServicePortNameOverride("calico-typha-v2"),
+			WithNodeAffinity(localNodeName),
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Or(Equal("10.0.0.4:8157"), Equal("10.0.0.2:8157")))
+		Expect(typhaAddr).To(Equal([]Typha{
+			{Addr: "10.0.0.4:8157", NodeName: &localNodeName},
+			{Addr: "10.0.0.2:8157", NodeName: &remoteNodeName},
+		}))
 	})
 
 	It("should bracket an IPv6 Typha address", func() {
@@ -122,7 +130,9 @@ var _ = Describe("Typha address discovery", func() {
 			WithKubeClient(k8sClient),
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("[fd5f:65af::2]:8156"))
+		Expect(typhaAddr).To(Equal([]Typha{
+			{Addr: "[fd5f:65af::2]:8156", NodeName: &remoteNodeName},
+		}))
 	})
 
 	It("should error if no Typhas", func() {
@@ -133,25 +143,6 @@ var _ = Describe("Typha address discovery", func() {
 			WithKubeClient(k8sClient),
 		)
 		Expect(err).To(HaveOccurred())
-	})
-
-	It("should choose random Typhas", func() {
-		seenAddresses := set.New()
-		expected := set.From("10.0.0.2:8156", "10.0.0.6:8156")
-		endpoints.Subsets[1].Addresses = append(endpoints.Subsets[1].Addresses, v1.EndpointAddress{IP: "10.0.0.6"})
-		refreshClient()
-
-		for i := 0; i < 32; i++ {
-			addr, err := DiscoverTyphaAddr(
-				WithKubeService("kube-system", "calico-typha-service"),
-				WithKubeClient(k8sClient),
-			)
-			Expect(err).NotTo(HaveOccurred())
-			seenAddresses.Add(addr)
-			if seenAddresses.ContainsAll(expected) {
-				return
-			}
-		}
-		Fail(fmt.Sprintf("Didn't get expected values; got %v", seenAddresses))
+		Expect(err).To(Equal(ErrServiceNotReady))
 	})
 })

--- a/typha/pkg/syncclient/sync_client.go
+++ b/typha/pkg/syncclient/sync_client.go
@@ -29,6 +29,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 	"github.com/projectcalico/calico/typha/pkg/syncproto"
 	"github.com/projectcalico/calico/typha/pkg/tlsutils"
 )
@@ -90,7 +91,7 @@ func (o *Options) validate() (err error) {
 }
 
 func New(
-	addr string,
+	addrs []discovery.Typha,
 	myVersion, myHostname, myInfo string,
 	cbs api.SyncerCallbacks,
 	options *Options,
@@ -110,7 +111,7 @@ func New(
 			"type":   options.SyncerType,
 		}),
 		callbacks: cbs,
-		addr:      addr,
+		addrs:     addrs,
 
 		myVersion:  myVersion,
 		myHostname: myHostname,
@@ -126,7 +127,8 @@ func New(
 type SyncerClient struct {
 	ID                            uint64
 	logCxt                        *log.Entry
-	addr                          string
+	addrs                         []discovery.Typha
+	connInfo                      *discovery.Typha
 	myHostname, myVersion, myInfo string
 	options                       *Options
 
@@ -146,10 +148,22 @@ type handshakeStatus struct {
 }
 
 func (s *SyncerClient) Start(cxt context.Context) error {
+	s.logCxt.WithField("addresses", s.addrs).Info("Syncer started")
 	// Connect synchronously.
-	err := s.connect(cxt)
-	if err != nil {
-		return err
+	var connectOk bool
+	for i, addr := range s.addrs {
+		s.logCxt.Info("connecting to typha endpoint %s (%d of %d)", addr, i+1, len(s.addrs))
+		err := s.connect(cxt, addr)
+		if err != nil {
+			s.logCxt.WithError(err).Warnf("error connecting to typha endpoint (%d of %d) %s", i+1, len(s.addrs), addr)
+		} else {
+			connectOk = true
+			break
+		}
+	}
+	// ran out of addresses with errors
+	if !connectOk {
+		return fmt.Errorf("connection to typhas (%v) failed", s.addrs)
 	}
 
 	// Then start our background goroutines.  We start the main loop and a second goroutine to
@@ -196,12 +210,12 @@ func (s *SyncerClient) SupportsNodeResourceUpdates(timeout time.Duration) (bool,
 	return false, fmt.Errorf("Timed out waiting for handshake to complete")
 }
 
-func (s *SyncerClient) connect(cxt context.Context) error {
+func (s *SyncerClient) connect(cxt context.Context, typhaAddr discovery.Typha) error {
 	log.Info("Starting Typha client")
 	var err error
-	logCxt := s.logCxt.WithField("address", s.addr)
+	logCxt := s.logCxt.WithField("address", typhaAddr)
 
-	var connFunc func() (net.Conn, error)
+	var connFunc func(string) (net.Conn, error)
 	if s.options.requiringTLS() {
 		cert, err := tls.LoadX509KeyPair(s.options.CertFile, s.options.KeyFile)
 		if err != nil {
@@ -236,21 +250,21 @@ func (s *SyncerClient) connect(cxt context.Context) error {
 			s.options.ServerURISAN,
 		)
 
-		connFunc = func() (net.Conn, error) {
+		connFunc = func(addr string) (net.Conn, error) {
 			return tls.DialWithDialer(
 				&net.Dialer{Timeout: 10 * time.Second},
 				"tcp",
-				s.addr,
+				addr,
 				&tlsConfig)
 		}
 	} else {
-		connFunc = func() (net.Conn, error) {
-			return net.DialTimeout("tcp", s.addr, 10*time.Second)
+		connFunc = func(addr string) (net.Conn, error) {
+			return net.DialTimeout("tcp", addr, 10*time.Second)
 		}
 	}
 	if cxt.Err() == nil {
 		logCxt.Info("Connecting to Typha.")
-		s.connection, err = connFunc()
+		s.connection, err = connFunc(typhaAddr.Addr)
 		if err != nil {
 			return err
 		}
@@ -265,6 +279,7 @@ func (s *SyncerClient) connect(cxt context.Context) error {
 		return cxt.Err()
 	}
 	logCxt.Info("Connected to Typha.")
+	s.connInfo = &discovery.Typha{}
 
 	// Log TLS connection details.
 	tlsConn, ok := s.connection.(*tls.Conn)
@@ -297,7 +312,7 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 	defer s.Finished.Done()
 	defer cancelFn()
 
-	logCxt := s.logCxt.WithField("address", s.addr)
+	logCxt := s.logCxt.WithField("connection", s.connInfo)
 	logCxt.Info("Started Typha client main loop")
 
 	s.encoder = gob.NewEncoder(s.connection)

--- a/typha/pkg/syncclientutils/startsyncerclient.go
+++ b/typha/pkg/syncclientutils/startsyncerclient.go
@@ -47,7 +47,7 @@ func MustStartSyncerClientIfTyphaConfigured(
 	if err != nil {
 		log.WithError(err).Fatal("Typha discovery enabled but discovery failed.")
 	}
-	if typhaAddr == "" {
+	if len(typhaAddr) == 0 {
 		log.Debug("Typha is not configured")
 		return false
 	}


### PR DESCRIPTION
## Description
-  Change Syncer client to accept a list of Typha endpoints to iterate through, supplied by discovery
-  Typha discovery will return a list of Typha IPs now instead of a random IP candidate
-  Both discovery and syncer have typha ip data including nodeName and bare IP
-  discovery unit tests updated,  existing tests updated where appropriate


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
