### PR TITLE
Fix networking-calico CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -546,7 +546,6 @@ blocks:
   task:
     prologue:
       commands:
-      - checkout
       - cd networking-calico
       - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
       - sudo pip3 install tox

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-setuptools!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0,>=21.0.0 # PSF/ZPL
+setuptools!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0,>=21.0.0,<60.0.0 # PSF/ZPL
 
 hacking<0.11,>=0.10.0
 


### PR DESCRIPTION
#### Remove duplicate checkout

#### Pin setuptools<60.0.0

Given that it was "python setup.py testr ..." that was hanging, and before showing any test output,
I guessed the problem might be caused by a setuptools change, and so tried pinning to various
earlier versions.

Without any pin, we were getting setuptools 61.0.0.  This wasn't visible in the Semaphore logs, but
I attached to the Semaphore VM and checked what was installed under the py38 venv.

Then, empirically:

- Pin setuptools<61.0.0: we still get a hang

- Pin setuptools<58.0.0: no hang, test runs through normally

- Pin setuptools<60.0.0: no hang, test runs through normally

So pinning <60.0.0 as it feels better to pin to as recent a version as possible.

Unfortunately I don't see anything, from v59 to v60 at
https://setuptools.pypa.io/en/latest/history.html, that obviously explains this hang, and it's not
ideal to do this pin without deeper understanding.  But it gets our CI green again for now.
Hopefully we'll have a chance to come back and understand better.
