### PR TITLE
Add resource limits to tigera-operator helm chart

### DIFF
--- a/calico/_includes/charts/tigera-operator/README.md
+++ b/calico/_includes/charts/tigera-operator/README.md
@@ -114,6 +114,10 @@ certs:
     commonName:
     caBundle:
 
+# Resources for the tigera/operator pod itself.
+# By default, no resource requests or limits are specified.
+resources: {}
+
 # Configuration for the tigera operator images to deploy.
 tigeraOperator:
   image: tigera/operator

--- a/calico/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/calico/_includes/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -37,6 +37,10 @@ spec:
             - name: var-lib-calico
               readOnly: true
               mountPath: /var/lib/calico
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
               value: ""

--- a/calico/_plugins/values.rb
+++ b/calico/_plugins/values.rb
@@ -21,6 +21,8 @@ def gen_values(versions, imageNames, imageRegistry, chart)
         commonName:
         caBundle:
 
+    resources: {}
+
     # Configuration for the tigera operator
     tigeraOperator:
       image: #{versions.fetch("tigera-operator").image}


### PR DESCRIPTION
## Description

Add support for customization of Kubernetes resource limits for tigera-operator helm chart.

## Related issues/PRs

fixes [<ISSUE LINK>](https://github.com/projectcalico/calico/issues/5877)

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Helm chart allows configuration of tigera-operator resource requirements. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
