### PR TITLE
Treat pending block affinities as if they did not exist

### DIFF
--- a/confd/tests/compiled_templates/explicit_peering/global-external/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-external/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global-ipv6/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/global/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/global/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop-global/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/keepnexthop/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/local-as-global/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as-global/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/local-as/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/local-as/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/route_reflector_v6_by_ip/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/selectors/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/selectors/step2/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/explicit_peering/specific_node/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/explicit_peering/specific_node/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/bgp-export/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/bgp-export/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/communities/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/communities/step2/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/communities/step2/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/hash/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/hash/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/ipip-always/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-always/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-cross-subnet/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/ipip-off/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/ipip-off/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/password/step1/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step1/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/password/step2/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step2/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/password/step3/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/password/step3/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/restart-time/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/restart-time/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/route-reflector-mesh-enabled/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
    # Static routes.
@@ -25,7 +24,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/static-routes/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
    # Static routes.
@@ -26,7 +25,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/static-routes/step2/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/static-routes/step2/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird_aggr.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird_aggr.cfg
@@ -4,7 +4,6 @@ protocol static {
    # IP blocks for this host.
    route 10.0.0.0/30 blackhole;
    route 10.1.0.0/24 blackhole;
-   route 192.168.221.0/26 blackhole;
    route 192.168.221.192/26 blackhole;
    route 192.168.221.64/26 blackhole;
 }
@@ -22,7 +21,6 @@ function calico_aggr ()
       # Block 10.2.0.1/32 is implicitly confirmed.
       if ( net = 10.2.0.1/32 ) then { accept; }
       if ( net ~ 10.2.0.1/32 ) then { reject; }
-      # Block 192.168.221.0/26 is pending
       # Block 192.168.221.192/26 is implicitly confirmed.
       if ( net = 192.168.221.192/26 ) then { accept; }
       if ( net ~ 192.168.221.192/26 ) then { reject; }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Potential fix for https://github.com/projectcalico/calico/issues/6001

Because of the way block affinities work, it's possible for two nodes to race and both get an affinity created. However, only one node can truly own the block, and this is represented via a status field on the affinity that is flipped from "pending" to "confirmed" when the ownership is assumed. 

This PR excludes "pending" blocks, since we don't want to advertise them from this node until they are confirmed. Blocks are only pending for a brief moment during block creation / claim by a node, OR as a long-standing result of this race condition (the affinity will eventually be cleaned up, but not necessarily right away).  

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Reject blocks that are not confirmed to a host
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.