### PR TITLE
Fix IP address truncation when using autodetection mode "k8s-internal-ip"

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
@@ -180,11 +180,15 @@ func autoDetectUsingK8sInternalIP(version int, k8sNode *v1.Node, getInterfaces f
 		}
 	}
 
-	_, ipNet, err := cnet.ParseCIDR(address)
+	ip, ipNet, err := cnet.ParseCIDR(address)
 	if err != nil {
 		log.Errorf("Unable to parse CIDR %v : %v", address, err)
 		return nil
 	}
+	// ParseCIDR masks off the IP addr of the IPNet it returns eg. ParseCIDR("192.168.1.2/24" will return
+	//"192.168.1.2, 192.168.1.0/24". Callers of this function (autoDetectUsingK8sInternalIP) expect the full IP address
+	// to be preserved in the CIDR ie. we should return 192.168.1.2/24
+	ipNet.IP = ip.IP
 	return ipNet
 }
 

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -943,6 +943,26 @@ var _ = Describe("UT for autodetection method k8s-internal-ip", func() {
 	)
 })
 
+var _ = Describe("UT for CIDR returned by IP address autodetection k8s-internal-ip method", func() {
+	It("Verify that CIDR value returned using autodetection method k8s-internal-ip is not masked", func() {
+		expectedV4Cidr := "192.168.1.10/24"
+		expectedV6Cidr := "2001:db8:85a3:8d3:1319:8a2e:370:7348/64"
+		mockGetInterface := func([]string, []string, int) ([]autodetection.Interface, error) {
+			return []autodetection.Interface{
+				{Name: "eth1", Cidrs: []net.IPNet{net.MustParseCIDR(expectedV4Cidr), net.MustParseCIDR("2001:db8:85a3:8d3:1319:8a2e:370:7348/64")}},
+			}, nil
+		}
+
+		k8sNode := makeK8sNode("192.168.1.10", "2001:db8:85a3:8d3:1319:8a2e:370:7348")
+
+		checkV4IPNet := autodetection.AutoDetectCIDR(autodetection.K8S_INTERNAL_IP, 4, k8sNode, mockGetInterface)
+		checkV6IPNet := autodetection.AutoDetectCIDR(autodetection.K8S_INTERNAL_IP, 6, k8sNode, mockGetInterface)
+
+		Expect(checkV4IPNet.String()).To(Equal(expectedV4Cidr))
+		Expect(checkV6IPNet.String()).To(Equal(expectedV6Cidr))
+	})
+})
+
 var _ = Describe("FV tests against K8s API server.", func() {
 	It("should not throw an error when multiple Nodes configure the same global CRD value.", func() {
 		ctx := context.Background()


### PR DESCRIPTION
## Description
This bug fix corrects the behaviour of calico-node to truncate/mask IP addresses when using the "k8s-internal-ip" autodetection setting.

New unit tests introduced to verify that both v4 and v6 addresses are returned as expected.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fixes [6141](https://github.com/projectcalico/calico/issues/6141) and [6142](https://github.com/projectcalico/calico/issues/6142)
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [X] Tests
- [X] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix IP address truncation when using autodetection method "k8s-internal-ip"
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.