### PR TITLE
Skip ipv6 vxlan route update with wireguard manager

### DIFF
--- a/felix/dataplane/linux/wireguard_mgr.go
+++ b/felix/dataplane/linux/wireguard_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,6 +68,10 @@ func (m *wireguardManager) OnUpdate(protoBufMsg interface{}) {
 			log.Errorf("error parsing RouteUpdate CIDR: %s", msg.Dst)
 			return
 		}
+		if cidr.Version() == 6 {
+			log.Debugf("ignore update for IPv6 CIDR: %s", msg.Dst)
+			return
+		}
 		switch msg.Type {
 		case proto.RouteType_REMOTE_HOST:
 			log.Debug("RouteUpdate is a remote host update")
@@ -95,6 +99,10 @@ func (m *wireguardManager) OnUpdate(protoBufMsg interface{}) {
 		cidr, err := ip.ParseCIDROrIP(msg.Dst)
 		if err != nil || cidr == nil {
 			log.Errorf("error parsing RouteUpdate CIDR: %s", msg.Dst)
+			return
+		}
+		if cidr.Version() == 6 {
+			log.Debugf("ignore update for IPv6 CIDR: %s", msg.Dst)
 			return
 		}
 		log.Debugf("Route removal for IPv4 CIDR: %s", cidr)

--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -456,7 +456,7 @@ func (r *RouteTable) getNetlink() (netlinkshim.Interface, error) {
 			log.WithField("numFailures", r.numConsistentNetlinkFailures).Panic(
 				"Repeatedly failed to connect to netlink.")
 		}
-		log.Info("Trying to connect to netlink")
+		log.Debug("Trying to connect to netlink")
 		nlHandle, err := r.newNetlinkHandle()
 		if err != nil {
 			r.numConsistentNetlinkFailures++


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Skip ipv6 vxlan route update with wireguard manager 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
