### PR TITLE
Update for default deny examples

### DIFF
--- a/calico/about/about-network-policy.md
+++ b/calico/about/about-network-policy.md
@@ -201,7 +201,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: default-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system"}
+  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "calico-apiserver"}
   types:
   - Ingress
   - Egress

--- a/calico/security/kubernetes-default-deny.md
+++ b/calico/security/kubernetes-default-deny.md
@@ -77,7 +77,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system"}
+  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "calico-apiserver"}
   types:
   - Ingress
   - Egress
@@ -91,7 +91,7 @@ spec:
       - 53
 ```
 
-It is important to note the above policy deliberately excludes the `kube-system` and `calico-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components. To secure the control plane you can write specific policies for each control plane component, though you should do so with care, ideally at cluster creation time, since getting these wrong can leave your cluster in a broken state. We recommend you always make sure you have the correct {{site.prodname}} [failsafe ports]({{site.baseurl}}/reference/felix/configuration) in place before you start trying to create policies for the control plane. 
+It is important to note the above policy deliberately excludes the `kube-system`, `calico-system` and `calico-apiserver` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components. To secure the control plane you can write specific policies for each control plane component, though you should do so with care, ideally at cluster creation time, since getting these wrong can leave your cluster in a broken state. We recommend you always make sure you have the correct {{site.prodname}} [failsafe ports]({{site.baseurl}}/reference/felix/configuration) in place before you start trying to create policies for the control plane. 
 
 #### Enable default deny {{site.prodname}} network policy, namespaced
 

--- a/calico/security/tutorials/calico-policy.md
+++ b/calico/security/tutorials/calico-policy.md
@@ -67,7 +67,7 @@ It returns the HTML of the google.com home page.
 
 ### 2. Lock down all traffic
 
-We will begin by using a default deny [Global Calico Network Policy]({{ site.baseurl }}/reference/resources/globalnetworkpolicy) (which you can only do using Calico) that will help us adopt best practices in using a [zero trust network model]({{ site.baseurl }}/security/adopt-zero-trust) to secure our workloads. Note that Global Calico Network Policies are not namespaced and effect all pods that match the policy selector. In contrast, Kubernetes Network Policies are namespaced, so you would need to create a default deny policy per namespace to achieve the same effect. Note that to simplify this tutorial we exclude pods in the kube-system namespace, so we don't have to consider the policies required to keep Kubernetes itself running smoothly when we apply our default deny.
+We will begin by using a default deny [Global Calico Network Policy]({{ site.baseurl }}/reference/resources/globalnetworkpolicy) (which you can only do using Calico) that will help us adopt best practices in using a [zero trust network model]({{ site.baseurl }}/security/adopt-zero-trust) to secure our workloads. Note that Global Calico Network Policies are not namespaced and effect all pods that match the policy selector. In contrast, Kubernetes Network Policies are namespaced, so you would need to create a default deny policy per namespace to achieve the same effect. Note that to simplify this tutorial we exclude pods in the `kube-system`,`calico-system` and `calico-apiserver` namespace, so we don't have to consider the policies required to keep Kubernetes itself running smoothly when we apply our default deny.
 
 ```bash
 calicoctl create -f - <<EOF
@@ -76,7 +76,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: default-deny
 spec:
-  selector: projectcalico.org/namespace not in  {'kube-system', 'calico-system'}
+  selector: projectcalico.org/namespace not in  {'kube-system', 'calico-system', 'calico-apiserver'}
   types:
   - Ingress
   - Egress


### PR DESCRIPTION
Documentation Update

Update: Adds the `calico-apiserver` namespace to the default deny examples.
