### PR TITLE
Set shopt nullglob in the .semaphore/publish-artifacts script

### DIFF
--- a/.semaphore/publish-artifacts
+++ b/.semaphore/publish-artifacts
@@ -17,6 +17,9 @@
 # No set -e so that we continue to collect artifacts even if some fail.
 set -x
 
+# set nullglob so that '*' is not used literally if the artifacts dir is empty
+shopt -s nullglob
+
 my_dir=$(dirname "$0")
 repo_dir=$my_dir/..
 

--- a/cni-plugin/.semaphore/run-win-fv.sh
+++ b/cni-plugin/.semaphore/run-win-fv.sh
@@ -40,7 +40,8 @@ ${SCP_CMD} -r ubuntu@${MASTER_IP}:/home/ubuntu/report /home/semaphore
 
 ls -ltr ./report
 mkdir /home/semaphore/fv.log
-mv /home/semaphore/report/*.log /home/semaphore/fv.log
+# check if *.log glob contains any files so that mv doesn't fail
+compgen -G /home/semaphore/report/*.log > /dev/null && mv /home/semaphore/report/*.log /home/semaphore/fv.log
 
 # Stop for debug
 echo "Check for pause file..."

--- a/felix/.semaphore/publish-artifacts
+++ b/felix/.semaphore/publish-artifacts
@@ -17,6 +17,9 @@
 # No set -e so that we continue to collect artifacts even if some fail.
 set -x
 
+# set nullglob so that '*' is not used literally if the artifacts dir is empty
+shopt -s nullglob
+
 my_dir=$(dirname "$0")
 repo_dir=$my_dir/..
 

--- a/felix/.semaphore/run-win-fv
+++ b/felix/.semaphore/run-win-fv
@@ -50,7 +50,8 @@ ${SCP_CMD} -r ubuntu@${MASTER_IP}:/home/ubuntu/report /home/semaphore
 
 ls -ltr ./report
 mkdir /home/semaphore/fv.log
-mv /home/semaphore/report/*.log /home/semaphore/fv.log
+# check if *.log glob contains any files so that mv doesn't fail
+compgen -G /home/semaphore/report/*.log > /dev/null && mv /home/semaphore/report/*.log /home/semaphore/fv.log
 
 # Stop for debug
 echo "Check for pause file..."


### PR DESCRIPTION
When the artifacts dir is empty (which happens if there are no failures), the script will try to push an artifact named '*' (which doesn't exist and thus CI will fail even though every test succeeded).

See https://stackoverflow.com/questions/30043225/looping-on-empty-directory-content-in-bash

Also check if *.log glob contains any files so that mv doesn't fail in run-win-fv.sh

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
