### PR TITLE
Updates for calico/vpp release v3.23.0

### DIFF
--- a/calico/_config.yml
+++ b/calico/_config.yml
@@ -75,7 +75,7 @@ defaults:
       show_title: true
       show_read_time: true
       show_toc: true
-      vppbranch: master  # The branch in vpp repo that these docs should point to for manifests, etc
+      vppbranch: v3.23.0  # The branch in vpp repo that these docs should point to for manifests, etc
       sitemap: true
       registry:
       # A lookup map for imageNames based on component names.

--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -7,9 +7,9 @@ canonical_url: '/getting-started/kubernetes/vpp/getting-started'
 
 ### Big picture
 
-Install {{site.prodname}} and enable the tech preview of the VPP dataplane.
+Install {{site.prodname}} and enable the beta release of the VPP dataplane.
 
-> **Warning!** The VPP dataplane is a tech preview and should not be used in production clusters. It has had limited testing and it will contain bugs (please report these on the [Calico Users slack](https://calicousers.slack.com/archives/C017220EXU1) or [Github](https://github.com/projectcalico/vpp-dataplane/issues)).  In addition, it does not support all the features of {{site.prodname}} and it is currently missing some security features such as Application Layer Policy.
+> **Warning!** The VPP dataplane is in beta and should not be used in production clusters. It has had lots of testing and is pretty stable. However, chances are that some bugs are still lurking around (please report these on the [Calico Users slack](https://calicousers.slack.com/archives/C017220EXU1) or [Github](https://github.com/projectcalico/vpp-dataplane/issues)).  In addition, it still does not support all the features of {{site.prodname}}.
 {: .alert .alert-danger }
 
 ### Value
@@ -26,7 +26,7 @@ The VPP dataplane is entirely compatible with the other {{site.prodname}} datapl
 
 In addition, the VPP dataplane offers some specific features for network-intensive applications, such as providing `memif` userspace packet interfaces to the pods (instead of regular Linux network devices), or exposing the VPP Host Stack to run optimized L4+ applications in the pods.
 
-Trying out the tech preview will give you a taste of these benefits and an opportunity to give feedback to the VPP dataplane team.
+Trying out the beta will give you a taste of these benefits and an opportunity to give feedback to the VPP dataplane team.
 
 
 ### Features


### PR DESCRIPTION
## Description
Updates for calico/vpp release v3.23.0:

- Update the "vppbranch" var for calico/vpp release v3.23.0
- Update calico/vpp Getting Started doc to reflect the switch from tech preview to beta.


## Related issues/PRs

## Todos

- [ ] Documentation


## Release Note

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
