### PR TITLE
Typha: Increase fall behind timeouts.

### DIFF
--- a/typha/pkg/config/config_params.go
+++ b/typha/pkg/config/config_params.go
@@ -115,8 +115,8 @@ type Config struct {
 	SnapshotCacheMaxBatchSize int `config:"int(1,);100"`
 
 	ServerMaxMessageSize                 int           `config:"int(1,);100"`
-	ServerMaxFallBehindSecs              time.Duration `config:"seconds;90"`
-	ServerNewClientFallBehindGracePeriod time.Duration `config:"seconds;90"`
+	ServerMaxFallBehindSecs              time.Duration `config:"seconds;300"`
+	ServerNewClientFallBehindGracePeriod time.Duration `config:"seconds;300"`
 	ServerMinBatchingAgeThresholdSecs    time.Duration `config:"seconds;0.01"`
 	ServerPingIntervalSecs               time.Duration `config:"seconds;10"`
 	ServerPongTimeoutSecs                time.Duration `config:"seconds;60"`

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -110,8 +110,8 @@ func init() {
 
 const (
 	defaultMaxMessageSize                 = 100
-	defaultMaxFallBehind                  = 90 * time.Second
-	defaultNewClientFallBehindGracePeriod = 90 * time.Second
+	defaultMaxFallBehind                  = 300 * time.Second
+	defaultNewClientFallBehindGracePeriod = 300 * time.Second
 	defaultBatchingAgeThreshold           = 100 * time.Millisecond
 	defaultPingInterval                   = 10 * time.Second
 	defaultDropInterval                   = 1 * time.Second

--- a/typha/pkg/syncserver/syncserver_test.go
+++ b/typha/pkg/syncserver/syncserver_test.go
@@ -34,8 +34,8 @@ var _ = Describe("With zero config", func() {
 		config.ApplyDefaults()
 		Expect(config).To(Equal(Config{
 			MaxMessageSize:                 100,
-			MaxFallBehind:                  90 * time.Second,
-			NewClientFallBehindGracePeriod: 90 * time.Second,
+			MaxFallBehind:                  300 * time.Second,
+			NewClientFallBehindGracePeriod: 300 * time.Second,
 			MinBatchingAgeThreshold:        100 * time.Millisecond,
 			PingInterval:                   10 * time.Second,
 			PongTimeout:                    60 * time.Second,


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Increase default max fall behind timeouts to 300s.
Customer on an older version (without the post-snapshot grace
period) saw snapshots taking >120s.  Increase the default timeout
to give headroom above that observed value.

This may cause typha to use more memory, but only if some clients
are actually falling that far behind.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Increase Typha's "max fall behind" timeout to 300s.  This means that Typha will keep up to 300s of history if needed instead of 90s (thus increasing RAM usage if clients are falling a bit behind) but it reduces the chance of disconnecting a client spuriously in a very large cluster.
```
