### PR TITLE
[release-v3.23] Automated cherry pick of #5709: windows: use upstream pause image instead of building our

### DIFF
--- a/calico/getting-started/windows-calico/openshift/installation.md
+++ b/calico/getting-started/windows-calico/openshift/installation.md
@@ -256,14 +256,6 @@ cp c:\k\config c:\k\kubeconfig
 c:\wmcb.exe configure-cni --cni-dir c:\k\cni --cni-config c:\k\cni\config\10-calico.conf
 ```
 
-Then, we need to override the pod infra image used by kubelet. This is to ensure
-the pod infrastructure image used is using the same base Windows Server OS as
-the node. (For more details, see this {% include open-new-window.html text='upstream issue' url='https://github.com/kubernetes/kubernetes/issues/87339' %}.) 
-
-```powershell
-docker tag kubeletwin/pause mcr.microsoft.com/k8s/core/pause:1.2.0
-```
-
 Finally, clean up the additional files created on the Windows node:
 
 ```powershell

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -58,6 +58,24 @@ function PrepareKubernetes()
     DownloadFiles
     ipmo C:\k\hns.psm1
     InstallK8sBinaries
+
+    # Prepull and tag the pause image for docker
+    if (-not (Get-IsContainerdRunning)) {
+        # If containerd is not running we assume the installation should be
+        # configured for docker. But in this case, docker has to be running.
+        $svc = Get-Service | where Name -EQ 'docker'
+        if ($svc -EQ $null) {
+            Write-Host "Docker service is not installed. Cannot prepare kubernetes pause image."
+            exit 1
+        }
+        if ($svc.Status -NE 'Running') {
+            Write-Host "Docker service is not running. Cannot prepare kubernetes pause image. Run 'Start-Service docker' and try again."
+            exit 1
+        }
+        $pause = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
+        docker pull $pause
+        docker tag $pause kubeletwin/pause
+    }
 }
 
 function InstallK8sBinaries()
@@ -365,10 +383,6 @@ if (!(Test-Path $CalicoZip))
 
 $platform=GetPlatformType
 
-if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
-    PrepareKubernetes
-}
-
 if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
     Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
     Exit
@@ -378,6 +392,11 @@ Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
 Write-Host "Unzip Calico for Windows release..."
 Expand-Archive -Force $CalicoZip c:\
 ipmo -force $RootDir\libs\calico\calico.psm1
+
+# This comes after we import calico.psm1
+if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
+    PrepareKubernetes
+}
 
 Write-Host "Setup Calico for Windows..."
 Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -50,35 +50,13 @@ function DownloadFiles()
     md $BaseDir\cni\config -ErrorAction Ignore
 
     Write-Host "Downloading Windows Kubernetes scripts"
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -Destination $BaseDir\InstallImages.ps1
     DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
-}
-
-function PrepareDockerFile()
-{
-    # Update Dockerfile for windows
-    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
-    $OSNumber = $OSInfo.WindowsVersion
-    $ExistOSNumber = cat c:\k\Dockerfile | findstr.exe $OSNumber
-    if (!$ExistOSNumber)
-    {
-        Write-Host "Update dockerfile for $OSNumber"
-
-        $ImageWithOSNumber = "nanoserver:" + $OSNumber
-        (get-content c:\k\Dockerfile) | foreach-object {$_ -replace "nanoserver", "$ImageWithOSNumber"} | set-content c:\k\Dockerfile
-    }
 }
 
 function PrepareKubernetes()
 {
     DownloadFiles
-    PrepareDockerFile
     ipmo C:\k\hns.psm1
-
-    # Prepare POD infra Images
-    c:\k\InstallImages.ps1
-
     InstallK8sBinaries
 }
 

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -50,7 +50,7 @@ function DownloadFiles()
     md $BaseDir\cni\config -ErrorAction Ignore
 
     Write-Host "Downloading Windows Kubernetes scripts"
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
 }
 
 function PrepareKubernetes()

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -65,7 +65,7 @@ else
     $argList += "--cni-bin-dir=""c:\k\cni"""
     $argList += "--cni-conf-dir=""c:\k\cni\config"""
     $argList += "--network-plugin=cni"
-    $argList += "--pod-infra-container-image=mcr.microsoft.com/oss/kubernetes/pause:3.6"
+    $argList += "--pod-infra-container-image=kubeletwin/pause"
     $argList += "--image-pull-progress-deadline=20m"
 }
 

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -65,7 +65,7 @@ else
     $argList += "--cni-bin-dir=""c:\k\cni"""
     $argList += "--cni-conf-dir=""c:\k\cni\config"""
     $argList += "--network-plugin=cni"
-    $argList += "--pod-infra-container-image=k8s.gcr.io/pause:3.6"
+    $argList += "--pod-infra-container-image=mcr.microsoft.com/oss/kubernetes/pause:3.6"
     $argList += "--image-pull-progress-deadline=20m"
 }
 

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -65,7 +65,7 @@ else
     $argList += "--cni-bin-dir=""c:\k\cni"""
     $argList += "--cni-conf-dir=""c:\k\cni\config"""
     $argList += "--network-plugin=cni"
-    $argList += "--pod-infra-container-image=kubeletwin/pause"
+    $argList += "--pod-infra-container-image=k8s.gcr.io/pause:3.6"
     $argList += "--image-pull-progress-deadline=20m"
 }
 


### PR DESCRIPTION
Cherry pick of #5709 on release-v3.23.

#5709: windows: use upstream pause image instead of building our

```release-note
windows: use upstream pause image in the quickstart for nodes using Docker as their runtime 
```