### PR TITLE
BPF FV Tests: only flush workload conntrack entries

### DIFF
--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -55,6 +55,11 @@ type Felix struct {
 	ExternalIP string
 
 	startupDelayed bool
+	Workloads      []workload
+}
+
+type workload interface {
+	GetIP() string
 }
 
 func (f *Felix) GetFelixPID() int {

--- a/felix/fv/infrastructure/infra_etcd.go
+++ b/felix/fv/infrastructure/infra_etcd.go
@@ -58,7 +58,12 @@ func GetEtcdDatastoreInfra() (*EtcdDatastoreInfra, error) {
 
 	// In BPF mode, start BPF logging.
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
-		eds.bpfLog = containers.Run("bpf-log", containers.RunOpts{AutoRemove: true}, "--privileged",
+		eds.bpfLog = containers.Run("bpf-log",
+			containers.RunOpts{
+				AutoRemove:       true,
+				IgnoreEmptyLines: true,
+			},
+			"--privileged",
 			"calico/bpftool:v5.3-amd64", "/bpftool", "prog", "tracelog")
 	}
 

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -164,7 +164,11 @@ func GetK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 func (kds *K8sDatastoreInfra) PerTestSetup() {
 	// In BPF mode, start BPF logging.
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
-		kds.bpfLog = containers.Run("bpf-log", containers.RunOpts{AutoRemove: true}, "--privileged",
+		kds.bpfLog = containers.Run("bpf-log",
+			containers.RunOpts{
+				AutoRemove:       true,
+				IgnoreEmptyLines: true,
+			}, "--privileged",
 			"calico/bpftool:v5.3-amd64", "/bpftool", "prog", "tracelog")
 	}
 	K8sInfra.runningTest = ginkgo.CurrentGinkgoTestDescription().FullTestText

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -60,6 +60,10 @@ type Workload struct {
 	MTU                   int
 }
 
+func (w *Workload) GetIP() string {
+	return w.IP
+}
+
 var workloadIdx = 0
 var sideServIdx = 0
 
@@ -131,7 +135,7 @@ func New(c *infrastructure.Felix, name, profile, ip, ports, protocol string, mtu
 		specifiedMTU = mtu[0]
 	}
 
-	return &Workload{
+	workload := &Workload{
 		C:                  c.Container,
 		Name:               n,
 		SpoofName:          spoofN,
@@ -143,6 +147,8 @@ func New(c *infrastructure.Felix, name, profile, ip, ports, protocol string, mtu
 		WorkloadEndpoint:   wep,
 		MTU:                specifiedMTU,
 	}
+	c.Workloads = append(c.Workloads, workload)
+	return workload
 }
 
 func run(c *infrastructure.Felix, name, profile, ip, ports, protocol string, mtu int) (w *Workload, err error) {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This fixes a flake in certain BPF tests caused by this pattern:
* Test makes an API change
* Test does a connectivity check with a before-retry action that cleans up conntrack entries
* The first iteration of the connectivity check loop fails triggering the before-retry action
* The before-retry action did a complete flush of Linux conntrack in each felix.
* This broke Felix's connection to the API server so that it never received the API update event.

Fix is to only clear workload conntrack entries.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
