### PR TITLE
[release-v3.23] Auto pick #5949: Add V6Addr.AsUint64Pair(), V6Addr.NthBit() and #5961: Add CALICO_IPV6POOL_VXLAN env var support to startup.go #5973: Miscellaneous changes for IPv6 VXLAN support: - Auto Host

### DIFF
--- a/calico/_includes/charts/calico/templates/calico-node.yaml
+++ b/calico/_includes/charts/calico/templates/calico-node.yaml
@@ -281,6 +281,9 @@ spec:
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
               value: "{{- if .Values.vxlan -}} CrossSubnet {{- else -}} Never {{- end -}}"
+            # Enable or Disable VXLAN on the default IPv6 IP pool.
+            - name: CALICO_IPV6POOL_VXLAN
+              value: "{{- if .Values.vxlan -}} CrossSubnet {{- else -}} Never {{- end -}}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:

--- a/calico/networking/vxlan-ipip.md
+++ b/calico/networking/vxlan-ipip.md
@@ -79,7 +79,7 @@ spec:
   <label:Manifest>
 <%
 
-For manifest installations of Calico, you can control the deafult IP pool encapsualtion mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` environment variables in the environment of the `calico-node` daemon set.
+For manifest installations of Calico, you can control the deafult IP pool encapsualtion mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` (and `CALICO_IPV6POOL_VXLAN` for IPv6) environment variables in the environment of the `calico-node` daemon set.
 
 %>
 {% endtabs %}

--- a/calico/networking/vxlan-ipip.md
+++ b/calico/networking/vxlan-ipip.md
@@ -79,7 +79,7 @@ spec:
   <label:Manifest>
 <%
 
-For manifest installations of Calico, you can control the deafult IP pool encapsualtion mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` (and `CALICO_IPV6POOL_VXLAN` for IPv6) environment variables in the environment of the `calico-node` daemon set.
+For manifest installations of Calico, you can control the default IP pool encapsulation mode using the `CALICO_IPV4POOL_VXLAN` and `CALICO_IPV4POOL_IPIP` (and `CALICO_IPV6POOL_VXLAN` for IPv6) environment variables in the environment of the `calico-node` daemon set.
 
 %>
 {% endtabs %}

--- a/calico/reference/node/configuration.md
+++ b/calico/reference/node/configuration.md
@@ -40,13 +40,14 @@ exist in the cluster. The following options control the parameters on the create
 | Environment   | Description | Schema |
 | ------------- | ----------- | ------ |
 | CALICO_IPV4POOL_CIDR | The IPv4 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. [Default: First not used in locally of (192.168.0.0/16, 172.16.0.0/16, .., 172.31.0.0/16) ] | IPv4 CIDR |
-| CALICO_IPV4POOL_BLOCK_SIZE | Block size to use for the IPv4 POOL created at startup.  Block size for IPv4 should be in the range 20-32 (inclusive) [Default: `26`] | int |
-| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 POOL created at start up. If set to a value other than `Never`, `CALICO_IPV4POOL_VXLAN` should not be set. [Default: `Always`] | Always, CrossSubnet, Never ("Off" is also accepted as a synonym for "Never") |
-| CALICO_IPV4POOL_VXLAN | VXLAN Mode to use for the IPv4 POOL created at start up.  If set to a value other than `Never`, `CALICO_IPV4POOL_IPIP` should not be set. [Default: `Never`] | Always, CrossSubnet, Never |
+| CALICO_IPV4POOL_BLOCK_SIZE | Block size to use for the IPv4 Pool created at startup.  Block size for IPv4 should be in the range 20-32 (inclusive) [Default: `26`] | int |
+| CALICO_IPV4POOL_IPIP | IPIP Mode to use for the IPv4 Pool created at start up. If set to a value other than `Never`, `CALICO_IPV4POOL_VXLAN` should not be set. [Default: `Always`] | Always, CrossSubnet, Never ("Off" is also accepted as a synonym for "Never") |
+| CALICO_IPV4POOL_VXLAN | VXLAN Mode to use for the IPv4 Pool created at start up.  If set to a value other than `Never`, `CALICO_IPV4POOL_IPIP` should not be set. [Default: `Never`] | Always, CrossSubnet, Never |
 | CALICO_IPV4POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv4 Pool created at start up. [Default: `true`] | boolean |
 | CALICO_IPV4POOL_NODE_SELECTOR | Controls the NodeSelector for the IPv4 Pool created at start up. [Default: `all()`] | [selector]({{site.baseurl}}/reference/resources/ippool#node-selector) |
 | CALICO_IPV6POOL_CIDR | The IPv6 Pool to create if none exists at start up. It is invalid to define this variable and NO_DEFAULT_POOLS. [Default: `<a randomly chosen /48 ULA>`] | IPv6 CIDR |
 | CALICO_IPV6POOL_BLOCK_SIZE | Block size to use for the IPv6 POOL created at startup.  Block size for IPv6 should be in the range 116-128 (inclusive) [Default: `122`] | int |
+| CALICO_IPV6POOL_VXLAN | VXLAN Mode to use for the IPv6 Pool created at start up. [Default: `Never`] | Always, CrossSubnet, Never |
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. [Default: `false`] | boolean |
 | CALICO_IPV6POOL_NODE_SELECTOR | Controls the NodeSelector for the IPv6 Pool created at start up. [Default: `all()`] | [selector]({{site.baseurl}}/reference/resources/ippool#node-selector) |
 | NO_DEFAULT_POOLS | Prevents  {{site.prodname}} from creating a default pool if one does not exist. [Default: `false`] | boolean |

--- a/felix/bpf/routes/map.go
+++ b/felix/bpf/routes/map.go
@@ -217,12 +217,12 @@ func LoadMap(rtm bpf.Map) (MapMem, error) {
 
 type LPMv4 struct {
 	sync.RWMutex
-	t *ip.V4Trie
+	t *ip.CIDRTrie
 }
 
 func NewLPMv4() *LPMv4 {
 	return &LPMv4{
-		t: new(ip.V4Trie),
+		t: new(ip.CIDRTrie),
 	}
 }
 

--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -70,20 +70,26 @@ type L3RouteResolver struct {
 }
 
 type l3rrNodeInfo struct {
-	Addr ip.V4Addr
-	CIDR ip.V4CIDR
+	V4Addr ip.V4Addr
+	V4CIDR ip.V4CIDR
+
+	V6Addr ip.V6Addr
+	V6CIDR ip.V6CIDR
 
 	// Tunnel IP addresses
 	IPIPAddr      ip.Addr
 	VXLANAddr     ip.Addr
+	VXLANV6Addr   ip.Addr
 	WireguardAddr ip.Addr
 
 	Addresses []ip.Addr
 }
 
 func (i l3rrNodeInfo) Equal(b l3rrNodeInfo) bool {
-	if i.Addr == b.Addr &&
-		i.CIDR == b.CIDR &&
+	if i.V4Addr == b.V4Addr &&
+		i.V4CIDR == b.V4CIDR &&
+		i.V6Addr == b.V6Addr &&
+		i.V6CIDR == b.V6CIDR &&
 		i.IPIPAddr == b.IPIPAddr &&
 		i.VXLANAddr == b.VXLANAddr &&
 		i.WireguardAddr == b.WireguardAddr {
@@ -114,25 +120,24 @@ func (i l3rrNodeInfo) Equal(b l3rrNodeInfo) bool {
 	return false
 }
 
-func (i l3rrNodeInfo) AddrAsCIDR() ip.V4CIDR {
-	return i.Addr.AsCIDR().(ip.V4CIDR)
+func (i l3rrNodeInfo) V4AddrAsCIDR() ip.V4CIDR {
+	return i.V4Addr.AsCIDR().(ip.V4CIDR)
 }
 
-func (i l3rrNodeInfo) AddresesV4AsCIDRs() []ip.V4CIDR {
-	addrs4 := make(map[ip.V4Addr]struct{})
+func (i l3rrNodeInfo) AddressesAsCIDRs() []ip.CIDR {
+	addrs := make(map[ip.Addr]struct{})
 
-	addrs4[i.Addr] = struct{}{}
+	addrs[i.V4Addr] = struct{}{}
+	addrs[i.V6Addr] = struct{}{}
 
 	for _, a := range i.Addresses {
-		if a.Version() == 4 {
-			addrs4[a.(ip.V4Addr)] = struct{}{}
-		}
+		addrs[a.(ip.Addr)] = struct{}{}
 	}
 
-	cidrs := make([]ip.V4CIDR, len(addrs4))
+	cidrs := make([]ip.CIDR, len(addrs))
 	idx := 0
-	for a := range addrs4 {
-		cidrs[idx] = a.AsCIDR().(ip.V4CIDR)
+	for a := range addrs {
+		cidrs[idx] = a.AsCIDR()
 		idx++
 	}
 
@@ -193,7 +198,7 @@ func (c *L3RouteResolver) OnWorkloadUpdate(update api.Update) (_ bool) {
 	var newCIDRs []cnet.IPNet
 	if update.Value != nil {
 		newWorkload := update.Value.(*model.WorkloadEndpoint)
-		newCIDRs = newWorkload.IPv4Nets
+		newCIDRs = append(newWorkload.IPv4Nets, newWorkload.IPv6Nets...)
 		logrus.WithField("workload", key).WithField("newCIDRs", newCIDRs).Debug("Workload update")
 	}
 
@@ -205,14 +210,14 @@ func (c *L3RouteResolver) OnWorkloadUpdate(update api.Update) (_ bool) {
 
 	// Incref the new CIDRs.
 	for _, newCIDR := range newCIDRs {
-		cidr := ip.CIDRFromCalicoNet(newCIDR).(ip.V4CIDR)
+		cidr := ip.CIDRFromCalicoNet(newCIDR)
 		c.trie.AddRef(cidr, key.Hostname, RefTypeWEP)
 		c.nodeRoutes.Add(nodenameRoute{key.Hostname, cidr})
 	}
 
 	// Decref the old.
 	for _, oldCIDR := range oldCIDRs {
-		cidr := ip.CIDRFromCalicoNet(oldCIDR).(ip.V4CIDR)
+		cidr := ip.CIDRFromCalicoNet(oldCIDR)
 		c.trie.RemoveRef(cidr, key.Hostname, RefTypeWEP)
 		c.nodeRoutes.Remove(nodenameRoute{key.Hostname, cidr})
 	}
@@ -241,7 +246,7 @@ func (c *L3RouteResolver) OnBlockUpdate(update api.Update) (_ bool) {
 		// We don't allow multiple blocks with the same CIDR, so no need to check
 		// for duplicates here. Look at the routes contributed by this block and determine if we
 		// need to send any updates.
-		newRoutes := c.v4RoutesFromBlock(update.Value.(*model.AllocationBlock))
+		newRoutes := c.routesFromBlock(update.Value.(*model.AllocationBlock))
 		logrus.WithField("numRoutes", len(newRoutes)).Debug("IPAM block update")
 		cachedRoutes, ok := c.blockToRoutes[key]
 		if !ok {
@@ -332,27 +337,47 @@ func (c *L3RouteResolver) OnResourceUpdate(update api.Update) (_ bool) {
 	var nodeInfo *l3rrNodeInfo
 	if update.Value != nil {
 		node := update.Value.(*apiv3.Node)
-		if node.Spec.BGP != nil && node.Spec.BGP.IPv4Address != "" {
+		if node.Spec.BGP != nil && (node.Spec.BGP.IPv4Address != "" || node.Spec.BGP.IPv6Address != "") {
 			bgp := node.Spec.BGP
-			// Use cnet.ParseCIDROrIP so we get the IP and the CIDR.  The parse functions in the ip package
-			// throw away one or the other.
-			ipv4, caliNodeCIDR, err := cnet.ParseCIDROrIP(bgp.IPv4Address)
-			if err != nil {
-				logrus.WithError(err).Panic("Failed to parse already-validated IP address")
+			nodeInfo = &l3rrNodeInfo{}
+			if bgp.IPv4Address != "" {
+				// Use cnet.ParseCIDROrIP so we get the IP and the CIDR.  The parse functions in the ip package
+				// throw away one or the other.
+				ipv4, caliNodeCIDR, err := cnet.ParseCIDROrIP(bgp.IPv4Address)
+				if err != nil {
+					logrus.WithError(err).Panic("Failed to parse already-validated IPv4 address")
+				}
+				nodeInfo.V4Addr = ip.FromCalicoIP(*ipv4).(ip.V4Addr)
+				nodeInfo.V4CIDR = ip.CIDRFromCalicoNet(*caliNodeCIDR).(ip.V4CIDR)
 			}
-			nodeInfo = &l3rrNodeInfo{
-				Addr: ip.FromCalicoIP(*ipv4).(ip.V4Addr),
-				CIDR: ip.CIDRFromCalicoNet(*caliNodeCIDR).(ip.V4CIDR),
+			if bgp.IPv6Address != "" {
+				ipv6, caliNodeCIDRV6, err := cnet.ParseCIDROrIP(bgp.IPv6Address)
+				if err != nil {
+					logrus.WithError(err).Panic("Failed to parse already-validated IPv6 address")
+				}
+				nodeInfo.V6Addr = ip.FromCalicoIP(*ipv6).(ip.V6Addr)
+				nodeInfo.V6CIDR = ip.CIDRFromCalicoNet(*caliNodeCIDRV6).(ip.V6CIDR)
 			}
 		} else {
-			ipv4, caliNodeCIDR := cresources.FindNodeAddress(node, apiv3.InternalIP)
+			ipv4, caliNodeCIDR := cresources.FindNodeAddress(node, apiv3.InternalIP, 4)
+			ipv6, caliNodeCIDRV6 := cresources.FindNodeAddress(node, apiv3.InternalIP, 6)
 			if ipv4 == nil {
-				ipv4, caliNodeCIDR = cresources.FindNodeAddress(node, apiv3.ExternalIP)
+				ipv4, caliNodeCIDR = cresources.FindNodeAddress(node, apiv3.ExternalIP, 4)
 			}
-			if ipv4 != nil && caliNodeCIDR != nil {
-				nodeInfo = &l3rrNodeInfo{
-					Addr: ip.FromCalicoIP(*ipv4).(ip.V4Addr),
-					CIDR: ip.CIDRFromCalicoNet(*caliNodeCIDR).(ip.V4CIDR),
+			if ipv6 == nil {
+				ipv6, caliNodeCIDRV6 = cresources.FindNodeAddress(node, apiv3.ExternalIP, 6)
+			}
+			hasIPv4 := (ipv4 != nil && caliNodeCIDR != nil)
+			hasIPv6 := (ipv6 != nil && caliNodeCIDRV6 != nil)
+			if hasIPv4 || hasIPv6 {
+				nodeInfo = &l3rrNodeInfo{}
+				if hasIPv4 {
+					nodeInfo.V4Addr = ip.FromCalicoIP(*ipv4).(ip.V4Addr)
+					nodeInfo.V4CIDR = ip.CIDRFromCalicoNet(*caliNodeCIDR).(ip.V4CIDR)
+				}
+				if hasIPv6 {
+					nodeInfo.V6Addr = ip.FromCalicoIP(*ipv6).(ip.V6Addr)
+					nodeInfo.V6CIDR = ip.CIDRFromCalicoNet(*caliNodeCIDRV6).(ip.V6CIDR)
 				}
 			}
 		}
@@ -368,6 +393,10 @@ func (c *L3RouteResolver) OnResourceUpdate(update api.Update) (_ bool) {
 
 			if node.Spec.IPv4VXLANTunnelAddr != "" {
 				nodeInfo.VXLANAddr = ip.FromString(node.Spec.IPv4VXLANTunnelAddr)
+			}
+
+			if node.Spec.IPv6VXLANTunnelAddr != "" {
+				nodeInfo.VXLANV6Addr = ip.FromString(node.Spec.IPv6VXLANTunnelAddr)
 			}
 
 			for _, a := range node.Spec.Addresses {
@@ -400,8 +429,8 @@ func (c *L3RouteResolver) OnHostIPUpdate(update api.Update) (_ bool) {
 		v4Addr, ok := ip.FromCalicoIP(*newCaliIP).(ip.V4Addr)
 		if ok { // Defensive; we only expect an IPv4.
 			newNodeInfo = &l3rrNodeInfo{
-				Addr: v4Addr,
-				CIDR: v4Addr.AsCIDR().(ip.V4CIDR), // Don't know the CIDR so use the /32.
+				V4Addr: v4Addr,
+				V4CIDR: v4Addr.AsCIDR().(ip.V4CIDR), // Don't know the CIDR so use the /32.
 			}
 		}
 	}
@@ -422,13 +451,17 @@ func (c *L3RouteResolver) onNodeUpdate(nodeName string, newNodeInfo *l3rrNodeInf
 
 	if nodeName == c.myNodeName {
 		// Check if our CIDR has changed and if so recalculate the "same subnet" tracking.
-		var myNewCIDR ip.V4CIDR
-		var myNewCIDRKnown bool
+		var myNewV4CIDR ip.V4CIDR
+		var myNewV4CIDRKnown bool
+		var myNewV6CIDR ip.V6CIDR
+		var myNewV6CIDRKnown bool
 		if newNodeInfo != nil {
-			myNewCIDR = newNodeInfo.CIDR
-			myNewCIDRKnown = true
+			myNewV4CIDR = newNodeInfo.V4CIDR
+			myNewV4CIDRKnown = true
+			myNewV6CIDR = newNodeInfo.V6CIDR
+			myNewV6CIDRKnown = true
 		}
-		if oldNodeInfo.CIDR != myNewCIDR {
+		if oldNodeInfo.V4CIDR != myNewV4CIDR {
 			// This node's CIDR has changed; some routes may now have an incorrect value for same-subnet.
 			c.visitAllRoutes(func(r nodenameRoute) {
 				if r.nodeName == c.myNodeName {
@@ -438,51 +471,76 @@ func (c *L3RouteResolver) onNodeUpdate(nodeName string, newNodeInfo *l3rrNodeInf
 				if !known {
 					return // Don't know other node's CIDR so ignore for now.
 				}
-				otherNodesIPv4 := otherNodeInfo.Addr
-				wasSameSubnet := nodeExisted && oldNodeInfo.CIDR.ContainsV4(otherNodesIPv4)
-				nowSameSubnet := myNewCIDRKnown && myNewCIDR.ContainsV4(otherNodesIPv4)
+				otherNodesIPv4 := otherNodeInfo.V4Addr
+				wasSameSubnet := nodeExisted && oldNodeInfo.V4CIDR.ContainsV4(otherNodesIPv4)
+				nowSameSubnet := myNewV4CIDRKnown && myNewV4CIDR.ContainsV4(otherNodesIPv4)
 				if wasSameSubnet != nowSameSubnet {
 					logrus.WithField("route", r).Debug("Update to our subnet invalidated route")
 					c.trie.MarkCIDRDirty(r.dst)
 				}
-			})
+			}, 4)
+		}
+		if oldNodeInfo.V6CIDR != myNewV6CIDR {
+			// This node's CIDR has changed; some routes may now have an incorrect value for same-subnet.
+			c.visitAllRoutes(func(r nodenameRoute) {
+				if r.nodeName == c.myNodeName {
+					return // Ignore self.
+				}
+				otherNodeInfo, known := c.nodeNameToNodeInfo[r.nodeName]
+				if !known {
+					return // Don't know other node's CIDR so ignore for now.
+				}
+				otherNodesIPv6 := otherNodeInfo.V6Addr
+				wasSameSubnet := nodeExisted && oldNodeInfo.V6CIDR.ContainsV6(otherNodesIPv6)
+				nowSameSubnet := myNewV6CIDRKnown && myNewV6CIDR.ContainsV6(otherNodesIPv6)
+				if wasSameSubnet != nowSameSubnet {
+					logrus.WithField("route", r).Debug("Update to our subnet invalidated route")
+					c.trie.MarkCIDRDirty(r.dst)
+				}
+			}, 6)
 		}
 	}
 
 	// Process the tunnel addresses. These are reference counted, so handle adds followed by deletes to minimize churn.
 	if newNodeInfo != nil {
 		if newNodeInfo.IPIPAddr != nil {
-			c.trie.AddRef(newNodeInfo.IPIPAddr.AsCIDR().(ip.V4CIDR), nodeName, RefTypeIPIP)
+			c.trie.AddRef(newNodeInfo.IPIPAddr.AsCIDR(), nodeName, RefTypeIPIP)
 		}
 		if newNodeInfo.VXLANAddr != nil {
-			c.trie.AddRef(newNodeInfo.VXLANAddr.AsCIDR().(ip.V4CIDR), nodeName, RefTypeVXLAN)
+			c.trie.AddRef(newNodeInfo.VXLANAddr.AsCIDR(), nodeName, RefTypeVXLAN)
+		}
+		if newNodeInfo.VXLANV6Addr != nil {
+			c.trie.AddRef(newNodeInfo.VXLANV6Addr.AsCIDR(), nodeName, RefTypeVXLAN)
 		}
 		if newNodeInfo.WireguardAddr != nil {
-			c.trie.AddRef(newNodeInfo.WireguardAddr.AsCIDR().(ip.V4CIDR), nodeName, RefTypeWireguard)
+			c.trie.AddRef(newNodeInfo.WireguardAddr.AsCIDR(), nodeName, RefTypeWireguard)
 		}
 	}
 	if nodeExisted {
 		if oldNodeInfo.IPIPAddr != nil {
-			c.trie.RemoveRef(oldNodeInfo.IPIPAddr.AsCIDR().(ip.V4CIDR), nodeName, RefTypeIPIP)
+			c.trie.RemoveRef(oldNodeInfo.IPIPAddr.AsCIDR(), nodeName, RefTypeIPIP)
 		}
 		if oldNodeInfo.VXLANAddr != nil {
-			c.trie.RemoveRef(oldNodeInfo.VXLANAddr.AsCIDR().(ip.V4CIDR), nodeName, RefTypeVXLAN)
+			c.trie.RemoveRef(oldNodeInfo.VXLANAddr.AsCIDR(), nodeName, RefTypeVXLAN)
+		}
+		if oldNodeInfo.VXLANV6Addr != nil {
+			c.trie.RemoveRef(oldNodeInfo.VXLANV6Addr.AsCIDR(), nodeName, RefTypeVXLAN)
 		}
 		if oldNodeInfo.WireguardAddr != nil {
-			c.trie.RemoveRef(oldNodeInfo.WireguardAddr.AsCIDR().(ip.V4CIDR), nodeName, RefTypeWireguard)
+			c.trie.RemoveRef(oldNodeInfo.WireguardAddr.AsCIDR(), nodeName, RefTypeWireguard)
 		}
 	}
 
 	// Process the node CIDR and cache the node info.
 	if nodeExisted {
 		delete(c.nodeNameToNodeInfo, nodeName)
-		for _, a := range oldNodeInfo.AddresesV4AsCIDRs() {
+		for _, a := range oldNodeInfo.AddressesAsCIDRs() {
 			c.trie.RemoveHost(a, nodeName)
 		}
 	}
 	if newNodeInfo != nil {
 		c.nodeNameToNodeInfo[nodeName] = *newNodeInfo
-		for _, a := range newNodeInfo.AddresesV4AsCIDRs() {
+		for _, a := range newNodeInfo.AddressesAsCIDRs() {
 			c.trie.AddHost(a, nodeName)
 		}
 	}
@@ -496,10 +554,19 @@ func (c *L3RouteResolver) markAllNodeRoutesDirty(nodeName string) {
 	})
 }
 
-func (c *L3RouteResolver) visitAllRoutes(v func(route nodenameRoute)) {
-	c.trie.t.Visit(func(cidr ip.V4CIDR, data interface{}) bool {
+func (c *L3RouteResolver) visitAllRoutes(v func(route nodenameRoute), ipVersion int) {
+	var trie *ip.CIDRTrie
+	switch ipVersion {
+	case 4:
+		trie = c.trie.v4T
+	case 6:
+		trie = c.trie.v6T
+	default:
+		logrus.WithField("ipVersion", ipVersion).Panic("Invalid IP version")
+	}
+	trie.Visit(func(cidr ip.CIDR, data interface{}) bool {
 		// Construct a nodenameRoute to pass to the visiting function.
-		ri := c.trie.t.Get(cidr).(RouteInfo)
+		ri := trie.Get(cidr).(RouteInfo)
 		nnr := nodenameRoute{dst: cidr}
 		if len(ri.Refs) > 0 {
 			// From a Ref.
@@ -526,26 +593,22 @@ func (c *L3RouteResolver) OnPoolUpdate(update api.Update) (_ bool) {
 	poolKey := k.String()
 	oldPool, oldPoolExists := c.allPools[poolKey]
 	oldPoolType := proto.IPPoolType_NONE
-	var poolCIDR ip.V4CIDR
+	var poolCIDR ip.CIDR
 	if oldPoolExists {
 		// Need explicit oldPoolExists check so that we don't pass a zero-struct to poolTypeForPool.
 		oldPoolType = c.poolTypeForPool(&oldPool)
-		poolCIDR = ip.CIDRFromCalicoNet(oldPool.CIDR).(ip.V4CIDR)
+		poolCIDR = ip.CIDRFromCalicoNet(oldPool.CIDR)
 	}
 	var newPool *model.IPPool
 	if update.Value != nil {
 		newPool = update.Value.(*model.IPPool)
-		if len(newPool.CIDR.IP.To4()) == 0 {
-			logrus.Debug("Ignoring IPv6 pool")
-			newPool = nil
-		}
 	}
 	newPoolType := c.poolTypeForPool(newPool)
 	logCxt := logrus.WithFields(logrus.Fields{"oldType": oldPoolType, "newType": newPoolType})
 	if newPool != nil && newPoolType != proto.IPPoolType_NONE {
 		logCxt.Info("Pool is active")
 		c.allPools[poolKey] = *newPool
-		poolCIDR = ip.CIDRFromCalicoNet(newPool.CIDR).(ip.V4CIDR)
+		poolCIDR = ip.CIDRFromCalicoNet(newPool.CIDR)
 		crossSubnet := newPool.IPIPMode == encap.CrossSubnet || newPool.VXLANMode == encap.CrossSubnet
 		c.trie.UpdatePool(poolCIDR, newPoolType, newPool.Masquerade, crossSubnet)
 	} else {
@@ -569,14 +632,9 @@ func (c *L3RouteResolver) poolTypeForPool(pool *model.IPPool) proto.IPPoolType {
 	return proto.IPPoolType_NO_ENCAP
 }
 
-// v4RoutesFromBlock returns a list of routes which should exist based on the provided
+// routesFromBlock returns a list of routes which should exist based on the provided
 // allocation block.
-func (c *L3RouteResolver) v4RoutesFromBlock(b *model.AllocationBlock) map[string]nodenameRoute {
-	if len(b.CIDR.IP.To4()) == 0 {
-		logrus.Debug("Ignoring IPv6 block")
-		return nil
-	}
-
+func (c *L3RouteResolver) routesFromBlock(b *model.AllocationBlock) map[string]nodenameRoute {
 	routes := make(map[string]nodenameRoute)
 	for _, alloc := range b.NonAffineAllocations() {
 		if alloc.Host == "" {
@@ -585,7 +643,7 @@ func (c *L3RouteResolver) v4RoutesFromBlock(b *model.AllocationBlock) map[string
 			continue
 		}
 		r := nodenameRoute{
-			dst:      ip.CIDRFromNetIP(alloc.Addr.IP).(ip.V4CIDR),
+			dst:      ip.CIDRFromNetIP(alloc.Addr.IP),
 			nodeName: alloc.Host,
 		}
 		routes[r.Key()] = r
@@ -595,7 +653,7 @@ func (c *L3RouteResolver) v4RoutesFromBlock(b *model.AllocationBlock) map[string
 	if host != "" {
 		logrus.WithField("host", host).Debug("Block has a host, including block-via-host route")
 		r := nodenameRoute{
-			dst:      ip.CIDRFromCalicoNet(b.CIDR).(ip.V4CIDR),
+			dst:      ip.CIDRFromCalicoNet(b.CIDR),
 			nodeName: host,
 		}
 		routes[r.Key()] = r
@@ -607,11 +665,21 @@ func (c *L3RouteResolver) v4RoutesFromBlock(b *model.AllocationBlock) map[string
 // flush() iterates over the CIDRs that are marked dirty in the trie and sends any route updates
 // that it finds.
 func (c *L3RouteResolver) flush() {
-	var buf []ip.V4TrieEntry
+	var buf []ip.CIDRTrieEntry
 	c.trie.dirtyCIDRs.Iter(func(item interface{}) error {
 		logCxt := logrus.WithField("cidr", item)
 		logCxt.Debug("Flushing dirty route")
-		cidr := item.(ip.V4CIDR)
+		var trie *ip.CIDRTrie
+		var ipVersion int
+		switch item.(type) {
+		case ip.V4CIDR:
+			ipVersion = 4
+			trie = c.trie.v4T
+		case ip.V6CIDR:
+			ipVersion = 6
+			trie = c.trie.v6T
+		}
+		cidr := item.(ip.CIDR)
 
 		// We know the CIDR may be dirty, look up the path through the trie to the CIDR.  This will
 		// give us the information about the enclosing CIDRs.  For example, if we have:
@@ -620,7 +688,7 @@ func (c *L3RouteResolver) flush() {
 		// - IP          10.0.0.1/32 node y
 		// Then, we'll see the pool, block and IP in turn on the lookup path allowing us to collect the
 		// relevant information from each.
-		buf = c.trie.t.LookupPath(buf, cidr)
+		buf = trie.LookupPath(buf, cidr)
 
 		if len(buf) == 0 {
 			// CIDR is not in the trie.  Nothing to do.  Route removed before it had even been sent?
@@ -723,17 +791,32 @@ func (c *L3RouteResolver) flush() {
 			}
 		}
 
+		var emptyV4Addr ip.V4Addr
+		var emptyV6Addr ip.V6Addr
+
 		if rt.DstNodeName != "" {
 			dstNodeInfo, exists := c.nodeNameToNodeInfo[rt.DstNodeName]
 			if exists {
-				rt.DstNodeIp = dstNodeInfo.Addr.String()
+				switch ipVersion {
+				case 4:
+					if dstNodeInfo.V4Addr != emptyV4Addr {
+						rt.DstNodeIp = dstNodeInfo.V4Addr.String()
+					}
+				case 6:
+					if dstNodeInfo.V6Addr != emptyV6Addr {
+						rt.DstNodeIp = dstNodeInfo.V6Addr.String()
+					}
+				}
 			}
 		}
 		rt.SameSubnet = poolAllowsCrossSubnet && c.nodeInOurSubnet(rt.DstNodeName)
 
-		logrus.WithField("route", rt).Debug("Sending route")
-		c.callbacks.OnRouteUpdate(rt)
-		c.trie.SetRouteSent(cidr, true)
+		if rt.Dst != emptyV4Addr.AsCIDR().String() && rt.Dst != emptyV6Addr.AsCIDR().String() {
+			// Skip sending a route for an empty CIDR
+			logrus.WithField("route", rt).Debug("Sending route")
+			c.callbacks.OnRouteUpdate(rt)
+			c.trie.SetRouteSent(cidr, true)
+		}
 
 		return set.RemoveItem
 	})
@@ -752,13 +835,16 @@ func (c *L3RouteResolver) nodeInOurSubnet(name string) bool {
 		return false
 	}
 
-	return localNodeInfo.CIDR.ContainsV4(nodeInfo.Addr)
+	sameV4 := localNodeInfo.V4CIDR.ContainsV4(nodeInfo.V4Addr)
+	sameV6 := localNodeInfo.V6CIDR != ip.V6CIDR{} && nodeInfo.V6Addr != ip.V6Addr{} && localNodeInfo.V6CIDR.ContainsV6(nodeInfo.V6Addr)
+
+	return sameV4 || sameV6
 }
 
 // nodenameRoute is the L3RouteResolver's internal representation of a route.
 type nodenameRoute struct {
 	nodeName string
-	dst      ip.V4CIDR
+	dst      ip.CIDR
 }
 
 func (r nodenameRoute) Key() string {
@@ -794,18 +880,20 @@ func (r nodenameRoute) String() string {
 // The RouteTrie maintains a set of dirty CIDRs.  When an IPAM pool is updated, all the CIDRs under it are
 // marked dirty.
 type RouteTrie struct {
-	t          *ip.V4Trie
+	v4T        *ip.CIDRTrie
+	v6T        *ip.CIDRTrie
 	dirtyCIDRs set.Set
 }
 
 func NewRouteTrie() *RouteTrie {
 	return &RouteTrie{
-		t:          &ip.V4Trie{},
+		v4T:        &ip.CIDRTrie{},
+		v6T:        &ip.CIDRTrie{},
 		dirtyCIDRs: set.New(),
 	}
 }
 
-func (r *RouteTrie) UpdatePool(cidr ip.V4CIDR, poolType proto.IPPoolType, natOutgoing bool, crossSubnet bool) {
+func (r *RouteTrie) UpdatePool(cidr ip.CIDR, poolType proto.IPPoolType, natOutgoing bool, crossSubnet bool) {
 	logrus.WithFields(logrus.Fields{
 		"cidr":        cidr,
 		"poolType":    poolType,
@@ -823,35 +911,44 @@ func (r *RouteTrie) UpdatePool(cidr ip.V4CIDR, poolType proto.IPPoolType, natOut
 	r.markChildrenDirty(cidr)
 }
 
-func (r *RouteTrie) markChildrenDirty(cidr ip.V4CIDR) {
+func (r *RouteTrie) markChildrenDirty(cidr ip.CIDR) {
 	// TODO: avoid full scan to mark children dirty
-	r.t.Visit(func(c ip.V4CIDR, data interface{}) bool {
-		if cidr.ContainsV4(c.Addr().(ip.V4Addr)) {
+	var trie *ip.CIDRTrie
+	switch cidr.(type) {
+	case ip.V4CIDR:
+		trie = r.v4T
+	case ip.V6CIDR:
+		trie = r.v6T
+	default:
+		logrus.WithField("cidr", cidr).Panic("Invalid CIDR type")
+	}
+	trie.Visit(func(c ip.CIDR, data interface{}) bool {
+		if cidr.Contains(c.Addr()) {
 			r.MarkCIDRDirty(c)
 		}
 		return true
 	})
 }
 
-func (r *RouteTrie) MarkCIDRDirty(cidr ip.V4CIDR) {
+func (r *RouteTrie) MarkCIDRDirty(cidr ip.CIDR) {
 	r.dirtyCIDRs.Add(cidr)
 }
 
-func (r *RouteTrie) RemovePool(cidr ip.V4CIDR) {
+func (r *RouteTrie) RemovePool(cidr ip.CIDR) {
 	r.UpdatePool(cidr, proto.IPPoolType_NONE, false, false)
 }
 
-func (r *RouteTrie) UpdateBlockRoute(cidr ip.V4CIDR, nodeName string) {
+func (r *RouteTrie) UpdateBlockRoute(cidr ip.CIDR, nodeName string) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
 		ri.Block.NodeName = nodeName
 	})
 }
 
-func (r *RouteTrie) RemoveBlockRoute(cidr ip.V4CIDR) {
+func (r *RouteTrie) RemoveBlockRoute(cidr ip.CIDR) {
 	r.UpdateBlockRoute(cidr, "")
 }
 
-func (r *RouteTrie) AddHost(cidr ip.V4CIDR, nodeName string) {
+func (r *RouteTrie) AddHost(cidr ip.CIDR, nodeName string) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
 		ri.Host.NodeNames = append(ri.Host.NodeNames, nodeName)
 		if len(ri.Host.NodeNames) > 1 {
@@ -865,7 +962,7 @@ func (r *RouteTrie) AddHost(cidr ip.V4CIDR, nodeName string) {
 	})
 }
 
-func (r *RouteTrie) RemoveHost(cidr ip.V4CIDR, nodeName string) {
+func (r *RouteTrie) RemoveHost(cidr ip.CIDR, nodeName string) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
 		var ns []string
 		for _, n := range ri.Host.NodeNames {
@@ -878,7 +975,7 @@ func (r *RouteTrie) RemoveHost(cidr ip.V4CIDR, nodeName string) {
 	})
 }
 
-func (r *RouteTrie) AddRef(cidr ip.V4CIDR, nodename string, rt RefType) {
+func (r *RouteTrie) AddRef(cidr ip.CIDR, nodename string, rt RefType) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
 		// Find the ref in the list for this nodename,
 		// if it exists. If it doesn't, we'll add it below.
@@ -906,7 +1003,7 @@ func (r *RouteTrie) AddRef(cidr ip.V4CIDR, nodename string, rt RefType) {
 	})
 }
 
-func (r *RouteTrie) RemoveRef(cidr ip.V4CIDR, nodename string, rt RefType) {
+func (r *RouteTrie) RemoveRef(cidr ip.CIDR, nodename string, rt RefType) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
 		for i := range ri.Refs {
 			if ri.Refs[i].NodeName == nodename && ri.Refs[i].RefType == rt {
@@ -930,13 +1027,27 @@ func (r *RouteTrie) RemoveRef(cidr ip.V4CIDR, nodename string, rt RefType) {
 	})
 }
 
-func (r *RouteTrie) SetRouteSent(cidr ip.V4CIDR, sent bool) {
+func (r *RouteTrie) SetRouteSent(cidr ip.CIDR, sent bool) {
 	r.updateCIDR(cidr, func(ri *RouteInfo) {
 		ri.WasSent = sent
 	})
 }
 
-func (r RouteTrie) updateCIDR(cidr ip.V4CIDR, updateFn func(info *RouteInfo)) bool {
+func (r RouteTrie) updateCIDR(cidr ip.CIDR, updateFn func(info *RouteInfo)) bool {
+	if cidr == nil {
+		logrus.WithField("cidr", cidr).Debug("Ignoring nil CIDR update")
+		return false
+	}
+
+	var trie *ip.CIDRTrie
+	switch cidr.(type) {
+	case ip.V4CIDR:
+		trie = r.v4T
+	case ip.V6CIDR:
+		trie = r.v6T
+	default:
+		logrus.WithField("cidr", cidr).Panic("Invalid CIDR type")
+	}
 	// Get the RouteInfo for the given CIDR and take a copy so we can compare.
 	ri := r.Get(cidr)
 	riCopy := ri.Copy()
@@ -957,18 +1068,27 @@ func (r RouteTrie) updateCIDR(cidr ip.V4CIDR, updateFn func(info *RouteInfo)) bo
 	if ri.IsZero() {
 		// No longer have *anything* to track about this CIDR, clean it up.
 		logrus.WithField("cidr", cidr).Debug("RouteInfo is zero, cleaning up.")
-		r.t.Delete(cidr)
+		trie.Delete(cidr)
 		return true
 	}
-	r.t.Update(cidr, ri)
+	trie.Update(cidr, ri)
 	return true
 }
 
-func (r RouteTrie) Get(cidr ip.V4CIDR) RouteInfo {
-	ri := r.t.Get(cidr)
+func (r RouteTrie) Get(cidr ip.CIDR) RouteInfo {
+	var ri interface{}
+
+	switch cidr.(type) {
+	case ip.V4CIDR:
+		ri = r.v4T.Get(cidr)
+	case ip.V6CIDR:
+		ri = r.v6T.Get(cidr)
+	}
+
 	if ri == nil {
 		return RouteInfo{}
 	}
+
 	return ri.(RouteInfo)
 }
 
@@ -1056,18 +1176,18 @@ func (r RouteInfo) Equals(other RouteInfo) bool {
 // It uses a reference counter so that we can properly handle intermediate cases where
 // the same CIDR might appear twice.
 type nodeRoutes struct {
-	cache map[string]map[ip.V4CIDR]int
+	cache map[string]map[ip.CIDR]int
 }
 
 func newNodeRoutes() nodeRoutes {
 	return nodeRoutes{
-		cache: map[string]map[ip.V4CIDR]int{},
+		cache: map[string]map[ip.CIDR]int{},
 	}
 }
 
 func (nr *nodeRoutes) Add(r nodenameRoute) {
 	if _, ok := nr.cache[r.nodeName]; !ok {
-		nr.cache[r.nodeName] = map[ip.V4CIDR]int{r.dst: 0}
+		nr.cache[r.nodeName] = map[ip.CIDR]int{r.dst: 0}
 	}
 	nr.cache[r.nodeName][r.dst]++
 }

--- a/felix/calc/resources_for_test.go
+++ b/felix/calc/resources_for_test.go
@@ -726,7 +726,7 @@ var remoteIPAMSlash32BlockKey = BlockKey{
 }
 
 var remotev6IPAMBlockKey = BlockKey{
-	CIDR: mustParseNet("feed:beef:0001::/96"),
+	CIDR: mustParseNet("feed:beef:0:0:1::/96"),
 }
 
 var localIPAMBlockKey = BlockKey{
@@ -749,7 +749,7 @@ var remoteIPAMBlockSlash32 = AllocationBlock{
 	Unallocated: []int{0},
 }
 var remotev6IPAMBlock = AllocationBlock{
-	CIDR:        mustParseNet("feed:beef:0001::/96"),
+	CIDR:        mustParseNet("feed:beef:0:0:1::/96"),
 	Affinity:    &remoteHostAffinity,
 	Allocations: make([]*int, 8),
 	Unallocated: []int{0, 1, 2, 3, 4, 5, 6, 7},
@@ -861,7 +861,7 @@ func intPtr(i int) *int {
 
 var localHostVXLANTunnelIP = "10.0.0.0"
 var remoteHostVXLANTunnelIP = "10.0.1.0"
-var remoteHostVXLANV6TunnelIP = "feed:beef:0001::0"
+var remoteHostVXLANV6TunnelIP = "feed:beef:0:0:1::0"
 var remoteHostVXLANTunnelIP2 = "10.0.1.1"
 var remoteHost2VXLANTunnelIP = "10.0.2.0"
 var remoteHostVXLANTunnelMAC = "66:74:c5:72:3f:01"

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -115,6 +115,27 @@ var routelocalWlTenDotThree = proto.RouteUpdate{
 	LocalWorkload: true,
 }
 
+var routelocalWlV6ColonOne = proto.RouteUpdate{
+	Type:          proto.RouteType_LOCAL_WORKLOAD,
+	Dst:           "fc00:fe11::1/128",
+	DstNodeName:   localHostname,
+	LocalWorkload: true,
+}
+
+var routelocalWlV6ColonTwo = proto.RouteUpdate{
+	Type:          proto.RouteType_LOCAL_WORKLOAD,
+	Dst:           "fc00:fe11::2/128",
+	DstNodeName:   localHostname,
+	LocalWorkload: true,
+}
+
+var routelocalWlV6ColonThree = proto.RouteUpdate{
+	Type:          proto.RouteType_LOCAL_WORKLOAD,
+	Dst:           "fc00:fe11::3/128",
+	DstNodeName:   localHostname,
+	LocalWorkload: true,
+}
+
 // localEp1WithPolicy adds a local endpoint to the mix.  It matches all and b=="b".
 var localEp1WithPolicy = withPolicy.withKVUpdates(
 	KVPair{Key: localWlEpKey1, Value: &localWlEp1},
@@ -143,6 +164,8 @@ var localEp1WithPolicy = withPolicy.withKVUpdates(
 	// Routes for the local WEPs.
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
 ).withName("ep1 local, policy")
 
 // localEp1WithNamedPortPolicy as above but with named port in the policy.
@@ -188,6 +211,8 @@ var localEp1WithNegatedNamedPortPolicy = empty.withKVUpdates(
 	// Routes for the local WEPs.
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
 ).withName("ep1 local, negated named port policy")
 
 // As above but using the destination fields in the policy instead of source.
@@ -256,6 +281,8 @@ var localEp1WithIngressPolicy = withPolicyIngressOnly.withKVUpdates(
 	// Routes for the local WEPs.
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
 ).withName("ep1 local, ingress-only policy")
 
 // localEp1WithNamedPortPolicy as above but with UDP named port in the policy.
@@ -478,6 +505,8 @@ func policyOrderState(policyOrders [3]float64, expectedOrder [3]string) State {
 		// Routes for the local WEPs.
 		routelocalWlTenDotOne,
 		routelocalWlTenDotTwo,
+		routelocalWlV6ColonOne,
+		routelocalWlV6ColonTwo,
 	).withName(fmt.Sprintf("ep1 local, 1 tier, policies %v", expectedOrder[:]))
 	return state
 }
@@ -507,6 +536,8 @@ var localEp2WithPolicy = withPolicy.withKVUpdates(
 	// Routes for the local WEPs.
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withName("ep2 local, policy")
 
 // localEpsWithPolicy contains both of the above endpoints, which have some
@@ -550,6 +581,9 @@ var localEpsWithPolicy = withPolicy.withKVUpdates(
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withName("2 local, overlapping IPs & a policy")
 
 var localEpsWithNamedPortsPolicy = localEpsWithPolicy.withKVUpdates(
@@ -619,6 +653,9 @@ var localEpsWithOverlappingIPsAndInheritedLabels = empty.withKVUpdates(
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 )
 
 // Building on the above, we add a policy to match on the inherited label, which should produce
@@ -724,6 +761,9 @@ var localEpsAndNamedPortPolicyBothEPsProfilesRemoved = localEpsAndNamedPortPolic
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withActiveProfiles().withName("2 local WEPs with no matches due to removing profiles from endpoints")
 
 // localEpsWithPolicyUpdatedIPs, when used with localEpsWithPolicy checks
@@ -763,6 +803,20 @@ var localEpsWithPolicyUpdatedIPs = localEpsWithPolicy.withKVUpdates(
 	},
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	proto.RouteUpdate{
+		Type:          proto.RouteType_LOCAL_WORKLOAD,
+		Dst:           "fc00:fe12::1/128",
+		DstNodeName:   localHostname,
+		LocalWorkload: true,
+	},
+	proto.RouteUpdate{
+		Type:          proto.RouteType_LOCAL_WORKLOAD,
+		Dst:           "fc00:fe12::2/128",
+		DstNodeName:   localHostname,
+		LocalWorkload: true,
+	},
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withName("2 local, non-overlapping IPs")
 
 // withProfile adds a profile to the initialised state.
@@ -805,6 +859,9 @@ var localEpsWithProfile = withProfile.withKVUpdates(
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withName("2 local, overlapping IPs & a profile")
 
 // localEpsWithNonMatchingProfile contains a pair of overlapping IP endpoints and a profile
@@ -824,6 +881,9 @@ var localEpsWithNonMatchingProfile = withProfile.withKVUpdates(
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withName("2 local, overlapping IPs & a non-matching profile")
 
 // localEpsWithUpdatedProfile Follows on from localEpsWithProfile, changing the
@@ -885,6 +945,9 @@ var localEpsWithTagInheritProfile = withProfileTagInherit.withKVUpdates(
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withName("2 local, overlapping IPs & a tag inherit profile")
 
 var withProfileTagOverriden = initialisedStore.withKVUpdates(
@@ -924,6 +987,9 @@ var localEpsWithTagOverriddenProfile = withProfileTagOverriden.withKVUpdates(
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
 	routelocalWlTenDotThree,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
+	routelocalWlV6ColonThree,
 ).withName("2 local, overlapping IPs & a tag inherit profile")
 
 var hostEp1WithPolicyAndANetworkSet = hostEp1WithPolicy.withKVUpdates(
@@ -1011,6 +1077,14 @@ var routeUpdateIPPoolVXLANCrossSubnet = proto.RouteUpdate{
 	NatOutgoing: ipPoolWithVXLANCrossSubnet.Masquerade,
 }
 
+// RouteUpdate expected for v6IPPoolWithVXLAN.
+var routeUpdateV6IPPoolVXLAN = proto.RouteUpdate{
+	Type:        proto.RouteType_CIDR_INFO,
+	IpPoolType:  proto.IPPoolType_VXLAN,
+	Dst:         v6IPPoolWithVXLAN.CIDR.String(),
+	NatOutgoing: v6IPPoolWithVXLAN.Masquerade,
+}
+
 // RouteUpdate expected for ipPoolWithIPIP.
 var routeUpdateIPPoolIPIP = proto.RouteUpdate{
 	Type:        proto.RouteType_CIDR_INFO,
@@ -1035,6 +1109,15 @@ var routeUpdateRemoteHost2 = proto.RouteUpdate{
 	Dst:         remoteHost2IP.String() + "/32",
 	DstNodeName: remoteHostname2,
 	DstNodeIp:   remoteHost2IP.String(),
+}
+
+// RouteUpdate expected for the remote host with its normal IPv6 address.
+var routeUpdateRemoteHostV6 = proto.RouteUpdate{
+	Type:        proto.RouteType_REMOTE_HOST,
+	IpPoolType:  proto.IPPoolType_NONE,
+	Dst:         remoteHostIPv6.String() + "/128",
+	DstNodeName: remoteHostname,
+	DstNodeIp:   remoteHostIPv6.String(),
 }
 
 // Minimal VXLAN set-up using WorkloadIPs for routing information rather than using
@@ -1187,7 +1270,21 @@ var vxlanWithBlockNodeRes = vxlanWithBlock.withKVUpdates(
 var vxlanWithIPv6Resources = vxlanWithBlock.withKVUpdates(
 	KVPair{Key: v6IPPoolKey, Value: &v6IPPool},
 	KVPair{Key: remotev6IPAMBlockKey, Value: &remotev6IPAMBlock},
-).withName("VXLAN with IPv6")
+).withRoutes(
+	append(vxlanWithBlockRoutes,
+		proto.RouteUpdate{
+			Type:        proto.RouteType_REMOTE_WORKLOAD,
+			IpPoolType:  proto.IPPoolType_NONE,
+			Dst:         "feed:beef:1::/96",
+			DstNodeName: remoteHostname,
+		},
+		proto.RouteUpdate{
+			Type:       proto.RouteType_CIDR_INFO,
+			IpPoolType: proto.IPPoolType_NO_ENCAP,
+			Dst:        "feed:beef::/64",
+		},
+	)...,
+).withName("VXLAN with IPv6 Resources")
 
 // Minimal VXLAN set-up with a MAC address override for the remote node.
 var vxlanWithMAC = vxlanWithBlock.withKVUpdates(
@@ -1416,6 +1513,9 @@ var vxlanLocalBlockWithBorrowsLocalWEP = vxlanLocalBlockWithBorrows.withKVUpdate
 	// Plus individual routes for the local WEPs.
 	localVXLANWep1Route1,
 	localVXLANWep1Route2,
+	// Plus V6 workloads
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
 ).withName("VXLAN local with borrows with local WEP override").withActiveProfiles(
 	proto.ProfileID{Name: "prof-1"},
 	proto.ProfileID{Name: "prof-2"},
@@ -1700,11 +1800,29 @@ var vxlanV6WithBlock = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true},
-)
+).withRoutes(vxlanV6WithBlockRoutes...)
+
+var vxlanV6WithBlockRoutes = []proto.RouteUpdate{
+	routeUpdateV6IPPoolVXLAN,
+	routeUpdateRemoteHostV6,
+	// Single route for the block.
+	proto.RouteUpdate{
+		Type:        proto.RouteType_REMOTE_WORKLOAD,
+		IpPoolType:  proto.IPPoolType_NONE,
+		Dst:         "feed:beef:1::/96",
+		DstNodeName: remoteHostname,
+		DstNodeIp:   remoteHostIPv6.String(),
+		//NatOutgoing: true, //TODO: should this be true?
+	},
+}
 
 var vxlanV6BlockDelete = vxlanV6WithBlock.withKVUpdates(
 	KVPair{Key: remotev6IPAMBlockKey, Value: nil},
-).withName("VXLAN IPv6 block removed").withVTEPs(
+).withName("VXLAN IPv6 block removed").withRoutes(
+	// VXLAN block route removed but still keep the IP pool and host routes.
+	routeUpdateV6IPPoolVXLAN,
+	routeUpdateRemoteHostV6,
+).withVTEPs(
 	// VTEP for the remote node.
 	proto.VXLANTunnelEndpointUpdate{
 		Node:             remoteHostname,
@@ -1720,7 +1838,16 @@ var vxlanV6NodeResIPDelete = vxlanV6WithBlock.withKVUpdates(
 			Name: remoteHostname,
 		},
 		Spec: apiv3.NodeSpec{BGP: &apiv3.NodeBGPSpec{}}}},
-).withName("VXLAN IPv6 Node Resource IP removed").withVTEPs()
+).withName("VXLAN IPv6 Node Resource IP removed").withRoutes(
+	routeUpdateV6IPPoolVXLAN,
+	proto.RouteUpdate{
+		Type:        proto.RouteType_REMOTE_WORKLOAD,
+		IpPoolType:  proto.IPPoolType_NONE,
+		Dst:         "feed:beef:1::/96",
+		DstNodeName: remoteHostname,
+		//NatOutgoing: true, //TODO: should this be true?
+	},
+).withVTEPs()
 
 var vxlanV6NodeResBGPDelete = vxlanV6WithBlock.withKVUpdates(
 	KVPair{Key: remoteNodeResKey, Value: &apiv3.Node{
@@ -1728,11 +1855,29 @@ var vxlanV6NodeResBGPDelete = vxlanV6WithBlock.withKVUpdates(
 			Name: remoteHostname,
 		},
 		Spec: apiv3.NodeSpec{BGP: nil}}},
-).withName("VXLAN IPv6 Node Resource BGP removed").withVTEPs()
+).withName("VXLAN IPv6 Node Resource BGP removed").withRoutes(
+	routeUpdateV6IPPoolVXLAN,
+	proto.RouteUpdate{
+		Type:        proto.RouteType_REMOTE_WORKLOAD,
+		IpPoolType:  proto.IPPoolType_NONE,
+		Dst:         "feed:beef:1::/96",
+		DstNodeName: remoteHostname,
+		//NatOutgoing: true, //TODO: should this be true?
+	},
+).withVTEPs()
 
 var vxlanV6NodeResDelete = vxlanV6WithBlock.withKVUpdates(
 	KVPair{Key: remoteNodeResKey, Value: nil},
-).withName("VXLAN IPv6 Node Resource removed").withVTEPs()
+).withName("VXLAN IPv6 Node Resource removed").withRoutes(
+	routeUpdateV6IPPoolVXLAN,
+	proto.RouteUpdate{
+		Type:        proto.RouteType_REMOTE_WORKLOAD,
+		IpPoolType:  proto.IPPoolType_NONE,
+		Dst:         "feed:beef:1::/96",
+		DstNodeName: remoteHostname,
+		//NatOutgoing: true, //TODO: should this be true?
+	},
+).withVTEPs()
 
 var vxlanV6TunnelIPDelete = vxlanV6WithBlock.withKVUpdates(
 	KVPair{Key: remoteHostVXLANV6TunnelConfigKey, Value: nil},
@@ -1779,11 +1924,15 @@ var vxlanV4V6WithBlock = empty.withKVUpdates(
 	},
 ).withExpectedEncapsulation(
 	proto.Encapsulation{IpipEnabled: false, VxlanEnabled: true},
-).withRoutes(vxlanWithBlockRoutes...)
+).withRoutes(append(vxlanWithBlockRoutes, vxlanV6WithBlockRoutes...)...)
 
 var vxlanV4V6BlockV6Delete = vxlanV4V6WithBlock.withKVUpdates(
 	KVPair{Key: remotev6IPAMBlockKey, Value: nil},
-).withName("VXLAN IPv4+IPv6 with IPv6 block removed").withVTEPs(
+).withName("VXLAN IPv4+IPv6 with IPv6 block removed").withRoutes(
+	append(vxlanWithBlockRoutes,
+		routeUpdateV6IPPoolVXLAN,
+		routeUpdateRemoteHostV6)...,
+).withVTEPs(
 	// VTEP for the remote node.
 	proto.VXLANTunnelEndpointUpdate{
 		Node:             remoteHostname,
@@ -1800,8 +1949,9 @@ var vxlanV4V6BlockV4Delete = vxlanV4V6WithBlock.withKVUpdates(
 	KVPair{Key: remoteIPAMBlockKey, Value: nil},
 ).withName("VXLAN IPv4+IPv6 with IPv4 block removed").withRoutes(
 	// VXLAN block route removed but still keep the IP pool and host routes.
-	routeUpdateIPPoolVXLAN,
-	routeUpdateRemoteHost,
+	append(vxlanV6WithBlockRoutes,
+		routeUpdateIPPoolVXLAN,
+		routeUpdateRemoteHost)...,
 ).withVTEPs(
 	// VTEP for the remote node.
 	proto.VXLANTunnelEndpointUpdate{
@@ -1824,16 +1974,17 @@ var vxlanV4V6NodeResIPv4Delete = vxlanV4V6WithBlock.withKVUpdates(
 			IPv6Address: remoteHostIPv6.String() + "/96",
 		}}}},
 ).withName("VXLAN IPv4+IPv6 Node Resource IPv4 removed").withRoutes(
-	routeUpdateIPPoolVXLAN,
-	// Host removed but keep the route without the node IP.
-	proto.RouteUpdate{
-		Type:        proto.RouteType_REMOTE_WORKLOAD,
-		IpPoolType:  proto.IPPoolType_VXLAN,
-		Dst:         "10.0.1.0/29",
-		DstNodeName: remoteHostname,
-		DstNodeIp:   "",
-		NatOutgoing: true,
-	},
+	append(vxlanV6WithBlockRoutes,
+		routeUpdateIPPoolVXLAN,
+		// Host removed but keep the route without the node IP.
+		proto.RouteUpdate{
+			Type:        proto.RouteType_REMOTE_WORKLOAD,
+			IpPoolType:  proto.IPPoolType_VXLAN,
+			Dst:         "10.0.1.0/29",
+			DstNodeName: remoteHostname,
+			DstNodeIp:   "",
+			NatOutgoing: true,
+		})...,
 ).withVTEPs(
 	// VTEP for the remote node.
 	proto.VXLANTunnelEndpointUpdate{
@@ -1853,7 +2004,15 @@ var vxlanV4V6NodeResIPv6Delete = vxlanV4V6WithBlock.withKVUpdates(
 			IPv4Address: remoteHostIP.String() + "/24",
 		}}}},
 ).withName("VXLAN IPv4+IPv6 Node Resource IPv6 removed").withRoutes(
-	vxlanWithBlockRoutes...,
+	append(vxlanWithBlockRoutes,
+		routeUpdateV6IPPoolVXLAN,
+		proto.RouteUpdate{
+			Type:        proto.RouteType_REMOTE_WORKLOAD,
+			IpPoolType:  proto.IPPoolType_NONE,
+			Dst:         "feed:beef:1::/96",
+			DstNodeName: remoteHostname,
+			//NatOutgoing: true, //TODO: should this be true?
+		})...,
 ).withVTEPs(
 	// VTEP for the remote node.
 	proto.VXLANTunnelEndpointUpdate{
@@ -1881,6 +2040,14 @@ var vxlanV4V6NodeResBGPDelete = vxlanV4V6WithBlock.withKVUpdates(
 		DstNodeIp:   "",
 		NatOutgoing: true,
 	},
+	routeUpdateV6IPPoolVXLAN,
+	proto.RouteUpdate{
+		Type:        proto.RouteType_REMOTE_WORKLOAD,
+		IpPoolType:  proto.IPPoolType_NONE,
+		Dst:         "feed:beef:1::/96",
+		DstNodeName: remoteHostname,
+		//NatOutgoing: true, //TODO: should this be true?
+	},
 ).withVTEPs()
 
 var vxlanV4V6NodeResDelete = vxlanV4V6WithBlock.withKVUpdates(
@@ -1895,6 +2062,14 @@ var vxlanV4V6NodeResDelete = vxlanV4V6WithBlock.withKVUpdates(
 		DstNodeName: remoteHostname,
 		DstNodeIp:   "",
 		NatOutgoing: true,
+	},
+	routeUpdateV6IPPoolVXLAN,
+	proto.RouteUpdate{
+		Type:        proto.RouteType_REMOTE_WORKLOAD,
+		IpPoolType:  proto.IPPoolType_NONE,
+		Dst:         "feed:beef:1::/96",
+		DstNodeName: remoteHostname,
+		//NatOutgoing: true, //TODO: should this be true?
 	},
 ).withVTEPs()
 
@@ -2115,8 +2290,14 @@ var nodesWithDifferentAddressTypes = nodesWithMoreIPs.withKVUpdates(
 				},
 			},
 		}}},
-).withRoutes(nodesWithMoreIPsRoutes...).
-	withName("routes for nodes with more IPs someof them unexpected/invalid")
+).withRoutes(append(nodesWithMoreIPsRoutes,
+	// IPv6 route is now valid
+	proto.RouteUpdate{
+		Type:        proto.RouteType_LOCAL_HOST,
+		Dst:         "feed:dead:beef::/128",
+		DstNodeName: localHostname,
+	})...,
+).withName("routes for nodes with more IPs some of them unexpected/invalid")
 
 var nodesWithMoreIPsRoutesDeletedExtras = append(vxlanWithBlockRoutes[0:len(vxlanWithBlockRoutes):len(vxlanWithBlockRoutes) /* force copy */],
 	proto.RouteUpdate{
@@ -2167,6 +2348,8 @@ var endpointSliceAndLocalWorkload = empty.withKVUpdates(
 	// Routes for the local WEP.
 	routelocalWlTenDotOne,
 	routelocalWlTenDotTwo,
+	routelocalWlV6ColonOne,
+	routelocalWlV6ColonTwo,
 ).withEndpoint(
 	localWlEp1Id,
 	[]mock.TierInfo{},

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -1274,8 +1274,8 @@ var vxlanWithIPv6Resources = vxlanWithBlock.withKVUpdates(
 	append(vxlanWithBlockRoutes,
 		proto.RouteUpdate{
 			Type:        proto.RouteType_REMOTE_WORKLOAD,
-			IpPoolType:  proto.IPPoolType_NONE,
-			Dst:         "feed:beef:1::/96",
+			IpPoolType:  proto.IPPoolType_NO_ENCAP,
+			Dst:         "feed:beef:0:0:1::/96",
 			DstNodeName: remoteHostname,
 		},
 		proto.RouteUpdate{
@@ -1808,11 +1808,11 @@ var vxlanV6WithBlockRoutes = []proto.RouteUpdate{
 	// Single route for the block.
 	proto.RouteUpdate{
 		Type:        proto.RouteType_REMOTE_WORKLOAD,
-		IpPoolType:  proto.IPPoolType_NONE,
-		Dst:         "feed:beef:1::/96",
+		IpPoolType:  proto.IPPoolType_VXLAN,
+		Dst:         "feed:beef:0:0:1::/96",
 		DstNodeName: remoteHostname,
 		DstNodeIp:   remoteHostIPv6.String(),
-		//NatOutgoing: true, //TODO: should this be true?
+		NatOutgoing: true,
 	},
 }
 
@@ -1842,10 +1842,10 @@ var vxlanV6NodeResIPDelete = vxlanV6WithBlock.withKVUpdates(
 	routeUpdateV6IPPoolVXLAN,
 	proto.RouteUpdate{
 		Type:        proto.RouteType_REMOTE_WORKLOAD,
-		IpPoolType:  proto.IPPoolType_NONE,
-		Dst:         "feed:beef:1::/96",
+		IpPoolType:  proto.IPPoolType_VXLAN,
+		Dst:         "feed:beef:0:0:1::/96",
 		DstNodeName: remoteHostname,
-		//NatOutgoing: true, //TODO: should this be true?
+		NatOutgoing: true,
 	},
 ).withVTEPs()
 
@@ -1859,10 +1859,10 @@ var vxlanV6NodeResBGPDelete = vxlanV6WithBlock.withKVUpdates(
 	routeUpdateV6IPPoolVXLAN,
 	proto.RouteUpdate{
 		Type:        proto.RouteType_REMOTE_WORKLOAD,
-		IpPoolType:  proto.IPPoolType_NONE,
-		Dst:         "feed:beef:1::/96",
+		IpPoolType:  proto.IPPoolType_VXLAN,
+		Dst:         "feed:beef:0:0:1::/96",
 		DstNodeName: remoteHostname,
-		//NatOutgoing: true, //TODO: should this be true?
+		NatOutgoing: true,
 	},
 ).withVTEPs()
 
@@ -1872,10 +1872,10 @@ var vxlanV6NodeResDelete = vxlanV6WithBlock.withKVUpdates(
 	routeUpdateV6IPPoolVXLAN,
 	proto.RouteUpdate{
 		Type:        proto.RouteType_REMOTE_WORKLOAD,
-		IpPoolType:  proto.IPPoolType_NONE,
-		Dst:         "feed:beef:1::/96",
+		IpPoolType:  proto.IPPoolType_VXLAN,
+		Dst:         "feed:beef:0:0:1::/96",
 		DstNodeName: remoteHostname,
-		//NatOutgoing: true, //TODO: should this be true?
+		NatOutgoing: true,
 	},
 ).withVTEPs()
 
@@ -2008,10 +2008,10 @@ var vxlanV4V6NodeResIPv6Delete = vxlanV4V6WithBlock.withKVUpdates(
 		routeUpdateV6IPPoolVXLAN,
 		proto.RouteUpdate{
 			Type:        proto.RouteType_REMOTE_WORKLOAD,
-			IpPoolType:  proto.IPPoolType_NONE,
-			Dst:         "feed:beef:1::/96",
+			IpPoolType:  proto.IPPoolType_VXLAN,
+			Dst:         "feed:beef:0:0:1::/96",
 			DstNodeName: remoteHostname,
-			//NatOutgoing: true, //TODO: should this be true?
+			NatOutgoing: true,
 		})...,
 ).withVTEPs(
 	// VTEP for the remote node.
@@ -2043,10 +2043,10 @@ var vxlanV4V6NodeResBGPDelete = vxlanV4V6WithBlock.withKVUpdates(
 	routeUpdateV6IPPoolVXLAN,
 	proto.RouteUpdate{
 		Type:        proto.RouteType_REMOTE_WORKLOAD,
-		IpPoolType:  proto.IPPoolType_NONE,
-		Dst:         "feed:beef:1::/96",
+		IpPoolType:  proto.IPPoolType_VXLAN,
+		Dst:         "feed:beef:0:0:1::/96",
 		DstNodeName: remoteHostname,
-		//NatOutgoing: true, //TODO: should this be true?
+		NatOutgoing: true,
 	},
 ).withVTEPs()
 
@@ -2066,10 +2066,10 @@ var vxlanV4V6NodeResDelete = vxlanV4V6WithBlock.withKVUpdates(
 	routeUpdateV6IPPoolVXLAN,
 	proto.RouteUpdate{
 		Type:        proto.RouteType_REMOTE_WORKLOAD,
-		IpPoolType:  proto.IPPoolType_NONE,
-		Dst:         "feed:beef:1::/96",
+		IpPoolType:  proto.IPPoolType_VXLAN,
+		Dst:         "feed:beef:0:0:1::/96",
 		DstNodeName: remoteHostname,
-		//NatOutgoing: true, //TODO: should this be true?
+		NatOutgoing: true,
 	},
 ).withVTEPs()
 

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -321,6 +321,7 @@ const (
 
 	ipipMTUOverhead      = 20
 	vxlanMTUOverhead     = 50
+	vxlanV6MTUOverhead   = 70
 	wireguardMTUOverhead = 60
 	aksMTUOverhead       = 100
 )
@@ -958,6 +959,12 @@ func ConfigureDefaultMTUs(hostMTU int, c *Config) {
 	if c.VXLANMTU == 0 {
 		log.Debug("Defaulting VXLAN MTU based on host")
 		c.VXLANMTU = hostMTU - vxlanMTUOverhead
+
+		if c.IPv6Enabled {
+			log.Debug("IPv6 is enabled, defaulting VXLAN MTU based on host")
+			c.VXLANMTU = hostMTU - vxlanV6MTUOverhead
+		}
+
 	}
 	if c.Wireguard.MTU == 0 {
 		if c.KubernetesProvider == config.ProviderAKS && c.Wireguard.EncryptHostTraffic {

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -41,539 +41,557 @@ import (
 )
 
 var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before adding host IPs to IP sets", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
-	for _, vxlanM := range []api.VXLANMode{api.VXLANModeCrossSubnet} {
-		vxlanMode := vxlanM
-		type testConf struct {
-			RouteSource string
-			BrokenXSum  bool
-		}
-		for _, testConfig := range []testConf{
-			{"CalicoIPAM", true},
-			{"WorkloadIPs", false},
-		} {
-			routeSource := testConfig.RouteSource
-			brokenXSum := testConfig.BrokenXSum
-			Describe(fmt.Sprintf("VXLAN mode set to %s, routeSource %s, brokenXSum: %v", vxlanMode, routeSource, brokenXSum), func() {
-				var (
-					infra           infrastructure.DatastoreInfra
-					felixes         []*infrastructure.Felix
-					client          client.Interface
-					w               [3]*workload.Workload
-					hostW           [3]*workload.Workload
-					cc              *connectivity.Checker
-					topologyOptions infrastructure.TopologyOptions
-				)
+	type testConf struct {
+		VXLANMode   api.VXLANMode
+		RouteSource string
+		BrokenXSum  bool
+		EnableIPv6  bool
+	}
+	for _, testConfig := range []testConf{
+		{api.VXLANModeCrossSubnet, "CalicoIPAM", true, true},
+		{api.VXLANModeCrossSubnet, "WorkloadIPs", false, true},
+		{api.VXLANModeCrossSubnet, "CalicoIPAM", true, false},
+		{api.VXLANModeCrossSubnet, "WorkloadIPs", false, false},
+	} {
+		vxlanMode := testConfig.VXLANMode
+		routeSource := testConfig.RouteSource
+		brokenXSum := testConfig.BrokenXSum
+		enableIPv6 := testConfig.EnableIPv6
+		Describe(fmt.Sprintf("VXLAN mode set to %s, routeSource %s, brokenXSum: %v, enableIPv6: %v", vxlanMode, routeSource, brokenXSum, enableIPv6), func() {
+			var (
+				infra           infrastructure.DatastoreInfra
+				felixes         []*infrastructure.Felix
+				client          client.Interface
+				w               [3]*workload.Workload
+				hostW           [3]*workload.Workload
+				cc              *connectivity.Checker
+				topologyOptions infrastructure.TopologyOptions
+			)
 
-				BeforeEach(func() {
-					infra = getInfra()
-					topologyOptions = infrastructure.DefaultTopologyOptions()
-					topologyOptions.VXLANMode = vxlanMode
-					topologyOptions.IPIPEnabled = false
-					topologyOptions.ExtraEnvVars["FELIX_ROUTESOURCE"] = routeSource
-					// We force the broken checksum handling on or off so that we're not dependent on kernel version
-					// for these tests.  Since we're testing in containers anyway, checksum offload can't really be
-					// tested but we can verify the state with ethtool.
-					topologyOptions.ExtraEnvVars["FELIX_FeatureDetectOverride"] = fmt.Sprintf("ChecksumOffloadBroken=%t", brokenXSum)
-					felixes, client = infrastructure.StartNNodeTopology(3, topologyOptions, infra)
+			BeforeEach(func() {
+				infra = getInfra()
+				topologyOptions = infrastructure.DefaultTopologyOptions()
+				topologyOptions.VXLANMode = vxlanMode
+				topologyOptions.IPIPEnabled = false
+				topologyOptions.EnableIPv6 = enableIPv6
+				topologyOptions.ExtraEnvVars["FELIX_ROUTESOURCE"] = routeSource
+				// We force the broken checksum handling on or off so that we're not dependent on kernel version
+				// for these tests.  Since we're testing in containers anyway, checksum offload can't really be
+				// tested but we can verify the state with ethtool.
+				topologyOptions.ExtraEnvVars["FELIX_FeatureDetectOverride"] = fmt.Sprintf("ChecksumOffloadBroken=%t", brokenXSum)
+				felixes, client = infrastructure.StartNNodeTopology(3, topologyOptions, infra)
 
-					// Install a default profile that allows all ingress and egress, in the absence of any Policy.
-					infra.AddDefaultAllow()
+				// Install a default profile that allows all ingress and egress, in the absence of any Policy.
+				infra.AddDefaultAllow()
 
-					// Wait until the vxlan device appears.
-					Eventually(func() error {
-						for i, f := range felixes {
-							out, err := f.ExecOutput("ip", "link")
-							if err != nil {
-								return err
-							}
-							if strings.Contains(out, "vxlan.calico") {
-								continue
-							}
-							return fmt.Errorf("felix %d has no vxlan device", i)
+				// Wait until the vxlan device appears.
+				Eventually(func() error {
+					for i, f := range felixes {
+						out, err := f.ExecOutput("ip", "link")
+						if err != nil {
+							return err
 						}
-						return nil
-					}, "10s", "100ms").ShouldNot(HaveOccurred())
-
-					// Create workloads, using that profile.  One on each "host".
-					for ii := range w {
-						wIP := fmt.Sprintf("10.65.%d.2", ii)
-						wName := fmt.Sprintf("w%d", ii)
-						err := client.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
-							IP:       net.MustParseIP(wIP),
-							HandleID: &wName,
-							Attrs: map[string]string{
-								ipam.AttributeNode: felixes[ii].Hostname,
-							},
-							Hostname: felixes[ii].Hostname,
-						})
-						Expect(err).NotTo(HaveOccurred())
-
-						w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
-						w[ii].ConfigureInInfra(infra)
-
-						hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
-					}
-
-					cc = &connectivity.Checker{}
-				})
-
-				AfterEach(func() {
-					if CurrentGinkgoTestDescription().Failed {
-						for _, felix := range felixes {
-							felix.Exec("iptables-save", "-c")
-							felix.Exec("ipset", "list")
-							felix.Exec("ip", "r")
-							felix.Exec("ip", "a")
+						if strings.Contains(out, "vxlan.calico") {
+							continue
 						}
+						return fmt.Errorf("felix %d has no vxlan device", i)
 					}
+					return nil
+				}, "10s", "100ms").ShouldNot(HaveOccurred())
 
-					for _, wl := range w {
-						wl.Stop()
-					}
-					for _, wl := range hostW {
-						wl.Stop()
-					}
-					for _, felix := range felixes {
-						felix.Stop()
-					}
+				// Create workloads, using that profile.  One on each "host".
+				for ii := range w {
+					wIP := fmt.Sprintf("10.65.%d.2", ii)
+					wName := fmt.Sprintf("w%d", ii)
+					err := client.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
+						IP:       net.MustParseIP(wIP),
+						HandleID: &wName,
+						Attrs: map[string]string{
+							ipam.AttributeNode: felixes[ii].Hostname,
+						},
+						Hostname: felixes[ii].Hostname,
+					})
+					Expect(err).NotTo(HaveOccurred())
 
-					if CurrentGinkgoTestDescription().Failed {
-						infra.DumpErrorData()
-					}
-					infra.Stop()
-				})
-				if brokenXSum {
-					It("should disable checksum offload", func() {
-						Eventually(func() string {
-							out, err := felixes[0].ExecOutput("ethtool", "-k", "vxlan.calico")
-							if err != nil {
-								return fmt.Sprintf("ERROR: %v", err)
-							}
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("tx-checksumming: off"))
-					})
-				} else {
-					It("should not disable checksum offload", func() {
-						Eventually(func() string {
-							out, err := felixes[0].ExecOutput("ethtool", "-k", "vxlan.calico")
-							if err != nil {
-								return fmt.Sprintf("ERROR: %v", err)
-							}
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("tx-checksumming: on"))
-					})
+					w[ii] = workload.Run(felixes[ii], wName, "default", wIP, "8055", "tcp")
+					w[ii].ConfigureInInfra(infra)
+
+					hostW[ii] = workload.Run(felixes[ii], fmt.Sprintf("host%d", ii), "", felixes[ii].IP, "8055", "tcp")
 				}
-				It("should use the --random-fully flag in the MASQUERADE rules", func() {
+
+				cc = &connectivity.Checker{}
+			})
+
+			AfterEach(func() {
+				if CurrentGinkgoTestDescription().Failed {
 					for _, felix := range felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("iptables-save", "-c")
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("--random-fully"))
+						felix.Exec("iptables-save", "-c")
+						felix.Exec("ipset", "list")
+						felix.Exec("ip", "r")
+						felix.Exec("ip", "a")
+					}
+				}
+
+				for _, wl := range w {
+					wl.Stop()
+				}
+				for _, wl := range hostW {
+					wl.Stop()
+				}
+				for _, felix := range felixes {
+					felix.Stop()
+				}
+
+				if CurrentGinkgoTestDescription().Failed {
+					infra.DumpErrorData()
+				}
+				infra.Stop()
+			})
+			if brokenXSum {
+				It("should disable checksum offload", func() {
+					Eventually(func() string {
+						out, err := felixes[0].ExecOutput("ethtool", "-k", "vxlan.calico")
+						if err != nil {
+							return fmt.Sprintf("ERROR: %v", err)
+						}
+						return out
+					}, "10s", "100ms").Should(ContainSubstring("tx-checksumming: off"))
+				})
+			} else {
+				It("should not disable checksum offload", func() {
+					Eventually(func() string {
+						out, err := felixes[0].ExecOutput("ethtool", "-k", "vxlan.calico")
+						if err != nil {
+							return fmt.Sprintf("ERROR: %v", err)
+						}
+						return out
+					}, "10s", "100ms").Should(ContainSubstring("tx-checksumming: on"))
+				})
+			}
+			It("should use the --random-fully flag in the MASQUERADE rules", func() {
+				for _, felix := range felixes {
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("iptables-save", "-c")
+						return out
+					}, "10s", "100ms").Should(ContainSubstring("--random-fully"))
+				}
+			})
+			It("should have workload to workload connectivity", func() {
+				cc.ExpectSome(w[0], w[1])
+				cc.ExpectSome(w[1], w[0])
+				cc.CheckConnectivity()
+			})
+
+			It("should have some blackhole routes installed", func() {
+				if routeSource == "WorkloadIPs" {
+					Skip("not applicable for workload ips")
+					return
+				}
+
+				nodes := []string{
+					"blackhole 10.65.0.0/26 proto 80",
+					"blackhole 10.65.1.0/26 proto 80",
+					"blackhole 10.65.2.0/26 proto 80",
+				}
+
+				for n, result := range nodes {
+					Eventually(func() string {
+						o, _ := felixes[n].ExecOutput("ip", "r", "s", "type", "blackhole")
+						return o
+					}, "10s", "100ms").Should(ContainSubstring(result))
+					wName := fmt.Sprintf("w%d", n)
+
+					err := client.IPAM().ReleaseByHandle(context.TODO(), wName)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = client.IPAM().ReleaseHostAffinities(context.TODO(), felixes[n].Hostname, true)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(func() string {
+						o, _ := felixes[n].ExecOutput("ip", "r", "s", "type", "blackhole")
+						return o
+					}, "10s", "100ms").Should(BeEmpty())
+				}
+			})
+
+			It("should have host to workload connectivity", func() {
+				cc.ExpectSome(felixes[0], w[1])
+				cc.ExpectSome(felixes[0], w[0])
+				cc.CheckConnectivity()
+			})
+
+			It("should have host to host connectivity", func() {
+				cc.ExpectSome(felixes[0], hostW[1])
+				cc.ExpectSome(felixes[1], hostW[0])
+				cc.CheckConnectivity()
+			})
+
+			Context("with host protection policy in place", func() {
+				BeforeEach(func() {
+					// Make sure our new host endpoints don't cut felix off from the datastore.
+					err := infra.AddAllowToDatastore("host-endpoint=='true'")
+					Expect(err).NotTo(HaveOccurred())
+
+					ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+					defer cancel()
+
+					for _, f := range felixes {
+						hep := api.NewHostEndpoint()
+						hep.Name = "eth0-" + f.Name
+						hep.Labels = map[string]string{
+							"host-endpoint": "true",
+						}
+						hep.Spec.Node = f.Hostname
+						hep.Spec.ExpectedIPs = []string{f.IP}
+						_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+						Expect(err).NotTo(HaveOccurred())
 					}
 				})
-				It("should have workload to workload connectivity", func() {
+
+				It("should have workload connectivity but not host connectivity", func() {
+					// Host endpoints (with no policies) block host-host traffic due to default drop.
+					cc.ExpectNone(felixes[0], hostW[1])
+					cc.ExpectNone(felixes[1], hostW[0])
+					// But the rules to allow VXLAN between our hosts let the workload traffic through.
+					cc.ExpectSome(w[0], w[1])
+					cc.ExpectSome(w[1], w[0])
+					cc.CheckConnectivity()
+				})
+			})
+
+			Context("with all-interfaces host protection policy in place", func() {
+				BeforeEach(func() {
+					// Make sure our new host endpoints don't cut felix off from the datastore.
+					err := infra.AddAllowToDatastore("host-endpoint=='true'")
+					Expect(err).NotTo(HaveOccurred())
+
+					ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+					defer cancel()
+
+					for _, f := range felixes {
+						hep := api.NewHostEndpoint()
+						hep.Name = "all-interfaces-" + f.Name
+						hep.Labels = map[string]string{
+							"host-endpoint": "true",
+							"hostname":      f.Hostname,
+						}
+						hep.Spec.Node = f.Hostname
+						hep.Spec.ExpectedIPs = []string{f.IP}
+						hep.Spec.InterfaceName = "*"
+						_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+					}
+				})
+
+				It("should have workload connectivity but not host connectivity", func() {
+					// Host endpoints (with no policies) block host-host traffic due to default drop.
+					cc.ExpectNone(felixes[0], hostW[1])
+					cc.ExpectNone(felixes[1], hostW[0])
+
+					// Host => workload is not allowed
+					cc.ExpectNone(felixes[0], w[1])
+					cc.ExpectNone(felixes[1], w[0])
+
+					// But host => own-workload is allowed
+					cc.ExpectSome(felixes[0], w[0])
+					cc.ExpectSome(felixes[1], w[1])
+
+					// But the rules to allow VXLAN between our hosts let the workload traffic through.
 					cc.ExpectSome(w[0], w[1])
 					cc.ExpectSome(w[1], w[0])
 					cc.CheckConnectivity()
 				})
 
-				It("should have some blackhole routes installed", func() {
-					if routeSource == "WorkloadIPs" {
-						Skip("not applicable for workload ips")
-						return
-					}
+				It("should allow felixes[0] to reach felixes[1] if ingress and egress policies are in place", func() {
+					// Create a policy selecting felix[0] that allows egress.
+					policy := api.NewGlobalNetworkPolicy()
+					policy.Name = "f0-egress"
+					policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
+					policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[0].Hostname)
+					_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+					Expect(err).NotTo(HaveOccurred())
 
-					nodes := []string{
-						"blackhole 10.65.0.0/26 proto 80",
-						"blackhole 10.65.1.0/26 proto 80",
-						"blackhole 10.65.2.0/26 proto 80",
-					}
+					// But there is no policy allowing ingress into felix[1].
+					cc.ExpectNone(felixes[0], hostW[1])
 
-					for n, result := range nodes {
-						Eventually(func() string {
-							o, _ := felixes[n].ExecOutput("ip", "r", "s", "type", "blackhole")
-							return o
-						}, "10s", "100ms").Should(ContainSubstring(result))
-						wName := fmt.Sprintf("w%d", n)
+					// felixes[1] can't reach felixes[0].
+					cc.ExpectNone(felixes[1], hostW[0])
 
-						err := client.IPAM().ReleaseByHandle(context.TODO(), wName)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = client.IPAM().ReleaseHostAffinities(context.TODO(), felixes[n].Hostname, true)
-						Expect(err).NotTo(HaveOccurred())
-
-						Eventually(func() string {
-							o, _ := felixes[n].ExecOutput("ip", "r", "s", "type", "blackhole")
-							return o
-						}, "10s", "100ms").Should(BeEmpty())
-					}
-				})
-
-				It("should have host to workload connectivity", func() {
-					cc.ExpectSome(felixes[0], w[1])
-					cc.ExpectSome(felixes[0], w[0])
+					// Workload connectivity is unchanged.
+					cc.ExpectSome(w[0], w[1])
+					cc.ExpectSome(w[1], w[0])
 					cc.CheckConnectivity()
-				})
 
-				It("should have host to host connectivity", func() {
+					cc.ResetExpectations()
+
+					// Now add a policy selecting felix[1] that allows ingress.
+					policy = api.NewGlobalNetworkPolicy()
+					policy.Name = "f1-ingress"
+					policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
+					policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[1].Hostname)
+					_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Now felixes[0] can reach felixes[1].
 					cc.ExpectSome(felixes[0], hostW[1])
-					cc.ExpectSome(felixes[1], hostW[0])
+
+					// felixes[1] still can't reach felixes[0].
+					cc.ExpectNone(felixes[1], hostW[0])
+
+					// Workload connectivity is unchanged.
+					cc.ExpectSome(w[0], w[1])
+					cc.ExpectSome(w[1], w[0])
 					cc.CheckConnectivity()
 				})
 
-				Context("with host protection policy in place", func() {
+				Context("with policy allowing port 8055", func() {
 					BeforeEach(func() {
-						// Make sure our new host endpoints don't cut felix off from the datastore.
-						err := infra.AddAllowToDatastore("host-endpoint=='true'")
-						Expect(err).NotTo(HaveOccurred())
-
-						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-						defer cancel()
-
-						for _, f := range felixes {
-							hep := api.NewHostEndpoint()
-							hep.Name = "eth0-" + f.Name
-							hep.Labels = map[string]string{
-								"host-endpoint": "true",
-							}
-							hep.Spec.Node = f.Hostname
-							hep.Spec.ExpectedIPs = []string{f.IP}
-							_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
-							Expect(err).NotTo(HaveOccurred())
-						}
-					})
-
-					It("should have workload connectivity but not host connectivity", func() {
-						// Host endpoints (with no policies) block host-host traffic due to default drop.
-						cc.ExpectNone(felixes[0], hostW[1])
-						cc.ExpectNone(felixes[1], hostW[0])
-						// But the rules to allow VXLAN between our hosts let the workload traffic through.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
-						cc.CheckConnectivity()
-					})
-				})
-
-				Context("with all-interfaces host protection policy in place", func() {
-					BeforeEach(func() {
-						// Make sure our new host endpoints don't cut felix off from the datastore.
-						err := infra.AddAllowToDatastore("host-endpoint=='true'")
-						Expect(err).NotTo(HaveOccurred())
-
-						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-						defer cancel()
-
-						for _, f := range felixes {
-							hep := api.NewHostEndpoint()
-							hep.Name = "all-interfaces-" + f.Name
-							hep.Labels = map[string]string{
-								"host-endpoint": "true",
-								"hostname":      f.Hostname,
-							}
-							hep.Spec.Node = f.Hostname
-							hep.Spec.ExpectedIPs = []string{f.IP}
-							hep.Spec.InterfaceName = "*"
-							_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
-							Expect(err).NotTo(HaveOccurred())
-						}
-					})
-
-					It("should have workload connectivity but not host connectivity", func() {
-						// Host endpoints (with no policies) block host-host traffic due to default drop.
-						cc.ExpectNone(felixes[0], hostW[1])
-						cc.ExpectNone(felixes[1], hostW[0])
-
-						// Host => workload is not allowed
-						cc.ExpectNone(felixes[0], w[1])
-						cc.ExpectNone(felixes[1], w[0])
-
-						// But host => own-workload is allowed
-						cc.ExpectSome(felixes[0], w[0])
-						cc.ExpectSome(felixes[1], w[1])
-
-						// But the rules to allow VXLAN between our hosts let the workload traffic through.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
-						cc.CheckConnectivity()
-					})
-
-					It("should allow felixes[0] to reach felixes[1] if ingress and egress policies are in place", func() {
-						// Create a policy selecting felix[0] that allows egress.
+						tcp := numorstring.ProtocolFromString("tcp")
+						udp := numorstring.ProtocolFromString("udp")
+						p8055 := numorstring.SinglePort(8055)
 						policy := api.NewGlobalNetworkPolicy()
-						policy.Name = "f0-egress"
-						policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
-						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[0].Hostname)
+						policy.Name = "allow-8055"
+						policy.Spec.Ingress = []api.Rule{
+							{
+								Protocol: &udp,
+								Destination: api.EntityRule{
+									Ports: []numorstring.Port{p8055},
+								},
+								Action: api.Allow,
+							},
+							{
+								Protocol: &tcp,
+								Destination: api.EntityRule{
+									Ports: []numorstring.Port{p8055},
+								},
+								Action: api.Allow,
+							},
+						}
+						policy.Spec.Egress = []api.Rule{
+							{
+								Protocol: &udp,
+								Destination: api.EntityRule{
+									Ports: []numorstring.Port{p8055},
+								},
+								Action: api.Allow,
+							},
+							{
+								Protocol: &tcp,
+								Destination: api.EntityRule{
+									Ports: []numorstring.Port{p8055},
+								},
+								Action: api.Allow,
+							},
+						}
+						policy.Spec.Selector = fmt.Sprintf("has(host-endpoint)")
 						_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
 						Expect(err).NotTo(HaveOccurred())
+					})
 
-						// But there is no policy allowing ingress into felix[1].
-						cc.ExpectNone(felixes[0], hostW[1])
+					// Please take care if adding other connectivity checks into this case, to
+					// avoid those other checks setting up conntrack state that allows the
+					// existing case to pass for a different reason.
+					It("allows host0 to remote Calico-networked workload via service IP", func() {
+						// Allocate a service IP.
+						serviceIP := "10.96.10.1"
 
-						// felixes[1] can't reach felixes[0].
-						cc.ExpectNone(felixes[1], hostW[0])
+						// Add a NAT rule for the service IP.
+						felixes[0].ProgramIptablesDNAT(serviceIP, w[1].IP, "OUTPUT")
 
-						// Workload connectivity is unchanged.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
-						cc.CheckConnectivity()
-
-						cc.ResetExpectations()
-
-						// Now add a policy selecting felix[1] that allows ingress.
-						policy = api.NewGlobalNetworkPolicy()
-						policy.Name = "f1-ingress"
-						policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
-						policy.Spec.Selector = fmt.Sprintf("hostname == '%s'", felixes[1].Hostname)
-						_, err = client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
-						Expect(err).NotTo(HaveOccurred())
-
-						// Now felixes[0] can reach felixes[1].
-						cc.ExpectSome(felixes[0], hostW[1])
-
-						// felixes[1] still can't reach felixes[0].
-						cc.ExpectNone(felixes[1], hostW[0])
-
-						// Workload connectivity is unchanged.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
+						// Expect to connect to the service IP.
+						cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)
 						cc.CheckConnectivity()
 					})
-
-					Context("with policy allowing port 8055", func() {
-						BeforeEach(func() {
-							tcp := numorstring.ProtocolFromString("tcp")
-							udp := numorstring.ProtocolFromString("udp")
-							p8055 := numorstring.SinglePort(8055)
-							policy := api.NewGlobalNetworkPolicy()
-							policy.Name = "allow-8055"
-							policy.Spec.Ingress = []api.Rule{
-								{
-									Protocol: &udp,
-									Destination: api.EntityRule{
-										Ports: []numorstring.Port{p8055},
-									},
-									Action: api.Allow,
-								},
-								{
-									Protocol: &tcp,
-									Destination: api.EntityRule{
-										Ports: []numorstring.Port{p8055},
-									},
-									Action: api.Allow,
-								},
-							}
-							policy.Spec.Egress = []api.Rule{
-								{
-									Protocol: &udp,
-									Destination: api.EntityRule{
-										Ports: []numorstring.Port{p8055},
-									},
-									Action: api.Allow,
-								},
-								{
-									Protocol: &tcp,
-									Destination: api.EntityRule{
-										Ports: []numorstring.Port{p8055},
-									},
-									Action: api.Allow,
-								},
-							}
-							policy.Spec.Selector = fmt.Sprintf("has(host-endpoint)")
-							_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						// Please take care if adding other connectivity checks into this case, to
-						// avoid those other checks setting up conntrack state that allows the
-						// existing case to pass for a different reason.
-						It("allows host0 to remote Calico-networked workload via service IP", func() {
-							// Allocate a service IP.
-							serviceIP := "10.96.10.1"
-
-							// Add a NAT rule for the service IP.
-							felixes[0].ProgramIptablesDNAT(serviceIP, w[1].IP, "OUTPUT")
-
-							// Expect to connect to the service IP.
-							cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)
-							cc.CheckConnectivity()
-						})
-					})
-				})
-
-				Context("after removing BGP address from third node", func() {
-					// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
-					BeforeEach(func() {
-						Eventually(func() int {
-							return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
-						}, "10s", "200ms").Should(Equal(len(felixes) - 1))
-
-						ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-						defer cancel()
-						infra.RemoveNodeAddresses(felixes[2])
-						node, err := client.Nodes().Get(ctx, felixes[2].Hostname, options.GetOptions{})
-						Expect(err).NotTo(HaveOccurred())
-
-						// Pause felix so it can't touch the dataplane!
-						pid := felixes[2].GetFelixPID()
-						felixes[2].Exec("kill", "-STOP", fmt.Sprint(pid))
-
-						node.Spec.BGP = nil
-						_, err = client.Nodes().Update(ctx, node, options.SetOptions{})
-					})
-
-					It("should have no connectivity from third felix and expected number of IPs in whitelist", func() {
-						Eventually(func() int {
-							return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
-						}, "5s", "200ms").Should(Equal(len(felixes) - 2))
-
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[1], w[0])
-						cc.ExpectNone(w[0], w[2])
-						cc.ExpectNone(w[1], w[2])
-						cc.ExpectNone(w[2], w[0])
-						cc.ExpectNone(w[2], w[1])
-						cc.CheckConnectivity()
-					})
-				})
-
-				// Explicitly verify that the VXLAN whitelist IP set is doing its job (since Felix makes multiple dataplane
-				// changes when the BGP IP disappears and we want to make sure that its the whitelist that's causing the
-				// connectivity to drop).
-				Context("after removing BGP address from third node, all felixes paused", func() {
-					// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
-					BeforeEach(func() {
-						// Check we initially have the expected number of whitelist entries.
-						for _, f := range felixes {
-							// Wait for Felix to set up the whitelist.
-							Eventually(func() int {
-								return getNumIPSetMembers(f.Container, "cali40all-vxlan-net")
-							}, "5s", "200ms").Should(Equal(len(felixes) - 1))
-						}
-
-						// Wait until dataplane has settled.
-						cc.ExpectSome(w[0], w[1])
-						cc.ExpectSome(w[0], w[2])
-						cc.ExpectSome(w[1], w[2])
-						cc.CheckConnectivity()
-						cc.ResetExpectations()
-
-						// Then pause all the felixes.
-						for _, f := range felixes {
-							pid := f.GetFelixPID()
-							f.Exec("kill", "-STOP", fmt.Sprint(pid))
-						}
-					})
-
-					if vxlanMode == api.VXLANModeAlways {
-						It("after manually removing third node from whitelist should have expected connectivity", func() {
-							felixes[0].Exec("ipset", "del", "cali40all-vxlan-net", felixes[2].IP)
-
-							cc.ExpectSome(w[0], w[1])
-							cc.ExpectSome(w[1], w[0])
-							cc.ExpectSome(w[1], w[2])
-							cc.ExpectNone(w[2], w[0])
-							cc.CheckConnectivity()
-						})
-					}
-				})
-
-				It("should configure the vxlan device correctly", func() {
-					// The VXLAN device should appear with default MTU, etc. FV environment uses MTU 1500,
-					// which means that we should expect 1450 after subracting VXLAN overhead.
-					for _, felix := range felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("mtu 1450"))
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("vxlan id 4096"))
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("dstport 4789"))
-					}
-
-					// Change the host device's MTU, and expect the VXLAN device to be updated.
-					for _, felix := range felixes {
-						Eventually(func() error {
-							_, err := felix.ExecOutput("ip", "link", "set", "eth0", "mtu", "1400")
-							return err
-						}, "10s", "100ms").Should(BeNil())
-					}
-
-					// MTU should be auto-detected, and updated to the host MTU minus 50 bytes overhead.
-					for _, felix := range felixes {
-						// Felix checks host MTU every 30s
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "60s", "100ms").Should(ContainSubstring("mtu 1350"))
-
-						// And expect the MTU file on disk to be updated.
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
-							return out
-						}, "30s", "100ms").Should(ContainSubstring("1350"))
-					}
-
-					// Explicitly configure the MTU.
-					felixConfig := api.NewFelixConfiguration() // Create a default FelixConfiguration
-					felixConfig.Name = "default"
-					mtu := 1300
-					vni := 4097
-					port := 4790
-					felixConfig.Spec.VXLANMTU = &mtu
-					felixConfig.Spec.VXLANPort = &port
-					felixConfig.Spec.VXLANVNI = &vni
-					_, err := client.FelixConfigurations().Create(context.Background(), felixConfig, options.SetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					// Expect the settings to be changed on the device.
-					for _, felix := range felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "30s", "100ms").Should(ContainSubstring("mtu 1300"))
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("vxlan id 4097"))
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("dstport 4790"))
-					}
-
-				})
-
-				It("should delete the vxlan device when vxlan is disabled", func() {
-					// Wait for the VXLAN device to be created.
-					for _, felix := range felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "10s", "100ms").Should(ContainSubstring("mtu 1450"))
-					}
-
-					// Disable VXLAN in Felix.
-					felixConfig := api.NewFelixConfiguration()
-					felixConfig.Name = "default"
-					enabled := false
-					felixConfig.Spec.VXLANEnabled = &enabled
-					_, err := client.FelixConfigurations().Create(context.Background(), felixConfig, options.SetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					// Expect the VXLAN device to be deleted.
-					for _, felix := range felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
-							return out
-						}, "10s", "100ms").ShouldNot(ContainSubstring("mtu 1450"))
-					}
 				})
 			})
-		}
+
+			Context("after removing BGP address from third node", func() {
+				// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
+				BeforeEach(func() {
+					Eventually(func() int {
+						return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
+					}, "10s", "200ms").Should(Equal(len(felixes) - 1))
+
+					ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+					defer cancel()
+					infra.RemoveNodeAddresses(felixes[2])
+					node, err := client.Nodes().Get(ctx, felixes[2].Hostname, options.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Pause felix so it can't touch the dataplane!
+					pid := felixes[2].GetFelixPID()
+					felixes[2].Exec("kill", "-STOP", fmt.Sprint(pid))
+
+					node.Spec.BGP = nil
+					_, err = client.Nodes().Update(ctx, node, options.SetOptions{})
+				})
+
+				It("should have no connectivity from third felix and expected number of IPs in whitelist", func() {
+					Eventually(func() int {
+						return getNumIPSetMembers(felixes[0].Container, "cali40all-vxlan-net")
+					}, "5s", "200ms").Should(Equal(len(felixes) - 2))
+
+					cc.ExpectSome(w[0], w[1])
+					cc.ExpectSome(w[1], w[0])
+					cc.ExpectNone(w[0], w[2])
+					cc.ExpectNone(w[1], w[2])
+					cc.ExpectNone(w[2], w[0])
+					cc.ExpectNone(w[2], w[1])
+					cc.CheckConnectivity()
+				})
+			})
+
+			// Explicitly verify that the VXLAN whitelist IP set is doing its job (since Felix makes multiple dataplane
+			// changes when the BGP IP disappears and we want to make sure that its the whitelist that's causing the
+			// connectivity to drop).
+			Context("after removing BGP address from third node, all felixes paused", func() {
+				// Simulate having a host send VXLAN traffic from an unknown source, should get blocked.
+				BeforeEach(func() {
+					// Check we initially have the expected number of whitelist entries.
+					for _, f := range felixes {
+						// Wait for Felix to set up the whitelist.
+						Eventually(func() int {
+							return getNumIPSetMembers(f.Container, "cali40all-vxlan-net")
+						}, "5s", "200ms").Should(Equal(len(felixes) - 1))
+					}
+
+					// Wait until dataplane has settled.
+					cc.ExpectSome(w[0], w[1])
+					cc.ExpectSome(w[0], w[2])
+					cc.ExpectSome(w[1], w[2])
+					cc.CheckConnectivity()
+					cc.ResetExpectations()
+
+					// Then pause all the felixes.
+					for _, f := range felixes {
+						pid := f.GetFelixPID()
+						f.Exec("kill", "-STOP", fmt.Sprint(pid))
+					}
+				})
+
+				if vxlanMode == api.VXLANModeAlways {
+					It("after manually removing third node from whitelist should have expected connectivity", func() {
+						felixes[0].Exec("ipset", "del", "cali40all-vxlan-net", felixes[2].IP)
+
+						cc.ExpectSome(w[0], w[1])
+						cc.ExpectSome(w[1], w[0])
+						cc.ExpectSome(w[1], w[2])
+						cc.ExpectNone(w[2], w[0])
+						cc.CheckConnectivity()
+					})
+				}
+			})
+
+			It("should configure the vxlan device correctly", func() {
+				// The VXLAN device should appear with default MTU, etc. FV environment uses MTU 1500,
+				// which means that we should expect 1450 after subracting VXLAN overhead for IPv4 or 1430 for IPv6.
+				mtuStr := "mtu 1450"
+				if enableIPv6 {
+					mtuStr = "mtu 1430"
+				}
+				for _, felix := range felixes {
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "10s", "100ms").Should(ContainSubstring(mtuStr))
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "10s", "100ms").Should(ContainSubstring("vxlan id 4096"))
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "10s", "100ms").Should(ContainSubstring("dstport 4789"))
+				}
+
+				// Change the host device's MTU, and expect the VXLAN device to be updated.
+				for _, felix := range felixes {
+					Eventually(func() error {
+						_, err := felix.ExecOutput("ip", "link", "set", "eth0", "mtu", "1400")
+						return err
+					}, "10s", "100ms").Should(BeNil())
+				}
+
+				// MTU should be auto-detected, and updated to the host MTU minus 50 bytes overhead for IPv4 or 70 bytes for IPv6.
+				mtuStr = "mtu 1350"
+				mtuValue := "1350"
+				if enableIPv6 {
+					mtuStr = "mtu 1330"
+					mtuValue = "1330"
+				}
+				for _, felix := range felixes {
+					// Felix checks host MTU every 30s
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "60s", "100ms").Should(ContainSubstring(mtuStr))
+
+					// And expect the MTU file on disk to be updated.
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
+						return out
+					}, "30s", "100ms").Should(ContainSubstring(mtuValue))
+				}
+
+				// Explicitly configure the MTU.
+				felixConfig := api.NewFelixConfiguration() // Create a default FelixConfiguration
+				felixConfig.Name = "default"
+				mtu := 1300
+				vni := 4097
+				port := 4790
+				felixConfig.Spec.VXLANMTU = &mtu
+				felixConfig.Spec.VXLANPort = &port
+				felixConfig.Spec.VXLANVNI = &vni
+				_, err := client.FelixConfigurations().Create(context.Background(), felixConfig, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect the settings to be changed on the device.
+				for _, felix := range felixes {
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "30s", "100ms").Should(ContainSubstring("mtu 1300"))
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "10s", "100ms").Should(ContainSubstring("vxlan id 4097"))
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "10s", "100ms").Should(ContainSubstring("dstport 4790"))
+				}
+
+			})
+
+			It("should delete the vxlan device when vxlan is disabled", func() {
+				// Wait for the VXLAN device to be created.
+				mtuStr := "mtu 1450"
+				if enableIPv6 {
+					mtuStr = "mtu 1430"
+				}
+				for _, felix := range felixes {
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "10s", "100ms").Should(ContainSubstring(mtuStr))
+				}
+
+				// Disable VXLAN in Felix.
+				felixConfig := api.NewFelixConfiguration()
+				felixConfig.Name = "default"
+				enabled := false
+				felixConfig.Spec.VXLANEnabled = &enabled
+				_, err := client.FelixConfigurations().Create(context.Background(), felixConfig, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect the VXLAN device to be deleted.
+				for _, felix := range felixes {
+					Eventually(func() string {
+						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
+						return out
+					}, "10s", "100ms").ShouldNot(ContainSubstring(mtuStr))
+				}
+			})
+		})
 	}
 })

--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -101,6 +101,21 @@ func (a V6Addr) AsCIDR() CIDR {
 	}
 }
 
+// AsUint64Pair returns a pair of uint64 representing a V6Addr as there is
+// no native 128 bit uint type in go.
+func (a V6Addr) AsUint64Pair() (uint64, uint64) {
+	return binary.BigEndian.Uint64(a[:8]), binary.BigEndian.Uint64(a[8:])
+}
+
+func (a V6Addr) NthBit(n uint) int {
+	h, l := a.AsUint64Pair()
+	if n < 64 {
+		return int(l >> (64 - n) & 1)
+	}
+
+	return int(h >> (128 - n) & 1)
+}
+
 func (a V6Addr) String() string {
 	return a.AsNetIP().String()
 }
@@ -171,6 +186,20 @@ func (c V6CIDR) ToIPNet() net.IPNet {
 		IP:   c.Addr().AsNetIP(),
 		Mask: net.CIDRMask(int(c.Prefix()), 128),
 	}
+}
+
+func (c V6CIDR) ContainsV6(addr V6Addr) bool {
+	a64_h, a64_l := c.addr.AsUint64Pair()
+	b64_h, b64_l := addr.AsUint64Pair()
+	xored_h := a64_h ^ b64_h // Has a zero bit wherever the two values are the same.
+	xored_l := a64_l ^ b64_l
+
+	commonPrefixLen := uint8(bits.LeadingZeros64(xored_h))
+	if xored_h == 0 {
+		commonPrefixLen = 64 + uint8(bits.LeadingZeros64(xored_l))
+	}
+
+	return commonPrefixLen >= c.prefix
 }
 
 func (c V6CIDR) String() string {

--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -45,6 +45,7 @@ type Addr interface {
 	AsCalicoNetIP() calinet.IP
 	AsCIDR() CIDR
 	String() string
+	NthBit(uint) int
 }
 
 type V4Addr [4]byte
@@ -110,10 +111,10 @@ func (a V6Addr) AsUint64Pair() (uint64, uint64) {
 func (a V6Addr) NthBit(n uint) int {
 	h, l := a.AsUint64Pair()
 	if n < 64 {
-		return int(l >> (64 - n) & 1)
+		return int(h >> (64 - n) & 1)
 	}
 
-	return int(h >> (128 - n) & 1)
+	return int(l >> (128 - n) & 1)
 }
 
 func (a V6Addr) String() string {
@@ -126,6 +127,7 @@ type CIDR interface {
 	Prefix() uint8
 	String() string
 	ToIPNet() net.IPNet
+	Contains(addr Addr) bool
 }
 
 type V4CIDR struct {
@@ -150,6 +152,15 @@ func (c V4CIDR) ToIPNet() net.IPNet {
 		IP:   c.Addr().AsNetIP(),
 		Mask: net.CIDRMask(int(c.Prefix()), 32),
 	}
+}
+
+func (c V4CIDR) Contains(addr Addr) bool {
+	v4Addr, ok := addr.(V4Addr)
+	if !ok {
+		return false
+	}
+
+	return c.ContainsV4(v4Addr)
 }
 
 func (c V4CIDR) ContainsV4(addr V4Addr) bool {
@@ -186,6 +197,15 @@ func (c V6CIDR) ToIPNet() net.IPNet {
 		IP:   c.Addr().AsNetIP(),
 		Mask: net.CIDRMask(int(c.Prefix()), 128),
 	}
+}
+
+func (c V6CIDR) Contains(addr Addr) bool {
+	v6Addr, ok := addr.(V6Addr)
+	if !ok {
+		return false
+	}
+
+	return c.ContainsV6(v6Addr)
 }
 
 func (c V6CIDR) ContainsV6(addr V6Addr) bool {

--- a/felix/ip/ip_addr_test.go
+++ b/felix/ip/ip_addr_test.go
@@ -74,3 +74,36 @@ var _ = DescribeTable("CIDR",
 		16,
 	),
 )
+
+var _ = DescribeTable("NthBit",
+	func(inputAddr string, n uint, expected int) {
+		addr := FromString(inputAddr)
+		Expect(addr.NthBit(n)).To(Equal(expected))
+	},
+	Entry("IPv4 32nd bit", "10.10.10.1", uint(32), 1),
+	Entry("IPv4 31st bit", "10.10.10.1", uint(31), 0),
+	Entry("IPv4 32nd bit 2", "192.168.0.2", uint(32), 0),
+	Entry("IPv4 31st bit 2", "192.168.0.2", uint(31), 1),
+	Entry("IPv4 1st bit", "192.168.0.2", uint(1), 1),
+	Entry("IPv6 128th bit", "fc00:fe11::1", uint(128), 1),
+	Entry("IPv6 127th bit", "fc00:fe11::1", uint(127), 0),
+	Entry("IPv6 128th bit 2", "fc00:fe11::2", uint(128), 0),
+	Entry("IPv6 127th bit 2", "fc00:fe11::2", uint(127), 1),
+	Entry("IPv6 1st bit", "fc00:fe11::2", uint(1), 1),
+)
+
+var _ = DescribeTable("Contains",
+	func(inputCIDR string, inputAddr string, expected bool) {
+		cidr := MustParseCIDROrIP(inputCIDR)
+		addr := FromString(inputAddr)
+		Expect(cidr.Contains(addr)).To(Equal(expected))
+	},
+	Entry("IPv4 /32 true", "10.10.10.1/32", "10.10.10.1", true),
+	Entry("IPv4 /32 false", "10.10.10.1/32", "10.10.10.2", false),
+	Entry("IPv4 /24 true", "10.10.10.0/24", "10.10.10.3", true),
+	Entry("IPv4 /24 false", "10.10.10.0/24", "10.10.11.3", false),
+	Entry("IPv6 /128 true", "fc00:fe11::1/128", "fc00:fe11::1", true),
+	Entry("IPv6 /128 false", "fc00:fe11::1/128", "fc00:fe11::2", false),
+	Entry("IPv6 /112 true", "fc00:fe11::/112", "fc00:fe11::3", true),
+	Entry("IPv6 /112 false", "fc00:fe11::/112", "fc00:fe12::3", false),
+)

--- a/felix/ip/trie.go
+++ b/felix/ip/trie.go
@@ -16,34 +16,40 @@ package ip
 
 import (
 	"encoding/binary"
+	"fmt"
 	"log"
 	"math/bits"
 )
 
-type V4Trie struct {
-	root *V4Node
+type CIDRTrie struct {
+	root *CIDRNode
 }
 
-type V4Node struct {
-	cidr     V4CIDR
-	children [2]*V4Node
+type CIDRNode struct {
+	cidr     CIDR
+	children [2]*CIDRNode
 	data     interface{}
 }
 
-func (t *V4Trie) Delete(cidr V4CIDR) {
+func (t *CIDRTrie) Delete(cidr CIDR) {
 	if t.root == nil {
 		// Trie is empty.
 		return
 	}
-	if V4CommonPrefix(t.root.cidr, cidr) != t.root.cidr {
+	if pfx, err := CommonPrefix(t.root.cidr, cidr); err != nil || pfx != t.root.cidr {
 		// Trie does not contain prefix.
 		return
 	}
 	t.root = deleteInternal(t.root, cidr)
 }
 
-func deleteInternal(n *V4Node, cidr V4CIDR) *V4Node {
-	if !n.cidr.ContainsV4(cidr.addr) {
+func deleteInternal(n *CIDRNode, cidr CIDR) *CIDRNode {
+	if n.cidr.Version() != cidr.Version() {
+		// IP version mismatch
+		return n
+	}
+
+	if !n.cidr.Contains(cidr.Addr()) {
 		// Not in trie.
 		return n
 	}
@@ -66,7 +72,7 @@ func deleteInternal(n *V4Node, cidr V4CIDR) *V4Node {
 
 	// If we get here, then this node is a parent of the CIDR we're looking for.
 	// Figure out which child to recurse on.
-	childIdx := cidr.addr.NthBit(uint(n.cidr.prefix + 1))
+	childIdx := cidr.Addr().NthBit(uint(n.cidr.Prefix() + 1))
 	oldChild := n.children[childIdx]
 	if oldChild == nil {
 		return n
@@ -83,12 +89,12 @@ func deleteInternal(n *V4Node, cidr V4CIDR) *V4Node {
 	return n
 }
 
-type V4TrieEntry struct {
-	CIDR V4CIDR
+type CIDRTrieEntry struct {
+	CIDR CIDR
 	Data interface{}
 }
 
-func (t *V4Trie) Get(cidr V4CIDR) interface{} {
+func (t *CIDRTrie) Get(cidr CIDR) interface{} {
 	return t.root.get(cidr)
 }
 
@@ -97,21 +103,21 @@ func (t *V4Trie) Get(cidr V4CIDR) interface{} {
 // if it is too short append() is used to extend it and the updated slice is returned.
 //
 // If the CIDR is not in the trie then an empty slice is returned.
-func (t *V4Trie) LookupPath(buffer []V4TrieEntry, cidr V4CIDR) []V4TrieEntry {
+func (t *CIDRTrie) LookupPath(buffer []CIDRTrieEntry, cidr CIDR) []CIDRTrieEntry {
 	return t.root.lookupPath(buffer[:0], cidr)
 }
 
 // LPM does a longest prefix match on the trie
-func (t *V4Trie) LPM(cidr V4CIDR) (V4CIDR, interface{}) {
+func (t *CIDRTrie) LPM(cidr CIDR) (CIDR, interface{}) {
 	n := t.root
-	var match *V4Node
+	var match *CIDRNode
 
 	for {
 		if n == nil {
 			break
 		}
 
-		if !n.cidr.ContainsV4(cidr.addr) {
+		if !n.cidr.Contains(cidr.Addr()) {
 			break
 		}
 
@@ -125,28 +131,38 @@ func (t *V4Trie) LPM(cidr V4CIDR) (V4CIDR, interface{}) {
 
 		// If we get here, then this node is a parent of the CIDR we're looking for.
 		// Figure out which child to recurse on.
-		childIdx := cidr.addr.NthBit(uint(n.cidr.prefix + 1))
+		childIdx := cidr.Addr().NthBit(uint(n.cidr.Prefix() + 1))
 		n = n.children[childIdx]
 	}
 
 	if match == nil || match.data == nil {
-		return V4CIDR{}, nil
+		switch cidr.Version() {
+		case 4:
+			return V4CIDR{}, nil
+		case 6:
+			return V6CIDR{}, nil
+		}
 	}
 	return match.cidr, match.data
 }
 
-func (n *V4Node) lookupPath(buffer []V4TrieEntry, cidr V4CIDR) []V4TrieEntry {
+func (n *CIDRNode) lookupPath(buffer []CIDRTrieEntry, cidr CIDR) []CIDRTrieEntry {
 	if n == nil {
 		return buffer[:0]
 	}
 
-	if !n.cidr.ContainsV4(cidr.addr) {
+	if n.cidr.Version() != cidr.Version() {
+		// IP version mismatch
+		return nil
+	}
+
+	if !n.cidr.Contains(cidr.Addr()) {
 		// Not in trie.
 		return nil
 	}
 
 	if n.data != nil {
-		buffer = append(buffer, V4TrieEntry{CIDR: n.cidr, Data: n.data})
+		buffer = append(buffer, CIDRTrieEntry{CIDR: n.cidr, Data: n.data})
 	}
 
 	if cidr == n.cidr {
@@ -159,17 +175,22 @@ func (n *V4Node) lookupPath(buffer []V4TrieEntry, cidr V4CIDR) []V4TrieEntry {
 
 	// If we get here, then this node is a parent of the CIDR we're looking for.
 	// Figure out which child to recurse on.
-	childIdx := cidr.addr.NthBit(uint(n.cidr.prefix + 1))
+	childIdx := cidr.Addr().NthBit(uint(n.cidr.Prefix() + 1))
 	child := n.children[childIdx]
 	return child.lookupPath(buffer, cidr)
 }
 
-func (n *V4Node) get(cidr V4CIDR) interface{} {
+func (n *CIDRNode) get(cidr CIDR) interface{} {
 	if n == nil {
 		return nil
 	}
 
-	if !n.cidr.ContainsV4(cidr.addr) {
+	if n.cidr.Version() != cidr.Version() {
+		// IP version mismatch
+		return nil
+	}
+
+	if !n.cidr.Contains(cidr.Addr()) {
 		// Not in trie.
 		return nil
 	}
@@ -184,25 +205,33 @@ func (n *V4Node) get(cidr V4CIDR) interface{} {
 
 	// If we get here, then this node is a parent of the CIDR we're looking for.
 	// Figure out which child to recurse on.
-	childIdx := cidr.addr.NthBit(uint(n.cidr.prefix + 1))
+	childIdx := cidr.Addr().NthBit(uint(n.cidr.Prefix() + 1))
 	child := n.children[childIdx]
 	return child.get(cidr)
 }
 
-func (t *V4Trie) CoveredBy(cidr V4CIDR) bool {
-	return V4CommonPrefix(t.root.cidr, cidr) == cidr
+func (t *CIDRTrie) CoveredBy(cidr CIDR) bool {
+	pfx, err := CommonPrefix(t.root.cidr, cidr)
+	if err != nil {
+		return false
+	}
+	return pfx == cidr
 }
 
-func (t *V4Trie) Covers(cidr V4CIDR) bool {
+func (t *CIDRTrie) Covers(cidr CIDR) bool {
 	return t.root.covers(cidr)
 }
 
-func (n *V4Node) covers(cidr V4CIDR) bool {
+func (n *CIDRNode) covers(cidr CIDR) bool {
 	if n == nil {
 		return false
 	}
 
-	if V4CommonPrefix(n.cidr, cidr) != n.cidr {
+	commonPfx, err := CommonPrefix(n.cidr, cidr)
+	if err != nil {
+		return false
+	}
+	if commonPfx != n.cidr {
 		// Not in trie.
 		return false
 	}
@@ -213,21 +242,24 @@ func (n *V4Node) covers(cidr V4CIDR) bool {
 
 	// If we get here, then this node is a parent of the CIDR we're looking for.
 	// Figure out which child to recurse on.
-	childIdx := cidr.addr.NthBit(uint(n.cidr.prefix + 1))
+	childIdx := cidr.Addr().NthBit(uint(n.cidr.Prefix() + 1))
 	child := n.children[childIdx]
 	return child.covers(cidr)
 }
 
-func (t *V4Trie) Intersects(cidr V4CIDR) bool {
+func (t *CIDRTrie) Intersects(cidr CIDR) bool {
 	return t.root.intersects(cidr)
 }
 
-func (n *V4Node) intersects(cidr V4CIDR) bool {
+func (n *CIDRNode) intersects(cidr CIDR) bool {
 	if n == nil {
 		return false
 	}
 
-	common := V4CommonPrefix(n.cidr, cidr)
+	common, err := CommonPrefix(n.cidr, cidr)
+	if err != nil {
+		return false
+	}
 
 	if common == cidr {
 		// This node's CIDR is contained within the target CIDR so we must have
@@ -242,17 +274,17 @@ func (n *V4Node) intersects(cidr V4CIDR) bool {
 
 	// If we get here, then this node is a parent of the CIDR we're looking for.
 	// Figure out which child to recurse on.
-	childIdx := cidr.addr.NthBit(uint(n.cidr.prefix + 1))
+	childIdx := cidr.Addr().NthBit(uint(n.cidr.Prefix() + 1))
 	child := n.children[childIdx]
 	return child.intersects(cidr)
 }
 
-func (n *V4Node) appendTo(s []V4TrieEntry) []V4TrieEntry {
+func (n *CIDRNode) appendTo(s []CIDRTrieEntry) []CIDRTrieEntry {
 	if n == nil {
 		return s
 	}
 	if n.data != nil {
-		s = append(s, V4TrieEntry{
+		s = append(s, CIDRTrieEntry{
 			CIDR: n.cidr,
 			Data: n.data,
 		})
@@ -262,7 +294,7 @@ func (n *V4Node) appendTo(s []V4TrieEntry) []V4TrieEntry {
 	return s
 }
 
-func (n *V4Node) visit(f func(cidr V4CIDR, data interface{}) bool) bool {
+func (n *CIDRNode) visit(f func(cidr CIDR, data interface{}) bool) bool {
 	if n == nil {
 		return true
 	}
@@ -280,17 +312,17 @@ func (n *V4Node) visit(f func(cidr V4CIDR, data interface{}) bool) bool {
 	return n.children[1].visit(f)
 }
 
-func (t *V4Trie) ToSlice() []V4TrieEntry {
+func (t *CIDRTrie) ToSlice() []CIDRTrieEntry {
 	return t.root.appendTo(nil)
 }
 
-func (t *V4Trie) Visit(f func(cidr V4CIDR, data interface{}) bool) {
+func (t *CIDRTrie) Visit(f func(cidr CIDR, data interface{}) bool) {
 	t.root.visit(f)
 }
 
-func (t *V4Trie) Update(cidr V4CIDR, value interface{}) {
+func (t *CIDRTrie) Update(cidr CIDR, value interface{}) {
 	if value == nil {
-		log.Panic("Can't store nil in a V4Trie")
+		log.Panic("Can't store nil in a CIDRTrie")
 	}
 	parentsPtr := &t.root
 	thisNode := t.root
@@ -298,7 +330,7 @@ func (t *V4Trie) Update(cidr V4CIDR, value interface{}) {
 	for {
 		if thisNode == nil {
 			// We've run off the end of the tree, create new child to hold this data.
-			newNode := &V4Node{
+			newNode := &CIDRNode{
 				cidr: cidr,
 				data: value,
 			}
@@ -317,40 +349,58 @@ func (t *V4Trie) Update(cidr V4CIDR, value interface{}) {
 		// - The new CIDR contains this node, in which case we need to insert a new node as the parent of this one.
 		// - The two CIDRs are disjoint, in which case we need to insert a new intermediate node as the parent of
 		//   thisNode and the new CIDR.
-		commonPrefix := V4CommonPrefix(cidr, thisNode.cidr)
+		commonPrefix, err := CommonPrefix(cidr, thisNode.cidr)
+		if err != nil {
+			return
+		}
 
-		if commonPrefix.prefix == thisNode.cidr.prefix {
+		if commonPrefix.Prefix() == thisNode.cidr.Prefix() {
 			// Common is this node's CIDR so this node is parent of the new CIDR. Figure out which child to recurse on.
-			childIdx := cidr.addr.NthBit(uint(commonPrefix.prefix + 1))
+			childIdx := cidr.Addr().NthBit(uint(commonPrefix.Prefix() + 1))
 			parentsPtr = &thisNode.children[childIdx]
 			thisNode = thisNode.children[childIdx]
 			continue
 		}
 
-		if commonPrefix.prefix == cidr.prefix {
+		if commonPrefix.Prefix() == cidr.Prefix() {
 			// Common is new CIDR so this node is a child of the new CIDR. Insert new node.
-			newNode := &V4Node{
+			newNode := &CIDRNode{
 				cidr: cidr,
 				data: value,
 			}
-			childIdx := thisNode.cidr.addr.NthBit(uint(commonPrefix.prefix + 1))
+			childIdx := thisNode.cidr.Addr().NthBit(uint(commonPrefix.Prefix() + 1))
 			newNode.children[childIdx] = thisNode
 			*parentsPtr = newNode
 			return
 		}
 
 		// Neither CIDR contains the other.  Create an internal node with this node and new CIDR as children.
-		newInternalNode := &V4Node{
+		newInternalNode := &CIDRNode{
 			cidr: commonPrefix,
 		}
-		childIdx := thisNode.cidr.addr.NthBit(uint(commonPrefix.prefix + 1))
+		childIdx := thisNode.cidr.Addr().NthBit(uint(commonPrefix.Prefix() + 1))
 		newInternalNode.children[childIdx] = thisNode
-		newInternalNode.children[1-childIdx] = &V4Node{
+		newInternalNode.children[1-childIdx] = &CIDRNode{
 			cidr: cidr,
 			data: value,
 		}
 		*parentsPtr = newInternalNode
 		return
+	}
+}
+
+func CommonPrefix(a, b CIDR) (CIDR, error) {
+	if a.Version() != b.Version() {
+		return nil, fmt.Errorf("Mismatched CIDR IP versions")
+	}
+
+	switch a.Version() {
+	case 4:
+		return V4CommonPrefix(a.(V4CIDR), b.(V4CIDR)), nil
+	case 6:
+		return V6CommonPrefix(a.(V6CIDR), b.(V6CIDR)), nil
+	default:
+		return nil, fmt.Errorf("Invalid CIDR IP version")
 	}
 }
 

--- a/felix/ip/trie.go
+++ b/felix/ip/trie.go
@@ -97,7 +97,7 @@ func (t *CIDRTrie) Get(cidr CIDR) interface{} {
 	return t.root.get(cidr)
 }
 
-// LookupPath looks up the given CIDR in the trie.  It returns a slice containing a V4TrieEntry for each
+// LookupPath looks up the given CIDR in the trie.  It returns a slice containing a CIDRTrieEntry for each
 // CIDR in the trie that encloses the given CIDR.  If buffer is non-nil, then it is used to store the entries;
 // if it is too short append() is used to extend it and the updated slice is returned.
 //

--- a/felix/ip/trie_test.go
+++ b/felix/ip/trie_test.go
@@ -54,19 +54,19 @@ func cpEntry(a, b, exp string) TableEntry {
 	return Entry(fmt.Sprintf("Common prefix of %v and %v should be %v", a, b, exp), a, b, exp)
 }
 
-var _ = Describe("V4Trie tests", func() {
-	var trie *ip.V4Trie
+var _ = Describe("CIDRTrie tests", func() {
+	var trie *ip.CIDRTrie
 
 	BeforeEach(func() {
-		trie = &ip.V4Trie{}
+		trie = &ip.CIDRTrie{}
 	})
 
 	update := func(cidr string) {
-		trie.Update(ip.MustParseCIDROrIP(cidr).(ip.V4CIDR), "data:"+cidr)
+		trie.Update(ip.MustParseCIDROrIP(cidr), "data:"+cidr)
 	}
 
 	remove := func(cidr string) {
-		trie.Delete(ip.MustParseCIDROrIP(cidr).(ip.V4CIDR))
+		trie.Delete(ip.MustParseCIDROrIP(cidr))
 	}
 
 	contents := func() []string {
@@ -90,12 +90,12 @@ var _ = Describe("V4Trie tests", func() {
 	}
 
 	lpm := func(cidr string, expectedCidr string) interface{} {
-		cidrIn := ip.MustParseCIDROrIP(cidr).(ip.V4CIDR)
+		cidrIn := ip.MustParseCIDROrIP(cidr)
 		cidrOut, data := trie.LPM(cidrIn)
 
 		if data != nil {
-			Expect(cidrOut.ContainsV4(cidrIn.Addr().(ip.V4Addr))).To(BeTrue())
-			cidrExp := ip.MustParseCIDROrIP(expectedCidr).(ip.V4CIDR)
+			Expect(cidrOut.Contains(cidrIn.Addr())).To(BeTrue())
+			cidrExp := ip.MustParseCIDROrIP(expectedCidr)
 			Expect(cidrExp).To(Equal(cidrOut))
 		}
 

--- a/felix/ip/trie_test.go
+++ b/felix/ip/trie_test.go
@@ -69,7 +69,8 @@ var _ = Describe("CIDRTrie tests", func() {
 	})
 
 	update := func(cidr string) {
-		trie.Update(ip.MustParseCIDROrIP(cidr), "data:"+cidr)
+		parsedCIDR := ip.MustParseCIDROrIP(cidr)
+		trie.Update(parsedCIDR, "data:"+parsedCIDR.String())
 	}
 
 	remove := func(cidr string) {
@@ -209,6 +210,13 @@ var _ = Describe("CIDRTrie tests", func() {
 			update("fc00:fe11::/96")
 			remove("fc00:fe11:0:2:2::/128")
 			Expect(contents()).To(ConsistOf("fc00:fe11::/96"))
+		})
+
+		It("should look up the full path to a CIDR correctly", func() {
+			update("feed:beef::/64")
+			update("feed:beef:0:0:1::/96")
+			update("feed:beef:0:0:1::1/128") // non-canonical
+			Expect(lookup("feed:beef:0:0:1::1/128")).To(ConsistOf("feed:beef::/64", "feed:beef:0:0:1::/96", "feed:beef::1:0:0:1/128"))
 		})
 
 		It("should fail to lookup in empty trie", func() {

--- a/felix/ip/trie_test.go
+++ b/felix/ip/trie_test.go
@@ -26,28 +26,35 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
-var _ = DescribeTable("V4CommonPrefix",
+var _ = DescribeTable("CommonPrefix",
 	func(a, b, expected string) {
-		aCIDR := ip.MustParseCIDROrIP(a).(ip.V4CIDR)
-		bCIDR := ip.MustParseCIDROrIP(b).(ip.V4CIDR)
-		expCIDR := ip.MustParseCIDROrIP(expected).(ip.V4CIDR)
+		aCIDR := ip.MustParseCIDROrIP(a)
+		bCIDR := ip.MustParseCIDROrIP(b)
+		expCIDR := ip.MustParseCIDROrIP(expected)
 
-		Expect(ip.V4CommonPrefix(aCIDR, bCIDR)).To(Equal(expCIDR))
-		Expect(ip.V4CommonPrefix(bCIDR, aCIDR)).To(Equal(expCIDR))
+		Expect(ip.CommonPrefix(aCIDR, bCIDR)).To(Equal(expCIDR))
+		Expect(ip.CommonPrefix(bCIDR, aCIDR)).To(Equal(expCIDR))
 	},
 	// Zero cases.
 	cpEntry("0.0.0.0/0", "0.0.0.0/0", "0.0.0.0/0"),
 	cpEntry("0.0.0.0/0", "10.0.0.0/8", "0.0.0.0/0"),
 	cpEntry("0.0.0.0/0", "0.0.3.0/24", "0.0.0.0/0"),
+	cpEntry("::/0", "::/0", "::/0"),
+	cpEntry("::/0", "fc00:fe11::/96", "::/0"),
+	cpEntry("::/0", "::3:0/120", "::/0"),
 
 	// One contained in the other.
 	cpEntry("10.0.0.0/8", "10.0.3.0/24", "10.0.0.0/8"),
+	cpEntry("fc00:fe11::/96", "fc00:fe11:3::/120", "fc00:fe11::/46"),
 
 	// Disjoint.
 	cpEntry("64.0.0.0/8", "65.0.3.0/24", "64.0.0.0/7"),
 	cpEntry("64.0.0.0/9", "65.0.3.128/25", "64.0.0.0/7"),
 	cpEntry("64.0.3.0/24", "65.0.3.0/24", "64.0.0.0/7"),
 	cpEntry("64.0.3.0/8", "64.0.3.0/24", "64.0.0.0/8"), // Non-canonical CIDR
+	cpEntry("fc00:fe11::/96", "fcff:fe11::/120", "fc00::/8"),
+	cpEntry("fc00:fe11::/112", "fcff:fe11::/120", "fc00::/8"),
+	cpEntry("fc00:fe11:3::/112", "fcff:fe11::/120", "fc00::/8"),
 )
 
 func cpEntry(a, b, exp string) TableEntry {
@@ -81,7 +88,7 @@ var _ = Describe("CIDRTrie tests", func() {
 
 	lookup := func(cidr string) []string {
 		var s []string
-		for _, t := range trie.LookupPath(nil, ip.MustParseCIDROrIP(cidr).(ip.V4CIDR)) {
+		for _, t := range trie.LookupPath(nil, ip.MustParseCIDROrIP(cidr)) {
 			cidrStr := t.CIDR.String()
 			Expect(t.Data).To(Equal("data:"+cidrStr), "Trie returned entry with unexpected data")
 			s = append(s, cidrStr)
@@ -102,118 +109,273 @@ var _ = Describe("CIDRTrie tests", func() {
 		return data
 	}
 
-	It("should allow inserting a single CIDR", func() {
-		update("10.0.0.0/8")
-		Expect(contents()).To(ConsistOf("10.0.0.0/8"))
+	Context("IPv4", func() {
+		BeforeEach(func() {
+			trie = &ip.CIDRTrie{}
+		})
+
+		It("should allow inserting a single CIDR", func() {
+			update("10.0.0.0/8")
+			Expect(contents()).To(ConsistOf("10.0.0.0/8"))
+		})
+
+		It("should ignore deletes on an empty trie", func() {
+			remove("11.0.0.0/8")
+			Expect(contents()).To(BeEmpty())
+		})
+
+		It("should ignore deletes for outside the trie", func() {
+			update("10.0.0.0/8")
+			remove("11.0.0.0/8")
+			Expect(contents()).To(ConsistOf("10.0.0.0/8"))
+		})
+
+		It("should ignore deletes when recursing on child that turns out to have a mismatch with the target", func() {
+			update("10.0.0.0/8")
+			update("10.0.1.0/24")
+			remove("10.0.0.1/32")
+			Expect(contents()).To(ConsistOf("10.0.0.0/8", "10.0.1.0/24"))
+		})
+
+		It("should ignore deletes when child is missing", func() {
+			update("10.0.0.0/8")
+			remove("10.0.0.1/32")
+			Expect(contents()).To(ConsistOf("10.0.0.0/8"))
+		})
+
+		It("should fail to lookup in empty trie", func() {
+			Expect(lookup("11.0.0.0/8")).To(BeEmpty())
+		})
+
+		It("should fail to lookup outside the trie", func() {
+			update("10.0.0.0/8")
+			Expect(lookup("11.0.0.0/8")).To(BeEmpty())
+		})
+
+		It("should fail to lookup intermediate node", func() {
+			update("0.0.0.0/1")
+			update("128.0.0.0/1")
+			Expect(lookup("0.0.0.0/0")).To(BeEmpty())
+		})
+
+		It("should fail to lookup when recursing on child that turns out to have a mismatch with the target", func() {
+			update("10.0.0.0/8")
+			update("10.0.1.0/24")
+			Expect(lookup("11.0.0.0/8")).To(BeEmpty())
+		})
+
+		It("should fail to lookup when child is missing", func() {
+			update("10.0.0.0/8")
+			Expect(lookup("11.0.0.0/8")).To(BeEmpty())
+		})
+
+		It("should panic when inserting/deleting/looking up a mismatched IP version CIDR", func() {
+			update("10.0.0.0/8")
+			Expect(func() { update("fc00:fe11::/96") }).To(Panic())
+			Expect(func() { remove("fc00:fe11::/96") }).To(Panic())
+			Expect(func() { lookup("fc00:fe11::/96") }).To(Panic())
+		})
 	})
 
-	It("should ignore deletes empty trie", func() {
-		remove("11.0.0.0/8")
-		Expect(contents()).To(BeEmpty())
-	})
+	Context("IPv6", func() {
+		BeforeEach(func() {
+			trie = &ip.CIDRTrie{}
+		})
 
-	It("should ignore deletes for outside the trie", func() {
-		update("10.0.0.0/8")
-		remove("11.0.0.0/8")
-		Expect(contents()).To(ConsistOf("10.0.0.0/8"))
-	})
+		It("should allow inserting a single CIDR", func() {
+			update("fc00:fe11::/96")
+			Expect(contents()).To(ConsistOf("fc00:fe11::/96"))
+		})
 
-	It("should ignore deletes when recursing on child that turns out to have a mismatch with the target", func() {
-		update("10.0.0.0/8")
-		update("10.0.1.0/24")
-		remove("10.0.0.1/32")
-		Expect(contents()).To(ConsistOf("10.0.0.0/8", "10.0.1.0/24"))
-	})
+		It("should ignore deletes on an empty trie", func() {
+			remove("fc00:fe12::/96")
+			Expect(contents()).To(BeEmpty())
+		})
 
-	It("should ignore deletes when child is missing", func() {
-		update("10.0.0.0/8")
-		remove("10.0.0.1/32")
-		Expect(contents()).To(ConsistOf("10.0.0.0/8"))
-	})
+		It("should ignore deletes for outside the trie", func() {
+			update("fc00:fe11::/96")
+			remove("fcff:fe11::/96")
+			Expect(contents()).To(ConsistOf("fc00:fe11::/96"))
+		})
 
-	It("should fail to lookup in empty trie", func() {
-		Expect(lookup("11.0.0.0/8")).To(BeEmpty())
-	})
+		It("should ignore deletes when recursing on child that turns out to have a mismatch with the target", func() {
+			update("fc00:fe11::/96")
+			update("fc00:fe11:0:1::/120")
+			remove("fc00:fe11:0:2:2::/128")
+			Expect(contents()).To(ConsistOf("fc00:fe11::/96", "fc00:fe11:0:1::/120"))
+		})
 
-	It("should fail to lookup outside the trie", func() {
-		update("10.0.0.0/8")
-		Expect(lookup("11.0.0.0/8")).To(BeEmpty())
-	})
+		It("should ignore deletes when child is missing", func() {
+			update("fc00:fe11::/96")
+			remove("fc00:fe11:0:2:2::/128")
+			Expect(contents()).To(ConsistOf("fc00:fe11::/96"))
+		})
 
-	It("should fail to lookup intermediate node", func() {
-		update("0.0.0.0/1")
-		update("128.0.0.0/1")
-		Expect(lookup("0.0.0.0/0")).To(BeEmpty())
-	})
+		It("should fail to lookup in empty trie", func() {
+			Expect(lookup("fc00:fe11:0:1::/120")).To(BeEmpty())
+		})
 
-	It("should fail to lookup when recursing on child that turns out to have a mismatch with the target", func() {
-		update("10.0.0.0/8")
-		update("10.0.1.0/24")
-		Expect(lookup("11.0.0.0/8")).To(BeEmpty())
-	})
+		It("should fail to lookup outside the trie", func() {
+			update("fc00:fe11::/96")
+			Expect(lookup("fcff:fe11::/96")).To(BeEmpty())
+		})
 
-	It("should fail to lookup when child is missing", func() {
-		update("10.0.0.0/8")
-		Expect(lookup("11.0.0.0/8")).To(BeEmpty())
+		It("should fail to lookup intermediate node", func() {
+			update("::/1")
+			update("fc00::/1")
+			Expect(lookup("::/0")).To(BeEmpty())
+		})
+
+		It("should fail to lookup when recursing on child that turns out to have a mismatch with the target", func() {
+			update("fc00:fe11::/96")
+			update("fc00:fe11:0:1::/120")
+			Expect(lookup("fcff:fe11:0:2:2::/96")).To(BeEmpty())
+		})
+
+		It("should fail to lookup when child is missing", func() {
+			update("fc00:fe11::/96")
+			Expect(lookup("fcff:fe11:0:2:2::/96")).To(BeEmpty())
+		})
+
+		It("should panic when inserting/deleting/looking up a mismatched IP version CIDR", func() {
+			update("fc00:fe11::/96")
+			Expect(func() { update("10.0.0.1/8") }).To(Panic())
+			Expect(func() { remove("10.0.0.1/8") }).To(Panic())
+			Expect(func() { lookup("10.0.0.1/8") }).To(Panic())
+		})
 	})
 
 	Context("LPM", func() {
-		Context("single node", func() {
+		Context("IPv4", func() {
 			BeforeEach(func() {
-				update("10.2.1.0/24")
+				trie = &ip.CIDRTrie{}
 			})
 
-			It("should find 10.2.1.1", func() {
-				Expect(lpm("10.2.1.1/32", "10.2.1.0/24")).NotTo(BeNil())
+			Context("single node", func() {
+				BeforeEach(func() {
+					update("10.2.1.0/24")
+				})
+
+				It("should find 10.2.1.1", func() {
+					Expect(lpm("10.2.1.1/32", "10.2.1.0/24")).NotTo(BeNil())
+				})
+
+				It("should not find 10.2.3.1", func() {
+					Expect(lpm("10.2.3.1/32", "")).To(BeNil())
+				})
 			})
 
-			It("should not find 10.2.3.1", func() {
-				Expect(lpm("10.2.3.1/32", "")).To(BeNil())
+			Context("without value in root", func() {
+				BeforeEach(func() {
+					update("1.1.1.1/8")
+					update("1.1.5.1/24")
+					update("1.1.1.1/16")
+					update("1.1.1.1/32")
+					update("2.1.1.1/8")
+					update("2.1.1.1/16")
+				})
+
+				It("should find precise", func() {
+					Expect(lpm("1.1.1.1/32", "1.1.1.1/32")).NotTo(BeNil())
+				})
+
+				It("should find prefix for precise", func() {
+					Expect(lpm("1.1.1.5/32", "1.1.1.1/16")).NotTo(BeNil())
+				})
+
+				It("should find internal node", func() {
+					Expect(lpm("1.1.0.0/16", "1.1.0.0/16")).NotTo(BeNil())
+				})
+
+				It("should find internal prefix", func() {
+					Expect(lpm("1.1.2.0/24", "1.1.0.0/16")).NotTo(BeNil())
+				})
+
+				It("should find root prefix", func() {
+					Expect(lpm("3.0.0.0/7", "2.1.1.1/8")).NotTo(BeNil())
+				})
+
+				It("should not find prefix", func() {
+					Expect(lpm("4.0.0.0/7", "")).To(BeNil())
+				})
+
+			})
+
+			Context("LPM with root", func() {
+				BeforeEach(func() {
+					update("0.0.0.0/0")
+				})
+
+				It("should find root", func() {
+					Expect(lpm("4.0.0.0/7", "0.0.0.0/0")).NotTo(BeNil())
+				})
 			})
 		})
 
-		Context("without value in root", func() {
+		Context("IPv6", func() {
 			BeforeEach(func() {
-				update("1.1.1.1/8")
-				update("1.1.5.1/24")
-				update("1.1.1.1/16")
-				update("1.1.1.1/32")
-				update("2.1.1.1/8")
-				update("2.1.1.1/16")
+				trie = &ip.CIDRTrie{}
 			})
 
-			It("should find precise", func() {
-				Expect(lpm("1.1.1.1/32", "1.1.1.1/32")).NotTo(BeNil())
+			Context("single node", func() {
+				BeforeEach(func() {
+					update("fc00:fe11::1/112")
+				})
+
+				It("should find fc00:fe11::1", func() {
+					Expect(lpm("fc00:fe11::1/128", "fc00:fe11::/112")).NotTo(BeNil())
+				})
+
+				It("should not find fcff:fe11::1", func() {
+					Expect(lpm("fcff:fe11::1/128", "")).To(BeNil())
+				})
 			})
 
-			It("should find prefix for precise", func() {
-				Expect(lpm("1.1.1.5/32", "1.1.1.1/16")).NotTo(BeNil())
+			Context("without value in root", func() {
+				BeforeEach(func() {
+					update("7c00:fe11::1/96")
+					update("7c00:fe11:5::1/112")
+					update("7c00:fe11::1/104")
+					update("7c00:fe11::1/128")
+					update("fc00:fe11::1/96")
+					update("fc00:fe11::1/104")
+				})
+
+				It("should find precise", func() {
+					Expect(lpm("7c00:fe11::1/128", "7c00:fe11::1/128")).NotTo(BeNil())
+				})
+
+				It("should find prefix for precise", func() {
+					Expect(lpm("7c00:fe11::5/128", "7c00:fe11::1/104")).NotTo(BeNil())
+				})
+
+				It("should find internal node", func() {
+					Expect(lpm("7c00:fe11::/104", "7c00:fe11::/104")).NotTo(BeNil())
+				})
+
+				It("should find internal prefix", func() {
+					Expect(lpm("7c00:fe11::/112", "7c00:fe11::/104")).NotTo(BeNil())
+				})
+
+				It("should find root prefix", func() {
+					// Expect(trie).To(BeNil()) //TODO
+					Expect(lpm("fc00:fe11::/32", "fc00:fe11::1/104")).NotTo(BeNil())
+				})
+
+				It("should not find prefix", func() {
+					Expect(lpm("8000::/8", "")).To(BeNil())
+				})
+
 			})
 
-			It("should find internal node", func() {
-				Expect(lpm("1.1.0.0/16", "1.1.0.0/16")).NotTo(BeNil())
-			})
+			Context("LPM with root", func() {
+				BeforeEach(func() {
+					update("::/0")
+				})
 
-			It("should find internal prefix", func() {
-				Expect(lpm("1.1.2.0/24", "1.1.0.0/16")).NotTo(BeNil())
-			})
-
-			It("should find root prefix", func() {
-				Expect(lpm("3.0.0.0/7", "2.1.1.1/8")).NotTo(BeNil())
-			})
-
-			It("should not find prefix", func() {
-				Expect(lpm("4.0.0.0/7", "")).To(BeNil())
-			})
-		})
-
-		Context("LPM with root", func() {
-			BeforeEach(func() {
-				update("0.0.0.0/0")
-			})
-
-			It("should find root", func() {
-				Expect(lpm("4.0.0.0/7", "0.0.0.0/0")).NotTo(BeNil())
+				It("should find root", func() {
+					Expect(lpm("fc00:fe11::1/112", "::/0")).NotTo(BeNil())
+				})
 			})
 		})
 	})
@@ -263,6 +425,12 @@ var _ = Describe("CIDRTrie tests", func() {
 		pEntry("132.2.3.4/32", "132.2.3.5/32", "132.2.3.6/32"),
 		pEntry("0.0.0.0/0", "128.0.0.0/1", "0.0.0.0/1"), // 0.0.0.0/0 is the intermediate node for the other two CIDRs.
 		pEntry("1.0.0.0/8", "1.0.0.0/24", "1.0.0.27/32"),
+		pEntry("::/0"),
+		pEntry("fc00:fe11::/96"),
+		pEntry("::/0", "fc00:fe11::/96", "fcff:fe11::/96"),
+		pEntry("fc00:fe11::4/128", "fc00:fe11::5/128", "fc00:fe11::6/128"),
+		pEntry("::/0", "8000::/1", "::/1"), // ::/0 is the intermediate node for the other two CIDRs.
+		pEntry("fc00:fe11::/96", "fc00:fe11:1:2:3::/120", "fc00:fe11:1:2:3::1/128"),
 	)
 })
 

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -325,6 +325,10 @@ func (c *autoHostEndpointController) getAutoHostendpointExpectedIPs(node *libapi
 		expectedIPs = append(expectedIPs, node.Spec.IPv4VXLANTunnelAddr)
 		ipMap[node.Spec.IPv4VXLANTunnelAddr] = struct{}{}
 	}
+	if node.Spec.IPv6VXLANTunnelAddr != "" {
+		expectedIPs = append(expectedIPs, node.Spec.IPv6VXLANTunnelAddr)
+		ipMap[node.Spec.IPv6VXLANTunnelAddr] = struct{}{}
+	}
 	if node.Spec.Wireguard != nil && node.Spec.Wireguard.InterfaceIPv4Address != "" {
 		expectedIPs = append(expectedIPs, node.Spec.Wireguard.InterfaceIPv4Address)
 		ipMap[node.Spec.Wireguard.InterfaceIPv4Address] = struct{}{}

--- a/kube-controllers/pkg/controllers/node/ipam_allocation.go
+++ b/kube-controllers/pkg/controllers/node/ipam_allocation.go
@@ -224,8 +224,9 @@ func (a *allocation) isPodIP() bool {
 func (a *allocation) isTunnelAddress() bool {
 	ipip := a.attrs[ipam.AttributeType] == ipam.AttributeTypeIPIP
 	vxlan := a.attrs[ipam.AttributeType] == ipam.AttributeTypeVXLAN
+	vxlanV6 := a.attrs[ipam.AttributeType] == ipam.AttributeTypeVXLANV6
 	wg := a.attrs[ipam.AttributeType] == ipam.AttributeTypeWireguard
-	return ipip || vxlan || wg
+	return ipip || vxlan || vxlanV6 || wg
 }
 
 func (a *allocation) isWindowsReserved() bool {

--- a/kube-controllers/tests/fv/node_auto_hep_test.go
+++ b/kube-controllers/tests/fv/node_auto_hep_test.go
@@ -158,10 +158,11 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 			cn.Spec.BGP.IPv4Address = "172.100.2.3"
 			cn.Spec.BGP.IPv4IPIPTunnelAddr = ""
 			cn.Spec.IPv4VXLANTunnelAddr = "10.10.20.1"
+			cn.Spec.IPv6VXLANTunnelAddr = "dead:beef::1"
 		})).NotTo(HaveOccurred())
 
 		// Expect the hostendpoint's expectedIPs to sync the new node IPs.
-		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1"}
+		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "dead:beef::1"}
 		Eventually(func() error {
 			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
@@ -174,7 +175,7 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 		})).NotTo(HaveOccurred())
 
 		// Expect the HEP to include the wireguard IP.
-		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "192.168.100.1"}
+		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "dead:beef::1", "192.168.100.1"}
 		Eventually(func() error {
 			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())
@@ -193,7 +194,7 @@ var _ = Describe("Auto Hostendpoint tests", func() {
 		})).NotTo(HaveOccurred())
 
 		// Expect the HEP to include the internal IP from Addresses.
-		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "192.168.100.1", "192.168.200.1"}
+		expectedIPs = []string{"172.100.2.3", "fe80::1", "10.10.20.1", "dead:beef::1", "192.168.100.1", "192.168.200.1"}
 		Eventually(func() error {
 			return testutils.ExpectHostendpoint(c, expectedHepName, expectedHepLabels, expectedIPs, autoHepProfiles)
 		}, time.Second*15, 500*time.Millisecond).Should(BeNil())

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/felixnodeprocessor.go
@@ -97,13 +97,13 @@ func (c *FelixNodeUpdateProcessor) Process(kvp *model.KVPair) ([]*model.KVPair, 
 		}
 		// Look for internal node address, if BGP is not running
 		if ipv4 == nil {
-			ip, _ := cresources.FindNodeAddress(node, libapiv3.InternalIP)
+			ip, _ := cresources.FindNodeAddress(node, libapiv3.InternalIP, 4)
 			if ip != nil {
 				ipv4 = ip
 			}
 		}
 		if ipv4 == nil {
-			ip, _ := cresources.FindNodeAddress(node, libapiv3.ExternalIP)
+			ip, _ := cresources.FindNodeAddress(node, libapiv3.ExternalIP, 4)
 			if ip != nil {
 				ipv4 = ip
 			}

--- a/libcalico-go/lib/resources/node.go
+++ b/libcalico-go/lib/resources/node.go
@@ -23,18 +23,18 @@ import (
 
 // FindNodeAddress returns node address of the specified type. Type can be one of
 // CalicoNodeIP, InternalIP or ExternalIP
-func FindNodeAddress(node *libapiv3.Node, ipType string) (*cnet.IP, *cnet.IPNet) {
+func FindNodeAddress(node *libapiv3.Node, ipType string, ipVersion int) (*cnet.IP, *cnet.IPNet) {
 	for _, addr := range node.Spec.Addresses {
 		if addr.Type == ipType {
 			ip, cidr, err := cnet.ParseCIDROrIP(addr.Address)
 			if err == nil {
-				if ip.To4() == nil {
+				if ipVersion != ip.Version() {
 					continue
 				}
-				log.WithFields(log.Fields{"ip": ip, "cidr": cidr}).Debug("Parsed IPv4 address")
+				log.WithFields(log.Fields{"ip": ip, "cidr": cidr}).Debug("Parsed IP address")
 				return ip, cidr
 			} else {
-				log.WithError(err).WithField("IPv4Address", addr.Address).Warn("Failed to parse IPv4Address")
+				log.WithError(err).WithField("IP address", addr.Address).Warn("Failed to parse IP address")
 			}
 		}
 	}

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -754,6 +754,7 @@ func configureIPPools(ctx context.Context, client client.Interface, kubeadmConfi
 
 	ipv4IpipModeEnvVar := strings.ToLower(os.Getenv("CALICO_IPV4POOL_IPIP"))
 	ipv4VXLANModeEnvVar := strings.ToLower(os.Getenv("CALICO_IPV4POOL_VXLAN"))
+	ipv6VXLANModeEnvVar := strings.ToLower(os.Getenv("CALICO_IPV6POOL_VXLAN"))
 
 	var (
 		ipv4BlockSize int
@@ -847,7 +848,7 @@ func configureIPPools(ctx context.Context, client client.Interface, kubeadmConfi
 		log.Debug("Create default IPv6 IP pool")
 		outgoingNATEnabled := evaluateENVBool("CALICO_IPV6POOL_NAT_OUTGOING", false)
 
-		createIPPool(ctx, client, ipv6Cidr, DEFAULT_IPV6_POOL_NAME, string(api.IPIPModeNever), string(api.VXLANModeNever), outgoingNATEnabled, ipv6BlockSize, ipv6NodeSelector)
+		createIPPool(ctx, client, ipv6Cidr, DEFAULT_IPV6_POOL_NAME, string(api.IPIPModeNever), ipv6VXLANModeEnvVar, outgoingNATEnabled, ipv6BlockSize, ipv6NodeSelector)
 	}
 }
 
@@ -880,7 +881,7 @@ func createIPPool(ctx context.Context, client client.Interface, cidr *cnet.IPNet
 	case "always":
 		vxlanMode = api.VXLANModeAlways
 	default:
-		log.Errorf("Unrecognized VXLAN mode specified in CALICO_IPV4POOL_VXLAN'%s'", vxlanModeName)
+		log.Errorf("Unrecognized VXLAN mode specified in CALICO_IPV%dPOOL_VXLAN '%s'", version, vxlanModeName)
 		utils.Terminate()
 	}
 

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -376,6 +376,10 @@ var _ = Describe("FV tests against a real etcd", func() {
 			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV6POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "CrossSubnet"}},
 			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN and CALICO_IPV6POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "CrossSubnet"}, {"CALICO_IPV6POOL_VXLAN", "CrossSubnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set CrossSubnet and CALICO_IPV6POOL_VXLAN set Always", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "CrossSubnet"}, {"CALICO_IPV6POOL_VXLAN", "Always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "Always", true, false, 26, 122, "all()", "all()"),
 	)
 
 	It("should properly clear node IPs", func() {

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -182,7 +182,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 	})
 
 	DescribeTable("Test IP pool env variables",
-		func(envList []EnvItem, expectedIPv4 string, expectedIPv6 string, expectIpv4IpipMode string, expectedIPV4NATOutgoing bool, expectedIPV6NATOutgoing bool, expectedIPv4BlockSize, expectedIPv6BlockSize int, expectedIPv4NodeSelector, expectedIPv6NodeSelector string) {
+		func(envList []EnvItem, expectedIPv4 string, expectedIPv6 string, expectIpv4IpipMode string, expectIpv4VXLANMode string, expectIpv6VXLANMode string, expectedIPV4NATOutgoing bool, expectedIPV6NATOutgoing bool, expectedIPv4BlockSize, expectedIPv6BlockSize int, expectedIPv4NodeSelector, expectedIPv6NodeSelector string) {
 			// Create a new client.
 			cfg, err := apiconfig.LoadClientConfigFromEnvironment()
 			Expect(err).NotTo(HaveOccurred())
@@ -234,6 +234,13 @@ var _ = Describe("FV tests against a real etcd", func() {
 
 					Expect(pool.Spec.IPIPMode).To(Equal(api.IPIPModeNever))
 
+					// off is not a real mode value but use it instead of empty string
+					if expectIpv6VXLANMode == "Off" {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANModeNever))
+					} else {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANMode(expectIpv6VXLANMode)))
+					}
+
 					Expect(pool.Spec.NATOutgoing).To(Equal(expectedIPV6NATOutgoing), "Expected IPv6 to be %t but was %t", expectedIPV6NATOutgoing, pool.Spec.NATOutgoing)
 
 					Expect(pool.Spec.BlockSize).To(Equal(expectedIPv6BlockSize), "Expected IPv6 blocksize to be %d but was %d", expectedIPv6BlockSize, pool.Spec.BlockSize)
@@ -246,6 +253,13 @@ var _ = Describe("FV tests against a real etcd", func() {
 						Expect(pool.Spec.IPIPMode).To(Equal(api.IPIPModeNever))
 					} else {
 						Expect(pool.Spec.IPIPMode).To(Equal(api.IPIPMode(expectIpv4IpipMode)))
+					}
+
+					// off is not a real mode value but use it instead of empty string
+					if expectIpv4VXLANMode == "Off" {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANModeNever))
+					} else {
+						Expect(pool.Spec.VXLANMode).To(Equal(api.VXLANMode(expectIpv4VXLANMode)))
 					}
 
 					Expect(pool.Spec.NATOutgoing).To(Equal(expectedIPV4NATOutgoing), "Expected IPv4 to be %t but was %t", expectedIPV4NATOutgoing, pool.Spec.NATOutgoing)
@@ -263,72 +277,105 @@ var _ = Describe("FV tests against a real etcd", func() {
 		},
 
 		Entry("No env variables set", []EnvItem{},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv4 Pool env var set",
 			[]EnvItem{{"CALICO_IPV4POOL_CIDR", "172.16.0.0/24"}},
-			"172.16.0.0/24", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"172.16.0.0/24", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv6 Pool env var set",
 			[]EnvItem{{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"}},
-			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("Both IPv4 and IPv6 Pool env var set",
 			[]EnvItem{
 				{"CALICO_IPV4POOL_CIDR", "172.16.0.0/24"},
 				{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"},
 			},
-			"172.16.0.0/24", "fdff:ffff:ffff:ffff:ffff::/80", "Off", true, false, 26, 122, "all()", "all()"),
+			"172.16.0.0/24", "fdff:ffff:ffff:ffff:ffff::/80", "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set off", []EnvItem{{"CALICO_IPV4POOL_IPIP", "off"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set Off", []EnvItem{{"CALICO_IPV4POOL_IPIP", "Off"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set Never", []EnvItem{{"CALICO_IPV4POOL_IPIP", "Never"}},
-			"192.168.0.0/16", randomULAPool, "Never", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Never", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set empty string", []EnvItem{{"CALICO_IPV4POOL_IPIP", ""}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set always", []EnvItem{{"CALICO_IPV4POOL_IPIP", "always"}},
-			"192.168.0.0/16", randomULAPool, "Always", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Always", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set Always", []EnvItem{{"CALICO_IPV4POOL_IPIP", "Always"}},
-			"192.168.0.0/16", randomULAPool, "Always", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Always", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set cross-subnet", []EnvItem{{"CALICO_IPV4POOL_IPIP", "cross-subnet"}},
-			"192.168.0.0/16", randomULAPool, "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "CrossSubnet", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_IPIP set CrossSubnet", []EnvItem{{"CALICO_IPV4POOL_IPIP", "CrossSubnet"}},
-			"192.168.0.0/16", randomULAPool, "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "CrossSubnet", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_BLOCK_SIZE set 27", []EnvItem{{"CALICO_IPV4POOL_BLOCK_SIZE", "27"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 27, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 27, 122, "all()", "all()"),
 		Entry("IPv6 Pool and IPIP set",
 			[]EnvItem{
 				{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"},
 				{"CALICO_IPV4POOL_IPIP", "always"},
 			},
-			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Always", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "Always", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv6 NATOutgoing Set Enabled",
 			[]EnvItem{
 				{"CALICO_IPV6POOL_NAT_OUTGOING", "true"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", true, true, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, true, 26, 122, "all()", "all()"),
 		Entry("IPv6 NATOutgoing Set Disabled",
 			[]EnvItem{
 				{"CALICO_IPV6POOL_NAT_OUTGOING", "false"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("IPv4 NATOutgoing Set Disabled",
 			[]EnvItem{
 				{"CALICO_IPV4POOL_NAT_OUTGOING", "false"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", false, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", false, false, 26, 122, "all()", "all()"),
 		Entry("IPv6 NAT OUTGOING and IPV4 NAT OUTGOING SET",
 			[]EnvItem{
 				{"CALICO_IPV4POOL_NAT_OUTGOING", "false"},
 				{"CALICO_IPV6POOL_NAT_OUTGOING", "true"},
 			},
-			"192.168.0.0/16", randomULAPool, "Off", false, true, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", false, true, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV6POOL_BLOCK_SIZE set 123", []EnvItem{{"CALICO_IPV6POOL_BLOCK_SIZE", "123"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 123, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 123, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_NODE_SELECTOR set all()", []EnvItem{{"CALICO_IPV4POOL_NODE_SELECTOR", "all()"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
 		Entry("CALICO_IPV4POOL_NODE_SELECTOR set has(something)", []EnvItem{{"CALICO_IPV4POOL_NODE_SELECTOR", "key == 'something'"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "key == 'something'", "all()"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "key == 'something'", "all()"),
 		Entry("CALICO_IPV6POOL_NODE_SELECTOR set failed", []EnvItem{{"CALICO_IPV6POOL_NODE_SELECTOR", "has(something)"}},
-			"192.168.0.0/16", randomULAPool, "Off", true, false, 26, 122, "all()", "has(something)"),
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "has(something)"),
+		Entry("CALICO_IPV4POOL_VXLAN set off", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set Off", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "Off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set Never", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "Never"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Never", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set empty string", []EnvItem{{"CALICO_IPV4POOL_VXLAN", ""}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set always", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Always", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set Always", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "Always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Always", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set cross-subnet", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "cross-subnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV4POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "CrossSubnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "CrossSubnet", "Off", true, false, 26, 122, "all()", "all()"),
+		// Reset CALICO_IPV4POOL_VXLAN here as well
+		Entry("CALICO_IPV6POOL_VXLAN set off", []EnvItem{{"CALICO_IPV4POOL_VXLAN", "off"}, {"CALICO_IPV6POOL_VXLAN", "off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set Off", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "Off"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set Never", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "Never"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Never", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set empty string", []EnvItem{{"CALICO_IPV6POOL_VXLAN", ""}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Off", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set always", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Always", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set Always", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "Always"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "Always", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set cross-subnet", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "cross-subnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
+		Entry("CALICO_IPV6POOL_VXLAN set CrossSubnet", []EnvItem{{"CALICO_IPV6POOL_VXLAN", "CrossSubnet"}},
+			"192.168.0.0/16", randomULAPool, "Off", "Off", "CrossSubnet", true, false, 26, 122, "all()", "all()"),
 	)
 
 	It("should properly clear node IPs", func() {

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -496,6 +496,9 @@ spec:
             # Enable or Disable VXLAN on the default IP pool.
             - name: CALICO_IPV4POOL_VXLAN
               value: "Never"
+            # Enable or Disable VXLAN on the default IPv6 IP pool.
+            - name: CALICO_IPV6POOL_VXLAN
+              value: "Never"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
               valueFrom:


### PR DESCRIPTION
Cherry pick of #5949 #5961 #5973 on release-v3.23.

#5949: Add V6Addr.AsUint64Pair(), V6Addr.NthBit() and
#5961: Add CALICO_IPV6POOL_VXLAN env var support to startup.go
#5973: Miscellaneous changes for IPv6 VXLAN support: - Auto Host