### PR TITLE
Add Declaration for eBPF arm64 support

### DIFF
--- a/calico/maintenance/ebpf/enabling-bpf.md
+++ b/calico/maintenance/ebpf/enabling-bpf.md
@@ -26,7 +26,7 @@ To learn more and see performance metrics from our test environment, see the blo
 
 eBPF mode currently has some limitations relative to the standard Linux pipeline mode:
 
-- eBPF mode only supports x86-64.  (The eBPF programs are not currently built for the other platforms.)
+- eBPF mode supports x86-64 and arm64. (For arm64, the support was added from version 3.21.4+)
 - eBPF mode does not yet support IPv6.
 - When enabling eBPF mode, pre-existing connections continue to use the non-BPF datapath; such connections should not be disrupted, but they do not benefit from eBPF mode's advantages.
 - Disabling eBPF mode _is_ disruptive; connections that were handled through the eBPF dataplane may be broken and services that do not detect and recover may need to be restarted.


### PR DESCRIPTION
With the information from the issue:
[Calico eBPF arm64 support]([https://github.com/projectcalico/calico/issues/6022])
https://github.com/projectcalico/calico/issues/6022
the Calico eBPF dataplane was supported on arm64
architecture with Calico version 3.21.4+
So add the declaration of arm64 support in the
ebpf document.

Signed-off-by: TrevorTaoARM <trevor.tao@arm.com>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
