### PR TITLE
Oss wireguard fixes master

### DIFF
--- a/felix/dataplane/linux/wireguard_mgr.go
+++ b/felix/dataplane/linux/wireguard_mgr.go
@@ -91,7 +91,7 @@ func (m *wireguardManager) OnUpdate(protoBufMsg interface{}) {
 			m.wireguardRouteTable.RouteUpdate(msg.DstNodeName, cidr)
 		default:
 			// It is not a workload CIDR - treat this as a route deletion.
-			log.Debug("RouteUpdate is not a workload update, treating as a deletion")
+			log.Debug("RouteUpdate is not a workload, remote host or tunnel update, treating as a deletion")
 			m.wireguardRouteTable.RouteRemove(cidr)
 		}
 	case *proto.RouteRemove:

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -756,7 +756,7 @@ func KeyForRoute(route *netlink.Route) string {
 	if table == 0 {
 		table = unix.RT_TABLE_MAIN
 	}
-	key := fmt.Sprintf("%v-%v-%v", table, route.LinkIndex, route.Dst)
+	key := fmt.Sprintf("%v-%v", table, route.Dst)
 	log.WithField("routeKey", key).Debug("Calculated route key")
 	return key
 }

--- a/felix/routetable/route_table_test.go
+++ b/felix/routetable/route_table_test.go
@@ -294,7 +294,7 @@ var _ = Describe("RouteTable", func() {
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -412,7 +412,7 @@ var _ = Describe("RouteTable", func() {
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -429,14 +429,14 @@ var _ = Describe("RouteTable", func() {
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  deviceRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 				}))
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.7/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.7/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.7/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -462,14 +462,14 @@ var _ = Describe("RouteTable", func() {
 				dataplane.PersistFailures = false
 				err = rt.Apply()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  deviceRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 				}))
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.7/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.7/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.7/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -807,18 +807,18 @@ var _ = Describe("RouteTable", func() {
 					Expect(dataplane.FailuresToSimulate).To(Equal(mocknetlink.FailNone))
 				})
 				It("should keep correct route", func() {
-					Expect(dataplane.RouteKeyToRoute["254-1-10.0.0.1/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute["254-10.0.0.1/32"]).To(Equal(netlink.Route{
 						LinkIndex: 1,
 						Dst:       &ip1,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
 						Scope:     netlink.SCOPE_LINK,
 					}))
-					Expect(dataplane.AddedRouteKeys.Contains("254-1-10.0.0.1/32")).To(BeFalse())
+					Expect(dataplane.AddedRouteKeys.Contains("254-10.0.0.1/32")).To(BeFalse())
 				})
 				It("should add new route", func() {
-					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-2-10.0.0.2/32"))
-					Expect(dataplane.RouteKeyToRoute["254-2-10.0.0.2/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-10.0.0.2/32"))
+					Expect(dataplane.RouteKeyToRoute["254-10.0.0.2/32"]).To(Equal(netlink.Route{
 						LinkIndex: 2,
 						Dst:       &ip2,
 						Type:      syscall.RTN_UNICAST,
@@ -827,15 +827,15 @@ var _ = Describe("RouteTable", func() {
 					}))
 				})
 				It("should update changed route", func() {
-					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-3-10.0.1.3/32"))
-					Expect(dataplane.RouteKeyToRoute["254-3-10.0.1.3/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-10.0.1.3/32"))
+					Expect(dataplane.RouteKeyToRoute["254-10.0.1.3/32"]).To(Equal(netlink.Route{
 						LinkIndex: 3,
 						Dst:       &ip13,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
 						Scope:     netlink.SCOPE_LINK,
 					}))
-					Expect(dataplane.DeletedRouteKeys.Contains("254-3-10.0.0.3/32")).To(BeTrue())
+					Expect(dataplane.DeletedRouteKeys.Contains("254-10.0.0.3/32")).To(BeTrue())
 					Eventually(dataplane.GetDeletedConntrackEntries).Should(Equal([]net.IP{net.ParseIP("10.0.0.3").To4()}))
 				})
 				It("should have expected number of routes at the end", func() {
@@ -1120,7 +1120,7 @@ var _ = Describe("RouteTable (table 100)", func() {
 
 	Describe("with some interfaces", func() {
 		var cali, eth0 *mocknetlink.MockLink
-		var gatewayRoute, caliRoute, caliRouteTable100, throwRoute netlink.Route
+		var gatewayRoute, caliRoute, caliRouteTable100, throwRoute, caliRouteTable100SameAsThrow netlink.Route
 		BeforeEach(func() {
 			eth0 = dataplane.AddIface(0, "eth0", true, true)
 			cali = dataplane.AddIface(1, "cali", true, true)
@@ -1158,6 +1158,16 @@ var _ = Describe("RouteTable (table 100)", func() {
 				Table:     100,
 			}
 			dataplane.AddMockRoute(&throwRoute)
+
+			// Used in tests but not added to the dataplane at the start.
+			caliRouteTable100SameAsThrow = netlink.Route{
+				LinkIndex: cali.LinkAttrs.Index,
+				Dst:       mustParseCIDR("10.10.10.10/32"),
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+				Table:     100,
+			}
 		})
 		It("should tidy up non-link routes immediately and wait for the route cleanup delay for interface routes", func() {
 			t.SetAutoIncrement(0 * time.Second)
@@ -1209,6 +1219,50 @@ var _ = Describe("RouteTable (table 100)", func() {
 			})
 		})
 
+		Describe("after configuring a throw route and then deleting and recreating the route via cali", func() {
+			JustBeforeEach(func() {
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeThrow,
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("the throw route should be removed and the interface route added", func() {
+				// Modify the action associated with a particular destination.
+				for ii := 0; ii < 100; ii++ {
+					rt.RouteRemove(InterfaceNone, ip.MustParseCIDROrIP("10.10.10.10/32"))
+					rt.RouteUpdate("cali", Target{
+						CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					})
+					err := rt.Apply()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, caliRouteTable100SameAsThrow))
+
+					rt.RouteRemove("cali", ip.MustParseCIDROrIP("10.10.10.10/32"))
+					rt.RouteUpdate(InterfaceNone, Target{
+						CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+						Type: TargetTypeThrow,
+					})
+					err = rt.Apply()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, throwRoute))
+				}
+			})
+		})
+
+		Describe("throw route configured in dataplane, actual route is via cali", func() {
+			It("the throw route should be removed and the interface route added", func() {
+				rt.RouteUpdate("cali", Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, caliRouteTable100SameAsThrow))
+			})
+		})
+
 		Describe("after configuring an existing throw route and then deleting it", func() {
 			JustBeforeEach(func() {
 				rt.RouteUpdate(InterfaceNone, Target{
@@ -1254,8 +1308,8 @@ var _ = Describe("RouteTable (table 100)", func() {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					Table:     100,
 				}))
-				Expect(dataplane.AddedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
-				Expect(dataplane.DeletedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.AddedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.DeletedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
 			})
 		})
 
@@ -1284,8 +1338,8 @@ var _ = Describe("RouteTable (table 100)", func() {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					Table:     100,
 				}))
-				Expect(dataplane.AddedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
-				Expect(dataplane.DeletedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.AddedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.DeletedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
 			})
 		})
 	})

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -131,25 +131,27 @@ type Wireguard struct {
 	ourPublicKey                       *wgtypes.Key
 	ourIPv4InterfaceAddr               ip.Addr
 	ourPublicKeyAgreesWithDataplaneMsg bool
+	ourHostAddr                        ip.Addr
 
-	// Local workload information
+	// Local route information. This contains the complete set of local routes: workloads, tunnels, hosts (for host
+	// encryption). This is always updated directly from the various update methods.
 	localIPs          set.Set
 	localCIDRs        set.Set
 	localCIDRsUpdated bool
 
-	// Current configuration
+	// CIDR to node mappings. This is always updated directly from the various update methods.
+	cidrToNodeName map[ip.CIDR]string
+
+	// Pending updates to apply to `nodes` and to the dataplane.
+	nodeUpdates map[string]*nodeUpdateData
+
+	// Current expected configuration for all nodes.
 	// - all nodeData information
 	// - mapping between CIDRs and nodeData
 	// - mapping between public key and nodes - this does not include the "zero" key, and will not include the local
 	//   node.
 	nodes                map[string]*nodeData
 	publicKeyToNodeNames map[wgtypes.Key]set.Set
-
-	// Pending updates
-	nodeUpdates map[string]*nodeUpdateData
-
-	// CIDR to node mappings - this is updated synchronously.
-	cidrToNodeName map[ip.CIDR]string
 
 	// Wireguard routing table and rule managers
 	routetable *routetable.RouteTable
@@ -158,6 +160,9 @@ type Wireguard struct {
 	// Callback function used to notify of public key updates for the local nodeData
 	statusCallback func(publicKey wgtypes.Key) error
 	opRecorder     logutils.OpRecorder
+
+	// The write proc sys function.
+	writeProcSys func(path, value string) error
 }
 
 func New(
@@ -179,6 +184,7 @@ func New(
 		timeshim.RealTime(),
 		deviceRouteProtocol,
 		statusCallback,
+		writeProcSys,
 		opRecorder,
 	)
 }
@@ -195,6 +201,7 @@ func NewWithShims(
 	timeShim timeshim.Interface,
 	deviceRouteProtocol netlink.RouteProtocol,
 	statusCallback func(publicKey wgtypes.Key) error,
+	writeProcSys func(path, value string) error,
 	opRecorder logutils.OpRecorder,
 ) *Wireguard {
 	// Create routetable. We provide dummy callbacks for ARP and conntrack processing.
@@ -245,6 +252,7 @@ func NewWithShims(
 		statusCallback:       statusCallback,
 		localIPs:             set.New(),
 		localCIDRs:           set.New(),
+		writeProcSys:         writeProcSys,
 		opRecorder:           opRecorder,
 	}
 }
@@ -271,6 +279,7 @@ func (w *Wireguard) OnIfaceStateChanged(ifaceName string, state ifacemonitor.Sta
 	w.routetable.OnIfaceStateChanged(ifaceName, state)
 }
 
+// EndpointUpdate is called when a wireguard endpoint (a node) is updated. This controls which peers to configure.
 func (w *Wireguard) EndpointUpdate(name string, ipv4Addr ip.Addr) {
 	logCxt := log.WithFields(log.Fields{"name": name, "ipv4Addr": ipv4Addr})
 	logCxt.Debug("EndpointUpdate")
@@ -278,7 +287,19 @@ func (w *Wireguard) EndpointUpdate(name string, ipv4Addr ip.Addr) {
 		logCxt.Debug("Not enabled - ignoring")
 		return
 	} else if name == w.hostname {
-		// We don't need our own IP address, just interested in the nodes.
+		// This is the IP of the local host.
+		w.ourHostAddr = ipv4Addr
+		logCxt.Debug("Storing local host IP")
+
+		// Host encryption is enabled *and* there is no interface IP specified set the interface IP to be the same as
+		// the node IP. An update from EndpointWireguardUpdate may overwrite this.
+		if w.config.EncryptHostTraffic && w.ourIPv4InterfaceAddr == nil {
+			logCxt.Debug("Use node IP as wireguard device IP for host encryption when no tunnel address specified")
+			w.ourIPv4InterfaceAddr = ipv4Addr
+			w.inSyncInterfaceAddr = false
+		}
+
+		// We don't treat this as a peer update, so nothing else to do here.
 		return
 	}
 
@@ -293,6 +314,7 @@ func (w *Wireguard) EndpointUpdate(name string, ipv4Addr ip.Addr) {
 	w.setNodeUpdate(name, update)
 }
 
+// EndpointRemove is called when a wireguard endpoint (a node) is removed. This controls which peers to configure.
 func (w *Wireguard) EndpointRemove(name string) {
 	logCxt := log.WithField("name", name)
 	logCxt.Debug("EndpointRemove")
@@ -304,7 +326,7 @@ func (w *Wireguard) EndpointRemove(name string) {
 		return
 	}
 
-	if _, ok := w.nodes[name]; ok {
+	if node, ok := w.nodes[name]; ok {
 		// Node data exists, so store a blank update with a deleted flag. The delete will be applied first, and then any
 		// subsequent updates. There is no need to remove the pending CIDR to node mappings since the route resolver
 		// provides self consistent route updates (i.e. we will get route removes or updates for these CIDRs).
@@ -312,6 +334,14 @@ func (w *Wireguard) EndpointRemove(name string) {
 		nu := newNodeUpdateData()
 		nu.deleted = true
 		w.setNodeUpdate(name, nu)
+
+		// Delete all CIDR->node mappings associated with the node. The routes will be deleted from the route table in
+		// handlePeerAndRouteDeletionFromNodeUpdates.
+		node.cidrs.Iter(func(item interface{}) error {
+			//cidr := item.(ip.CIDR)
+			//delete(w.cidrToNodeName, cidr)
+			return nil
+		})
 	} else {
 		// Node data is not yet programmed so just delete the pending update.
 		logCxt.Debug("Node removed which has not yet been programmed - remove any pending update")
@@ -319,6 +349,8 @@ func (w *Wireguard) EndpointRemove(name string) {
 	}
 }
 
+// RouteUpdate is called when a route is updated. This controls the wireguard peer allowed IPs. It includes pod and
+// tunnel addresses, and for host encryption will include the host addresses.
 func (w *Wireguard) RouteUpdate(name string, cidr ip.CIDR) {
 	logCxt := log.WithFields(log.Fields{"name": name, "cidr": cidr})
 	logCxt.Debug("RouteUpdate")
@@ -348,6 +380,8 @@ func (w *Wireguard) RouteUpdate(name string, cidr ip.CIDR) {
 	}
 }
 
+// RouteRemove is called when a route is removed. This controls the wireguard peer allowed IPs. It includes pod and
+// tunnel addresses, and for host encryption will include the host addresses.
 func (w *Wireguard) RouteRemove(cidr ip.CIDR) {
 	logCxt := log.WithField("cidr", cidr)
 	logCxt.Debug("RouteRemove")
@@ -356,7 +390,7 @@ func (w *Wireguard) RouteRemove(cidr ip.CIDR) {
 		return
 	}
 
-	// Determine which node this CIDR belongs to. Check the updates first and then the processed.
+	// Determine which node this CIDR belongs to.
 	name, ok := w.cidrToNodeName[cidr]
 	if !ok {
 		// The wireguard manager filters out some of the CIDR updates, but not the removes, so it's possible to get
@@ -475,6 +509,8 @@ func (w *Wireguard) peerAllowedCIDRRemove(name string, cidr ip.CIDR) {
 	w.setNodeUpdate(name, update)
 }
 
+// EndpointWireguardUpdate is called when the wireguard configuration for an endpoint (a node) is updated. This controls
+// the local wireguard interface address and public key, and the peer public keys.
 func (w *Wireguard) EndpointWireguardUpdate(name string, publicKey wgtypes.Key, ipv4InterfaceAddr ip.Addr) {
 	logCxt := log.WithFields(log.Fields{"node": name, "publicKey": publicKey, "ipv4InterfaceAddr": ipv4InterfaceAddr})
 	logCxt.Debug("EndpointWireguardUpdate")
@@ -489,7 +525,16 @@ func (w *Wireguard) EndpointWireguardUpdate(name string, publicKey wgtypes.Key, 
 			// Public key does not match that stored. Flag as not in-sync, we will update the value from the dataplane
 			// and publish.
 			logCxt.Debug("Stored public key does not match key queried from dataplane")
-			w.ourPublicKeyAgreesWithDataplaneMsg = false
+			w.ourPublicKey = &publicKey
+			w.inSyncWireguard = false
+		}
+
+		if ipv4InterfaceAddr == nil && w.config.EncryptHostTraffic && w.ourHostAddr != nil {
+			// If there is no interface address configured and we are encrypting host traffic, use the host IP as the
+			// interface address.
+			logCxt = log.WithField("ipv4InterfaceAddr", w.ourHostAddr)
+			logCxt.Debug("Use node IP as wireguard device IP for host encryption without IPPools")
+			ipv4InterfaceAddr = w.ourHostAddr
 		}
 		if w.ourIPv4InterfaceAddr != ipv4InterfaceAddr {
 			logCxt.Debug("Local interface addr updated")
@@ -514,6 +559,8 @@ func (w *Wireguard) EndpointWireguardUpdate(name string, publicKey wgtypes.Key, 
 	w.setNodeUpdate(name, update)
 }
 
+// EndpointWireguardRemove is called when the wireguard configuration for an endpoint (a node) is removed. This
+// controls the local wireguard interface address and public key, and the peer public keys.
 func (w *Wireguard) EndpointWireguardRemove(name string) {
 	logCxt := log.WithField("node", name)
 	logCxt.Debug("EndpointWireguardRemove")
@@ -897,13 +944,12 @@ func (w *Wireguard) handlePeerAndRouteDeletionFromNodeUpdates(conflictingKeys se
 			logCxt.Info("Node is deleted, remove associated routes and wireguard peer")
 			delete(w.nodes, name)
 
-			// Delete all of the node routes for the nodeData and remove CIDR->node association. Note that we always
-			// update the routing table routes using delta updates even during a full resync. The routetable component
-			// takes care of its own kernel-cache synchronization.
+			// Delete all routes associated with the nodeData. Note that we always update the routing table routes
+			// using delta updates even during a full resync. The routetable component takes care of its own
+			// kernel-cache synchronization.
 			node.cidrs.Iter(func(item interface{}) error {
 				cidr := item.(ip.CIDR)
 				w.routetable.RouteRemove(w.config.InterfaceName, cidr)
-				delete(w.cidrToNodeName, cidr)
 				logCxt.WithField("cidr", cidr).Debug("Deleting route")
 				return nil
 			})
@@ -1353,8 +1399,8 @@ func (w *Wireguard) ensureLink(netlinkClient netlinkshim.Interface) (bool, error
 	logCxt := log.WithField("ifaceName", w.config.InterfaceName)
 
 	if w.config.EncryptHostTraffic {
-		log.Info("Enabling src valid mark for WireGuard")
-		if err := writeProcSys(allSrcValidMarkPath, "1"); err != nil {
+		log.Debug("Enabling src valid mark for WireGuard")
+		if err := w.writeProcSys(allSrcValidMarkPath, "1"); err != nil {
 			return false, err
 		}
 	}

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -524,7 +524,7 @@ func updateNodeWithAddress(ctx context.Context, c client.Interface, nodename str
 			log.WithField("node", node.Name).WithError(err).Warning("Error updating node")
 		}
 
-		return nil
+		return err
 	}
 	return fmt.Errorf("Too many retries attempting to update node with tunnel address")
 }


### PR DESCRIPTION
## Description

Looking into some wireguard issues after reports of problems on an AKS deployment.  Turned out that there was an IPPool configured that overlapped with the pod and node CIDR ranges.  This obviously caused some problems, but it also highlighted a few bugs in the code:
-  We were seeing local and remote routes to the same CIDR (so routable was trying to add a throw route and a link route to the wireguard table for the same CIDR).  This was failing because of identical CIDR.  The wireguard code should protect against a single use of a CIDR so there is a bug in the handling,  After much digging the only path I can see to hit this involves node deletion and aggressive IP reuse.
- startup logs indicated that a wireguard interface device IP was not assigned despite it not appearing on the node resource.
- For AKS and EKS where we may not want to configure an IPPool (the exception is for egress gateway but the pool is locked down for special use) - we need to worry about IP of the wireguard device to ensure correct source assignment by the kernel.

So with the above in mind, this PR fixes the following:
- Handle errors correctly in tunnel IP setting on the node
- When there is no allocated Wireguard interface IP and host encryption is enabled the host IP is used as the device IP.  This ensures source IP selection will choose the correct host IP when routing over WG.
- Fix the handling of CIDR->node mapping in the depths of the wireguard module. It is supposed to be kept immediately in-sync from the update messages.  A combination of node deletions and workload IP relocation previously could result in multiple nodes having the same CIDR.  I added a UT for this (and tested prior to my fix).

Other changes:
- Routeable index in the mock routable should only be based on table index and CIDR.  This PR fixes that. This is required to ensure our UTs error under the same conditions as the kernel.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
