### PR TITLE
helm/tigera-operator: use supplied tolerations/nodeSelector

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -121,6 +121,18 @@ certs:
 # By default, no resource requests or limits are specified.
 resources: {}
 
+# Tolerations for the tigera/operator pod itself.
+# By default, will schedule on all possible place.
+tolerations:
+- effect: NoExecute
+  operator: Exists
+- effect: NoSchedule
+  operator: Exists
+
+# NodeSelector for the tigera/operator pod itself.
+nodeSelector:
+  kubernetes.io/os: linux
+
 # Configuration for the tigera operator images to deploy.
 tigeraOperator:
   image: tigera/operator

--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -16,13 +16,14 @@ spec:
         name: tigera-operator
         k8s-app: tigera-operator
     spec:
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-        kubernetes.io/os: linux
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-        - effect: NoExecute
-          operator: Exists
-        - effect: NoSchedule
-          operator: Exists
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: tigera-operator
       hostNetwork: true
       # This must be set when hostNetwork is true or else the cluster services won't resolve

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -20,6 +20,18 @@ certs:
 
 resources: {}
 
+# Tolerations for the tigera/operator pod itself.
+# By default, will schedule on all possible place.
+tolerations:
+- effect: NoExecute
+  operator: Exists
+- effect: NoSchedule
+  operator: Exists
+
+# NodeSelector for the tigera/operator pod itself.
+nodeSelector:
+  kubernetes.io/os: linux
+
 # Configuration for the tigera operator
 tigeraOperator:
   image: tigera/operator


### PR DESCRIPTION
## Description

Impact only tigera-operator chart.

When using specialized pools, default tolerations are too broad. This keeps default
behavior but allow to override scheduling parameters during helm installation.
