### PR TITLE
bpf test fixes

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -59,7 +59,7 @@ struct bpf_map_def_extended {
 // CALI_L3_DEV is set for any L3 device such as wireguard and IPIP tunnels that act fully
 // at layer 3. In kernerls before 5.14 (rhel 4.18.0-330) IPIP tunnels on inbound
 // direction were acting differently, where they could see outer ethernet and ip headers.
-#define CALI_L3_DEV 	(1<<5)
+#define CALI_TC_L3_DEV 	(1<<5)
 // CALI_XDP_PROG is set for programs attached to the XDP hook
 #define CALI_XDP_PROG 	(1<<6)
 
@@ -77,7 +77,7 @@ struct bpf_map_def_extended {
 #define CALI_F_HEP     	 ((CALI_COMPILE_FLAGS) & CALI_TC_HOST_EP)
 #define CALI_F_WEP     	 (!CALI_F_HEP)
 #define CALI_F_TUNNEL  	 ((CALI_COMPILE_FLAGS) & CALI_TC_TUNNEL)
-#define CALI_F_L3_DEV ((CALI_COMPILE_FLAGS) & CALI_L3_DEV)
+#define CALI_F_L3_DEV ((CALI_COMPILE_FLAGS) & CALI_TC_L3_DEV)
 
 #define CALI_F_XDP ((CALI_COMPILE_FLAGS) & CALI_XDP_PROG)
 

--- a/felix/bpf-gpl/calculate-flags
+++ b/felix/bpf-gpl/calculate-flags
@@ -49,7 +49,7 @@ flags=0
 ((CALI_TC_TUNNEL = 1 << 2))
 ((CALI_CGROUP = 1 << 3))
 ((CALI_TC_DSR = 1 << 4))
-((CALI_L3_DEV = 1 << 5))
+((CALI_TC_L3_DEV = 1 << 5))
 ((CALI_XDP_PROG = 1 << 6))
 
 if [[ "${filename}" =~ .*hep.* ]]; then
@@ -64,7 +64,7 @@ elif [[ "${filename}" =~ .*tnl.* ]]; then
   ep_type="tunnel"
 elif [[ "${filename}" =~ .*l3.* ]]; then
   # Any l3 device.
-  ((flags |= CALI_L3_DEV | CALI_TC_HOST_EP))
+  ((flags |= CALI_TC_L3_DEV | CALI_TC_HOST_EP))
   args+=("-DCALI_DEBUG_ALLOW_ALL" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="l3dev"
 elif [[ "${filename}" =~ .*connect.* ]]; then

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -166,7 +166,7 @@ skip_redir_ifindex:
 #ifdef BPF_CORE_SUPPORTED
 		case BPF_FIB_LKUP_RET_NO_NEIGH:
 			if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_redirect_neigh)) {
-				CALI_DEBUG("FIB lookup succeeded - not neigh - gw %x\n", fib_params.ipv4_dst);
+				CALI_DEBUG("FIB lookup succeeded - not neigh - gw %x\n", bpf_ntohl(fib_params.ipv4_dst));
 				struct bpf_redir_neigh nh_params = {};
 
 				nh_params.nh_family = fib_params.family;

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -431,8 +431,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					cc.ExpectSome(w[1], w[0])
 					cc.ExpectNone(w[1], hostW)
 					cc.ExpectSome(hostW, w[0])
-					cc.CheckConnectivity()
-					checkNodeConntrack(felixes)
+					cc.CheckConnectivity(conntrackChecks(felixes)...)
 				})
 			})
 
@@ -474,8 +473,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					cc.ExpectSome(w[1], w[0])
 					cc.ExpectSome(w[1], hostW)
 					cc.ExpectSome(hostW, w[0])
-					cc.CheckConnectivity()
-					checkNodeConntrack(felixes)
+					cc.CheckConnectivity(conntrackChecks(felixes)...)
 				})
 			})
 
@@ -905,8 +903,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				It("should handle NAT outgoing", func() {
 					By("SNATting outgoing traffic with the flag set")
 					cc.ExpectSNAT(w[0][0], felixes[0].IP, hostW[1])
-					cc.CheckConnectivity()
-					checkNodeConntrack(felixes)
+					cc.CheckConnectivity(conntrackChecks(felixes)...)
 
 					if testOpts.tunnel == "none" {
 						By("Leaving traffic alone with the flag clear")
@@ -917,8 +914,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						Expect(err).NotTo(HaveOccurred())
 						cc.ResetExpectations()
 						cc.ExpectSNAT(w[0][0], w[0][0].IP, hostW[1])
-						cc.CheckConnectivity()
-						checkNodeConntrack(felixes)
+						cc.CheckConnectivity(conntrackChecks(felixes)...)
 
 						By("SNATting again with the flag set")
 						pool.Spec.NATOutgoing = true
@@ -926,8 +922,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						Expect(err).NotTo(HaveOccurred())
 						cc.ResetExpectations()
 						cc.ExpectSNAT(w[0][0], felixes[0].IP, hostW[1])
-						cc.CheckConnectivity()
-						checkNodeConntrack(felixes)
+						cc.CheckConnectivity(conntrackChecks(felixes)...)
 					}
 				})
 
@@ -935,8 +930,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					cc.ExpectSome(w[0][1], w[0][0])
 					cc.ExpectSome(w[1][0], w[0][0])
 					cc.ExpectSome(w[1][1], w[0][0])
-					cc.CheckConnectivity()
-					checkNodeConntrack(felixes)
+					cc.CheckConnectivity(conntrackChecks(felixes)...)
 				})
 
 				if (testOpts.protocol == "tcp" || (testOpts.protocol == "udp" && !testOpts.udpUnConnected)) &&
@@ -1516,8 +1510,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						cc.ExpectSome(w[0][1], TargetIP(ip), port)
 						cc.ExpectSome(w[1][0], TargetIP(ip), port)
 						cc.ExpectSome(w[1][1], TargetIP(ip), port)
-						cc.CheckConnectivity()
-						checkNodeConntrack(felixes)
+						cc.CheckConnectivity(conntrackChecks(felixes)...)
 					})
 
 					/* Below Context handles the following transitions.
@@ -1539,8 +1532,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							cc.ExpectSome(w[1][0], TargetIP(ip[0]), port)
 							cc.ExpectSome(w[0][1], TargetIP(ip[0]), port)
 							cc.ExpectSome(w[1][1], TargetIP(ip[0]), port)
-							cc.CheckConnectivity()
-							checkNodeConntrack(felixes)
+							cc.CheckConnectivity(conntrackChecks(felixes)...)
 						})
 						Context("change service type from external IP to LoadBalancer", func() {
 							srcIPRange := []string{}
@@ -1556,8 +1548,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								cc.ExpectSome(w[1][0], TargetIP(ip[0]), port)
 								cc.ExpectSome(w[1][1], TargetIP(ip[0]), port)
 								cc.ExpectSome(w[0][1], TargetIP(ip[0]), port)
-								cc.CheckConnectivity()
-								checkNodeConntrack(felixes)
+								cc.CheckConnectivity(conntrackChecks(felixes)...)
 							})
 						})
 
@@ -1913,8 +1904,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 						cc.ExpectSome(w[0][1], TargetIP(ip), port)
 						cc.ExpectSome(w[1][0], TargetIP(ip), port)
-						cc.CheckConnectivity()
-						checkNodeConntrack(felixes)
+						cc.CheckConnectivity(conntrackChecks(felixes)...)
 
 						By("Checking timestamps on conntrack entries are sane")
 						// This test verifies that we correctly interpret conntrack entry timestamps by reading them back
@@ -1924,7 +1914,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						re := regexp.MustCompile(`LastSeen:\s*(\d+)`)
 						matches := re.FindAllStringSubmatch(ctDump, -1)
 						Expect(matches).ToNot(BeEmpty(), "didn't find any conntrack entries")
-						checkNodeConntrack(felixes)
 						for _, match := range matches {
 							lastSeenNanos, err := strconv.ParseInt(match[1], 10, 64)
 							Expect(err).NotTo(HaveOccurred())
@@ -3026,8 +3015,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							cc.ResetExpectations()
 							cc.Expect(Some, felixes[0], hostW[1])
 							cc.Expect(Some, felixes[1], hostW[0])
-							cc.CheckConnectivity()
-							checkNodeConntrack(felixes)
+							cc.CheckConnectivity(conntrackChecks(felixes)...)
 						})
 
 						By("checking pod-pod connectivity fails", func() {
@@ -3048,8 +3036,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							cc.Expect(Some, w[0][1], w[0][0])
 							cc.Expect(Some, w[1][0], w[0][0])
 							cc.Expect(Some, w[1][1], w[0][0])
-							cc.CheckConnectivity()
-							checkNodeConntrack(felixes)
+							cc.CheckConnectivity(conntrackChecks(felixes)...)
 						})
 					})
 				})
@@ -3200,16 +3187,14 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 						cc.ExpectSome(w[1][0], w[0][0])
 						cc.ExpectSome(w[1][1], w[0][0])
-						cc.CheckConnectivity()
+						cc.CheckConnectivity(conntrackChecks(felixes)...)
 						cc.ResetExpectations()
-						checkNodeConntrack(felixes)
 					})
 
 					By("checking connectivity to the external workload", func() {
 						cc.Expect(Some, w[0][0], extWorkload, ExpectWithPorts(4321), ExpectWithSrcIPs(felixes[0].IP))
 						cc.Expect(Some, w[1][0], extWorkload, ExpectWithPorts(4321), ExpectWithSrcIPs(felixes[1].IP))
-						cc.CheckConnectivity()
-						checkNodeConntrack(felixes)
+						cc.CheckConnectivity(conntrackChecks(felixes)...)
 					})
 				})
 
@@ -3462,7 +3447,7 @@ func k8sCreateLBServiceWithEndPoints(k8sClient kubernetes.Interface, name, clust
 	return testSvc
 }
 
-func checkNodeConntrack(felixes []*infrastructure.Felix) {
+func checkNodeConntrack(felixes []*infrastructure.Felix) error {
 	for i, felix := range felixes {
 		conntrack, err := felix.ExecOutput("conntrack", "-L")
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "conntrack -L failed")
@@ -3472,9 +3457,34 @@ func checkNodeConntrack(felixes []*infrastructure.Felix) {
 			if strings.Contains(line, "src=") {
 				// Wheather traffic is generated in host namespace, or involves NAT, each
 				// contrack entry should be related to node's address
-				ExpectWithOffset(1, strings.Contains(line, felix.IP)).
-					To(BeTrue(), fmt.Sprintf("unexpected conntrack not from host (felix[%d]): %s", i, line))
+				if !strings.Contains(line, felix.IP) {
+					return fmt.Errorf("unexpected conntrack not from host (felix[%d]): %s", i, line)
+				}
 			}
 		}
+	}
+
+	return nil
+}
+
+func conntrackCheck(felixes []*infrastructure.Felix) func() error {
+	return func() error {
+		return checkNodeConntrack(felixes)
+	}
+}
+
+func conntrackFlush(felixes []*infrastructure.Felix) func() {
+	return func() {
+		for _, felix := range felixes {
+			err := felix.ExecMayFail("conntrack", "-F")
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "conntrack -F failed")
+		}
+	}
+}
+
+func conntrackChecks(felixes []*infrastructure.Felix) []interface{} {
+	return []interface{}{
+		CheckWithFinalTest(conntrackCheck(felixes)),
+		CheckWithBeforeRetry(conntrackFlush(felixes)),
 	}
 }

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3463,15 +3463,17 @@ func k8sCreateLBServiceWithEndPoints(k8sClient kubernetes.Interface, name, clust
 }
 
 func checkNodeConntrack(felixes []*infrastructure.Felix) {
-	for _, felix := range felixes {
+	for i, felix := range felixes {
 		conntrack, err := felix.ExecOutput("conntrack", "-L")
-		Expect(err).NotTo(HaveOccurred())
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "conntrack -L failed")
 		lines := strings.Split(conntrack, "\n")
 		for _, line := range lines {
 			line = strings.Trim(line, " ")
 			if strings.Contains(line, "src=") {
-				// Wheather traffic is generated in host namespace, or involves NAT, each contrack entry should be related to node's address
-				Expect(strings.Contains(line, felix.IP)).To(BeTrue())
+				// Wheather traffic is generated in host namespace, or involves NAT, each
+				// contrack entry should be related to node's address
+				ExpectWithOffset(1, strings.Contains(line, felix.IP)).
+					To(BeTrue(), fmt.Sprintf("unexpected conntrack not from host (felix[%d]): %s", i, line))
 			}
 		}
 	}


### PR DESCRIPTION
## Description
    fv/bpf: improve on test error reporting
    
    It is important to see where from checkNodeConntrack was called from.
    Also helpfull to see which of the asserts failed and what was the
    unexpected conntrack entry.

    felix/bpf: CALI_L3_DEV -> CALI_TC_L3_DEV
    
    To stick with the convention for TC programs

    fv/bpf: conntrack checks are "eventually" like
    
    Conntrack check can be executed as part of the connectivity checker.
    
    In general, we can make a final test after connectivity passed and if
    that test fails, we can retry the whole connectivity test.
    
    We can also cleanup with an already existing hook that is executed just
    before retrying.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
