### PR TITLE
Miscellaneous changes for IPv6 VXLAN support

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -321,6 +321,7 @@ const (
 
 	ipipMTUOverhead      = 20
 	vxlanMTUOverhead     = 50
+	vxlanV6MTUOverhead   = 70
 	wireguardMTUOverhead = 60
 	aksMTUOverhead       = 100
 )
@@ -958,6 +959,12 @@ func ConfigureDefaultMTUs(hostMTU int, c *Config) {
 	if c.VXLANMTU == 0 {
 		log.Debug("Defaulting VXLAN MTU based on host")
 		c.VXLANMTU = hostMTU - vxlanMTUOverhead
+
+		if c.IPv6Enabled {
+			log.Debug("IPv6 is enabled, defaulting VXLAN MTU based on host")
+			c.VXLANMTU = hostMTU - vxlanV6MTUOverhead
+		}
+
 	}
 	if c.Wireguard.MTU == 0 {
 		if c.KubernetesProvider == config.ProviderAKS && c.Wireguard.EncryptHostTraffic {

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -325,6 +325,10 @@ func (c *autoHostEndpointController) getAutoHostendpointExpectedIPs(node *libapi
 		expectedIPs = append(expectedIPs, node.Spec.IPv4VXLANTunnelAddr)
 		ipMap[node.Spec.IPv4VXLANTunnelAddr] = struct{}{}
 	}
+	if node.Spec.IPv6VXLANTunnelAddr != "" {
+		expectedIPs = append(expectedIPs, node.Spec.IPv6VXLANTunnelAddr)
+		ipMap[node.Spec.IPv6VXLANTunnelAddr] = struct{}{}
+	}
 	if node.Spec.Wireguard != nil && node.Spec.Wireguard.InterfaceIPv4Address != "" {
 		expectedIPs = append(expectedIPs, node.Spec.Wireguard.InterfaceIPv4Address)
 		ipMap[node.Spec.Wireguard.InterfaceIPv4Address] = struct{}{}

--- a/kube-controllers/pkg/controllers/node/ipam_allocation.go
+++ b/kube-controllers/pkg/controllers/node/ipam_allocation.go
@@ -224,8 +224,9 @@ func (a *allocation) isPodIP() bool {
 func (a *allocation) isTunnelAddress() bool {
 	ipip := a.attrs[ipam.AttributeType] == ipam.AttributeTypeIPIP
 	vxlan := a.attrs[ipam.AttributeType] == ipam.AttributeTypeVXLAN
+	vxlanV6 := a.attrs[ipam.AttributeType] == ipam.AttributeTypeVXLANV6
 	wg := a.attrs[ipam.AttributeType] == ipam.AttributeTypeWireguard
-	return ipip || vxlan || wg
+	return ipip || vxlan || vxlanV6 || wg
 }
 
 func (a *allocation) isWindowsReserved() bool {


### PR DESCRIPTION
Miscellaneous changes for IPv6 VXLAN support:
- Auto Host Endpoint support for IPv6 VXLAN tunnel address
- IPv6 VXLAN MTU calculation support (with a larger overhead as compared
  to IPv4 VXLAN)
- isTunnelAddress() support for IPv6 VXLAN in ipam_allocation.go

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
