### PR TITLE
Update image path in app-policy README to use relative path

### DIFF
--- a/app-policy/README.md
+++ b/app-policy/README.md
@@ -3,7 +3,7 @@
 Application Layer Policy for [Project Calico][calico] enforces network and
 application layer authorization policies using [Istio].
 
-![arch](https://github.com/projectcalico/app-policy/raw/master/docs/arch.png)
+![arch](docs/arch.png)
 
 Istio mints and distributes cryptographic identities and uses them to establish mutually authenticated TLS connections
 between pods.  Calico enforces authorization policy on this communication integrating cryptographic identities and 


### PR DESCRIPTION
## Description

The architecture diagram image in app-policy README points to an invalid URL (https://github.com/projectcalico/app-policy/raw/master/docs/arch.png) following the move to the monorepo.

This PR fixes it by using a relative path to the image.

This this only affects the README, there is no other tests, documentation or release notes required.


## Related issues/PRs

N/A

## Todos

N/A

## Release Note

N/A

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
