### PR TITLE
Adding HTTP /terminate path to Dikastes for graceful termination

### DIFF
--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -134,8 +134,6 @@ func runServer(arguments map[string]interface{}) {
 		}
 	}()
 
-	var httpServer *http.Server = nil
-	var httpServerWg *sync.WaitGroup = nil
 	th := httpTerminationHandler{make(chan bool, 1)}
 	if httpPort, ok := arguments["--http-port"].(string); ok {
 		i, err := strconv.Atoi(httpPort)
@@ -144,7 +142,7 @@ func runServer(arguments map[string]interface{}) {
 		} else if i < 1 {
 			log.Fatal("please provide non-zero, non-negative port number for HTTP listening port")
 		}
-		httpServer, httpServerWg = th.RunHTTPServer(arguments)
+		httpServer, httpServerWg := th.RunHTTPServer(arguments)
 		defer httpServerWg.Wait()
 		defer func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -153,7 +151,6 @@ func runServer(arguments map[string]interface{}) {
 				log.Fatalf("error while shutting down HTTP server: %v", err)
 			}
 		}()
-
 	}
 
 	// Use a buffered channel so we don't miss any signals

--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -189,7 +189,9 @@ type terminationHandler struct {
 
 func (h *terminationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.sigChan <- syscall.SIGTERM
-	io.WriteString(w, "terminating Dikastes\n")
+	if _, err := io.WriteString(w, "terminating Dikastes\n"); err != nil {
+		log.Fatalf("error writing HTTP response: %v", err)
+	}
 }
 
 func (h *terminationHandler) RunHttpServer(arguments map[string]interface{}) (*http.Server, *sync.WaitGroup) {

--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -55,7 +55,6 @@ Options:
   -h --help              Show this screen.
   -l --listen <port>     Unix domain socket path [default: /var/run/dikastes/dikastes.sock]
   -d --dial <target>     Target to dial. [default: localhost:50051]
-  -h --http-port <port>  Local port number to listen for HTTP requests on. Used to gracefully terminate.
   --debug                Log at Debug level.`
 
 var VERSION string

--- a/app-policy/cmd/dikastes/dikastes.go
+++ b/app-policy/cmd/dikastes/dikastes.go
@@ -17,9 +17,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/projectcalico/calico/app-policy/checker"
@@ -50,6 +53,7 @@ Options:
   -h --help              Show this screen.
   -l --listen <port>     Unix domain socket path [default: /var/run/dikastes/dikastes.sock]
   -d --dial <target>     Target to dial. [default: localhost:50051]
+  -h --http-port <port>  Local port number to listen for HTTP requests on. Used to gracefully terminate. [default: 7777]
   --debug                Log at Debug level.`
 
 var VERSION string
@@ -129,12 +133,18 @@ func runServer(arguments map[string]interface{}) {
 	}()
 
 	// Use a buffered channel so we don't miss any signals
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	th := terminationHandler{make(chan os.Signal, 2)}
+	signal.Notify(th.sigChan, os.Interrupt, syscall.SIGTERM)
+
+	httpServer, httpServerWg := th.RunHttpServer(arguments)
 
 	// Block until a signal is received.
-	log.Infof("Got signal: %v", <-c)
+	log.Infof("Got signal: %v", <-th.sigChan)
 	gs.GracefulStop()
+	if err = httpServer.Shutdown(context.TODO()); err != nil {
+		panic(err)
+	}
+	httpServerWg.Wait()
 }
 
 func runClient(arguments map[string]interface{}) {
@@ -171,4 +181,33 @@ func runClient(arguments map[string]interface{}) {
 		log.Fatalf("Failed %v", err)
 	}
 	log.Infof("Check response:\n %v", resp)
+}
+
+type terminationHandler struct {
+	sigChan chan os.Signal
+}
+
+func (h *terminationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.sigChan <- syscall.SIGTERM
+	io.WriteString(w, "terminating Dikastes\n")
+}
+
+func (h *terminationHandler) RunHttpServer(arguments map[string]interface{}) (*http.Server, *sync.WaitGroup) {
+	httpServerPort := arguments["--http-port"].(string)
+	httpServerPortStr := fmt.Sprintf(":%s", httpServerPort)
+	httpServer := &http.Server{Addr: httpServerPortStr}
+	httpServerWg := &sync.WaitGroup{}
+	httpServerWg.Add(1)
+
+	http.Handle("/terminate", h)
+
+	go func() {
+		defer httpServerWg.Done()
+		log.Infof("starting HTTP server on port %v", httpServerPort)
+		if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatalf("HTTP server closed unexpectedly: %v", err)
+		}
+	}()
+
+	return httpServer, httpServerWg
 }

--- a/app-policy/cmd/dikastes/dikastes_test.go
+++ b/app-policy/cmd/dikastes/dikastes_test.go
@@ -17,13 +17,11 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"syscall"
 	"testing"
 )
 
 func TestTerminationHandler_ServeHTTP(t *testing.T) {
-	th := terminationHandler{make(chan os.Signal, 2)}
+	th := httpTerminationHandler{make(chan bool, 1)}
 	req := httptest.NewRequest("POST", "http://127.0.0.1:7777/terminate", nil)
 	w := httptest.NewRecorder()
 	th.ServeHTTP(w, req)
@@ -36,10 +34,8 @@ func TestTerminationHandler_ServeHTTP(t *testing.T) {
 	}
 
 	select {
-	case rcvSig := <-th.sigChan:
-		if rcvSig != syscall.SIGTERM {
-			t.Errorf("expect syscall.SIGTERM but instead got %v", rcvSig)
-		}
+	case <-th.termChan:
+		return
 	default:
 		t.Error("termination handler did not write to channel as expected")
 	}

--- a/app-policy/cmd/dikastes/dikastes_test.go
+++ b/app-policy/cmd/dikastes/dikastes_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestTerminationHandler_ServeHTTP(t *testing.T) {
+	th := terminationHandler{make(chan os.Signal, 2)}
+	req := httptest.NewRequest("POST", "http://127.0.0.1:7777/terminate", nil)
+	w := httptest.NewRecorder()
+	th.ServeHTTP(w, req)
+
+	resp := w.Result()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected OK but instead got %v", resp.StatusCode)
+		return
+	}
+
+	select {
+	case rcvSig := <-th.sigChan:
+		if rcvSig != syscall.SIGTERM {
+			t.Errorf("expect syscall.SIGTERM but instead got %v", rcvSig)
+		}
+	default:
+		t.Error("termination handler did not write to channel as expected")
+	}
+}

--- a/calico/reference/architecture/overview.md
+++ b/calico/reference/architecture/overview.md
@@ -86,7 +86,7 @@ Confd dynamically generates BIRD configuration files based on the updates to dat
 
 (Optional) {{site.prodname}} enforces network policy for workloads at both the Linux kernel (using iptables, L3-L4), and at L3-L7 using a Envoy sidecar proxy called Dikastes, with cryptographic authentication of requests. Using multiple enforcement points establishes the identity of the remote endpoint based on multiple criteria. The host Linux kernel enforcement protects your workloads even if the workload pod is compromised, and the Envoy proxy is bypassed.
 
-> **Note**: Dikastes can be terminated by issuing an HTTP POST request to /terminate on localhost at the HTTP port specified with the --http-port option when starting Dikastes (default 7777). This is to allow for graceful termination so that Kubernetes Jobs can complete successfully and is analogous to Envoy's /quitquitquit. eg. `curl -XPOST http://127.0.0.1:7777/terminate`
+> **Note**: Dikastes can be terminated by issuing an HTTP POST request to /terminate on localhost at the HTTP port specified with the `--http-port` option when starting Dikastes. This is to allow for graceful termination so that Kubernetes Jobs can complete successfully and is analogous to Envoy's /quitquitquit. eg. `curl -XPOST http://127.0.0.1:7777/terminate`
 {: .alert .alert-info}
 ### CNI plugin
 

--- a/calico/reference/architecture/overview.md
+++ b/calico/reference/architecture/overview.md
@@ -86,7 +86,7 @@ Confd dynamically generates BIRD configuration files based on the updates to dat
 
 (Optional) {{site.prodname}} enforces network policy for workloads at both the Linux kernel (using iptables, L3-L4), and at L3-L7 using a Envoy sidecar proxy called Dikastes, with cryptographic authentication of requests. Using multiple enforcement points establishes the identity of the remote endpoint based on multiple criteria. The host Linux kernel enforcement protects your workloads even if the workload pod is compromised, and the Envoy proxy is bypassed.
 
-> **Note**: Dikastes can be terminated by issuing an HTTP POST request to /terminate on localhost at the HTTP port specified with the `--http-port` option when starting Dikastes. This is to allow for graceful termination so that Kubernetes Jobs can complete successfully and is analogous to Envoy's /quitquitquit. eg. `curl -XPOST http://127.0.0.1:7777/terminate`
+> **Note**: Dikastes can be terminated by issuing an HTTP POST request to /terminate on the socket address specified using environment variables `DIKASTES_HTTP_BIND_ADDR` and `DIKASTES_HTTP_BIND_PORT`. This is to allow for graceful termination so that Kubernetes Jobs can complete successfully and is analogous to Envoy's /quitquitquit. eg. `curl -XPOST http://127.0.0.1:7777/terminate`
 {: .alert .alert-info}
 ### CNI plugin
 

--- a/calico/reference/architecture/overview.md
+++ b/calico/reference/architecture/overview.md
@@ -86,6 +86,8 @@ Confd dynamically generates BIRD configuration files based on the updates to dat
 
 (Optional) {{site.prodname}} enforces network policy for workloads at both the Linux kernel (using iptables, L3-L4), and at L3-L7 using a Envoy sidecar proxy called Dikastes, with cryptographic authentication of requests. Using multiple enforcement points establishes the identity of the remote endpoint based on multiple criteria. The host Linux kernel enforcement protects your workloads even if the workload pod is compromised, and the Envoy proxy is bypassed.
 
+> **Note**: Dikastes can be terminated by issuing an HTTP POST request to /terminate on localhost at the HTTP port specified with the --http-port option when starting Dikastes (default 7777). This is to allow for graceful termination so that Kubernetes Jobs can complete successfully and is analogous to Envoy's /quitquitquit. eg. `curl -XPOST http://127.0.0.1:7777/terminate`
+{: .alert .alert-info}
 ### CNI plugin
 
 **Main task**: Provides {{site.prodname}} networking for Kubernetes clusters.


### PR DESCRIPTION
## Description
Introduces an HTTP path "/terminate" for graceful termination of Dikastes to allow for successful completion of Kubernetes jobs. Envoy has an analogous /quitquitquit path so this Dikastes equivalent should be familiar with anyone who has used Envoy outside of Calico

Tested via newly introduced unit tests as well as by manually creating a Job that includes a POST operation via curl to shutdown both Dikastes and Envoy and observing that the Job is successfully marked as completed.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fixes [5227](https://github.com/projectcalico/calico/issues/5227)
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add HTTP /terminate endpoint for graceful termination of Dikastes sidecar container to facilitate Kubernetes Job completion
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
