### PR TITLE
felix/bpf: CALI_SKB_MARK_BYPASS_FWD should skip RPF

### DIFF
--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -211,7 +211,7 @@ skip_fib:
 		 * XXX We should check ourselves that we got our tunnel packets only from
 		 * XXX those devices where we expect them before we even decap.
 		 */
-		if (CALI_F_FROM_HEP && state->tun_ip != 0) {
+		if (CALI_F_FROM_HEP && state->tun_ip != 0 && ctx->fwd.mark != CALI_SKB_MARK_BYPASS_FWD) {
 			ctx->fwd.mark = CALI_SKB_MARK_SKIP_RPF;
 		}
 		/* Packet is towards host namespace, mark it so that downstream

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -22,6 +22,7 @@ const (
 	MarkSeenFallThrough              = MarkSeen | 0x04000000
 	MarkSeenFallThroughMask          = MarkSeenMask | MarkSeenFallThrough
 	MarkSeenBypassForward            = MarkSeenBypass | 0x00300000
+	MarkSeenBypassForwardMask        = MarkSeenBypassMask | 0x00f00000
 	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x00500000
 	MarkSeenBypassSkipRPF            = MarkSeenBypass | 0x00400000
 	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0x00f00000

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1009,10 +1009,18 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 		})
 
 		// Do not RPF check what is marked as to be skipped by RPF check.
-		rpfRules = []Rule{{
-			Match:  Match().MarkMatchesWithMask(tcdefs.MarkSeenBypassSkipRPF, tcdefs.MarkSeenBypassSkipRPFMask),
-			Action: ReturnAction{},
-		}}
+		rpfRules = []Rule{
+			{
+				Match:   Match().MarkMatchesWithMask(tcdefs.MarkSeenBypassSkipRPF, tcdefs.MarkSeenBypassSkipRPFMask),
+				Action:  ReturnAction{},
+				Comment: []string{"Skip RPF if requested"},
+			},
+			{
+				Match:   Match().MarkMatchesWithMask(tcdefs.MarkSeenBypassForward, tcdefs.MarkSeenBypassForwardMask),
+				Action:  ReturnAction{},
+				Comment: []string{"Skip RPF on packets returning from tunnel to the client"},
+			},
+		}
 
 		// For anything we approved for forward, permit accept_local as it is
 		// traffic encapped for NodePort, ICMP replies etc. - stuff we trust.


### PR DESCRIPTION
    felix/bpf: CALI_SKB_MARK_BYPASS_FWD should skip RPF
    
    When CALI_SKB_MARK_BYPASS_FWD we are forwarding traffic returning from a
    tunnel (known) to the client (known).
    
    It is a special case in which skip RPF was wrongly enforced, however, to
    skip RPF we cannot set both at the same time. Therefore make the
    iptables rules that enforce the strict check skip it.


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
