### PR TITLE
Make sure we seed the random number generator (once).

### DIFF
--- a/apiserver/cmd/apiserver/apiserver.go
+++ b/apiserver/cmd/apiserver/apiserver.go
@@ -25,10 +25,15 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	"github.com/projectcalico/calico/apiserver/cmd/apiserver/server"
 )
 
 func main() {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/apiserver/test/integration/framework.go
+++ b/apiserver/test/integration/framework.go
@@ -25,6 +25,8 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
@@ -40,7 +42,7 @@ import (
 const defaultEtcdPathPrefix = ""
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	seedrng.EnsureSeeded()
 }
 
 type TestServerConfig struct {

--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -28,6 +28,7 @@ import (
 	"github.com/projectcalico/calico/app-policy/proto"
 	"github.com/projectcalico/calico/app-policy/syncher"
 	"github.com/projectcalico/calico/app-policy/uds"
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 
 	"github.com/docopt/docopt-go"
 	authz_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
@@ -54,6 +55,9 @@ Options:
 var VERSION string
 
 func main() {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	arguments, err := docopt.ParseArgs(usage, nil, VERSION)
 	if err != nil {
 		println(usage)

--- a/calicoctl/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl/calicoctl.go
@@ -22,11 +22,16 @@ import (
 	"github.com/docopt/docopt-go"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
 func main() {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	name, desc := util.NameAndDescription()
 	doc := fmt.Sprintf(`Usage:
   <BINARY_NAME> [options] <command> [<args>...]

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -34,6 +34,8 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"k8s.io/client-go/rest"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/node/pkg/cni"
@@ -119,6 +121,9 @@ func loadConfig() config {
 }
 
 func Install() error {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	// Configure logging before anything else.
 	logrus.SetFormatter(&logutils.Formatter{Component: "cni-installer"})
 

--- a/cni-plugin/pkg/ipamplugin/ipam_plugin.go
+++ b/cni-plugin/pkg/ipamplugin/ipam_plugin.go
@@ -33,6 +33,8 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/sirupsen/logrus"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/cni-plugin/internal/pkg/utils"
@@ -47,6 +49,9 @@ import (
 )
 
 func Main(version string) {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	// Set up logging formatting.
 	logrus.SetFormatter(&logutils.Formatter{})
 

--- a/cni-plugin/pkg/plugin/plugin.go
+++ b/cni-plugin/pkg/plugin/plugin.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/cni-plugin/internal/pkg/utils"
@@ -688,6 +690,9 @@ func cmdDummyCheck(args *skel.CmdArgs) (err error) {
 }
 
 func Main(version string) {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	// Set up logging formatting.
 	logrus.SetFormatter(&logutils.Formatter{})
 

--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
@@ -162,7 +164,7 @@ func getKubernetesClient() *kubernetes.Clientset {
 
 var _ = Describe("Kubernetes CNI tests", func() {
 	// Create a random seed
-	rand.Seed(time.Now().UTC().UnixNano())
+	seedrng.EnsureSeeded()
 	hostname, _ := names.Hostname()
 	ctx := context.Background()
 	calicoClient, err := client.NewFromEnv()

--- a/cni-plugin/win_tests/calico_cni_k8s_windows_test.go
+++ b/cni-plugin/win_tests/calico_cni_k8s_windows_test.go
@@ -46,6 +46,7 @@ import (
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/calico/libcalico-go/lib/names"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -91,7 +92,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 	BeforeSuite(func() {
 		log.Infof("CONTAINER_RUNTIME=%v", os.Getenv("CONTAINER_RUNTIME"))
 
-		//Clean-up Networks if left over in previous run
+		// Clean-up Networks if left over in previous run
 		hnsNetworkList, _ := hcsshim.HNSListNetworkRequest("GET", "", "")
 		log.WithField("hnsNetworkList: ", hnsNetworkList).Infof("List of Network")
 		for _, network := range hnsNetworkList {
@@ -102,7 +103,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 		}
 		// Create a random seed
-		rand.Seed(time.Now().UTC().UnixNano())
+		seedrng.EnsureSeeded()
 		hostname, _ = names.Hostname()
 		ctx = context.Background()
 		for i := 1; i <= 3; i++ {
@@ -1556,7 +1557,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					lastNWName = podNwName
 					nwsName = append(nwsName, podNwName)
 				}
-				//Network should  be same
+				// Network should  be same
 				Expect(nwName).Should(Equal(podNwName))
 			}
 		})
@@ -2051,7 +2052,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			log.Infof("Checking timestamp container 1 %s", containerID1)
 			justDeleted, err := utils.CheckWepJustDeleted(containerID1, 12)
 			Expect(err).ShouldNot(HaveOccurred())
-			//JustDeleted for container1 could vary because it depends on how long it takes to delete container2.
+			// JustDeleted for container1 could vary because it depends on how long it takes to delete container2.
 
 			log.Infof("Checking timestamp container 2 %s", containerID2)
 			justDeleted, err = utils.CheckWepJustDeleted(containerID2, 12)

--- a/confd/confd.go
+++ b/confd/confd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectcalico/calico/confd/pkg/buildinfo"
 	"github.com/projectcalico/calico/confd/pkg/config"
 	"github.com/projectcalico/calico/confd/pkg/run"
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 )
 
 var (
@@ -17,6 +18,9 @@ var (
 )
 
 func main() {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
 	flag.Parse()
 	if printVersion {

--- a/felix/cmd/calico-bpf/commands/root.go
+++ b/felix/cmd/calico-bpf/commands/root.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
@@ -35,6 +37,9 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -32,6 +31,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
@@ -113,8 +114,8 @@ const (
 // main config parameters by exiting and allowing itself to be restarted by the init
 // daemon.
 func Run(configFile string, gitVersion string, buildDate string, gitRevision string) {
-	// Go's RNG is not seeded by default.  Do that now.
-	rand.Seed(time.Now().UTC().UnixNano())
+	// Go's RNG is not seeded by default.  Make sure that's done.
+	seedrng.EnsureSeeded()
 
 	// Special-case handling for environment variable-configured logging:
 	// Initialise early so we can trace out config parsing.

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/pkg/profile"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	log "github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/client/pkg/v3/srv"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
@@ -62,6 +64,9 @@ var (
 )
 
 func init() {
+	// Make sure the RNG is seeded.
+	seedrng.EnsureSeeded()
+
 	// Add a flag to check the version.
 	flag.BoolVar(&version, "version", false, "Display version")
 	flag.StringVar(&statusFile, "status-file", status.DefaultStatusFile, "File to write status information to")

--- a/libcalico-go/lib/clientv3/client.go
+++ b/libcalico-go/lib/clientv3/client.go
@@ -23,6 +23,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
+
 	"github.com/google/uuid"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -36,6 +38,12 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
+
+func init() {
+	// We use rand for backoffs and the like, make sure it's seeded (seedrng uses a sync.Once to avoid
+	// doing this multiple times).
+	seedrng.EnsureSeeded()
+}
 
 // client implements the client.Interface.
 type client struct {

--- a/libcalico-go/lib/seedrng/seed_rng.go
+++ b/libcalico-go/lib/seedrng/seed_rng.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package seedrng provides a utility function seedrng.EnsureSeeded() to seed the main math/rand RNG exactly once.
+package seedrng
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var once sync.Once
+
+// EnsureSeeded seeds the math/rand PRNG on the first call; subsequent calls are no-ops.  This allows EnsureSeeded()
+// calls to be sprinkled around the codebase in packages that actively use the PRNG.  That way, we always make
+// sure the PRNG is seeded before it is used in anger.
+func EnsureSeeded() {
+	once.Do(Reseed)
+}
+
+func Reseed() {
+	rand.Seed(time.Now().UnixNano())
+}

--- a/node/cmd/calico-node/main.go
+++ b/node/cmd/calico-node/main.go
@@ -21,6 +21,7 @@ import (
 
 	confdConfig "github.com/projectcalico/calico/confd/pkg/config"
 	confd "github.com/projectcalico/calico/confd/pkg/run"
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 	"github.com/projectcalico/calico/node/pkg/nodeinit"
 
 	"github.com/sirupsen/logrus"
@@ -84,6 +85,9 @@ var confdConfDir = flagSet.String("confd-confdir", "/etc/calico/confd", "Confd c
 var initHostpaths = flagSet.Bool("hostpath-init", false, "Initialize hostpaths for non-root access")
 
 func main() {
+	// Make sure the RNG is seeded, we use it for backoffs and the like.
+	seedrng.EnsureSeeded()
+
 	// Log to stdout.  this prevents our logs from being interpreted as errors by, for example,
 	// fluentd's default configuration.
 	logrus.SetOutput(os.Stdout)

--- a/typha/cmd/typha-client/typha-client.go
+++ b/typha/cmd/typha-client/typha-client.go
@@ -15,17 +15,16 @@
 package main
 
 import (
+	"context"
 	"os"
+	"runtime"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 
-	"math/rand"
-	"runtime"
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 
 	"github.com/docopt/docopt-go"
-
-	"context"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/typha/pkg/buildinfo"
@@ -74,7 +73,7 @@ func (s *syncerCallbacks) OnUpdates(updates []api.Update) {
 
 func main() {
 	// Go's RNG is not seeded by default.  Do that now.
-	rand.Seed(time.Now().UTC().UnixNano())
+	seedrng.EnsureSeeded()
 
 	// Set up logging.
 	logutils.ConfigureEarlyLogging()

--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -17,7 +17,6 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
@@ -33,6 +32,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
@@ -144,7 +145,7 @@ func (t *TyphaDaemon) InitializeAndServeForever(cxt context.Context) error {
 // DoEarlyRuntimeSetup does early runtime/logging configuration that needs to happen before we do any work.
 func (t *TyphaDaemon) DoEarlyRuntimeSetup() {
 	// Go's RNG is not seeded by default.  Do that now.
-	rand.Seed(time.Now().UTC().UnixNano())
+	seedrng.EnsureSeeded()
 
 	// Special-case handling for environment variable-configured logging:
 	// Initialise early so we can trace out config parsing.

--- a/typha/pkg/discovery/discovery.go
+++ b/typha/pkg/discovery/discovery.go
@@ -25,7 +25,15 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 )
+
+func init() {
+	// We use rand for picking a typha, make sure it's seeded; seedrng uses a sync.Once to avoid
+	// doing this multiple times).
+	seedrng.EnsureSeeded()
+}
 
 var ErrServiceNotReady = errors.New("Kubernetes service missing IP or port")
 

--- a/typha/pkg/discovery/discovery_test.go
+++ b/typha/pkg/discovery/discovery_test.go
@@ -15,9 +15,7 @@
 package discovery
 
 import (
-	"math/rand"
 	"reflect"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -42,7 +40,6 @@ var _ = Describe("Typha address discovery", func() {
 		localNodeName = "felix-local"
 		remoteNodeName = "felix-remote"
 
-		rand.Seed(time.Now().UTC().UnixNano())
 		endpoints = &v1.Endpoints{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Noticed that, apart from Felix, the other Typha clients all seemed
to pick the same typha every time.  This was because they weren't
seeding the math/rand PRNG before use.

Introduce a new seedrng package that uses a sync.Once to manage
seeding math/rand.  Then sprinkle calls to EnsureSeeded in
main() functions and in packages that rely heavily on math/rand.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that some components failed to seed the simple (math/rand) random number generator before use.  One side effect of this was that several components would always choose the same Typha to connect to.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
