### PR TITLE
felix/bpf: udp ctlb affinity per socket

### DIFF
--- a/felix/bpf-gpl/nat_lookup.h
+++ b/felix/bpf-gpl/nat_lookup.h
@@ -21,7 +21,8 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup(__be32 ip_sr
 								    bool from_tun,
 								    nat_lookup_result *res,
 								    int affinity_always_timeo,
-								    bool affinity_tmr_update)
+								    bool affinity_tmr_update,
+								    __u32 cookie)
 {
 	struct calico_nat_v4_key nat_key = {
 		.prefixlen = NAT_PREFIX_LEN_WITH_SRC_MATCH_IN_BITS,
@@ -33,7 +34,9 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup(__be32 ip_sr
 	struct calico_nat_v4_value *nat_lv1_val;
 	struct calico_nat_secondary_v4_key nat_lv2_key;
 	struct calico_nat_dest *nat_lv2_val;
-	struct calico_nat_v4_affinity_key affkey = {};
+	struct calico_nat_v4_affinity_key affkey = {
+		.cookie = cookie,
+	};
 	__u64 now = 0;
 
 	nat_lv1_val = cali_v4_nat_fe_lookup_elem(&nat_key);
@@ -198,7 +201,7 @@ static CALI_BPF_INLINE struct calico_nat_dest* calico_v4_nat_lookup2(__be32 ip_s
 								    bool from_tun,
 								    nat_lookup_result *res)
 {
-	return calico_v4_nat_lookup(ip_src, ip_dst, ip_proto, dport, from_tun, res, 0, false);
+	return calico_v4_nat_lookup(ip_src, ip_dst, ip_proto, dport, from_tun, res, 0, false, 0);
 }
 
 #endif /* __CALI_NAT_LOOKUP_H__ */

--- a/felix/bpf-gpl/nat_types.h
+++ b/felix/bpf-gpl/nat_types.h
@@ -86,7 +86,7 @@ CALI_MAP_V1(cali_v4_nat_be,
 struct calico_nat_v4_affinity_key {
 	struct calico_nat_v4 nat_key;
 	__u32 client_ip;
-	__u32 padding;
+	__u32 cookie;
 };
 
 struct calico_nat_v4_affinity_val {


### PR DESCRIPTION
Use the socket cookie to distinguish clients. We use piggyback on the
per-client affinity to maintain affinity per socket.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
