### PR TITLE
Enable E2e test arm64

### DIFF
--- a/calico/maintenance/ebpf/enabling-bpf.md
+++ b/calico/maintenance/ebpf/enabling-bpf.md
@@ -79,10 +79,10 @@ eBPF mode has the following pre-requisites:
   while preserving source IP.  eBPF mode honours the Felix `VXLANMTU` setting (see [Configuring MTU]({{ site.baseurl }}/networking/mtu)).
 - A stable way to address the Kubernetes API server. Since eBPF mode takes over from kube-proxy, {{site.prodname}}
   needs a way to reach the API server directly.
-- The base [requirements]({{site.baseurl}}/getting-started/kubernetes/requirements.md) also apply.
+- The base [requirements]({{site.baseurl}}/getting-started/kubernetes/requirements) also apply.
 
 > **Note**: The default kernel used by EKS is not compatible with eBPF mode.  If you wish to try eBPF mode with EKS,
-> follow the [Creating an EKS cluster for eBPF mode](./ebpf-and-eks.md) guide, which explain how to set up a suitable cluster.
+> follow the [Creating an EKS cluster for eBPF mode](./ebpf-and-eks) guide, which explain how to set up a suitable cluster.
 {: .alert .alert-info}
 
 ### How to

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1217,7 +1217,7 @@ kind $(KIND):
 
 kubectl $(KUBECTL):
 	mkdir -p $(KIND_DIR)
-	curl -L https://storage.googleapis.com/kubernetes-release/release/$(K8S_VERSION)/bin/linux/amd64/kubectl -o $@
+	curl -L https://storage.googleapis.com/kubernetes-release/release/$(K8S_VERSION)/bin/linux/$(ARCH)/kubectl -o $@
 	chmod +x $@
 
 ###############################################################################

--- a/node/Makefile
+++ b/node/Makefile
@@ -370,7 +370,7 @@ k8s-test:
 
 .PHONY: kind-k8st-setup
 kind-k8st-setup: $(K8ST_IMAGE_TARS) kind-cluster-create
-	KUBECONFIG=$(KIND_KUBECONFIG) ./tests/k8st/deploy_resources_on_kind_cluster.sh
+	KUBECONFIG=$(KIND_KUBECONFIG) ARCH=$(ARCH) ./tests/k8st/deploy_resources_on_kind_cluster.sh
 
 .PHONY: kind-k8st-run-test
 kind-k8st-run-test: .calico_test.created $(KIND_KUBECONFIG)

--- a/node/tests/k8st/deploy_resources_on_kind_cluster.sh
+++ b/node/tests/k8st/deploy_resources_on_kind_cluster.sh
@@ -2,6 +2,7 @@
 
 # test directory.
 TEST_DIR=./tests/k8st
+ARCH=${ARCH:-amd64}
 
 # kubectl binary.
 : ${kubectl:=../hack/test/kind/kubectl}
@@ -55,10 +56,14 @@ $TEST_DIR/load_images_on_kind_cluster.sh
 
 echo "Install Calico and Calicoctl for dualstack"
 cp $TEST_DIR/infra/calico-kdd.yaml $TEST_DIR/infra/calico.yaml.tmp
+sed -i "s/amd64/${ARCH}/" $TEST_DIR/infra/calico.yaml.tmp
 enable_dual_stack $TEST_DIR/infra/calico.yaml.tmp
 ${kubectl} apply -f $TEST_DIR/infra/calico.yaml.tmp
 rm $TEST_DIR/infra/calico.yaml.tmp
-${kubectl} apply -f $TEST_DIR/infra/calicoctl.yaml
+cp $TEST_DIR/infra/calicoctl.yaml $TEST_DIR/infra/calicoctl.yaml.tmp
+sed -i "s/amd64/${ARCH}/" $TEST_DIR/infra/calicoctl.yaml.tmp
+${kubectl} apply -f $TEST_DIR/infra/calicoctl.yaml.tmp
+rm $TEST_DIR/infra/calicoctl.yaml.tmp
 echo
 
 echo "Wait Calico to be ready..."
@@ -92,7 +97,10 @@ echo "client and webserver pods are running."
 echo
 
 echo "Deploy Calico apiserver"
-${kubectl} create -f ${TEST_DIR}/infra/apiserver.yaml
+cp $TEST_DIR/infra/apiserver.yaml $TEST_DIR/infra/apiserver.yaml.tmp
+sed -i "s/amd64/${ARCH}/" $TEST_DIR/infra/apiserver.yaml.tmp
+${kubectl} create -f ${TEST_DIR}/infra/apiserver.yaml.tmp
+rm $TEST_DIR/infra/apiserver.yaml.tmp
 openssl req -x509 -nodes -newkey rsa:4096 -keyout apiserver.key -out apiserver.crt -days 365 -subj "/" -addext "subjectAltName = DNS:calico-api.calico-apiserver.svc"
 ${kubectl} create secret -n calico-apiserver generic calico-apiserver-certs --from-file=apiserver.key --from-file=apiserver.crt
 ${kubectl} patch apiservice v3.projectcalico.org -p \


### PR DESCRIPTION
## Description

Enable E2E-test on Arm64 platform

Now we want to enable the e2e-test on arm64 platform as well as amd64:
1. Add ARCH variable to download the right kubectl for arm64 platform;
2. Add ARCH variable when deploy the Calico on kind cluster;
3. Replace the Calico images with ARCH variables;

The e2e-test was verified both on amd64 and arm64 platform.

The e2e-test on arm64(tx2) output is like:
 "
 Ran 41 of 469 Specs in 1199.742 seconds
 SUCCESS! -- 41 Passed | 0 Failed | 0 Pending | 428 Skipped
"
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
