### PR TITLE
Call context cancel() func on error

### DIFF
--- a/apiserver/pkg/storage/calico/watcher.go
+++ b/apiserver/pkg/storage/calico/watcher.go
@@ -30,6 +30,7 @@ func (rs *resourceStore) watchResource(ctx context.Context, resourceVersion stri
 	ctx, cancel := context.WithCancel(ctx)
 	lWatch, err := rs.watch(ctx, rs.client, opts)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	wc := &watchChan{

--- a/libcalico-go/lib/clientv3/resources.go
+++ b/libcalico-go/lib/clientv3/resources.go
@@ -253,6 +253,7 @@ func (c *resources) Watch(ctx context.Context, opts options.ListOptions, kind st
 	ctx, cancel := context.WithCancel(ctx)
 	backend, err := c.backend.Watch(ctx, list, opts.ResourceVersion)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	w := &watcher{


### PR DESCRIPTION
## Description

The `cancel` function is not used on all paths (possible context leak).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
