### PR TITLE
Add CALICO_IPV6POOL_VXLAN env var support to startup.go

### DIFF
--- a/calico/_includes/charts/calico/templates/calico-node.yaml
+++ b/calico/_includes/charts/calico/templates/calico-node.yaml
@@ -281,6 +281,9 @@ spec:
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
               value: "{{- if .Values.vxlan -}} CrossSubnet {{- else -}} Never {{- end -}}"
+            # Enable or Disable VXLAN on the default IPv6 IP pool.
+            - name: CALICO_IPV6POOL_VXLAN
+              value: "{{- if .Values.vxlan -}} CrossSubnet {{- else -}} Never {{- end -}}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:

--- a/calico/networking/vxlan-ipip.md
+++ b/calico/networking/vxlan-ipip.md
@@ -79,7 +79,7 @@ spec:
   <label:Manifest>
 <%
 
-For manifest installations of Calico, you can control the deafult IP pool encapsualtion mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` environment variables in the environment of the `calico-node` daemon set.
+For manifest installations of Calico, you can control the deafult IP pool encapsualtion mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` (and `CALICO_IPV6POOL_VXLAN` for IPv6) environment variables in the environment of the `calico-node` daemon set.
 
 %>
 {% endtabs %}

--- a/calico/networking/vxlan-ipip.md
+++ b/calico/networking/vxlan-ipip.md
@@ -79,7 +79,7 @@ spec:
   <label:Manifest>
 <%
 
-For manifest installations of Calico, you can control the deafult IP pool encapsualtion mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` (and `CALICO_IPV6POOL_VXLAN` for IPv6) environment variables in the environment of the `calico-node` daemon set.
+For manifest installations of Calico, you can control the default IP pool encapsulation mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` (and `CALICO_IPV6POOL_VXLAN` for IPv6) environment variables in the environment of the `calico-node` daemon set.
 
 %>
 {% endtabs %}

--- a/calico/reference/node/configuration.md
+++ b/calico/reference/node/configuration.md
@@ -40,13 +40,14 @@ exist in the cluster. The following options control the parameters on the create
 | Environment   | Description | Schema |
 | ------------- | ----------- | ------ |
 | CALICO_IPV4POOL_CIDR | The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. [Default: First not used in locally of (192.168.0.0/16, 172.16.0.0/16, .., 172.31.0.0/16) ] | IPv4 CIDR |
-| CALICO_IPV4POOL_BLOCK_SIZE | Block size to use for the IPv4 POOL created at startup.  Block size for IPv4 should be in the range 20-32 (inclusive) [Default: `26`] | int |
-| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up. If set to a value other than `Never`, `CALICO_IPV4POOL_VXLAN` should not be set. [Default: `Always`] | Always, CrossSubnet, Never ("Off" is also accepted as a synonym for "Never") |
-| CALICO_IPV4POOL_VXLAN | VXLAN Mode to use for the IPv4 POOL created at start up.  If set to a value other than `Never`, `CALICO_IPV4POOL_IPIP` should not be set. [Default: `Never`] | Always, CrossSubnet, Never |
+| CALICO_IPV4POOL_BLOCK_SIZE | Block size to use for the IPv4 Pool created at startup.  Block size for IPv4 should be in the range 20-32 (inclusive) [Default: `26`] | int |
+| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 Pool created at start up. If set to a value other than `Never`, `CALICO_IPV4POOL_VXLAN` should not be set. [Default: `Always`] | Always, CrossSubnet, Never ("Off" is also accepted as a synonym for "Never") |
+| CALICO_IPV4POOL_VXLAN | VXLAN Mode to use for the IPv4 Pool created at start up.  If set to a value other than `Never`, `CALICO_IPV4POOL_IPIP` should not be set. [Default: `Never`] | Always, CrossSubnet, Never |
 | CALICO_IPV4POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv4 Pool created at start up. [Default: `true`] | boolean |
 | CALICO_IPV4POOL_NODE_SELECTOR | Controls the NodeSelector for the IPv4 Pool created at start up. [Default: `all()`] | [selector]({{site.baseurl}}/reference/resources/ippool#node-selector) |
 | CALICO_IPV6POOL_CIDR | The IPv6 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. [Default: `<a randomly chosen /48 ULA>`] | IPv6 CIDR |
 | CALICO_IPV6POOL_BLOCK_SIZE | Block size to use for the IPv6 POOL created at startup.  Block size for IPv6 should be in the range 116-128 (inclusive) [Default: `122`] | int |
+| CALICO_IPV6POOL_VXLAN | VXLAN Mode to use for the IPv6 Pool created at start up. [Default: `Never`] | Always, CrossSubnet, Never |
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. [Default: `false`] | boolean |
 | CALICO_IPV6POOL_NODE_SELECTOR | Controls the NodeSelector for the IPv6 Pool created at start up. [Default: `all()`] | [selector]({{site.baseurl}}/reference/resources/ippool#node-selector) |
 | NO_DEFAULT_POOLS | Prevents  {{site.prodname}} from creating a default pool if one does not exist. [Default: `false`] | boolean |

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -754,6 +754,7 @@ func configureIPPools(ctx context.Context, client client.Interface, kubeadmConfi
 
 	ipv4IpipModeEnvVar := strings.ToLower(os.Getenv("CALICO_IPV4POOL_IPIP"))
 	ipv4VXLANModeEnvVar := strings.ToLower(os.Getenv("CALICO_IPV4POOL_VXLAN"))
+	ipv6VXLANModeEnvVar := strings.ToLower(os.Getenv("CALICO_IPV6POOL_VXLAN"))
 
 	var (
 		ipv4BlockSize int
@@ -847,7 +848,7 @@ func configureIPPools(ctx context.Context, client client.Interface, kubeadmConfi
 		log.Debug("Create default IPv6 IP pool")
 		outgoingNATEnabled := evaluateENVBool("CALICO_IPV6POOL_NAT_OUTGOING", false)
 
-		createIPPool(ctx, client, ipv6Cidr, DEFAULT_IPV6_POOL_NAME, string(api.IPIPModeNever), string(api.VXLANModeNever), outgoingNATEnabled, ipv6BlockSize, ipv6NodeSelector)
+		createIPPool(ctx, client, ipv6Cidr, DEFAULT_IPV6_POOL_NAME, string(api.IPIPModeNever), ipv6VXLANModeEnvVar, outgoingNATEnabled, ipv6BlockSize, ipv6NodeSelector)
 	}
 }
 
@@ -880,7 +881,7 @@ func createIPPool(ctx context.Context, client client.Interface, cidr *cnet.IPNet
 	case "always":
 		vxlanMode = api.VXLANModeAlways
 	default:
-		log.Errorf("Unrecognized VXLAN mode specified in CALICO_IPV4POOL_VXLAN'%s'", vxlanModeName)
+		log.Errorf("Unrecognized VXLAN mode specified in CALICO_IPV%dPOOL_VXLAN '%s'", version, vxlanModeName)
 		utils.Terminate()
 	}
 

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -376,6 +376,10 @@ var _ = Describe("FV tests against a real etcd", func() {
 			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV6POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "CrossSubnet"}},
 			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN and CALICO_IPV6POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "CrossSubnet"}, {"CALICO_IPV6POOL_VXLAN", "CrossSubnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set CrossSubnet and CALICO_IPV6POOL_VXLAN set Always", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "CrossSubnet"}, {"CALICO_IPV6POOL_VXLAN", "Always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "Always", true, false, 26, 122, "all()", "all()"),
 	)
 
 	It("should properly clear node IPs", func() {

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -182,7 +182,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 	})
 
 	DescribeTable("Test IP pool env variables",
-		func(envList []EnvItem, expectedIPv4 string, expectedIPv6 string, expectIpv4IpipMode string, expectedIPV4NATOutgoing bool, expectedIPV6NATOutgoing bool, expectedIPv4BlockSize, expectedIPv6BlockSize int, expectedIPv4NodeSelector, expectedIPv6NodeSelector string) {
+		func(envList []EnvItem, expectedIPv4 string, expectedIPv6 string, expectIpv4IpipMode string, expectIpv4VXLANMode string, expectIpv6VXLANMode string, expectedIPV4NATOutgoing bool, expectedIPV6NATOutgoing bool, expectedIPv4BlockSize, expectedIPv6BlockSize int, expectedIPv4NodeSelector, expectedIPv6NodeSelector string) {
 			// Create a new client.
 			cfg, err := apiconfig.LoadClientConfigFromEnvironment()
 			Expect(err).NotTo(HaveOccurred())
@@ -234,6 +234,13 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 					Expect(pool.Spec.IPIPMode).To(Equal(api.IPIPModeNever))
 
+					// off is not a real mode value but use it instead of empty string
+					if expectIpv6VXLANMode == "Off" {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANModeNever))
+					} else {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANMode(expectIpv6VXLANMode)))
+					}
+
 					Expect(pool.Spec.NATOutgoing).To(Equal(expectedIPV6NATOutgoing), "Expected IPv6 to be %t but was %t", expectedIPV6NATOutgoing, pool.Spec.NATOutgoing)
 
 					Expect(pool.Spec.BlockSize).To(Equal(expectedIPv6BlockSize), "Expected IPv6 blocksize to be %d but was %d", expectedIPv6BlockSize, pool.Spec.BlockSize)
@@ -246,6 +253,13 @@ var _ = Describe("FV tests against a real etcd", func() {
 						Expect(pool.Spec.IPIPMode).To(Equal(api.IPIPModeNever))
 					} else {
 						Expect(pool.Spec.IPIPMode).To(Equal(api.IPIPMode(expectIpv4IpipMode)))
+					}
+
+					// off is not a real mode value but use it instead of empty string
+					if expectIpv4VXLANMode == "Off" {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANModeNever))
+					} else {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANMode(expectIpv4VXLANMode)))
 					}
 
 					Expect(pool.Spec.NATOutgoing).To(Equal(expectedIPV4NATOutgoing), "Expected IPv4 to be %t but was %t", expectedIPV4NATOutgoing, pool.Spec.NATOutgoing)
@@ -263,72 +277,105 @@ var _ = Describe("FV tests against a real etcd", func() {
 		},
 
 		Entry("No env variables set", []EnvItem{},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv4 Pool env var set",
 			[]EnvItem{{"CALICO_IPV4POOL_CIDR", "172.16.0.0/24"}},
-			"172.16.0.0/24", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"172.16.0.0/24", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv6 Pool env var set",
 			[]EnvItem{{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"}},
-			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("Both IPv4 and IPv6 Pool env var set",
 			[]EnvItem{
 				{"CALICO_IPV4POOL_CIDR", "172.16.0.0/24"},
 				{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"},
 			},
-			"172.16.0.0/24", "fdff:ffff:ffff:ffff:ffff::/80", "Off", true, false, 26, 122, "all()", "all()"),
+			"172.16.0.0/24", "fdff:ffff:ffff:ffff:ffff::/80", "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set off", []EnvItem{{"CALICO_IPV4POOL_IPIP", "off"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set Off", []EnvItem{{"CALICO_IPV4POOL_IPIP", "Off"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set Never", []EnvItem{{"CALICO_IPV4POOL_IPIP", "Never"}},
-			"192.168.0.0/16", randomULAPool, "Never", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Never", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set empty string", []EnvItem{{"CALICO_IPV4POOL_IPIP", ""}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set always", []EnvItem{{"CALICO_IPV4POOL_IPIP", "always"}},
-			"192.168.0.0/16", randomULAPool, "Always", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Always", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set Always", []EnvItem{{"CALICO_IPV4POOL_IPIP", "Always"}},
-			"192.168.0.0/16", randomULAPool, "Always", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Always", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set cross-subnet", []EnvItem{{"CALICO_IPV4POOL_IPIP", "cross-subnet"}},
-			"192.168.0.0/16", randomULAPool, "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "CrossSubnet", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set CrossSubnet", []EnvItem{{"CALICO_IPV4POOL_IPIP", "CrossSubnet"}},
-			"192.168.0.0/16", randomULAPool, "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "CrossSubnet", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_BLOCK_SIZE set 27", []EnvItem{{"CALICO_IPV4POOL_BLOCK_SIZE", "27"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 27, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 27, 122, "all()", "all()"),
 		Entry("IPv6 Pool and IPIP set",
 			[]EnvItem{
 				{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"},
 				{"CALICO_IPV4POOL_IPIP", "always"},
 			},
-			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Always", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Always", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv6 NATOutgoing Set Enabled",
 			[]EnvItem{
 				{"CALICO_IPV6POOL_NAT_OUTGOING", "true"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", true, true, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, true, 26, 122, "all()", "all()"),
 		Entry("IPv6 NATOutgoing Set Disabled",
 			[]EnvItem{
 				{"CALICO_IPV6POOL_NAT_OUTGOING", "false"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv4 NATOutgoing Set Disabled",
 			[]EnvItem{
 				{"CALICO_IPV4POOL_NAT_OUTGOING", "false"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", false, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", false, false, 26, 122, "all()", "all()"),
 		Entry("IPv6 NAT OUTGOING and IPV4 NAT OUTGOING SET",
 			[]EnvItem{
 				{"CALICO_IPV4POOL_NAT_OUTGOING", "false"},
 				{"CALICO_IPV6POOL_NAT_OUTGOING", "true"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", false, true, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", false, true, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV6POOL_BLOCK_SIZE set 123", []EnvItem{{"CALICO_IPV6POOL_BLOCK_SIZE", "123"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 123, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 123, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_NODE_SELECTOR set all()", []EnvItem{{"CALICO_IPV4POOL_NODE_SELECTOR", "all()"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_NODE_SELECTOR set has(something)", []EnvItem{{"CALICO_IPV4POOL_NODE_SELECTOR", "key == 'something'"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "key == 'something'", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "key == 'something'", "all()"),
 		Entry("CALICO_IPV6POOL_NODE_SELECTOR set failed", []EnvItem{{"CALICO_IPV6POOL_NODE_SELECTOR", "has(something)"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "has(something)"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "has(something)"),
+		Entry("CALICO_IPV4POOL_VXLAN set off", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set Off", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "Off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set Never", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "Never"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Never", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set empty string", []EnvItem{{"CALICO_IPV4POOL_VXLAN", ""}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set always", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Always", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set Always", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "Always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Always", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set cross-subnet", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "cross-subnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "CrossSubnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "Off", true, false, 26, 122, "all()", "all()"),
+		// Reset CALICO_IPV4POOL_VXLAN here as well
+		Entry("CALICO_IPV6POOL_VXLAN set off", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "off"}, {"CALICO_IPV6POOL_VXLAN", "off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set Off", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "Off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set Never", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "Never"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Never", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set empty string", []EnvItem{{"CALICO_IPV6POOL_VXLAN", ""}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set always", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Always", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set Always", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "Always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Always", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set cross-subnet", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "cross-subnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "CrossSubnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
 	)
 
 	It("should properly clear node IPs", func() {

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -496,6 +496,9 @@ spec:
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
               value: "Never"
+            # Enable or Disable VXLAN on the default IPv6 IP pool.
+            - name: CALICO_IPV6POOL_VXLAN
+              value: "Never"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:


### PR DESCRIPTION
Add CALICO_IPV6POOL_VXLAN env var support to startup.go

Add CALICO_IPV4POOL_VXLAN and CALICO_IPV6POOL_VXLAN testing to startup_test.go

Update yamls and docs accordingly.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added CALICO_IPV6POOL_VXLAN environment variable support to calico node.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
