### PR TITLE
[release-v3.23] Automated cherry pick of #6036: Update docs to include VXLAN IPv6 support

### DIFF
--- a/calico/networking/ipv6.md
+++ b/calico/networking/ipv6.md
@@ -74,15 +74,15 @@ apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:
   name: default
-  pec:
-   calicoNetwork:
-     # Note: The ipPools section cannot be modified post-install.
-    ipPools:
-    - blockSize: 122
-      cidr: 2001::00/64 
-      encapsulation: None 
-      natOutgoing: Enabled 
-      nodeSelector: all()
+spec:
+  calicoNetwork:
+    # Note: The ipPools section cannot be modified post-install.
+   ipPools:
+   - blockSize: 122
+     cidr: 2001::00/64
+     encapsulation: None
+     natOutgoing: Enabled
+     nodeSelector: all()
 ```
 
 %>
@@ -151,21 +151,21 @@ apiVersion: operator.tigera.io/v1
 kind: Installation
 metadata:
   name: default
-  pec:
-   # Configures Calico networking.
-   calicoNetwork:
-     # Note: The ipPools section cannot be modified post-install.
-    ipPools:
-    - blockSize: 26
-      cidr: 10.48.0.0/21
-      encapsulation: IPIP
-      natOutgoing: Enabled
-      nodeSelector: all()
-    - blockSize: 122
-      cidr: 2001::00/64 
-      encapsulation: None 
-      natOutgoing: Enabled 
-      nodeSelector: all()
+spec:
+  # Configures Calico networking.
+  calicoNetwork:
+    # Note: The ipPools section cannot be modified post-install.
+  ipPools:
+  - blockSize: 26
+    cidr: 10.48.0.0/21
+    encapsulation: IPIP
+    natOutgoing: Enabled
+    nodeSelector: all()
+  - blockSize: 122
+    cidr: 2001::00/64
+    encapsulation: None
+    natOutgoing: Enabled
+    nodeSelector: all()
 ```
 
 %>

--- a/calico/networking/mtu.md
+++ b/calico/networking/mtu.md
@@ -51,14 +51,14 @@ The following table lists common MTU sizes for {{site.prodname}} environments. B
 
 **Common MTU sizes**
 
-| Network MTU            | {{site.prodname}} MTU | {{site.prodname}} MTU with IP-in-IP (IPv4) | {{site.prodname}} MTU with VXLAN (IPv4) | {{site.prodname}} MTU with WireGuard (IPv4) |
-| ---------------------- | --------------------- | ------------------------------------------ | --------------------------------------- | ------------------------------------------- |
-| 1500                   | 1500                  | 1480                                       | 1450                                    | 1440                                        |
-| 9000                   | 9000                  | 8980                                       | 8950                                    | 8940                                        |
-| 1500 (AKS)             | 1500                  | 1480                                       | 1450                                    | 1340                                        |
-| 1460 (GCE)             | 1460                  | 1440                                       | 1410                                    | 1400                                        |
-| 9001 (AWS Jumbo)       | 9001                  | 8981                                       | 8951                                    | 8941                                        |
-| 1450 (OpenStack VXLAN) | 1450                  | 1430                                       | 1400                                    | 1390                                        |
+| Network MTU            | {{site.prodname}} MTU | {{site.prodname}} MTU with IP-in-IP (IPv4) | {{site.prodname}} MTU with VXLAN (IPv4) | {{site.prodname}} MTU with VXLAN (IPv6)     | {{site.prodname}} MTU with WireGuard (IPv4) |
+| ---------------------- | --------------------- | ------------------------------------------ | --------------------------------------- | ------------------------------------------- |                                             |
+| 1500                   | 1500                  | 1480                                       | 1450                                    | 1430                                        | 1440                                        |
+| 9000                   | 9000                  | 8980                                       | 8950                                    | 8930                                        | 8940                                        |
+| 1500 (AKS)             | 1500                  | 1480                                       | 1450                                    | 1430                                        | 1340                                        |
+| 1460 (GCE)             | 1460                  | 1440                                       | 1410                                    | 1390                                        | 1400                                        |
+| 9001 (AWS Jumbo)       | 9001                  | 8981                                       | 8951                                    | 8931                                        | 8941                                        |
+| 1450 (OpenStack VXLAN) | 1450                  | 1430                                       | 1400                                    | 1380                                        | 1390                                        |
 
 **Recommended MTU for overlay networking**
 

--- a/calico/networking/vxlan-ipip.md
+++ b/calico/networking/vxlan-ipip.md
@@ -45,7 +45,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 #### IPv4/6 address support
 
-IP in IP and VXLAN support only IPv4 addresses.
+IP in IP supports only IPv4 addresses.
 
 #### Best practice
 

--- a/calico/reference/resources/felixconfig.md
+++ b/calico/reference/resources/felixconfig.md
@@ -93,7 +93,8 @@ spec:
 | usageReportingInitialDelay         | Minimum initial delay before first usage report. | `5s`, `10s`, `1m` etc. | duration | `300s` |
 | usageReportingInterval             | The interval at which Felix does usage reports.  The default is 1 day.  | `5s`, `10s`, `1m` etc. | duration | `24h` |
 | vxlanEnabled                       | Optional, you shouldn't need to change this setting as Felix calculates if VXLAN should be enabled based on the existing IP Pools. When set, this overrides whether Felix should create the VXLAN tunnel device for VXLAN networking. | `true`, `false`, unset | optional boolean | unset |
-| vxlanMTU                           | MTU to use for the VXLAN tunnel device. Zero value means auto-detect. Also controls NodePort MTU when eBPF enabled. | int | int | `0` |
+| vxlanMTU                           | MTU to use for the IPv4 VXLAN tunnel device. Zero value means auto-detect. Also controls NodePort MTU when eBPF enabled.                                                                                                              | int                    | int              | `0`   |
+| vxlanMTUV6                         | MTU to use for the IPv6 VXLAN tunnel device. Zero value means auto-detect. Also controls NodePort MTU when eBPF enabled.                                                                                                              | int                    | int              | `0`   |
 | vxlanPort                          | Port to use for VXLAN traffic. A value of `0` means "use the kernel default". | int | int | `4789` |
 | vxlanVNI                           | Virtual network ID to use for VXLAN traffic. A value of `0` means "use the kernel default". | int | int | `4096` |
 | allowVXLANPacketsFromWorkloads     | Set to `true` to allow VXLAN encapsulated traffic from workloads. | boolean | boolean | `false` |


### PR DESCRIPTION
Cherry pick of #6036 on release-v3.23.

#6036: Update docs to include VXLAN IPv6 support