### PR TITLE
Felix supports authenticating with user/password etcd

### DIFF
--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -655,8 +655,8 @@ func (config *Config) DatastoreConfig() apiconfig.CalicoAPIConfig {
 		cfg.Spec.EtcdUsername = config.EtcdUsername
 	}
 	if config.setByConfigFileOrEnvironment("EtcdPassword") {
-		log.Infof("Overriding EtcdUsername from felix config to %s", config.EtcdPassword)
-		cfg.Spec.EtcdPassword = config.EtcdUsername
+		log.Infof("Overriding EtcdPassword from felix config to %s", config.EtcdPassword)
+		cfg.Spec.EtcdPassword = config.EtcdPassword
 	}
 
 	if !(config.Encapsulation.IPIPEnabled || config.Encapsulation.VXLANEnabled || config.BPFEnabled) {

--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -207,6 +207,8 @@ type Config struct {
 	EtcdCertFile  string   `config:"file(must-exist);;local"`
 	EtcdCaFile    string   `config:"file(must-exist);;local"`
 	EtcdEndpoints []string `config:"endpoint-list;;local"`
+	EtcdUsername  string   `config:"etcd_username;;local,non-zero"`
+	EtcdPassword  string   `config:"etcd_password;;local,non-zero"`
 
 	TyphaAddr           string        `config:"authority;;local"`
 	TyphaK8sServiceName string        `config:"string;;local"`
@@ -647,6 +649,18 @@ func (config *Config) DatastoreConfig() apiconfig.CalicoAPIConfig {
 	if config.setByConfigFileOrEnvironment("EtcdCaFile") {
 		log.Infof("Overriding EtcdCaFile from felix config to %s", config.EtcdCaFile)
 		cfg.Spec.EtcdCACertFile = config.EtcdCaFile
+	}
+	if config.setByConfigFileOrEnvironment("EtcdUsername") {
+		log.Infof("Overriding EtcdUsername from felix config to %s", config.EtcdUsername)
+		cfg.Spec.EtcdUsername = config.EtcdUsername
+	}
+	if config.setByConfigFileOrEnvironment("EtcdUsername") {
+		log.Infof("Overriding EtcdUsername from felix config to %s", config.EtcdUsername)
+		cfg.Spec.EtcdUsername = config.EtcdUsername
+	}
+	if config.setByConfigFileOrEnvironment("EtcdPassword") {
+		log.Infof("Overriding EtcdUsername from felix config to %s", config.EtcdPassword)
+		cfg.Spec.EtcdPassword = config.EtcdUsername
 	}
 
 	if !(config.Encapsulation.IPIPEnabled || config.Encapsulation.VXLANEnabled || config.BPFEnabled) {

--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -207,8 +207,8 @@ type Config struct {
 	EtcdCertFile  string   `config:"file(must-exist);;local"`
 	EtcdCaFile    string   `config:"file(must-exist);;local"`
 	EtcdEndpoints []string `config:"endpoint-list;;local"`
-	EtcdUsername  string   `config:"etcd_username;;local,non-zero"`
-	EtcdPassword  string   `config:"etcd_password;;local,non-zero"`
+	EtcdUsername  string   `config:"string;;local"`
+	EtcdPassword  string   `config:"string;;local"`
 
 	TyphaAddr           string        `config:"authority;;local"`
 	TyphaK8sServiceName string        `config:"string;;local"`
@@ -649,10 +649,6 @@ func (config *Config) DatastoreConfig() apiconfig.CalicoAPIConfig {
 	if config.setByConfigFileOrEnvironment("EtcdCaFile") {
 		log.Infof("Overriding EtcdCaFile from felix config to %s", config.EtcdCaFile)
 		cfg.Spec.EtcdCACertFile = config.EtcdCaFile
-	}
-	if config.setByConfigFileOrEnvironment("EtcdUsername") {
-		log.Infof("Overriding EtcdUsername from felix config to %s", config.EtcdUsername)
-		cfg.Spec.EtcdUsername = config.EtcdUsername
 	}
 	if config.setByConfigFileOrEnvironment("EtcdUsername") {
 		log.Infof("Overriding EtcdUsername from felix config to %s", config.EtcdUsername)

--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -128,9 +128,9 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 	}
 
 	client, err := clientv3.New(cfg)
-	fmt.Printf("AAAAAAA: %v", cfg)
-	fmt.Printf("BBBBB: %s", cfg.Username)
-	fmt.Printf("CCC: %s", cfg.Password)
+	fmt.Printf("Configfile content: %v", cfg)
+	fmt.Printf("ETCD_USERNAME: %s\n", cfg.Username)
+	fmt.Printf("ETCD_PASSWORD: %s\n", cfg.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -128,9 +128,6 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 	}
 
 	client, err := clientv3.New(cfg)
-	fmt.Printf("Configfile content: %v", cfg)
-	fmt.Printf("ETCD_USERNAME: %s\n", cfg.Username)
-	fmt.Printf("ETCD_PASSWORD: %s\n", cfg.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -129,6 +129,8 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 
 	client, err := clientv3.New(cfg)
 	fmt.Printf("AAAAAAA: %v", cfg)
+	fmt.Printf("BBBBB: %s", cfg.Username)
+	fmt.Printf("CCC: %s", cfg.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -128,6 +128,7 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 	}
 
 	client, err := clientv3.New(cfg)
+	fmt.Printf("AAAAAAA: %v", cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

- Calico-Felix does not support authenticating username and password with etcd. As the result, the Etcd cluster can not be enabled in authenticated mode. we can't set role base access to every Felix agent. When Felix agent is hacked, a hacker can change rules and execute more actions. 

## Todos

- [x] Add configuration username password to felix agent
- [x] example /etc/calico/felix.cfg file
```
DatastoreType=etcdv3
EtcdEndpoints=https://127.0.0.1:2379
EtcdCertFile=/home/bienkma/tmp/server.crt
EtcdCaFile=/home/bienkma/tmp/ca.pem
EtcdKeyFile=/home/bienkma/tmp/server.pem
LogPrefix=/var/log/calico/felix.log
EtcdUsername=calico-ro
EtcdPassword=change_me
```
