### PR TITLE
update ipset for arm64

### DIFF
--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -15,6 +15,7 @@ ARG ARCH=aarch64
 ARG GIT_VERSION=unknown
 ARG IPTABLES_VER=1.8.4-17
 ARG LIBNFTNL_VER=1.1.5-4
+ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
 ARG QEMU_IMAGE
 ARG BIRD_IMAGE=calico/bird:latest
@@ -34,10 +35,13 @@ COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 ARG ARCH
 ARG IPTABLES_VER
 ARG LIBNFTNL_VER
+ARG IPSET_VER
 ARG RUNIT_VER
 ARG CENTOS_MIRROR_BASE_URL=http://linuxsoft.cern.ch/centos-vault/8.4.2105
 ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/libnftnl-${LIBNFTNL_VER}.el8.src.rpm
 ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/iptables-${IPTABLES_VER}.el8.src.rpm
+ARG STREAM9_MIRROR_BASE_URL=https://iad.mirror.rackspace.com/centos-stream/9-stream
+ARG IPSET_SOURCERPM_URL=${STREAM9_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.
 RUN dnf install -y 'dnf-command(config-manager)' && \
@@ -91,6 +95,11 @@ RUN sed -i '/%files$/a \
 # Finally rebuild iptables.
 RUN rpmbuild -bb /root/rpmbuild/SPECS/iptables.spec
 
+# Install source RPM for ipset and install its build dependencies.
+RUN rpm -i ${IPSET_SOURCERPM_URL} && \
+    yum-builddep -y --spec /root/rpmbuild/SPECS/ipset.spec && \
+    rpmbuild -bb /root/rpmbuild/SPECS/ipset.spec
+
 # runit is not available in ubi or CentOS repos so build it.
 RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
     gunzip /tmp/runit-${RUNIT_VER}.tar.gz && \
@@ -113,6 +122,7 @@ ARG ARCH
 ARG GIT_VERSION
 ARG IPTABLES_VER
 ARG LIBNFTNL_VER
+ARG IPSET_VER
 ARG RUNIT_VER
 
 # Enable non-native builds of this image on an amd64 hosts.
@@ -145,7 +155,6 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     --setopt=tsflags=nodocs \
     # Needed for iptables
     libpcap libmnl libnfnetlink libnetfilter_conntrack \
-    ipset \
     iputils \
     # Need arp
     net-tools \
@@ -169,6 +178,9 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     # Install compatible libnftnl version with selected iptables version
     rpm --force -i /tmp/rpms/libnftnl-${LIBNFTNL_VER}.el8.${ARCH}.rpm && \
     rpm -i /tmp/rpms/iptables-${IPTABLES_VER}.el8.${ARCH}.rpm && \
+    # Install ipset version
+    rpm --force -i /tmp/rpms/ipset-libs-${IPSET_VER}.el8.${ARCH}.rpm && \
+    rpm -i /tmp/rpms/ipset-${IPSET_VER}.el8.${ARCH}.rpm && \
     # Set alternatives
     alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-legacy 1 && \
     alternatives --install /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-legacy 1


### PR DESCRIPTION
This PR is based on https://github.com/projectcalico/calico/pull/5485 to address the ARMv64 issues outlined in #5717.

This is a cherry-pick to fix v3.22 since the original amd64 fix was introduced on this branch.

This is my very first contribution to calico so please let me know if there's anything else I need to do.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update the ipset package from 7.1 to 7.11 for ARM builds
```