### PR TITLE
Introduce new Pod annotation for assigning specified MAC address to container veth

### DIFF
--- a/calico/_data/navbars/networking.yml
+++ b/calico/_data/navbars/networking.yml
@@ -21,6 +21,8 @@ section:
     path: /networking/use-ipvs
   - title: Accelerate Istio network performance
     path: /networking/sidecar-acceleration
+  - title: Use a specific MAC address for a pod
+    path: /networking/pod-mac-address
 - title: Customize IP address management
   path: /networking/ipam
   section:

--- a/calico/networking/pod-mac-address.md
+++ b/calico/networking/pod-mac-address.md
@@ -1,0 +1,41 @@
+---
+title: Use a specific MAC address for a pod
+canonical_url: '/networking/pod-mac-address'
+description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+---
+
+### Big picture
+
+Choose the MAC address for a pod instead of allowing the operating system to assign one.
+
+### Value
+
+Some applications bind software licenses to networking interface MAC addresses.
+
+### Features
+
+This how-to guide uses the following features: 
+
+- Kubernetes Pod annotations
+
+### Concepts
+
+#### Container MAC address
+
+The MAC address configured by the annotation described here will be visible from within the container on the eth0 interface. Since it is isolated to the container it will not collide with any other MAC addresses assigned to other pods on the same node.
+
+### Before you begin...
+
+Your cluster must be using Calico CNI in order to use this feature.
+
+[Configuring the Calico CNI Plugins]({{ site.baseurl }}/reference/cni-plugin/configuration)
+
+### How to
+
+Annotate the pod with cni.projectcalico.org/hwAddr set to the desired MAC address. For example:
+
+<pre>
+  "cni.projectcalico.org/hwAddr": "1c:0c:0a:c0:ff:ee"
+</pre>
+
+The annotation must be present when the pod is created; adding it later has no effect.


### PR DESCRIPTION

## Description

Introduce new Pod annotation "cni.projectcalico.org/hwAddr" that will be used to assign a specified MAC address to the
container-side Veth interface

Added new unit tests that pass, as well as manually verified by creating a container within a cluster and examining the MAC address of eth0 from within the container to make sure it matched the address specified by annotation.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fixes [5196](https://github.com/projectcalico/calico/issues/5196)
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add new Pod annotation for assigning specified MAC address to container veth
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
