### PR TITLE
Automated cherry pick of #6045: Fix bug in handling of RV too old errors

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/errors.go
+++ b/libcalico-go/lib/backend/k8s/resources/errors.go
@@ -60,6 +60,10 @@ func K8sErrorToCalico(ke error, id interface{}) error {
 			Identifier: id,
 		}
 	}
+	if kerrors.IsResourceExpired(ke) {
+		// Re-use the Kubernetes resource expired type.
+		return ke
+	}
 	if keStat, ok := ke.(kerrors.APIStatus); ok {
 		// Look for the errors we get when we try to patch a resource but it has been recreated or revved.
 		if details := keStat.Status().Details; details != nil {

--- a/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
+++ b/libcalico-go/lib/backend/watchersyncer/watchersyncer_test.go
@@ -26,13 +26,13 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/watchersyncer"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -74,11 +74,11 @@ var (
 	}
 	notSupported = cerrors.ErrorOperationNotSupported{}
 	notExists    = cerrors.ErrorResourceDoesNotExist{}
+	tooOldRV     = kerrors.NewResourceExpired("test error")
 	genError     = errors.New("Generic error")
 )
 
 var _ = Describe("Test the backend datastore multi-watch syncer", func() {
-
 	r1 := watchersyncer.ResourceType{
 		ListInterface: model.ResourceListOptions{Kind: apiv3.KindNetworkPolicy},
 	}
@@ -136,8 +136,44 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUnchanged()
 	})
 
-	It("should handle reconnection if watchers fail to be created", func() {
+	// Tests the scenario found in this issue: https://github.com/projectcalico/calico/issues/6032
+	It("should handle resourceVersion expired errors", func() {
+		// Temporarily reduce the watch and list poll interval to make the tests faster.
+		// Since we are timing the processing, we still need the interval to be sufficiently
+		// large to make the measurements more accurate.
+		defer setWatchIntervals(watchersyncer.ListRetryInterval, watchersyncer.WatchPollInterval)
+		setWatchIntervals(500*time.Millisecond, 2000*time.Millisecond)
 
+		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1})
+		rs.ExpectStatusUpdate(api.WaitForDatastore)
+		rs.clientListResponse(r1, tooOldRV)
+		rs.clientListResponse(r1, emptyList)
+		rs.ExpectStatusUpdate(api.ResyncInProgress)
+		rs.ExpectStatusUpdate(api.InSync)
+
+		// Send a watch error. This will trigger a re-list from the revision
+		// the watcher cache has stored.
+		rs.clientWatchResponse(r1, notSupported)
+		rs.clientListResponse(r1, emptyList)
+
+		// Expect List and watch be called with the emptylist revision.
+		Eventually(rs.fc.getLatestListRevision, 5*time.Second, 100*time.Millisecond).Should(Equal(emptyList.Revision))
+		Eventually(rs.fc.getLatestWatchRevision, 5*time.Second, 100*time.Millisecond).Should(Equal(emptyList.Revision))
+
+		// Send a watch error, followed by a resource version too old error
+		// on the list. This should trigger the watcher cache to retry the list
+		// without a revision.
+		rs.clientWatchResponse(r1, genError)
+		rs.clientListResponse(r1, tooOldRV)
+		Eventually(rs.fc.getLatestListRevision, 5*time.Second, 100*time.Millisecond).Should(Equal("0"))
+
+		// Simulate a successful list using the 0 revision - we should see the watch started from the correct
+		// revision again.
+		rs.clientListResponse(r1, emptyList)
+		Eventually(rs.fc.getLatestWatchRevision, 5*time.Second, 100*time.Millisecond).Should(Equal(emptyList.Revision))
+	})
+
+	It("should handle reconnection if watchers fail to be created", func() {
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 
@@ -178,7 +214,7 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 		rs.ExpectStatusUnchanged()
 		rs.clientListResponse(r1, emptyList)
 		rs.ExpectStatusUnchanged()
-		//rs.ExpectStatusUpdate(api.InSync)
+		// rs.ExpectStatusUpdate(api.InSync)
 		rs.clientWatchResponse(r1, nil)
 		rs.clientListResponse(r2, emptyList)
 		rs.clientWatchResponse(r2, notSupported)
@@ -234,7 +270,6 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 	})
 
 	It("Should handle reconnection and syncing when the watcher sends a watch terminated error", func() {
-
 		rs := newWatcherSyncerTester([]watchersyncer.ResourceType{r1, r2, r3})
 		rs.ExpectStatusUpdate(api.WaitForDatastore)
 		rs.clientListResponse(r1, emptyList)
@@ -580,7 +615,6 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 				UpdateType: api.UpdateTypeKVDeleted,
 			},
 		}, false)
-
 	})
 
 	It("Should invoke the supplied converter to alter the update", func() {
@@ -667,7 +701,6 @@ var _ = Describe("Test the backend datastore multi-watch syncer", func() {
 			},
 		})
 		rs.ExpectParseError("zzzzz", "xxxxx")
-
 	})
 })
 
@@ -961,6 +994,18 @@ func (rst *watcherSyncerTester) clientWatchResponse(r watchersyncer.ResourceType
 // the events
 type fakeClient struct {
 	lws map[string]*listWatchSource
+
+	// Allows us to track the revision that the syncer is using.
+	latestListRevision  string
+	latestWatchRevision string
+}
+
+func (c *fakeClient) getLatestListRevision() string {
+	return c.latestListRevision
+}
+
+func (c *fakeClient) getLatestWatchRevision() string {
+	return c.latestWatchRevision
 }
 
 // We don't implement any of the CRUD related methods, just the Watch method to return
@@ -969,34 +1014,42 @@ func (c *fakeClient) Create(ctx context.Context, object *model.KVPair) (*model.K
 	panic("should not be called")
 	return nil, nil
 }
+
 func (c *fakeClient) Update(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
 	panic("should not be called")
 	return nil, nil
 }
+
 func (c *fakeClient) Apply(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
 	panic("should not be called")
 	return nil, nil
 }
+
 func (c *fakeClient) DeleteKVP(ctx context.Context, kvp *model.KVPair) (*model.KVPair, error) {
 	panic("should not be called")
 	return nil, nil
 }
+
 func (c *fakeClient) Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
 	panic("should not be called")
 	return nil, nil
 }
+
 func (c *fakeClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
 	panic("should not be called")
 	return nil, nil
 }
+
 func (c *fakeClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
 	panic("should not be called")
 	return nil
 }
+
 func (c *fakeClient) EnsureInitialized() error {
 	panic("should not be called")
 	return nil
 }
+
 func (c *fakeClient) Clean() error {
 	panic("should not be called")
 	return nil
@@ -1005,10 +1058,11 @@ func (c *fakeClient) Clean() error {
 func (c *fakeClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
 	// Create a fake watcher keyed off the ListOptions (root path).
 	name := model.ListOptionsToDefaultPathRoot(list)
-	log.WithField("Name", name).Info("List request")
+	log.WithField("Name", name).WithField("rev", revision).Info("List request")
 	if l, ok := c.lws[name]; !ok || l == nil {
 		panic("List for unhandled resource type")
 	} else {
+		c.latestListRevision = revision
 		return l.list()
 	}
 }
@@ -1020,6 +1074,7 @@ func (c *fakeClient) Watch(ctx context.Context, list model.ListInterface, revisi
 	if l, ok := c.lws[name]; !ok || l == nil {
 		panic("Watch for unhandled resource type")
 	} else {
+		c.latestWatchRevision = revision
 		return l.watch()
 	}
 }


### PR DESCRIPTION
Cherry pick of #6045 on release-v3.23.

#6045: Fix bug in handling of RV too old errors

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR attempts to capture errors of the form "ResourceVersion for the provided list is
too old" and retry the list with a zero'd out revision number.

It also clears the resync flag after a successful sync so that we'll
only retry a List() if an error is hit.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/6032

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix bug where Calico would not recover after listing from a too old resource version
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.