### PR TITLE
IPv6 VXLAN: Add IPv6 support to flannel migration

### DIFF
--- a/calico/getting-started/kubernetes/flannel/migration-from-flannel.md
+++ b/calico/getting-started/kubernetes/flannel/migration-from-flannel.md
@@ -100,10 +100,12 @@ which can be set as environment variables within the pod.
 | Configuration options            | Description                                                          | Default                                    |
 |----------------------------------|----------------------------------------------------------------------|--------------------------------------------|
 | FLANNEL_NETWORK                  | IPv4 network CIDR used by flannel for the cluster.                   | Automatically detected                     |
+| FLANNEL_IPV6_NETWORK             | IPv6 network CIDR used by flannel for the cluster.                   | Automatically detected                     |
 | FLANNEL_DAEMONSET_NAME           | Name of the flannel daemon set in the kube-system namespace.         | kube-flannel-ds-amd64                      |
 | FLANNEL_MTU                      | MTU for the flannel VXLAN device.                                    | Automatically detected                     |
 | FLANNEL_IP_MASQ                  | Whether masquerading is enabled for outbound traffic.                | Automatically detected                     |
-| FLANNEL_SUBNET_LEN               | Per-node subnet length used by flannel.                              | 24                                         |
+| FLANNEL_SUBNET_LEN               | Per-node IPv4 subnet length used by flannel.                         | 24                                         |
+| FLANNEL_IPV6_SUBNET_LEN          | Per-node IPv6 subnet length used by flannel.                         | 64                                         |
 | FLANNEL_ANNOTATION_PREFIX        | Value provided via the kube-annotation-prefix option to flannel.     |  flannel.alpha.coreos.com                  |
 | FLANNEL_VNI                      | The VNI used for the flannel network.                                |  1                                         |
 | FLANNEL_PORT                     | UDP port used for VXLAN.                                             |  8472                                      |

--- a/kube-controllers/pkg/controllers/flannelmigration/config_test.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/config_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Config", func() {
 	unsetEnv := func() {
 		os.Unsetenv("FLANNEL_DAEMONSET_NAME")
 		os.Unsetenv("FLANNEL_SUBNET_LEN")
+		os.Unsetenv("FLANNEL_IPV6_SUBNET_LEN")
 		os.Unsetenv("FLANNEL_ANNOTATION_PREFIX")
 		os.Unsetenv("FLANNEL_VNI")
 		os.Unsetenv("FLANNEL_PORT")
@@ -75,10 +76,12 @@ var _ = Describe("Config", func() {
 
 		// Assert default values
 		Expect(config.FlannelNetwork).To(Equal(""))
+		Expect(config.FlannelIpv6Network).To(Equal(""))
 		Expect(config.FlannelMTU).To(Equal(0))
 		Expect(config.FlannelIPMasq).To(Equal(true))
 		Expect(config.FlannelDaemonsetName).To(Equal("kube-flannel-ds-amd64"))
 		Expect(config.FlannelSubnetLen).To(Equal(24))
+		Expect(config.FlannelIpv6SubnetLen).To(Equal(64))
 		Expect(config.FlannelAnnotationPrefix).To(Equal("flannel.alpha.coreos.com"))
 		Expect(config.FlannelVNI).To(Equal(1))
 		Expect(config.FlannelPort).To(Equal(8472))
@@ -100,10 +103,40 @@ var _ = Describe("Config", func() {
 
 		// Assert values
 		Expect(config.FlannelNetwork).To(Equal("10.244.0.0/16"))
+		Expect(config.FlannelIpv6Network).To(Equal(""))
 		Expect(config.FlannelMTU).To(Equal(8951))
 		Expect(config.FlannelIPMasq).To(Equal(false))
 		Expect(config.FlannelDaemonsetName).To(Equal("flannel-daemonset"))
 		Expect(config.FlannelSubnetLen).To(Equal(25))
+		Expect(config.FlannelIpv6SubnetLen).To(Equal(64))
+		Expect(config.FlannelAnnotationPrefix).To(Equal("flannel-prefix"))
+		Expect(config.FlannelVNI).To(Equal(3))
+		Expect(config.FlannelPort).To(Equal(1234))
+		Expect(config.CalicoDaemonsetName).To(Equal("calico-daemonset"))
+		Expect(config.CniConfigDir).To(Equal("/cni/config"))
+		Expect(config.PodNodeName).To(Equal("test-node"))
+	})
+
+	It("with valid IPv6 user defined values", func() {
+		// Set environment variables
+		setEnv()
+		os.Setenv("FLANNEL_IPV6_SUBNET_LEN", "66")
+		os.Setenv("FLANNEL_SUBNET_ENV", "FLANNEL_NETWORK=10.244.0.0/16;FLANNEL_SUBNET=10.244.1.1/24;FLANNEL_MTU=8951;FLANNEL_IPMASQ=false;FLANNEL_IPV6_NETWORK=2001:cafe:42::/56;FLANNEL_IPV6_SUBNET=2001:cafe:42::1/64;")
+		defer unsetEnv()
+
+		// Parse config
+		config := new(fm.Config)
+		err := config.Parse()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Assert values
+		Expect(config.FlannelNetwork).To(Equal("10.244.0.0/16"))
+		Expect(config.FlannelIpv6Network).To(Equal("2001:cafe:42::/56"))
+		Expect(config.FlannelMTU).To(Equal(8951))
+		Expect(config.FlannelIPMasq).To(Equal(false))
+		Expect(config.FlannelDaemonsetName).To(Equal("flannel-daemonset"))
+		Expect(config.FlannelSubnetLen).To(Equal(25))
+		Expect(config.FlannelIpv6SubnetLen).To(Equal(66))
 		Expect(config.FlannelAnnotationPrefix).To(Equal("flannel-prefix"))
 		Expect(config.FlannelVNI).To(Equal(3))
 		Expect(config.FlannelPort).To(Equal(1234))


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Read and parse IPv6-related flannel config.
    
Optionally create IPv6 IP pool with VXLAN enabled if IPv6 flannel is present and valid.

Update docs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add IPv6 support for flannel migration.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
