### PR TITLE
[master] Auto pick #5998: Use Mac/MacV6 from VTEP updates in vxlanManager

### DIFF
--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -403,7 +403,7 @@ func (m *vxlanManager) CompleteDeferredWork() error {
 		// known VTEPs.
 		var l2routes []routetable.L2Target
 		for _, u := range m.vtepsByNode {
-			mac, err := net.ParseMAC(u.Mac)
+			mac, err := m.parseMacForIPVersion(u)
 			if err != nil {
 				// Don't block programming of other VTEPs if somehow we receive one with a bad mac.
 				logrus.WithError(err).Warn("Failed to parse VTEP mac address")
@@ -585,6 +585,17 @@ func (m *vxlanManager) getParentInterface(localVTEP *proto.VXLANTunnelEndpointUp
 	return nil, fmt.Errorf("Unable to find parent interface with address %s", parentDeviceIP)
 }
 
+func (m *vxlanManager) parseMacForIPVersion(vtep *proto.VXLANTunnelEndpointUpdate) (net.HardwareAddr, error) {
+	switch m.ipVersion {
+	case 4:
+		return net.ParseMAC(vtep.Mac)
+	case 6:
+		return net.ParseMAC(vtep.MacV6)
+	default:
+		return nil, fmt.Errorf("Invalid IP version")
+	}
+}
+
 // configureVXLANDevice ensures the VXLAN tunnel device is up and configured correctly.
 func (m *vxlanManager) configureVXLANDevice(mtu int, localVTEP *proto.VXLANTunnelEndpointUpdate, xsumBroken bool) error {
 	logCxt := logrus.WithFields(logrus.Fields{"device": m.vxlanDevice})
@@ -593,7 +604,7 @@ func (m *vxlanManager) configureVXLANDevice(mtu int, localVTEP *proto.VXLANTunne
 	if err != nil {
 		return err
 	}
-	mac, err := net.ParseMAC(localVTEP.Mac)
+	mac, err := m.parseMacForIPVersion(localVTEP)
 	if err != nil {
 		return err
 	}

--- a/felix/dataplane/linux/vxlan_mgr_test.go
+++ b/felix/dataplane/linux/vxlan_mgr_test.go
@@ -253,14 +253,14 @@ var _ = Describe("VXLANManager", func() {
 	It("successfully adds a IPv6 route to the parent interface", func() {
 		managerV6.OnUpdate(&proto.VXLANTunnelEndpointUpdate{
 			Node:             "node1",
-			Mac:              "00:0a:74:9d:68:16",
+			MacV6:            "00:0a:74:9d:68:16",
 			Ipv6Addr:         "fd00:10:244::",
 			ParentDeviceIpv6: "fc00:10:96::2",
 		})
 
 		managerV6.OnUpdate(&proto.VXLANTunnelEndpointUpdate{
 			Node:             "node2",
-			Mac:              "00:0a:95:9d:68:16",
+			MacV6:            "00:0a:95:9d:68:16",
 			Ipv6Addr:         "fd00:10:96::/112",
 			ParentDeviceIpv6: "fc00:10:10::1",
 		})
@@ -378,7 +378,7 @@ var _ = Describe("VXLANManager", func() {
 		go managerV6.KeepVXLANDeviceInSync(1400, false, 1*time.Second)
 		managerV6.OnUpdate(&proto.VXLANTunnelEndpointUpdate{
 			Node:             "node2",
-			Mac:              "00:0a:95:9d:68:16",
+			MacV6:            "00:0a:95:9d:68:16",
 			Ipv6Addr:         "fd00:10:96::/112",
 			ParentDeviceIpv6: "fc00:10:10::1",
 		})
@@ -400,7 +400,7 @@ var _ = Describe("VXLANManager", func() {
 
 		managerV6.OnUpdate(&proto.VXLANTunnelEndpointUpdate{
 			Node:             "node1",
-			Mac:              "00:0a:74:9d:68:16",
+			MacV6:            "00:0a:74:9d:68:16",
 			Ipv6Addr:         "fd00:10:244::",
 			ParentDeviceIpv6: "fc00:10:96::2",
 		})


### PR DESCRIPTION
Cherry pick of #5998 on master.

#5998: Use Mac/MacV6 from VTEP updates in vxlanManager