### PR TITLE
libcalico: prettify test outputs

### DIFF
--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/configurationprocessor_test.go
@@ -377,61 +377,61 @@ func checkExpectedConfigs(kvps []*model.KVPair, dataType int, expectedNum int, e
 			case model.ReadyFlagKey:
 				name = "ready-flag"
 			default:
-				Expect(kvp.Key).To(BeAssignableToTypeOf(model.GlobalConfigKey{}))
+				ExpectWithOffset(1, kvp.Key).To(BeAssignableToTypeOf(model.GlobalConfigKey{}))
 				name = kvp.Key.(model.GlobalConfigKey).Name
 			}
 		case isNodeFelixConfig:
 			switch kt := kvp.Key.(type) {
 			case model.HostConfigKey:
 				node := kt.Hostname
-				Expect(node).To(Equal("mynode"))
+				ExpectWithOffset(1, node).To(Equal("mynode"))
 				name = kt.Name
 			case model.HostIPKey:
 				// Although the HostIPKey is not in the same key space as the HostConfig, we
 				// special case this to make this test reusable for more tests.
 				node := kt.Hostname
-				Expect(node).To(Equal("mynode"))
+				ExpectWithOffset(1, node).To(Equal("mynode"))
 				name = hostIPMarker
 				logrus.Warnf("IP in key: %s", kvp.Value)
 			case model.ResourceKey:
 				node := kt.Name
-				Expect(node).To(Equal("mynode"))
+				ExpectWithOffset(1, node).To(Equal("mynode"))
 				name = nodeMarker
 			case model.WireguardKey:
 				node := kt.NodeName
-				Expect(node).To(Equal("mynode"))
+				ExpectWithOffset(1, node).To(Equal("mynode"))
 				name = wireguardMarker
 			default:
-				Expect(kvp.Key).To(BeAssignableToTypeOf(model.HostConfigKey{}))
+				ExpectWithOffset(1, kvp.Key).To(BeAssignableToTypeOf(model.HostConfigKey{}))
 			}
 		case isGlobalBgpConfig:
-			Expect(kvp.Key).To(BeAssignableToTypeOf(model.GlobalBGPConfigKey{}))
+			ExpectWithOffset(1, kvp.Key).To(BeAssignableToTypeOf(model.GlobalBGPConfigKey{}))
 			name = kvp.Key.(model.GlobalBGPConfigKey).Name
 		case isNodeBgpConfig:
-			Expect(kvp.Key).To(BeAssignableToTypeOf(model.NodeBGPConfigKey{}))
+			ExpectWithOffset(1, kvp.Key).To(BeAssignableToTypeOf(model.NodeBGPConfigKey{}))
 			node := kvp.Key.(model.NodeBGPConfigKey).Nodename
-			Expect(node).To(Equal("bgpnode1"))
+			ExpectWithOffset(1, node).To(Equal("bgpnode1"))
 			name = kvp.Key.(model.NodeBGPConfigKey).Name
 		}
 
 		// Validate and track the expected values.
 		if v, ok := ev[name]; ok {
 			if v == nil {
-				Expect(kvp.Value).To(BeNil(), "Field: "+name)
+				ExpectWithOffset(1, kvp.Value).To(BeNil(), "Field: "+name)
 			} else {
-				Expect(kvp.Value).To(Equal(v), "Field: "+name)
+				ExpectWithOffset(1, kvp.Value).To(Equal(v), "Field: "+name)
 			}
 			delete(ev, name)
 		} else {
-			Expect(kvp.Value).To(BeNil(), "Field: "+name)
+			ExpectWithOffset(1, kvp.Value).To(BeNil(), "Field: "+name)
 		}
 
 		// Validate the fields we have seen, checking for duplicates.
 		_, ok := allNames[name]
-		Expect(ok).To(BeFalse(), fmt.Sprintf("config name is repeated in response: %s", name))
+		ExpectWithOffset(1, ok).To(BeFalse(), fmt.Sprintf("config name is repeated in response: %s", name))
 		allNames[name] = struct{}{}
 	}
 
 	By(" - checking all expected values were accounted for")
-	Expect(ev).To(HaveLen(0), fmt.Sprintf("config name missing in response"))
+	ExpectWithOffset(1, ev).To(HaveLen(0), fmt.Sprintf("config name missing in response"))
 }


### PR DESCRIPTION
It is more important which test failed then where. The latter should be
obvious from the error message. The former it otherwise unknown.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
