### PR TITLE
[release-v3.22] Auto pick #5498: felix/bpf: fix err handling in bpf_program_attach_cgroup

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -46,6 +46,7 @@ GENERATED_FILES=proto/felixbackend.pb.go bpf/asm/opcode_string.go
 
 # All Felix go files.
 SRC_FILES:=$(shell find . $(foreach dir,$(NON_FELIX_DIRS) fv,-path ./$(dir) -prune -o) -type f -name '*.go' -print) $(GENERATED_FILES)
+SRC_FILES+=$(shell find bpf -name '*.h')
 FV_SRC_FILES:=$(shell find fv -type f -name '*.go' -print)
 EXTRA_DOCKER_ARGS+=--init -v $(CURDIR)/../pod2daemon:/go/src/github.com/projectcalico/calico/pod2daemon:rw
 

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -139,8 +139,10 @@ struct bpf_link *bpf_program_attach_cgroup(struct bpf_object *obj, int cgroup_fd
 		goto out;
 	}
 
-	if (!(link = bpf_program__attach_cgroup(prog, cgroup_fd))) {
-		err = libbpf_get_error(link);
+	link = bpf_program__attach_cgroup(prog, cgroup_fd);
+	err = libbpf_get_error(link);
+	if (err) {
+		link = NULL;
 		goto out;
 	}
 

--- a/felix/fv/bpf_attach_test.go
+++ b/felix/fv/bpf_attach_test.go
@@ -15,6 +15,7 @@
 package fv
 
 import (
+	"os"
 	"regexp"
 
 	. "github.com/onsi/ginkgo"
@@ -25,6 +26,12 @@ import (
 )
 
 var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object", []apiconfig.DatastoreType{apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
+
+	if os.Getenv("FELIX_FV_ENABLE_BPF") != "true" {
+		// Non-BPF run.
+		return
+	}
+
 	var (
 		infra   infrastructure.DatastoreInfra
 		felixes []*infrastructure.Felix


### PR DESCRIPTION
Cherry pick of #5498 on release-v3.22.

#5498: felix/bpf: fix err handling in bpf_program_attach_cgroup

# Original PR Body below

As the error is encoded in the link pointer, it it not NULL in case of
an error.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/5957

refs https://github.com/projectcalico/calico/issues/5979

refs https://github.com/projectcalico/calico/issues/5775

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixed error handling in attaching cgroup (ctlb) programs with libbpf so that a fallback method is executed when the current method fails. Otherwise success is reported and ctlb programs are not loaded (fresh install) or old are not replaced (upon upgrade)
```