### PR TITLE
Add input filter rule for wireguard

### DIFF
--- a/felix/dataplane/driver.go
+++ b/felix/dataplane/driver.go
@@ -173,55 +173,6 @@ func StartDataplaneDriver(configParams *config.Config,
 			log.WithError(err).Warning("Unable to assign table index for wireguard")
 		}
 
-		// If wireguard is enabled, update the failsafe ports to include the wireguard port.
-		failsafeInboundHostPorts := configParams.FailsafeInboundHostPorts
-		failsafeOutboundHostPorts := configParams.FailsafeOutboundHostPorts
-		if configParams.WireguardEnabled {
-			found := false
-			for _, i := range failsafeInboundHostPorts {
-				if i.Port == uint16(configParams.WireguardListeningPort) && i.Protocol == "udp" {
-					log.WithFields(log.Fields{
-						"net":      i.Net,
-						"port":     i.Port,
-						"protocol": i.Protocol,
-					}).Debug("FailsafeInboundHostPorts is already configured for wireguard")
-					found = true
-					break
-				}
-			}
-			if !found {
-				failsafeInboundHostPorts = make([]config.ProtoPort, len(configParams.FailsafeInboundHostPorts)+1)
-				copy(failsafeInboundHostPorts, configParams.FailsafeInboundHostPorts)
-				log.Debug("Adding permissive FailsafeInboundHostPorts for wireguard")
-				failsafeInboundHostPorts[len(configParams.FailsafeInboundHostPorts)] = config.ProtoPort{
-					Port:     uint16(configParams.WireguardListeningPort),
-					Protocol: "udp",
-				}
-			}
-
-			found = false
-			for _, i := range failsafeOutboundHostPorts {
-				if i.Port == uint16(configParams.WireguardListeningPort) && i.Protocol == "udp" {
-					log.WithFields(log.Fields{
-						"net":      i.Net,
-						"port":     i.Port,
-						"protocol": i.Protocol,
-					}).Debug("FailsafeOutboundHostPorts is already configured for wireguard")
-					found = true
-					break
-				}
-			}
-			if !found {
-				failsafeOutboundHostPorts = make([]config.ProtoPort, len(configParams.FailsafeOutboundHostPorts)+1)
-				copy(failsafeOutboundHostPorts, configParams.FailsafeOutboundHostPorts)
-				log.Debug("Adding permissive FailsafeOutboundHostPorts for wireguard")
-				failsafeOutboundHostPorts[len(configParams.FailsafeOutboundHostPorts)] = config.ProtoPort{
-					Port:     uint16(configParams.WireguardListeningPort),
-					Protocol: "udp",
-				}
-			}
-		}
-
 		dpConfig := intdataplane.Config{
 			Hostname:           configParams.FelixHostname,
 			FloatingIPsEnabled: strings.EqualFold(configParams.FloatingIPs, string(apiv3.FloatingIPsEnabled)),
@@ -285,8 +236,8 @@ func StartDataplaneDriver(configParams *config.Config,
 				IptablesFilterAllowAction: configParams.IptablesFilterAllowAction,
 				IptablesMangleAllowAction: configParams.IptablesMangleAllowAction,
 
-				FailsafeInboundHostPorts:  failsafeInboundHostPorts,
-				FailsafeOutboundHostPorts: failsafeOutboundHostPorts,
+				FailsafeInboundHostPorts:  configParams.FailsafeInboundHostPorts,
+				FailsafeOutboundHostPorts: configParams.FailsafeOutboundHostPorts,
 
 				DisableConntrackInvalid: configParams.DisableConntrackInvalidCheck,
 

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -447,17 +447,17 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 
 		for _, ai := range []bool{true, false} {
 			allInterfaces := ai
-			desc := "should add wireguard port as a failsafe"
+			desc := "wireguard traffic is allowed with a blocking host endpoint policy"
 			if ai {
 				desc += " (using * HostEndpoint)"
 			} else {
 				desc += " (using eth0 HostEndpoint)"
 			}
 			It(desc, func() {
-				By("Creating policy to deny wireguard port on main felix host endpoint")
+				By("Creating policy to deny wireguard port on main felix host endpoint.")
 				policy := api.NewGlobalNetworkPolicy()
 				policy.Name = "deny-wg-port"
-				prot := numorstring.ProtocolFromString(numorstring.ProtocolUDP)
+				port := numorstring.ProtocolFromString(numorstring.ProtocolUDP)
 				policy.Spec.Egress = []api.Rule{
 					{
 						// Deny egress UDP to the wireguard port.
@@ -474,7 +474,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 					{
 						// Deny all UDP traffic to the hosts.
 						Action:   api.Deny,
-						Protocol: &prot,
+						Protocol: &port,
 						Destination: api.EntityRule{
 							Selector: "has(host-endpoint)",
 							Ports:    []numorstring.Port{numorstring.SinglePort(wireguardListeningPortDefault)},

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -462,7 +462,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 					{
 						// Deny egress UDP to the wireguard port.
 						Action:   api.Deny,
-						Protocol: &prot,
+						Protocol: &port,
 						Destination: api.EntityRule{
 							Selector: "has(host-endpoint)",
 							Ports:    []numorstring.Port{numorstring.SinglePort(wireguardListeningPortDefault)},

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -272,6 +272,19 @@ func (r *DefaultRuleRenderer) filterInputChain(ipVersion uint8) *Chain {
 		)
 	}
 
+	if ipVersion == 4 && r.WireguardEnabled {
+		inputRules = append(inputRules,
+			Rule{
+				Match: Match().ProtocolNum(ProtoUDP).
+					DestPorts(uint16(r.Config.WireguardListeningPort)).
+					DestAddrType(AddrTypeLocal),
+				Action:  r.filterAllowAction,
+				Comment: []string{"Allow incoming IPv4 Wireguard packets"},
+			},
+			// No drop rule is added because wireguard does its own validation of authenticity of incoming packets
+		)
+	}
+
 	// Note that we do not need to do this filtering for wireguard because it already has the peering and allowed IPs
 	// baked into the crypto routing table.
 


### PR DESCRIPTION
## Description

Without this rule, in an environment with a default drop, Wireguard
traffic will not be accepted. This change adds a static input rule in the
same fashion as done for other encapsulation modes (ipip, vxlan) to
ensure these packets are accepted. No drop rule is needed however as
wireguard does its own validation of incoming messages.

## Todos

- [X] Tests
- [ ] Documentation
- [X] Release note

## Release Note

```release-note
Calico will now add an ACCEPT rule for the Wireguard UDP port when enabled to ensure policy doesn't drop Calico Wireguard traffic.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
