### PR TITLE
Automated cherry pick of #6094: Fixes for flannel migration

### DIFF
--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -55,9 +55,11 @@ import (
 )
 
 // VERSION is filled out during the build process (using git describe output)
-var VERSION string
-var version bool
-var statusFile string
+var (
+	VERSION    string
+	version    bool
+	statusFile string
+)
 
 func init() {
 	// Add a flag to check the version.
@@ -284,7 +286,6 @@ func runHealthChecks(ctx context.Context, s *status.Status, k8sClientset *kubern
 
 // Starts an etcdv3 compaction goroutine with the given config.
 func startCompactor(ctx context.Context, interval time.Duration) {
-
 	if interval.Nanoseconds() == 0 {
 		log.Info("Disabling periodic etcdv3 compaction")
 		return
@@ -374,7 +375,6 @@ func newEtcdV3Client() (*clientv3.Client, error) {
 		KeyFile:       config.Spec.EtcdKeyFile,
 	}
 	tlsClient, err := tlsInfo.ClientConfig()
-
 	if err != nil {
 		return nil, err
 	}

--- a/kube-controllers/pkg/controllers/flannelmigration/ipam_migrator.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/ipam_migrator.go
@@ -364,7 +364,7 @@ func (m *ipamMigrator) SetVXLANEnabled(ctx context.Context, enabled bool) error 
 	if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
 		// Doesn't exist - create it.
 		defaultConfig = &api.FelixConfiguration{}
-		defaultConfig.Name = "default"
+		defaultConfig.Name = defaultIpv4PoolName
 	} else if err != nil {
 		log.WithError(err).Errorf("Error getting default FelixConfiguration resource")
 		return err
@@ -425,7 +425,7 @@ func updateOrCreateDefaultFelixConfiguration(ctx context.Context, client client.
 
 	// Do nothing if the correct value has been set.
 	if currentVNI == vni && currentPort == port && currentMTU == mtu {
-		log.Infof("Default Felix configration has got correct VNI(%d), port(%d), mtu(%d).", currentVNI, currentPort, currentMTU)
+		log.Infof("Default Felix configration has correct VNI(%d), port(%d), mtu(%d).", currentVNI, currentPort, currentMTU)
 		return nil
 	}
 

--- a/kube-controllers/pkg/controllers/flannelmigration/ipam_migrator.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/ipam_migrator.go
@@ -358,6 +358,36 @@ func createDefaultVxlanIPPool(ctx context.Context, client client.Interface, cidr
 	return nil
 }
 
+func (m *ipamMigrator) SetVXLANEnabled(ctx context.Context, enabled bool) error {
+	log.Infof("Setting FelixConfiguration VXLANEnabled=%t", enabled)
+	defaultConfig, err := m.calicoClient.FelixConfigurations().Get(ctx, defaultFelixConfigurationName, options.GetOptions{})
+	if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+		// Doesn't exist - create it.
+		defaultConfig = &api.FelixConfiguration{}
+		defaultConfig.Name = "default"
+	} else if err != nil {
+		log.WithError(err).Errorf("Error getting default FelixConfiguration resource")
+		return err
+	}
+	defaultConfig.Spec.VXLANEnabled = &enabled
+
+	if defaultConfig.ResourceVersion != "" {
+		_, err = m.calicoClient.FelixConfigurations().Update(ctx, defaultConfig, options.SetOptions{})
+		if err != nil {
+			log.WithError(err).Errorf("Failed to update default FelixConfiguration.")
+			return err
+		}
+	} else {
+		_, err = m.calicoClient.FelixConfigurations().Create(ctx, defaultConfig, options.SetOptions{})
+		if err != nil {
+			log.WithError(err).Errorf("Failed to create default FelixConfiguration.")
+			return err
+		}
+	}
+	log.Infof("FelixConfiguration updated VXLANEnabled=%t", enabled)
+	return nil
+}
+
 // Update default FelixConfiguration with specified VNI, port and MTU.
 // If migrating from Flannel, return error if vxlan is not enabled.
 // If migrating from Canal, set vxlan enabled.

--- a/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
@@ -169,7 +169,7 @@ func (c *flannelMigrationController) Run(stopCh chan struct{}) {
 	// Disable VXLAN in Felix explicitly. We don't want to turn this on until we have
 	// updated the Calico nodes with the necessary VTEP information from flannel. This ensures
 	// that Calico will respect flannel's VXLAN traffic once enabled.
-	if err := c.ipamMigrator.SetVXLANEnabled(context.TODO(), false); err != nil {
+	if err := c.ipamMigrator.SetVXLANMode(context.TODO(), vxlanModeDisabled); err != nil {
 		log.WithError(err).Errorf("Error disabling VXLAN")
 		c.HandleError(err)
 	}
@@ -197,8 +197,10 @@ func (c *flannelMigrationController) Run(stopCh chan struct{}) {
 		c.HandleError(err)
 	}
 
-	// Now that we have populated Calico with flannel's VXLAN data, we can enable VXLAN in Felix.
-	if err := c.ipamMigrator.SetVXLANEnabled(context.TODO(), true); err != nil {
+	// Now that we have populated Calico with flannel's VXLAN data, we can clear the VXLAN bit
+	// in Felix - Felix will determine that VXLAN is enabled based on the fact that it is
+	// set on an IP pool.
+	if err := c.ipamMigrator.SetVXLANMode(context.TODO(), vxlanModeCleared); err != nil {
 		log.WithError(err).Errorf("Error enabling VXLAN")
 		c.HandleError(err)
 	}

--- a/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/migration_controller.go
@@ -166,6 +166,14 @@ func (c *flannelMigrationController) Run(stopCh chan struct{}) {
 
 	// Start migration process.
 
+	// Disable VXLAN in Felix explicitly. We don't want to turn this on until we have
+	// updated the Calico nodes with the necessary VTEP information from flannel. This ensures
+	// that Calico will respect flannel's VXLAN traffic once enabled.
+	if err := c.ipamMigrator.SetVXLANEnabled(context.TODO(), false); err != nil {
+		log.WithError(err).Errorf("Error disabling VXLAN")
+		c.HandleError(err)
+	}
+
 	// Initialise Calico IPAM before we handle any nodes.
 	err = c.ipamMigrator.InitialiseIPPoolAndFelixConfig()
 	if err != nil {
@@ -186,6 +194,12 @@ func (c *flannelMigrationController) Run(stopCh chan struct{}) {
 	c.flannelNodes, err = c.runIpamMigrationForNodes()
 	if err != nil {
 		log.WithError(err).Errorf("Error running ipam migration.")
+		c.HandleError(err)
+	}
+
+	// Now that we have populated Calico with flannel's VXLAN data, we can enable VXLAN in Felix.
+	if err := c.ipamMigrator.SetVXLANEnabled(context.TODO(), true); err != nil {
+		log.WithError(err).Errorf("Error enabling VXLAN")
 		c.HandleError(err)
 	}
 
@@ -318,7 +332,7 @@ func (c *flannelMigrationController) CheckShouldMigrate() (bool, error) {
 		return false, nil
 	}
 
-	//Check if addon manager label exists
+	// Check if addon manager label exists
 	found, val, err := d.getLabelValue(c.k8sClientset, namespaceKubeSystem, addOnManagerLabelKey)
 	if err != nil {
 		return false, err

--- a/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/network_migrator.go
@@ -138,12 +138,10 @@ func (m *networkMigrator) checkCalicoVxlan(node *v1.Node) error {
 // Drain node, remove Flannel and setup Calico network for a node.
 func (m *networkMigrator) setupCalicoNetworkForNode(node *v1.Node) error {
 	log.Infof("Setting node label to disable Flannel daemonset pod on node %s.", node.Name)
-	// Set two node labels at the beginning of network migration.
-	// - Label nodeNetworkNone stops Flannel pod from being scheduled on this node.
-	//   Flannel pod currently running on the node starts to be evicted as the side effect.
-	// - Label nodeMigrationInProgress marks that the node is in migration process.
+
+	// Label nodeMigrationInProgress marks that the node is in migration process.
 	n := k8snode(node.Name)
-	err := n.addNodeLabels(m.k8sClientset, nodeNetworkNone, nodeMigrationInProgress)
+	err := n.addNodeLabels(m.k8sClientset, nodeMigrationInProgress)
 	if err != nil {
 		log.WithError(err).Errorf("Error adding node labels to disable Flannel network and mark migration in process for node %s.", node.Name)
 		return err
@@ -153,6 +151,13 @@ func (m *networkMigrator) setupCalicoNetworkForNode(node *v1.Node) error {
 	err = n.Drain()
 	if err != nil {
 		log.WithError(err).Errorf("failed to drain node %s", node.Name)
+		return err
+	}
+
+	// Label the node to evict the flannel / canal pod from this node. Do this after evicting other pods.
+	err = n.addNodeLabels(m.k8sClientset, nodeNetworkNone)
+	if err != nil {
+		log.WithError(err).Errorf("Error adding node labels to disable Flannel network and mark migration in process for node %s.", node.Name)
 		return err
 	}
 

--- a/kube-controllers/tests/fv/flannel_migration_test.go
+++ b/kube-controllers/tests/fv/flannel_migration_test.go
@@ -342,12 +342,26 @@ func validateCalicoIPAM(fc *testutils.FlannelCluster, client client.Interface, b
 	Expect(defaultPool.Spec.NATOutgoing).To(Equal(true))
 	Expect(defaultPool.Spec.VXLANMode).To(Equal(api.VXLANMode(api.VXLANModeAlways)))
 
-	// Check felix configuration.
-	defaultConfig, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
-	Expect(err).ShouldNot(HaveOccurred())
-	Expect(*defaultConfig.Spec.VXLANVNI).To(Equal(1))
-	Expect(*defaultConfig.Spec.VXLANPort).To(Equal(8472))
-	Expect(*defaultConfig.Spec.VXLANMTU).To(Equal(8951))
+	// Check felix configuration. This might take a second or two.
+	Eventually(func() error {
+		defaultConfig, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if defaultConfig.Spec.VXLANEnabled != nil {
+			return fmt.Errorf("VXLAN is explicitly set")
+		}
+		if *defaultConfig.Spec.VXLANVNI != 1 {
+			return fmt.Errorf("Wrong VXLAN VNI: %d", *defaultConfig.Spec.VXLANVNI)
+		}
+		if *defaultConfig.Spec.VXLANPort != 8472 {
+			return fmt.Errorf("Wrong VXLAN port: %d", *defaultConfig.Spec.VXLANPort)
+		}
+		if *defaultConfig.Spec.VXLANMTU != 8951 {
+			return fmt.Errorf("Wrong VXLAN MTU: %d", *defaultConfig.Spec.VXLANMTU)
+		}
+		return nil
+	}, 5*time.Second).ShouldNot(HaveOccurred())
 
 	// Check each node.
 	for nodeName, fn := range fc.FlannelNodes {


### PR DESCRIPTION
Cherry pick of #6094 on release-v3.23.

#6094: Fixes for flannel migration

# Original PR Body below

Cherry pick of #6075 on master.

#6075: Fixes for flannel migration

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes a few flannel migration issues:

- Ensures VXLAN is disabled until we update node metadata.
- Ensure we evict flannel / canal pods after we evict app pods.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix migration race conditions when upgrading from canal to Calico
```