### PR TITLE
add total table count checks to routeTableRanges option for apiserver

### DIFF
--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -479,6 +479,15 @@ type RouteTableIDRange struct {
 
 type RouteTableRanges []RouteTableIDRange
 
+func (r RouteTableRanges) Len() int {
+	var len int = 0
+	for _, rng := range r {
+		len += rng.Max - rng.Min
+	}
+
+	return len
+}
+
 // ProtoPort is combination of protocol, port, and CIDR. Protocol and port must be specified.
 type ProtoPort struct {
 	Protocol string `json:"protocol"`

--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -479,10 +479,10 @@ type RouteTableIDRange struct {
 
 type RouteTableRanges []RouteTableIDRange
 
-func (r RouteTableRanges) Len() int {
+func (r RouteTableRanges) NumDesignatedTables() int {
 	var len int = 0
 	for _, rng := range r {
-		len += rng.Max - rng.Min
+		len += (rng.Max - rng.Min) + 1 // add one, since range is inclusive
 	}
 
 	return len

--- a/calico/reference/resources/felixconfig.md
+++ b/calico/reference/resources/felixconfig.md
@@ -168,7 +168,7 @@ calicoctl patch felixconfig default --type=merge -p '{"spec":{"routeTableRanges"
 
 *Note*, for performance reasons, the maximum total number of routing tables that Felix will accept is 65535 (or 2*16).
 
-If both `RouteTableRanges` and `RouteTableRange` are set, `RouteTableRanges` takes precedence and `RouteTableRange` is ignored.
+Specifying both the `RouteTableRange` and `RouteTableRanges` arguments is not supported and will result in an error from the api.
 
 #### AWS IAM Role/Policy for source-destination-check configuration
 

--- a/felix/config/param_types.go
+++ b/felix/config/param_types.go
@@ -591,7 +591,8 @@ func (r *RegionParam) Parse(raw string) (result interface{}, err error) {
 	return raw, nil
 }
 
-// linux can support route-tables with indices up to 0xfffffff, however, using all of them would likely blow up, so cap the limit at 65535
+// linux can support route-table indices up to 0xFFFFFFFF
+// however, using 0xFFFFFFFF tables would require too much computation, so the total number of designated tables is capped at 0xFFFF
 const routeTableMaxLinux = 0xffffffff
 const routeTableRangeMaxTables = 0xffff
 

--- a/libcalico-go/lib/validator/v3/validator.go
+++ b/libcalico-go/lib/validator/v3/validator.go
@@ -45,7 +45,8 @@ const (
 	// Maximum size of annotations.
 	totalAnnotationSizeLimitB int64 = 256 * (1 << 10) // 256 kB
 
-	// linux can support route-tables with indices up to 0xfffffff, however, using all of them would likely blow up, so cap the limit at 65535
+	// linux can support route-table indices up to 0xFFFFFFFF
+	// however, using 0xFFFFFFFF tables would require too much computation, so the total number of designated tables is capped at 0xFFFF
 	routeTableMaxLinux       uint32 = 0xffffffff
 	routeTableRangeMaxTables uint32 = 0xffff
 
@@ -794,7 +795,7 @@ func validateFelixConfigSpec(structLevel validator.StructLevel) {
 			"RouteTableRange", "", reason("cannot be set when `RouteTableRanges` is also set"), "")
 	}
 
-	if c.RouteTableRanges != nil && c.RouteTableRanges.Len() > int(routeTableRangeMaxTables) {
+	if c.RouteTableRanges != nil && c.RouteTableRanges.NumDesignatedTables() > int(routeTableRangeMaxTables) {
 		structLevel.ReportError(reflect.ValueOf(c.RouteTableRanges),
 			"RouteTableRanges", "", reason("targets too many tables"), "")
 	}

--- a/libcalico-go/lib/validator/v3/validator.go
+++ b/libcalico-go/lib/validator/v3/validator.go
@@ -45,8 +45,9 @@ const (
 	// Maximum size of annotations.
 	totalAnnotationSizeLimitB int64 = 256 * (1 << 10) // 256 kB
 
-	// linux can support route-tables with indices up to 0xfffffff
-	routeTableMaxLinux uint32 = 0xffffffff
+	// linux can support route-tables with indices up to 0xfffffff, however, using all of them would likely blow up, so cap the limit at 65535
+	routeTableMaxLinux       uint32 = 0xffffffff
+	routeTableRangeMaxTables uint32 = 0xffff
 
 	globalSelector = "global()"
 )
@@ -791,6 +792,11 @@ func validateFelixConfigSpec(structLevel validator.StructLevel) {
 	if c.RouteTableRange != nil && c.RouteTableRanges != nil {
 		structLevel.ReportError(reflect.ValueOf(c.RouteTableRange),
 			"RouteTableRange", "", reason("cannot be set when `RouteTableRanges` is also set"), "")
+	}
+
+	if c.RouteTableRanges != nil && c.RouteTableRanges.Len() > int(routeTableRangeMaxTables) {
+		structLevel.ReportError(reflect.ValueOf(c.RouteTableRanges),
+			"RouteTableRanges", "", reason("targets too many tables"), "")
 	}
 }
 
@@ -1612,7 +1618,6 @@ func validateRouteTableIDRange(structLevel validator.StructLevel) {
 		)
 	}
 
-	// cast both ints to 64bit as casting the max 32-bit integer to int() would overflow on 32bit systems
 	if int64(r.Max) > int64(routeTableMaxLinux) {
 		log.Warningf("RouteTableRange is invalid: %v", r)
 		structLevel.ReportError(

--- a/libcalico-go/lib/validator/v3/validator_test.go
+++ b/libcalico-go/lib/validator/v3/validator_test.go
@@ -723,6 +723,8 @@ func init() {
 		Entry("should reject route table ranges min negative", api.FelixConfigurationSpec{RouteTableRanges: &api.RouteTableRanges{{Min: -5, Max: 250}}}, false),
 		Entry("should reject route table ranges max < min", api.FelixConfigurationSpec{RouteTableRanges: &api.RouteTableRanges{{Min: 50, Max: 45}}}, false),
 		Entry("should reject route table ranges max too large", api.FelixConfigurationSpec{RouteTableRanges: &api.RouteTableRanges{{Min: 1, Max: 0xf00000000}}}, false),
+		Entry("should reject single route table ranges targeting too many tables", api.FelixConfigurationSpec{RouteTableRanges: &api.RouteTableRanges{{Min: 1, Max: 0x10000}}}, false),
+		Entry("should reject multitple route table ranges targeting too many tables", api.FelixConfigurationSpec{RouteTableRanges: &api.RouteTableRanges{{Min: 1, Max: 2}, {Min: 3, Max: 4}, {Min: 5, Max: 0x10000}}}, false),
 
 		Entry("should reject spec with both RouteTableRanges and RouteTableRange set", api.FelixConfigurationSpec{
 			RouteTableRanges: &api.RouteTableRanges{


### PR DESCRIPTION
## Description
Cherrypick from EE. Adds apiserver valdation to limit the maximum number of tables targeted by `routeTableRanges`  Felixconfig option. This validation is already present in Felix itself, so currently, adding an oversized `routeTableRanges` arg via `kubectl` or similar will succeed when patching FelixConfig, but then cause Felix to panic. This PR causes such a patch to fail immediately instead.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
