### PR TITLE
fix: ErrorActionPreference must continue for kubectl commands Issue #6127

### DIFF
--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -214,7 +214,9 @@ function GetCalicoNamespace() {
         return $ns
     }
 
+    $ErrorActionPreference = 'Continue'
     $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get ns calico-system
+    $ErrorActionPreference = 'Stop'
     if ([string]::IsNullOrEmpty($name)) {
         write-host "Calico running in kube-system namespace"
         return ("kube-system")
@@ -264,7 +266,9 @@ function GetCalicoKubeConfig()
             exit 1
         }
     } else {
+        $ErrorActionPreference = 'Continue'
         $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretName | select -first 1
+        $ErrorActionPreference = 'Stop'
         if ([string]::IsNullOrEmpty($name)) {
             throw "$SecretName service account does not exist."
         }
@@ -312,7 +316,9 @@ function SetupEtcdTlsFiles()
 
     $path = "$RootDir\etcd-tls"
 
+    $ErrorActionPreference = 'Continue'
     $found=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -n $CalicoNamespace
+    $ErrorActionPreference = 'Stop'
     if ([string]::IsNullOrEmpty($found)) {
         throw "$SecretName does not exist."
     }
@@ -367,6 +373,7 @@ function InstallCalico()
     Write-Host "`nCalico for Windows installed`n"
 }
 
+# kubectl errors are expected, so there are places where this is reset to "Continue" temporarily
 $ErrorActionPreference = "Stop"
 
 $BaseDir="c:\k"


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This *bug fix* is a hack/workaround for the issue described in issue #6127 where `$ErrorActionPreference` should not be set to `Stop` for `kubectl.exe` commands.

This was tested manually in AWS using `microk8s` as `microk8s` installs Calico in `kube-system` which triggers the issue.

```
ubuntu@ip-10-0-12-150:~$ kubectl get nodes -o wide
NAME                                       STATUS   ROLES    AGE    VERSION                    INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION    CONTAINER-RUNTIME
ip-10-0-12-35.us-east-2.compute.internal   Ready    <none>   9m2s   v1.22.9                    10.0.12.35    <none>        Windows Server 2019 Datacenter   10.0.17763.3046   docker://20.10.9
ip-10-0-12-150                             Ready    <none>   35m    v1.22.9-3+b6876a8b1b090b   10.0.12.150   <none>        Ubuntu 22.04 LTS                 5.15.0-1014-aws   containerd://1.5.11

```


## Related issues/PRs

fixes #6127

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
