### PR TITLE
revert changes to calico-node.yaml template

### DIFF
--- a/calico/_includes/charts/calico/templates/calico-node.yaml
+++ b/calico/_includes/charts/calico/templates/calico-node.yaml
@@ -178,25 +178,6 @@ spec:
 {{- end }}
           securityContext:
             privileged: true
-        # This init container mounts the necessary filesystems needed by the BPF data plane
-        # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
-        # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
-        - name: "mount-bpffs"
-          image: {{.Values.node.image}}:{{.Values.node.tag}}
-          command: ["calico-node", "-init", "-best-effort"]
-          volumeMounts:
-            - mountPath: /sys/fs
-              name: sys-fs
-              # Bidirectional is required to ensure that the new mount we make at /sys/fs/bpf propagates to the host
-              # so that it outlives the init container.
-              mountPropagation: Bidirectional
-            # Mount /proc/1/ from host which usually is an init program at /initproc. It's needed by mountns binary,
-            # executed by calico-node, to mount root cgroup2 fs at /run/calico/cgroup to attach CTLB programs correctly.
-            - mountPath: /initproc
-              name: init-proc
-              readOnly: true
-          securityContext:
-            privileged: true
       containers:
         # Runs {{ include "nodeName" . }} container on each Kubernetes node. This
         # container programs network policy and routes on each
@@ -434,8 +415,11 @@ spec:
               mountPath: /var/run/nodeagent
             # For eBPF mode, we need to be able to mount the BPF filesystem at /sys/fs/bpf so we mount in the
             # parent directory.
-            - name: bpffs
-              mountPath: /sys/fs/bpf
+            - name: sysfs
+              mountPath: /sys/fs/
+              # Bidirectional means that, if we mount the BPF filesystem at /sys/fs/bpf it will propagate to the host.
+              # If the host is known to mount that filesystem already then Bidirectional can be omitted.
+              mountPropagation: Bidirectional
             - name: cni-log-dir
               mountPath: /var/log/calico/cni
               readOnly: true
@@ -568,18 +552,10 @@ spec:
           hostPath:
             path: /run/xtables.lock
             type: FileOrCreate
-        - name: sys-fs
+        - name: sysfs
           hostPath:
             path: /sys/fs/
             type: DirectoryOrCreate
-        - name: bpffs
-          hostPath:
-            path: /sys/fs/bpf
-            type: Directory
-        # mount /proc/1 at /initproc to be used by mount-bpffs initContainer to mount root cgroup2 fs.
-        - name: init-proc
-          hostPath:
-            path: /proc/1
 {{- if and (eq .Values.network "flannel") (eq .Values.datastore "kubernetes") }}
         # Used by flannel.
         - name: flannel-cfg


### PR DESCRIPTION
## Description
Revert changes to calico-node.yaml template from PR https://github.com/projectcalico/calico/pull/6240

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
