### PR TITLE
[release-v3.23] Added a closing tag `%>` to fix broken tab structure

### DIFF
--- a/calico/reference/node/configuration.md
+++ b/calico/reference/node/configuration.md
@@ -21,8 +21,10 @@ various settings.
   <label:Operator,active:true>
 <%
 
-calico/node does not need to be configured directly when installed by the operator. For a complete operator 
+`{{site.nodecontainer}}` does not need to be configured directly when installed by the operator. For a complete operator 
 configuration reference, see [the installation API reference documentation][installation].
+
+%>
 
   <label:Manifest>
 <%


### PR DESCRIPTION
Cherrypick of 6db48009da11c1c84c58ce781e949a5d64d5eaac

See #6089 