### PR TITLE
felix/bpf: Set the tunnel mtu the same as veth mtu for workload programs.

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -805,12 +805,9 @@ func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *p
 	ap := m.calculateTCAttachPoint(polDirection, ifaceName)
 	// Host side of the veth is always configured as 169.254.1.1.
 	ap.HostIP = calicoRouterIP
-	// * VXLAN MTU should be the host ifaces MTU -50, in order to allow space for VXLAN.
-	// * We also expect that to be the MTU used on veths.
-	// * We do encap on the veths, and there's a bogus kernel MTU check in the BPF helper
-	//   for resizing the packet, so we have to reduce the apparent MTU by another 50 bytes
-	//   when we cannot encap the packet - non-GSO & too close to veth MTU
-	ap.TunnelMTU = uint16(m.vxlanMTU - 50)
+	// * Since we don't pass packet length when doing fib lookup, MTU check is skipped.
+	// * Hence it is safe to set the tunnel mtu same as veth mtu
+	ap.TunnelMTU = uint16(m.vxlanMTU)
 	ap.IntfIP = calicoRouterIP
 	ap.ExtToServiceConnmark = uint32(m.bpfExtToServiceConnmark)
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -2730,45 +2730,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							if testOpts.protocol == "tcp" {
 
 								const (
-									npEncapOverhead = 50
-									hostIfaceMTU    = 1500
-									podIfaceMTU     = 1450
-									sendLen         = hostIfaceMTU
-									recvLen         = podIfaceMTU - npEncapOverhead
+									hostIfaceMTU = 1500
+									podIfaceMTU  = 1450
+									sendLen      = hostIfaceMTU
+									recvLen      = podIfaceMTU
 								)
 
 								Context("with TCP, tx/rx close to MTU size on NP via node1->node0 ", func() {
-
-									negative := ""
-									adjusteMTU := podIfaceMTU - npEncapOverhead
-									if testOpts.dsr {
-										negative = "not "
-										adjusteMTU = 0
-									}
-
-									It("should "+negative+"adjust MTU on workload side", func() {
-										// force non-GSO packets when workload replies
-										_, err := w[0][0].RunCmd("ethtool", "-K", "eth0", "gso", "off")
-										Expect(err).NotTo(HaveOccurred())
-										_, err = w[0][0].RunCmd("ethtool", "-K", "eth0", "tso", "off")
-										Expect(err).NotTo(HaveOccurred())
-
-										pmtu, err := w[0][0].PathMTU(externalClient.IP)
-										Expect(err).NotTo(HaveOccurred())
-										Expect(pmtu).To(Equal(0)) // nothing specific for this path yet
-
-										cc.Expect(Some, externalClient, TargetIP(felixes[1].IP),
-											ExpectWithPorts(npPort),
-											ExpectWithSendLen(sendLen),
-											ExpectWithRecvLen(recvLen),
-											ExpectWithClientAdjustedMTU(hostIfaceMTU, hostIfaceMTU),
-										)
-										cc.CheckConnectivity()
-
-										pmtu, err = w[0][0].PathMTU(externalClient.IP)
-										Expect(err).NotTo(HaveOccurred())
-										Expect(pmtu).To(Equal(adjusteMTU))
-									})
 
 									It("should not adjust MTU on client side if GRO off on nodes", func() {
 										// force non-GSO packets on node ingress


### PR DESCRIPTION
## Description

we were passing packet length to the fib lookup helper which was doing mtu check and thus failing if the packet length is greater than veth mtu. Now that we pass 0 to fib lookup, mtu check is skipped. As a result, we can accomodate 50 bytes more in case of nodeport in the return path.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf - workloads no longer adjust pmtu when FIB fails due to mtu check - the check is not needed anymore.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
