### PR TITLE
Add reject logic for IPv6 VXLAN IP pools to bird templates

### DIFF
--- a/confd/etc/calico/confd/templates/bird6_ipam.cfg.template
+++ b/confd/etc/calico/confd/templates/bird6_ipam.cfg.template
@@ -47,5 +47,13 @@ filter calico_kernel_programming {
   {{- end}}
 
 {{- end}}
+{{range ls "/v1/ipam/v6/pool"}}{{$data := json (getv (printf "/v1/ipam/v6/pool/%s" .))}}
+{{- if $data.vxlan_mode}}
+  if ( net ~ {{$data.cidr}} ) then {
+    # Don't program VXLAN routes into the kernel - these are handled by Felix.
+    reject;
+  }
+{{- end}}{{/* End of '$data.vxlan_mode' */}}
+{{- end}}{{/* End of 'range ls...' */}}
   accept;                                  {{- /* Destination is not in any ipPool, accept  */}}
 }

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
@@ -43,4 +43,58 @@ protocol direct {
                                           # export cluster IPs.
 }
 
-# IPv6 disabled on this node.
+
+# Template for all BGP clients
+template bgp bgp_template {
+  debug { states };
+  description "Connection to BGP peer";
+  local as 64512;
+  multihop;
+  gateway recursive; # This should be the default, but just in case.
+  import all;        # Import all routes, since we don't know what the upstream
+                     # topology is and therefore have to trust the ToR/RR.
+  export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
+  add paths on;
+  graceful restart;  # See comment in kernel section about graceful restart.
+  connect delay time 2;
+  connect retry time 5;
+  error wait time 5,30;
+}
+
+# ------------- Node-to-node mesh -------------
+
+
+
+
+
+# For peer /host/kube-master/ip_addr_v6
+# Skipping ourselves (fdf5:10::2)
+
+
+
+# For peer /host/kube-node-1/ip_addr_v6
+protocol bgp Mesh_fdf5_10__3 from bgp_template {
+  neighbor fdf5:10::3 as 64512;
+  source address fdf5:10::2;  # The local address we use for the TCP connection
+  passive on; # Mesh is unidirectional, peer will connect to us.
+}
+
+
+
+# For peer /host/kube-node-2/ip_addr_v6
+protocol bgp Mesh_fdf5_10__4 from bgp_template {
+  neighbor fdf5:10::4 as 64512;
+  source address fdf5:10::2;  # The local address we use for the TCP connection
+  passive on; # Mesh is unidirectional, peer will connect to us.
+}
+
+
+
+# ------------- Global peers -------------
+# No global peers configured.
+
+
+# ------------- Node-specific peers -------------
+
+# No node-specific peers configured.
+

--- a/confd/tests/compiled_templates/mesh/vxlan-always/bird6_ipam.cfg
+++ b/confd/tests/compiled_templates/mesh/vxlan-always/bird6_ipam.cfg
@@ -9,9 +9,18 @@ filter calico_export_to_bgp_peers {
   apply_communities();
   calico_aggr();
 
+  if ( net ~ dead:beef::/64 ) then {
+    accept;
+  }
   reject;
 }
 
 filter calico_kernel_programming {
+
+  if ( net ~ dead:beef::/64 ) then {
+    # Don't program VXLAN routes into the kernel - these are handled by Felix.
+    reject;
+  }
+
   accept;
 }

--- a/confd/tests/mock_data/calicoctl/mesh/vxlan-always/delete.yaml
+++ b/confd/tests/mock_data/calicoctl/mesh/vxlan-always/delete.yaml
@@ -4,5 +4,18 @@ metadata:
   name: ippool-1
 spec:
   cidr: 192.168.0.0/16
-  ipipMode: Always
+  ipipMode: Never
+  vxlanMode: Always
+  natOutgoing: true
+
+---
+
+kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: ippool-v6-1
+spec:
+  cidr: dead::beef::/64
+  ipipMode: Never
+  vxlanMode: Always
   natOutgoing: true

--- a/confd/tests/mock_data/calicoctl/mesh/vxlan-always/input.yaml
+++ b/confd/tests/mock_data/calicoctl/mesh/vxlan-always/input.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   bgp:
     ipv4Address: 10.192.0.2/16
+    ipv6Address: fdf5:10::2/112
 
 ---
 
@@ -23,6 +24,7 @@ metadata:
 spec:
   bgp:
     ipv4Address: 10.192.0.3/16
+    ipv6Address: fdf5:10::3/112
 
 ---
 
@@ -33,6 +35,7 @@ metadata:
 spec:
   bgp:
     ipv4Address: 10.192.0.4/16
+    ipv6Address: fdf5:10::4/112
 
 ---
 
@@ -42,6 +45,18 @@ metadata:
   name: ippool-1
 spec:
   cidr: 192.168.0.0/16
+  ipipMode: Never
+  vxlanMode: Always
+  natOutgoing: true
+
+---
+
+kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: ippool-v6-1
+spec:
+  cidr: dead:beef::/64
   ipipMode: Never
   vxlanMode: Always
   natOutgoing: true


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add logic to reject routes from IPv6 VXLAN pools in bird templates (because Felix programs these routes).
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
