### PR TITLE
Add version checking compatibility.

### DIFF
--- a/calicoctl/calicoctl/commands/common/version_mismatch.go
+++ b/calicoctl/calicoctl/commands/common/version_mismatch.go
@@ -70,9 +70,9 @@ func CheckVersionMismatch(configArg, allowMismatchArg interface{}) error {
 		return nil
 	}
 
-	clusterv = strings.Split(clusterv, "-")[0]
+	clusterv = strings.Split(strings.TrimPrefix(clusterv, "v"), "-")[0]
 
-	clientv := strings.Split(VERSION, "-")[0]
+	clientv := strings.Split(strings.TrimPrefix(VERSION, "v"), "-")[0]
 
 	if clusterv != clientv {
 		return fmt.Errorf("Version mismatch.\nClient Version:   %s\nCluster Version:  %s\nUse --allow-version-mismatch to override.\n", VERSION, clusterv)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

Fixs #6027

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Ignore v prefix when comparing cluster and client version in calicoctl
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
