### PR TITLE
Enable Native Building for Node Image on arm64

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -237,7 +237,8 @@ endif
 DOCKER_BUILD=docker buildx build --pull \
 	     --build-arg QEMU_IMAGE=$(CALICO_BUILD) \
 	     --build-arg UBI_IMAGE=$(UBI_IMAGE) \
-	     --build-arg GIT_VERSION=$(GIT_VERSION) $(TARGET_PLATFORM)
+	     --build-arg GIT_VERSION=$(GIT_VERSION) $(TARGET_PLATFORM) \
+	     --build-arg TARGET_ARCH=$(ARCH)
 
 DOCKER_RUN := mkdir -p ../.go-pkg-cache bin $(GOMOD_CACHE) && \
 	docker run --rm \

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -19,8 +19,9 @@ ARG RUNIT_VER=2.1.2
 ARG QEMU_IMAGE
 ARG BIRD_IMAGE=calico/bird:latest
 ARG UBI_IMAGE
+ARG TARGET_ARCH
 
-FROM calico/bpftool:v5.0-arm64 as bpftool
+FROM calico/bpftool:v5.0-$TARGET_ARCH as bpftool
 FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 
@@ -92,22 +93,27 @@ RUN sed -i '/%files$/a \
 RUN rpmbuild -bb /root/rpmbuild/SPECS/iptables.spec
 
 # runit is not available in ubi or CentOS repos so build it.
-RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
-    gunzip /tmp/runit-${RUNIT_VER}.tar.gz && \
-    tar -xpf /tmp/runit-${RUNIT_VER}.tar -C /tmp && \
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN wget -P /tmp https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz && \
+    gunzip /tmp/runit_${RUNIT_VER}.orig.tar.gz && \
+    tar -xpf /tmp/runit_${RUNIT_VER}.orig.tar -C /tmp && \
     cd /tmp/admin/runit-${RUNIT_VER}/ && \
     # runit compilation trigger a false positive error halting the process.
-    sed -i "s/runit-init/\/tmp\/admin\/runit-2.1.2\/compile\/runit-init/" src/runit-init.dist && \
-    sed -i "s/runsv/\/tmp\/admin\/runit-2.1.2\/compile\/runsv/" src/runsv.dist && \
-    sed -i "s/runsvchdir/\/tmp\/admin\/runit-2.1.2\/compile\/runsvchdir/" src/runsvchdir.dist && \
-    sed -i "s/runsvdir/\/tmp\/admin\/runit-2.1.2\/compile\/runsvdir/" src/runsvdir.dist && \
-    sed -i "s/svlogd/\/tmp\/admin\/runit-2.1.2\/compile\/svlogd/" src/svlogd.dist && \
-    sed -i "s/utmpset/\/tmp\/admin\/runit-2.1.2\/compile\/utmpset/" src/utmpset.dist && \
+    if [[ "$BUILDPLATFORM" != "$TARGETPLATFORM" ]]; then \
+      sed -i "s/runit-init/\/tmp\/admin\/runit-2.1.2\/compile\/runit-init/" src/runit-init.dist &&  \
+      sed -i "s/runsv/\/tmp\/admin\/runit-2.1.2\/compile\/runsv/" src/runsv.dist && \
+      sed -i "s/runsvchdir/\/tmp\/admin\/runit-2.1.2\/compile\/runsvchdir/" src/runsvchdir.dist && \
+      sed -i "s/runsvdir/\/tmp\/admin\/runit-2.1.2\/compile\/runsvdir/" src/runsvdir.dist && \
+      sed -i "s/svlogd/\/tmp\/admin\/runit-2.1.2\/compile\/svlogd/" src/svlogd.dist && \
+      sed -i "s/utmpset/\/tmp\/admin\/runit-2.1.2\/compile\/utmpset/" src/utmpset.dist;  \
+    fi && \
     package/install
 
 ARG UBI_DIGEST
 
-FROM --platform=linux/arm64 ${UBI_IMAGE} as ubi
+FROM --platform=$TARGETPLATFORM ${UBI_IMAGE} as ubi
 
 ARG ARCH
 ARG GIT_VERSION


### PR DESCRIPTION
This PR enables the native building for node image
on arm64 platform which fixes the error met and
adds target arch build-arg to enable possible unified
Dockerfile in the future.
The native building for Node image on arm64 is needed
for running the e2e test on arm64.

When building on native arm64 platform(not cross-building
on amd64), the modification to Runit source code is not
needed and must be ignored to avoid building errors.

And we switch to use the same set of Runit src code as
that of amd64 which would be more consistent for both
platforms.

Verified the building both on amd64(crossbuilding)
and arm64.

Signed-off-by: TrevorTaoARM <trevor.tao@arm.com>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
