### PR TITLE
Document Wireguard network requirements

### DIFF
--- a/calico/_includes/content/reqs-sys.md
+++ b/calico/_includes/content/reqs-sys.md
@@ -66,7 +66,7 @@ Ensure that your hosts and firewalls allow the necessary traffic based on your c
 {%- else if include.orch == "Kubernetes" %}
 | {{site.prodname}} networking with VXLAN enabled              | All                  | Bidirectional   | UDP 4789 |
 | {{site.prodname}} networking with Typha enabled              | Typha agent hosts    | Incoming        | TCP 5473 (default) |
-| {{site.prodname}} networking with Wireguard enabled          | All                  | Bidirectional   | UDP 51820 |
+| {{site.prodname}} networking with Wireguard enabled          | All                  | Bidirectional   | UDP 51820 (default) |
 | flannel networking (VXLAN)                                   | All                  | Bidirectional   | UDP 4789 |
 | All                                                          | kube-apiserver host  | Incoming        | Often TCP 443 or 6443\* |
 | etcd datastore                                               | etcd hosts           | Incoming        | {% include open-new-window.html text='Officially' url='http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt' %}  TCP 2379 but can vary |

--- a/calico/_includes/content/reqs-sys.md
+++ b/calico/_includes/content/reqs-sys.md
@@ -66,6 +66,7 @@ Ensure that your hosts and firewalls allow the necessary traffic based on your c
 {%- else if include.orch == "Kubernetes" %}
 | {{site.prodname}} networking with VXLAN enabled              | All                  | Bidirectional   | UDP 4789 |
 | {{site.prodname}} networking with Typha enabled              | Typha agent hosts    | Incoming        | TCP 5473 (default) |
+| {{site.prodname}} networking with Wireguard enabled          | All                  | Bidirectional   | UDP 51820 |
 | flannel networking (VXLAN)                                   | All                  | Bidirectional   | UDP 4789 |
 | All                                                          | kube-apiserver host  | Incoming        | Often TCP 443 or 6443\* |
 | etcd datastore                                               | etcd hosts           | Incoming        | {% include open-new-window.html text='Officially' url='http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt' %}  TCP 2379 but can vary |


### PR DESCRIPTION
## Description

Add wireguard UDP port 51820 to network requirements.

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
