### PR TITLE
Automated cherry pick of #6030: Reduce log level on spammy VXLAN logs

### DIFF
--- a/felix/calc/vxlan_resolver.go
+++ b/felix/calc/vxlan_resolver.go
@@ -160,7 +160,8 @@ func (c *VXLANResolver) onNodeIPUpdate(nodeName string, newIPv4 string, newIPv6 
 		"newIPv4":  newIPv4,
 		"currIPv4": currIPv4,
 		"newIPv6":  newIPv6,
-		"currIPv6": currIPv6})
+		"currIPv6": currIPv6,
+	})
 	logCtx.Debug("Node IP update")
 
 	// net.IP.String() may return an actual string with value "<nil>"
@@ -266,20 +267,20 @@ func (c *VXLANResolver) hasVTEPInfo(node string) (bool, bool) {
 	hasV4Info, hasV6Info := true, true
 
 	if _, ok := c.nodeNameToVXLANTunnelAddr[node]; !ok {
-		logCtx.Info("Missing IPv4 VXLAN tunnel address for node")
+		logCtx.Debug("Missing IPv4 VXLAN tunnel address for node")
 		hasV4Info = false
 	}
 	if _, ok := c.nodeNameToIPv4Addr[node]; !ok {
-		logCtx.Info("Missing IPv4 address for node")
+		logCtx.Debug("Missing IPv4 address for node")
 		hasV4Info = false
 	}
 
 	if _, ok := c.nodeNameToVXLANTunnelAddrV6[node]; !ok {
-		logCtx.Info("Missing IPv6 VXLAN tunnel address for node")
+		logCtx.Debug("Missing IPv6 VXLAN tunnel address for node")
 		hasV6Info = false
 	}
 	if _, ok := c.nodeNameToIPv6Addr[node]; !ok {
-		logCtx.Info("Missing IPv6 address for node")
+		logCtx.Debug("Missing IPv6 address for node")
 		hasV6Info = false
 	}
 


### PR DESCRIPTION
Cherry pick of #6030 on release-v3.23.

#6030: Reduce log level on spammy VXLAN logs

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.