### PR TITLE
Fix AKS BYO with pod cidr option

### DIFF
--- a/calico/getting-started/kubernetes/managed-public-cloud/aks.md
+++ b/calico/getting-started/kubernetes/managed-public-cloud/aks.md
@@ -32,6 +32,8 @@ To enable {{site.prodname}} network policy enforcement, follow these step-by-ste
 
 The geeky details of what you get:
 {% include geek-details.html details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:Calico,Datastore:Kubernetes' %}
+> **Note**: Bring your own Container Network Interface (CNI) plugin is a preview feature with AKS.
+{: .alert .alert-info}
 
 1. Create an Azure AKS cluster with no Kubernetes CNI pre-installed. Please refer to [Bring your own CNI with AKS](https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli) for details.
    ``` 
@@ -43,7 +45,7 @@ The geeky details of what you get:
     # Create a resource group
     az group create --name my-calico-rg --location westcentralus
 
-    az aks create --resource-group my-calico-rg --name my-calico-cluster --location westcentralus --network-plugin none
+    az aks create --resource-group my-calico-rg --name my-calico-cluster --location westcentralus --pod-cidr 192.168.0.0/16 --network-plugin none
     ```
 
 1. Get credentials to allow you to access the cluster with `kubectl`:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We need to set pod CIDR to `192.168.0.0/16` with `--pod-cidr` option to create AKS BYO cluster, because the default pod CIDR for kube-proxy is `10.244.0.0/16` which is overlapping with host ip range. 


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
