### PR TITLE
Prevent runaway informer sync loops

### DIFF
--- a/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
@@ -176,8 +176,9 @@ func (c *flannelMigrationController) Run(stopCh chan struct{}) {
 	// Wait till k8s cache is synced
 	go c.informer.Run(stopCh)
 	log.Infof("Waiting to sync with Kubernetes API (Nodes)")
-	for !c.informer.HasSynced() {
-		time.Sleep(100 * time.Millisecond)
+	if !cache.WaitForNamedCacheSync("flannelMigrationController", stopCh, c.informer.HasSynced) {
+		log.Info("Failed to sync resources, received signal for controller to shut down.")
+		return
 	}
 	log.Infof("Finished syncing with Kubernetes API (Nodes)")
 

--- a/kube-controllers/pkg/controllers/namespace/namespace_controller.go
+++ b/kube-controllers/pkg/controllers/namespace/namespace_controller.go
@@ -160,7 +160,9 @@ func (c *namespaceController) Run(stopCh chan struct{}) {
 	// Wait till k8s cache is synced
 	log.Debug("Waiting to sync with Kubernetes API (Namespaces)")
 	go c.informer.Run(stopCh)
-	for !c.informer.HasSynced() {
+	if !cache.WaitForNamedCacheSync("namespaces", stopCh, c.informer.HasSynced) {
+		log.Info("Failed to sync resources, received signal for controller to shut down.")
+		return
 	}
 	log.Debug("Finished syncing with Kubernetes API (Namespaces)")
 

--- a/kube-controllers/pkg/controllers/networkpolicy/policy_controller.go
+++ b/kube-controllers/pkg/controllers/networkpolicy/policy_controller.go
@@ -152,7 +152,9 @@ func (c *policyController) Run(stopCh chan struct{}) {
 	// Wait until we are in sync with the Kubernetes API before starting the
 	// resource cache.
 	log.Debug("Waiting to sync with Kubernetes API (NetworkPolicy)")
-	for !c.informer.HasSynced() {
+	if !cache.WaitForNamedCacheSync("network-policies", stopCh, c.informer.HasSynced) {
+		log.Info("Failed to sync resources, received signal for controller to shut down.")
+		return
 	}
 	log.Debug("Finished syncing with Kubernetes API (NetworkPolicy)")
 

--- a/kube-controllers/pkg/controllers/pod/pod_controller.go
+++ b/kube-controllers/pkg/controllers/pod/pod_controller.go
@@ -234,7 +234,9 @@ func (c *podController) Run(stopCh chan struct{}) {
 
 	// Wait till k8s cache is synced.
 	log.Debug("Waiting to sync with Kubernetes API (Pods)")
-	for !c.informer.HasSynced() {
+	if !cache.WaitForNamedCacheSync("pods", stopCh, c.informer.HasSynced) {
+		log.Info("Failed to sync resources, received signal for controller to shut down.")
+		return
 	}
 	log.Debug("Finished syncing with Kubernetes API (Pods)")
 

--- a/kube-controllers/pkg/controllers/serviceaccount/serviceaaccount_controller.go
+++ b/kube-controllers/pkg/controllers/serviceaccount/serviceaaccount_controller.go
@@ -154,7 +154,9 @@ func (c *serviceAccountController) Run(stopCh chan struct{}) {
 	// Wait till k8s cache is synced
 	log.Debug("Waiting to sync with Kubernetes API (ServiceAccount)")
 	go c.informer.Run(stopCh)
-	for !c.informer.HasSynced() {
+	if !cache.WaitForNamedCacheSync("service-accounts", stopCh, c.informer.HasSynced) {
+		log.Info("Failed to sync resources, received signal for controller to shut down.")
+		return
 	}
 	log.Debug("Finished syncing with Kubernetes API (ServiceAccount)")
 


### PR DESCRIPTION
## Description
This commit uses the cache.WaitForNamedCacheSync function to wait for
the informer caches to finish syncing instead of tight loop that will
eat up as much CPU as it possibly can until the caches sync.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
