### PR TITLE
felix/bpf: remove iptable chains that enforce RPF

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -141,7 +141,7 @@ static CALI_BPF_INLINE void __compile_asserts(void) {
 
      . . . .  . . 1 1  . . . .       BYPASS => SEEN and no further policy checking needed;
                                      remaining bits indicate options for how to treat such
-                                     packets: FWD, FWD_SRC_FIXUP, SKIP_RPF and NAT_OUT
+                                     packets: FWD, FWD_SRC_FIXUP and NAT_OUT
 
      . . . .  . 1 0 1  . . . .       FALLTHROUGH => SEEN but no BPF CT state; need to check
                                      against Linux CT state
@@ -178,10 +178,6 @@ enum calico_skb_mark {
 	 * such packets based on their Linux conntrack state. This allows for us to handle flows that
 	 * were live before BPF was enabled. */
 	CALI_SKB_MARK_FALLTHROUGH            = CALI_SKB_MARK_SEEN    | 0x04000000,
-	/* The SKIP_RPF bit is used by programs that are towards the host namespace to disable our
-	 * RPF check for that packet.  Typically used for a packet that we originate (such as an ICMP
-	 * response). */
-	CALI_SKB_MARK_SKIP_RPF               = CALI_SKB_MARK_BYPASS  | 0x00400000,
 	/* The NAT_OUT bit is used by programs that are towards the host namespace to tell iptables to
 	 * do SNAT for this flow.  Subsequent packets will also be allowed to fall through to the host
 	 * netns. */

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -204,16 +204,6 @@ cancel_fib:
 skip_fib:
 
 	if (CALI_F_TO_HOST) {
-		/* If we received the packet from the tunnel and we forward it to a
-		 * workload we need to skip RPF check since there might be a better path
-		 * for the packet if the host has multiple ifaces and might get dropped.
-		 *
-		 * XXX We should check ourselves that we got our tunnel packets only from
-		 * XXX those devices where we expect them before we even decap.
-		 */
-		if (CALI_F_FROM_HEP && state->tun_ip != 0 && ctx->fwd.mark != CALI_SKB_MARK_BYPASS_FWD) {
-			ctx->fwd.mark = CALI_SKB_MARK_SKIP_RPF;
-		}
 		/* Packet is towards host namespace, mark it so that downstream
 		 * programs know that they're not the first to see the packet.
 		 */

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -854,7 +854,6 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				goto icmp_too_big;
 			}
 			state->ip_src = HOST_IP;
-			seen_mark = CALI_SKB_MARK_SKIP_RPF;
 
 			/* We cannot enforce RPF check on encapped traffic, do FIB if you can */
 			fib = true;

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -24,8 +24,6 @@ const (
 	MarkSeenBypassForward            = MarkSeenBypass | 0x00300000
 	MarkSeenBypassForwardMask        = MarkSeenBypassMask | 0x00f00000
 	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x00500000
-	MarkSeenBypassSkipRPF            = MarkSeenBypass | 0x00400000
-	MarkSeenBypassSkipRPFMask        = MarkSeenBypassMask | 0x00f00000
 	MarkSeenNATOutgoing              = MarkSeenBypass | 0x00800000
 	MarkSeenNATOutgoingMask          = MarkSeenBypassMask | 0x00f00000
 	MarkSeenMASQ                     = MarkSeenBypass | 0x00600000

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -527,7 +527,7 @@ func TestNATNodePort(t *testing.T) {
 
 	hostIP = net.IPv4(0, 0, 0, 0) // workloads do not have it set
 
-	skbMark = tcdefs.MarkSeenBypassSkipRPF // CALI_SKB_MARK_SKIP_RPF
+	skbMark = tcdefs.MarkSeen
 
 	// Insert the reverse route for backend for RPF check.
 	resetRTMap(rtMap)
@@ -1976,7 +1976,7 @@ func TestNATSourceCollision(t *testing.T) {
 
 	hostIP = net.IPv4(0, 0, 0, 0) // workloads do not have it set
 
-	skbMark = tcdefs.MarkSeenBypassSkipRPF // CALI_SKB_MARK_SKIP_RPF
+	skbMark = tcdefs.MarkSeen
 
 	// Arriving at workload at node 2
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1392,7 +1392,6 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 	for _, t := range d.iptablesRawTables {
 		t.UpdateChains(d.ruleRenderer.StaticBPFModeRawChains(t.IPVersion,
 			d.config.Wireguard.EncryptHostTraffic, d.config.BPFHostConntrackBypass,
-			d.config.BPFEnforceRPF == "Strict",
 		))
 		t.InsertOrAppendRules("PREROUTING", []iptables.Rule{{
 			Action: iptables.JumpAction{Target: rules.ChainRawPrerouting},

--- a/felix/rules/rule_defs.go
+++ b/felix/rules/rule_defs.go
@@ -175,7 +175,7 @@ type RuleRenderer interface {
 	StaticNATTableChains(ipVersion uint8) []*iptables.Chain
 	StaticNATPostroutingChains(ipVersion uint8) []*iptables.Chain
 	StaticRawTableChains(ipVersion uint8) []*iptables.Chain
-	StaticBPFModeRawChains(ipVersion uint8, wgEncryptHost, disableConntrack, enforceRPF bool) []*iptables.Chain
+	StaticBPFModeRawChains(ipVersion uint8, wgEncryptHost, disableConntrack bool) []*iptables.Chain
 	StaticMangleTableChains(ipVersion uint8) []*iptables.Chain
 	StaticFilterForwardAppendRules() []iptables.Rule
 

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1040,46 +1040,9 @@ func (r *DefaultRuleRenderer) StaticRawTableChains(ipVersion uint8) []*Chain {
 }
 
 func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
-	wgEncryptHost, bypassHostConntrack, enforceRPF bool) []*Chain {
+	wgEncryptHost, bypassHostConntrack bool) []*Chain {
 
-	var rawRules, rpfRules []Rule
-
-	if enforceRPF {
-		rawRules = append(rawRules, Rule{
-			Action: JumpAction{Target: RPFChain},
-		})
-
-		// Do not RPF check what is marked as to be skipped by RPF check.
-		rpfRules = []Rule{
-			{
-				Match:   Match().MarkMatchesWithMask(tcdefs.MarkSeenBypassSkipRPF, tcdefs.MarkSeenBypassSkipRPFMask),
-				Action:  ReturnAction{},
-				Comment: []string{"Skip RPF if requested"},
-			},
-			{
-				Match:   Match().MarkMatchesWithMask(tcdefs.MarkSeenBypassForward, tcdefs.MarkSeenBypassForwardMask),
-				Action:  ReturnAction{},
-				Comment: []string{"Skip RPF on packets returning from tunnel to the client"},
-			},
-		}
-
-		// For anything we approved for forward, permit accept_local as it is
-		// traffic encapped for NodePort, ICMP replies etc. - stuff we trust.
-		rpfRules = append(rpfRules, Rule{
-			Match:  Match().MarkMatchesWithMask(tcdefs.MarkSeenBypassForward, tcdefs.MarksMask).RPFCheckPassed(true),
-			Action: ReturnAction{},
-		})
-
-		if r.WireguardEnabled && len(r.WireguardInterfaceName) > 0 && wgEncryptHost {
-			// Set a mark on packets coming from any interface except for lo, wireguard, or pod veths to ensure the RPF
-			// check allows it.
-			log.Debug("Adding Wireguard iptables rule chain")
-			rawRules = append(rawRules, Rule{
-				Match:  nil,
-				Action: JumpAction{Target: ChainSetWireguardIncomingMark},
-			})
-		}
-	}
+	var rawRules []Rule
 
 	rawRules = append(rawRules,
 		Rule{
@@ -1164,13 +1127,6 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 		bpfUntrackedFlowChain,
 		r.failsafeOutChain("raw", ipVersion),
 		r.WireguardIncomingMarkChain(),
-	}
-
-	if enforceRPF {
-		chains = append(chains, &Chain{
-			Name:  RPFChain,
-			Rules: rpfRules,
-		})
 	}
 
 	if ipVersion == 4 {


### PR DESCRIPTION
Since RPF is now fully enforce by BPF, we can safely remove this code.

In addition, we free up CALI_SKB_MARK_SKIP_RPF marks for other use.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
