### PR TITLE
Add Kustomization to CRD directory

### DIFF
--- a/libcalico-go/config/crd/kustomization.yaml
+++ b/libcalico-go/config/crd/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - crd.projectcalico.org_bgpconfigurations.yaml
+  - crd.projectcalico.org_bgppeers.yaml
+  - crd.projectcalico.org_blockaffinities.yaml
+  - crd.projectcalico.org_caliconodestatuses.yaml
+  - crd.projectcalico.org_clusterinformations.yaml
+  - crd.projectcalico.org_felixconfigurations.yaml
+  - crd.projectcalico.org_globalnetworkpolicies.yaml
+  - crd.projectcalico.org_globalnetworksets.yaml
+  - crd.projectcalico.org_hostendpoints.yaml
+  - crd.projectcalico.org_ipamblocks.yaml
+  - crd.projectcalico.org_ipamconfigs.yaml
+  - crd.projectcalico.org_ipamhandles.yaml
+  - crd.projectcalico.org_ippools.yaml
+  - crd.projectcalico.org_ipreservations.yaml
+  - crd.projectcalico.org_kubecontrollersconfigurations.yaml
+  - crd.projectcalico.org_networkpolicies.yaml
+  - crd.projectcalico.org_networksets.yaml


### PR DESCRIPTION
This will allow users of calico to point a kustomization at the
upstream repository and install CRD's from this repository directly.

## Description

This PR adds a `kustomization.yaml` to the CRD directory, this will allow
users calico to install the CRD's in their cluster using a file similar to the
example below.

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - git@github.com:TheRealDwright/calico/libcalico-go/config/crd?ref=add-kustomization-for-crds
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Kustomize

Adds kustomization.yaml for CRD's allowing users to install using `kubectl apply -k`

```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
