### PR TITLE
updates to calico/vpp doc

### DIFF
--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -220,9 +220,9 @@ The VPP dataplane has the following requirements:
 - A blank Kubernetes cluster, where no CNI was ever configured.
 - These [base requirements]({{site.baseurl}}/getting-started/kubernetes/requirements), except those related to the management of `cali*`, `tunl*` and `vxlan.calico` interfaces.
 
-> **Note**: If using `kubeadm` to create the cluster please make sure to specify the pod network CIDR using `--pod-network-cidr` command-line argument, for example, `sudo kubeadm init --pod-network-cidr=192.168.0.0/16`. If 192.168.0.0/16 is already in use within your network you must select a different pod network CIDR.
+   > **Note**: If you are using `kubeadm` to create the cluster please make sure to specify the pod network CIDR using the `--pod-network-cidr` command-line argument, i.e., `sudo kubeadm init --pod-network-cidr=192.168.0.0/16`. If 192.168.0.0/16 is already in use within your network you must select a different pod network CIDR.
    {: .alert .alert-info}
-   
+
 **Optional**
 For some hardware, the following hugepages configuration may enable VPP to use more efficient drivers:
 


### PR DESCRIPTION
…d for

specifying a pod network CIDR while creating the cluster otherwise the
operator complains about:

    kubeadm configuration is missing required podSubnet field

## Description

Add a note to the calico/vpp Getting Started doc highlighting the need for
specifying a pod network CIDR while creating the cluster otherwise the
operator complains about:

    kubeadm configuration is missing required podSubnet field

## Related issues/PRs

## Todos

- [ ] Documentation


## Release Note


```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
