### PR TITLE
[release-v3.23] Add HostProcess support for Calico for Windows (#5864)

### DIFF
--- a/calico/_config.yml
+++ b/calico/_config.yml
@@ -35,6 +35,7 @@ imageNames:
   cni: docker.io/calico/cni
   kubeControllers: docker.io/calico/kube-controllers
   calico-upgrade: docker.io/calico/upgrade
+  calico/windows: docker.io/calico/windows
   flannel: quay.io/coreos/flannel
   flannelMigration: docker.io/calico/flannel-migration-controller
   dikastes: docker.io/calico/dikastes
@@ -86,7 +87,8 @@ defaults:
         calico/cni: calico/cni
         calico/apiserver: calico/apiserver
         calico/kube-controllers: calico/kube-controllers
-        calico-upgrade: calico/upgrade
+        calico-upgrade: calico-upgrade
+        calico/windows: calico/windows
         flannel: quay.io/coreos/flannel
         flannelMigration: calico/flannel-migration-controller
         calico/dikastes: calico/dikastes

--- a/calico/_data/versions.yml
+++ b/calico/_data/versions.yml
@@ -21,6 +21,8 @@
       version: release-v3.23
      calico/flannel-migration-controller:
       version: release-v3.23
+     calico/windows:
+      version: release-v3.23
      networking-calico:
       version: release-v3.23
      flannel:

--- a/calico/_includes/content/calico-windows-install.md
+++ b/calico/_includes/content/calico-windows-install.md
@@ -1,0 +1,114 @@
+{%- if include.networkingType == "vxlan" %}
+1. Ensure that BGP is disabled since you're using VXLAN.
+   If you installed Calico using operator, you can do this by:
+
+   ```bash
+   kubectl patch installation default --type=merge -p '{"spec": {"calicoNetwork": {"bgp": "Disabled"}}}'
+   ```
+   If you installed Calico using the manifest from https://projectcalico.docs.tigera.io/manifests/calico-vxlan.yaml then BGP is already disabled.
+{%- else %}
+1. Enable BGP service on the Windows nodes (instead of VXLAN).
+   Install the RemoteAccess service using the following Powershell commands:
+
+   ```powershell
+   Install-WindowsFeature RemoteAccess
+   Install-WindowsFeature RSAT-RemoteAccess-PowerShell
+   Install-WindowsFeature Routing
+   ```
+
+   Then restart the computer:
+
+   ```powershell
+   Restart-Computer -Force
+   ```
+
+   before running:
+
+   ```powershell
+   Install-RemoteAccess -VpnType RoutingOnly
+   ```
+   Sometimes the remote access service fails to start automatically after install. To make sure it is running, execute the following command:
+
+   ```powershell
+   Start-Service RemoteAccess
+   ```
+{%- endif %}
+
+1. Download the {{site.prodnameWindows}} installation manifest.
+
+   ```bash
+{%- if include.networkingType == "vxlan" %}
+   curl {{ "/manifests/calico-windows-vxlan.yaml" | absolute_url }} -o calico-windows.yaml
+{%- else %}
+   curl {{ "/manifests/calico-windows-bgp.yaml" | absolute_url }} -o calico-windows.yaml
+{%- endif %}
+   ```
+
+1. Get the cluster's Kubernetes API server host and port, which will be used to update the {{site.prodnameWindows}} config map.
+   The API server host and port is required so that the {{site.prodnameWindows}} installation script can create a kubeconfig file for Calico services.
+   If your Windows nodes already have {{site.prodnameWindows}} installed manually, skip this step. The installation script will
+   use the API server host and port from your node's existing kubeconfig file if the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` variables
+   are not provided in the `calico-windows-config` configmap.
+
+   {% include content/kube-apiserver-host-port.md %}
+
+1. Edit the `calico-windows-config` configmap in the downloaded manifest and ensure the required variables are correct for your cluster:
+{%- if include.networkingType == "vxlan" %}
+   - `CALICO_NETWORKING_BACKEND`: This should be set to **vxlan**.
+{%- else %}
+   - `CALICO_NETWORKING_BACKEND`: This should be set to **windows-bgp**.
+{%- endif %}
+   - `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT`: The Kubernetes API server host and port (discovered in the previous step) used to create a kubeconfig file for Calico services. If your node already has an existing kubeconfig file, leave these variables blank.
+   - `K8S_SERVICE_CIDR`: The Kubernetes service clusterIP range configured in your cluster. This must match the service-cluster-ip-range used by kube-apiserver.
+   - `CNI_BIN_DIR`: Path where Calico CNI binaries will be installed. This must match the CNI bin value in the ContainerD service configuration. If you used the provided Install-Containerd.ps1 script, you should use the CNI bin path value you provided to that script.
+   - `CNI_CONF_DIR`: Path where Calico CNI configuration will be installed. This must match the CNI conf value in the ContainerD service configuration. If you used the provided Install-Containerd.ps1 script, you should use the CNI conf path value you provided to that script.
+   - `DNS_NAME_SERVERS`: The DNS nameservers that will be used in the CNI configuration.
+   - `FELIX_HEALTHENABLED`: The Felix health check server must be enabled.
+
+1. Apply the {{site.prodnameWindows}} installation manifest.
+
+   ```bash
+   kubectl create -f calico-windows.yaml
+   ```
+
+1. Monitor the installation.
+
+   ```bash
+   kubectl logs -f -n calico-system -l k8s-app=calico-node-windows -c install
+   ```
+
+   Once the log `Calico for Windows installed` appears, installation is complete.
+   Next, the {{site.prodnameWindows}} services are started in separate containers:
+
+   ```bash
+   kubectl logs -f -n calico-system -l k8s-app=calico-node-windows -c node
+   kubectl logs -f -n calico-system -l k8s-app=calico-node-windows -c felix
+{%- if include.networkingType == "windows-bgp" %}
+   kubectl logs -f -n calico-system -l k8s-app=calico-node-windows -c confd
+{%- endif %}
+   ```
+
+1. Install kube-proxy
+
+   Depending on your platform, you may already have kube-proxy running on your Windows nodes.
+   If kube-proxy is already running on your Windows nodes, skip this step. If kube-proxy is not running,
+   you must install and run kube-proxy on each of the Windows nodes in your cluster.
+   Note: the provided manifest depends on the kubeconfig provided by the `kube-proxy` configmap in the `kube-system` namespace.
+
+   - Download the kube-proxy manifest:
+   ```bash
+   curl {{ "/manifests/windows-kube-proxy.yaml" | absolute_url }} -o windows-kube-proxy.yaml
+   ```
+   - Edit the downloaded manifest
+       - Replace `VERSION` with your Windows nodes' server version. E.g. `1809`.
+       - Update the `K8S_VERSION` env variable value with your Kubernetes cluster version.
+
+   - Apply the manifest
+   ```bash
+   kubectl apply -f windows-kube-proxy.yaml
+   ```
+
+   - Verify the kube-proxy-windows daemonset is running
+   ```bash
+   kubectl describe ds -n kube-system kube-proxy-windows
+   ```

--- a/calico/_includes/content/kube-apiserver-host-port.md
+++ b/calico/_includes/content/kube-apiserver-host-port.md
@@ -1,0 +1,29 @@
+First, make a note of the address of the API server:
+
+   - If you have a single API server with a static IP address, you can use its IP address and port.  The IP can be found by running:
+
+     ```bash
+     kubectl get endpoints kubernetes -o wide
+     ```
+
+     The output should look like the following, with a single IP address and port under "ENDPOINTS":
+
+     ```
+     NAME         ENDPOINTS             AGE
+     kubernetes   172.16.101.157:6443   40m
+     ```
+
+     If there are multiple entries under "ENDPOINTS" then your cluster must have more than one API server.  In that case, you should try to determine the load balancing approach used by your cluster and use the appropriate option below.
+
+   - If using DNS load balancing (as used by `kops`), use the FQDN and port of the API server `api.internal.<clustername>`.
+   - If you have multiple API servers with a load balancer in front, you should use the IP and port of the load balancer.
+
+   > **Tip**: If your cluster uses a ConfigMap to configure `kube-proxy` you can find the "right" way to reach the API
+   > server by examining the config map.  For example:
+   > ```
+   > $ kubectl get configmap -n kube-system kube-proxy -o yaml | grep server`
+   >     server: https://d881b853ae312e00302a84f1e346a77.gr7.us-west-2.eks.amazonaws.com
+   > ```
+   > In this case, the server is `d881b853aea312e00302a84f1e346a77.gr7.us-west-2.eks.amazonaws.com` and the port is
+   > 443 (the standard HTTPS port).
+   {: .alert .alert-success}

--- a/calico/_includes/non-helm-manifests/calico-windows.yaml
+++ b/calico/_includes/non-helm-manifests/calico-windows.yaml
@@ -1,0 +1,153 @@
+{%- assign installDirName = "CalicoWindows" -%}
+{%- assign networkingType = include.networking -%}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: calico-windows-config
+  namespace: calico-system
+data:
+  # Valid values for Calico networking are: "vxlan", "windows-bgp"
+  # For non-Calico networking, the only value is "none".
+  CALICO_NETWORKING_BACKEND: "{{ networkingType }}"
+  # The Kubernetes API server host and port. This is required to
+  # bootstrap Calico for Windows.
+  KUBERNETES_SERVICE_HOST: ""
+  KUBERNETES_SERVICE_PORT: ""
+  # The Kubernetes service clusterIP range configured in your cluster.
+  # This must match the service-cluster-ip-range used by kube-apiserver.
+  K8S_SERVICE_CIDR: "10.96.0.0/12"
+  # The DNS nameservers that will be used in the CNI configuration.
+  DNS_NAME_SERVERS: "10.96.0.10"
+  # The CNI bin dir. This must match the containerd configuration on the Windows nodes.
+  CNI_BIN_DIR: "c:\\opt\\cni\\bin"
+  # The CNI conf dir. This must match the containerd configuration on the Windows nodes.
+  CNI_CONF_DIR: "c:\\etc\\cni\\net.d"
+  # Felix health must be enabled.
+  FELIX_HEALTHENABLED: "true"
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: calico-node-windows
+  namespace: calico-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node-windows
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node-windows
+    spec:
+      serviceAccountName: calico-node
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
+      hostNetwork: true
+      tolerations:
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      initContainers:
+      - name: install
+        image: {{page.registry}}{{page.imageNames["calico/windows"]}}:{{site.data.versions.first.components["calico/windows"].version}}
+        args:
+          - ".\\host-process-install.ps1"
+        imagePullPolicy: Always
+        envFrom:
+        - configMapRef:
+            name: calico-windows-config
+        # Calico needs to know the name of the node on which it is running.
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+      containers:
+      - name: node
+        image: {{page.registry}}{{page.imageNames["calico/windows"]}}:{{site.data.versions.first.components["calico/windows"].version}}
+        imagePullPolicy: Always
+        args:
+          - ".\\node\\node-service.ps1"
+        # The node container's working dir is in c:\{{installDirName}} on the host,
+        # which is two-levels up from the CONTAINER_SANDBOX_MOUNT_POINT.
+        workingDir: "..\\..\\{{installDirName}}"
+        envFrom:
+        - configMapRef:
+            name: calico-windows-config
+        # Calico needs to know the name of the node on which it is running.
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+      - name: felix
+        image: {{page.registry}}{{page.imageNames["calico/windows"]}}:{{site.data.versions.first.components["calico/windows"].version}}
+        imagePullPolicy: Always
+        args:
+        - ".\\felix\\felix-service.ps1"
+        # The felix container's working dir is in c:\{{installDirName}} on the host,
+        # which is two-levels up from the CONTAINER_SANDBOX_MOUNT_POINT.
+        workingDir: "..\\..\\{{installDirName}}"
+        envFrom:
+        - configMapRef:
+            name: calico-windows-config
+        # Calico needs to know the name of the node on which it is running.
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        livenessProbe:
+          exec:
+            command:
+            - c:\\{{installDirName}}\\calico-node.exe
+            - -felix-live
+          periodSeconds: 10
+          initialDelaySeconds: 10
+          failureThreshold: 6
+          timeoutSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - c:\\{{installDirName}}\\calico-node.exe
+            - -felix-ready
+          periodSeconds: 10
+          timeoutSeconds: 10
+      {% if networkingType == "windows-bgp" -%}
+      - name: confd
+        image: {{page.registry}}{{page.imageNames["calico/windows"]}}:{{site.data.versions.first.components["calico/windows"].version}}
+        imagePullPolicy: Always
+        args:
+          - ".\\confd\\confd-service.ps1"
+        # The confd container's working dir is in c:\CalicoWindows on the host,
+        # which is two-levels up from the CONTAINER_SANDBOX_MOUNT_POINT.
+        workingDir: "..\\..\\{{installDirName}}"
+        envFrom:
+        - configMapRef:
+            name: calico-windows-config
+        # Calico needs to know the name of the node on which it is running.
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+      {% endif -%}
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/calico/getting-started/windows-calico/kubernetes/rancher.md
+++ b/calico/getting-started/windows-calico/kubernetes/rancher.md
@@ -103,7 +103,7 @@ The following steps will outline the installation of {{site.prodname}} networkin
    calicoctl ipam configure --strictaffinity=true
    ```
 
-1. Finally, follow the {{site.prodnameWindows}} [quickstart guide for Kubernetes]({{site.baseurl}}/getting-started/windows-calico/quickstart#install-calico-for-windows)
+1. Finally, follow the {{site.prodnameWindows}} [quickstart guide for Kubernetes]({{site.baseurl}}/getting-started/windows-calico/quickstart#install-calico-for-windows-manually)
    For VXLAN clusters, follow the instructions under the "Kubernetes VXLAN" tab. For BGP clusters, follow the instructions under the "Kubernetes BGP" tab.
 
    > **Note**: For Rancher default values for service CIDR and DNS cluster IP, see the {% include open-new-window.html text='Rancher kube-api service options' url='https://rancher.com/docs/rke/latest/en/config-options/services/#kubernetes-api-server-options' %}.

--- a/calico/maintenance/ebpf/enabling-bpf.md
+++ b/calico/maintenance/ebpf/enabling-bpf.md
@@ -162,35 +162,7 @@ This section explains how to make sure your cluster is suitable for eBPF mode.
 
 In eBPF mode, {{site.prodname}} implements Kubernetes service networking directly (rather than relying on `kube-proxy`).  This means that, like `kube-proxy`,  {{site.prodname}} must connect _directly_ to the Kubernetes API server rather than via the API server's ClusterIP.
 
-First, make a note of the address of the API server:
-
-* If you have a single API server with a static IP address, you can use its IP address and port.  The IP can be found by running:
-
-  ```
-  kubectl get endpoints kubernetes -o wide
-  ```
-
-  The output should look like the following, with a single IP address and port under "ENDPOINTS":
-
-  ```
-  NAME         ENDPOINTS             AGE
-  kubernetes   172.16.101.157:6443   40m
-  ```
-
-  If there are multiple entries under "ENDPOINTS" then your cluster must have more than one API server.  In that case, you should try to determine the load balancing approach used by your cluster and use the appropriate option below.
-
-* If using DNS load balancing (as used by `kops`), use the FQDN and port of the API server `api.internal.<clustername>`.
-* If you have multiple API servers with a load balancer in front, you should use the IP and port of the load balancer.
-
-> **Tip**: If your cluster uses a ConfigMap to configure `kube-proxy` you can find the "right" way to reach the API
-> server by examining the config map.  For example:
-> ```
-> $ kubectl get configmap -n kube-system kube-proxy -o yaml | grep server`
->     server: https://d881b853ae312e00302a84f1e346a77.gr7.us-west-2.eks.amazonaws.com
-> ```
-> In this case, the server is `d881b853aea312e00302a84f1e346a77.gr7.us-west-2.eks.amazonaws.com` and the port is
-> 443 (the standard HTTPS port).
-{: .alert .alert-success}
+{% include content/kube-apiserver-host-port.md %}
 
 **The next step depends on whether you installed {{site.prodname}} using the operator, or a manifest:**
 

--- a/calico/manifests/calico-windows-bgp.yaml
+++ b/calico/manifests/calico-windows-bgp.yaml
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{% include non-helm-manifests/calico-windows.yaml networking="windows-bgp" %}

--- a/calico/manifests/calico-windows-vxlan.yaml
+++ b/calico/manifests/calico-windows-vxlan.yaml
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{% include non-helm-manifests/calico-windows.yaml networking="vxlan" %}

--- a/calico/manifests/windows-kube-proxy.yaml
+++ b/calico/manifests/windows-kube-proxy.yaml
@@ -1,0 +1,98 @@
+---
+layout: null
+---
+# Adapted from: https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/hostprocess/calico/kube-proxy/start.ps1
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-proxy-windows
+  namespace: kube-system
+data:
+  run.ps1: |
+    $ErrorActionPreference = "Stop"
+    # otherwise kube-proxy.exe takes too long to download
+    $ProgressPreference = 'SilentlyContinue'
+
+    if (-not $env:K8S_VERSION) {
+      Write-Host "The environment variable K8S_VERSION must be specified, e.g. v1.23.4"
+      exit 1
+    }
+
+    # Download kube-proxy based on environment variable
+    $url = "https://dl.k8s.io/${env:K8S_VERSION}/bin/windows/amd64/kube-proxy.exe"
+    $kubeProxyPath = "$PSScriptRoot/kube-proxy.exe"
+    Write-Host "Downloading kube-proxy.exe from $url ..."
+    curl $url -o $kubeProxyPath
+    Write-Host "Downloaded kube-proxy.exe to $kubeProxyPath"
+
+    # Modify the kubeconfig so that references to /var/run/secrets point to this sandbox.
+    $kubeConfigPath = "$PSScriptRoot/kubeconfig.conf"
+    Write-Host "Modifying kubeconfig /var/run/secrets paths and copying to $kubeConfigPath"
+    ((Get-Content -Path ./var/lib/kube-proxy/kubeconfig.conf -Raw) -replace '/var',"$env:CONTAINER_SANDBOX_MOUNT_POINT/var") | Set-Content -Path $kubeConfigPath 
+
+    # Download kube-proxy service script
+    curl https://raw.githubusercontent.com/projectcalico/calico/{{site.data.versions.first.components["calico/node"].version}}/node/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1 -o $PSScriptRoot/kube-proxy-service.ps1
+
+    & "$PSScriptRoot/kube-proxy-service.ps1" -CalicoWindowsDir "/CalicoWindows" -Kubeconfig $kubeConfigPath -KubeProxy $kubeProxyPath
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-proxy-windows
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy-windows
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-proxy-windows
+    spec:
+      serviceAccountName: kube-proxy
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
+      hostNetwork: true
+      volumes:
+      - name: kube-proxy
+        configMap:
+          name: kube-proxy
+      - name: kube-proxy-windows
+        configMap:
+          name: kube-proxy-windows
+      containers:
+      - name: kube-proxy
+        # Update VERSION to match your Windows server version.
+        image: mcr.microsoft.com/windows/nanoserver:VERSION
+        command:
+          - powershell
+          - -c
+          - ./kube-proxy/run.ps1
+        imagePullPolicy: Always
+        env:
+        # Update K8S_VERSION to match your cluster version. E.g. "v1.23.4"
+        - name: K8S_VERSION
+          value: "v1.23.4"
+        # Calico needs to know the name of the node on which it is running.
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: kube-proxy
+          mountPath: /var/lib/kube-proxy
+        - name: kube-proxy-windows
+          mountPath: /kube-proxy/run.ps1
+          subPath: run.ps1
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/calico/scripts/Install-Containerd.ps1
+++ b/calico/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/calico/scripts/PrepareNode.ps1
+++ b/calico/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -32,6 +32,7 @@ Param(
     [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $DownloadOnly="no",
+    [parameter(Mandatory = $false)] $StartCalico="yes",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",
     [parameter(Mandatory = $false)] $EtcdEndpoints="",
     [parameter(Mandatory = $false)] $EtcdTlsSecretName="",
@@ -140,20 +141,42 @@ function GetBackendType()
         return $CalicoBackend
     }
 
+    # For hostprocess installs, if CALICO_NETWORKING_BACKEND is set to a valid value, try to use it.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT -and $env:CALICO_NETWORKING_BACKEND) {
+        $backend = $env:CALICO_NETWORKING_BACKEND
+        if (($backend -eq "vxlan") -or ($backend -eq "windows-bgp")) {
+            return $backend
+        }
+
+        if ($backend -NE $null) {
+            Write-Host "Invalid Calico backend type: $backend. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If CALICO_NETWORKING_BACKEND is not set we can only continue if the
+        # kubeconfig and kubectl.exe both exist.
+        if ((-not (Test-Path $KubeConfigPath)) -or (-not (Test-Path "c:\k\kubectl.exe"))) {
+            Write-Host "No CALICO_NETWORKING_BACKEND provided. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If we reach here, we can continue auto-detecting the backend type.
+    }
+
     # Auto detect backend type
     if ($Datastore -EQ "kubernetes") {
-        $encap=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}' -n $CalicoNamespace
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}' -n $CalicoNamespace
         if ($encap -EQ "true") {
             throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
         }
 
-        $encap=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}' -n $CalicoNamespace
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}' -n $CalicoNamespace
         if ($encap -EQ "true") {
             return ("vxlan")
         }
         return ("bgp")
     } else {
-        $CalicoBackend=c:\k\kubectl.exe --kubeconfig="$RootDir\calico-kube-config" get configmap calico-config -n $CalicoNamespace -o jsonpath='{.data.calico_backend}'
+        $CalicoBackend=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get configmap calico-config -n $CalicoNamespace -o jsonpath='{.data.calico_backend}'
         if ($CalicoBackend -EQ "vxlan") {
             return ("vxlan")
         }
@@ -165,6 +188,14 @@ function GetCalicoNamespace() {
     param(
       [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
     )
+
+    # If we are running inside a HostProcess container then return our
+    # namespace.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        $ns = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/namespace
+        write-host ("Install script is running in a HostProcess container. This namespace is {0}" -f $ns)
+        return $ns
+    }
 
     $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get ns calico-system
     if ([string]::IsNullOrEmpty($name)) {
@@ -190,15 +221,44 @@ function GetCalicoKubeConfig()
         Import-Module $eksAWSToolsModulePath
     }
 
-    $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretName | select -first 1
-    if ([string]::IsNullOrEmpty($name)) {
-        throw "$SecretName service account does not exist."
-    }
-    $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
-    $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.token}' -n $CalicoNamespace
-    $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
+    # If we are running inside a HostProcess container then we already have
+    # access to the serviceaccount token and ca cert.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        Write-Host "Install script is running in a HostProcess container, using mounted serviceaccount ca cert and token."
+        # CA needs to be base64-encoded.
+        $ca = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        $ca = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ca))
+        # But not the token.
+        $token = Get-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/token
 
-    $server=findstr https:// $KubeConfigPath
+        # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are used if both
+        # provided. If this is not the case, fallback to using $KubeConfigPath
+        # if it exists.
+        $k8sHost = $env:KUBERNETES_SERVICE_HOST
+        $k8sPort = $env:KUBERNETES_SERVICE_PORT
+        if ($k8sHost -and $k8sPort) {
+            $server = "server: https://{0}:{1}" -f $k8sHost, $k8sPort
+            Write-Host "Using KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT env variables for kubeconfig. $server"
+        } elseif (Test-Path $KubeConfigPath) {
+            $server=findstr https:// $KubeConfigPath
+            Write-Host ("Using existing kubeconfig at $KubeConfigPath for API server host and port. {0}" -f $server.Trim())
+        } else {
+            Write-Host "Cannot determine API server host and port. Add KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to calico-windows-config in calico-system namespace"
+            exit 1
+        }
+    } else {
+        $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretName | select -first 1
+        if ([string]::IsNullOrEmpty($name)) {
+            throw "$SecretName service account does not exist."
+        }
+        # CA from the k8s secret is already base64-encoded.
+        $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
+        # Token from the k8s secret is base64-encoded but we need the jwt token.
+        $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.token}' -n $CalicoNamespace
+        $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
+
+        $server=findstr https:// $KubeConfigPath
+    }
 
     (Get-Content $RootDir\calico-kube-config.template).replace('<ca>', $ca).replace('<server>', $server.Trim()).replace('<token>', $token) | Set-Content $RootDir\calico-kube-config -Force
 }
@@ -255,15 +315,6 @@ function SetupEtcdTlsFiles()
     $script:EtcdCaCert = "$path\ca.crt"
 }
 
-function SetConfigParameters {
-    param(
-        [parameter(Mandatory=$true)] $OldString,
-        [parameter(Mandatory=$true)] $NewString
-    )
-
-    (Get-Content $RootDir\config.ps1).replace($OldString, $NewString) | Set-Content $RootDir\config.ps1 -Force
-}
-
 function SetAKSCalicoStaticRules {
     $fileName  = [Io.path]::Combine("$RootDir", "static-rules.json")
     echo '{
@@ -288,20 +339,29 @@ function SetAKSCalicoStaticRules {
 }' | Out-File -encoding ASCII -filepath $fileName
 }
 
-function StartCalico()
+function InstallCalico()
 {
-    Write-Host "`nStart Calico for Windows...`n"
+    Write-Host "`nStart Calico for Windows install...`n"
 
     pushd
     cd $RootDir
     .\install-calico.ps1
     popd
-    Write-Host "`nCalico for Windows Started`n"
+    Write-Host "`nCalico for Windows installed`n"
 }
+
+$ErrorActionPreference = "Stop"
 
 $BaseDir="c:\k"
 $RootDir="c:\CalicoWindows"
+
+# If this script is run from a HostProcess container then the installation archive
+# will be in the mount point.
+if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+$CalicoZip="$env:CONTAINER_SANDBOX_MOUNT_POINT\calico-windows.zip"
+} else {
 $CalicoZip="c:\calico-windows.zip"
+}
 
 # Must load the helper modules before doing anything else.
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -332,34 +392,34 @@ if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
 }
 
 if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
-Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
-Exit
+    Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
+    Exit
 }
 
 Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
 Write-Host "Unzip Calico for Windows release..."
 Expand-Archive -Force $CalicoZip c:\
-ipmo $RootDir\libs\calico\calico.psm1
+ipmo -force $RootDir\libs\calico\calico.psm1
 
 Write-Host "Setup Calico for Windows..."
-SetConfigParameters -OldString '<your datastore type>' -NewString $Datastore
-SetConfigParameters -OldString '<your etcd endpoints>' -NewString "$EtcdEndpoints"
+Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
+Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
 
 if (-Not [string]::IsNullOrEmpty($EtcdTlsSecretName)) {
     $calicoNs = GetCalicoNamespace
     SetupEtcdTlsFiles -SecretName "$EtcdTlsSecretName" -CalicoNamespace $calicoNs
 }
-SetConfigParameters -OldString '<your etcd key>' -NewString "$EtcdKey"
-SetConfigParameters -OldString '<your etcd cert>' -NewString "$EtcdCert"
-SetConfigParameters -OldString '<your etcd ca cert>' -NewString "$EtcdCaCert"
-SetConfigParameters -OldString '<your service cidr>' -NewString $ServiceCidr
-SetConfigParameters -OldString '<your dns server ips>' -NewString $DNSServerIPs
+Set-ConfigParameters -var 'ETCD_KEY_FILE' -value $EtcdKey
+Set-ConfigParameters -var 'ETCD_CERT_FILE' -value $EtcdCert
+Set-ConfigParameters -var 'ETCD_CA_CERT_FILE' -value $EtcdCaCert
+Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
+Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
 
 if ($platform -EQ "aks") {
     Write-Host "Setup Calico for Windows for AKS..."
     $Backend="none"
-    SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="none"'
-    SetConfigParameters -OldString 'KUBE_NETWORK = "Calico.*"' -NewString 'KUBE_NETWORK = "azure.*"'
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
 
     $calicoNs = "calico-system"
     GetCalicoKubeConfig -CalicoNamespace $calicoNs
@@ -373,10 +433,10 @@ if ($platform -EQ "eks") {
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for EKS, node name $awsNodeName ..."
     $Backend = "none"
-    $awsNodeNameQuote = """$awsNodeName"""
-    SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"
-    SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="none"'
-    SetConfigParameters -OldString 'KUBE_NETWORK = "Calico.*"' -NewString 'KUBE_NETWORK = "vpc.*"'
+
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "vpc.*"
 
     $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
     GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
@@ -385,8 +445,7 @@ if ($platform -EQ "ec2") {
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for AWS, node name $awsNodeName ..."
-    $awsNodeNameQuote = """$awsNodeName"""
-    SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$awsNodeNameQuote"
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
 
     $calicoNs = GetCalicoNamespace
     GetCalicoKubeConfig -CalicoNamespace $calicoNs
@@ -394,14 +453,14 @@ if ($platform -EQ "ec2") {
 
     Write-Host "Backend networking is $Backend"
     if ($Backend -EQ "bgp") {
-        SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="windows-bgp"'
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
     }
 }
 if ($platform -EQ "gce") {
     $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for GCE, node name $gceNodeName ..."
     $gceNodeNameQuote = """$gceNodeName"""
-    SetConfigParameters -OldString '$(hostname).ToLower()' -NewString "$gceNodeNameQuote"
+    Set-ConfigParameters -var 'NODENAME' -value $gceNodeNameQuote
 
     $calicoNs = GetCalicoNamespace
     GetCalicoKubeConfig -CalicoNamespace $calicoNs
@@ -409,7 +468,7 @@ if ($platform -EQ "gce") {
 
     Write-Host "Backend networking is $Backend"
     if ($Backend -EQ "bgp") {
-        SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="windows-bgp"'
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
     }
 }
 if ($platform -EQ "bare-metal") {
@@ -419,7 +478,7 @@ if ($platform -EQ "bare-metal") {
 
     Write-Host "Backend networking is $Backend"
     if ($Backend -EQ "bgp") {
-        SetConfigParameters -OldString 'CALICO_NETWORKING_BACKEND="vxlan"' -NewString 'CALICO_NETWORKING_BACKEND="windows-bgp"'
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
     }
 }
 
@@ -428,7 +487,29 @@ if ($DownloadOnly -EQ "yes") {
     Exit
 }
 
-StartCalico
+InstallCalico
+
+if ($StartCalico -EQ "yes") {
+    Write-Host "Starting Calico..."
+    Write-Host "This may take several seconds if the vSwitch needs to be created."
+
+    Start-Service CalicoNode
+    Wait-ForCalicoInit
+    Start-Service CalicoFelix
+
+    if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")
+    {
+        Start-Service CalicoConfd
+    }
+
+    while ((Get-Service | where Name -Like 'Calico*' | where Status -NE Running) -NE $null) {
+        Write-Host "Waiting for the Calico services to be running..."
+        Start-Sleep 1
+    }
+
+    Write-Host "Done, the Calico services are running:"
+    Get-Service | where Name -Like 'Calico*'
+}
 
 if ($Backend -NE "none") {
     New-NetFirewallRule -Name KubectlExec10250 -Description "Enable kubectl exec and log" -Action Allow -LocalPort 10250 -Enabled True -DisplayName "kubectl exec 10250" -Protocol TCP -ErrorAction SilentlyContinue

--- a/node/Makefile
+++ b/node/Makefile
@@ -8,9 +8,13 @@ DEV_TAG_SUFFIX        ?=0.dev
 # Name of the images.
 # e.g., <registry>/<name>:<tag>
 NODE_IMAGE            ?=node
+WINDOWS_IMAGE         ?=windows
 WINDOWS_UPGRADE_IMAGE ?=windows-upgrade
 
 WINDOWS_VERSIONS?=1809 2004 20H2 ltsc2022
+
+# We don't include the windows images here because we build them differently
+# using targets within this makefile.
 BUILD_IMAGES ?=$(NODE_IMAGE)
 
 # Paths within the build container for BPF source.
@@ -67,6 +71,7 @@ WINDOWS_INSTALL_SCRIPT := dist/install-calico-windows.ps1
 
 # Variables for the Windows packaging.
 # Name of the Windows release ZIP archive.
+WINDOWS_PACKAGING_ROOT := windows-packaging
 WINDOWS_ARCHIVE_ROOT := windows-packaging/CalicoWindows
 WINDOWS_ARCHIVE_BINARY := $(WINDOWS_ARCHIVE_ROOT)/calico-node.exe
 WINDOWS_ARCHIVE_TAG?=$(GIT_VERSION)
@@ -112,18 +117,25 @@ MICROSOFT_SDN_GITHUB_RAW_URL := https://raw.githubusercontent.com/microsoft/SDN/
 WINDOWS_UPGRADE_ROOT         ?= windows-upgrade
 WINDOWS_UPGRADE_DIST          = dist/windows-upgrade
 
-# The directory that holds temporary files used to build the windows upgrade zip
-# archive.
+# The directory for temporary files used to build the windows upgrade zip archive.
 WINDOWS_UPGRADE_DIST_STAGE    = $(WINDOWS_UPGRADE_DIST)/stage
+
+# Windows upgrade archive components.
 WINDOWS_UPGRADE_INSTALL_FILE ?= $(WINDOWS_UPGRADE_DIST_STAGE)/install-calico-windows.ps1
 WINDOWS_UPGRADE_INSTALL_ZIP  ?= $(WINDOWS_UPGRADE_DIST_STAGE)/calico-windows-$(WINDOWS_ARCHIVE_TAG).zip
 WINDOWS_UPGRADE_SCRIPT       ?= $(WINDOWS_UPGRADE_DIST_STAGE)/calico-upgrade.ps1
 
-# The directory used for the upgrade image docker build context.
+# The directory for the upgrade image docker build context.
 WINDOWS_UPGRADE_BUILD        ?= $(WINDOWS_UPGRADE_ROOT)/build
 
 # The final zip archive used in the upgrade image.
 WINDOWS_UPGRADE_ARCHIVE      ?= $(WINDOWS_UPGRADE_BUILD)/calico-windows-upgrade.zip
+
+# The directory for windows image tarball
+WINDOWS_DIST        = dist/windows
+
+# The directory for temporary files used to build the windows image
+WINDOWS_DIST_STAGE  = $(WINDOWS_DIST)/stage
 
 # Variables used by the tests
 ST_TO_RUN?=tests/st/
@@ -152,7 +164,7 @@ SRC_FILES=$(shell find ./pkg -name '*.go') \
 BINDIR?=bin
 
 ## Clean enough that a new release build will be clean
-clean: clean-windows-upgrade
+clean: clean-windows
 	# Clean .created files which indicate images / releases have been built.
 	find . -name '.*.created*' -type f -delete
 	find . -name '.*.published*' -type f -delete
@@ -160,13 +172,6 @@ clean: clean-windows-upgrade
 	rm -rf .go-pkg-cache
 	rm -rf certs *.tar $(NODE_CONTAINER_BIN_DIR)
 	rm -rf $(REMOTE_DEPS)
-	rm -f $(WINDOWS_ARCHIVE_BINARY) $(WINDOWS_BINARY)
-	rm -f $(WINDOWS_ARCHIVE_ROOT)/libs/hns/hns.psm1
-	rm -f $(WINDOWS_ARCHIVE_ROOT)/libs/hns/License.txt
-	rm -f $(WINDOWS_ARCHIVE_ROOT)/cni/*.exe
-	rm -f $(WINDOWS_INSTALL_SCRIPT)
-	rm -f $(WINDOWS_UPGRADE_INSTALL_FILE)
-	rm -f $(WINDOWS_UPGRADE_BUILD)/*.zip
 	rm -rf filesystem/included-source
 	rm -rf dist
 	rm -rf bin
@@ -177,8 +182,14 @@ clean: clean-windows-upgrade
 	docker rmi $(TEST_CONTAINER_NAME) || true
 	docker rmi $(addprefix $(WINDOWS_UPGRADE_IMAGE):latest-,$(WINDOWS_VERSIONS)) || true
 
-clean-windows-upgrade:
-	-rm -f "$(WINDOWS_UPGRADE_DIST_STAGE)"
+clean-windows:
+	-rm -f $(WINDOWS_ARCHIVE) $(WINDOWS_ARCHIVE_BINARY) $(WINDOWS_BINARY)
+	-rm -f $(WINDOWS_ARCHIVE_ROOT)/libs/hns/hns.psm1
+	-rm -f $(WINDOWS_ARCHIVE_ROOT)/libs/hns/License.txt
+	-rm -f $(WINDOWS_ARCHIVE_ROOT)/cni/*.exe
+	-rm -f $(WINDOWS_INSTALL_SCRIPT)
+	-rm -rf "$(WINDOWS_DIST)"
+	-rm -rf "$(WINDOWS_UPGRADE_DIST)"
 	-rm -rf "$(WINDOWS_UPGRADE_BUILD)"
 
 ###############################################################################
@@ -424,10 +435,10 @@ st: $(REMOTE_DEPS) image dist/calicoctl busybox.tar calico-node.tar workload.tar
 # CI/CD
 ###############################################################################
 .PHONY: ci
-ci: static-checks ut fv image build-windows-archive st
+ci: static-checks ut fv image build-windows-upgrade-archive image-tar-windows-all st
 
 ## Deploys images to registry
-cd: cd-common cd-windows-upgrade
+cd: cd-common cd-windows-all
 
 check-boring-ssl: $(NODE_CONTAINER_BIN_DIR)/calico-node-amd64
 	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
@@ -467,8 +478,8 @@ release-publish: release-prereqs .release-$(VERSION).published
 	# Push node images.
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 
-	# Push Windows upgrade images.
-	$(MAKE) cd-windows-upgrade RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
+	# Push Windows images.
+	$(MAKE) cd-windows-all RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 
 	touch $@
 
@@ -564,18 +575,18 @@ $(WINDOWS_UPGRADE_INSTALL_FILE): $(WINDOWS_UPGRADE_DIST_STAGE) $(WINDOWS_INSTALL
 release-windows-upgrade-archive: release-prereqs
 	$(MAKE) build-windows-upgrade-archive WINDOWS_ARCHIVE_TAG=$(VERSION)
 
-# Build the Windows upgrade zip archive.
-build-windows-upgrade-archive: clean-windows-upgrade $(WINDOWS_UPGRADE_INSTALL_ZIP) $(WINDOWS_UPGRADE_INSTALL_FILE) $(WINDOWS_UPGRADE_SCRIPT) $(WINDOWS_UPGRADE_BUILD)
+# Build the Windows upgrade zip archive, which also builds the windows archive.
+build-windows-upgrade-archive: clean-windows $(WINDOWS_UPGRADE_INSTALL_ZIP) $(WINDOWS_UPGRADE_INSTALL_FILE) $(WINDOWS_UPGRADE_SCRIPT) $(WINDOWS_UPGRADE_BUILD)
 	rm $(WINDOWS_UPGRADE_ARCHIVE) || true
 	cd $(WINDOWS_UPGRADE_DIST_STAGE) && zip -r "$(CURDIR)/$(WINDOWS_UPGRADE_ARCHIVE)" *.zip *.ps1
 
 # Sets up the docker builder used to create Windows image tarballs.
 setup-windows-builder:
-	-docker buildx rm calico-windows-upgrade-builder
-	docker buildx create --name=calico-windows-upgrade-builder --use --platform windows/amd64
+	-docker buildx rm calico-windows-builder
+	docker buildx create --name=calico-windows-builder --use --platform windows/amd64
 
 # Builds all the Windows image tarballs for each version in WINDOWS_VERSIONS
-image-tar-windows-all: setup-windows-builder $(addprefix sub-image-tar-windows-,$(WINDOWS_VERSIONS))
+image-tar-windows-all: setup-windows-builder $(addprefix sub-image-tar-windows-,$(WINDOWS_VERSIONS)) $(addprefix sub-image-tar-windows-upgrade-,$(WINDOWS_VERSIONS))
 
 CRANE_BINDMOUNT_CMD := \
 	docker run --rm \
@@ -598,9 +609,30 @@ CRANE_BINDMOUNT = echo [DRY RUN] $(CRANE_BINDMOUNT_CMD)
 DOCKER_MANIFEST = echo [DRY RUN] $(DOCKER_MANIFEST_CMD)
 endif
 
-# Uses the docker builder to create a Windows image tarball for a single Windows
-# version.
+# Uses the docker builder to create a Windows image tarball for a single Windows version.
 sub-image-tar-windows-%:
+	# ensure dir for windows image tars
+	-mkdir -p $(WINDOWS_DIST)
+	# ensure docker build dir exists
+	-mkdir -p $(WINDOWS_DIST_STAGE)
+	# copy dockerfile to staging dir
+	cp $(WINDOWS_PACKAGING_ROOT)/Dockerfile $(WINDOWS_DIST_STAGE)
+	# copy install entrypoint script to staging dir
+	cp $(WINDOWS_PACKAGING_ROOT)/host-process-install.ps1 $(WINDOWS_DIST_STAGE)
+	# build and copy install script to staging dir
+	make -C ../calico build
+	cp ../calico/_site/scripts/install-calico-windows.ps1 $(WINDOWS_DIST_STAGE)
+	# copy calico install zip file to staging dir
+	cp dist/calico-windows-$(GIT_VERSION).zip $(WINDOWS_DIST_STAGE)/calico-windows.zip
+	cd $(WINDOWS_DIST_STAGE) && \
+	docker buildx build \
+		--platform windows/amd64 \
+		--output=type=docker,dest=$(CURDIR)/$(WINDOWS_DIST)/image-$(GIT_VERSION)-$*.tar \
+		--pull \
+		--build-arg=WINDOWS_VERSION=$* .
+
+# Uses the docker builder to create a Windows upgrade image tarball for a single Windows version.
+sub-image-tar-windows-upgrade-%:
 	-mkdir -p $(WINDOWS_UPGRADE_DIST)
 	cd $(WINDOWS_UPGRADE_ROOT) && \
 		docker buildx build \
@@ -610,13 +642,17 @@ sub-image-tar-windows-%:
 			--no-cache \
 			--build-arg=WINDOWS_VERSION=$* .
 
-# The calico-windows-upgrade cd is different because we do not build docker images directly.
+cd-windows-all:
+	$(MAKE) cd-windows-windows WINDOWS_IMAGE_TAR_ROOT=$(WINDOWS_DIST)
+	$(MAKE) cd-windows-windows-upgrade WINDOWS_IMAGE_TAR_ROOT=$(WINDOWS_UPGRADE_DIST)
+
+# Windows image pushing is different because we do not build docker images directly.
 # Since the build machine is linux, we output the images to a tarball. (We can
 # produce images but there will be no output because docker images
 # built for Windows cannot be loaded on linux.)
 #
 # The resulting image tarball is then pushed to registries during cd/release.
-# The image tarballs are located in dist/windows-upgrade and have files names
+# The image tarballs are located in WINDOWS_IMAGE_TAR_ROOT and have files names
 # with the format 'image-v3.21.0-2-abcdef-20H2.tar'.
 #
 # In addition to pushing the individual images, we also create the manifest
@@ -629,14 +665,18 @@ sub-image-tar-windows-%:
 #   Setting os.image in the manifest is required for Windows hosts to load the
 #   correct image in manifest.
 # - Finally we push the manifest, "purging" the local manifest.
-cd-windows-upgrade:
+cd-windows-%:
+# WINDOWS_IMAGE_TAR_ROOT is the dir containing image tarballs to push.
+ifndef WINDOWS_IMAGE_TAR_ROOT
+	$(error WINDOWS_IMAGE_TAR_ROOT is not set)
+endif
 	for registry in $(DEV_REGISTRIES); do \
 		echo Pushing Windows images to $${registry}; \
 		all_images=""; \
-		manifest_image="$${registry}/$(WINDOWS_UPGRADE_IMAGE):$(GIT_VERSION)"; \
+		manifest_image="$${registry}/$*:$(GIT_VERSION)"; \
 		for win_ver in $(WINDOWS_VERSIONS); do \
-			image_tar="$(WINDOWS_UPGRADE_DIST)/image-$(GIT_VERSION)-$${win_ver}.tar"; \
-			image="$${registry}/$(WINDOWS_UPGRADE_IMAGE):$(GIT_VERSION)-windows-$${win_ver}"; \
+			image_tar="$(WINDOWS_IMAGE_TAR_ROOT)/image-$(GIT_VERSION)-$${win_ver}.tar"; \
+			image="$${registry}/$*:$(GIT_VERSION)-windows-$${win_ver}"; \
 			echo Pushing image $${image} ...; \
 			$(CRANE_BINDMOUNT) push $${image_tar} $${image}$(double_quote) & \
 			all_images="$${all_images} $${image}"; \
@@ -645,7 +685,7 @@ cd-windows-upgrade:
 		$(DOCKER_MANIFEST) create --amend $${manifest_image} $${all_images}; \
 		for win_ver in $(WINDOWS_VERSIONS); do \
 			version=$$(docker manifest inspect mcr.microsoft.com/windows/nanoserver:$${win_ver} | grep "os.version" | head -n 1 | awk -F\" '{print $$4}'); \
-			image="$${registry}/$(WINDOWS_UPGRADE_IMAGE):$(GIT_VERSION)-windows-$${win_ver}"; \
+			image="$${registry}/$*:$(GIT_VERSION)-windows-$${win_ver}"; \
 			$(DOCKER_MANIFEST) annotate --os windows --arch amd64 --os-version $${version} $${manifest_image} $${image}; \
 		done; \
 		$(DOCKER_MANIFEST) push --purge $${manifest_image}; \

--- a/node/pkg/lifecycle/startup/startup_windows.go
+++ b/node/pkg/lifecycle/startup/startup_windows.go
@@ -54,7 +54,6 @@ func ensureNetworkForOS(ctx context.Context, c client.Interface, nodeName string
 	case "none":
 		logrus.Info("Backend networking is none, no network setup needed.")
 	case "vxlan", "windows-bgp":
-		logrus.Info("Backend networking is vxlan, ensure vxlan network.")
 		rsvdAttrWindows := &ipam.HostReservedAttr{
 			StartOfBlock: 3,
 			EndOfBlock:   1,
@@ -76,6 +75,7 @@ func ensureNetworkForOS(ctx context.Context, c client.Interface, nodeName string
 		networkName := "Calico"
 
 		if backend == "vxlan" {
+			logrus.Info("Backend networking is vxlan, ensure vxlan network.")
 			vniString := os.Getenv("VXLAN_VNI")
 			vni, err := strconv.ParseInt(vniString, 10, 64)
 			if err != nil {
@@ -99,6 +99,7 @@ func ensureNetworkForOS(ctx context.Context, c client.Interface, nodeName string
 				return err
 			}
 		} else {
+			logrus.Info("Backend networking is windows-bgp, ensure l2bridge network.")
 			_, err = windows.SetupL2bridgeNetwork(networkName, subnet, logrus.WithField("subnet", subnet.String()))
 			if err != nil {
 				return err

--- a/node/windows-packaging/CalicoWindows/config.ps1
+++ b/node/windows-packaging/CalicoWindows/config.ps1
@@ -1,66 +1,67 @@
 $baseDir = "$PSScriptRoot"
-ipmo $baseDir\libs\calico\calico.psm1
+ipmo $baseDir\libs\calico\calico.psm1 -Force
+
+Write-Host "Setting environment variables if not set..."
 
 ## Cluster configuration:
 
 # KUBE_NETWORK should be set to a regular expression that matches the HNS network(s) used for pods.
 # The default, "Calico.*", is correct for Calico CNI. 
-$env:KUBE_NETWORK = "Calico.*"
+Set-EnvVarIfNotSet -var "KUBE_NETWORK" -defaultValue "Calico.*"
 
 # Set this to one of the following values:
 # - "vxlan" for Calico VXLAN networking
 # - "windows-bgp" for Calico BGP networking using the Windows BGP router.
 # - "none" to disable the Calico CNI plugin (so that you can use another plugin).
-$env:CALICO_NETWORKING_BACKEND="vxlan"
+Set-EnvVarIfNotSet -var "CALICO_NETWORKING_BACKEND" -defaultValue "vxlan"
 
 # Set to match your Kubernetes service CIDR.
-$env:K8S_SERVICE_CIDR = "<your service cidr>"
-$env:DNS_NAME_SERVERS = "<your dns server ips>"
-$env:DNS_SEARCH = "svc.cluster.local"
-
+Set-EnvVarIfNotSet -var "K8S_SERVICE_CIDR" -defaultValue "<your service cidr>"
+Set-EnvVarIfNotSet -var "DNS_NAME_SERVERS" -defaultValue "<your dns server ips>"
+Set-EnvVarIfNotSet -var "DNS_SEARCH" -defaultValue "svc.cluster.local"
 
 ## Datastore configuration:
 
 # Set this to "kubernetes" to use the kubernetes datastore, or "etcdv3" for etcd.
-$env:CALICO_DATASTORE_TYPE = "<your datastore type>"
+Set-EnvVarIfNotSet -var "CALICO_DATASTORE_TYPE" -defaultValue "<your datastore type>"
 
 # Set KUBECONFIG to the path of your kubeconfig file.
-$env:KUBECONFIG = "$PSScriptRoot\calico-kube-config"
+Set-EnvVarIfNotSet -var "KUBECONFIG" -defaultValue "$PSScriptRoot\calico-kube-config"
 
 # For the "etcdv3" datastore only: set ETCD_ENDPOINTS, format: "http://<host>:<port>,..."
-$env:ETCD_ENDPOINTS = "<your etcd endpoints>"
+Set-EnvVarIfNotSet -var "ETCD_ENDPOINTS" -defaultValue "<your etcd endpoints>"
 # For etcd over TLS, set these lines to point to your keys/certs:
-$env:ETCD_KEY_FILE = "<your etcd key>"
-$env:ETCD_CERT_FILE = "<your etcd cert>"
-$env:ETCD_CA_CERT_FILE = "<your etcd ca cert>"
-
+Set-EnvVarIfNotSet -var "ETCD_KEY_FILE" -defaultValue "<your etcd key>"
+Set-EnvVarIfNotSet -var "ETCD_CERT_FILE" -defaultValue "<your etcd cert>"
+Set-EnvVarIfNotSet -var "ETCD_CA_CERT_FILE" -defaultValue "<your etcd ca cert>"
 
 ## CNI configuration, only used for the "vxlan" networking backends.
 
-# Place to install the CNI plugin to.  Should match kubelet's --cni-bin-dir.
-$env:CNI_BIN_DIR = "c:\k\cni"
-# Place to install the CNI config to.  Should be located in kubelet's --cni-conf-dir.
-$env:CNI_CONF_DIR = "c:\k\cni\config"
-
 if (Get-IsContainerdRunning)
 {
-    $env:CNI_BIN_DIR = Get-ContainerdCniBinDir
-    $env:CNI_CONF_DIR = Get-ContainerdCniConfDir
+    Set-EnvVarIfNotSet -var "CNI_BIN_DIR" -defaultValue (Get-ContainerdCniBinDir)
+    Set-EnvVarIfNotSet -var "CNI_CONF_DIR" -defaultValue (Get-ContainerdCniConfDir)
+} else {
+    # Place to install the CNI plugin to. For docker, this should match kubelet's --cni-bin-dir.
+    Set-EnvVarIfNotSet -var "CNI_BIN_DIR" -defaultValue "c:\k\cni"
+    # Place to install the CNI config to. For docker, this hould be located in kubelet's --cni-conf-dir.
+    Set-EnvVarIfNotSet -var "CNI_CONF_DIR" -defaultValue "c:\k\cni\config"
 }
 
-$env:CNI_CONF_FILENAME = "10-calico.conf"
+Set-EnvVarIfNotSet -var "CNI_CONF_FILENAME" -defaultValue "10-calico.conf"
 # IPAM type to use with Calico's CNI plugin.  One of "calico-ipam" or "host-local".
-$env:CNI_IPAM_TYPE = "calico-ipam"
+Set-EnvVarIfNotSet -var "CNI_IPAM_TYPE" -defaultValue "calico-ipam"
 
 ## VXLAN-specific configuration.
 
 # The VXLAN VNI / VSID.  Must match the VXLANVNI felix configuration parameter used
 # for Linux nodes.
-$env:VXLAN_VNI = "4096"
+Set-EnvVarIfNotSet -var "VXLAN_VNI" -defaultValue 4096
 # Prefix used when generating MAC addresses for virtual NICs.
 $env:VXLAN_MAC_PREFIX = "0E-2A"
+Set-EnvVarIfNotSet -var "VXLAN_MAC_PREFIX" -defaultValue "0E-2A"
 # Network Adapter used on VXLAN, leave blank for primary NIC. 
-$env:VXLAN_ADAPTER = ""
+Set-EnvVarIfNotSet -var "VXLAN_ADAPTER" -defaultValue ""
 
 ## Node configuration.
 
@@ -69,31 +70,31 @@ $env:VXLAN_ADAPTER = ""
 #
 # Note: on AWS, kubelet is often configured to use the internal domain name of the host rather than
 # the simple hostname, for example "ip-172-16-101-135.us-west-2.compute.internal".
-$env:NODENAME = $(hostname).ToLower()
+Set-EnvVarIfNotSet -var "NODENAME" -defaultValue $(hostname).ToLower()
 # Similarly, CALICO_K8S_NODE_REF should be set to the Kubernetes Node name.  When using etcd,
 # the Calico kube-controllers pod will clean up Calico node objects if the corresponding Kubernetes Node is
 # cleaned up.
-$env:CALICO_K8S_NODE_REF = $env:NODENAME
+Set-EnvVarIfNotSet -var "CALICO_K8S_NODE_REF" -defaultValue $env:NODENAME
 
 # The time out to wait for a valid IP of an interface to be assigned before initialising Calico
 # after a reboot.
-$env:STARTUP_VALID_IP_TIMEOUT = 90
+Set-EnvVarIfNotSet -var "STARTUP_VALID_IP_TIMEOUT" -defaultValue 90
 
 # The IP of the node; the default will auto-detect a usable IP in most cases.
-$env:IP = "autodetect"
+Set-EnvVarIfNotSet -var "IP" -defaultValue "autodetect"
 
 ## Logging.
 
-$env:CALICO_LOG_DIR = "$PSScriptRoot\logs"
+Set-EnvVarIfNotSet -var "CALICO_LOG_DIR" -defaultValue "$PSScriptRoot\logs"
 
 # Felix logs to screen at info level by default.  Uncomment this line to override the log
 # level.  Alternatively, (if this is commented out) the log level can be controlled via
 # the FelixConfiguration resource in the datastore.
 # $env:FELIX_LOGSEVERITYSCREEN = "info"
 # Disable logging to file by default since the service wrapper will redirect our log to file.
-$env:FELIX_LOGSEVERITYFILE = "none"
+Set-EnvVarIfNotSet -var "FELIX_LOGSEVERITYFILE" -defaultValue "none"
 # Disable syslog logging, which is not supported on Windows.
-$env:FELIX_LOGSEVERITYSYS = "none"
+Set-EnvVarIfNotSet -var "FELIX_LOGSEVERITYSYS" -defaultValue "none"
 # confd logs to screen at info level by default.  Uncomment this line to override the log
 # level.
-#$env:BGP_LOGSEVERITYSCREEN = "debug"
+#Set-EnvVarIfNotSet -var "BGP_LOGSEVERITYSCREEN" -defaultValue "debug"

--- a/node/windows-packaging/CalicoWindows/kubernetes/install-kube-services.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/install-kube-services.ps1
@@ -99,7 +99,6 @@ if (($service -ne "") -and ($service -notin "kubelet", "kube-proxy"))
     Exit
 }
 
-Write-Host the param is $service
 if ($service -eq "")
 {
     Install-KubeletService

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -14,22 +14,22 @@
 
 Param(
     [string]$NodeIp="",
-    [string]$InterfaceName="Ethernet"
+    [string]$InterfaceName="vEthernet (Ethernet*"
 )
 
 $baseDir = "$PSScriptRoot\.."
 . $baseDir\config.ps1
-ipmo $baseDir\libs\calico\calico.psm1
+ipmo $baseDir\libs\calico\calico.psm1 -Force
 
 Write-Host "Running kubelet service."
 Write-Host "Using configured nodename: $env:NODENAME DNS: $env:DNS_NAME_SERVERS"
 
-Write-Host "Auto-detecting node IP, looking for interface named 'vEthernet ($InterfaceName...'."
-$na = Get-NetAdapter | ? Name -Like "vEthernet ($InterfaceName*" | ? Status -EQ Up
+Write-Host "Auto-detecting node IP, looking for interface named like '$InterfaceName' ..."
+$na = Get-NetAdapter | ? Name -Like "$InterfaceName" | ? Status -EQ Up
 while ($na -EQ $null) {
-    Write-Host "Waiting for interface named 'vEthernet ($InterfaceName...'."
+    Write-Host "Waiting for interface named like '$InterfaceName' ..."
     Start-Sleep 3
-    $na = Get-NetAdapter | ? Name -Like "vEthernet ($InterfaceName*" | ? Status -EQ Up
+    $na = Get-NetAdapter | ? Name -Like "$InterfaceName" | ? Status -EQ Up
 }
 $NodeIp = (Get-NetIPAddress -InterfaceAlias $na.ifAlias -AddressFamily IPv4).IPAddress
 Write-Host "Detected node IP: $NodeIp."

--- a/node/windows-packaging/CalicoWindows/libs/calico/calico.psm1
+++ b/node/windows-packaging/CalicoWindows/libs/calico/calico.psm1
@@ -92,6 +92,30 @@ function Test-CalicoConfiguration()
     }
 }
 
+function Set-EnvVarIfNotSet {
+    param(
+        [parameter(Mandatory=$true)] $var,
+        [parameter(Mandatory=$true)] $defaultValue
+    )
+    if (-not (Test-Path "env:$var"))
+    {
+        Write-Host ("Environment variable $var is not set. Setting it to the default value: {0}" -f $defaultValue)
+        [Environment]::SetEnvironmentVariable($var, $defaultValue, 'Process')
+    } else {
+        Write-Host ("Environment variable $var is already set: {0}" -f (gci env:$var | select -expand Value))
+    }
+}
+
+function Set-ConfigParameters {
+    param(
+        [parameter(Mandatory=$true)] $var,
+        [parameter(Mandatory=$true)] $value
+    )
+    $OldString='Set-EnvVarIfNotSet -var "{0}".*$' -f $var
+    $NewString='Set-EnvVarIfNotSet -var "{0}" -defaultValue "{1}"' -f $var, $value
+    (Get-Content $baseDir\config.ps1) -replace $OldString, $NewString | Set-Content $baseDir\config.ps1 -Force
+}
+
 function Install-CNIPlugin()
 {
     Write-Host "Copying CNI binaries to $env:CNI_BIN_DIR"
@@ -152,9 +176,16 @@ function Install-CNIPlugin()
 function Remove-CNIPlugin()
 {
     $cniConfFile = $env:CNI_CONF_DIR + "\" + $env:CNI_CONF_FILENAME
-    Write-Host "Removing $cniConfFile and Calico binaries."
-    rm $cniConfFile
-    rm "$env:CNI_BIN_DIR/calico*.exe"
+    if (Test-Path $cniConfFile) {
+        Write-Host "Removing Calico CNI conf file at $cniConfFile ..."
+        rm $cniConfFile
+    }
+
+    $cniBinPath = "$env:CNI_BIN_DIR/calico*.exe"
+    if (Test-Path $cniBinPath) {
+        Write-Host "Removing Calico CNI binaries at $cniBinPath ..."
+        rm $cniBinPath
+    }
 }
 
 function Install-NodeService()

--- a/node/windows-packaging/CalicoWindows/node/node-service.ps1
+++ b/node/windows-packaging/CalicoWindows/node/node-service.ps1
@@ -15,8 +15,8 @@
 # This script is run from the main Calico folder.
 . .\config.ps1
 
-ipmo .\libs\calico\calico.psm1
-ipmo .\libs\hns\hns.psm1
+ipmo .\libs\calico\calico.psm1 -Force
+ipmo .\libs\hns\hns.psm1 -Force
 
 $lastBootTime = Get-LastBootTime
 $Stored = Get-StoredLastBootTime
@@ -118,6 +118,9 @@ if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp" -OR $env:CALICO_NETWORKING_
     }
 }
 
+# For Windows, we expect the nodename file to exist in the root directory of the
+# Calico for Windows installation. The CNI config field 'nodename_file' will
+# always be $RootDir\nodename
 $env:CALICO_NODENAME_FILE = ".\nodename"
 
 # We use this setting as a trigger for the other scripts to proceed.
@@ -125,17 +128,22 @@ Set-StoredLastBootTime $lastBootTime
 $Stored = Get-StoredLastBootTime
 Write-Host "Stored new lastBootTime $Stored"
 
-# The old version of Calico upgrade service may still be running.
-while (Get-UpgradeService)
-{
+# The old version of Calico upgrade service may still be running
+# so try to remove it while it exists.
+#
+# Upgrade service is not needed if node is running in a hostprocess container.
+if (-not $env:CONTAINER_SANDBOX_MOUNT_POINT) {
+    while (Get-UpgradeService)
+    {
 
-    Remove-UpgradeService
-    if ($LastExitCode -EQ 0) {
-        Write-Host "CalicoUpgrade service removed"
-        break
+        Remove-UpgradeService
+        if ($LastExitCode -EQ 0) {
+            Write-Host "CalicoUpgrade service removed"
+            break
+        }
+        Start-Sleep 5
+        Write-Host "Failed to clean up old CalicoUpgrade service, retrying..."
     }
-    Start-Sleep 5
-    Write-Host "Failed to clean up old CalicoUpgrade service, retrying..."
 }
 
 # Run the startup script whenever kubelet (re)starts. This makes sure that we refresh our Node annotations if
@@ -171,12 +179,15 @@ while ($True)
         $kubeletPid = -1
     }
 
-    if (!(Get-UpgradeService)) {
-        # If upgrade service has not been running, check if we should run upgrade service.
-        .\calico-node.exe -should-install-windows-upgrade
-        if ($LastExitCode -EQ 0) {
-            Install-UpgradeService
-            Start-Service CalicoUpgrade
+    # Upgrade service is not needed if node is running in a hostprocess container.
+    if (-not $env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        if (!(Get-UpgradeService)) {
+            # If upgrade service has not been running, check if we should run upgrade service.
+            .\calico-node.exe -should-install-windows-upgrade
+            if ($LastExitCode -EQ 0) {
+                Install-UpgradeService
+                Start-Service CalicoUpgrade
+            }
         }
     }
 

--- a/node/windows-packaging/CalicoWindows/start-calico.ps1
+++ b/node/windows-packaging/CalicoWindows/start-calico.ps1
@@ -14,10 +14,22 @@
 
 . $PSScriptRoot\config.ps1
 
+Write-Host "Starting Calico..."
+Write-Host "This may take several seconds if the vSwitch needs to be created."
+
 Start-Service CalicoNode
+Wait-ForCalicoInit
 Start-Service CalicoFelix
 
 if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")
 {
     Start-Service CalicoConfd
 }
+
+while ((Get-Service | where Name -Like 'Calico*' | where Status -NE Running) -NE $null) {
+    Write-Host "Waiting for the Calico services to be running..."
+    Start-Sleep 1
+}
+
+Write-Host "Done, the Calico services are running:"
+Get-Service | where Name -Like 'Calico*'

--- a/node/windows-packaging/CalicoWindows/uninstall-calico.ps1
+++ b/node/windows-packaging/CalicoWindows/uninstall-calico.ps1
@@ -24,6 +24,16 @@ Test-CalicoConfiguration
 
 $ErrorActionPreference = 'SilentlyContinue'
 
+# If running in a hostprocess container, remove Calico CNI if installed.
+# Skip the rest of the logic that applies to manual installations only.
+if (($env:CONTAINER_SANDBOX_MOUNT_POINT) -and ($env:CALICO_NETWORKING_BACKEND -NE "none"))
+{
+    if ($env:CALICO_NETWORKING_BACKEND -NE "none") {
+        Remove-CNIPlugin
+    }
+    exit $lastexitcode
+}
+
 Write-Host "Stopping Calico if it is running..."
 & $PSScriptRoot\stop-calico.ps1 -ExceptUpgradeService $ExceptUpgradeService
 
@@ -44,4 +54,5 @@ if (-Not $ExceptUpgradeService) {
     Remove-UpgradeService
 }
 
+Get-Module 'calico' | Remove-Module -Force
 Write-Host "Done."

--- a/node/windows-packaging/Dockerfile
+++ b/node/windows-packaging/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright (c) 2022 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This dockerfile is used to build the image used for running Calico for Windows
+# as a daemonset using a HostProcess pod.
+# This is inspired by and borrows from:
+# https://github.com/kubernetes-sigs/sig-windows-tools/tree/master/hostprocess/calico
+
+ARG WINDOWS_VERSION
+
+# The files in this image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host.
+FROM mcr.microsoft.com/windows/nanoserver:${WINDOWS_VERSION}
+
+ENV PATH="C:\Program Files\PowerShell;C:\utils;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;"
+
+COPY install-calico-windows.ps1 /
+COPY calico-windows.zip /
+COPY host-process-install.ps1 /
+
+# The nanoserver image does not have powershell but this works because
+# this container will be running on the host.
+ENTRYPOINT ["powershell"]
+

--- a/node/windows-packaging/host-process-install.ps1
+++ b/node/windows-packaging/host-process-install.ps1
@@ -1,0 +1,77 @@
+# Copyright (c) 2022 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is the entrypoint for the install container for the HostProcess
+$ErrorActionPreference = "Stop"
+$rootDir = "c:\CalicoWindows"
+
+Write-Host "Uninstalling any existing Calico install before proceeding with installation..."
+if ((Get-Service | where Name -Like 'Calico*') -NE $null) {
+    Write-Host "Calico services running. Executing $rootDir\uninstall-calico.ps1..."
+    & "$rootDir\uninstall-calico.ps1"
+}
+# If this is a hostprocess install, and the root install dir exists, try
+# removing any Calico CNI config install
+elseif (Test-Path $RootDir) {
+    # Load existing config and check if Calico CNI was configured.
+    if ((Test-Path "$rootDir\config.ps1") -and $env:CALICO_NETWORKING_BACKEND -NE "none") {
+        . $RootDir\config.ps1
+        Write-Host "Root dir $rootDir exists. Removing Calico CNI plugin if installed..."
+        Remove-CNIPlugin
+    }
+} else {
+    Write-Host "No Calico services found."
+}
+
+# Finally, start the install script.
+& ".\install-calico-windows.ps1" -StartCalico no
+if ($LastExitCode -NE 0) {
+    exit $LastExitCode
+}
+
+# Restart kubelet and/or kube-proxy services if they are installed by Calico and
+# running since their service files may have been updated in-place.
+$kubeProxySvc = Get-CimInstance -Query 'select * from win32_service where name="kube-proxy"'
+if (($kubeProxySvc -NE $null) -and ($kubeProxySvc.PathName.StartsWith($rootDir, 'CurrentCultureIgnoreCase'))) {
+    if ($kubeProxySvc.State -EQ "Running") {
+        Write-Host "Restarting running kube-proxy service managed by Calico to reload service"
+        Restart-Service kube-proxy
+        $svc = Get-Service kube-proxy
+
+        try {
+            $svc.WaitForStatus("Running", "00:00:10")
+        } catch {
+            Write-Host "Error waiting for kube-proxy service to be Running"
+            Write-Host $_
+            exit $LastExitCode
+        }
+    }
+}
+
+$kubeletSvc = Get-CimInstance -Query 'select * from win32_service where name="kubelet"'
+if (($kubeletSvc -NE $null) -and ($kubeletSvc.PathName.StartsWith($rootDir, 'CurrentCultureIgnoreCase'))) {
+    if ($kubeletSvc.State -EQ "Running") {
+        Write-Host "Restarting running kubelet service managed by Calico to reload service"
+        Restart-Service kubelet
+        $svc = Get-Service kubelet
+
+        try {
+            $svc.WaitForStatus("Running", "00:00:10")
+        } catch {
+            Write-Host "Error waiting for kubelet service to be Running"
+            Write-Host $_
+            exit $LastExitCode
+        }
+    }
+}


### PR DESCRIPTION
## Description

Deploy preview: https://deploy-preview-5968--calico-v3-23.netlify.app/getting-started/windows-calico/quickstart#install-calico-for-windows-using-hostprocess-containers

Pick of #5864 
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add tech-preview support for Calico for Windows using HostProcess containers
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
