### PR TITLE
Trim /lib64 and /lib in typha, dikastes, flexvol, kube-controllers, flannel-migration controller images

### DIFF
--- a/app-policy/Dockerfile.amd64
+++ b/app-policy/Dockerfile.amd64
@@ -39,8 +39,9 @@ ADD bin/dikastes-amd64 /dikastes
 ADD bin/healthz-amd64 /healthz
 
 # Include libraries from UBI for dynamic linking.
-COPY --from=ubi /lib64 /lib64
-COPY --from=ubi /lib /lib
+COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
+COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
+COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
 # Typical Linux systems start numbering human users at 1000, reserving 1-999
 # for services, so we pick 999 to be least likely to overlap.  It's not a big

--- a/kube-controllers/Dockerfile.amd64
+++ b/kube-controllers/Dockerfile.amd64
@@ -42,10 +42,9 @@ COPY --from=ubi /profiles /profiles
 COPY --from=ubi /status /status
 
 COPY --from=ubi /usr/include /usr/include
-COPY --from=ubi /lib64/ld-* /lib64/
-COPY --from=ubi /lib64/libc-* /lib64/
-COPY --from=ubi /lib64/libc.* /lib64/
-COPY --from=ubi /lib64/libpthread* /lib64/
+COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
+COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
+COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ADD bin/check-status-linux-amd64 /usr/bin/check-status

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -126,8 +126,12 @@ ut fv: $(TEST_BINARIES)
 
 # Produce test binaries for each package that needs them.
 # ginkgo doesn't let you produce a single test binary with multiple packages.
+# Only do this if there are .go files in the path.
 %/ut.test: $(SRC_FILES)
+	GO_FILES_IN_PATH=$(shell find $* -name '*.go')
+ifneq ($(GO_FILES_IN_PATH),)
 	$(DOCKER_RUN) $(CALICO_BUILD) go test ./$* -c --tags fvtests -o $@
+endif
 
 ###############################################################################
 # CI

--- a/kube-controllers/docker-images/flannel-migration/Dockerfile.amd64
+++ b/kube-controllers/docker-images/flannel-migration/Dockerfile.amd64
@@ -37,8 +37,9 @@ LABEL name="Calico Flannel migration controller" \
 COPY --from=ubi /licenses /licenses
 COPY --from=ubi /status /status
 COPY --from=ubi /usr/include /usr/include
-COPY --from=ubi /lib64 /lib64
-COPY --from=ubi /lib /lib
+COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
+COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
+COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
 ADD bin/kubectl-amd64 /usr/bin/kubectl
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers

--- a/pod2daemon/Dockerfile.amd64
+++ b/pod2daemon/Dockerfile.amd64
@@ -43,10 +43,21 @@ LABEL name="Calico FlexVolume driver installer" \
 
 COPY --from=ubi /licenses /licenses
 COPY --from=ubi /bin /bin
-COPY --from=ubi /lib64 /lib64
-COPY --from=ubi /usr/lib64 /usr/lib64
 COPY --from=ubi /usr/bin /usr/bin
 COPY --from=ubi /usr/local/bin/flexvol.sh /usr/local/bin/flexvol.sh
+
+# copy only the required libs, identified by running 'ldd' on the '/usr/local/bin/flexvol' binary, as well as on the remaining binaries on '/bin' and '/usr/bin' that were left after running 'clean.sh'
+COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=ubi /lib64/libacl.so.1 /lib64/libacl.so.1
+COPY --from=ubi /lib64/libattr.so.1 /lib64/libattr.so.1
+COPY --from=ubi /lib64/libcap.so.2 /lib64/libcap.so.2
+COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
+COPY --from=ubi /lib64/libdl.so.2 /lib64/libdl.so.2
+COPY --from=ubi /lib64/libpcre2-8.so.0 /lib64/libpcre2-8.so.0
+COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
+COPY --from=ubi /lib64/librt.so.1 /lib64/librt.so.1
+COPY --from=ubi /lib64/libselinux.so.1 /lib64/libselinux.so.1
+COPY --from=ubi /lib64/libtinfo.so.6 /lib64/libtinfo.so.6
 
 ADD bin/flexvol-amd64 /usr/local/bin/flexvol
 

--- a/typha/docker-image/Dockerfile.amd64
+++ b/typha/docker-image/Dockerfile.amd64
@@ -41,10 +41,11 @@ COPY --from=ubi /sbin/tini /sbin/tini
 COPY --from=ubi /licenses /licenses
 
 COPY --from=ubi /usr/include /usr/include
-COPY --from=ubi /lib64/ld-* /lib64/
-COPY --from=ubi /lib64/libc-* /lib64/
-COPY --from=ubi /lib64/libc.* /lib64/
-COPY --from=ubi /lib64/libpthread* /lib64/
+
+# lib dependencies for typha
+COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
+COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
+COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.


### PR DESCRIPTION
## Description
Explicitly copy necessary libs from UBI instead of whole /lib and /lib64 dirs
for the typha, dikastes, flexvol, kube-controllers, flannel-migration controller images


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Explicitly copy necessary libs from UBI instead of whole /lib and /lib64 dirs for the typha, dikastes, flexvol, kube-controllers, flannel-migration controller images
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
