### PR TITLE
bpf fix attach gap

### DIFF
--- a/felix/bpf-gpl/conntrack.h
+++ b/felix/bpf-gpl/conntrack.h
@@ -652,7 +652,11 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 		if (CALI_F_FROM_HEP && tc_ctx->state->tun_ip && result.tun_ip && result.tun_ip != tc_ctx->state->tun_ip) {
 			CALI_CT_DEBUG("tunnel src changed from %x to %x\n",
 					bpf_ntohl(result.tun_ip), bpf_ntohl(tc_ctx->state->tun_ip));
-			ct_result_set_flag(result.rc, CALI_CT_TUN_SRC_CHANGED);
+			ct_result_set_flag(result.rc, CT_RES_TUN_SRC_CHANGED);
+		}
+
+		if (tracking_v->a_to_b.whitelisted && tracking_v->b_to_a.whitelisted) {
+			ct_result_set_flag(result.rc, CT_RES_CONFIRMED);
 		}
 
 		break;
@@ -713,6 +717,11 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			CALI_CT_DEBUG("Hit! NAT REV entry but not connection opener: ESTABLISHED.\n");
 			result.rc =	CALI_CT_ESTABLISHED;
 		}
+
+		if (v->a_to_b.whitelisted && v->b_to_a.whitelisted) {
+			ct_result_set_flag(result.rc, CT_RES_CONFIRMED);
+		}
+
 		break;
 
 	case CALI_CT_TYPE_NORMAL:
@@ -743,6 +752,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 
 		if (v->a_to_b.whitelisted && v->b_to_a.whitelisted) {
 			result.rc = CALI_CT_ESTABLISHED_BYPASS;
+			ct_result_set_flag(result.rc, CT_RES_CONFIRMED);
 		} else {
 			result.rc = CALI_CT_ESTABLISHED;
 		}
@@ -763,7 +773,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 
 	int ret_from_tun = CALI_F_FROM_HEP &&
 				tc_ctx->state->tun_ip &&
-				result.rc == CALI_CT_ESTABLISHED_DNAT &&
+				ct_result_rc(result.rc) == CALI_CT_ESTABLISHED_DNAT &&
 				src_to_dst->whitelisted &&
 				result.flags & CALI_CT_FLAG_NP_FWD;
 
@@ -851,7 +861,7 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 			 * Do not check if packets are returning from the NP vxlan tunnel.
 			 */
 			if (!same_if && !ret_from_tun && !hep_rpf_check(tc_ctx, false) && !CALI_F_NAT_IF) {
-				ct_result_set_flag(result.rc, CALI_CT_RPF_FAILED);
+				ct_result_set_flag(result.rc, CT_RES_RPF_FAILED);
 			} else {
 				src_to_dst->ifindex = ifindex;
 			}
@@ -875,14 +885,14 @@ static CALI_BPF_INLINE struct calico_ct_result calico_ct_v4_lookup(struct cali_t
 
 	if (syn) {
 		CALI_CT_DEBUG("packet is SYN\n");
-		ct_result_set_flag(result.rc, CALI_CT_SYN);
+		ct_result_set_flag(result.rc, CT_RES_SYN);
 	}
 
 
 	CALI_CT_DEBUG("result: 0x%x\n", result.rc);
 
 	if (related) {
-		ct_result_set_flag(result.rc, CALI_CT_RELATED);
+		ct_result_set_flag(result.rc, CT_RES_RELATED);
 		CALI_CT_DEBUG("result: related\n");
 	}
 

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -169,21 +169,23 @@ enum calico_ct_result_type {
 	CALI_CT_INVALID = 6,
 };
 
-#define CALI_CT_RELATED         0x100
-#define CALI_CT_RPF_FAILED      0x200
-#define CALI_CT_TUN_SRC_CHANGED 0x400
-#define CALI_CT_RESERVED_800	0x800
-#define CALI_CT_SYN		0x1000
+#define CT_RES_RELATED         0x100
+#define CT_RES_RPF_FAILED      0x200
+#define CT_RES_TUN_SRC_CHANGED 0x400
+#define CT_RES_RESERVED_800	0x800
+#define CT_RES_SYN		0x1000
+#define CT_RES_CONFIRMED	0x2000
 
 #define ct_result_rc(rc)		((rc) & 0xff)
 #define ct_result_flags(rc)		((rc) & ~0xff)
 #define ct_result_set_rc(val, rc)	((val) = ct_result_flags(val) | (rc))
 #define ct_result_set_flag(val, flags)	((val) |= (flags))
 
-#define ct_result_is_related(rc)	((rc) & CALI_CT_RELATED)
-#define ct_result_rpf_failed(rc)	((rc) & CALI_CT_RPF_FAILED)
-#define ct_result_tun_src_changed(rc)	((rc) & CALI_CT_TUN_SRC_CHANGED)
-#define ct_result_is_syn(rc)		((rc) & CALI_CT_SYN)
+#define ct_result_is_related(rc)	((rc) & CT_RES_RELATED)
+#define ct_result_rpf_failed(rc)	((rc) & CT_RES_RPF_FAILED)
+#define ct_result_tun_src_changed(rc)	((rc) & CT_RES_TUN_SRC_CHANGED)
+#define ct_result_is_syn(rc)		((rc) & CT_RES_SYN)
+#define ct_result_is_confirmed(rc)	((rc) & CT_RES_CONFIRMED)
 
 struct calico_ct_result {
 	__s16 rc;

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -31,13 +31,13 @@ static CALI_BPF_INLINE bool fib_approve(struct cali_tc_ctx *ctx, __u32 ifindex)
 		struct ifstate_val *val;
 
 		if (!(val = (struct ifstate_val *)cali_iface_lookup_elem(&ifindex))) {
-			CALI_DEBUG("FIB succes not approved - connection to unknown ep %d not confirmed.\n", ifindex);
+			CALI_DEBUG("FIB not approved - connection to unknown ep %d not confirmed.\n", ifindex);
 			return false;
 		}
 
-		if (iface_is_worload(val->flags) && !iface_is_ready(val->flags)) {
+		if (iface_is_workload(val->flags) && !iface_is_ready(val->flags)) {
 			ctx->fwd.mark |= CALI_SKB_MARK_SKIP_FIB;
-			CALI_DEBUG("FIB succes not approved - connection to unready 0x%x ep %s (%d) not confirmed.\n",
+			CALI_DEBUG("FIB not approved - connection to unready 0x%x ep %s (%d) not confirmed.\n",
 					val->flags, val->name, ifindex);
 			return false;
 		}

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -99,12 +99,6 @@ skip_redir_ifindex:
 #if CALI_FIB_ENABLED
 	// Try a short-circuit FIB lookup.
 	if (fwd_fib(&ctx->fwd)) {
-		/* XXX we might include the tot_len in the fwd, set it once when
-		 * we get the ip_header the first time and only adjust the value
-		 * when we modify the packet - to avoid getting the header here
-		 * again - it is simpler though.
-		 */
-
 		/* Revalidate the access to the packet */
 		if (skb_refresh_validate_ptrs(ctx, UDP_SIZE)) {
 			ctx->fwd.reason = CALI_REASON_SHORT;

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -28,16 +28,17 @@ static CALI_BPF_INLINE bool fib_approve(struct cali_tc_ctx *ctx, __u32 ifindex)
 	 * iptables that will filter out packets to non-ready workloads.
 	 */
 	if (!ct_result_is_confirmed(state->ct_result.rc)) {
-		__u32 *val;
+		struct ifstate_val *val;
 
-		if (!(val = (__u32 *)cali_iface_lookup_elem(&ifindex))) {
+		if (!(val = (struct ifstate_val *)cali_iface_lookup_elem(&ifindex))) {
 			CALI_DEBUG("FIB succes not approved - connection to unknown ep %d not confirmed.\n", ifindex);
 			return false;
 		}
 
-		if (iface_is_worload(*val) && !iface_is_ready(*val)) {
+		if (iface_is_worload(val->flags) && !iface_is_ready(val->flags)) {
 			ctx->fwd.mark |= CALI_SKB_MARK_SKIP_FIB;
-			CALI_DEBUG("FIB succes not approved - connection to unready 0x%x ep %d not confirmed.\n", *val, ifindex);
+			CALI_DEBUG("FIB succes not approved - connection to unready 0x%x ep %s (%d) not confirmed.\n",
+					val->flags, val->name, ifindex);
 			return false;
 		}
 	}

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -7,6 +7,7 @@
 
 #include "types.h"
 #include "skb.h"
+#include "ifstate.h"
 
 #if CALI_FIB_ENABLED
 #define fwd_fib(fwd)			((fwd)->fib)
@@ -17,6 +18,32 @@
 #define fwd_fib_set(fwd, v)
 #define fwd_fib_set_flags(fwd, flags)
 #endif
+
+static CALI_BPF_INLINE bool fib_approve(struct cali_tc_ctx *ctx, __u32 ifindex)
+{
+	struct cali_tc_state *state = ctx->state;
+
+	/* To avoid forwarding packets to workloads that are not yet ready, i.e
+	 * their tc programs are not attached yet, send unconfirmed packets via
+	 * iptables that will filter out packets to non-ready workloads.
+	 */
+	if (!ct_result_is_confirmed(state->ct_result.rc)) {
+		__u32 *val;
+
+		if (!(val = (__u32 *)cali_iface_lookup_elem(&ifindex))) {
+			CALI_DEBUG("FIB succes not approved - connection to unknown ep not confirmed");
+			return false;
+		}
+
+		if (iface_is_worload(val) && !iface_is_ready(val)) {
+			ctx->fwd.mark |= CALI_SKB_MARK_SKIP_FIB;
+			CALI_DEBUG("FIB succes not approved - connection to unready ep not confirmed");
+			return false;
+		}
+	}
+
+	return true;
+}
 
 static CALI_BPF_INLINE int forward_or_drop(struct cali_tc_ctx *ctx)
 {
@@ -145,6 +172,9 @@ skip_redir_ifindex:
 		switch (rc) {
 		case 0:
 			CALI_DEBUG("FIB lookup succeeded - with neigh\n");
+			if (!fib_approve(ctx, fib_params.ifindex)) {
+				goto cancel_fib;
+			}
 
 			// Update the MACs.
 			struct ethhdr *eth_hdr = ctx->data_start;
@@ -161,6 +191,11 @@ skip_redir_ifindex:
 		case BPF_FIB_LKUP_RET_NO_NEIGH:
 			if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_redirect_neigh)) {
 				CALI_DEBUG("FIB lookup succeeded - not neigh - gw %x\n", bpf_ntohl(fib_params.ipv4_dst));
+
+				if (!fib_approve(ctx, fib_params.ifindex)) {
+					goto cancel_fib;
+				}
+
 				struct bpf_redir_neigh nh_params = {};
 
 				nh_params.nh_family = fib_params.family;

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -1,0 +1,19 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+#ifndef __CALI_IFSTATE_H__
+#define __CALI_IFSTATE_H__
+
+CALI_MAP(cali_iface, 2,
+		BPF_MAP_TYPE_HASH,
+		__u32, __u32,
+		1000, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+
+#define IFACE_STATE_WEP		0x1
+#define IFACE_STATE_READY	0x2
+
+#define iface_is_worload(state)		((state) & IFACE_STATE_WEP)
+#define iface_is_ready(state)		((state) & IFACE_STATE_READY)
+
+#endif /* __CALI_IFSTATE_H__ */

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -5,9 +5,14 @@
 #ifndef __CALI_IFSTATE_H__
 #define __CALI_IFSTATE_H__
 
+struct ifstate_val {
+	__u32 flags;
+	char  name[16];
+};
+
 CALI_MAP(cali_iface, 2,
 		BPF_MAP_TYPE_HASH,
-		__u32, __u32,
+		__u32, struct ifstate_val,
 		1000, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
 
 #define IFACE_STATE_WEP		0x1

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -18,7 +18,7 @@ CALI_MAP(cali_iface, 2,
 #define IFACE_STATE_WEP		0x1
 #define IFACE_STATE_READY	0x2
 
-#define iface_is_worload(state)		((state) & IFACE_STATE_WEP)
+#define iface_is_workload(state)		((state) & IFACE_STATE_WEP)
 #define iface_is_ready(state)		((state) & IFACE_STATE_READY)
 
 #endif /* __CALI_IFSTATE_H__ */

--- a/felix/bpf-gpl/reasons.h
+++ b/felix/bpf-gpl/reasons.h
@@ -26,6 +26,7 @@ enum calico_reason {
 	CALI_REASON_UNAUTH_SOURCE = 0xed,
 	CALI_REASON_RT_UNKNOWN = 0xdead,
 	CALI_REASON_ACCEPTED_BY_XDP = 0xd9,
+	CALI_REASON_WEP_NOT_READY = 0xffdead,
 };
 
 #endif /* __CALI_REASONS_H__ */

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -26,13 +26,22 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/failsafes"
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/bpf/ipsets"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	"github.com/projectcalico/calico/felix/bpf/state"
 )
 
-func CreateBPFMapContext(ipsetsMapSize, natFEMapSize, natBEMapSize, natAffMapSize, routeMapSize, ctMapSize int, repinEnabled bool) *bpf.MapContext {
+func CreateBPFMapContext(
+	ipsetsMapSize,
+	natFEMapSize,
+	natBEMapSize,
+	natAffMapSize,
+	routeMapSize,
+	ctMapSize int,
+	repinEnabled bool,
+) *bpf.MapContext {
 	bpfMapContext := &bpf.MapContext{
 		RepinningEnabled: repinEnabled,
 		MapSizes:         map[string]uint32{},
@@ -49,6 +58,7 @@ func CreateBPFMapContext(ipsetsMapSize, natFEMapSize, natBEMapSize, natAffMapSiz
 	bpfMapContext.MapSizes[failsafes.MapParams.VersionedName()] = uint32(failsafes.MapParams.MaxEntries)
 	bpfMapContext.MapSizes[nat.SendRecvMsgMapParameters.VersionedName()] = uint32(nat.SendRecvMsgMapParameters.MaxEntries)
 	bpfMapContext.MapSizes[nat.CTNATsMapParameters.VersionedName()] = uint32(nat.CTNATsMapParameters.MaxEntries)
+	bpfMapContext.MapSizes[ifstate.MapParams.VersionedName()] = uint32(ifstate.MapParams.MaxEntries)
 
 	return bpfMapContext
 }
@@ -105,6 +115,9 @@ func CreateBPFMaps(mc *bpf.MapContext) error {
 
 	mc.CtNatsMap = nat.AllNATsMsgMap(mc)
 	maps = append(maps, mc.CtNatsMap)
+
+	mc.IfStateMap = ifstate.Map(mc)
+	maps = append(maps, mc.IfStateMap)
 
 	for _, bpfMap := range maps {
 		err := bpfMap.EnsureExists()

--- a/felix/bpf/cachingmap/caching_map.go
+++ b/felix/bpf/cachingmap/caching_map.go
@@ -154,6 +154,11 @@ func (c *CachingMap) SetDesired(k, v []byte) {
 	c.pendingUpdates.Set(k, v)
 }
 
+// GetDesired returns the desired (latest) value.
+func (c *CachingMap) GetDesired(k []byte) []byte {
+	return c.desiredStateOfDataplane.Get(k)
+}
+
 func slicesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false

--- a/felix/bpf/cachingmap/caching_map.go
+++ b/felix/bpf/cachingmap/caching_map.go
@@ -154,11 +154,6 @@ func (c *CachingMap) SetDesired(k, v []byte) {
 	c.pendingUpdates.Set(k, v)
 }
 
-// GetDesired returns the desired (latest) value.
-func (c *CachingMap) GetDesired(k []byte) []byte {
-	return c.desiredStateOfDataplane.Get(k)
-}
-
 func slicesEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false

--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ifstate
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/projectcalico/calico/felix/bpf"
+)
+
+const (
+	KeySize    = 4
+	ValueSize  = 4
+	MaxEntries = 1000
+)
+
+const (
+	FlgWEP   = uint32(0x1)
+	FlgReady = uint32(0x2)
+)
+
+var MapParams = bpf.MapParameters{
+	Filename:     "/sys/fs/bpf/tc/globals/cali_iface",
+	Type:         "hash",
+	KeySize:      KeySize,
+	ValueSize:    ValueSize,
+	MaxEntries:   MaxEntries,
+	Name:         "cali_iface",
+	Flags:        unix.BPF_F_NO_PREALLOC,
+	Version:      2,
+	UpdatedByBPF: false,
+}
+
+func Map(mc *bpf.MapContext) bpf.Map {
+	return mc.NewPinnedMap(MapParams)
+}
+
+type Key [4]byte
+
+func NewKey(ifIndex uint32) Key {
+	var k Key
+
+	binary.LittleEndian.PutUint32(k[:], ifIndex)
+
+	return k
+}
+
+func (k Key) AsBytes() []byte {
+	return k[:]
+}
+
+func (k Key) IfIndex() uint32 {
+	return binary.LittleEndian.Uint32(k[:])
+}
+
+type Value [4]byte
+
+func NewValue(flags uint32) Value {
+	var v Value
+
+	binary.LittleEndian.PutUint32(v[:], flags)
+
+	return v
+}
+
+func (v Value) AsBytes() []byte {
+	return v[:]
+}
+
+func (v Value) Flags() uint32 {
+	return binary.LittleEndian.Uint32(v[:])
+}

--- a/felix/bpf/maps.go
+++ b/felix/bpf/maps.go
@@ -101,6 +101,7 @@ type MapContext struct {
 	CtMap            Map
 	SrMsgMap         Map
 	CtNatsMap        Map
+	IfStateMap       Map
 	MapSizes         map[string]uint32
 }
 

--- a/felix/bpf/mock/map.go
+++ b/felix/bpf/mock/map.go
@@ -123,6 +123,11 @@ func (m *Map) CopyDeltaFromOldMap() error {
 	return nil
 }
 
+func (m *Map) ContainsKey(k []byte) bool {
+	_, ok := m.Contents[string(k)]
+	return ok
+}
+
 func NewMockMap(params bpf.MapParameters) *Map {
 	if params.KeySize <= 0 {
 		logrus.WithField("params", params).Panic("KeySize should be >0")

--- a/felix/cmd/calico-bpf/commands/ifstate.go
+++ b/felix/cmd/calico-bpf/commands/ifstate.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	ifstateCmd.AddCommand(ifstateDumpCmd)
+	rootCmd.AddCommand(ifstateCmd)
+}
+
+var ifstateDumpCmd = &cobra.Command{
+	Use:   "dump",
+	Short: "dumps interface states",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := dumpIfState(cmd); err != nil {
+			log.WithError(err).Error("Failed to dump interface states map.")
+		}
+	},
+}
+
+// ifstateCmd represents the ifstate command
+var ifstateCmd = &cobra.Command{
+	Use:   "ifstate",
+	Short: "Manipulates ifstate",
+}
+
+func dumpIfState(cmd *cobra.Command) error {
+	ifstateMap := ifstate.Map(&bpf.MapContext{})
+
+	if err := ifstateMap.Open(); err != nil {
+		return errors.WithMessage(err, "failed to open map")
+	}
+
+	err := ifstateMap.Iter(func(k, v []byte) bpf.IteratorAction {
+		var (
+			key ifstate.Key
+			val ifstate.Value
+		)
+
+		copy(key[:], k[:])
+		copy(val[:], v[:])
+
+		cmd.Printf("%5d : %s\n", key.IfIndex(), val)
+
+		return bpf.IterNone
+	})
+
+	return err
+}

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/tc"
 	"github.com/projectcalico/calico/felix/bpf/xdp"
@@ -164,6 +165,8 @@ type bpfEndpointManager struct {
 	bpfExtToServiceConnmark int
 	psnatPorts              numorstring.Port
 	bpfMapContext           *bpf.MapContext
+	ifStateMap              bpf.Map
+	ifaceNameToIdx          map[string]ifaceIdx
 
 	ruleRenderer        bpfAllowChainRenderer
 	iptablesFilterTable iptablesTable
@@ -218,6 +221,11 @@ type bpfAllowChainRenderer interface {
 	WorkloadInterfaceAllowChains(endpoints map[proto.WorkloadEndpointID]*proto.WorkloadEndpoint) []*iptables.Chain
 }
 
+type ifaceIdx struct {
+	ifindex  int
+	workload bool
+}
+
 func newBPFEndpointManager(
 	dp bpfDataplane,
 	config *Config,
@@ -257,6 +265,8 @@ func newBPFEndpointManager(
 		bpfExtToServiceConnmark: config.BPFExtToServiceConnmark,
 		psnatPorts:              config.BPFPSNATPorts,
 		bpfMapContext:           bpfMapContext,
+		ifStateMap:              bpfMapContext.IfStateMap,
+		ifaceNameToIdx:          map[string]ifaceIdx{},
 		ruleRenderer:            iptablesRuleRenderer,
 		iptablesFilterTable:     iptablesFilterTable,
 		mapCleanupRunner: ratelimited.NewRunner(jumpMapCleanupInterval, func(ctx context.Context) {
@@ -497,6 +507,30 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 					log.WithError(err).Warnf("Failed to set rp_filter for %s.", update.Name)
 				}
 			}
+
+			oldIdx, ok := m.ifaceNameToIdx[update.Name]
+			if !ok || oldIdx.ifindex != update.Index {
+				val := ifaceIdx{
+					ifindex:  update.Index,
+					workload: m.isWorkloadIface(update.Name),
+				}
+				m.ifaceNameToIdx[update.Name] = val
+				flags := uint32(0)
+				if val.workload {
+					flags = ifstate.FlgWEP
+				}
+				// If it errors, we will update it when we load a program
+				err := m.ifStateMap.Update(
+					ifstate.NewKey(uint32(val.ifindex)).AsBytes(),
+					ifstate.NewValue(flags).AsBytes(),
+				)
+				if err != nil {
+					log.WithError(err).Warnf("Failed to write iface %s into BPF map.", update.Name)
+				} else {
+					log.Debugf("ifstate new %s:%d 0x%x", update.Name, val.ifindex, flags)
+				}
+			}
+
 			if _, hostEpConfigured := m.hostIfaceToEpMap[update.Name]; m.wildcardExists && !hostEpConfigured {
 				log.Debugf("Map host-* endpoint for %v", update.Name)
 				m.addHEPToIndexes(update.Name, &m.wildcardHostEndpoint)
@@ -545,6 +579,15 @@ func (m *bpfEndpointManager) onWorkloadEnpdointRemove(msg *proto.WorkloadEndpoin
 
 	m.withIface(oldWEP.Name, func(iface *bpfInterface) bool {
 		iface.info.endpointID = nil
+		val, ok := m.ifaceNameToIdx[oldWEP.Name]
+		if ok {
+			err := m.ifStateMap.Delete(ifstate.NewKey(uint32(val.ifindex)).AsBytes())
+			if err != nil && !bpf.IsNotExists(err) {
+				log.WithError(err).Warnf("Failed to delete iface %s idx %d from bpf map.", oldWEP.Name, val.ifindex)
+			}
+			delete(m.ifaceNameToIdx, oldWEP.Name)
+		}
+
 		return false
 	})
 }
@@ -756,6 +799,11 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 
 		m.opReporter.RecordOperation("update-workload-iface")
 
+		if val, ok := m.ifaceNameToIdx[ifaceName]; !ok || val.ifindex == 0 {
+			errs[ifaceName] = fmt.Errorf("unknown ifindex for dev %s", ifaceName)
+			return nil
+		}
+
 		if err := sem.Acquire(context.Background(), 1); err != nil {
 			// Should only happen if the context finishes.
 			log.WithError(err).Panic("Failed to acquire semaphore")
@@ -792,11 +840,17 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 		if err == nil {
 			log.WithField("iface", ifaceName).Info("Updated workload interface.")
 			if wlID != nil && m.allWEPs[*wlID] != nil {
+				var err error
 				if m.happyWEPs[*wlID] == nil {
+					err = m.wepIfaceReady(ifaceName, true)
 					log.WithField("id", wlID).Info("Adding workload interface to iptables allow list.")
 					m.happyWEPsDirty = true
 				}
-				m.happyWEPs[*wlID] = m.allWEPs[*wlID]
+				if err == nil {
+					m.happyWEPs[*wlID] = m.allWEPs[*wlID]
+				} else {
+					delete(m.happyWEPs, *wlID)
+				}
 			}
 			return set.RemoveItem
 		} else {
@@ -804,6 +858,9 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 				if !isLinkNotFoundError(err) {
 					log.WithField("id", *wlID).WithError(err).Warning(
 						"Failed to add policy to workload, removing from iptables allow list")
+				}
+				if err := m.wepIfaceReady(ifaceName, false); err != nil {
+					log.WithError(err).Warnf("Failed to delete iface %s state from BPF map: %s", ifaceName, err)
 				}
 				delete(m.happyWEPs, *wlID)
 				m.happyWEPsDirty = true
@@ -821,6 +878,24 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 		}).Warn("Failed to apply policy to endpoint, leaving it dirty")
 		return nil
 	})
+}
+
+func (m *bpfEndpointManager) wepIfaceReady(iface string, ready bool) error {
+	val := m.ifaceNameToIdx[iface]
+
+	flgReady := ifstate.FlgReady
+	if !ready {
+		flgReady = 0
+	}
+
+	err := m.ifStateMap.Update(
+		ifstate.NewKey(uint32(val.ifindex)).AsBytes(),
+		ifstate.NewValue(ifstate.FlgWEP|flgReady).AsBytes(),
+	)
+
+	log.WithError(err).Debugf("ifstate update %s:%d %t", iface, val.ifindex, ready)
+
+	return err
 }
 
 // applyPolicy actually applies the policy to the given workload.

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -841,11 +841,6 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 
 		m.opReporter.RecordOperation("update-workload-iface")
 
-		if val, ok := m.ifaceNameToIdx[ifaceName]; !ok || val.ifindex == 0 {
-			errs[ifaceName] = fmt.Errorf("unknown ifindex for dev %s", ifaceName)
-			return nil
-		}
-
 		if err := sem.Acquire(context.Background(), 1); err != nil {
 			// Should only happen if the context finishes.
 			log.WithError(err).Panic("Failed to acquire semaphore")
@@ -857,6 +852,18 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 			defer wg.Done()
 			defer sem.Release(1)
 			err := m.applyPolicy(ifaceName)
+			if err != nil {
+				if isLinkNotFoundError(err) {
+					// Interface is gone, nothing to do.
+					log.WithField("ifaceName", ifaceName).Debug(
+						"Ignoring request to program interface that is not present.")
+					err = nil
+				}
+			} else {
+				if val, ok := m.ifaceNameToIdx[ifaceName]; !ok || val.ifindex == 0 {
+					errs[ifaceName] = fmt.Errorf("unknown ifindex for dev %s", ifaceName)
+				}
+			}
 			mutex.Lock()
 			errs[ifaceName] = err
 			mutex.Unlock()
@@ -972,12 +979,6 @@ func (m *bpfEndpointManager) applyPolicy(ifaceName string) error {
 	// Attach the qdisc first; it is shared between the directions.
 	err := m.dp.ensureQdisc(ifaceName)
 	if err != nil {
-		if isLinkNotFoundError(err) {
-			// Interface is gone, nothing to do.
-			log.WithField("ifaceName", ifaceName).Debug(
-				"Ignoring request to program interface that is not present.")
-			return nil
-		}
 		return err
 	}
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
+	"github.com/projectcalico/calico/felix/bpf/cachingmap"
 	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/tc"
@@ -165,7 +166,7 @@ type bpfEndpointManager struct {
 	bpfExtToServiceConnmark int
 	psnatPorts              numorstring.Port
 	bpfMapContext           *bpf.MapContext
-	ifStateMap              bpf.Map
+	ifStateMap              *cachingmap.CachingMap
 	ifaceNameToIdx          map[string]ifaceIdx
 
 	ruleRenderer        bpfAllowChainRenderer
@@ -265,7 +266,7 @@ func newBPFEndpointManager(
 		bpfExtToServiceConnmark: config.BPFExtToServiceConnmark,
 		psnatPorts:              config.BPFPSNATPorts,
 		bpfMapContext:           bpfMapContext,
-		ifStateMap:              bpfMapContext.IfStateMap,
+		ifStateMap:              cachingmap.New(ifstate.MapParams, bpfMapContext.IfStateMap),
 		ifaceNameToIdx:          map[string]ifaceIdx{},
 		ruleRenderer:            iptablesRuleRenderer,
 		iptablesFilterTable:     iptablesFilterTable,
@@ -282,6 +283,10 @@ func newBPFEndpointManager(
 		// TODO: set ipv6Enabled to config.Ipv6Enabled when IPv6 support is complete
 		ipv6Enabled:          config.BPFIpv6Enabled,
 		rpfStrictModeEnabled: config.BPFEnforceRPF,
+	}
+
+	if err := m.ifStateMap.LoadCacheFromDataplane(); err != nil {
+		return nil, fmt.Errorf("loading caching map for ifstate: %w", err)
 	}
 
 	// Calculate allowed XDP attachment modes.  Note, in BPF mode untracked ingress policy is
@@ -472,6 +477,43 @@ func (m *bpfEndpointManager) onInterfaceAddrsUpdate(update *ifaceAddrsUpdate) {
 	}
 }
 
+func (m *bpfEndpointManager) wepIfaceUpdateIndex(iface string, ifindex int) {
+	oldIdx, ok := m.ifaceNameToIdx[iface]
+	if !ok || oldIdx.ifindex != ifindex {
+		val := ifaceIdx{
+			ifindex:  ifindex,
+			workload: m.isWorkloadIface(iface),
+		}
+		m.ifaceNameToIdx[iface] = val
+		flags := uint32(0)
+		if val.workload {
+			flags = ifstate.FlgWEP
+		}
+
+		kBytes := ifstate.NewKey(uint32(ifindex)).AsBytes()
+
+		// If we get an update and the wep is alredy marked as ready.
+		oldValBytes := m.ifStateMap.GetDesired(kBytes)
+		if oldValBytes != nil {
+			var oldVal ifstate.Value
+			copy(oldVal[:], oldValBytes)
+			if oldName := oldVal.IfName(); oldName != iface {
+				log.Debugf("dev %s reuses ifindex %d previously %s.", iface, ifindex, oldName)
+			} else if oldVal.Flags()&ifstate.FlgReady != 0 {
+				flags |= ifstate.FlgReady
+				log.Debugf("dev %s ifindex %d already ready.", iface, ifindex)
+			}
+		} else {
+			log.Debugf("ifindex %d free to use by %s", ifindex, iface)
+		}
+		m.ifStateMap.SetDesired(
+			kBytes,
+			ifstate.NewValue(flags, iface).AsBytes(),
+		)
+		log.Debugf("ifstate update %s:%d 0x%x", iface, val.ifindex, flags)
+	}
+}
+
 func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 	log.Debugf("Interface update for %v, state %v", update.Name, update.State)
 
@@ -508,49 +550,7 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 				}
 			}
 
-			oldIdx, ok := m.ifaceNameToIdx[update.Name]
-			if !ok || oldIdx.ifindex != update.Index {
-				val := ifaceIdx{
-					ifindex:  update.Index,
-					workload: m.isWorkloadIface(update.Name),
-				}
-				m.ifaceNameToIdx[update.Name] = val
-				flags := uint32(0)
-				if val.workload {
-					flags = ifstate.FlgWEP
-				}
-
-				kBytes := ifstate.NewKey(uint32(update.Index)).AsBytes()
-
-				// If we get an update and the wep is alredy marked as ready,
-				// e.g. after felix restarted, we should not make it unready.
-				oldValBytes, err := m.ifStateMap.Get(kBytes)
-				if err == nil {
-					var oldVal ifstate.Value
-					copy(oldVal[:], oldValBytes)
-					if oldName := oldVal.IfName(); oldName != update.Name {
-						log.Debugf("dev %s reuses ifindex %d previously %s.", update.Name, update.Index, oldName)
-					} else if oldVal.Flags()&ifstate.FlgReady != 0 {
-						flags |= ifstate.FlgReady
-						log.Debugf("dev %s ifindex %d already ready.", update.Name, update.Index)
-					}
-				} else if err != nil && !bpf.IsNotExists(err) {
-					log.WithError(err).Warnf("Failed to read ifstate ifindex %d for %s from bpf map",
-						update.Index, update.Name)
-				} else {
-					log.Debugf("ifindex %d free to use by %s", update.Index, update.Name)
-				}
-				// If it errors, we will update it when we load a program
-				err = m.ifStateMap.Update(
-					kBytes,
-					ifstate.NewValue(flags, update.Name).AsBytes(),
-				)
-				if err != nil {
-					log.WithError(err).Warnf("Failed to write iface %s into BPF map.", update.Name)
-				} else {
-					log.Debugf("ifstate update %s:%d 0x%x", update.Name, val.ifindex, flags)
-				}
-			}
+			m.wepIfaceUpdateIndex(update.Name, update.Index)
 
 			if _, hostEpConfigured := m.hostIfaceToEpMap[update.Name]; m.wildcardExists && !hostEpConfigured {
 				log.Debugf("Map host-* endpoint for %v", update.Name)
@@ -579,6 +579,24 @@ func (m *bpfEndpointManager) onWorkloadEndpointUpdate(msg *proto.WorkloadEndpoin
 	wl := msg.Endpoint
 	m.allWEPs[wlID] = wl
 	m.addWEPToIndexes(wlID, wl)
+
+	// Make sure that we know the ifindex. The wep could have been removed, but we may not
+	// get a new status update for the device as the device does not change.
+	if _, ok := m.ifaceNameToIdx[wl.Name]; !ok {
+		nl, err := netlinkshim.NewRealNetlink()
+		if err != nil {
+			log.WithError(err).Warn("Failed to create nelink")
+		} else {
+			link, err := nl.LinkByName(wl.Name)
+			if err != nil {
+				// Do nothink, the link does not exist, if it gets created, we will get an update.
+				log.WithError(err).Debugf("Link %s does not exist.", wl.Name)
+			} else {
+				m.wepIfaceUpdateIndex(wl.Name, link.Attrs().Index)
+			}
+		}
+	}
+
 	m.withIface(wl.Name, func(iface *bpfInterface) bool {
 		iface.info.endpointID = &wlID
 		return true // Force interface to be marked dirty in case policies changed.
@@ -602,11 +620,9 @@ func (m *bpfEndpointManager) onWorkloadEnpdointRemove(msg *proto.WorkloadEndpoin
 		iface.info.endpointID = nil
 		val, ok := m.ifaceNameToIdx[oldWEP.Name]
 		if ok {
-			err := m.ifStateMap.Delete(ifstate.NewKey(uint32(val.ifindex)).AsBytes())
-			if err != nil && !bpf.IsNotExists(err) {
-				log.WithError(err).Warnf("Failed to delete iface %s idx %d from bpf map.", oldWEP.Name, val.ifindex)
-			}
+			m.ifStateMap.DeleteDesired(ifstate.NewKey(uint32(val.ifindex)).AsBytes())
 			delete(m.ifaceNameToIdx, oldWEP.Name)
+			log.Debugf("ifstate delete %s %v", oldWEP.Name, val)
 		}
 
 		return false
@@ -695,6 +711,11 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 
 	bpfEndpointsGauge.Set(float64(len(m.nameToIface)))
 	bpfDirtyEndpointsGauge.Set(float64(m.dirtyIfaceNames.Len()))
+
+	if err := m.ifStateMap.ApplyAllChanges(); err != nil {
+		log.WithError(err).Warn("Failed to write updates to ifstate BPF map.")
+		return err
+	}
 
 	if m.happyWEPsDirty {
 		chains := m.ruleRenderer.WorkloadInterfaceAllowChains(m.happyWEPs)
@@ -861,19 +882,14 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 		if err == nil {
 			log.WithField("iface", ifaceName).Info("Updated workload interface.")
 			if wlID != nil && m.allWEPs[*wlID] != nil {
-				var err error
 				if m.happyWEPs[*wlID] == nil {
-					err = m.wepIfaceReady(ifaceName, true)
+					m.wepIfaceReady(ifaceName, true)
 					log.WithFields(log.Fields{
 						"id":    wlID,
 						"iface": ifaceName,
 					}).Info("Adding workload interface to iptables allow list.")
 				}
-				if err == nil {
-					m.happyWEPs[*wlID] = m.allWEPs[*wlID]
-				} else {
-					delete(m.happyWEPs, *wlID)
-				}
+				m.happyWEPs[*wlID] = m.allWEPs[*wlID]
 				m.happyWEPsDirty = true
 			}
 			return set.RemoveItem
@@ -883,9 +899,7 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 					log.WithField("id", *wlID).WithError(err).Warning(
 						"Failed to add policy to workload, removing from iptables allow list")
 				}
-				if err := m.wepIfaceReady(ifaceName, false); err != nil {
-					log.WithError(err).Warnf("Failed to delete iface %s state from BPF map: %s", ifaceName, err)
-				}
+				m.wepIfaceReady(ifaceName, false)
 				delete(m.happyWEPs, *wlID)
 				m.happyWEPsDirty = true
 			}
@@ -904,7 +918,7 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 	})
 }
 
-func (m *bpfEndpointManager) wepIfaceReady(iface string, ready bool) error {
+func (m *bpfEndpointManager) wepIfaceReady(iface string, ready bool) {
 	val := m.ifaceNameToIdx[iface]
 
 	flgReady := ifstate.FlgReady
@@ -912,14 +926,12 @@ func (m *bpfEndpointManager) wepIfaceReady(iface string, ready bool) error {
 		flgReady = 0
 	}
 
-	err := m.ifStateMap.Update(
+	m.ifStateMap.SetDesired(
 		ifstate.NewKey(uint32(val.ifindex)).AsBytes(),
 		ifstate.NewValue(ifstate.FlgWEP|flgReady, iface).AsBytes(),
 	)
 
-	log.WithError(err).Debugf("ifstate update %s:%d %t", iface, val.ifindex, ready)
-
-	return err
+	log.Debugf("ifstate update %s:%d %t", iface, val.ifindex, ready)
 }
 
 // applyPolicy actually applies the policy to the given workload.

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -268,11 +268,11 @@ var _ = Describe("BPF Endpoint Manager", func() {
 	genIfaceUpdate := func(name string, state ifacemonitor.State, index int) func() {
 		return func() {
 			bpfEpMgr.OnUpdate(&ifaceUpdate{Name: name, State: state, Index: index})
+			err := bpfEpMgr.CompleteDeferredWork()
+			Expect(err).NotTo(HaveOccurred())
 			if state == ifacemonitor.StateUp {
 				Expect(ifStateMap.ContainsKey(ifstate.NewKey(uint32(index)).AsBytes())).To(BeTrue())
 			}
-			err := bpfEpMgr.CompleteDeferredWork()
-			Expect(err).NotTo(HaveOccurred())
 		}
 	}
 

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -30,7 +30,9 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	bpfipsets "github.com/projectcalico/calico/felix/bpf/ipsets"
+	"github.com/projectcalico/calico/felix/bpf/mock"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/state"
 	"github.com/projectcalico/calico/felix/idalloc"
@@ -189,6 +191,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		rrConfigNormal       rules.Config
 		ruleRenderer         rules.RuleRenderer
 		filterTableV4        iptablesTable
+		ifStateMap           *mock.Map
 	)
 
 	BeforeEach(func() {
@@ -205,6 +208,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		bpfMapContext.IpsetsMap = bpfipsets.Map(bpfMapContext)
 		bpfMapContext.StateMap = state.Map(bpfMapContext)
 		bpfMapContext.CtMap = conntrack.Map(bpfMapContext)
+		ifStateMap = mock.NewMockMap(ifstate.MapParams)
+		bpfMapContext.IfStateMap = ifStateMap
 		rrConfigNormal = rules.Config{
 			IPIPEnabled:                 true,
 			IPIPTunnelAddress:           nil,
@@ -263,6 +268,9 @@ var _ = Describe("BPF Endpoint Manager", func() {
 	genIfaceUpdate := func(name string, state ifacemonitor.State, index int) func() {
 		return func() {
 			bpfEpMgr.OnUpdate(&ifaceUpdate{Name: name, State: state, Index: index})
+			if state == ifacemonitor.StateUp {
+				Expect(ifStateMap.ContainsKey(ifstate.NewKey(uint32(index)).AsBytes())).To(BeTrue())
+			}
 			err := bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -579,8 +579,15 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		defaultRPFilter = []byte{'1'}
 	}
 
-	bpfMapContext := bpfmap.CreateBPFMapContext(config.BPFMapSizeIPSets, config.BPFMapSizeNATFrontend,
-		config.BPFMapSizeNATBackend, config.BPFMapSizeNATAffinity, config.BPFMapSizeRoute, config.BPFMapSizeConntrack, config.BPFMapRepin)
+	bpfMapContext := bpfmap.CreateBPFMapContext(
+		config.BPFMapSizeIPSets,
+		config.BPFMapSizeNATFrontend,
+		config.BPFMapSizeNATBackend,
+		config.BPFMapSizeNATAffinity,
+		config.BPFMapSizeRoute,
+		config.BPFMapSizeConntrack,
+		config.BPFMapRepin,
+	)
 
 	var bpfEndpointManager *bpfEndpointManager
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -602,7 +602,8 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						Eventually(func() string {
 							out, _ := felixes[0].ExecOutput("tc", "filter", "show", "ingress", "dev", w[0].InterfaceName)
 							return out
-						}, "5s", "200ms").Should(ContainSubstring("calico_from_wor"))
+						}, "5s", "200ms").Should(ContainSubstring("calico_from_wor"),
+							fmt.Sprintf("from wep not loaded for %s", w[0].InterfaceName))
 
 						By("handling egress program removal")
 						felixes[0].Exec("tc", "filter", "del", "egress", "dev", w[0].InterfaceName)
@@ -615,7 +616,8 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						Eventually(func() string {
 							out, _ := felixes[0].ExecOutput("tc", "filter", "show", "egress", "dev", w[0].InterfaceName)
 							return out
-						}, "5s", "200ms").Should(ContainSubstring("calico_to_wor"))
+						}, "5s", "200ms").Should(ContainSubstring("calico_to_wor"),
+							fmt.Sprintf("to wep not loaded for %s", w[0].InterfaceName))
 						cc.CheckConnectivity()
 
 						By("Handling qdisc removal")
@@ -628,11 +630,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						Eventually(func() string {
 							out, _ := felixes[0].ExecOutput("tc", "filter", "show", "ingress", "dev", w[0].InterfaceName)
 							return out
-						}, "5s", "200ms").Should(ContainSubstring("calico_from_wor"))
+						}, "5s", "200ms").Should(ContainSubstring("calico_from_wor"),
+							fmt.Sprintf("from wep not loaded for %s", w[0].InterfaceName))
 						Eventually(func() string {
 							out, _ := felixes[0].ExecOutput("tc", "filter", "show", "egress", "dev", w[0].InterfaceName)
 							return out
-						}, "5s", "200ms").Should(ContainSubstring("calico_to_wor"))
+						}, "5s", "200ms").Should(ContainSubstring("calico_to_wor"),
+							fmt.Sprintf("to wep not loaded for %s", w[0].InterfaceName))
 						cc.CheckConnectivity()
 						cc.ResetExpectations()
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -309,6 +309,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					felix.Exec("calico-bpf", "nat", "aff")
 					felix.Exec("calico-bpf", "conntrack", "dump")
 					felix.Exec("calico-bpf", "arp", "dump")
+					felix.Exec("calico-bpf", "ifstate", "dump")
 					log.Infof("[%d]FrontendMap: %+v", i, currBpfsvcs[i])
 					log.Infof("[%d]NATBackend: %+v", i, currBpfeps[i])
 					log.Infof("[%d]SendRecvMap: %+v", i, dumpSendRecvMap(felix))


### PR DESCRIPTION
## Description

    felix/bpf: bpf_ep_mgr.ifStateMap is a cachingmap
    
    This reconciles state after restarts and makes sure that unused entries
    do not stay for ever.

    felix/bpf: ifstate map contains iface name
    
    For easier debugging and more robustnes in detecting what has changed
    and what was the previous state.

    felix/bpf: drop packets for disapproved FIB success

    felix/bpf: bpfEndpointManager marks weps as ready.
    
    When bpfEndpointManager has ifindex and applies tc programs to a WEP, it
    also records in a bpf map that the iface is "ready". Thereafter tc
    programs that have successful FIB lookup can redirec straight to the
    wep. Otherwise the packet is dropped as it is unsafe to forward it and
    it it pointless to let it be dropped by iptables for the same reason.

    felix/bpf: approve FIB success
    
    When we have a FIB success, we need to approve it otherwise we could
    redirect packets to a local workload that does not have it's tc programs
    and a policy applied yet. That leaves security hole.

    felix/bpf: remove comment that is no longer true

    felix/bpf: CT_RES_CONFIRMED set when both sides approved
    
    CALI_CT_ESTABLISHED_BYPASS still required because that is a special case
    for connections that have no NAT.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: we drop packets that are about to be redirected to a workload endpoint that does not have a tc attached program yet, hence is unprotected.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
