### PR TITLE
Automated cherry pick of #6000: Bump go-build to pick up go version update to 1.17.9

### DIFF
--- a/metadata.mk
+++ b/metadata.mk
@@ -3,7 +3,7 @@
 #################################################################################################
 
 # The version of github.com/projectcalico/go-build to use.
-GO_BUILD_VER = v0.70
+GO_BUILD_VER = v0.72
 
 # Version of Kubernetes to use for tests.
 K8S_VERSION     = v1.23.3


### PR DESCRIPTION
Cherry pick of #6000 on release-v3.23.

#6000: Bump go-build to pick up go version update to 1.17.9

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
go version update to 1.17.9
```