### PR TITLE
generic caching map

### DIFF
--- a/felix/bpf/cachingmap/caching_map.go
+++ b/felix/bpf/cachingmap/caching_map.go
@@ -16,25 +16,32 @@ package cachingmap
 
 import (
 	"fmt"
-	"log"
-	"reflect"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf"
 )
 
-// CachingMap provides a caching layer around a bpf.Map, when one of the Apply methods is called, it applies
+// DataplaneMap is an interface of the underlying map that is being cached by the
+// CachingMap. It implements interaction with the dataplane.
+type DataplaneMap[K comparable, V comparable] interface {
+	Update(K, V) error
+	Get(K) (V, error)
+	Delete(K) error
+	Load() (map[K]V, error)
+}
+
+// CachingMap provides a caching layer around a DataplaneMap, when one of the Apply methods is called, it applies
 // a minimal set of changes to the dataplane map to bring it into sync with the desired state.  Updating the
 // desired state in and of itself has no effect on the dataplane.
 //
 // CachingMap will load a cache of the dataplane state on the first call to ApplyXXX, or the cache can be loaded
 // explicitly by calling LoadCacheFromDataplane().  This allows for client code to inspect the dataplane cache
 // with IterDataplaneCache and GetDataplaneCache.
-type CachingMap struct {
-	// dataplaneMap is the backing map in the dataplane
-	dataplaneMap bpf.Map
-	params       bpf.MapParameters
+type CachingMap[K comparable, V comparable] struct {
+	// dpMap is the backing map in the dataplane
+	dpMap DataplaneMap[K, V]
+	name  string
 
 	// desiredStateOfDataplane stores the complete set of key/value pairs that we _want_ to
 	// be in the dataplane.  Calling ApplyAllChanges attempts to bring the dataplane into
@@ -42,50 +49,48 @@ type CachingMap struct {
 	//
 	// For occupancy's sake we may want to drop this copy and instead maintain the invariant:
 	// desiredStateOfDataplane = cacheOfDataplane - pendingDeletions + pendingUpdates.
-	desiredStateOfDataplane *ByteArrayToByteArrayMap
+	desiredStateOfDataplane map[K]V
 
-	cacheOfDataplane *ByteArrayToByteArrayMap
-	pendingUpdates   *ByteArrayToByteArrayMap
-	pendingDeletions *ByteArrayToByteArrayMap
+	cacheOfDataplane map[K]V
+	pendingUpdates   map[K]V
+	pendingDeletions map[K]V
 }
 
-func New(mapParams bpf.MapParameters, dataplaneMap bpf.Map) *CachingMap {
-	cm := &CachingMap{
-		params:                  mapParams,
-		dataplaneMap:            dataplaneMap,
-		desiredStateOfDataplane: NewByteArrayToByteArrayMap(mapParams.KeySize, mapParams.ValueSize),
+func New[K comparable, V comparable](name string, dpMap DataplaneMap[K, V]) *CachingMap[K, V] {
+	cm := &CachingMap[K, V]{
+		name:                    name,
+		dpMap:                   dpMap,
+		desiredStateOfDataplane: make(map[K]V),
 	}
 	return cm
 }
 
 // LoadCacheFromDataplane loads the contents of the BPF map into the dataplane cache, allowing it to be queried with
 // GetDataplaneCache and IterDataplaneCache.
-func (c *CachingMap) LoadCacheFromDataplane() error {
-	logrus.WithField("name", c.params.Name).Debug("Loading cache of dataplane state.")
+func (c *CachingMap[K, V]) LoadCacheFromDataplane() error {
+	logrus.WithField("name", c.name).Debug("Loading cache of dataplane state.")
 	c.initCache()
-	err := c.dataplaneMap.Iter(func(k, v []byte) bpf.IteratorAction {
-		c.cacheOfDataplane.Set(k, v)
-		return bpf.IterNone
-	})
+	dp, err := c.dpMap.Load()
+
 	if err != nil {
-		logrus.WithError(err).WithField("name", c.params.Name).Warn("Failed to load cache of BPF map")
+		logrus.WithError(err).WithField("name", c.name).Warn("Failed to load cache of dataplane map")
 		c.clearCache()
 		return err
 	}
-	logrus.WithField("name", c.params.Name).WithField("count", c.cacheOfDataplane.Len()).Info(
-		"Loaded cache of BPF map")
+	c.cacheOfDataplane = dp
+	logrus.WithField("name", c.name).WithField("count", len(c.cacheOfDataplane)).Info(
+		"Loaded cache from dataplane.")
 	c.recalculatePendingOperations()
 	return nil
 }
 
-func (c *CachingMap) initCache() {
-	c.cacheOfDataplane = NewByteArrayToByteArrayMap(c.params.KeySize, c.params.ValueSize)
-	c.pendingUpdates = NewByteArrayToByteArrayMap(c.params.KeySize, c.params.ValueSize)
-	c.pendingDeletions = NewByteArrayToByteArrayMap(c.params.KeySize, c.params.ValueSize)
+func (c *CachingMap[K, V]) initCache() {
+	c.pendingUpdates = make(map[K]V)
+	c.pendingDeletions = make(map[K]V)
 }
 
-func (c *CachingMap) clearCache() {
-	logrus.WithField("name", c.params.Name).Debug("Clearing cache of BPF map")
+func (c *CachingMap[K, V]) clearCache() {
+	logrus.WithField("name", c.name).Debug("Clearing cache of dataplane map")
 	c.cacheOfDataplane = nil
 	c.pendingDeletions = nil
 	c.pendingUpdates = nil
@@ -93,22 +98,21 @@ func (c *CachingMap) clearCache() {
 
 // recalculatePendingOperations compares the dataplane cache against he desired state and adds entries to
 // pendingUpdates/pendingDeletions that would bring the dataplane into sync with the desired state.
-func (c *CachingMap) recalculatePendingOperations() {
+func (c *CachingMap[K, V]) recalculatePendingOperations() {
 	debug := logrus.GetLevel() >= logrus.DebugLevel
 
 	// Look for any discrepancies and queue up updates.
-	c.desiredStateOfDataplane.Iter(func(k, desiredVal []byte) {
-		actualVal := c.cacheOfDataplane.Get(k)
-		if slicesEqual(actualVal, desiredVal) {
-			return
+	for k, desiredVal := range c.desiredStateOfDataplane {
+		actualVal := c.cacheOfDataplane[k]
+		if actualVal != desiredVal {
+			c.pendingUpdates[k] = desiredVal
 		}
-		c.pendingUpdates.Set(k, desiredVal)
-	})
+	}
 
 	// Scan for any dataplane keys that are not in the desired map at all and
 	// queue up deletions.
-	c.cacheOfDataplane.Iter(func(k, actualVal []byte) {
-		desiredVal := c.desiredStateOfDataplane.Get(k)
+	for k, actualVal := range c.cacheOfDataplane {
+		desiredVal, ok := c.desiredStateOfDataplane[k]
 		if debug {
 			logrus.WithFields(logrus.Fields{
 				"k":        k,
@@ -116,103 +120,93 @@ func (c *CachingMap) recalculatePendingOperations() {
 				"expected": desiredVal,
 			}).Debug("Checking cache against desired")
 		}
-		if desiredVal == nil {
-			c.pendingDeletions.Set(k, actualVal)
-			return
+		if !ok {
+			c.pendingDeletions[k] = actualVal
 		}
-	})
+	}
 
 	logrus.WithFields(logrus.Fields{
-		"cached":         c.cacheOfDataplane.Len(),
-		"pendingDels":    c.pendingDeletions.Len(),
-		"pendingUpdates": c.pendingUpdates.Len(),
-		"name":           c.params.Name,
+		"cached":         len(c.cacheOfDataplane),
+		"pendingDels":    len(c.pendingDeletions),
+		"pendingUpdates": len(c.pendingUpdates),
+		"name":           c.name,
 	}).Info("Recalculated pending operations")
 }
 
 // SetDesired sets the desired state of the given key to the given value. This is an in-memory operation,
 // it doesn't actually touch the dataplane.
-func (c *CachingMap) SetDesired(k, v []byte) {
+func (c *CachingMap[K, V]) SetDesired(k K, v V) {
 	if logrus.GetLevel() >= logrus.DebugLevel {
-		logrus.WithFields(logrus.Fields{"name": c.params.Name, "k": k, "v": v}).Debug("SetDesired")
+		logrus.WithFields(logrus.Fields{"name": c.name, "k": k, "v": v}).Debug("SetDesired")
 	}
-	c.desiredStateOfDataplane.Set(k, v)
+	c.desiredStateOfDataplane[k] = v
 	if c.cacheOfDataplane == nil {
 		logrus.Debug("SetDesired: initial sync pending.")
 		return // Initial sync is pending, we're not tracking deltas yet.
 	}
-	c.pendingDeletions.Delete(k)
+	delete(c.pendingDeletions, k)
 
 	// Check if we think we need to update the dataplane as a result.
-	currentVal := c.cacheOfDataplane.Get(k)
-	if slicesEqual(currentVal, v) {
+	currentVal, ok := c.cacheOfDataplane[k]
+	if ok && currentVal == v {
 		// Dataplane already agrees with the new value so clear any pending update.
 		logrus.Debug("SetDesired: Key in dataplane already, ignoring.")
-		c.pendingUpdates.Delete(k)
+		delete(c.pendingUpdates, k)
 		return
 	}
-	c.pendingUpdates.Set(k, v)
-}
-
-func slicesEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if b[i] != v {
-			return false
-		}
-	}
-	return true
+	c.pendingUpdates[k] = v
 }
 
 // DeleteDesired deletes the given key from the desired state of the dataplane. This is an in-memory operation,
 // it doesn't actually touch the dataplane.
-func (c *CachingMap) DeleteDesired(k []byte) {
+func (c *CachingMap[K, V]) DeleteDesired(k K) {
 	if logrus.GetLevel() >= logrus.DebugLevel {
-		logrus.WithFields(logrus.Fields{"name": c.params.Name, "k": k}).Debug("DeleteDesired")
+		logrus.WithFields(logrus.Fields{"name": c.name, "k": k}).Debug("DeleteDesired")
 	}
-	c.desiredStateOfDataplane.Delete(k)
+	delete(c.desiredStateOfDataplane, k)
 	if c.cacheOfDataplane == nil {
 		logrus.Debug("DeleteDesired: initial sync pending.")
 		return // Initial sync is pending, we're not tracking deltas yet.
 	}
-	c.pendingUpdates.Delete(k)
+	delete(c.pendingUpdates, k)
 
 	// Check if we need to update the dataplane.
-	currentVal := c.cacheOfDataplane.Get(k)
-	if currentVal == nil {
+	currentVal, ok := c.cacheOfDataplane[k]
+	if !ok {
 		// We don't think this value is in the dataplane so clear any pending delete.
 		logrus.Debug("DeleteDesired: Key not in dataplane, ignoring.")
-		c.pendingDeletions.Delete(k)
+		delete(c.pendingDeletions, k)
 		return
 	}
-	c.pendingDeletions.Set(k, currentVal)
+	c.pendingDeletions[k] = currentVal
 }
 
 // DeleteAllDesired deletes all entries from the in-memory desired state of the map.  It doesn't actually touch
 // the dataplane.
-func (c *CachingMap) DeleteAllDesired() {
-	logrus.WithField("name", c.params.Name).Debug("DeleteAll")
-	c.desiredStateOfDataplane.Iter(func(k, v []byte) {
+func (c *CachingMap[K, V]) DeleteAllDesired() {
+	logrus.WithField("name", c.name).Debug("DeleteAll")
+	for k := range c.desiredStateOfDataplane {
 		c.DeleteDesired(k)
-	})
+	}
 }
 
 // IterDataplaneCache iterates over the cache of the dataplane. The cache must have previously been loaded with
 // a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
-func (c *CachingMap) IterDataplaneCache(f func(k, v []byte)) {
-	c.cacheOfDataplane.Iter(f)
+func (c *CachingMap[K, V]) IterDataplaneCache(f func(k K, v V)) {
+	for k, v := range c.cacheOfDataplane {
+		f(k, v)
+	}
 }
 
 // GetDataplaneCache gets a single value from the cache of the dataplane. The cache must have previously been
 // loaded with a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
-func (c *CachingMap) GetDataplaneCache(k []byte) []byte {
-	return c.cacheOfDataplane.Get(k)
+func (c *CachingMap[K, V]) GetDataplaneCache(k K) (V, bool) {
+	v, ok := c.cacheOfDataplane[k]
+	return v, ok
 }
 
 // ApplyAllChanges attempts to bring the dataplane map into sync with the desired state.
-func (c *CachingMap) ApplyAllChanges() error {
+func (c *CachingMap[K, V]) ApplyAllChanges() error {
 	var errs ErrSlice
 	err := c.ApplyDeletionsOnly()
 	if err != nil {
@@ -228,7 +222,7 @@ func (c *CachingMap) ApplyAllChanges() error {
 	return nil
 }
 
-func (c *CachingMap) maybeLoadCache() error {
+func (c *CachingMap[K, V]) maybeLoadCache() error {
 	if c.cacheOfDataplane == nil {
 		err := c.LoadCacheFromDataplane()
 		if err != nil {
@@ -240,23 +234,23 @@ func (c *CachingMap) maybeLoadCache() error {
 
 // ApplyUpdatesOnly applies any pending adds/updates to the dataplane map.  It doesn't delete any keys that are no
 // longer wanted.
-func (c *CachingMap) ApplyUpdatesOnly() error {
-	logrus.WithField("name", c.params.Name).Debug("Applying updates to BPF map.")
+func (c *CachingMap[K, V]) ApplyUpdatesOnly() error {
+	logrus.WithField("name", c.name).Debug("Applying updates to BPF map.")
 	err := c.maybeLoadCache()
 	if err != nil {
 		return err
 	}
 	var errs ErrSlice
-	c.pendingUpdates.Iter(func(k, v []byte) {
-		err := c.dataplaneMap.Update(k, v)
+	for k, v := range c.pendingUpdates {
+		err := c.dpMap.Update(k, v)
 		if err != nil {
 			logrus.WithError(err).Warn("Error while updating BPF map")
 			errs = append(errs, err)
 		} else {
-			c.pendingUpdates.Delete(k)
-			c.cacheOfDataplane.Set(k, v)
+			delete(c.pendingUpdates, k)
+			c.cacheOfDataplane[k] = v
 		}
-	})
+	}
 	if len(errs) > 0 {
 		return errs
 	}
@@ -265,23 +259,23 @@ func (c *CachingMap) ApplyUpdatesOnly() error {
 
 // ApplyDeletionsOnly applies any pending deletions to the dataplane map.  It doesn't add or update any keys that
 // are new/changed.
-func (c *CachingMap) ApplyDeletionsOnly() error {
-	logrus.WithField("name", c.params.Name).Debug("Applying deletions to BPF map.")
+func (c *CachingMap[K, V]) ApplyDeletionsOnly() error {
+	logrus.WithField("name", c.name).Debug("Applying deletions to BPF map.")
 	err := c.maybeLoadCache()
 	if err != nil {
 		return err
 	}
 	var errs ErrSlice
-	c.pendingDeletions.Iter(func(k, v []byte) {
-		err := c.dataplaneMap.Delete(k)
+	for k := range c.pendingDeletions {
+		err := c.dpMap.Delete(k)
 		if err != nil && !bpf.IsNotExists(err) {
 			logrus.WithError(err).Warn("Error while deleting from BPF map")
 			errs = append(errs, err)
 		} else {
-			c.pendingDeletions.Delete(k)
-			c.cacheOfDataplane.Delete(k)
+			delete(c.pendingDeletions, k)
+			delete(c.cacheOfDataplane, k)
 		}
-	})
+	}
 	if len(errs) > 0 {
 		return errs
 	}
@@ -292,107 +286,4 @@ type ErrSlice []error
 
 func (e ErrSlice) Error() string {
 	return fmt.Sprintf("multiple errors while updating dataplane (%d)", len(e))
-}
-
-// ByteArrayToByteArrayMap uses reflection to implements a map from a fixed size array of bytes to
-// a fixed size array of bytes where the key and value sizes are set at map creation time.  It exposes
-// an API that uses slices for Get/Set/Delete, making it much more convenient to interact with.
-// All operations panic if passed a slice of incorrect size.
-type ByteArrayToByteArrayMap struct {
-	keySize   int
-	valueSize int
-	keyType   reflect.Type
-	valueType reflect.Type
-
-	m reflect.Value // map[[keySize]byte][valueSize]byte
-
-	// key and value that we reuse when reading/writing the map.  Since the map uses value types (not
-	// pointers), we can reuse the same key/value to read/write the map and the map will save the
-	// actual key/value internally rather than sharing storage with our reflect.Value.
-	key        reflect.Value
-	value      reflect.Value
-	keySlice   []byte // Slice backed by key
-	valueSlice []byte // Slice backed by value
-}
-
-func NewByteArrayToByteArrayMap(keySize, valueSize int) *ByteArrayToByteArrayMap {
-	// Effectively make(map[[keySize]byte][valueSize]byte)
-	keyType := reflect.ArrayOf(keySize, reflect.TypeOf(byte(0)))
-	valueType := reflect.ArrayOf(valueSize, reflect.TypeOf(byte(0)))
-	mapType := reflect.MapOf(keyType, valueType)
-	mapVal := reflect.MakeMap(mapType)
-
-	key := reflect.New(keyType).Elem()
-	value := reflect.New(valueType).Elem()
-	return &ByteArrayToByteArrayMap{
-		keySize:    keySize,
-		valueSize:  valueSize,
-		keyType:    keyType,
-		valueType:  valueType,
-		m:          mapVal,
-		key:        key,
-		value:      value,
-		keySlice:   key.Slice(0, keySize).Interface().([]byte),
-		valueSlice: value.Slice(0, valueSize).Interface().([]byte),
-	}
-}
-
-func (b *ByteArrayToByteArrayMap) Set(k, v []byte) {
-	if len(k) != b.keySize {
-		log.Panic("ByteArrayToByteArrayMap.Set() called with incorrect key length")
-	}
-	if len(v) != b.valueSize {
-		log.Panic("ByteArrayToByteArrayMap.Set() called with incorrect key length")
-	}
-
-	copy(b.keySlice, k)
-	copy(b.valueSlice, v)
-	b.m.SetMapIndex(b.key, b.value)
-}
-
-func (b *ByteArrayToByteArrayMap) Get(k []byte) []byte {
-	if len(k) != b.keySize {
-		log.Panic("ByteArrayToByteArrayMap.Get() called with incorrect key length")
-	}
-
-	copy(b.keySlice, k)
-	valVal := b.m.MapIndex(b.key)
-	if !valVal.IsValid() {
-		return nil
-	}
-	valSlice := make([]byte, b.valueSize)
-	reflect.Copy(reflect.ValueOf(valSlice), valVal)
-	return valSlice
-}
-
-func (b *ByteArrayToByteArrayMap) Delete(k []byte) {
-	if len(k) != b.keySize {
-		log.Panic("ByteArrayToByteArrayMap.Delete() called with incorrect key length")
-	}
-
-	copy(b.keySlice, k)
-	var zeroVal reflect.Value
-	b.m.SetMapIndex(b.key, zeroVal)
-}
-
-// Iter iterates over the map, passing each key/value to the given func as a slice.  For performance,
-// The slice is reused between iterations and should not be retained.  As with a normal map, it is safe
-// to delete from the map during iteration.
-func (b *ByteArrayToByteArrayMap) Iter(f func(k, v []byte)) {
-	iter := b.m.MapRange()
-	// Since it's valid for a user to call Get/Set while we're iterating, make sure we have our own
-	// values for key/value to avoid aliasing.
-	key := reflect.New(b.keyType).Elem()
-	val := reflect.New(b.valueType).Elem()
-	keySlice := key.Slice(0, b.keySize).Interface().([]byte)
-	valSlice := val.Slice(0, b.valueSize).Interface().([]byte)
-	for iter.Next() {
-		reflect.Copy(key, iter.Key())
-		reflect.Copy(val, iter.Value())
-		f(keySlice, valSlice)
-	}
-}
-
-func (b *ByteArrayToByteArrayMap) Len() int {
-	return b.m.Len()
 }

--- a/felix/bpf/cachingmap/caching_map_test.go
+++ b/felix/bpf/cachingmap/caching_map_test.go
@@ -37,6 +37,26 @@ var cachingMapParams = bpf.MapParameters{
 	ValueSize: 4,
 }
 
+type Key [2]byte
+
+func (k Key) String() string {
+	return string(k[:])
+}
+
+func (k Key) AsBytes() []byte {
+	return k[:]
+}
+
+type Value [4]byte
+
+func (v Value) String() string {
+	return string(v[:])
+}
+
+func (v Value) AsBytes() []byte {
+	return v[:]
+}
+
 // TestCachingMap_Empty verifies loading of an empty map with no changes queued.
 func TestCachingMap_Empty(t *testing.T) {
 	mockMap, cm := setupCachingMapTest(t)
@@ -56,7 +76,7 @@ func TestCachingMap_Errors(t *testing.T) {
 
 	// Failure should have cleared the cache again so next Apply should see this new entry.
 	mockMap.Contents = map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
 	}
 	mockMap.IterErr = nil
 	err = cm.ApplyAllChanges()
@@ -64,7 +84,7 @@ func TestCachingMap_Errors(t *testing.T) {
 	Expect(mockMap.Contents).To(BeEmpty())
 
 	// Now check errors on update
-	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 4})
+	cm.SetDesired(Key{1, 1}, Value{1, 2, 4, 4})
 	mockMap.UpdateErr = ErrFail
 	err = cm.ApplyAllChanges()
 	Expect(err).To(HaveOccurred())
@@ -74,7 +94,7 @@ func TestCachingMap_Errors(t *testing.T) {
 	err = cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.Contents).To(Equal(map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 4}),
+		Key{1, 1}.String(): Value{1, 2, 4, 4}.String(),
 	}))
 
 	// And delete.
@@ -92,8 +112,8 @@ func TestCachingMap_Errors(t *testing.T) {
 // TestCachingMap_CleanUp verifies cleaning up of a whole map.
 func TestCachingMap_CleanUp(t *testing.T) {
 	mockMap, cm := setupCachingMapTest(t)
-	_ = mockMap.Update([]byte{1, 2}, []byte{1, 2, 3, 4})
-	_ = mockMap.Update([]byte{1, 3}, []byte{1, 2, 4, 4})
+	_ = mockMap.Update(Key{1, 2}.AsBytes(), Value{1, 2, 3, 4}.AsBytes())
+	_ = mockMap.Update(Key{1, 3}.AsBytes(), Value{1, 2, 4, 4}.AsBytes())
 
 	err := cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
@@ -104,24 +124,24 @@ func TestCachingMap_CleanUp(t *testing.T) {
 func TestCachingMap_SplitUpdateAndDelete(t *testing.T) {
 	mockMap, cm := setupCachingMapTest(t)
 	mockMap.Contents = map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
-		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 4}.String(),
+		Key{1, 3}.String(): Value{1, 2, 4, 4}.String(),
 	}
 
-	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
-	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
-	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+	cm.SetDesired(Key{1, 1}, Value{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired(Key{1, 2}, Value{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired(Key{1, 4}, Value{1, 2, 3, 5}) // New K/V
 	// Shouldn't do anything until we hit apply.
 	Expect(mockMap.OpCount()).To(Equal(0))
 
 	err := cm.ApplyUpdatesOnly()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.Contents).To(Equal(map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}), // No change
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}), // Updated
-		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}), // Not desired but should be left alone
-		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}), // Added
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(), // No change
+		Key{1, 2}.String(): Value{1, 2, 3, 6}.String(), // Updated
+		Key{1, 3}.String(): Value{1, 2, 4, 4}.String(), // Not desired but should be left alone
+		Key{1, 4}.String(): Value{1, 2, 3, 5}.String(), // Added
 	}))
 	// Two updates and an iteration to load the map initially.
 	Expect(mockMap.UpdateCount).To(Equal(2))
@@ -133,9 +153,9 @@ func TestCachingMap_SplitUpdateAndDelete(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(mockMap.Contents).To(Equal(map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
-		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 6}.String(),
+		Key{1, 4}.String(): Value{1, 2, 3, 5}.String(),
 	}))
 	// No new updates or iterations but should get one extra deletion.
 	Expect(mockMap.UpdateCount).To(Equal(2))
@@ -154,23 +174,23 @@ func TestCachingMap_SplitUpdateAndDelete(t *testing.T) {
 func TestCachingMap_ApplyAll(t *testing.T) {
 	mockMap, cm := setupCachingMapTest(t)
 	mockMap.Contents = map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
-		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 4}.String(),
+		Key{1, 3}.String(): Value{1, 2, 4, 4}.String(),
 	}
 
-	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
-	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
-	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+	cm.SetDesired(Key{1, 1}, Value{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired(Key{1, 2}, Value{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired(Key{1, 4}, Value{1, 2, 3, 5}) // New K/V
 	// Shouldn't do anything until we hit apply.
 	Expect(mockMap.OpCount()).To(Equal(0))
 
 	err := cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.Contents).To(Equal(map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
-		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 6}.String(),
+		Key{1, 4}.String(): Value{1, 2, 3, 5}.String(),
 	}))
 	// Two updates and an iteration to load the map initially.
 	Expect(mockMap.UpdateCount).To(Equal(2))
@@ -203,24 +223,24 @@ func TestCachingMap_ApplyAll(t *testing.T) {
 func TestCachingMap_DeleteBeforeLoad(t *testing.T) {
 	mockMap, cm := setupCachingMapTest(t)
 	mockMap.Contents = map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
-		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 4}.String(),
+		Key{1, 3}.String(): Value{1, 2, 4, 4}.String(),
 	}
 
-	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
-	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
-	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
-	cm.DeleteDesired([]byte{1, 2})                  // Changed my mind.
-	cm.DeleteDesired([]byte{1, 4})                  // Changed my mind.
-	cm.DeleteDesired([]byte{1, 8})                  // Delete of non-existent key is a no-op.
+	cm.SetDesired(Key{1, 1}, Value{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired(Key{1, 2}, Value{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired(Key{1, 4}, Value{1, 2, 3, 5}) // New K/V
+	cm.DeleteDesired(Key{1, 2})                 // Changed my mind.
+	cm.DeleteDesired(Key{1, 4})                 // Changed my mind.
+	cm.DeleteDesired(Key{1, 8})                 // Delete of non-existent key is a no-op.
 	// Shouldn't do anything until we hit apply.
 	Expect(mockMap.OpCount()).To(Equal(0))
 
 	err := cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.Contents).To(Equal(map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
 	}))
 	// Just the two deletes.
 	Expect(mockMap.UpdateCount).To(Equal(0))
@@ -239,9 +259,9 @@ func TestCachingMap_DeleteBeforeLoad(t *testing.T) {
 func TestCachingMap_PreLoad(t *testing.T) {
 	mockMap, cm := setupCachingMapTest(t)
 	mockMap.Contents = map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
-		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 4}.String(),
+		Key{1, 3}.String(): Value{1, 2, 4, 4}.String(),
 	}
 	err := cm.LoadCacheFromDataplane()
 	Expect(err).NotTo(HaveOccurred())
@@ -249,24 +269,26 @@ func TestCachingMap_PreLoad(t *testing.T) {
 	Expect(mockMap.OpCount()).To(Equal(1))
 
 	// Check we can query the cache.
-	Expect(cm.GetDataplaneCache([]byte{1, 1})).To(Equal([]byte{1, 2, 4, 3}))
+	v, ok := cm.GetDataplaneCache(Key{1, 1})
+	Expect(ok).To(BeTrue())
+	Expect(v).To(Equal(Value{1, 2, 4, 3}))
 	seenValues := make(map[string]string)
-	cm.IterDataplaneCache(func(k, v []byte) {
-		seenValues[string(k)] = string(v)
+	cm.IterDataplaneCache(func(k Key, v Value) {
+		seenValues[k.String()] = v.String()
 	})
 	Expect(seenValues).To(Equal(mockMap.Contents))
 
-	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
-	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
-	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
-	cm.DeleteDesired([]byte{1, 8})                  // Delete of non-existent key is a no-op.
+	cm.SetDesired(Key{1, 1}, Value{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired(Key{1, 2}, Value{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired(Key{1, 4}, Value{1, 2, 3, 5}) // New K/V
+	cm.DeleteDesired(Key{1, 8})                 // Delete of non-existent key is a no-op.
 
 	err = cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.Contents).To(Equal(map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
-		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 6}.String(),
+		Key{1, 4}.String(): Value{1, 2, 3, 5}.String(),
 	}))
 	// Two updates and an iteration to load the map initially.
 	Expect(mockMap.UpdateCount).To(Equal(2))
@@ -287,18 +309,18 @@ func TestCachingMap_PreLoad(t *testing.T) {
 func TestCachingMap_Resync(t *testing.T) {
 	mockMap, cm := setupCachingMapTest(t)
 	mockMap.Contents = map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 4}),
-		string([]byte{1, 3}): string([]byte{1, 2, 4, 4}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 4}.String(),
+		Key{1, 3}.String(): Value{1, 2, 4, 4}.String(),
 	}
 	err := cm.LoadCacheFromDataplane()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.IterCount).To(Equal(1))
 	Expect(mockMap.OpCount()).To(Equal(1))
 
-	cm.SetDesired([]byte{1, 1}, []byte{1, 2, 4, 3}) // Same value for existing key.
-	cm.SetDesired([]byte{1, 2}, []byte{1, 2, 3, 6}) // New value for existing key.
-	cm.SetDesired([]byte{1, 4}, []byte{1, 2, 3, 5}) // New K/V
+	cm.SetDesired(Key{1, 1}, Value{1, 2, 4, 3}) // Same value for existing key.
+	cm.SetDesired(Key{1, 2}, Value{1, 2, 3, 6}) // New value for existing key.
+	cm.SetDesired(Key{1, 4}, Value{1, 2, 3, 5}) // New K/V
 
 	// At this point we've got some updates and a deletion queued up. Change the contents
 	// of the map:
@@ -306,7 +328,7 @@ func TestCachingMap_Resync(t *testing.T) {
 	// - Remove the key that we were about to delete.
 	// - Correct the value of the other key.
 	mockMap.Contents = map[string]string{
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
+		Key{1, 2}.String(): Value{1, 2, 3, 6}.String(),
 	}
 
 	err = cm.LoadCacheFromDataplane()
@@ -315,9 +337,9 @@ func TestCachingMap_Resync(t *testing.T) {
 	err = cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mockMap.Contents).To(Equal(map[string]string{
-		string([]byte{1, 1}): string([]byte{1, 2, 4, 3}),
-		string([]byte{1, 2}): string([]byte{1, 2, 3, 6}),
-		string([]byte{1, 4}): string([]byte{1, 2, 3, 5}),
+		Key{1, 1}.String(): Value{1, 2, 4, 3}.String(),
+		Key{1, 2}.String(): Value{1, 2, 3, 6}.String(),
+		Key{1, 4}.String(): Value{1, 2, 3, 5}.String(),
 	}))
 	// Two updates and an iteration to load the map initially.
 	Expect(mockMap.UpdateCount).To(Equal(2))
@@ -332,39 +354,24 @@ func TestCachingMap_Resync(t *testing.T) {
 	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
 }
 
-func setupCachingMapTest(t *testing.T) (*mock.Map, *CachingMap) {
+func setupCachingMapTest(t *testing.T) (*mock.Map, *CachingMap[Key, Value]) {
 	RegisterTestingT(t)
 	mockMap := mock.NewMockMap(cachingMapParams)
-	cm := New(cachingMapParams, mockMap)
+
+	cm := New[Key, Value]("mock-map",
+		bpf.NewTypedMap[Key, Value](mockMap,
+			func(b []byte) Key {
+				var k Key
+				copy(k[:], b)
+				return k
+			},
+			func(b []byte) Value {
+				var v Value
+				copy(v[:], b)
+				return v
+			},
+		),
+	)
+
 	return mockMap, cm
-}
-
-func TestByteArrayToByteArrayMap(t *testing.T) {
-	RegisterTestingT(t)
-
-	m := NewByteArrayToByteArrayMap(2, 4)
-
-	Expect(m.Get([]byte{1, 2})).To(BeNil(), "New map should not contain a value")
-	m.Set([]byte{1, 2}, []byte{1, 2, 3, 4})
-	Expect(m.Get([]byte{1, 2})).To(Equal([]byte{1, 2, 3, 4}), "Map should contain set value")
-	m.Set([]byte{1, 2}, []byte{1, 2, 3, 5})
-	Expect(m.Get([]byte{1, 2})).To(Equal([]byte{1, 2, 3, 5}), "Map should record updates")
-	m.Set([]byte{3, 4}, []byte{1, 2, 3, 6})
-	Expect(m.Get([]byte{3, 4})).To(Equal([]byte{1, 2, 3, 6}), "Map should record updates")
-
-	seenValues := map[string][]byte{}
-	m.Iter(func(k, v []byte) {
-		Expect(k).To(HaveLen(2))
-		Expect(v).To(HaveLen(4))
-		vCopy := make([]byte, len(v))
-		copy(vCopy, v)
-		seenValues[string(k)] = vCopy
-	})
-	Expect(seenValues).To(Equal(map[string][]byte{
-		string([]byte{1, 2}): {1, 2, 3, 5},
-		string([]byte{3, 4}): {1, 2, 3, 6},
-	}))
-
-	m.Delete([]byte{1, 2})
-	Expect(m.Get([]byte{1, 2})).To(BeNil(), "Deletion should remove the value")
 }

--- a/felix/bpf/nat/maps.go
+++ b/felix/bpf/nat/maps.go
@@ -139,6 +139,12 @@ func (k FrontendKey) String() string {
 	return fmt.Sprintf("NATKey{Proto:%v Addr:%v Port:%v SrcAddr:%v}", k.Proto(), k.Addr(), k.Port(), k.SrcCIDR())
 }
 
+func FrontendKeyFromBytes(b []byte) FrontendKey {
+	var k FrontendKey
+	copy(k[:], b)
+	return k
+}
+
 const (
 	NATFlgExternalLocal = 0x1
 	NATFlgInternalLocal = 0x2
@@ -215,6 +221,12 @@ func (v FrontendValue) AsBytes() []byte {
 	return v[:]
 }
 
+func FrontendValueFromBytes(b []byte) FrontendValue {
+	var v FrontendValue
+	copy(v[:], b)
+	return v
+}
+
 type BackendKey [backendKeySize]byte
 
 func NewNATBackendKey(id, ordinal uint32) BackendKey {
@@ -238,6 +250,12 @@ func (v BackendKey) String() string {
 
 func (k BackendKey) AsBytes() []byte {
 	return k[:]
+}
+
+func BackendKeyFromBytes(b []byte) BackendKey {
+	var k BackendKey
+	copy(k[:], b)
+	return k
 }
 
 type BackendValue [backendValueSize]byte
@@ -267,6 +285,12 @@ func (k BackendValue) String() string {
 
 func (k BackendValue) AsBytes() []byte {
 	return k[:]
+}
+
+func BackendValueFromBytes(b []byte) BackendValue {
+	var v BackendValue
+	copy(v[:], b)
+	return v
 }
 
 var FrontendMapParameters = bpf.MapParameters{

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -114,8 +114,14 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 	copy(withLocalNP, hostIPs)
 	withLocalNP = append(withLocalNP, podNPIP)
 
-	feCache := cachingmap.New(nat.FrontendMapParameters, kp.frontendMap)
-	beCache := cachingmap.New(nat.BackendMapParameters, kp.backendMap)
+	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+		bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
+			kp.frontendMap, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes,
+		))
+	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+		bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](
+			kp.backendMap, nat.BackendKeyFromBytes, nat.BackendValueFromBytes,
+		))
 
 	syncer, err := NewSyncer(withLocalNP, feCache, beCache, kp.affinityMap, kp.rt)
 	if err != nil {

--- a/felix/bpf/proxy/lb_src_range_test.go
+++ b/felix/bpf/proxy/lb_src_range_test.go
@@ -17,6 +17,7 @@ package proxy_test
 import (
 	"net"
 
+	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/cachingmap"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/logutils"
@@ -49,8 +50,10 @@ func testfn(makeIPs func(ips []string) proxy.K8sServicePortOption) {
 	externalIP := makeIPs([]string{"35.0.0.2"})
 	twoExternalIPs := makeIPs([]string{"35.0.0.2", "45.0.1.2"})
 
-	feCache := cachingmap.New(nat.FrontendMapParameters, svcs)
-	beCache := cachingmap.New(nat.BackendMapParameters, eps)
+	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+		bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+		bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 
 	s, _ := proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
 
@@ -205,8 +208,12 @@ func testfn(makeIPs func(ips []string) proxy.K8sServicePortOption) {
 				externalIP,
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
 			)
-			feCache := cachingmap.New(nat.FrontendMapParameters, svcs)
-			beCache := cachingmap.New(nat.BackendMapParameters, eps)
+			feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+				bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
+					svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+			beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+				bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](
+					eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 			s, _ = proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
@@ -220,8 +227,12 @@ func testfn(makeIPs func(ips []string) proxy.K8sServicePortOption) {
 				v1.ProtocolTCP,
 				externalIP,
 			)
-			feCache := cachingmap.New(nat.FrontendMapParameters, svcs)
-			beCache := cachingmap.New(nat.BackendMapParameters, eps)
+			feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+				bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
+					svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+			beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+				bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](
+					eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 			s, _ = proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())

--- a/felix/bpf/proxy/proxy_bench_test.go
+++ b/felix/bpf/proxy/proxy_bench_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/cachingmap"
 
 	"github.com/projectcalico/calico/felix/bpf/nat"
@@ -45,8 +46,12 @@ func benchmarkProxyUpdates(b *testing.B, svcN, epsN int) {
 		eps := makeEps(svcN, epsN)
 		k8s := fake.NewSimpleClientset(append(svcs, eps...)...)
 
-		feCache := cachingmap.New(nat.FrontendMapParameters, &mock.DummyMap{})
-		beCache := cachingmap.New(nat.BackendMapParameters, &mock.DummyMap{})
+		feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+			bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
+				&mock.DummyMap{}, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+		beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+			bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](
+				&mock.DummyMap{}, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 
 		syncer, err := proxy.NewSyncer(
 			[]net.IP{net.IPv4(1, 1, 1, 1)},

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -104,8 +104,8 @@ type stickyFrontend struct {
 // Syncer is an implementation of DPSyncer interface. It is not thread safe and
 // should be called only once at a time
 type Syncer struct {
-	bpfSvcs *cachingmap.CachingMap
-	bpfEps  *cachingmap.CachingMap
+	bpfSvcs *cachingmap.CachingMap[nat.FrontendKey, nat.FrontendValue]
+	bpfEps  *cachingmap.CachingMap[nat.BackendKey, nat.BackendValue]
 	bpfAff  bpf.Map
 
 	nextSvcID uint32
@@ -192,7 +192,11 @@ func uniqueIPs(ips []net.IP) []net.IP {
 }
 
 // NewSyncer returns a new Syncer
-func NewSyncer(nodePortIPs []net.IP, svcsmap, epsmap *cachingmap.CachingMap, affmap bpf.Map, rt Routes) (*Syncer, error) {
+func NewSyncer(nodePortIPs []net.IP,
+	svcsmap *cachingmap.CachingMap[nat.FrontendKey, nat.FrontendValue],
+	epsmap *cachingmap.CachingMap[nat.BackendKey, nat.BackendValue],
+	affmap bpf.Map, rt Routes) (*Syncer, error) {
+
 	s := &Syncer{
 		bpfSvcs:     svcsmap,
 		bpfEps:      epsmap,
@@ -272,12 +276,7 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 
 	// Walk the frontend bpf map that was read into memory and match it against the
 	// references build from the state
-	s.bpfSvcs.IterDataplaneCache(func(k, v []byte) {
-		var svck nat.FrontendKey
-		var svcv nat.FrontendValue
-		copy(svck[:], k)
-		copy(svcv[:], v)
-
+	s.bpfSvcs.IterDataplaneCache(func(svck nat.FrontendKey, svcv nat.FrontendValue) {
 		xref, ok := svcRef[svck]
 		if !ok {
 			return
@@ -313,14 +312,12 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 		}
 		for i := 0; i < count; i++ {
 			epk := nat.NewNATBackendKey(id, uint32(i))
-			epSlice := s.bpfEps.GetDataplaneCache(epk[:])
-			if epSlice == nil {
+			ep, ok := s.bpfEps.GetDataplaneCache(epk)
+			if !ok {
 				log.Warnf("inconsistent backed map, missing ep %s", epk)
 				inconsistent = true
 				break
 			}
-			var ep nat.BackendValue
-			copy(ep[:], epSlice)
 			s.prevEpsMap[svckey.sname] = append(s.prevEpsMap[svckey.sname],
 				&k8sp.BaseEndpointInfo{
 					Endpoint: net.JoinHostPort(ep.Addr().String(), strconv.Itoa(int(ep.Port()))),
@@ -754,7 +751,7 @@ func (s *Syncer) writeSvcBackend(svcID uint32, idx uint32, ep k8sp.Endpoint) err
 		return errors.Errorf("no port for endpoint %q: %s", ep, err)
 	}
 	val := nat.NewNATBackendValue(ip, uint16(tgtPort))
-	s.bpfEps.SetDesired(key[:], val[:])
+	s.bpfEps.SetDesired(key, val)
 
 	if s.stickyEps[svcID] != nil {
 		s.stickyEps[svcID][val] = struct{}{}
@@ -819,14 +816,14 @@ func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, c
 		if log.GetLevel() >= log.DebugLevel {
 			log.Debugf("bpf map writing %s:%s", key, val)
 		}
-		s.bpfSvcs.SetDesired(key[:], val[:])
+		s.bpfSvcs.SetDesired(key, val)
 	}
 	key, err = getSvcNATKey(svc)
 	if err != nil {
 		return err
 	}
 	val = nat.NewNATValue(svcID, nat.BlackHoleCount, uint32(0), uint32(0))
-	s.bpfSvcs.SetDesired(key[:], val[:])
+	s.bpfSvcs.SetDesired(key, val)
 	return nil
 }
 
@@ -846,7 +843,7 @@ func (s *Syncer) writeSvc(svc k8sp.ServicePort, svcID uint32, count, local int, 
 	if log.GetLevel() >= log.DebugLevel {
 		log.Debugf("bpf map writing %s:%s", key, val)
 	}
-	s.bpfSvcs.SetDesired(key[:], val[:])
+	s.bpfSvcs.SetDesired(key, val)
 
 	var affkey nat.FrontEndAffinityKey
 	copy(affkey[:], key.Affinitykey())

--- a/felix/bpf/proxy/syncer_bench_test.go
+++ b/felix/bpf/proxy/syncer_bench_test.go
@@ -75,7 +75,10 @@ func makeState(svcCnt, epCnt int, opts ...K8sServicePortOption) DPSyncerState {
 	return state
 }
 
-func stateToBPFMaps(state DPSyncerState) (*cachingmap.CachingMap, *cachingmap.CachingMap) {
+func stateToBPFMaps(state DPSyncerState) (
+	*cachingmap.CachingMap[nat.FrontendKey, nat.FrontendValue],
+	*cachingmap.CachingMap[nat.BackendKey, nat.BackendValue],
+) {
 	fe := mock.NewMockMap(nat.FrontendMapParameters)
 	be := mock.NewMockMap(nat.BackendMapParameters)
 
@@ -100,8 +103,10 @@ func stateToBPFMaps(state DPSyncerState) (*cachingmap.CachingMap, *cachingmap.Ca
 		id++
 	}
 
-	feCache := cachingmap.New(nat.FrontendMapParameters, fe)
-	beCache := cachingmap.New(nat.BackendMapParameters, be)
+	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+		bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](fe, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+		bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](be, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 
 	return feCache, beCache
 }
@@ -159,8 +164,12 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 
 	if mockMaps {
 
-		feCache := cachingmap.New(nat.FrontendMapParameters, &mock.DummyMap{})
-		beCache := cachingmap.New(nat.BackendMapParameters, &mock.DummyMap{})
+		feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+			bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
+				&mock.DummyMap{}, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+		beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+			bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](
+				&mock.DummyMap{}, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 
 		syncer, err = NewSyncer(
 			[]net.IP{net.IPv4(1, 1, 1, 1)},
@@ -178,8 +187,12 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 		err = beMap.EnsureExists()
 		Expect(err).ShouldNot(HaveOccurred())
 
-		feCache := cachingmap.New(nat.FrontendMapParameters, feMap)
-		beCache := cachingmap.New(nat.BackendMapParameters, beMap)
+		feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+			bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
+				feMap, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+		beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+			bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](
+				beMap, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 
 		syncer, err = NewSyncer(
 			[]net.IP{net.IPv4(1, 1, 1, 1)},

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -54,8 +54,12 @@ var _ = Describe("BPF Syncer", func() {
 	nodeIPs := []net.IP{net.IPv4(192, 168, 0, 1), net.IPv4(10, 123, 0, 1)}
 	rt := proxy.NewRTCache()
 
-	feCache := cachingmap.New(nat.FrontendMapParameters, svcs)
-	beCache := cachingmap.New(nat.BackendMapParameters, eps)
+	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
+		bpf.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
+			svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
+		bpf.NewTypedMap[nat.BackendKey, nat.BackendValue](
+			eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 
 	s, _ := proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
 


### PR DESCRIPTION
## Description
    felix/bpf: CachingMap uses generics
    
    This makes it type safe, no need for reflections and reduces copying.
    
    A temporary step in the introduction of bpf.TypedMap. That is necessary
    until all the bpf maps are based on generics as well so that they have a
    defined type.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
