### PR TITLE
Add create-namespace to Helm installation docs.

### DIFF
--- a/calico/_includes/charts/tigera-operator/README.md
+++ b/calico/_includes/charts/tigera-operator/README.md
@@ -24,16 +24,10 @@ Calico’s flexible architecture supports a wide range of deployment options, us
    helm repo add projectcalico https://projectcalico.docs.tigera.io/charts
    ```
 
-1. Create the tigera-operator namespace.
-
-   ```
-   kubectl create namespace tigera-operator
-   ```
-
 1. Install the helm chart into the `tigera-operator` namespace.
 
    ```
-   helm install calico projectcalico/tigera-operator --namespace tigera-operator
+   helm install calico projectcalico/tigera-operator --namespace tigera-operator -- create-namespace
    ```
 
 # Upgrading

--- a/calico/_includes/charts/tigera-operator/README.md
+++ b/calico/_includes/charts/tigera-operator/README.md
@@ -27,7 +27,7 @@ Calico’s flexible architecture supports a wide range of deployment options, us
 1. Install the helm chart into the `tigera-operator` namespace.
 
    ```
-   helm install calico projectcalico/tigera-operator --namespace tigera-operator -- create-namespace
+   helm install calico projectcalico/tigera-operator --namespace tigera-operator --create-namespace
    ```
 
 # Upgrading

--- a/calico/getting-started/kubernetes/helm.md
+++ b/calico/getting-started/kubernetes/helm.md
@@ -75,22 +75,18 @@ If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubern
 
 #### Install {{site.prodname}}
 
-1. Create the `tigera-operator` namespace.
+1. Install the Tigera {{site.prodname}} operator and custom resource definitions using the Helm chart, into the `tigera-operator` namespace:
 
    ```
-   kubectl create namespace tigera-operator
-   ```
-
-1. Install the Tigera {{site.prodname}} operator and custom resource definitions using the Helm chart:
-
-   ```
-   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}} --namespace tigera-operator
+   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}} \
+   --namespace tigera-operator --create-namespace
    ```
 
    or if you created a `values.yaml` above:
 
    ```
-   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}} -f values.yaml --namespace tigera-operator
+   helm install {{site.prodname | downcase}} projectcalico/tigera-operator --version {{site.data.versions[0].title}} -f values.yaml \
+   --namespace tigera-operator --create-namespace
    ```
 
 1. Confirm that all of the pods are running with the following command.


### PR DESCRIPTION
## Description

The `helm install` command has a `--create-namespace` option. Remove additional step to create the `tigera-operator` namespace, and add the `--create-namespace` to the Calico installation with Helm docs.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
