### PR TITLE
Support for custom pod labels/annotations for tigera-operator chart

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -133,6 +133,12 @@ tolerations:
 nodeSelector:
   kubernetes.io/os: linux
 
+# Custom annotations for the tigera/operator pod itself
+podAnnotations: {}
+
+# Custom labels for the tigera/operator pod itself
+podLabels: {}
+
 # Configuration for the tigera operator images to deploy.
 tigeraOperator:
   image: tigera/operator

--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -15,6 +15,13 @@ spec:
       labels:
         name: tigera-operator
         k8s-app: tigera-operator
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -32,6 +32,12 @@ tolerations:
 nodeSelector:
   kubernetes.io/os: linux
 
+# Custom annotations for the tigera/operator pod itself
+podAnnotations: {}
+
+# Custom labels for the tigera/operator pod itself
+podLabels: {}
+
 # Configuration for the tigera operator
 tigeraOperator:
   image: tigera/operator


### PR DESCRIPTION
## Description

This change allows the user to specify custom labels and annotations for the `tigera-operator` pod. This allows doing things using the `cluster-autoscaler.kubernetes.io/safe-to-evict: true` annotation to allow the `cluster-autoscaler` to evict the operator pod with its `/var/lib/calico` `hostPath` volume (which I'm not sure is even needed).


## Related issues/PRs

N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Ability to configure labels / annotations for the tigera-operator pod via helm
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
