### PR TITLE
Automated cherry pick of #5670: fixed install command for linux kubectl plugin

### DIFF
--- a/calico/maintenance/clis/calicoctl/install.md
+++ b/calico/maintenance/clis/calicoctl/install.md
@@ -209,7 +209,7 @@ you want to install the binary.
 1. Use the following command to download the `calicoctl` binary.
 
    ```bash
-   curl -L {{ url }}/calicoctl-linux-arm64 -o kubectl-calico
+   curl -L {{ url }}/calicoctl-linux-amd64 -o kubectl-calico
    ```
 
 1. Set the file to be executable.


### PR DESCRIPTION
Cherry pick of #5670 on release-v3.22.

#5670: fixed install command for linux kubectl plugin

Fixes: https://github.com/projectcalico/calico/issues/6021

# Original PR Body below

## Description

fixed install command for linux kubectl plugin in documentation
https://projectcalico.docs.tigera.io/maintenance/clis/calicoctl/install#install-calicoctl-as-a-kubectl-plugin-on-a-single-host

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note