### PR TITLE
Wireguard fixes v3.22

### DIFF
--- a/felix/dataplane/linux/wireguard_mgr.go
+++ b/felix/dataplane/linux/wireguard_mgr.go
@@ -87,7 +87,7 @@ func (m *wireguardManager) OnUpdate(protoBufMsg interface{}) {
 			m.wireguardRouteTable.RouteUpdate(msg.DstNodeName, cidr)
 		default:
 			// It is not a workload CIDR - treat this as a route deletion.
-			log.Debug("RouteUpdate is not a workload update, treating as a deletion")
+			log.Debug("RouteUpdate is not a workload, remote host or tunnel update, treating as a deletion")
 			m.wireguardRouteTable.RouteRemove(cidr)
 		}
 	case *proto.RouteRemove:

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -753,7 +753,7 @@ func KeyForRoute(route *netlink.Route) string {
 	if table == 0 {
 		table = unix.RT_TABLE_MAIN
 	}
-	key := fmt.Sprintf("%v-%v-%v", table, route.LinkIndex, route.Dst)
+	key := fmt.Sprintf("%v-%v", table, route.Dst)
 	log.WithField("routeKey", key).Debug("Calculated route key")
 	return key
 }

--- a/felix/routetable/route_table_test.go
+++ b/felix/routetable/route_table_test.go
@@ -283,7 +283,7 @@ var _ = Describe("RouteTable", func() {
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -401,7 +401,7 @@ var _ = Describe("RouteTable", func() {
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -418,14 +418,14 @@ var _ = Describe("RouteTable", func() {
 				})
 				err := rt.Apply()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  deviceRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 				}))
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.7/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.7/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.7/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -451,14 +451,14 @@ var _ = Describe("RouteTable", func() {
 				dataplane.PersistFailures = false
 				err = rt.Apply()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.6/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.6/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.6/32"),
 					Type:      syscall.RTN_UNICAST,
 					Protocol:  deviceRouteProtocol,
 					Scope:     netlink.SCOPE_LINK,
 				}))
-				Expect(dataplane.RouteKeyToRoute["254-6-10.0.0.7/32"]).To(Equal(netlink.Route{
+				Expect(dataplane.RouteKeyToRoute["254-10.0.0.7/32"]).To(Equal(netlink.Route{
 					LinkIndex: addLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.7/32"),
 					Type:      syscall.RTN_UNICAST,
@@ -796,18 +796,18 @@ var _ = Describe("RouteTable", func() {
 					Expect(dataplane.FailuresToSimulate).To(Equal(mocknetlink.FailNone))
 				})
 				It("should keep correct route", func() {
-					Expect(dataplane.RouteKeyToRoute["254-1-10.0.0.1/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute["254-10.0.0.1/32"]).To(Equal(netlink.Route{
 						LinkIndex: 1,
 						Dst:       &ip1,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
 						Scope:     netlink.SCOPE_LINK,
 					}))
-					Expect(dataplane.AddedRouteKeys.Contains("254-1-10.0.0.1/32")).To(BeFalse())
+					Expect(dataplane.AddedRouteKeys.Contains("254-10.0.0.1/32")).To(BeFalse())
 				})
 				It("should add new route", func() {
-					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-2-10.0.0.2/32"))
-					Expect(dataplane.RouteKeyToRoute["254-2-10.0.0.2/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-10.0.0.2/32"))
+					Expect(dataplane.RouteKeyToRoute["254-10.0.0.2/32"]).To(Equal(netlink.Route{
 						LinkIndex: 2,
 						Dst:       &ip2,
 						Type:      syscall.RTN_UNICAST,
@@ -816,15 +816,15 @@ var _ = Describe("RouteTable", func() {
 					}))
 				})
 				It("should update changed route", func() {
-					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-3-10.0.1.3/32"))
-					Expect(dataplane.RouteKeyToRoute["254-3-10.0.1.3/32"]).To(Equal(netlink.Route{
+					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-10.0.1.3/32"))
+					Expect(dataplane.RouteKeyToRoute["254-10.0.1.3/32"]).To(Equal(netlink.Route{
 						LinkIndex: 3,
 						Dst:       &ip13,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
 						Scope:     netlink.SCOPE_LINK,
 					}))
-					Expect(dataplane.DeletedRouteKeys.Contains("254-3-10.0.0.3/32")).To(BeTrue())
+					Expect(dataplane.DeletedRouteKeys.Contains("254-10.0.0.3/32")).To(BeTrue())
 					Eventually(dataplane.GetDeletedConntrackEntries).Should(Equal([]net.IP{net.ParseIP("10.0.0.3").To4()}))
 				})
 				It("should have expected number of routes at the end", func() {
@@ -1107,7 +1107,7 @@ var _ = Describe("RouteTable (table 100)", func() {
 
 	Describe("with some interfaces", func() {
 		var cali, eth0 *mocknetlink.MockLink
-		var gatewayRoute, caliRoute, caliRouteTable100, throwRoute netlink.Route
+		var gatewayRoute, caliRoute, caliRouteTable100, throwRoute, caliRouteTable100SameAsThrow netlink.Route
 		BeforeEach(func() {
 			eth0 = dataplane.AddIface(0, "eth0", true, true)
 			cali = dataplane.AddIface(1, "cali", true, true)
@@ -1145,6 +1145,16 @@ var _ = Describe("RouteTable (table 100)", func() {
 				Table:     100,
 			}
 			dataplane.AddMockRoute(&throwRoute)
+
+			// Used in tests but not added to the dataplane at the start.
+			caliRouteTable100SameAsThrow = netlink.Route{
+				LinkIndex: cali.LinkAttrs.Index,
+				Dst:       mustParseCIDR("10.10.10.10/32"),
+				Type:      syscall.RTN_UNICAST,
+				Protocol:  FelixRouteProtocol,
+				Scope:     netlink.SCOPE_LINK,
+				Table:     100,
+			}
 		})
 		It("should tidy up non-link routes immediately and wait for the route cleanup delay for interface routes", func() {
 			t.SetAutoIncrement(0 * time.Second)
@@ -1196,6 +1206,50 @@ var _ = Describe("RouteTable (table 100)", func() {
 			})
 		})
 
+		Describe("after configuring a throw route and then deleting and recreating the route via cali", func() {
+			JustBeforeEach(func() {
+				rt.RouteUpdate(InterfaceNone, Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					Type: TargetTypeThrow,
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("the throw route should be removed and the interface route added", func() {
+				// Modify the action associated with a particular destination.
+				for ii := 0; ii < 100; ii++ {
+					rt.RouteRemove(InterfaceNone, ip.MustParseCIDROrIP("10.10.10.10/32"))
+					rt.RouteUpdate("cali", Target{
+						CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+					})
+					err := rt.Apply()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, caliRouteTable100SameAsThrow))
+
+					rt.RouteRemove("cali", ip.MustParseCIDROrIP("10.10.10.10/32"))
+					rt.RouteUpdate(InterfaceNone, Target{
+						CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+						Type: TargetTypeThrow,
+					})
+					err = rt.Apply()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, throwRoute))
+				}
+			})
+		})
+
+		Describe("throw route configured in dataplane, actual route is via cali", func() {
+			It("the throw route should be removed and the interface route added", func() {
+				rt.RouteUpdate("cali", Target{
+					CIDR: ip.MustParseCIDROrIP("10.10.10.10/32"),
+				})
+				err := rt.Apply()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dataplane.RouteKeyToRoute).To(ConsistOf(caliRoute, gatewayRoute, caliRouteTable100SameAsThrow))
+			})
+		})
+
 		Describe("after configuring an existing throw route and then deleting it", func() {
 			JustBeforeEach(func() {
 				rt.RouteUpdate(InterfaceNone, Target{
@@ -1241,8 +1295,8 @@ var _ = Describe("RouteTable (table 100)", func() {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					Table:     100,
 				}))
-				Expect(dataplane.AddedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
-				Expect(dataplane.DeletedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.AddedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.DeletedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
 			})
 		})
 
@@ -1271,8 +1325,8 @@ var _ = Describe("RouteTable (table 100)", func() {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					Table:     100,
 				}))
-				Expect(dataplane.AddedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
-				Expect(dataplane.DeletedRouteKeys.Contains("100-0-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.AddedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
+				Expect(dataplane.DeletedRouteKeys.Contains("100-10.10.10.10/32")).To(BeTrue())
 			})
 		})
 	})

--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -95,7 +95,7 @@ type nodeUpdateData struct {
 	cidrsAdded   set.Set
 	cidrsDeleted set.Set
 
-	// Only used for nodes.
+	// Only used for peers.
 	deleted          bool
 	ipv4EndpointAddr *ip.Addr
 	publicKey        *wgtypes.Key
@@ -131,25 +131,27 @@ type Wireguard struct {
 	ourPublicKey                       *wgtypes.Key
 	ourIPv4InterfaceAddr               ip.Addr
 	ourPublicKeyAgreesWithDataplaneMsg bool
+	ourHostAddr                        ip.Addr
 
-	// Local workload information
+	// Local route information. This contains the complete set of local routes: workloads, tunnels, hosts (for host
+	// encryption). This is always updated directly from the various update methods.
 	localIPs          set.Set
 	localCIDRs        set.Set
 	localCIDRsUpdated bool
 
-	// Current configuration
+	// CIDR to node mappings. This is always updated directly from the various update methods.
+	cidrToNodeName map[ip.CIDR]string
+
+	// Pending updates to apply to `nodes` and to the dataplane.
+	nodeUpdates map[string]*nodeUpdateData
+
+	// Current expected configuration for all nodes.
 	// - all nodeData information
 	// - mapping between CIDRs and nodeData
 	// - mapping between public key and nodes - this does not include the "zero" key, and will not include the local
 	//   node.
 	nodes                map[string]*nodeData
 	publicKeyToNodeNames map[wgtypes.Key]set.Set
-
-	// Pending updates
-	nodeUpdates map[string]*nodeUpdateData
-
-	// CIDR to node mappings - this is updated synchronously.
-	cidrToNodeName map[ip.CIDR]string
 
 	// Wireguard routing table and rule managers
 	routetable *routetable.RouteTable
@@ -158,6 +160,9 @@ type Wireguard struct {
 	// Callback function used to notify of public key updates for the local nodeData
 	statusCallback func(publicKey wgtypes.Key) error
 	opRecorder     logutils.OpRecorder
+
+	// The write proc sys function.
+	writeProcSys func(path, value string) error
 }
 
 func New(
@@ -179,6 +184,7 @@ func New(
 		timeshim.RealTime(),
 		deviceRouteProtocol,
 		statusCallback,
+		writeProcSys,
 		opRecorder,
 	)
 }
@@ -195,6 +201,7 @@ func NewWithShims(
 	timeShim timeshim.Interface,
 	deviceRouteProtocol netlink.RouteProtocol,
 	statusCallback func(publicKey wgtypes.Key) error,
+	writeProcSys func(path, value string) error,
 	opRecorder logutils.OpRecorder,
 ) *Wireguard {
 	// Create routetable. We provide dummy callbacks for ARP and conntrack processing.
@@ -245,6 +252,7 @@ func NewWithShims(
 		statusCallback:       statusCallback,
 		localIPs:             set.New(),
 		localCIDRs:           set.New(),
+		writeProcSys:         writeProcSys,
 		opRecorder:           opRecorder,
 	}
 }
@@ -271,6 +279,7 @@ func (w *Wireguard) OnIfaceStateChanged(ifaceName string, state ifacemonitor.Sta
 	w.routetable.OnIfaceStateChanged(ifaceName, state)
 }
 
+// EndpointUpdate is called when a wireguard endpoint (a node) is updated. This controls which peers to configure.
 func (w *Wireguard) EndpointUpdate(name string, ipv4Addr ip.Addr) {
 	logCxt := log.WithFields(log.Fields{"name": name, "ipv4Addr": ipv4Addr})
 	logCxt.Debug("EndpointUpdate")
@@ -278,7 +287,19 @@ func (w *Wireguard) EndpointUpdate(name string, ipv4Addr ip.Addr) {
 		logCxt.Debug("Not enabled - ignoring")
 		return
 	} else if name == w.hostname {
-		// We don't need our own IP address, just interested in the nodes.
+		// This is the IP of the local host.
+		w.ourHostAddr = ipv4Addr
+		logCxt.Debug("Storing local host IP")
+
+		// Host encryption is enabled *and* there is no interface IP specified set the interface IP to be the same as
+		// the node IP. An update from EndpointWireguardUpdate may overwrite this.
+		if w.config.EncryptHostTraffic && w.ourIPv4InterfaceAddr == nil {
+			logCxt.Debug("Use node IP as wireguard device IP for host encryption when no tunnel address specified")
+			w.ourIPv4InterfaceAddr = ipv4Addr
+			w.inSyncInterfaceAddr = false
+		}
+
+		// We don't treat this as a peer update, so nothing else to do here.
 		return
 	}
 
@@ -290,9 +311,11 @@ func (w *Wireguard) EndpointUpdate(name string, ipv4Addr ip.Addr) {
 		logCxt.Debug("Update contains new IPv4 address")
 		update.ipv4EndpointAddr = &ipv4Addr
 	}
+	update.deleted = false
 	w.setNodeUpdate(name, update)
 }
 
+// EndpointRemove is called when a wireguard endpoint (a node) is removed. This controls which peers to configure.
 func (w *Wireguard) EndpointRemove(name string) {
 	logCxt := log.WithField("name", name)
 	logCxt.Debug("EndpointRemove")
@@ -304,21 +327,14 @@ func (w *Wireguard) EndpointRemove(name string) {
 		return
 	}
 
-	if _, ok := w.nodes[name]; ok {
-		// Node data exists, so store a blank update with a deleted flag. The delete will be applied first, and then any
-		// subsequent updates. There is no need to remove the pending CIDR to node mappings since the route resolver
-		// provides self consistent route updates (i.e. we will get route removes or updates for these CIDRs).
-		logCxt.Debug("Existing node is flagged for removal")
-		nu := newNodeUpdateData()
-		nu.deleted = true
-		w.setNodeUpdate(name, nu)
-	} else {
-		// Node data is not yet programmed so just delete the pending update.
-		logCxt.Debug("Node removed which has not yet been programmed - remove any pending update")
-		delete(w.nodeUpdates, name)
-	}
+	update := w.getOrInitNodeUpdateData(name)
+	update.deleted = true
+	update.ipv4EndpointAddr = nil
+	w.setNodeUpdate(name, update)
 }
 
+// RouteUpdate is called when a route is updated. This controls the wireguard peer allowed IPs. It includes pod and
+// tunnel addresses, and for host encryption will include the host addresses.
 func (w *Wireguard) RouteUpdate(name string, cidr ip.CIDR) {
 	logCxt := log.WithFields(log.Fields{"name": name, "cidr": cidr})
 	logCxt.Debug("RouteUpdate")
@@ -348,6 +364,8 @@ func (w *Wireguard) RouteUpdate(name string, cidr ip.CIDR) {
 	}
 }
 
+// RouteRemove is called when a route is removed. This controls the wireguard peer allowed IPs. It includes pod and
+// tunnel addresses, and for host encryption will include the host addresses.
 func (w *Wireguard) RouteRemove(cidr ip.CIDR) {
 	logCxt := log.WithField("cidr", cidr)
 	logCxt.Debug("RouteRemove")
@@ -356,7 +374,7 @@ func (w *Wireguard) RouteRemove(cidr ip.CIDR) {
 		return
 	}
 
-	// Determine which node this CIDR belongs to. Check the updates first and then the processed.
+	// Determine which node this CIDR belongs to.
 	name, ok := w.cidrToNodeName[cidr]
 	if !ok {
 		// The wireguard manager filters out some of the CIDR updates, but not the removes, so it's possible to get
@@ -475,6 +493,8 @@ func (w *Wireguard) peerAllowedCIDRRemove(name string, cidr ip.CIDR) {
 	w.setNodeUpdate(name, update)
 }
 
+// EndpointWireguardUpdate is called when the wireguard configuration for an endpoint (a node) is updated. This controls
+// the local wireguard interface address and public key, and the peer public keys.
 func (w *Wireguard) EndpointWireguardUpdate(name string, publicKey wgtypes.Key, ipv4InterfaceAddr ip.Addr) {
 	logCxt := log.WithFields(log.Fields{"node": name, "publicKey": publicKey, "ipv4InterfaceAddr": ipv4InterfaceAddr})
 	logCxt.Debug("EndpointWireguardUpdate")
@@ -489,7 +509,16 @@ func (w *Wireguard) EndpointWireguardUpdate(name string, publicKey wgtypes.Key, 
 			// Public key does not match that stored. Flag as not in-sync, we will update the value from the dataplane
 			// and publish.
 			logCxt.Debug("Stored public key does not match key queried from dataplane")
-			w.ourPublicKeyAgreesWithDataplaneMsg = false
+			w.ourPublicKey = &publicKey
+			w.inSyncWireguard = false
+		}
+
+		if ipv4InterfaceAddr == nil && w.config.EncryptHostTraffic && w.ourHostAddr != nil {
+			// If there is no interface address configured and we are encrypting host traffic, use the host IP as the
+			// interface address.
+			logCxt = log.WithField("ipv4InterfaceAddr", w.ourHostAddr)
+			logCxt.Debug("Use node IP as wireguard device IP for host encryption without IPPools")
+			ipv4InterfaceAddr = w.ourHostAddr
 		}
 		if w.ourIPv4InterfaceAddr != ipv4InterfaceAddr {
 			logCxt.Debug("Local interface addr updated")
@@ -514,6 +543,8 @@ func (w *Wireguard) EndpointWireguardUpdate(name string, publicKey wgtypes.Key, 
 	w.setNodeUpdate(name, update)
 }
 
+// EndpointWireguardRemove is called when the wireguard configuration for an endpoint (a node) is removed. This
+// controls the local wireguard interface address and public key, and the peer public keys.
 func (w *Wireguard) EndpointWireguardRemove(name string) {
 	logCxt := log.WithField("node", name)
 	logCxt.Debug("EndpointWireguardRemove")
@@ -622,9 +653,8 @@ func (w *Wireguard) Apply() (err error) {
 	// 3. Update of route table routes.
 	// 4. Construction of wireguard delta (if performing deltas, or re-sync of wireguard configuration)
 	// 5. Simultaneous updates of wireguard and routes.
-	var conflictingKeys = set.New()
-	wireguardPeerDelete := w.handlePeerAndRouteDeletionFromNodeUpdates(conflictingKeys)
-	w.updateCacheFromNodeUpdates(conflictingKeys)
+	wireguardPeerDelete := w.prepareWireguardPeerDeletion()
+	conflictingKeys := w.updateCacheFromNodeUpdates()
 	w.updateRouteTableFromNodeUpdates()
 
 	defer func() {
@@ -640,6 +670,12 @@ func (w *Wireguard) Apply() (err error) {
 				} else {
 					log.WithField("node", name).Debug("Flag node as not programmed")
 					node.programmedInWireguard = false
+				}
+
+				// Delete any nodes from the cache that no longer have any wireguard or routing configuration.
+				if node.ipv4EndpointAddr == nil && node.cidrs.Len() == 0 && node.publicKey == zeroKey {
+					log.WithField("node", name).Debug("Delete node configuration")
+					delete(w.nodes, name)
 				}
 			}
 		}
@@ -874,13 +910,19 @@ func (w *Wireguard) getLocalNodeCIDRUpdates() *nodeUpdateData {
 	return nodeUpdate
 }
 
-// handlePeerAndRouteDeletionFromNodeUpdates handles wireguard peer deletion preparation:
-// -  Updates routing table to remove routes for permantently deleted nodes
-// -  Creates a wireguard config update for deleted nodes, or for nodes whose public key has changed (which for
-//    wireguard is effectively a different peer)
+// prepareWireguardPeerDeletion handles wireguard peer deletion. It creates a wireguard config update for deleted nodes,
+// or for nodes whose public key has changed (which for wireguard is effectively a different peer). It also updates the
+// nodes to indicate that wireguard is not programmed.
 //
 // This method does not perform any dataplane updates.
-func (w *Wireguard) handlePeerAndRouteDeletionFromNodeUpdates(conflictingKeys set.Set) *wgtypes.Config {
+func (w *Wireguard) prepareWireguardPeerDeletion() *wgtypes.Config {
+	if !w.inSyncWireguard {
+		// Wireguard is not in-sync. We don't bother constructing a delete from the deltas because we'll just handle
+		// any deltas during the re-sync.
+		log.Debug("Wireguard is not in-sync")
+		return nil
+	}
+
 	var wireguardPeerDelete wgtypes.Config
 	for name, update := range w.nodeUpdates {
 		// Get existing peer configuration. If peer not seen before then no deletion processing is required.
@@ -892,56 +934,28 @@ func (w *Wireguard) handlePeerAndRouteDeletionFromNodeUpdates(conflictingKeys se
 			continue
 		}
 
-		if update.deleted {
-			// Node is deleted, so remove the node configuration and the associated routes.
-			logCxt.Info("Node is deleted, remove associated routes and wireguard peer")
-			delete(w.nodes, name)
-
-			// Delete all of the node routes for the nodeData and remove CIDR->node association. Note that we always
-			// update the routing table routes using delta updates even during a full resync. The routetable component
-			// takes care of its own kernel-cache synchronization.
-			node.cidrs.Iter(func(item interface{}) error {
-				cidr := item.(ip.CIDR)
-				w.routetable.RouteRemove(w.config.InterfaceName, cidr)
-				delete(w.cidrToNodeName, cidr)
-				logCxt.WithField("cidr", cidr).Debug("Deleting route")
-				return nil
-			})
-		} else if update.publicKey == nil || *update.publicKey == node.publicKey {
-			// It's not a delete, and the public key hasn't changed so no key deletion processing required.
-			logCxt.Debug("Node updated, but public key is the same - no wireguard peer deletion required")
+		if !node.programmedInWireguard {
+			// The node is not programmed in wireguard, so no need to delete the node.
+			logCxt.Debug("Node had no public key assigned")
 			continue
-		}
-
-		if node.publicKey == zeroKey {
-			// The node did not have a key assigned, so no peer tidy-up required.
-			logCxt.Debug("Node had no public key assigned - no deletion of wireguard peer necessary")
-			continue
-		}
-
-		// If we aren't doing a full re-sync then delete the associated peer if it was previously configured.
-		if node.programmedInWireguard && w.inSyncWireguard {
-			logCxt.WithField("publicKey", node.publicKey).Debug("Adding peer deletion config update for key")
-			wireguardPeerDelete.Peers = append(wireguardPeerDelete.Peers, wgtypes.PeerConfig{
-				PublicKey: node.publicKey,
-				Remove:    true,
-			})
-			node.programmedInWireguard = false
-		}
-
-		// Remove the key to node reference.
-		nodenames := w.publicKeyToNodeNames[node.publicKey]
-		nodenames.Discard(name)
-		if nodenames.Len() == 0 {
-			// This was the only node with its public key
-			logCxt.WithField("publicKey", node.publicKey).Debug("Removed the only node claiming public key")
-			delete(w.publicKeyToNodeNames, node.publicKey)
+		} else if update.deleted {
+			// We have received a node deletion message and the peer is programmed in wireguard. We need to send a
+			// delete.
+			logCxt.Info("Node is deleted, remove wireguard peer")
+		} else if update.publicKey != nil && *update.publicKey != node.publicKey {
+			// The public key has changed. We need to send a delete.
+			logCxt.Debug("Peer public key updated - remove wireguard peer")
 		} else {
-			// This is or was a conflicting key. Recheck the nodes associated with this key at the end.
-			log.WithField("publicKey", node.publicKey).Info("Removed node which claimed the same public key as at least one other node")
-			conflictingKeys.Add(node.publicKey)
+			// No peer deletion required for this peer.
+			continue
 		}
-		node.publicKey = zeroKey
+
+		logCxt.WithField("publicKey", node.publicKey).Debug("Adding peer deletion config update for key")
+		wireguardPeerDelete.Peers = append(wireguardPeerDelete.Peers, wgtypes.PeerConfig{
+			PublicKey: node.publicKey,
+			Remove:    true,
+		})
+		node.programmedInWireguard = false
 	}
 
 	if len(wireguardPeerDelete.Peers) > 0 {
@@ -955,7 +969,8 @@ func (w *Wireguard) handlePeerAndRouteDeletionFromNodeUpdates(conflictingKeys se
 //
 // This method applies the current set of node updates on top of the current cache. It removes updates that are no
 // ops so that they are not re-processed further down the pipeline.
-func (w *Wireguard) updateCacheFromNodeUpdates(conflictingKeys set.Set) {
+func (w *Wireguard) updateCacheFromNodeUpdates() (conflictingKeys set.Set) {
+	conflictingKeys = set.New()
 	for name, update := range w.nodeUpdates {
 		node := w.getOrInitNodeData(name)
 
@@ -967,9 +982,30 @@ func (w *Wireguard) updateCacheFromNodeUpdates(conflictingKeys set.Set) {
 			logCxt.WithField("ipv4EndpointAddr", *update.ipv4EndpointAddr).Debug("Store IPv4 address")
 			node.ipv4EndpointAddr = *update.ipv4EndpointAddr
 			updated = true
+		} else if update.deleted {
+			logCxt.Debug("Peer deleted")
+			node.ipv4EndpointAddr = nil
+			updated = true
 		}
+
 		if update.publicKey != nil {
 			logCxt.WithField("publicKey", *update.publicKey).Debug("Store public key")
+			if node.publicKey != zeroKey {
+				// Remove the key to node reference.
+				nodenames := w.publicKeyToNodeNames[node.publicKey]
+				nodenames.Discard(name)
+				if nodenames.Len() == 0 {
+					// This was the only node with its public key
+					logCxt.WithField("publicKey", node.publicKey).Debug("Removed the only node claiming public key")
+					delete(w.publicKeyToNodeNames, node.publicKey)
+				} else {
+					// This is or was a conflicting key. Recheck the nodes associated with this key at the end.
+					log.WithField("publicKey", node.publicKey).Info("Removed node which claimed the same public key as at least one other node")
+					conflictingKeys.Add(node.publicKey)
+				}
+			}
+
+			// Update the node public key and the key to node mapping.
 			node.publicKey = *update.publicKey
 			if node.publicKey != zeroKey {
 				if nodenames := w.publicKeyToNodeNames[node.publicKey]; nodenames == nil {
@@ -983,6 +1019,7 @@ func (w *Wireguard) updateCacheFromNodeUpdates(conflictingKeys set.Set) {
 			}
 			updated = true
 		}
+
 		update.cidrsDeleted.Iter(func(item interface{}) error {
 			cidr := item.(ip.CIDR)
 			logCxt.WithField("cidr", cidr).Debug("Discarding CIDR")
@@ -1008,25 +1045,25 @@ func (w *Wireguard) updateCacheFromNodeUpdates(conflictingKeys set.Set) {
 			delete(w.nodeUpdates, name)
 		}
 	}
+
+	return conflictingKeys
 }
 
 // updateRouteTable updates the route table from the node updates.
 func (w *Wireguard) updateRouteTableFromNodeUpdates() {
-	// Do all deletes first. Then adds or updates separarately. This ensures a CIDR that has been deleted from one node
+	// Do all deletes first. Then adds or updates separately. This ensures a CIDR that has been deleted from one node
 	// and added to another will not add first then delete (which will remove the route, since the route table does not
 	// care about destination node).
-	for name, update := range w.nodeUpdates {
-		// Delete routes that are no longer required in routing.
-		node := w.getOrInitNodeData(name)
-		ifaceName := routetable.InterfaceNone
-		if node != nil && node.programmedInWireguard {
-			ifaceName = w.config.InterfaceName
-		}
-		logCxt := log.WithFields(log.Fields{"node": name, "ifaceName": ifaceName})
+	for _, update := range w.nodeUpdates {
+		// Delete routes that are no longer required in routing. Just delete both the wireguard and throw routes - this
+		// is somewhat defensive as we have the information to decide which route we need to remove - however we have
+		// also had bugs related to state tracking so deleting both is reasonable - routetable ignores the one that is
+		// not programmed.
 		update.cidrsDeleted.Iter(func(item interface{}) error {
 			cidr := item.(ip.CIDR)
-			logCxt.WithField("cidr", cidr).Debug("Removing CIDR from routetable interface")
-			w.routetable.RouteRemove(ifaceName, cidr)
+			log.WithField("cidr", cidr).Debug("Removing CIDR from routetable interface")
+			w.routetable.RouteRemove(w.config.InterfaceName, cidr)
+			w.routetable.RouteRemove(routetable.InterfaceNone, cidr)
 			return nil
 		})
 	}
@@ -1051,20 +1088,18 @@ func (w *Wireguard) updateRouteTableFromNodeUpdates() {
 		}
 
 		var targetType routetable.TargetType
-		var ifaceName, deleteIfaceName string
+		var ifaceName string
 		if !shouldRouteToWireguard {
 			// If we should not route to wireguard then we need to use a throw directive to skip wireguard routing and
 			// return to normal routing. We may also need to delete the existing route to wireguard.
 			logCxt.Debug("Not routing to wireguard - set route type to throw")
 			targetType = routetable.TargetTypeThrow
 			ifaceName = routetable.InterfaceNone
-			deleteIfaceName = w.config.InterfaceName
 		} else {
 			// If we should route to wireguard then route to the wireguard interface. We may also need to delete the
 			// existing throw route that was used to circumvent wireguard routing.
 			logCxt.Debug("Routing to wireguard interface")
 			ifaceName = w.config.InterfaceName
-			deleteIfaceName = routetable.InterfaceNone
 		}
 
 		updateSet.Iter(func(item interface{}) error {
@@ -1076,8 +1111,12 @@ func (w *Wireguard) updateRouteTableFromNodeUpdates() {
 				// never added - the routetable component handles that gracefully. We need to do these deletes because
 				// routetable component groups by interface and we are essentially moving routes between the wireguard
 				// interface and the "none" interface.
-				updateLogCxt.WithField("ifacename", deleteIfaceName).Debug("Wireguard routing has changed - delete previous route for interface")
-				w.routetable.RouteRemove(deleteIfaceName, cidr)
+				// Just delete both the wireguard and throw routes - this is somewhat defensive as we have the
+				// information to decide which route we need to remove - however we have also had bugs related to state
+				// tracking so deleting both is reasonable - routetable ignores the one that is not programmed.
+				updateLogCxt.Debug("Wireguard routing has changed - delete previous route")
+				w.routetable.RouteRemove(routetable.InterfaceNone, cidr)
+				w.routetable.RouteRemove(w.config.InterfaceName, cidr)
 			}
 			w.routetable.RouteUpdate(ifaceName, routetable.Target{
 				Type: targetType,
@@ -1349,8 +1388,8 @@ func (w *Wireguard) ensureLink(netlinkClient netlinkshim.Interface) (bool, error
 	logCxt := log.WithField("ifaceName", w.config.InterfaceName)
 
 	if w.config.EncryptHostTraffic {
-		log.Info("Enabling src valid mark for WireGuard")
-		if err := writeProcSys(allSrcValidMarkPath, "1"); err != nil {
+		log.Debug("Enabling src valid mark for WireGuard")
+		if err := w.writeProcSys(allSrcValidMarkPath, "1"); err != nil {
 			return false, err
 		}
 	}
@@ -1680,6 +1719,14 @@ func (w *Wireguard) setAllInSync(inSync bool) {
 	w.inSyncWireguard = inSync
 	w.inSyncLink = inSync
 	w.inSyncInterfaceAddr = inSync
+}
+
+// DebugNodes returns the set of nodes in the internal cache. Used for testing purposes to test node cleanup.
+func (w *Wireguard) DebugNodes() (nodes []string) {
+	for node := range w.nodes {
+		nodes = append(nodes, node)
+	}
+	return
 }
 
 // getOnlyItemInSet returns the only item in the set, or nil if the set is nil or the set does not contain only one

--- a/felix/wireguard/wireguard_test.go
+++ b/felix/wireguard/wireguard_test.go
@@ -55,27 +55,31 @@ var (
 	ipv4_int1 = ip.FromString("192.168.0.0")
 	ipv4_int2 = ip.FromString("192.168.10.0")
 
-	ipv4_host  = ip.FromString("1.2.3.0")
-	ipv4_peer1 = ip.FromString("1.2.3.5")
-	ipv4_peer2 = ip.FromString("1.2.3.6")
-	ipv4_peer3 = ip.FromString("10.10.20.20")
-	ipv4_peer4 = ip.FromString("10.10.20.30")
+	ipv4_host    = ip.FromString("1.2.3.0")
+	ipv4_peer1   = ip.FromString("1.2.3.5")
+	ipv4_peer2   = ip.FromString("1.2.3.6")
+	ipv4_peer2_2 = ip.FromString("1.2.3.7")
+	ipv4_peer3   = ip.FromString("10.10.20.20")
+	ipv4_peer4   = ip.FromString("10.10.20.30")
 
-	cidr_local                = ip.MustParseCIDROrIP("192.180.0.0/30")
-	cidr_1                    = ip.MustParseCIDROrIP("192.168.1.0/24")
-	cidr_2                    = ip.MustParseCIDROrIP("192.168.2.0/24")
-	cidr_3                    = ip.MustParseCIDROrIP("192.168.3.0/24")
-	cidr_4                    = ip.MustParseCIDROrIP("192.168.4.0/26")
-	cidr_5                    = ip.MustParseCIDROrIP("192.168.5.0/26")
-	ipnet_1                   = cidr_1.ToIPNet()
-	ipnet_2                   = cidr_2.ToIPNet()
-	ipnet_3                   = cidr_3.ToIPNet()
-	ipnet_4                   = cidr_4.ToIPNet()
-	routekey_cidr_local_throw = fmt.Sprintf("%d-%d-%s", tableIndex, 0, cidr_local)
-	//routekey_1_throw = fmt.Sprintf("%d-%d-%s", tableIndex, 0, cidr_1)
-	//routekey_2_throw = fmt.Sprintf("%d-%d-%s", tableIndex, 0, cidr_2)
-	routekey_3_throw = fmt.Sprintf("%d-%d-%s", tableIndex, 0, cidr_3)
-	routekey_4_throw = fmt.Sprintf("%d-%d-%s", tableIndex, 0, cidr_4)
+	cidr_local = ip.MustParseCIDROrIP("192.180.0.0/30")
+	cidr_1     = ip.MustParseCIDROrIP("192.168.1.0/24")
+	cidr_2     = ip.MustParseCIDROrIP("192.168.2.0/24")
+	cidr_3     = ip.MustParseCIDROrIP("192.168.3.0/24")
+	cidr_4     = ip.MustParseCIDROrIP("192.168.4.0/26")
+	cidr_5     = ip.MustParseCIDROrIP("192.168.5.0/26")
+	cidr_6     = ip.MustParseCIDROrIP("192.168.6.0/32") // Single IP
+	ipnet_1    = cidr_1.ToIPNet()
+	ipnet_2    = cidr_2.ToIPNet()
+	ipnet_3    = cidr_3.ToIPNet()
+	ipnet_4    = cidr_4.ToIPNet()
+	//ipnet_6             = cidr_6.ToIPNet()
+	routekey_cidr_local = fmt.Sprintf("%d-%s", tableIndex, cidr_local)
+	//routekey_1 = fmt.Sprintf("%d-%s", tableIndex, cidr_1)
+	//routekey_2 = fmt.Sprintf("%d-%s", tableIndex, cidr_2)
+	//routekey_3 = fmt.Sprintf("%d-%s", tableIndex, cidr_3)
+	routekey_4 = fmt.Sprintf("%d-%s", tableIndex, cidr_4)
+	routekey_6 = fmt.Sprintf("%d-%s", tableIndex, cidr_6)
 )
 
 func mustGeneratePrivateKey() wgtypes.Key {
@@ -119,28 +123,43 @@ func (a *applyWithErrors) LastError() error {
 	return a.errors[len(a.errors)-1]
 }
 
-type mockStatus struct {
-	numCallbacks int
-	err          error
-	key          wgtypes.Key
+type mockCallbacks struct {
+	numStatusCallbacks int
+	statusErr          error
+	statusKey          wgtypes.Key
+
+	numProcSysCallbacks int
+	procSysPath         string
+	procSysValue        string
+	procSysErr          error
 }
 
-func (m *mockStatus) status(publicKey wgtypes.Key) error {
+func (m *mockCallbacks) status(publicKey wgtypes.Key) error {
 	log.Debugf("Status update with public key: %s", publicKey)
-	m.numCallbacks++
-	if m.err != nil {
-		return m.err
+	m.numStatusCallbacks++
+	if m.statusErr != nil {
+		return m.statusErr
 	}
-	m.key = publicKey
+	m.statusKey = publicKey
 
-	log.Debugf("Num callbacks: %d", m.numCallbacks)
+	log.Debugf("Num callbacks: %d", m.numStatusCallbacks)
+	return nil
+}
+
+func (m *mockCallbacks) writeProcSys(path, value string) error {
+	m.numProcSysCallbacks++
+	if m.procSysErr != nil {
+		return m.procSysErr
+	}
+	m.procSysPath = path
+	m.procSysValue = value
 	return nil
 }
 
 var _ = Describe("Enable wireguard", func() {
 	var wgDataplane, rtDataplane, rrDataplane *mocknetlink.MockNetlinkDataplane
 	var t *mocktime.MockTime
-	var s *mockStatus
+	var s *mockCallbacks
 	var wg *Wireguard
 	var rule *netlink.Rule
 
@@ -149,7 +168,7 @@ var _ = Describe("Enable wireguard", func() {
 		rtDataplane = mocknetlink.New()
 		rrDataplane = mocknetlink.New()
 		t = mocktime.New()
-		s = &mockStatus{}
+		s = &mockCallbacks{}
 		// Setting an auto-increment greater than the route cleanup delay effectively
 		// disables the grace period for these tests.
 		t.SetAutoIncrement(11 * time.Second)
@@ -164,6 +183,7 @@ var _ = Describe("Enable wireguard", func() {
 				RoutingTableIndex:   tableIndex,
 				InterfaceName:       ifaceName,
 				MTU:                 mtu,
+				EncryptHostTraffic:  true,
 			},
 			rtDataplane.NewMockNetlink,
 			rrDataplane.NewMockNetlink,
@@ -173,6 +193,7 @@ var _ = Describe("Enable wireguard", func() {
 			t,
 			FelixRouteProtocol,
 			s.status,
+			s.writeProcSys,
 			logutils.NewSummarizer("test loop"),
 		)
 
@@ -237,10 +258,10 @@ var _ = Describe("Enable wireguard", func() {
 		It("should handle status update raising an error", func() {
 			wgDataplane.SetIface(ifaceName, true, true)
 			wg.OnIfaceStateChanged(ifaceName, ifacemonitor.StateUp)
-			s.err = errors.New("foobarbaz")
+			s.statusErr = errors.New("foobarbaz")
 			err := wg.Apply()
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(s.err))
+			Expect(err).To(Equal(s.statusErr))
 		})
 
 		Describe("set the link up", func() {
@@ -259,8 +280,8 @@ var _ = Describe("Enable wireguard", func() {
 				Expect(link.WireguardListenPort).To(Equal(listeningPort))
 				Expect(link.WireguardPrivateKey).NotTo(Equal(zeroKey))
 				Expect(link.WireguardPrivateKey.PublicKey()).To(Equal(link.WireguardPublicKey))
-				Expect(s.numCallbacks).To(Equal(1))
-				Expect(s.key).To(Equal(link.WireguardPublicKey))
+				Expect(s.numStatusCallbacks).To(Equal(1))
+				Expect(s.statusKey).To(Equal(link.WireguardPublicKey))
 			})
 
 			It("should add the routing rule when wireguard device is configured", func() {
@@ -295,9 +316,9 @@ var _ = Describe("Enable wireguard", func() {
 			It("after endpoint update with incorrect key should program the interface address and resend same key as status", func() {
 				link := wgDataplane.NameToLink[ifaceName]
 				Expect(link.WireguardPrivateKey).NotTo(Equal(zeroKey))
-				Expect(s.numCallbacks).To(Equal(1))
+				Expect(s.numStatusCallbacks).To(Equal(1))
 				key := link.WireguardPrivateKey
-				Expect(s.key).To(Equal(key.PublicKey()))
+				Expect(s.statusKey).To(Equal(key.PublicKey()))
 
 				ipv4 := ip.FromString("1.2.3.4")
 				wg.EndpointWireguardUpdate(hostname, zeroKey, ipv4)
@@ -311,14 +332,14 @@ var _ = Describe("Enable wireguard", func() {
 				Expect(link.WireguardListenPort).To(Equal(listeningPort))
 				Expect(link.WireguardPrivateKey).To(Equal(key))
 				Expect(link.WireguardPrivateKey.PublicKey()).To(Equal(link.WireguardPublicKey))
-				Expect(s.numCallbacks).To(Equal(2))
-				Expect(s.key).To(Equal(key.PublicKey()))
+				Expect(s.numStatusCallbacks).To(Equal(2))
+				Expect(s.statusKey).To(Equal(key.PublicKey()))
 			})
 
 			It("after endpoint update with correct key should program the interface address and not send another status update", func() {
 				link := wgDataplane.NameToLink[ifaceName]
 				Expect(link.WireguardPrivateKey).NotTo(Equal(zeroKey))
-				Expect(s.numCallbacks).To(Equal(1))
+				Expect(s.numStatusCallbacks).To(Equal(1))
 				key := link.WireguardPrivateKey
 
 				ipv4 := ip.FromString("1.2.3.4")
@@ -333,7 +354,54 @@ var _ = Describe("Enable wireguard", func() {
 				Expect(link.WireguardListenPort).To(Equal(listeningPort))
 				Expect(link.WireguardPrivateKey).To(Equal(key))
 				Expect(link.WireguardPrivateKey.PublicKey()).To(Equal(link.WireguardPublicKey))
-				Expect(s.numCallbacks).To(Equal(1))
+				Expect(s.numStatusCallbacks).To(Equal(1))
+			})
+
+			It("will use node IP on EndpointUpdate when interface is not specified on previous EndpointWireguardUpdate", func() {
+				link := wgDataplane.NameToLink[ifaceName]
+				Expect(link.WireguardPrivateKey).NotTo(Equal(zeroKey))
+				Expect(s.numStatusCallbacks).To(Equal(1))
+				key := link.WireguardPrivateKey
+
+				ipv4 := ip.FromString("1.2.3.4")
+				wg.EndpointWireguardUpdate(hostname, key.PublicKey(), nil)
+				wg.EndpointUpdate(hostname, ipv4)
+				err := wg.Apply()
+
+				Expect(err).NotTo(HaveOccurred())
+				link = wgDataplane.NameToLink[ifaceName]
+				Expect(link.Addrs).To(HaveLen(1))
+				Expect(link.Addrs[0].IP).To(Equal(ipv4.AsNetIP()))
+				Expect(wgDataplane.WireguardOpen).To(BeTrue())
+				Expect(link.WireguardFirewallMark).To(Equal(10))
+				Expect(link.WireguardListenPort).To(Equal(listeningPort))
+				Expect(link.WireguardPrivateKey).To(Equal(key))
+				Expect(link.WireguardPrivateKey.PublicKey()).To(Equal(link.WireguardPublicKey))
+				Expect(s.numStatusCallbacks).To(Equal(1))
+			})
+
+			It("will use node IP from previous EndpointUpdate when interface is not specified on EndpointWireguardUpdate", func() {
+				link := wgDataplane.NameToLink[ifaceName]
+				Expect(link.WireguardPrivateKey).NotTo(Equal(zeroKey))
+				Expect(s.numStatusCallbacks).To(Equal(1))
+				key := link.WireguardPrivateKey
+
+				// Basically the same test as before but calls are reveresed.
+				ipv4 := ip.FromString("1.2.3.4")
+				wg.EndpointUpdate(hostname, ipv4)
+				wg.EndpointWireguardUpdate(hostname, key.PublicKey(), nil)
+				err := wg.Apply()
+
+				Expect(err).NotTo(HaveOccurred())
+				link = wgDataplane.NameToLink[ifaceName]
+				Expect(link.Addrs).To(HaveLen(1))
+				Expect(link.Addrs[0].IP).To(Equal(ipv4.AsNetIP()))
+				Expect(wgDataplane.WireguardOpen).To(BeTrue())
+				Expect(link.WireguardFirewallMark).To(Equal(10))
+				Expect(link.WireguardListenPort).To(Equal(listeningPort))
+				Expect(link.WireguardPrivateKey).To(Equal(key))
+				Expect(link.WireguardPrivateKey.PublicKey()).To(Equal(link.WireguardPublicKey))
+				Expect(s.numStatusCallbacks).To(Equal(1))
 			})
 
 			Describe("add local routes with overlap", func() {
@@ -404,8 +472,8 @@ var _ = Describe("Enable wireguard", func() {
 				var key_peer1, key_peer2 wgtypes.Key
 				var link *mocknetlink.MockLink
 				BeforeEach(func() {
-					Expect(s.numCallbacks).To(Equal(1))
-					wg.EndpointWireguardUpdate(hostname, s.key, nil)
+					Expect(s.numStatusCallbacks).To(Equal(1))
+					wg.EndpointWireguardUpdate(hostname, s.statusKey, nil)
 					key_peer1 = mustGeneratePrivateKey().PublicKey()
 					wg.EndpointWireguardUpdate(peer1, key_peer1, nil)
 					wg.EndpointUpdate(peer1, ipv4_peer1)
@@ -494,18 +562,82 @@ var _ = Describe("Enable wireguard", func() {
 				It("should trigger another status message if deleting the local Wireguard config", func() {
 					wgDataplane.ResetDeltas()
 					rtDataplane.ResetDeltas()
-					Expect(s.numCallbacks).To(Equal(1))
+					Expect(s.numStatusCallbacks).To(Equal(1))
 					wg.EndpointWireguardRemove(hostname)
 					err := wg.Apply()
 					Expect(err).NotTo(HaveOccurred())
-					Expect(s.numCallbacks).To(Equal(2))
+					Expect(s.numStatusCallbacks).To(Equal(2))
 				})
 
 				It("should contain a throw route for the local CIDR", func() {
 					Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
-					Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_cidr_local_throw))
+					Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_cidr_local))
 					Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
 					Expect(rtDataplane.DeletedRouteKeys).To(BeEmpty())
+				})
+
+				Describe("add local workload as a single IP", func() {
+					BeforeEach(func() {
+						// Update the routetable dataplane so it knows about the interface.
+						rtDataplane.NameToLink[ifaceName] = link
+
+						wgDataplane.ResetDeltas()
+						rtDataplane.ResetDeltas()
+						wg.RouteUpdate(hostname, cidr_6)
+						err := wg.Apply()
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should have a throw route to the local IP", func() {
+						Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+						Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+						Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_6))
+					})
+
+					It("should handle the IP being deleted and then moved to another node", func() {
+						wgDataplane.ResetDeltas()
+						rtDataplane.ResetDeltas()
+
+						wg.RouteRemove(cidr_6)
+						wg.RouteUpdate(peer1, cidr_6)
+						err := wg.Apply()
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+						Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_6))
+						Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+						Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_6))
+					})
+
+					It("should handle the IP being moved to another node without first deleting", func() {
+						wgDataplane.ResetDeltas()
+						rtDataplane.ResetDeltas()
+
+						wg.RouteUpdate(peer1, cidr_6)
+						err := wg.Apply()
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+						Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_6))
+						Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+						Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_6))
+					})
+
+					It("should handle the IP being moved to another node with a deletion in between", func() {
+						wgDataplane.ResetDeltas()
+						rtDataplane.ResetDeltas()
+
+						wg.RouteUpdate(peer1, cidr_6)
+						wg.RouteRemove(cidr_6)
+						wg.RouteUpdate(peer1, cidr_6)
+						err := wg.Apply()
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+						Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_6))
+						Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+						Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_6))
+					})
 				})
 
 				Describe("public key updated to conflict on two nodes", func() {
@@ -596,9 +728,9 @@ var _ = Describe("Enable wireguard", func() {
 						BeforeEach(func() {
 							// Update the mock routing table dataplane so that it knows about the wireguard interface.
 							rtDataplane.NameToLink[ifaceName] = link
-							routekey_1 = fmt.Sprintf("%d-%d-%s", tableIndex, link.LinkAttrs.Index, cidr_1)
-							routekey_2 = fmt.Sprintf("%d-%d-%s", tableIndex, link.LinkAttrs.Index, cidr_2)
-							routekey_3 = fmt.Sprintf("%d-%d-%s", tableIndex, link.LinkAttrs.Index, cidr_3)
+							routekey_1 = fmt.Sprintf("%d-%s", tableIndex, cidr_1)
+							routekey_2 = fmt.Sprintf("%d-%s", tableIndex, cidr_2)
+							routekey_3 = fmt.Sprintf("%d-%s", tableIndex, cidr_3)
 
 							wg.RouteUpdate(hostname, cidr_local)
 							wg.RouteUpdate(peer1, cidr_1)
@@ -636,7 +768,7 @@ var _ = Describe("Enable wireguard", func() {
 							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_1))
 							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_2))
 							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3))
-							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_4_throw))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_4))
 							Expect(rtDataplane.RouteKeyToRoute[routekey_1]).To(Equal(netlink.Route{
 								LinkIndex: link.LinkAttrs.Index,
 								Dst:       &ipnet_1,
@@ -661,7 +793,7 @@ var _ = Describe("Enable wireguard", func() {
 								Scope:     netlink.SCOPE_LINK,
 								Table:     tableIndex,
 							}))
-							Expect(rtDataplane.RouteKeyToRoute[routekey_4_throw]).To(Equal(netlink.Route{
+							Expect(rtDataplane.RouteKeyToRoute[routekey_4]).To(Equal(netlink.Route{
 								Dst:      &ipnet_4,
 								Type:     syscall.RTN_THROW,
 								Protocol: FelixRouteProtocol,
@@ -741,12 +873,312 @@ var _ = Describe("Enable wireguard", func() {
 							Expect(err).NotTo(HaveOccurred())
 							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
 							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(2))
-							Expect(rtDataplane.AddedRouteKeys).NotTo(HaveKey(routekey_3))
-							Expect(rtDataplane.AddedRouteKeys).NotTo(HaveKey(routekey_3_throw))
-							Expect(rtDataplane.AddedRouteKeys).NotTo(HaveKey(routekey_4_throw))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_4))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
 							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
-							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
 							Expect(link.WireguardPeers).To(HaveLen(1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+						})
+
+						It("should handle deletion of a wireguard peer over multiple applies: endpoint, wireguard, route", func() {
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+
+							// Remove the endpoint. Wireguard config should be removed at this point. The route should
+							// be converted to a throw route.
+							By("Removing the node")
+							wg.EndpointRemove(peer2)
+							err := wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
+							Expect(link.WireguardPeers).To(HaveLen(1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+							Expect(rtDataplane.RouteKeyToRoute[routekey_3]).To(Equal(netlink.Route{
+								Dst:      &ipnet_3,
+								Type:     syscall.RTN_THROW,
+								Protocol: FelixRouteProtocol,
+								Scope:    netlink.SCOPE_UNIVERSE,
+								Table:    tableIndex,
+							}))
+
+							// Remove the wireguard config for this peer. Should have no further impact.
+							By("Removing the wireguard configuration")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.EndpointWireguardRemove(peer2)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeFalse())
+							Expect(link.WireguardPeers).To(HaveLen(1))
+
+							// Remove the route.
+							// This is the last bit of configuration for the peer and so the node should be removed
+							// from the cache.
+							By("Removing the route")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.RouteRemove(cidr_3)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(3))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(link.WireguardPeers).To(HaveLen(1))
+						})
+
+						It("should handle deletion of a wireguard peer over multiple applies: route, endpoint, wireguard", func() {
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+
+							// Remove the route.
+							By("Removing the route")
+							wg.RouteRemove(cidr_3)
+							err := wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.RouteKeyToRoute).ToNot(HaveKey(routekey_3))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
+							Expect(link.WireguardPeers).To(HaveLen(2))
+
+							// Remove the endpoint. Wireguard config should be removed at this point. The route should
+							// be converted to a throw route.
+							By("Removing the node")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.EndpointRemove(peer2)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
+							Expect(link.WireguardPeers).To(HaveLen(1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+
+							// Remove the wireguard config for this peer.
+							// This is the last bit of configuration for the peer and so the node should be removed
+							// from the cache.
+							By("Removing the wireguard configuration")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.EndpointWireguardRemove(peer2)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(3))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeFalse())
+							Expect(link.WireguardPeers).To(HaveLen(1))
+						})
+
+						It("should handle deletion of a wireguard peer over multiple applies: route, endpoint, wireguard", func() {
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+
+							// Remove the wireguard config for this peer. Wireguard config should be removed at this
+							// point. The route should be converted to a throw route.
+							By("Removing the wireguard configuration")
+							wg.EndpointWireguardRemove(peer2)
+							err := wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
+							Expect(rtDataplane.RouteKeyToRoute[routekey_3]).To(Equal(netlink.Route{
+								Dst:      &ipnet_3,
+								Type:     syscall.RTN_THROW,
+								Protocol: FelixRouteProtocol,
+								Scope:    netlink.SCOPE_UNIVERSE,
+								Table:    tableIndex,
+							}))
+							Expect(link.WireguardPeers).To(HaveLen(1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+
+							// Remove the route.
+							By("Removing the route")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.RouteRemove(cidr_3)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.RouteKeyToRoute).ToNot(HaveKey(routekey_3))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeFalse())
+							Expect(link.WireguardPeers).To(HaveLen(1))
+
+							// Remove the endpoint.
+							// This is the last bit of configuration for the peer and so the node should be removed
+							// from the cache.
+							By("Removing the node")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.EndpointRemove(peer2)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(3))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeFalse())
+							Expect(link.WireguardPeers).To(HaveLen(1))
+						})
+
+						It("should handle deletion and re-adding an endpoint over multiple applies", func() {
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+
+							// Remove the endpoint. Wireguard config should be removed at this point. The route should
+							// be converted to a throw route.
+							By("Removing the node")
+							wg.EndpointRemove(peer2)
+							err := wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
+							Expect(link.WireguardPeers).To(HaveLen(1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+							Expect(rtDataplane.RouteKeyToRoute[routekey_3]).To(Equal(netlink.Route{
+								Dst:      &ipnet_3,
+								Type:     syscall.RTN_THROW,
+								Protocol: FelixRouteProtocol,
+								Scope:    netlink.SCOPE_UNIVERSE,
+								Table:    tableIndex,
+							}))
+
+							// Re-add the endpoint. Wireguard config will be added back in.
+							By("Re-adding the node")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.EndpointUpdate(peer2, ipv4_peer2)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
+							Expect(link.WireguardPeers).To(HaveLen(2))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer2))
+							Expect(rtDataplane.RouteKeyToRoute[routekey_3]).To(Equal(netlink.Route{
+								LinkIndex: link.LinkAttrs.Index,
+								Dst:       &ipnet_3,
+								Type:      syscall.RTN_UNICAST,
+								Protocol:  FelixRouteProtocol,
+								Scope:     netlink.SCOPE_LINK,
+								Table:     tableIndex,
+							}))
+						})
+
+						It("should handle deletion and re-adding an endpoint in a single apply", func() {
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+
+							// Remove the endpoint. Wireguard config should be removed at this point. The route should
+							// be converted to a throw route.
+							By("Removing the node")
+							wg.EndpointRemove(peer2)
+							wg.EndpointUpdate(peer2, ipv4_peer2)
+							err := wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeFalse())
+							Expect(link.WireguardPeers).To(HaveLen(2))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer2))
+						})
+
+						It("should handle deletion and re-adding an endpoint with a different IP in a single apply", func() {
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+
+							// Remove the endpoint. Wireguard config should be removed at this point. The route should
+							// be converted to a throw route.
+							By("Removing the node")
+							wg.EndpointRemove(peer2)
+							wg.EndpointUpdate(peer2, ipv4_peer2_2)
+							err := wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(wg.DebugNodes()).To(HaveLen(4))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+							Expect(wgDataplane.WireguardConfigUpdated).To(BeTrue())
+							Expect(link.WireguardPeers).To(HaveLen(2))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer1))
+							Expect(link.WireguardPeers).To(HaveKey(key_peer2))
+							Expect(link.WireguardPeers[key_peer2].Endpoint.IP).To(Equal(ipv4_peer2_2.AsNetIP()))
+						})
+
+						It("should handle immediate and subsequent reuse after a node deletion", func() {
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.EndpointRemove(peer2)
+							wg.EndpointWireguardRemove(peer2)
+							wg.RouteRemove(cidr_3)
+							wg.RouteUpdate(hostname, cidr_3)
+							By("Applying deletion and IP moving to local host")
+							err := wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3))
+							Expect(rtDataplane.RouteKeyToRoute[routekey_3]).To(Equal(netlink.Route{
+								Dst:      &ipnet_3,
+								Type:     syscall.RTN_THROW,
+								Protocol: FelixRouteProtocol,
+								Scope:    netlink.SCOPE_UNIVERSE,
+								Table:    tableIndex,
+							}))
+
+							By("Deleting local route")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.RouteRemove(cidr_3)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.RouteKeyToRoute).NotTo(HaveKey(routekey_3))
+
+							By("Applying the same route to be remote")
+							wgDataplane.ResetDeltas()
+							rtDataplane.ResetDeltas()
+							wg.RouteUpdate(peer1, cidr_3)
+							err = wg.Apply()
+							Expect(err).NotTo(HaveOccurred())
+							Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
+							Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
+							Expect(rtDataplane.RouteKeyToRoute[routekey_3]).To(Equal(netlink.Route{
+								LinkIndex: link.LinkAttrs.Index,
+								Dst:       &ipnet_3,
+								Type:      syscall.RTN_UNICAST,
+								Protocol:  FelixRouteProtocol,
+								Scope:     netlink.SCOPE_LINK,
+								Table:     tableIndex,
+							}))
 						})
 
 						Describe("move a route from peer1 to peer2 and a route from peer2 to peer3", func() {
@@ -784,8 +1216,8 @@ var _ = Describe("Enable wireguard", func() {
 								Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
 								Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
 								Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_3))
-								Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3_throw))
-								Expect(rtDataplane.RouteKeyToRoute[routekey_3_throw]).To(Equal(netlink.Route{
+								Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_3))
+								Expect(rtDataplane.RouteKeyToRoute[routekey_3]).To(Equal(netlink.Route{
 									Dst:      &ipnet_3,
 									Type:     syscall.RTN_THROW,
 									Protocol: FelixRouteProtocol,
@@ -836,10 +1268,10 @@ var _ = Describe("Enable wireguard", func() {
 							})
 
 							It("should reprogram the route to peer3 only", func() {
-								routekey_4 := fmt.Sprintf("%d-%d-%s", tableIndex, link.LinkAttrs.Index, cidr_4)
+								routekey_4 := fmt.Sprintf("%d-%s", tableIndex, cidr_4)
 								Expect(rtDataplane.AddedRouteKeys).To(HaveLen(1))
 								Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(1))
-								Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_4_throw))
+								Expect(rtDataplane.DeletedRouteKeys).To(HaveKey(routekey_4))
 								Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_4))
 								Expect(rtDataplane.RouteKeyToRoute[routekey_4]).To(Equal(netlink.Route{
 									LinkIndex: link.LinkAttrs.Index,
@@ -901,7 +1333,7 @@ var _ = Describe("Enable wireguard", func() {
 		Expect(link.WireguardListenPort).To(Equal(1000))
 		Expect(link.WireguardPrivateKey).To(Equal(key))
 		Expect(link.WireguardPrivateKey.PublicKey()).To(Equal(link.WireguardPublicKey))
-		Expect(s.numCallbacks).To(Equal(1))
+		Expect(s.numStatusCallbacks).To(Equal(1))
 	})
 
 	Describe("wireguard initially not supported", func() {
@@ -978,9 +1410,9 @@ var _ = Describe("Enable wireguard", func() {
 				// We expect the link to exist.
 				link = wgDataplane.NameToLink[ifaceName]
 				Expect(link).ToNot(BeNil())
-				routekey_1 = fmt.Sprintf("%d-%d-%s", tableIndex, link.LinkAttrs.Index, cidr_1)
-				routekey_2 = fmt.Sprintf("%d-%d-%s", tableIndex, link.LinkAttrs.Index, cidr_2)
-				routekey_3 = fmt.Sprintf("%d-%d-%s", tableIndex, link.LinkAttrs.Index, cidr_3)
+				routekey_1 = fmt.Sprintf("%d-%s", tableIndex, cidr_1)
+				routekey_2 = fmt.Sprintf("%d-%s", tableIndex, cidr_2)
+				routekey_3 = fmt.Sprintf("%d-%s", tableIndex, cidr_3)
 
 				// Set the interface to be up
 				wgDataplane.SetIface(ifaceName, true, true)
@@ -1024,7 +1456,7 @@ var _ = Describe("Enable wireguard", func() {
 				Expect(rtDataplane.DeletedRouteKeys).To(HaveLen(0))
 				Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_1))
 				Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_2))
-				Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_cidr_local_throw))
+				Expect(rtDataplane.AddedRouteKeys).To(HaveKey(routekey_cidr_local))
 
 				// All of these failures will trigger an attempt to get a either a new netlink or wireguard client.
 				if failFlags&(mocknetlink.FailNextNewWireguard|mocknetlink.FailNextWireguardConfigureDevice|mocknetlink.FailNextWireguardDeviceByName) != 0 {
@@ -1119,8 +1551,8 @@ var _ = Describe("Enable wireguard", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect a zero key status update.
-				Expect(s.key).To(Equal(zeroKey))
-				Expect(s.numCallbacks).To(Equal(1))
+				Expect(s.statusKey).To(Equal(zeroKey))
+				Expect(s.numStatusCallbacks).To(Equal(1))
 
 				// Always expect to attempt to create the netlink client
 				Expect(wgDataplane.NumNewNetlinkCalls).To(Equal(1))
@@ -1143,8 +1575,8 @@ var _ = Describe("Enable wireguard", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect an updated public key and the previously failed client to have been re-requested.
-				Expect(s.key).NotTo(Equal(zeroKey))
-				Expect(s.numCallbacks).To(Equal(2))
+				Expect(s.statusKey).NotTo(Equal(zeroKey))
+				Expect(s.numStatusCallbacks).To(Equal(2))
 				if failFlags&mocknetlink.FailNextNewWireguardNotSupported != 0 {
 					// And if emulating the wireguard failure, we expect a call to that too.
 					Expect(wgDataplane.NumNewWireguardCalls).To(Equal(1))
@@ -1269,7 +1701,7 @@ var _ = Describe("Enable wireguard", func() {
 var _ = Describe("Wireguard (disabled)", func() {
 	var wgDataplane, rtDataplane, rrDataplane *mocknetlink.MockNetlinkDataplane
 	var t *mocktime.MockTime
-	var s mockStatus
+	var s mockCallbacks
 	var wg *Wireguard
 
 	BeforeEach(func() {
@@ -1300,6 +1732,7 @@ var _ = Describe("Wireguard (disabled)", func() {
 			t,
 			FelixRouteProtocol,
 			s.status,
+			s.writeProcSys,
 			logutils.NewSummarizer("test loop"),
 		)
 	})
@@ -1453,7 +1886,7 @@ var _ = Describe("Wireguard (disabled)", func() {
 var _ = Describe("Wireguard (with no table index)", func() {
 	var wgDataplane, rtDataplane, rrDataplane *mocknetlink.MockNetlinkDataplane
 	var t *mocktime.MockTime
-	var s mockStatus
+	var s mockCallbacks
 	var wgFn func(bool)
 
 	BeforeEach(func() {
@@ -1483,6 +1916,7 @@ var _ = Describe("Wireguard (with no table index)", func() {
 				t,
 				FelixRouteProtocol,
 				s.status,
+				s.writeProcSys,
 				logutils.NewSummarizer("test loop"),
 			)
 		}

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -22,9 +22,11 @@ import (
 	"reflect"
 	"time"
 
-	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	felixconfig "github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	libapi "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
@@ -60,13 +62,21 @@ func Run(done <-chan struct{}) {
 		log.Panic("NODENAME environment is not set")
 	}
 
+	// Load felix environment configuration. Note that this does not perform the full hierarchical load of felix
+	// configuration nor does this watch for changes, so if it is critical that the configuration value used is correct
+	// and may be defined outside of an environment variable, do not use this.
+	felixEnvConfig := loadFelixEnvConfig()
+
 	// Load the client config from environment.
 	cfg, c := calicoclient.CreateClient()
 
-	run(nodename, cfg, c, done)
+	run(nodename, cfg, c, felixEnvConfig, done)
 }
 
-func run(nodename string, cfg *apiconfig.CalicoAPIConfig, c client.Interface, done <-chan struct{}) {
+func run(
+	nodename string, cfg *apiconfig.CalicoAPIConfig, c client.Interface,
+	felixEnvConfig *felixconfig.Config, done <-chan struct{},
+) {
 	// If configured to use host-local IPAM, there is no need to configure tunnel addresses as they use the
 	// first IP of the pod CIDR - this is handled in the k8s backend code in libcalico-go.
 	if cfg.Spec.K8sUsePodCIDR {
@@ -80,17 +90,18 @@ func run(nodename string, cfg *apiconfig.CalicoAPIConfig, c client.Interface, do
 
 	if done == nil {
 		// Running in single shot mode, so assign addresses and exit.
-		reconcileTunnelAddrs(nodename, cfg, c)
+		reconcileTunnelAddrs(nodename, cfg, c, felixEnvConfig)
 		return
 	}
 
 	// This is running as a daemon. Create a long-running reconciler.
 	r := &reconciler{
-		nodename: nodename,
-		cfg:      cfg,
-		client:   c,
-		ch:       make(chan struct{}),
-		data:     make(map[string]interface{}),
+		nodename:       nodename,
+		cfg:            cfg,
+		client:         c,
+		ch:             make(chan struct{}),
+		data:           make(map[string]interface{}),
+		felixEnvConfig: felixEnvConfig,
 	}
 
 	// Either create a typha syncclient or a local syncer depending on configuration. This calls back into the
@@ -120,12 +131,13 @@ func run(nodename string, cfg *apiconfig.CalicoAPIConfig, c client.Interface, do
 // reconciler watches IPPool and Node configuration and triggers a reconciliation of the Tunnel IP addresses whenever
 // it spots a configuration change that may impact IP selection.
 type reconciler struct {
-	nodename string
-	cfg      *apiconfig.CalicoAPIConfig
-	client   client.Interface
-	ch       chan struct{}
-	data     map[string]interface{}
-	inSync   bool
+	nodename       string
+	cfg            *apiconfig.CalicoAPIConfig
+	client         client.Interface
+	ch             chan struct{}
+	data           map[string]interface{}
+	felixEnvConfig *felixconfig.Config
+	inSync         bool
 }
 
 // run is the main reconciliation loop, it loops until done.
@@ -137,7 +149,7 @@ func (r reconciler) run(done <-chan struct{}) {
 			// Received an update that requires reconciliation.  If the reconciliation fails it will cause the daemon
 			// to exit this is fine - it will be restarted, and the syncer will trigger a reconciliation when in-sync
 			// again.
-			reconcileTunnelAddrs(r.nodename, r.cfg, r.client)
+			reconcileTunnelAddrs(r.nodename, r.cfg, r.client, r.felixEnvConfig)
 		case <-done:
 			return
 		}
@@ -207,7 +219,9 @@ func (r *reconciler) OnUpdates(updates []bapi.Update) {
 }
 
 // reconcileTunnelAddrs performs a single shot update of the tunnel IP allocations.
-func reconcileTunnelAddrs(nodename string, cfg *apiconfig.CalicoAPIConfig, c client.Interface) {
+func reconcileTunnelAddrs(
+	nodename string, cfg *apiconfig.CalicoAPIConfig, c client.Interface, felixEnvConfig *felixconfig.Config,
+) {
 	ctx := context.Background()
 	// Get node resource for given nodename.
 	node, err := c.Nodes().Get(ctx, nodename, options.GetOptions{})
@@ -223,7 +237,7 @@ func reconcileTunnelAddrs(nodename string, cfg *apiconfig.CalicoAPIConfig, c cli
 
 	// If wireguard is enabled then allocate an IP for the wireguard device. We do this for all deployment types even
 	// when pod CIDRs are not managed by Calico.
-	if cidrs := determineEnabledPoolCIDRs(*node, *ipPoolList, ipam.AttributeTypeWireguard); len(cidrs) > 0 {
+	if cidrs := determineEnabledPoolCIDRs(*node, *ipPoolList, felixEnvConfig, ipam.AttributeTypeWireguard); len(cidrs) > 0 {
 		ensureHostTunnelAddress(ctx, c, nodename, cidrs, ipam.AttributeTypeWireguard)
 	} else {
 		removeHostTunnelAddr(ctx, c, nodename, ipam.AttributeTypeWireguard)
@@ -231,7 +245,7 @@ func reconcileTunnelAddrs(nodename string, cfg *apiconfig.CalicoAPIConfig, c cli
 
 	// Query the IPIP enabled pools and either configure the tunnel
 	// address, or remove it.
-	if cidrs := determineEnabledPoolCIDRs(*node, *ipPoolList, ipam.AttributeTypeIPIP); len(cidrs) > 0 {
+	if cidrs := determineEnabledPoolCIDRs(*node, *ipPoolList, felixEnvConfig, ipam.AttributeTypeIPIP); len(cidrs) > 0 {
 		ensureHostTunnelAddress(ctx, c, nodename, cidrs, ipam.AttributeTypeIPIP)
 	} else {
 		removeHostTunnelAddr(ctx, c, nodename, ipam.AttributeTypeIPIP)
@@ -239,7 +253,7 @@ func reconcileTunnelAddrs(nodename string, cfg *apiconfig.CalicoAPIConfig, c cli
 
 	// Query the VXLAN enabled pools and either configure the tunnel
 	// address, or remove it.
-	if cidrs := determineEnabledPoolCIDRs(*node, *ipPoolList, ipam.AttributeTypeVXLAN); len(cidrs) > 0 {
+	if cidrs := determineEnabledPoolCIDRs(*node, *ipPoolList, felixEnvConfig, ipam.AttributeTypeVXLAN); len(cidrs) > 0 {
 		ensureHostTunnelAddress(ctx, c, nodename, cidrs, ipam.AttributeTypeVXLAN)
 	} else {
 		removeHostTunnelAddr(ctx, c, nodename, ipam.AttributeTypeVXLAN)
@@ -617,12 +631,22 @@ func removeHostTunnelAddr(ctx context.Context, c client.Interface, nodename stri
 
 // determineEnabledPools returns all enabled pools. If vxlan is true, then it will only return VXLAN pools. Otherwise
 // it will only return IPIP enabled pools.
-func determineEnabledPoolCIDRs(node libapi.Node, ipPoolList api.IPPoolList, attrType string) []net.IPNet {
-	// For wireguard, return no valid pools if the wireguard public key has not been set. Only once wireguard has been
-	// enabled *and* the wireguard device has been initialized do we require an IP address to be configured.
-	if attrType == ipam.AttributeTypeWireguard && node.Status.WireguardPublicKey == "" {
-		log.Debugf("Wireguard is not running on node %s", node.Name)
-		return nil
+func determineEnabledPoolCIDRs(
+	node libapi.Node, ipPoolList api.IPPoolList, felixEnvConfig *felixconfig.Config, attrType string,
+) []net.IPNet {
+	// For wireguard, an IP is only allocated from a pool if wireguard is actually running (there will be a public
+	// key configured on the node), and the cluster is not running in host encryption mode (which is required for
+	// managed cloud with non-Calico CNI). When running in host encryption mode, the wireguard dataplane will use the
+	// node IP for the device.
+	if attrType == ipam.AttributeTypeWireguard {
+		if felixEnvConfig.WireguardHostEncryptionEnabled {
+			log.Debug("Wireguard is running in host encryption mode, do not allocate a device IP")
+			return nil
+		}
+		if node.Status.WireguardPublicKey == "" {
+			log.Debugf("Wireguard is not running on node %s, do not allocate a device IP", node.Name)
+			return nil
+		}
 	}
 
 	var cidrs []net.IPNet
@@ -689,4 +713,19 @@ func getLogger(attrType string) *log.Entry {
 // backendClientAccessor is an interface to access the backend client from the main v2 client.
 type backendClientAccessor interface {
 	Backend() bapi.Client
+}
+
+// loadFelixEnvConfig loads the felix configuration from environment. It does not perform a hierarchical load across
+// env, file and felixconfigurations resources and as such this is should only be used for configuration that is only
+// expected to be specified through environment.
+func loadFelixEnvConfig() *felixconfig.Config {
+	// Load locally-defined config from the environment variables.
+	configParams := felixconfig.New()
+	envConfig := felixconfig.LoadConfigFromEnvironment(os.Environ())
+	// Parse and merge the local config.
+	_, err := configParams.UpdateFrom(envConfig, felixconfig.EnvironmentVariable)
+	if err != nil {
+		log.WithError(err).Panic("Failed to parse Felix environments")
+	}
+	return configParams
 }

--- a/node/pkg/allocateip/allocateip.go
+++ b/node/pkg/allocateip/allocateip.go
@@ -486,7 +486,7 @@ func updateNodeWithAddress(ctx context.Context, c client.Interface, nodename str
 			continue
 		}
 
-		return nil
+		return err
 	}
 	return fmt.Errorf("Too many retries attempting to update node with tunnel address")
 }

--- a/node/pkg/allocateip/allocateip_test.go
+++ b/node/pkg/allocateip/allocateip_test.go
@@ -24,13 +24,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/projectcalico/calico/node/pkg/calicoclient"
-
 	log "github.com/sirupsen/logrus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
+	felixconfig "github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	libapi "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend"
@@ -41,6 +41,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
+	"github.com/projectcalico/calico/node/pkg/calicoclient"
 )
 
 func allocateIPDescribe(description string, tunnelType []string, body func(tunnelType string)) bool {
@@ -198,7 +199,7 @@ var _ = Describe("FV tests", func() {
 
 		// Run the allocateip code.
 		cfg, c := calicoclient.CreateClient()
-		reconcileTunnelAddrs(nodename, cfg, c)
+		reconcileTunnelAddrs(nodename, cfg, c, felixconfig.New())
 
 		// Assert that the node has the same IP on it.
 		newNode, err := c.Nodes().Get(ctx, nodename, options.GetOptions{})
@@ -242,7 +243,7 @@ var _ = Describe("FV tests", func() {
 
 		// Run the allocateip code.
 		cfg, c := calicoclient.CreateClient()
-		reconcileTunnelAddrs(nodename, cfg, c)
+		reconcileTunnelAddrs(nodename, cfg, c, felixconfig.New())
 
 		// Assert that the node no longer has the same IP on it.
 		newNode, err := c.Nodes().Get(ctx, nodename, options.GetOptions{})
@@ -286,7 +287,7 @@ var _ = Describe("FV tests", func() {
 
 		// Run the allocateip code.
 		cfg, c := calicoclient.CreateClient()
-		reconcileTunnelAddrs(nodename, cfg, c)
+		reconcileTunnelAddrs(nodename, cfg, c, felixconfig.New())
 
 		// Assert that the node no longer has the same IP on it.
 		newNode, err := c.Nodes().Get(ctx, nodename, options.GetOptions{})
@@ -333,7 +334,7 @@ var _ = Describe("FV tests", func() {
 
 		// Run the allocateip code.
 		cfg, c := calicoclient.CreateClient()
-		reconcileTunnelAddrs(nodename, cfg, c)
+		reconcileTunnelAddrs(nodename, cfg, c, felixconfig.New())
 
 		// Assert that the node no longer has the same IP on it.
 		newNode, err := c.Nodes().Get(ctx, nodename, options.GetOptions{})
@@ -734,7 +735,7 @@ var _ = Describe("Running as daemon", func() {
 		done := make(chan struct{})
 		completed := make(chan struct{})
 		go func() {
-			run("test.node", cfg, c, done)
+			run("test.node", cfg, c, felixconfig.New(), done)
 			close(completed)
 		}()
 
@@ -822,7 +823,7 @@ var _ = Describe("determineEnabledPoolCIDRs", func() {
 					}}}
 
 			// Execute and test assertions.
-			cidrs := determineEnabledPoolCIDRs(n, pl, ipam.AttributeTypeIPIP)
+			cidrs := determineEnabledPoolCIDRs(n, pl, felixconfig.New(), ipam.AttributeTypeIPIP)
 			_, cidr1, _ := net.ParseCIDR("172.0.0.1/9")
 			_, cidr2, _ := net.ParseCIDR("172.128.0.1/9")
 			Expect(cidrs).To(ContainElement(*cidr1))
@@ -855,7 +856,7 @@ var _ = Describe("determineEnabledPoolCIDRs", func() {
 					}}}
 
 			// Execute and test assertions.
-			cidrs := determineEnabledPoolCIDRs(n, pl, ipam.AttributeTypeVXLAN)
+			cidrs := determineEnabledPoolCIDRs(n, pl, felixconfig.New(), ipam.AttributeTypeVXLAN)
 			_, cidr1, _ := net.ParseCIDR("172.0.0.1/9")
 			_, cidr2, _ := net.ParseCIDR("172.128.0.1/9")
 			Expect(cidrs).To(ContainElement(*cidr1))
@@ -885,7 +886,7 @@ var _ = Describe("determineEnabledPoolCIDRs", func() {
 					}}}
 
 			// Execute and test assertions.
-			cidrs := determineEnabledPoolCIDRs(n, pl, ipam.AttributeTypeVXLAN)
+			cidrs := determineEnabledPoolCIDRs(n, pl, felixconfig.New(), ipam.AttributeTypeVXLAN)
 			_, cidr1, _ := net.ParseCIDR("172.0.0.1/9")
 			_, cidr2, _ := net.ParseCIDR("172.128.0.1/9")
 			Expect(cidrs).To(ContainElement(*cidr1))
@@ -919,7 +920,7 @@ var _ = Describe("determineEnabledPoolCIDRs", func() {
 					}}}
 
 			// Execute and test assertions.
-			cidrs := determineEnabledPoolCIDRs(n, pl, ipam.AttributeTypeWireguard)
+			cidrs := determineEnabledPoolCIDRs(n, pl, felixconfig.New(), ipam.AttributeTypeWireguard)
 			_, cidr1, _ := net.ParseCIDR("172.0.0.1/9")
 			_, cidr2, _ := net.ParseCIDR("172.128.0.1/9")
 			Expect(cidrs).To(ContainElement(*cidr1))
@@ -947,7 +948,7 @@ var _ = Describe("determineEnabledPoolCIDRs", func() {
 					}}}
 
 			// Execute and test assertions.
-			cidrs := determineEnabledPoolCIDRs(n, pl, ipam.AttributeTypeWireguard)
+			cidrs := determineEnabledPoolCIDRs(n, pl, felixconfig.New(), ipam.AttributeTypeWireguard)
 			Expect(cidrs).To(HaveLen(0))
 		})
 	})


### PR DESCRIPTION
## Description

Cherry-pick of #6185 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Handle errors correctly in wireguard tunnel IP setting on the node
```
```release-note
When there is no allocated Wireguard interface IP and host encryption is enabled the host IP is used as the device IP.  This ensures source IP selection will choose the correct host IP when routing over Wireguard
```

```release-note
Fix that a combination of node deletions and workload IP relocation previously could result in multiple nodes having the same CIDR.
```

```release-note
Don't allocate wireguard device IPs for managed cloud non-calico CNI
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
