### PR TITLE
Fix warning message from importing hns.psm1

### DIFF
--- a/calico/getting-started/windows-calico/limitations.md
+++ b/calico/getting-started/windows-calico/limitations.md
@@ -102,7 +102,7 @@ One example is the VXLAN VNI setting. To change such parameters:
 - Delete the {{site.prodname}} HNS network:
 
    ```powershell
-   Import-Module {{site.rootDirWindows}}\libs\hns\hns.psm1
+   Import-Module -DisableNameChecking {{site.rootDirWindows}}\libs\hns\hns.psm1
    Get-HNSNetwork | ? Name -EQ "{{site.prodname}}" | Remove-HNSNetwork
    ```
 - Update the configuration in `config.ps1`, run `uninstall-calico.ps1` and then `install-calico.ps1` to regenerate the CNI configuration.

--- a/calico/getting-started/windows-calico/troubleshoot.md
+++ b/calico/getting-started/windows-calico/troubleshoot.md
@@ -11,7 +11,7 @@ canonical_url: /getting-started/windows-calico/troubleshoot
 When using the {{site.prodname}} CNI plugin, each {{site.prodname}} IPAM block (or the single podCIDR in host-local IPAM mode), is represented as a HNS l2bridge network. Use the following command to inspect the networks.
 
 ```powershell
-ipmo {{site.rootDirWindows}}\libs\hns\hns.psm1
+ipmo -DisableNameChecking {{site.rootDirWindows}}\libs\hns\hns.psm1
 Get-HNSNetwork
 ```
 
@@ -20,7 +20,7 @@ Get-HNSNetwork
 Use the following command to view the HNS endpoints on the system. There should be one HNS endpoint per pod networked with {{site.prodname}}:
 
 ```powershell
-ipmo {{site.rootDirWindows}}\libs\hns\hns.psm1
+ipmo -DisableNameChecking {{site.rootDirWindows}}\libs\hns\hns.psm1
 Get-HNSEndpoint
 ```
 

--- a/calico/scripts/PrepareNode.ps1
+++ b/calico/scripts/PrepareNode.ps1
@@ -78,7 +78,7 @@ if ($ContainerRuntime -eq "Docker") {
     docker network create -d nat host
 } elseif ($ContainerRuntime -eq "ContainerD") {
     DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
-    Import-Module "c:\k\hns.psm1"
+    Import-Module -DisableNameChecking "c:\k\hns.psm1"
     if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
         New-HnsNetwork -Type NAT -Name nat
     }

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -56,7 +56,7 @@ function DownloadFiles()
 function PrepareKubernetes()
 {
     DownloadFiles
-    ipmo C:\k\hns.psm1
+    ipmo -DisableNameChecking C:\k\hns.psm1
     InstallK8sBinaries
 
     # Prepull and tag the pause image for docker
@@ -392,8 +392,8 @@ if (!(Test-Path $helperv2))
 {
     Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $BaseDir\helper.v2.psm1
 }
-ipmo -force $helper
-ipmo -force $helperv2
+ipmo -force -DisableNameChecking $helper
+ipmo -force -DisableNameChecking $helperv2
 
 if (!(Test-Path $CalicoZip))
 {

--- a/node/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kube-proxy-service.ps1
@@ -20,7 +20,7 @@ Param(
 )
 
 # Import HNS libraries, included in the package.
-ipmo -Force $CalicoWindowsDir\libs\hns\hns.psm1
+ipmo -Force -DisableNameChecking $CalicoWindowsDir\libs\hns\hns.psm1
 
 . $CalicoWindowsDir\config.ps1
 ipmo -Force $CalicoWindowsDir\libs\calico\calico.psm1

--- a/node/windows-packaging/CalicoWindows/node/node-service.ps1
+++ b/node/windows-packaging/CalicoWindows/node/node-service.ps1
@@ -16,7 +16,7 @@
 . .\config.ps1
 
 ipmo .\libs\calico\calico.psm1 -Force
-ipmo .\libs\hns\hns.psm1 -Force
+ipmo .\libs\hns\hns.psm1 -Force -DisableNameChecking
 
 $lastBootTime = Get-LastBootTime
 $Stored = Get-StoredLastBootTime


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We are getting warning messages from importing hns.psm1 module. 
```
WARNING: The names of some imported commands from the module 'hns' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.
```
Since hns.psm1 is a third party module, we can work around this issue by adding `-DisableNameChecking`

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
