### PR TITLE
Reduced amount of libraries included in several container images.

### DIFF
--- a/cni-plugin/Dockerfile.amd64
+++ b/cni-plugin/Dockerfile.amd64
@@ -33,8 +33,10 @@ ADD licenses/ /licenses
 ADD LICENSE /licenses/
 
 # Include libraries from UBI for dynamic linking.
-COPY --from=ubi /lib64 /lib64
-COPY --from=ubi /lib /lib
+COPY --from=ubi /lib64/ld-* /lib64/
+COPY --from=ubi /lib64/libc-* /lib64/
+COPY --from=ubi /lib64/libc.* /lib64/
+COPY --from=ubi /lib64/libpthread* /lib64/
 
 ADD $BIN_DIR/ /opt/cni/bin/
 

--- a/kube-controllers/Dockerfile.amd64
+++ b/kube-controllers/Dockerfile.amd64
@@ -42,8 +42,10 @@ COPY --from=ubi /profiles /profiles
 COPY --from=ubi /status /status
 
 COPY --from=ubi /usr/include /usr/include
-COPY --from=ubi /lib64 /lib64
-COPY --from=ubi /lib /lib
+COPY --from=ubi /lib64/ld-* /lib64/
+COPY --from=ubi /lib64/libc-* /lib64/
+COPY --from=ubi /lib64/libc.* /lib64/
+COPY --from=ubi /lib64/libpthread* /lib64/
 
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ADD bin/check-status-linux-amd64 /usr/bin/check-status

--- a/typha/docker-image/Dockerfile.amd64
+++ b/typha/docker-image/Dockerfile.amd64
@@ -41,8 +41,10 @@ COPY --from=ubi /sbin/tini /sbin/tini
 COPY --from=ubi /licenses /licenses
 
 COPY --from=ubi /usr/include /usr/include
-COPY --from=ubi /lib64 /lib64
-COPY --from=ubi /lib /lib
+COPY --from=ubi /lib64/ld-* /lib64/
+COPY --from=ubi /lib64/libc-* /lib64/
+COPY --from=ubi /lib64/libc.* /lib64/
+COPY --from=ubi /lib64/libpthread* /lib64/
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Reduced amount of libraries included in several container images.

Only very few dynamic libraries are actually required in the cni, typha
and kube-controllers containers as most functionality is statically linked
into the binaries. Therefore, it is not required to bundle all libraries
from the base image, but it is sufficient to only include a select few.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes #6123 

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes #6123.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
