### PR TITLE
Wireguard bootstrap master

### DIFF
--- a/felix/daemon/bootstrap_linux.go
+++ b/felix/daemon/bootstrap_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,19 +15,36 @@
 package daemon
 
 import (
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/felix/netlinkshim"
 	"github.com/projectcalico/calico/felix/wireguard"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 )
 
-func bootstrapWireguard(configParams *config.Config, v3Client clientv3.Interface) error {
+// bootstrapWireguard performs some start-up single shot bootstrapping of wireguard configuration.
+func bootstrapWireguardAndFilterTyphaAddresses(
+	configParams *config.Config, v3Client clientv3.Interface, typhas []discovery.Typha,
+) ([]discovery.Typha, error) {
 	log.Debug("bootstrapping wireguard host connectivity")
-	return wireguard.BootstrapHostConnectivity(
+	return wireguard.BootstrapHostConnectivityAndFilterTyphaAddresses(
 		configParams,
+		netlinkshim.NewRealNetlink,
 		netlinkshim.NewRealWireguard,
+		v3Client,
+		typhas,
+	)
+}
+
+// bootstrapRemoveWireguard removes the local wireguard configuration to force unencrypted traffic. This is a last
+// resort used when failing to connect to typha.
+func bootstrapRemoveWireguard(configParams *config.Config, v3Client clientv3.Interface) error {
+	log.Debug("bootstrapping wireguard host connectivity by removing wireguard config")
+	return wireguard.RemoveWireguardForHostEncryptionBootstrapping(
+		configParams,
+		netlinkshim.NewRealNetlink,
 		v3Client,
 	)
 }

--- a/felix/daemon/bootstrap_linux.go
+++ b/felix/daemon/bootstrap_linux.go
@@ -42,7 +42,7 @@ func bootstrapWireguardAndFilterTyphaAddresses(
 // resort used when failing to connect to typha.
 func bootstrapRemoveWireguard(configParams *config.Config, v3Client clientv3.Interface) error {
 	log.Debug("bootstrapping wireguard host connectivity by removing wireguard config")
-	return wireguard.RemoveWireguardForHostEncryptionBootstrapping(
+	return wireguard.RemoveWireguardConditionallyOnBootstrap(
 		configParams,
 		netlinkshim.NewRealNetlink,
 		v3Client,

--- a/felix/daemon/bootstrap_linux.go
+++ b/felix/daemon/bootstrap_linux.go
@@ -25,11 +25,13 @@ import (
 )
 
 // bootstrapWireguard performs some start-up single shot bootstrapping of wireguard configuration.
+//
+// See wireguard.BootstrapAndFilterTyphaAddresses for details.
 func bootstrapWireguardAndFilterTyphaAddresses(
 	configParams *config.Config, v3Client clientv3.Interface, typhas []discovery.Typha,
 ) ([]discovery.Typha, error) {
 	log.Debug("bootstrapping wireguard host connectivity")
-	return wireguard.BootstrapHostConnectivityAndFilterTyphaAddresses(
+	return wireguard.BootstrapAndFilterTyphaAddresses(
 		configParams,
 		netlinkshim.NewRealNetlink,
 		netlinkshim.NewRealWireguard,

--- a/felix/daemon/bootstrap_windows.go
+++ b/felix/daemon/bootstrap_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,15 @@ package daemon
 import (
 	"github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 )
 
-func bootstrapWireguard(_ *config.Config, _ clientv3.Interface) error {
+func bootstrapWireguardAndFilterTyphaAddresses(
+	_ *config.Config, _ clientv3.Interface, typhas []discovery.Typha,
+) ([]discovery.Typha, error) {
+	return typhas, nil
+} // no filtering
+
+func bootstrapRemoveWireguard(_ *config.Config, _ clientv3.Interface) error {
 	return nil
 } // no-op

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -383,22 +383,12 @@ configRetry:
 
 	// Perform wireguard bootstrap processing. This may remove wireguard configuration if wireguard is disabled or
 	// if the configuration is obviously broken. This also filters the typha addresses based on whether routing is
-	// obviously broken to the typha node (due to wireguard routing asymmetry). If we end up filtering out all of the
-	// typha addresses then we will need to remove our wireguard configuration to proceed.
+	// obviously broken to the typha node (due to wireguard routing asymmetry). If all typhas would be filtered out then
+	// wireguard is removed from the node and all typhas are returned (unfiltered).
 	typhaAddresses, err := bootstrapWireguardAndFilterTyphaAddresses(configParams, v3Client, typhaAddresses)
 	if err != nil {
 		time.Sleep(2 * time.Second) // avoid a tight restart loop
 		log.WithError(err).Fatal("Couldn't bootstrap WireGuard host connectivity")
-	}
-
-	felixConfiguredToUseTypha := configParams.TyphaK8sServiceName != ""
-	if felixConfiguredToUseTypha && len(typhaAddresses) == 0 {
-		// typha configured but with zero available typhas filtered, for now
-		log.WithFields(log.Fields{
-			"subject":     "felix-typha-config",
-			"namespace":   configParams.TyphaK8sNamespace,
-			"servicename": configParams.TyphaK8sServiceName,
-		}).Fatal("No valid Typha candidates in spite of being configured to use Typha")
 	}
 
 	// Start up the dataplane driver.  This may be the internal go-based driver or an external

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -391,6 +391,16 @@ configRetry:
 		log.WithError(err).Fatal("Couldn't bootstrap WireGuard host connectivity")
 	}
 
+	felixConfiguredToUseTypha := configParams.TyphaK8sServiceName != ""
+	if felixConfiguredToUseTypha && len(typhaAddresses) == 0 {
+		// typha configured but with zero available typhas filtered, for now
+		log.WithFields(log.Fields{
+			"subject":     "felix-typha-config",
+			"namespace":   configParams.TyphaK8sNamespace,
+			"servicename": configParams.TyphaK8sServiceName,
+		}).Fatal("No valid Typha candidates in spite of being configured to use Typha")
+	}
+
 	// Start up the dataplane driver.  This may be the internal go-based driver or an external
 	// one.
 	var dpDriver dp.DataplaneDriver

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -171,7 +171,7 @@ func Run(configFile string, gitVersion string, buildDate string, gitRevision str
 	var v3Client client.Interface
 	var datastoreConfig apiconfig.CalicoAPIConfig
 	var configParams *config.Config
-	var typhaAddr string
+	var typhaAddresses []discovery.Typha
 	var numClientsCreated int
 	var k8sClientSet *kubernetes.Clientset
 	var kubernetesVersion string
@@ -330,7 +330,7 @@ configRetry:
 		}
 
 		// If we're configured to discover Typha, do that now so we can retry if we fail.
-		typhaAddr, err = discoverTyphaAddr(configParams, k8sClientSet)
+		typhaAddresses, err = discoverTyphaAddr(configParams, k8sClientSet)
 		if err != nil {
 			log.WithError(err).Error("Typha discovery enabled but discovery failed.")
 			time.Sleep(1 * time.Second)
@@ -470,11 +470,12 @@ configRetry:
 	var syncer Startable
 	var typhaConnection *syncclient.SyncerClient
 	syncerToValidator := calc.NewSyncerCallbacksDecoupler()
-	if typhaAddr != "" {
+
+	if len(typhaAddresses) > 0 {
 		// Use a remote Syncer, via the Typha server.
-		log.WithField("addr", typhaAddr).Info("Connecting to Typha.")
+		log.WithField("addresses", typhaAddresses).Info("Connecting to Typha.")
 		typhaConnection = syncclient.New(
-			typhaAddr,
+			typhaAddresses,
 			buildinfo.GitVersion,
 			configParams.FelixHostname,
 			fmt.Sprintf("Revision: %s; Build date: %s",
@@ -1229,8 +1230,15 @@ func (fc *DataplaneConnector) Start() {
 	go fc.handleWireguardStatUpdateFromDataplane()
 }
 
-func discoverTyphaAddr(configParams *config.Config, k8sClientSet kubernetes.Interface) (string, error) {
+func discoverTyphaAddr(configParams *config.Config, k8sClientSet kubernetes.Interface) ([]discovery.Typha, error) {
 	typhaDiscoveryOpts := configParams.TyphaDiscoveryOpts()
-	typhaDiscoveryOpts = append(typhaDiscoveryOpts, discovery.WithKubeClient(k8sClientSet))
-	return discovery.DiscoverTyphaAddr(typhaDiscoveryOpts...)
+	typhaDiscoveryOpts = append(typhaDiscoveryOpts,
+		discovery.WithKubeClient(k8sClientSet),
+		discovery.WithNodeAffinity(configParams.FelixHostname),
+	)
+	res, err := discovery.DiscoverTyphaAddr(typhaDiscoveryOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }

--- a/felix/daemon/daemon_test.go
+++ b/felix/daemon/daemon_test.go
@@ -83,20 +83,20 @@ var _ = Describe("Typha address discovery", func() {
 
 	It("should return address if configured", func() {
 		configParams.TyphaAddr = "10.0.0.1:8080"
-		typhaAddr, err := discoverTyphaAddr(configParams, nil)
+		typhaAddr, err := discoverTyphaAddrs(configParams, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(typhaAddr).To(Equal([]discovery.Typha{{Addr: "10.0.0.1:8080"}}))
 	})
 
 	It("should return nothing if no service name", func() {
 		configParams.TyphaK8sServiceName = ""
-		typhaAddr, err := discoverTyphaAddr(configParams, nil)
+		typhaAddr, err := discoverTyphaAddrs(configParams, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(typhaAddr).To(BeNil())
 	})
 
 	It("should return IP from endpoints", func() {
-		typhaAddr, err := discoverTyphaAddr(configParams, k8sClient)
+		typhaAddr, err := discoverTyphaAddrs(configParams, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(typhaAddr).To(ConsistOf(
 			discovery.Typha{Addr: "10.0.0.2:8156", IP: "10.0.0.2"},
@@ -106,7 +106,7 @@ var _ = Describe("Typha address discovery", func() {
 	It("should bracket an IPv6 Typha address", func() {
 		endpoints.Subsets[1].Addresses[0].IP = "fd5f:65af::2"
 		refreshClient()
-		typhaAddr, err := discoverTyphaAddr(configParams, k8sClient)
+		typhaAddr, err := discoverTyphaAddrs(configParams, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(typhaAddr).To(ConsistOf(
 			discovery.Typha{Addr: "[fd5f:65af::2]:8156", IP: "fd5f:65af::2"},
@@ -116,16 +116,15 @@ var _ = Describe("Typha address discovery", func() {
 	It("should error if no Typhas", func() {
 		endpoints.Subsets = nil
 		refreshClient()
-		_, err := discoverTyphaAddr(configParams, k8sClient)
+		_, err := discoverTyphaAddrs(configParams, k8sClient)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should choose random Typhas", func() {
-		// Skip("skip random test")
 		endpoints.Subsets[1].Addresses = append(endpoints.Subsets[1].Addresses, v1.EndpointAddress{IP: "10.0.0.6"})
 		refreshClient()
 
-		addr, err := discoverTyphaAddr(configParams, k8sClient)
+		addr, err := discoverTyphaAddrs(configParams, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(addr).To(
 			ContainElements(

--- a/felix/daemon/daemon_test.go
+++ b/felix/daemon/daemon_test.go
@@ -15,15 +15,12 @@
 package daemon
 
 import (
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/projectcalico/calico/libcalico-go/lib/set"
-
 	"github.com/projectcalico/calico/felix/config"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -88,20 +85,22 @@ var _ = Describe("Typha address discovery", func() {
 		configParams.TyphaAddr = "10.0.0.1:8080"
 		typhaAddr, err := discoverTyphaAddr(configParams, nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("10.0.0.1:8080"))
+		Expect(typhaAddr).To(Equal([]discovery.Typha{{Addr: "10.0.0.1:8080"}}))
 	})
 
 	It("should return nothing if no service name", func() {
 		configParams.TyphaK8sServiceName = ""
 		typhaAddr, err := discoverTyphaAddr(configParams, nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal(""))
+		Expect(typhaAddr).To(BeNil())
 	})
 
 	It("should return IP from endpoints", func() {
 		typhaAddr, err := discoverTyphaAddr(configParams, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("10.0.0.2:8156"))
+		Expect(typhaAddr).To(ConsistOf(
+			discovery.Typha{Addr: "10.0.0.2:8156", IP: "10.0.0.2"},
+		))
 	})
 
 	It("should bracket an IPv6 Typha address", func() {
@@ -109,7 +108,9 @@ var _ = Describe("Typha address discovery", func() {
 		refreshClient()
 		typhaAddr, err := discoverTyphaAddr(configParams, k8sClient)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typhaAddr).To(Equal("[fd5f:65af::2]:8156"))
+		Expect(typhaAddr).To(ConsistOf(
+			discovery.Typha{Addr: "[fd5f:65af::2]:8156", IP: "fd5f:65af::2"},
+		))
 	})
 
 	It("should error if no Typhas", func() {
@@ -120,19 +121,17 @@ var _ = Describe("Typha address discovery", func() {
 	})
 
 	It("should choose random Typhas", func() {
-		seenAddresses := set.New()
-		expected := set.From("10.0.0.2:8156", "10.0.0.6:8156")
+		// Skip("skip random test")
 		endpoints.Subsets[1].Addresses = append(endpoints.Subsets[1].Addresses, v1.EndpointAddress{IP: "10.0.0.6"})
 		refreshClient()
 
-		for i := 0; i < 32; i++ {
-			addr, err := discoverTyphaAddr(configParams, k8sClient)
-			Expect(err).NotTo(HaveOccurred())
-			seenAddresses.Add(addr)
-			if seenAddresses.ContainsAll(expected) {
-				return
-			}
-		}
-		Fail(fmt.Sprintf("Didn't get expected values; got %v", seenAddresses))
+		addr, err := discoverTyphaAddr(configParams, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(addr).To(
+			ContainElements(
+				discovery.Typha{Addr: "10.0.0.2:8156", IP: "10.0.0.2"},
+				discovery.Typha{Addr: "10.0.0.6:8156", IP: "10.0.0.6"},
+			),
+		)
 	})
 })

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -572,7 +572,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 
 			cc.ExpectSome(wls[0], wls[1])
 			cc.ExpectSome(wls[1], wls[0])
-			cc.CheckConnectivity()
+			cc.CheckConnectivity()  //RLB <<< Flaking
 
 			By("verifying tunnelled packet count is non-zero")
 			for i := range felixes {

--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,110 +19,472 @@ package wireguard
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/clock"
 
 	"github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/felix/netlinkshim"
+	apiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 )
 
-// BootstrapHostConnectivity forces WireGuard peers with hostencryption enabled to communicate with this node unencrypted.
-// This ensures connectivity in scenarios where we have lost our WireGuard config, but will be sent WireGuard traffic
-// e.g. after a node restart, during felix startup, when we need to fetch config from Typha (calico/issues/5125)
-func BootstrapHostConnectivity(configParams *config.Config, getWireguardHandle func() (netlinkshim.Wireguard, error), calicoClient clientv3.Interface) error {
+// This file implements a set of functions that are called as part of the felix-start up processing. The purpose is
+// primarily focussed on deployments that have HostEncryptionEnabled set to true, and is to fix up routing issues that
+// may arise from mismatched routing configuration between nodes.
+//
+// Note that even when routing is broken between nodes, all nodes should still be able to reach the API server because
+// the HostEncryptionEnabled option should only be used for clusters where the control plane nodes are not running
+// Calico.
+//
+// The problem:                          - Turn on wireguard
+//                                       - Felix1 and Felix2 restart, install wireguard and publish a public key
+// ┌────────────┐        ┌────────────┐  - Felix1 gets a response from Typha1 about the key update for Node2, and
+// │     Node1  │        │     Node2  │    programs routing to route to Node2 via Wireguard (since we will encrypt
+// │ ┌────────┐ │        │            │    node to node traffic for supporting nodes)
+// │ │ Typha1 ◄─┼────────┼──────┐     │  - Felix2 has not yet had an update from Typha1 about the public key for
+// │ └────▲───┘ │        │      │     │    Node1, therefore routing to Node1 is still direct and not via Wireguard.
+// │ ┌────┴───┐ │        │ ┌────┴───┐ │
+// │ │ Felix1 │ │        │ │ Felix2 │ │  We now have broken routing:
+// │ └────────┘ │        │ └────────┘ │  - Packets routed over Wireguard from Node1 to Node2 will be dropped by the
+// └────────────┘        └────────────┘    Wireguard device on Node2 because Node1 is not one of its known peers.
+//                                       - Packets routed direct from Node2 to Node1 will be dropped because of RPF
+//                                         checks since the reverse path would be via Wireguard.
+//
+// With routing broken to typha, Felix2 is then unable to get updated configuration for Node1 to fix its routing.
+//
+// Since Felix1 does not necessarily connect to its local typha, there can be a chain, or circular mismatched routing.
+//
+// The current solution. For the most part, most of the following is only valid when HostEncrytpionEnabled is set to
+// true. There are some exceptions which are marked in the text below with [**ALL**].
+// -  Typha discovery returns the set of available typhas, randomized but with a preference to use the local typha.
+//    In most cases, felix will connect to the local typha first. The upshot is that the routing for typha nodes
+//    should be (relatively) stable. [**ALL**]
+// -  The dataplane daemon during start-up will call into BootstrapHostConnectivity to do the following:
+//    -  If wireguard is disabled, remove the wireguard interface and publish an empty key. Typha will pick this up
+//       and can distribute the fact that this node is now not running wireguard. With the interface deleted
+//       normal routing will resume on this node. Once the typha nodes have fixed up their routing to be direct to this
+//       node, this node will then be able to connect to the typha nodes. [**ALL**]
+//    -  If wireguard is enabled and the published key does not match the kernel then remove the wireguard interface and
+//       publish an empty key (see previous bullet).
+// - The dataplane daemon will later call into FilterTyphaEndpoints to filter the set of typha endpoints removing any
+//   where we know routing will be broken. This only applies on HostEncryptionEnabled.
+//    -  If there is no wireguard routing on this node, or if HostEncryptionEnabled is false, then no endpoints will be
+//       filtered out.
+//    -  Otherwise, we remove any typha endpoint that is on a node where the node public key is not currently configured
+//       in our wireguard routing table. We know this is very unlikely(*) to work because the node with typha will be
+//       know our public key and use that to route to us over wireguard. However, we will be routing to typha directly.
+//       (*) If typha is on a node whose felix is unable to connect to typha, then it is possible the typha node will
+//           not know about our nodes public key and therefore be routing to us directly. In that case including the
+//           endpoint would be (transiently) useful. However, since we favor felix connecting to local typha this should
+//           be less common.
+//       In general it is better to attempt all nodes, but removing nodes that we really should not be able to attach to
+//       should decrease the time to successful connection.
+// - The dataplane driver has a filtered set of typha endpoints to use.  If it fails to connect to typha then remove all
+//   wireguard configuration (interface and published key) before restarting felix.
+//
+// It's possible that there are multiple flaps before things settle down, but with the local typha preference, things
+// seems to settle extremely quickly, with the worst case scenario being a full startup timeout (minimum 40s and will
+// scale with the number of typhas) before the local wireguard configuration is removed and felix tries again.
+
+const (
+	bootstrapBackoffDuration    = 200 * time.Millisecond
+	bootstrapBackoffExpFactor   = 2
+	bootstrapBackoffMax         = 2 * time.Second
+	bootstrapJitter             = 0.2
+	bootstrapMaxRetriesFailFast = 2
+	bootstrapMaxRetries         = 5
+	boostrapK8sClientTimeout    = 10 * time.Second
+)
+
+// BootstrapHostConnectivityAndFilterTyphaAddresses performs wireguard boostrap processing and filtering of typha
+// addresses primarily to handle the fact that Host Encryption can cause routing asymmetry due to timing windows
+// resulting in felixes being locked out from typhas.
+// - If wireguard is disabled then just remove all wireguard configuration from the node (kernel and published key).
+// - If the published key and the kernel key don't match remove all wireguard configuraton from the node.
+// - If the kernel has no programmed peers then remove all wireguard configuration from the node (since we can't
+//   be talking over wireguard yet anyways).
+//
+// If a set of typha endpoints has been supplied, filter them to exclude endpoints that we know we cannot reach
+// due to asymmetric routing.  This will be the case if this node currently has a published wireguard key and:
+// - Typha node does not have a public key, but the typha IP address programmed in the kernel as a wireguard peer.
+// - Typha node has a public key but the key does not match any of the peer keys programmed in the kernel.
+func BootstrapHostConnectivityAndFilterTyphaAddresses(
+	configParams *config.Config,
+	getNetlinkHandle func() (netlinkshim.Interface, error),
+	getWireguardHandle func() (netlinkshim.Wireguard, error),
+	calicoClient clientv3.Interface,
+	typhas []discovery.Typha,
+) ([]discovery.Typha, error) {
 	wgDeviceName := configParams.WireguardInterfaceName
 	nodeName := configParams.FelixHostname
 
-	_, dbgBootstrap := os.LookupEnv("FELIX_DBG_WGBOOTSTRAP")
+	logCxt := log.WithFields(log.Fields{
+		"iface":    wgDeviceName,
+		"nodeName": nodeName,
+	})
+	logCxt.Debug("Bootstrapping wireguard")
 
-	if !configParams.WireguardHostEncryptionEnabled && !dbgBootstrap {
+	if !configParams.WireguardEnabled || configParams.WireguardInterfaceName == "" {
+		// Always remove wireguard configuration if not enabled.
+		logCxt.Info("Wireguard is not enabled - ensure no wireguard config")
+		return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+	}
+
+	if !configParams.WireguardHostEncryptionEnabled {
+		// The remaining of the bootstrap processing is only required on clusters that have host encryption enabled
+		// (even if wireguard is not).
+		logCxt.Debug("Host encryption is not enabled - no wireguard bootstrapping required")
+		return typhas, nil
+	}
+
+	// Get the local public key and the peer public keys currently programmed in the kernel.
+	kernelPublicKey, kernelPeerKeys := getWireguardDeviceInfo(logCxt, wgDeviceName, getWireguardHandle)
+
+	// If there is no valid wireguard configuration in the kernel then remove all traces of wireguard.
+	if kernelPublicKey == "" || kernelPeerKeys.Len() == 0 {
+		logCxt.Info("No valid wireguard kernel routing - removing wireguard configuration completely")
+		return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+	}
+
+	// Get the published public key for this node.
+	storedPublicKey, err := getPublicKeyForNode(logCxt, nodeName, calicoClient, bootstrapMaxRetries)
+	if err != nil {
+		return typhas, err
+	}
+
+	if storedPublicKey != kernelPublicKey {
+		// The public key configured in the kernel differs from the value stored in the node. Remove all wireguard
+		// configuration.
+		logCxt.Info("Found mismatch between kernel and datastore wireguard keys - removing wireguard configuration")
+		return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+	}
+
+	// The configured and stored wireguard key match.
+	logCxt.WithField("peerKeys", kernelPeerKeys).Info("Wireguard public key matches kernel")
+
+	// If we have any typha endpoints then filter them based on whether wireguard asymetry will prevent access.
+	if len(typhas) > 0 {
+		filtered := filterTyphaEndpoints(configParams, calicoClient, typhas, kernelPeerKeys)
+
+		if len(filtered) == 0 {
+			// We have filtered out all of the typha endpoints, i.e. with our current wireguard configuration none of
+			// the typhas will be accessible due to asymmetric routing. Best thing to do is just delete our wireguard
+			// configuration after which all of the typha endpoints should eventually become acceessible.
+			log.Warning("None of the typhas will be accessible due to wireguard routing asymmetry - remove wireguard")
+			return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+		}
+
+		return filtered, nil
+	}
+
+	return typhas, nil
+}
+
+// RemoveWireguardForHostEncryptionBootstrapping removes all wireguard configuration. This includes:
+// - The wireguard public key
+// - The wireguard device (which in turn will delete all wireguard routing rules).
+func RemoveWireguardForHostEncryptionBootstrapping(
+	configParams *config.Config,
+	getNetlinkHandle func() (netlinkshim.Interface, error),
+	calicoClient clientv3.Interface,
+) error {
+	if !configParams.WireguardHostEncryptionEnabled {
+		// HostEncryption is currently enabled in environments by operator rather than through FelixConfiguration.
+		// This should not change for a given deployment. Only host encryption should impact typha connectivity.
+		log.Debug("No host encryption - not necessary to remove wireguard configuration")
 		return nil
 	}
 
-	logCtx := log.WithFields(log.Fields{
-		"iface":    wgDeviceName,
-		"hostName": nodeName,
-		"ref":      "wgBootstrap",
-	})
+	return removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+}
 
-	logCtx.Debug("Bootstrapping wireguard")
+// filterTyphaEndpoints filters the supplied set of typha endpoints to the set where wireguard routing is most likely
+// to succeed. Any errors encountered are swallowed and the associated peer is just included.
+func filterTyphaEndpoints(
+	configParams *config.Config,
+	calicoClient clientv3.Interface,
+	typhas []discovery.Typha,
+	peers set.Set,
+) []discovery.Typha {
+	log.Debugf("Filtering typha endpoints for wireguard: %v", typhas)
 
-	var storedPublicKey string
-	var kernelPublicKey string
-	const (
-		backoffDuration  = 2 * time.Second
-		backoffExpFactor = 2
-		backoffMax       = 32 * time.Second
-		jitter           = 0.2
-	)
-	maxRetries := 3
-	expBackoffMgr := wait.NewExponentialBackoffManager(
-		backoffDuration, backoffMax, time.Minute, backoffExpFactor, jitter, clock.RealClock{})
-	defer expBackoffMgr.Backoff().Stop()
+	var filtered []discovery.Typha
 
-	wg, err := getWireguardHandle()
-	if err != nil {
-		logCtx.Info("Couldn't acquire WireGuard handle, treating public key as unset")
-	} else {
-		kernelPublicKey = getPublicKey(logCtx, wgDeviceName, wg).String()
-		defer wg.Close()
+	for _, typha := range typhas {
+		logCxt := log.WithField("typhaAddr", typha.Addr)
+		if typha.NodeName == nil {
+			logCxt.Debug("Typha endpoint has no node information - include typha endpoint")
+			filtered = append(filtered, typha)
+			continue
+		}
+
+		typhaNodeName := *typha.NodeName
+		logCxt = logCxt.WithField("typhaNodeName", typhaNodeName)
+		if typhaNodeName == configParams.FelixHostname {
+			// This is a local typha. We should always be able to connect.
+			logCxt.Info("Typha endpoint is local - include typha endpoint")
+			filtered = append(filtered, typha)
+			continue
+		}
+
+		// Get the public key configured for the typha node. Better to just include more typha nodes than we think will
+		// work, so fail fast when getting the node.
+		typhaNodeKey, err := getPublicKeyForNode(logCxt, typhaNodeName, calicoClient, bootstrapMaxRetriesFailFast)
+		if err != nil {
+			// If we were unable to determine the public key then just include the endpoint.
+			logCxt.WithError(err).Info("Unable to determine public key for node")
+			filtered = append(filtered, typha)
+			continue
+		}
+		logCxt = logCxt.WithField("typhaNodeKey", typhaNodeKey)
+
+		if typhaNodeKey == "" {
+			// There is no key configured and we don't have it in our kernel routing table. Include this typha.
+			logCxt.Info("Typha node does not have a wireguard key and not in kernel - include typha endpoint")
+			filtered = append(filtered, typha)
+		} else if peers.Contains(typhaNodeKey) {
+			// The public key on the typha node is configured in the local routing table. Include this typha.
+			logCxt.Debug("Typha node has a wireguard key that is in the local wireguard routing table - include typha endpoint")
+			filtered = append(filtered, typha)
+		} else {
+			// The public key on the typha node is not configured in the local routing table. There is no point in
+			// including this typha because routing will not work and we'll take longer to find a working typha.
+			logCxt.Warning("Typha node has wireguard key that is not in the local wireguard routing table - exclude typha endpoint")
+		}
 	}
 
-	// make a few attempts to read our publickey from the datastore, compare, and update if required
-	for r := 0; r < maxRetries; r++ {
+	log.Infof("Filtered typha endpoints: %v", filtered)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		thisNode, err := calicoClient.Nodes().Get(ctx, nodeName, options.GetOptions{})
+	return filtered
+}
+
+// removeWireguardForHostEncryptionBootstrapping unconditionally removes all wireguard configuration. This includes:
+// - The wireguard public key
+// - The wireguard device (which in turn will delete all wireguard routing rules).
+func removeWireguardForHostEncryptionBootstrapping(
+	configParams *config.Config,
+	getNetlinkHandle func() (netlinkshim.Interface, error),
+	calicoClient clientv3.Interface,
+) error {
+	// Remove all wireguard configuration that we can.
+	err1 := removeWireguardDevice(configParams, getNetlinkHandle)
+	err2 := removeWireguardPublicKey(configParams, calicoClient)
+
+	if err1 != nil {
+		return err1
+	} else if err2 != nil {
+		return err2
+	}
+	return nil
+}
+
+// getPublicKeyForNode returns the configured wireguard public key for a given node.
+func getPublicKeyForNode(logCxt *log.Entry, nodeName string, calicoClient clientv3.Interface, maxRetries int) (string, error) {
+	expBackoffMgr := wait.NewExponentialBackoffManager(
+		bootstrapBackoffDuration,
+		bootstrapBackoffMax,
+		time.Minute,
+		bootstrapBackoffExpFactor,
+		bootstrapJitter,
+		clock.RealClock{},
+	)
+	defer expBackoffMgr.Backoff().Stop()
+
+	var err error
+	var node *apiv3.Node
+	for r := 0; r < maxRetries; r++ {
+		cxt, cancel := context.WithTimeout(context.Background(), boostrapK8sClientTimeout)
+		node, err = calicoClient.Nodes().Get(cxt, nodeName, options.GetOptions{})
 		cancel()
 		if err != nil {
-			logCtx.WithError(err).Warn("Couldn't fetch node config from datastore, retrying")
+			logCxt.WithError(err).Warn("Couldn't fetch node config from datastore, retrying")
+			<-expBackoffMgr.Backoff().C() // safe to block here as we're not dependent on other threads
+			continue
+		}
+
+		return node.Status.WireguardPublicKey, nil
+	}
+
+	return "", fmt.Errorf("couldn't determine public key configured for node after %d retries: %v", maxRetries, err)
+}
+
+// getWireguardDeviceInfo attempts to fetch the current wireguard state from the kernel:
+// - Public key
+// - Set of peer public keys
+func getWireguardDeviceInfo(
+	logCxt *log.Entry, wgIfaceName string, getWireguardHandle func() (netlinkshim.Wireguard, error),
+) (string, set.Set) {
+	wg, err := getWireguardHandle()
+	if err != nil {
+		logCxt.Info("Couldn't acquire wireguard handle")
+		return "", nil
+	}
+	defer func() {
+		if err = wg.Close(); err != nil {
+			logCxt.WithError(err).Info("Couldn't close wireguard handle")
+		}
+	}()
+
+	dev, err := wg.DeviceByName(wgIfaceName)
+	if err != nil {
+		logCxt.WithError(err).Info("Couldn't find wireguard device, assuming no wireguard config")
+		return "", nil
+	}
+
+	if dev.PublicKey == zeroKey {
+		// No public key on device - treat as no config.
+		logCxt.Info("No public key configured on device")
+		return "", nil
+	}
+
+	// Construct the set of peer public keys.
+	peers := set.New()
+	for _, peer := range dev.Peers {
+		if peer.PublicKey != zeroKey {
+			peers.Add(peer.PublicKey.String())
+		}
+	}
+
+	// Return the public key and the set of peer keys that are configured in the kernel.
+	return dev.PublicKey.String(), peers
+}
+
+// removeWireguardDevice removes the wireguard device
+func removeWireguardDevice(
+	configParams *config.Config,
+	getNetlinkHandle func() (netlinkshim.Interface, error),
+) error {
+	wgDeviceName := configParams.WireguardInterfaceName
+	nodeName := configParams.FelixHostname
+
+	logCxt := log.WithFields(log.Fields{
+		"iface":    wgDeviceName,
+		"nodeName": nodeName,
+	})
+
+	if wgDeviceName == "" {
+		logCxt.Debug("No wireguard device specified")
+		return nil
+	}
+
+	logCxt.Debug("Removing wireguard device")
+
+	expBackoffMgr := wait.NewExponentialBackoffManager(
+		bootstrapBackoffDuration,
+		bootstrapBackoffMax,
+		time.Minute,
+		bootstrapBackoffExpFactor,
+		bootstrapJitter,
+		clock.RealClock{},
+	)
+	defer expBackoffMgr.Backoff().Stop()
+
+	// Make a few attempts to delete the wireguard device.
+	var err error
+	var handle netlinkshim.Interface
+	for r := 0; r < bootstrapMaxRetries; r++ {
+		if handle == nil {
+			if handle, err = getNetlinkHandle(); err != nil {
+				<-expBackoffMgr.Backoff().C()
+				continue
+			}
+			defer handle.Delete()
+		}
+		if err = removeDevice(logCxt, wgDeviceName, handle); err != nil {
+			<-expBackoffMgr.Backoff().C()
+			continue
+		}
+		return nil
+	}
+
+	return fmt.Errorf("couldn't remove wireguard device after %d retries: %v", bootstrapMaxRetries, err)
+}
+
+// removeWireguardPublicKey removes the public key from the node.
+func removeWireguardPublicKey(
+	configParams *config.Config,
+	calicoClient clientv3.Interface,
+) error {
+	nodeName := configParams.FelixHostname
+
+	logCxt := log.WithFields(log.Fields{
+		"nodeName": nodeName,
+	})
+
+	logCxt.Debug("Removing wireguard public key")
+
+	expBackoffMgr := wait.NewExponentialBackoffManager(
+		bootstrapBackoffDuration,
+		bootstrapBackoffMax,
+		time.Minute,
+		bootstrapBackoffExpFactor,
+		bootstrapJitter,
+		clock.RealClock{},
+	)
+	defer expBackoffMgr.Backoff().Stop()
+
+	// Make a few attempts to remove the public key from the datastore.
+	var err error
+	var thisNode *apiv3.Node
+	for r := 0; r < bootstrapMaxRetries; r++ {
+		cxt, cancel := context.WithTimeout(context.Background(), boostrapK8sClientTimeout)
+		thisNode, err = calicoClient.Nodes().Get(cxt, nodeName, options.GetOptions{})
+		cancel()
+		if err != nil {
+			logCxt.WithError(err).Warn("Couldn't fetch node config from datastore, retrying")
 			<-expBackoffMgr.Backoff().C() // safe to block here as we're not dependent on other threads
 			continue
 		}
 
 		// if there is any config mismatch, wipe the datastore's publickey (forces peers to send unencrypted traffic)
-		storedPublicKey = thisNode.Status.WireguardPublicKey
-		if storedPublicKey != kernelPublicKey {
-			logCtx.Info("Found mismatch between kernel and datastore WireGuard keys. Clearing stale key from datastore")
+		if thisNode.Status.WireguardPublicKey != "" {
+			logCxt.Info("Wireguard key set on node - removing")
 			thisNode.Status.WireguardPublicKey = ""
-			ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
-			_, err := calicoClient.Nodes().Update(ctx, thisNode, options.SetOptions{})
+			cxt, cancel = context.WithTimeout(context.Background(), boostrapK8sClientTimeout)
+			_, err = calicoClient.Nodes().Update(cxt, thisNode, options.SetOptions{})
 			cancel()
 			if err != nil {
 				switch err.(type) {
 				case cerrors.ErrorResourceUpdateConflict:
-					logCtx.Infof("Conflict while clearing WireGuard config, retrying update (%v)", err)
-
+					logCxt.Infof("Conflict while clearing wireguard config, retrying update (%v)", err)
 				default:
-					logCtx.Errorf("Failed to clear WireGuard config: %v", err)
+					logCxt.Errorf("Failed to clear wireguard config: %v", err)
 				}
 				<-expBackoffMgr.Backoff().C()
 				continue
 			}
-			logCtx.Info("Cleared WireGuard public key from datastore")
+			logCxt.Info("Cleared wireguard public key from datastore")
+		} else {
+			logCxt.Info("Wireguard public key not set in datastore")
 		}
 		return nil
 	}
 
-	return fmt.Errorf("couldn't bootstrap host connecivity after %d retries", maxRetries)
+	return fmt.Errorf("couldn't delete wireguard public key after %d retries: %v", bootstrapMaxRetries, err)
 }
 
-// getPublicKey attempts to fetch a wireguard key from the kernel statelessly
-// this is intended for use during startup; an error may simply mean wireguard is not configured
-func getPublicKey(log *log.Entry, wgIfaceName string, wg netlinkshim.Wireguard) wgtypes.Key {
-	dev, err := wg.DeviceByName(wgIfaceName)
-	if err != nil {
-		log.WithError(err).Debugf("Couldn't find WireGuard device '%s', reporting unset key", wgIfaceName)
-		return zeroKey
+// removeDevice removes the named link.
+func removeDevice(logCxt *log.Entry, name string, netlinkClient netlinkshim.Interface) error {
+	link, err := netlinkClient.LinkByName(name)
+	if err == nil {
+		logCxt.Info("Deleting device")
+		if err := netlinkClient.LinkDel(link); err != nil {
+			log.WithError(err).Error("Error deleting device")
+			return err
+		}
+		logCxt.Info("Deleted wireguard device")
+	} else if netlinkshim.IsNotExist(err) {
+		logCxt.Debug("Device does not exist")
+	} else if err != nil {
+		logCxt.WithError(err).Error("Unable to determine if device exists")
+		return err
 	}
-
-	return dev.PublicKey
+	return nil
 }

--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -134,12 +134,11 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 	if !configParams.WireguardEnabled || configParams.WireguardInterfaceName == "" {
 		// Always remove wireguard configuration if not enabled.
 		logCxt.Info("Wireguard is not enabled - ensure no wireguard config")
-		return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+		return typhas, removeWireguardForBootstrapping(configParams, getNetlinkHandle, calicoClient)
 	}
 
 	if !configParams.WireguardHostEncryptionEnabled {
 		// The remaining of the bootstrap processing is only required on clusters that have host encryption enabled
-		// (even if wireguard is not).
 		logCxt.Debug("Host encryption is not enabled - no wireguard bootstrapping required")
 		return typhas, nil
 	}
@@ -150,7 +149,7 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 	// If there is no valid wireguard configuration in the kernel then remove all traces of wireguard.
 	if kernelPublicKey == "" || kernelPeerKeys.Len() == 0 {
 		logCxt.Info("No valid wireguard kernel routing - removing wireguard configuration completely")
-		return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+		return typhas, removeWireguardForBootstrapping(configParams, getNetlinkHandle, calicoClient)
 	}
 
 	// Get the published public key for this node.
@@ -163,7 +162,7 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 		// The public key configured in the kernel differs from the value stored in the node. Remove all wireguard
 		// configuration.
 		logCxt.Info("Found mismatch between kernel and datastore wireguard keys - removing wireguard configuration")
-		return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+		return typhas, removeWireguardForBootstrapping(configParams, getNetlinkHandle, calicoClient)
 	}
 
 	// The configured and stored wireguard key match.
@@ -178,7 +177,7 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 			// the typhas will be accessible due to asymmetric routing. Best thing to do is just delete our wireguard
 			// configuration after which all of the typha endpoints should eventually become acceessible.
 			log.Warning("None of the typhas will be accessible due to wireguard routing asymmetry - remove wireguard")
-			return typhas, removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+			return typhas, removeWireguardForBootstrapping(configParams, getNetlinkHandle, calicoClient)
 		}
 
 		return filtered, nil
@@ -187,22 +186,29 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 	return typhas, nil
 }
 
-// RemoveWireguardForHostEncryptionBootstrapping removes all wireguard configuration. This includes:
+// RemoveWireguardConditionallyOnBootstrap removes all wireguard configuration based on
+// configuration conditions. This includes:
 // - The wireguard public key
 // - The wireguard device (which in turn will delete all wireguard routing rules).
-func RemoveWireguardForHostEncryptionBootstrapping(
+func RemoveWireguardConditionallyOnBootstrap(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
 	calicoClient clientv3.Interface,
 ) error {
-	if !configParams.WireguardHostEncryptionEnabled {
-		// HostEncryption is currently enabled in environments by operator rather than through FelixConfiguration.
-		// This should not change for a given deployment. Only host encryption should impact typha connectivity.
+	/*
+		| WireguardEnabled | WireguardHostEncryptionEnabled | Clear Wireguard PK + Device? |
+		|------------------|--------------------------------|------------------------------|
+		| YES			   | NO								| NO						   |
+		| YES			   | YES							| NO						   |
+		| NO			   | NO								| YES						   |
+		| NO			   | YES							| YES						   |
+	*/
+	if !configParams.WireguardEnabled || !configParams.WireguardHostEncryptionEnabled {
 		log.Debug("No host encryption - not necessary to remove wireguard configuration")
 		return nil
 	}
 
-	return removeWireguardForHostEncryptionBootstrapping(configParams, getNetlinkHandle, calicoClient)
+	return removeWireguardForBootstrapping(configParams, getNetlinkHandle, calicoClient)
 }
 
 // filterTyphaEndpoints filters the supplied set of typha endpoints to the set where wireguard routing is most likely
@@ -265,23 +271,26 @@ func filterTyphaEndpoints(
 	return filtered
 }
 
-// removeWireguardForHostEncryptionBootstrapping unconditionally removes all wireguard configuration. This includes:
+// removeWireguardForBootstrapping unconditionally removes all wireguard configuration. This includes:
 // - The wireguard public key
 // - The wireguard device (which in turn will delete all wireguard routing rules).
-func removeWireguardForHostEncryptionBootstrapping(
+func removeWireguardForBootstrapping(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
 	calicoClient clientv3.Interface,
 ) error {
+	var errors []error
 	// Remove all wireguard configuration that we can.
-	err1 := removeWireguardDevice(configParams, getNetlinkHandle)
-	err2 := removeWireguardPublicKey(configParams, calicoClient)
-
-	if err1 != nil {
-		return err1
-	} else if err2 != nil {
-		return err2
+	if err := removeWireguardDevice(configParams, getNetlinkHandle); err != nil {
+		errors = append(errors, fmt.Errorf("cannot remove wireguard device: %w", err))
 	}
+	if err2 := removeWireguardPublicKey(configParams, calicoClient); err2 != nil {
+		errors = append(errors, fmt.Errorf("cannot remove wireguard public key: %w", err2))
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("encountered errors during wireguard device bootstrap: %v", errors)
+	}
+
 	return nil
 }
 

--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -66,26 +66,27 @@ import (
 // -  Typha discovery returns the set of available typhas, randomized but with a preference to use the local typha.
 //    In most cases, felix will connect to the local typha first. The upshot is that the routing for typha nodes
 //    should be (relatively) stable. [**ALL**]
-// -  The dataplane daemon during start-up will call into BootstrapHostConnectivity to do the following:
+// -  The dataplane daemon during start-up will call into BootstrapAndFilterTyphaAddresses to do the
+//    following:
 //    -  If wireguard is disabled, remove the wireguard interface and publish an empty key. Typha will pick this up
 //       and can distribute the fact that this node is now not running wireguard. With the interface deleted
 //       normal routing will resume on this node. Once the typha nodes have fixed up their routing to be direct to this
 //       node, this node will then be able to connect to the typha nodes. [**ALL**]
 //    -  If wireguard is enabled and the published key does not match the kernel then remove the wireguard interface and
 //       publish an empty key (see previous bullet).
-// - The dataplane daemon will later call into FilterTyphaEndpoints to filter the set of typha endpoints removing any
-//   where we know routing will be broken. This only applies on HostEncryptionEnabled.
-//    -  If there is no wireguard routing on this node, or if HostEncryptionEnabled is false, then no endpoints will be
-//       filtered out.
-//    -  Otherwise, we remove any typha endpoint that is on a node where the node public key is not currently configured
-//       in our wireguard routing table. We know this is very unlikely(*) to work because the node with typha will be
-//       know our public key and use that to route to us over wireguard. However, we will be routing to typha directly.
-//       (*) If typha is on a node whose felix is unable to connect to typha, then it is possible the typha node will
-//           not know about our nodes public key and therefore be routing to us directly. In that case including the
-//           endpoint would be (transiently) useful. However, since we favor felix connecting to local typha this should
-//           be less common.
-//       In general it is better to attempt all nodes, but removing nodes that we really should not be able to attach to
-//       should decrease the time to successful connection.
+//    -  Filter the supplied set of typha addresses to removes addresses where connectivity will be broken:
+//       -  If there is no wireguard routing on this node, or if HostEncryptionEnabled is false, then no endpoints will
+//          be filtered out.
+//       -  Otherwise, we remove any typha endpoint that is on a node where the node public key is not currently
+//          configured in our wireguard routing table. We know this is very unlikely(*) to work because the node with
+//          typha will be know our public key and use that to route to us over wireguard. However, we will be routing to
+//          typha directly.
+//          (*) If typha is on a node whose felix is unable to connect to typha, then it is possible the typha node will
+//              not know about our nodes public key and therefore be routing to us directly. In that case including the
+//              endpoint would be (transiently) useful. However, since we favor felix connecting to local typha this
+//              should be less common.
+//          In general it is better to attempt all nodes, but removing nodes that we really should not be able to attach
+//          to should decrease the time to successful connection.
 // - The dataplane driver has a filtered set of typha endpoints to use.  If it fails to connect to typha then remove all
 //   wireguard configuration (interface and published key) before restarting felix.
 //
@@ -103,19 +104,27 @@ const (
 	boostrapK8sClientTimeout    = 10 * time.Second
 )
 
-// BootstrapHostConnectivityAndFilterTyphaAddresses performs wireguard boostrap processing and filtering of typha
-// addresses primarily to handle the fact that Host Encryption can cause routing asymmetry due to timing windows
-// resulting in felixes being locked out from typhas.
+// BootstrapAndFilterTyphaAddresses performs wireguard boostrap processing and filtering of typha addresses. This is
+// primarily to handle the fact that Host Encryption can cause routing asymmetry due to timing windows. This results in
+// felixes being locked out from typhas.
 // - If wireguard is disabled then just remove all wireguard configuration from the node (kernel and published key).
+//   We do this whether host encryption is enabled or not.
+//
+// For host encryption only:
 // - If the published key and the kernel key don't match remove all wireguard configuraton from the node.
 // - If the kernel has no programmed peers then remove all wireguard configuration from the node (since we can't
 //   be talking over wireguard yet anyways).
+// -  If a set of typha endpoints has been supplied, filter them to exclude endpoints that we know we cannot reach
+//    due to asymmetric routing.  This will be the case if this node currently has a published wireguard key and:
+//    - Typha node does not have a public key, but the typha IP address programmed in the kernel as a wireguard peer.
+//    - Typha node has a public key but the key does not match any of the peer keys programmed in the kernel.
 //
-// If a set of typha endpoints has been supplied, filter them to exclude endpoints that we know we cannot reach
-// due to asymmetric routing.  This will be the case if this node currently has a published wireguard key and:
-// - Typha node does not have a public key, but the typha IP address programmed in the kernel as a wireguard peer.
-// - Typha node has a public key but the key does not match any of the peer keys programmed in the kernel.
-func BootstrapHostConnectivityAndFilterTyphaAddresses(
+// -----
+//
+// Note that if a non-empty slice of typha endpoints has been supplied this will *always* return a non-empty slice of
+// endpoints. In the scenario where all typha addresses would be filtered out, wireguard configuration is removed from
+// the node and then all typha addresses are returned.
+func BootstrapAndFilterTyphaAddresses(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
 	getWireguardHandle func() (netlinkshim.Wireguard, error),
@@ -146,7 +155,7 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 	// Get the local public key and the peer public keys currently programmed in the kernel.
 	kernelPublicKey, kernelPeerKeys := getWireguardDeviceInfo(logCxt, wgDeviceName, getWireguardHandle)
 
-	// If there is no valid wireguard configuration in the kernel then remove all traces of wireguard.
+	// If there is no useful wireguard configuration in the kernel then remove all traces of wireguard.
 	if kernelPublicKey == "" || kernelPeerKeys.Len() == 0 {
 		logCxt.Info("No valid wireguard kernel routing - removing wireguard configuration completely")
 		return typhas, removeWireguardForBootstrapping(configParams, getNetlinkHandle, calicoClient)
@@ -168,7 +177,8 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 	// The configured and stored wireguard key match.
 	logCxt.WithField("peerKeys", kernelPeerKeys).Info("Wireguard public key matches kernel")
 
-	// If we have any typha endpoints then filter them based on whether wireguard asymetry will prevent access.
+	// If we have any typha endpoints then filter them based on whether wireguard asymmetry will prevent access.
+	// It is possible, that there will be no typhas - in this case the nodes are connecting directly to the API server.
 	if len(typhas) > 0 {
 		filtered := filterTyphaEndpoints(configParams, calicoClient, typhas, kernelPeerKeys)
 
@@ -186,28 +196,29 @@ func BootstrapHostConnectivityAndFilterTyphaAddresses(
 	return typhas, nil
 }
 
-// RemoveWireguardConditionallyOnBootstrap removes all wireguard configuration based on
-// configuration conditions. This includes:
+// RemoveWireguardConditionallyOnBootstrap removes all wireguard configuration based on configuration conditions. This
+// is called as a last resort after failing to connect to typha.
+//
+// The following wireguard conifguration will be removed if HostEncryptionEnabled is true:
 // - The wireguard public key
 // - The wireguard device (which in turn will delete all wireguard routing rules).
+//
+// It is assumed that BootstrapAndFilterTyphaAddresses was called prior to calling this function.
 func RemoveWireguardConditionallyOnBootstrap(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
 	calicoClient clientv3.Interface,
 ) error {
-	/*
-		| WireguardEnabled | WireguardHostEncryptionEnabled | Clear Wireguard PK + Device? |
-		|------------------|--------------------------------|------------------------------|
-		| YES			   | NO								| NO						   |
-		| YES			   | YES							| NO						   |
-		| NO			   | NO								| YES						   |
-		| NO			   | YES							| YES						   |
-	*/
-	if !configParams.WireguardEnabled || !configParams.WireguardHostEncryptionEnabled {
+	if !configParams.WireguardEnabled {
+		log.Debug("Wireguard is not enabled - configuration will have been removed in initial bootstrap")
+		return nil
+	}
+	if !configParams.WireguardHostEncryptionEnabled {
 		log.Debug("No host encryption - not necessary to remove wireguard configuration")
 		return nil
 	}
 
+	log.Info("Removing wireguard device for bootstrapping")
 	return removeWireguardForBootstrapping(configParams, getNetlinkHandle, calicoClient)
 }
 
@@ -240,8 +251,11 @@ func filterTyphaEndpoints(
 			continue
 		}
 
-		// Get the public key configured for the typha node. Better to just include more typha nodes than we think will
-		// work, so fail fast when getting the node.
+		// Get the public key configured for the typha node. We use this to check if we have a matching key in our
+		// kernel wireguard routing. Since we know we have a published key any remote node with a key will in theory
+		// route to us via wireguard - so if we do not have a wireguard route to this node then there is no point in
+		// attempting to connect to this node. That said, it is better to include too many nodes, so fail fast when
+		// getting querying the node.
 		typhaNodeKey, err := getPublicKeyForNode(logCxt, typhaNodeName, calicoClient, bootstrapMaxRetriesFailFast)
 		if err != nil {
 			// If we were unable to determine the public key then just include the endpoint.

--- a/felix/wireguard/bootstrap_test.go
+++ b/felix/wireguard/bootstrap_test.go
@@ -154,8 +154,8 @@ var _ = Describe("Wireguard bootstrapping", func() {
 			}
 		})
 
-		It("no-ops for BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+		It("no-ops for BootstrapAndFilterTyphaAddresses", func() {
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, nil,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -211,7 +211,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 
 		It("returns the correct filtered typhas when calling BootstrapHostConnectivity", func() {
 			typhas := []discovery.Typha{typha1, typha2, typha3, typha4}
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -237,7 +237,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 				PublicKey: pvt.PublicKey(),
 			}
 
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -265,7 +265,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 				PublicKey: pvt.PublicKey(),
 			}
 
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -290,7 +290,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 			link.WireguardPrivateKey = otherKey
 			link.WireguardPublicKey = otherKey.PublicKey()
 			typhas := []discovery.Typha{typha2, typha3}
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -401,11 +401,11 @@ var _ = Describe("Wireguard bootstrapping", func() {
 			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).ToNot(Equal(""))
 		})
 
-		It("deletes all wireguard from node 1 if wireguard is disabled when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+		It("deletes all wireguard from node 1 if wireguard is disabled when calling BootstrapAndFilterTyphaAddresses", func() {
 			configParams.WireguardHostEncryptionEnabled = false
 			configParams.WireguardEnabled = false
 			typhas := []discovery.Typha{typha2, typha3}
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -420,10 +420,10 @@ var _ = Describe("Wireguard bootstrapping", func() {
 			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
 		})
 
-		It("deletes wireguard key from node 1 if wireguard intface is empty when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+		It("deletes wireguard key from node 1 if wireguard intface is empty when calling BootstrapAndFilterTyphaAddresses", func() {
 			configParams.WireguardInterfaceName = ""
 			typhas := []discovery.Typha{typha2, typha3}
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -435,10 +435,10 @@ var _ = Describe("Wireguard bootstrapping", func() {
 			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
 		})
 
-		It("deletes wireguard key from node 1 if wireguard interface is not present when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+		It("deletes wireguard key from node 1 if wireguard interface is not present when calling BootstrapAndFilterTyphaAddresses", func() {
 			delete(netlinkDataplane.NameToLink, "wireguard.cali")
 			typhas := []discovery.Typha{typha2, typha3}
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -450,10 +450,10 @@ var _ = Describe("Wireguard bootstrapping", func() {
 			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
 		})
 
-		It("deletes wireguard key from node 1 if wireguard interface has no peers when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+		It("deletes wireguard key from node 1 if wireguard interface has no peers when calling BootstrapAndFilterTyphaAddresses", func() {
 			link.WireguardPeers = nil
 			typhas := []discovery.Typha{typha2, typha3}
-			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+			f, err := BootstrapAndFilterTyphaAddresses(
 				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/felix/wireguard/bootstrap_test.go
+++ b/felix/wireguard/bootstrap_test.go
@@ -1,0 +1,469 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wireguard_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/vishvananda/netlink"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/calico/felix/config"
+	mocknetlink "github.com/projectcalico/calico/felix/netlinkshim/mocknetlink"
+	. "github.com/projectcalico/calico/felix/wireguard"
+	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	nodeName1 = "nodeName1"
+	nodeName2 = "nodeName2"
+	nodeName3 = "nodeName3"
+	typha1    = discovery.Typha{
+		Addr:     "1.2.3.4:2222",
+		IP:       "1.2.3.4",
+		NodeName: &nodeName1,
+	}
+	typha2 = discovery.Typha{
+		Addr:     "1.2.5.5:1111",
+		IP:       "1.2.3.5",
+		NodeName: &nodeName2,
+	}
+	typha3 = discovery.Typha{
+		Addr:     "1.2.6.7:1234",
+		IP:       "1.2.6.7",
+		NodeName: &nodeName3,
+	}
+	typha4 = discovery.Typha{
+		Addr:     "1.2.6.7:1234",
+		IP:       "",
+		NodeName: nil,
+	}
+	node1PrivateKey, _ = wgtypes.GeneratePrivateKey()
+	node2PrivateKey, _ = wgtypes.GeneratePrivateKey()
+	node1              = &libapiv3.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Name: nodeName1,
+		},
+		Status: libapiv3.NodeStatus{
+			WireguardPublicKey: node1PrivateKey.PublicKey().String(),
+		},
+	}
+	node2 = &libapiv3.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Name: nodeName2,
+		},
+		Status: libapiv3.NodeStatus{
+			WireguardPublicKey: node2PrivateKey.PublicKey().String(),
+		},
+	}
+	node3 = &libapiv3.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Name: nodeName3,
+		},
+		Status: libapiv3.NodeStatus{
+			WireguardPublicKey: "",
+		},
+	}
+)
+
+func newMockClient() *mockClient {
+	return &mockClient{
+		nodes: make(map[string]*libapiv3.Node),
+	}
+}
+
+type mockClient struct {
+	clientv3.Interface
+	clientv3.NodeInterface
+
+	numGets         int
+	numUpdates      int
+	numGetErrors    int
+	numUpdateErrors int
+	nodes           map[string]*libapiv3.Node
+}
+
+func (c *mockClient) Nodes() clientv3.NodeInterface {
+	return c
+}
+
+func (c *mockClient) Get(_ context.Context, name string, _ options.GetOptions) (*libapiv3.Node, error) {
+	c.numGets++
+	if c.numGetErrors > 0 {
+		c.numGetErrors--
+		return nil, errors.New("Generic error getting node")
+	}
+	n, ok := c.nodes[name]
+	if !ok {
+		return nil, errors.New("Generic error getting node")
+	}
+	return n.DeepCopy(), nil
+}
+
+func (c *mockClient) Update(_ context.Context, res *libapiv3.Node, _ options.SetOptions) (*libapiv3.Node, error) {
+	c.numUpdates++
+	if c.numUpdateErrors > 0 {
+		c.numUpdateErrors--
+		return nil, errors.New("Generic error getting node")
+	}
+	n, ok := c.nodes[res.Name]
+	if !ok {
+		return nil, errors.New("Generic error getting node")
+	}
+	c.nodes[res.Name] = res
+	return n, nil
+}
+
+var _ = Describe("Wireguard bootstrapping", func() {
+	var nodeClient *mockClient
+	var netlinkDataplane *mocknetlink.MockNetlinkDataplane
+	var configParams *config.Config
+
+	BeforeEach(func() {
+		nodeClient = newMockClient()
+		netlinkDataplane = mocknetlink.New()
+	})
+
+	Context("HostEncryption is not enabled but wireguard is", func() {
+		BeforeEach(func() {
+			configParams = &config.Config{
+				WireguardHostEncryptionEnabled: false,
+				WireguardEnabled:               true,
+				WireguardInterfaceName:         "wireguard.cali",
+				FelixHostname:                  nodeName1,
+			}
+		})
+
+		It("no-ops for BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(BeNil())
+			Expect(nodeClient.numGets).To(BeZero())
+			Expect(nodeClient.numUpdates).To(BeZero())
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(BeZero())
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+		})
+
+		It("no-ops for RemoveWireguardForHostEncryptionBootstrapping", func() {
+			err := RemoveWireguardForHostEncryptionBootstrapping(
+				configParams,
+				netlinkDataplane.NewMockNetlink,
+				nodeClient,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeClient.numGets).To(BeZero())
+			Expect(nodeClient.numUpdates).To(BeZero())
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(BeZero())
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+		})
+	})
+
+	Context("Wireguard is programmed in the kernel for node 2 and not node 3", func() {
+		var link *mocknetlink.MockLink
+		BeforeEach(func() {
+			configParams = &config.Config{
+				WireguardHostEncryptionEnabled: true,
+				WireguardEnabled:               true,
+				WireguardInterfaceName:         "wireguard.cali",
+				FelixHostname:                  nodeName1,
+			}
+			link = &mocknetlink.MockLink{
+				LinkAttrs: netlink.LinkAttrs{
+					Name:  "wireguard.cali",
+					Index: 10,
+				},
+				LinkType:            "wireguard",
+				WireguardPrivateKey: node1PrivateKey,
+				WireguardPublicKey:  node1PrivateKey.PublicKey(),
+				WireguardPeers: map[wgtypes.Key]wgtypes.Peer{
+					node2PrivateKey.PublicKey(): {
+						PublicKey: node2PrivateKey.PublicKey(),
+					},
+				},
+			}
+			netlinkDataplane.NameToLink["wireguard.cali"] = link
+			nodeClient.nodes[nodeName1] = node1.DeepCopy()
+			nodeClient.nodes[nodeName2] = node2.DeepCopy()
+			nodeClient.nodes[nodeName3] = node3.DeepCopy()
+		})
+
+		It("returns the correct filtered typhas when calling BootstrapHostConnectivity", func() {
+			typhas := []discovery.Typha{typha1, typha2, typha3, typha4}
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// We expect all typhas:
+			// typha1 (local), typha2 (key is in kernel), typha3 (no key and IP not in kernel), typha4 (missing in client)
+			Expect(f).To(Equal(typhas))
+
+			// Get for local node and the two remote typhas with node names.
+			Expect(nodeClient.numGets).To(Equal(3))
+
+			// No updates made.
+			Expect(nodeClient.numUpdates).To(Equal(0))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(0))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(Equal(1))
+		})
+
+		It("returns the correct filtered typhas (filters out missing key) when calling BootstrapHostConnectivity", func() {
+			typhas := []discovery.Typha{typha1, typha2, typha3, typha4}
+			delete(link.WireguardPeers, node2PrivateKey.PublicKey())
+			pvt, _ := wgtypes.GeneratePrivateKey()
+			link.WireguardPeers[pvt.PublicKey()] = wgtypes.Peer{
+				PublicKey: pvt.PublicKey(),
+			}
+
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// We expect typhas:
+			// typha1 (local), typha3 (no key and IP not in kernel), typha4 (missing in client)
+			// Filtered:
+			// typha2 (key is not in kernel)
+			Expect(f).To(Equal([]discovery.Typha{typha1, typha3, typha4}))
+
+			// Get for local node and the two remote typhas with node names.
+			Expect(nodeClient.numGets).To(Equal(3))
+
+			// No updates.
+			Expect(nodeClient.numUpdates).To(Equal(0))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(0))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(Equal(1))
+		})
+
+		It("returns all typhas and deletes wireguard if all typhas would be filtered when calling BootstrapHostConnectivity", func() {
+			typhas := []discovery.Typha{typha2}
+			delete(link.WireguardPeers, node2PrivateKey.PublicKey())
+			pvt, _ := wgtypes.GeneratePrivateKey()
+			link.WireguardPeers[pvt.PublicKey()] = wgtypes.Peer{
+				PublicKey: pvt.PublicKey(),
+			}
+
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// All typhas would be filtered out (missing key and Ip in kernel). Therefore wireguard will be deleted and
+			// no typhas will be filtered out.
+			Expect(f).To(Equal(typhas))
+
+			// Get for local node, one remote node for typha, local node for deleting WG.
+			Expect(nodeClient.numGets).To(Equal(3))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+
+			// Device will be deleted.
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(Equal(1))
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("deletes all wireguard from node 1 if public key does not match kernel when calling BootstrapHostConnectivity", func() {
+			otherKey, _ := wgtypes.GeneratePrivateKey()
+			link.WireguardPrivateKey = otherKey
+			link.WireguardPublicKey = otherKey.PublicKey()
+			typhas := []discovery.Typha{typha2, typha3}
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(Equal(typhas)) // Should be unchanged.
+			// Two gets - once for the check, once for the update.
+			Expect(nodeClient.numGets).To(Equal(2))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(Equal(1))
+			Expect(netlinkDataplane.NetlinkOpen).To(BeFalse())
+			Expect(netlinkDataplane.WireguardOpen).To(BeFalse())
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("RemoveWireguardForHostEncryptionBootstrapping deletes all wireguard configuration", func() {
+			err := RemoveWireguardForHostEncryptionBootstrapping(
+				configParams,
+				netlinkDataplane.NewMockNetlink,
+				nodeClient,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeClient.numGets).To(Equal(1))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+			Expect(netlinkDataplane.NetlinkOpen).To(BeFalse())
+			Expect(netlinkDataplane.WireguardOpen).To(BeFalse())
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("RemoveWireguardForHostEncryptionBootstrapping deletes key from node even if device is not found", func() {
+			delete(netlinkDataplane.NameToLink, "wireguard.cali")
+			err := RemoveWireguardForHostEncryptionBootstrapping(
+				configParams,
+				netlinkDataplane.NewMockNetlink,
+				nodeClient,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeClient.numGets).To(Equal(1))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+			Expect(netlinkDataplane.NetlinkOpen).To(BeFalse())
+			Expect(netlinkDataplane.WireguardOpen).To(BeFalse())
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("RemoveWireguardForHostEncryptionBootstrapping deletes all wireguard config with temporary netlink and client errors", func() {
+			netlinkDataplane.FailuresToSimulate = mocknetlink.FailNextLinkByName | mocknetlink.FailNextLinkDel
+			nodeClient.numGetErrors = 2
+			nodeClient.numUpdateErrors = 1
+
+			err := RemoveWireguardForHostEncryptionBootstrapping(
+				configParams,
+				netlinkDataplane.NewMockNetlink,
+				nodeClient,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			// 2 failures, 1 get + failed update, 1 get +  successful update.
+			Expect(nodeClient.numGets).To(Equal(4))
+			Expect(nodeClient.numUpdates).To(Equal(2))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+			Expect(netlinkDataplane.NetlinkOpen).To(BeFalse())
+			Expect(netlinkDataplane.WireguardOpen).To(BeFalse())
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("RemoveWireguardForHostEncryptionBootstrapping deletes public key but leaves link with permanent netlink errors", func() {
+			netlinkDataplane.FailuresToSimulate = mocknetlink.FailNextLinkByName | mocknetlink.FailNextLinkDel
+			netlinkDataplane.PersistFailures = true
+			err := RemoveWireguardForHostEncryptionBootstrapping(
+				configParams,
+				netlinkDataplane.NewMockNetlink,
+				nodeClient,
+			)
+			Expect(err).To(HaveOccurred())
+			// 2 failures, 1 get + failed update, 1 get +  successful update.
+			Expect(nodeClient.numGets).To(Equal(1))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+			Expect(netlinkDataplane.NetlinkOpen).To(BeFalse())
+			Expect(netlinkDataplane.WireguardOpen).To(BeFalse())
+			Expect(netlinkDataplane.NameToLink).To(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("RemoveWireguardForHostEncryptionBootstrapping deletes device but leaves key with too many client errors", func() {
+			nodeClient.numGetErrors = 5
+			err := RemoveWireguardForHostEncryptionBootstrapping(
+				configParams,
+				netlinkDataplane.NewMockNetlink,
+				nodeClient,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(nodeClient.numGets).To(Equal(5))
+			Expect(nodeClient.numUpdates).To(BeZero())
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+			Expect(netlinkDataplane.NetlinkOpen).To(BeFalse())
+			Expect(netlinkDataplane.WireguardOpen).To(BeFalse())
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).ToNot(Equal(""))
+		})
+
+		It("deletes all wireguard from node 1 if wireguard is disabled when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+			configParams.WireguardHostEncryptionEnabled = false
+			configParams.WireguardEnabled = false
+			typhas := []discovery.Typha{typha2, typha3}
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(Equal(typhas))
+			Expect(nodeClient.numGets).To(Equal(1))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+			Expect(netlinkDataplane.NetlinkOpen).To(BeFalse())
+			Expect(netlinkDataplane.WireguardOpen).To(BeFalse())
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("deletes wireguard key from node 1 if wireguard intface is empty when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+			configParams.WireguardInterfaceName = ""
+			typhas := []discovery.Typha{typha2, typha3}
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(Equal(typhas))
+			Expect(nodeClient.numGets).To(Equal(1))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(BeZero())
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(BeZero())
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("deletes wireguard key from node 1 if wireguard interface is not present when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+			delete(netlinkDataplane.NameToLink, "wireguard.cali")
+			typhas := []discovery.Typha{typha2, typha3}
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(Equal(typhas))
+			Expect(nodeClient.numGets).To(Equal(1))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(Equal(1))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+
+		It("deletes wireguard key from node 1 if wireguard interface has no peers when calling BootstrapHostConnectivityAndFilterTyphaAddresses", func() {
+			link.WireguardPeers = nil
+			typhas := []discovery.Typha{typha2, typha3}
+			f, err := BootstrapHostConnectivityAndFilterTyphaAddresses(
+				configParams, netlinkDataplane.NewMockNetlink, netlinkDataplane.NewMockWireguard, nodeClient, typhas,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(f).To(Equal(typhas))
+			Expect(nodeClient.numGets).To(Equal(1))
+			Expect(nodeClient.numUpdates).To(Equal(1))
+			Expect(netlinkDataplane.NumNewNetlinkCalls).To(Equal(1))
+			Expect(netlinkDataplane.NumNewWireguardCalls).To(Equal(1))
+			Expect(netlinkDataplane.NameToLink).ToNot(HaveKey("wireguard.cali"))
+			Expect(nodeClient.nodes[nodeName1].Status.WireguardPublicKey).To(Equal(""))
+		})
+	})
+})

--- a/felix/wireguard/bootstrap_test.go
+++ b/felix/wireguard/bootstrap_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 		})
 
 		It("no-ops for RemoveWireguardForHostEncryptionBootstrapping", func() {
-			err := RemoveWireguardForHostEncryptionBootstrapping(
+			err := RemoveWireguardConditionallyOnBootstrap(
 				configParams,
 				netlinkDataplane.NewMockNetlink,
 				nodeClient,
@@ -307,7 +307,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 		})
 
 		It("RemoveWireguardForHostEncryptionBootstrapping deletes all wireguard configuration", func() {
-			err := RemoveWireguardForHostEncryptionBootstrapping(
+			err := RemoveWireguardConditionallyOnBootstrap(
 				configParams,
 				netlinkDataplane.NewMockNetlink,
 				nodeClient,
@@ -325,7 +325,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 
 		It("RemoveWireguardForHostEncryptionBootstrapping deletes key from node even if device is not found", func() {
 			delete(netlinkDataplane.NameToLink, "wireguard.cali")
-			err := RemoveWireguardForHostEncryptionBootstrapping(
+			err := RemoveWireguardConditionallyOnBootstrap(
 				configParams,
 				netlinkDataplane.NewMockNetlink,
 				nodeClient,
@@ -346,7 +346,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 			nodeClient.numGetErrors = 2
 			nodeClient.numUpdateErrors = 1
 
-			err := RemoveWireguardForHostEncryptionBootstrapping(
+			err := RemoveWireguardConditionallyOnBootstrap(
 				configParams,
 				netlinkDataplane.NewMockNetlink,
 				nodeClient,
@@ -366,7 +366,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 		It("RemoveWireguardForHostEncryptionBootstrapping deletes public key but leaves link with permanent netlink errors", func() {
 			netlinkDataplane.FailuresToSimulate = mocknetlink.FailNextLinkByName | mocknetlink.FailNextLinkDel
 			netlinkDataplane.PersistFailures = true
-			err := RemoveWireguardForHostEncryptionBootstrapping(
+			err := RemoveWireguardConditionallyOnBootstrap(
 				configParams,
 				netlinkDataplane.NewMockNetlink,
 				nodeClient,
@@ -385,7 +385,7 @@ var _ = Describe("Wireguard bootstrapping", func() {
 
 		It("RemoveWireguardForHostEncryptionBootstrapping deletes device but leaves key with too many client errors", func() {
 			nodeClient.numGetErrors = 5
-			err := RemoveWireguardForHostEncryptionBootstrapping(
+			err := RemoveWireguardConditionallyOnBootstrap(
 				configParams,
 				netlinkDataplane.NewMockNetlink,
 				nodeClient,

--- a/felix/wireguard/config.go
+++ b/felix/wireguard/config.go
@@ -1,3 +1,16 @@
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package wireguard
 
 import "time"

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -671,6 +671,9 @@ func (w *Wireguard) Apply() (err error) {
 			log.Info("Waiting for wireguard link to come up...")
 			return nil
 		}
+
+		// The link is now sync'd.
+		w.inSyncLink = true
 	}
 
 	// Get the wireguard client. This may not always be possible.

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/wireguard/wireguard_suite_test.go
+++ b/felix/wireguard/wireguard_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/typha/cmd/typha-client/typha-client.go
+++ b/typha/cmd/typha-client/typha-client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/typha/pkg/buildinfo"
 	"github.com/projectcalico/calico/typha/pkg/config"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 	"github.com/projectcalico/calico/typha/pkg/logutils"
 	"github.com/projectcalico/calico/typha/pkg/syncclient"
 	"github.com/projectcalico/calico/typha/pkg/syncproto"
@@ -117,7 +118,7 @@ func main() {
 	}
 
 	hostname, _ := os.Hostname()
-	client := syncclient.New(addr, buildinfo.GitVersion, hostname, "typha command-line client", callbacks, options)
+	client := syncclient.New([]discovery.Typha{{Addr: addr}}, buildinfo.GitVersion, hostname, "typha command-line client", callbacks, options)
 	err = client.Start(context.Background())
 	if err != nil {
 		log.WithError(err).Panic("Client failed")

--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -45,6 +45,7 @@ import (
 	calinet "github.com/projectcalico/calico/libcalico-go/lib/net"
 	. "github.com/projectcalico/calico/typha/fv-tests"
 	"github.com/projectcalico/calico/typha/pkg/calc"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 	"github.com/projectcalico/calico/typha/pkg/snapcache"
 	"github.com/projectcalico/calico/typha/pkg/syncclient"
 	"github.com/projectcalico/calico/typha/pkg/syncproto"
@@ -186,8 +187,9 @@ var _ = Describe("With an in-process Server", func() {
 	createClient := func(id interface{}, syncType syncproto.SyncerType) clientState {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
+		serverAddr := fmt.Sprintf("127.0.0.1:%d", server.Port())
 		client := syncclient.New(
-			fmt.Sprintf("127.0.0.1:%d", server.Port()),
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			fmt.Sprintf("test-host-%v", id),
 			"test-info",
@@ -690,7 +692,7 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
 		client := syncclient.New(
-			serverAddr,
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host",
 			"test-info",
@@ -724,7 +726,7 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 		recorder := NewRecorder()
 
 		client := syncclient.New(
-			serverAddr,
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host",
 			"test-info",
@@ -945,7 +947,7 @@ var _ = Describe("With an in-process Server with long ping interval", func() {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
 		client := syncclient.New(
-			serverAddr,
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host",
 			"test-info",
@@ -1090,7 +1092,7 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			recorder.BlockAfterNUpdates(1, 2500*time.Millisecond)
 
 			client := syncclient.New(
-				serverAddr,
+				[]discovery.Typha{{Addr: serverAddr}},
 				"test-version",
 				"test-host",
 				"test-info",
@@ -1139,7 +1141,7 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			recorder.BlockAfterNUpdates(initialSnapshotSize+1, 2500*time.Millisecond)
 
 			client := syncclient.New(
-				serverAddr,
+				[]discovery.Typha{{Addr: serverAddr}},
 				"test-version",
 				"test-host",
 				"test-info",
@@ -1323,8 +1325,9 @@ var _ = Describe("with server requiring TLS", func() {
 	createClient := func(options *syncclient.Options) clientState {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
+		serverAddr := fmt.Sprintf("127.0.0.1:%d", server.Port())
 		client := syncclient.New(
-			fmt.Sprintf("127.0.0.1:%d", server.Port()),
+			[]discovery.Typha{{Addr: serverAddr}},
 			"test-version",
 			"test-host-1",
 			"test-info",

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/projectcalico/calico/typha/pkg/daemon"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
 
 	"context"
 	"fmt"
@@ -163,9 +164,10 @@ var _ = Describe("Daemon", func() {
 
 				// Get the chosen port then start a real client in a context we can cancel.
 				port := d.Server.Port()
+				addr := fmt.Sprintf("127.0.0.1:%d", port)
 				cbs := fvtests.NewRecorder()
 				client := syncclient.New(
-					fmt.Sprintf("127.0.0.1:%d", port),
+					[]discovery.Typha{{Addr: addr}},
 					"",
 					"",
 					"",

--- a/typha/pkg/discovery/discovery.go
+++ b/typha/pkg/discovery/discovery.go
@@ -87,14 +87,15 @@ func WithNodeAffinity(nodeName string) Option {
 	}
 }
 
-// DiscoverTyphaAddr tries to discover the best address(es) to use to connect to Typha.
+// DiscoverTyphaAddrs tries to discover the best address(es) to use to connect to Typha.
 //
-// If an AddrOverride is supplied then that takes precedence, otherwise, DiscoverTyphaAddr will
+// If an AddrOverride is supplied then that takes precedence, otherwise, DiscoverTyphaAddrs will
 // try to lookup one of the backend endpoints of the typha service (using the K8sServiceName and
 // K8sNamespace fields).
 //
-// Returns "" if typha is not enabled (i.e. fields are empty).
-func DiscoverTyphaAddr(opts ...Option) ([]Typha, error) {
+// Returns nil if typha is not enabled (i.e. fields are empty). If typha is enabled, this will return a non-empty slice
+// or an error.
+func DiscoverTyphaAddrs(opts ...Option) ([]Typha, error) {
 	options := options{
 		k8sServicePortName: "calico-typha",
 	}

--- a/typha/pkg/discovery/discovery_test.go
+++ b/typha/pkg/discovery/discovery_test.go
@@ -217,8 +217,8 @@ var _ = Describe("Typha address discovery", func() {
 			Expect(newTyphaAddr[:3]).To(ConsistOf(typhaAddr[:3]))
 			Expect(newTyphaAddr[3:]).To(ConsistOf(typhaAddr[3:]))
 
-			shuffledLocal = !reflect.DeepEqual(newTyphaAddr[:3], typhaAddr[:3])
-			shuffledRemote = !reflect.DeepEqual(newTyphaAddr[3:], typhaAddr[3:])
+			shuffledLocal = shuffledLocal || !reflect.DeepEqual(newTyphaAddr[:3], typhaAddr[:3])
+			shuffledRemote = shuffledRemote || !reflect.DeepEqual(newTyphaAddr[3:], typhaAddr[3:])
 		}
 
 		Expect(shuffledLocal).To(BeTrue())

--- a/typha/pkg/discovery/discovery_test.go
+++ b/typha/pkg/discovery/discovery_test.go
@@ -16,6 +16,7 @@ package discovery
 
 import (
 	"math/rand"
+	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -80,25 +81,25 @@ var _ = Describe("Typha address discovery", func() {
 	})
 
 	It("should return address if configured", func() {
-		typhaAddr, err := DiscoverTyphaAddr(WithAddrOverride("10.0.0.1:8080"))
+		typhaAddr, err := DiscoverTyphaAddrs(WithAddrOverride("10.0.0.1:8080"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(typhaAddr).To(Equal([]Typha{{Addr: "10.0.0.1:8080"}}))
 	})
 
 	It("should return nothing if no service name and no client", func() {
-		typhaAddr, err := DiscoverTyphaAddr()
+		typhaAddr, err := DiscoverTyphaAddrs()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(typhaAddr).To(Equal(noTyphas))
 	})
 
 	It("should return nothing if no service name with client", func() {
-		typhaAddr, err := DiscoverTyphaAddr(WithKubeClient(k8sClient))
+		typhaAddr, err := DiscoverTyphaAddrs(WithKubeClient(k8sClient))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(typhaAddr).To(Equal(noTyphas))
 	})
 
 	It("should return IP from endpoints", func() {
-		typhaAddr, err := DiscoverTyphaAddr(
+		typhaAddr, err := DiscoverTyphaAddrs(
 			WithKubeService("kube-system", "calico-typha-service"),
 			WithKubeClient(k8sClient),
 		)
@@ -109,7 +110,7 @@ var _ = Describe("Typha address discovery", func() {
 	})
 
 	It("should return v2 IP from endpoints if port name override is used, ordered with local endpoint first", func() {
-		typhaAddr, err := DiscoverTyphaAddr(
+		typhaAddr, err := DiscoverTyphaAddrs(
 			WithKubeService("kube-system", "calico-typha-service"),
 			WithKubeClient(k8sClient),
 			WithKubeServicePortNameOverride("calico-typha-v2"),
@@ -125,7 +126,7 @@ var _ = Describe("Typha address discovery", func() {
 	It("should bracket an IPv6 Typha address", func() {
 		endpoints.Subsets[1].Addresses[0].IP = "fd5f:65af::2"
 		refreshClient()
-		typhaAddr, err := DiscoverTyphaAddr(
+		typhaAddr, err := DiscoverTyphaAddrs(
 			WithKubeService("kube-system", "calico-typha-service"),
 			WithKubeClient(k8sClient),
 		)
@@ -138,11 +139,89 @@ var _ = Describe("Typha address discovery", func() {
 	It("should error if no Typhas", func() {
 		endpoints.Subsets = nil
 		refreshClient()
-		_, err := DiscoverTyphaAddr(
+		_, err := DiscoverTyphaAddrs(
 			WithKubeService("kube-system", "calico-typha-service"),
 			WithKubeClient(k8sClient),
 		)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(Equal(ErrServiceNotReady))
+	})
+
+	It("should shuffle local and remote endpoints and have local first", func() {
+		endpoints.Subsets = append(endpoints.Subsets, []v1.EndpointSubset{
+			// Unrealistic, but have multiple endpoints on the same node, just with different IPs. This is to
+			// test the local and remote endpoint shuffling.
+			{
+				Addresses: []v1.EndpointAddress{
+					{IP: "10.0.0.5", NodeName: &localNodeName},
+				},
+				NotReadyAddresses: []v1.EndpointAddress{},
+				Ports: []v1.EndpointPort{
+					{Name: "calico-typha-v2", Port: 8157, Protocol: v1.ProtocolUDP},
+				},
+			},
+			{
+				Addresses: []v1.EndpointAddress{
+					{IP: "10.0.0.6", NodeName: &localNodeName},
+				},
+				NotReadyAddresses: []v1.EndpointAddress{},
+				Ports: []v1.EndpointPort{
+					{Name: "calico-typha-v2", Port: 8157, Protocol: v1.ProtocolUDP},
+				},
+			},
+			{
+				Addresses: []v1.EndpointAddress{
+					{IP: "10.0.0.3"},
+					{IP: "10.0.0.7", NodeName: &remoteNodeName},
+				},
+				Ports: []v1.EndpointPort{
+					{Name: "calico-typha-v2", Port: 8157, Protocol: v1.ProtocolUDP},
+				},
+			},
+		}...)
+		refreshClient()
+
+		typhaAddr, err := DiscoverTyphaAddrs(
+			WithKubeService("kube-system", "calico-typha-service"),
+			WithKubeClient(k8sClient),
+			WithKubeServicePortNameOverride("calico-typha-v2"),
+			WithNodeAffinity(localNodeName),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typhaAddr).To(HaveLen(6))
+
+		// First 3 should always be the local ones.  Last 3 the remote ones.
+		Expect(typhaAddr[:3]).To(ConsistOf([]Typha{
+			{Addr: "10.0.0.4:8157", IP: "10.0.0.4", NodeName: &localNodeName},
+			{Addr: "10.0.0.5:8157", IP: "10.0.0.5", NodeName: &localNodeName},
+			{Addr: "10.0.0.6:8157", IP: "10.0.0.6", NodeName: &localNodeName},
+		}))
+		Expect(typhaAddr[3:]).To(ConsistOf([]Typha{
+			{Addr: "10.0.0.2:8157", IP: "10.0.0.2", NodeName: &remoteNodeName},
+			{Addr: "10.0.0.3:8157", IP: "10.0.0.3"},
+			{Addr: "10.0.0.7:8157", IP: "10.0.0.7", NodeName: &remoteNodeName},
+		}))
+
+		// Check that multiple calls to discover the addresses shuffles the order.
+		var shuffledLocal bool
+		var shuffledRemote bool
+		for i := 0; i < 10; i++ {
+			newTyphaAddr, err := DiscoverTyphaAddrs(
+				WithKubeService("kube-system", "calico-typha-service"),
+				WithKubeClient(k8sClient),
+				WithKubeServicePortNameOverride("calico-typha-v2"),
+				WithNodeAffinity(localNodeName),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newTyphaAddr).To(HaveLen(6))
+			Expect(newTyphaAddr[:3]).To(ConsistOf(typhaAddr[:3]))
+			Expect(newTyphaAddr[3:]).To(ConsistOf(typhaAddr[3:]))
+
+			shuffledLocal = !reflect.DeepEqual(newTyphaAddr[:3], typhaAddr[:3])
+			shuffledRemote = !reflect.DeepEqual(newTyphaAddr[3:], typhaAddr[3:])
+		}
+
+		Expect(shuffledLocal).To(BeTrue())
+		Expect(shuffledRemote).To(BeTrue())
 	})
 })

--- a/typha/pkg/syncclientutils/startsyncerclient.go
+++ b/typha/pkg/syncclientutils/startsyncerclient.go
@@ -39,7 +39,7 @@ func MustStartSyncerClientIfTyphaConfigured(
 	myVersion, myHostname, myInfo string,
 	cbs api.SyncerCallbacks,
 ) bool {
-	typhaAddr, err := discovery.DiscoverTyphaAddr(
+	typhaAddr, err := discovery.DiscoverTyphaAddrs(
 		discovery.WithAddrOverride(typhaConfig.Addr),
 		discovery.WithInClusterKubeClient(), /* defer creation of a client until its needed. */
 		discovery.WithKubeService(typhaConfig.K8sNamespace, typhaConfig.K8sServiceName),

--- a/typha/pkg/syncclientutils/startsyncerclient.go
+++ b/typha/pkg/syncclientutils/startsyncerclient.go
@@ -47,7 +47,7 @@ func MustStartSyncerClientIfTyphaConfigured(
 	if err != nil {
 		log.WithError(err).Fatal("Typha discovery enabled but discovery failed.")
 	}
-	if typhaAddr == "" {
+	if len(typhaAddr) == 0 {
 		log.Debug("Typha is not configured")
 		return false
 	}


### PR DESCRIPTION
## Description

Cherry-pick of #5845 

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

Handle bootstrapping of Wireguard to ensure felix is able to connect to typha. This fixes a bug that is present when HostEncryptionEnabled is set to true (which is required for using wireguard with AKS). Previously, when nodes shared their wireguard public keys, depending on the order they keys were shared, it was possible to end up with asymmetric node-to- node routing. Packets will be dropped between impacted nodes. If the typha nodes are impacted then it is possible for other nodes to be effectively locked out from connecting to typha and the routing issue will persist. This will be apparent through persistent readiness checks failing on the node.