### PR TITLE
Fix announcement of /32 and /128 entries for serviceLoadBalancerIPs.

### DIFF
--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1368,10 +1368,10 @@ func (c *client) onClusterIPsUpdate(clusterCIDRs []string) {
 }
 
 func (c *client) onLoadBalancerIPsUpdate(lbIPs []string) {
-	//	We advertise the given LB IP ranges from every node in order to satisfy services with external traffic policy of "cluster".
-	//	However, we don't want to advertise single IPs in this way because it breaks any "local" type services the user creates,
-	//	which should instead be advertised from only a subset of nodes.
-	//	So, we handle advertisement of any single-addresses found in the config on a per-service basis from within the routeGenerator.
+	// We advertise the given LB IP ranges from every node in order to satisfy services with external traffic policy of "cluster".
+	// However, we don't want to advertise single IPs in this way because it breaks any "local" type services the user creates,
+	// which should instead be advertised from only a subset of nodes.
+	// So, we handle advertisement of any single-addresses found in the config on a per-service basis from within the routeGenerator.
 	var globalLbIPs []string
 	for _, lbIP := range lbIPs {
 		if strings.Contains(lbIP, ":") {

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1368,6 +1368,10 @@ func (c *client) onClusterIPsUpdate(clusterCIDRs []string) {
 }
 
 func (c *client) onLoadBalancerIPsUpdate(lbIPs []string) {
+	//	We advertise the given LB IP ranges from every node in order to satisfy services with external traffic policy of "cluster".
+	//	However, we don't want to advertise single IPs in this way because it breaks any "local" type services the user creates,
+	//	which should instead be advertised from only a subset of nodes.
+	//	So, we handle advertisement of any single-addresses found in the config on a per-service basis from within the routeGenerator.
 	var globalLbIPs []string
 	for _, lbIP := range lbIPs {
 		if strings.Contains(lbIP, ":") {

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1382,7 +1382,7 @@ func (c *client) onLoadBalancerIPsUpdate(lbIPs []string) {
 			globalLbIPs = append(globalLbIPs, lbIP)
 		}
 	}
-	if err := c.updateGlobalRoutes(c.loadBalancerIPs, globalLbIPs); err == nil {
+	if err := c.updateGlobalRoutes(globalLbIPs, c.LoadBalancerIPRouteIndex); err == nil {
 		c.loadBalancerIPs = lbIPs
 		c.loadBalancerIPNets = parseIPNets(c.loadBalancerIPs)
 		log.Infof("Updated with new Loadbalancer IP CIDRs: %s", lbIPs)

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1374,9 +1374,7 @@ func (c *client) onLoadBalancerIPsUpdate(lbIPs []string) {
 			if !strings.HasSuffix(lbIP, "/128") {
 				globalLbIPs = append(globalLbIPs, lbIP)
 			}
-			continue
-		}
-		if !strings.HasSuffix(lbIP, "/32") {
+		} else if !strings.HasSuffix(lbIP, "/32") {
 			globalLbIPs = append(globalLbIPs, lbIP)
 		}
 	}
@@ -1790,21 +1788,6 @@ func (c *client) DeleteStaticRoutes(cidrs []string) {
 	c.incrementCacheRevision()
 	c.deleteRoutesLockHeld(routeKeyPrefix, routeKeyPrefixV6, cidrs)
 	c.onNewUpdates()
-}
-
-// StaticRouteExists check if static route exists
-func (c *client) StaticRouteExists(cidr string) bool {
-	var k string
-	c.cacheLock.Lock()
-	defer c.cacheLock.Unlock()
-
-	if strings.Contains(cidr, ":") {
-		k = routeKeyPrefix + strings.Replace(cidr, "/", "-", 1)
-	} else {
-		k = routeKeyPrefixV6 + strings.Replace(cidr, "/", "-", 1)
-	}
-	_, exists := c.cache[k]
-	return exists
 }
 
 func (c *client) setPeerConfigFieldsFromV3Resource(peers []*bgpPeer, v3res *apiv3.BGPPeer) {

--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -302,9 +302,6 @@ func (rg *routeGenerator) setRoutesForKey(key string, routes []string) {
 		// Advertise route if not already advertised for this key.
 		if _, ok := advertisedRoutes[route]; !ok {
 			rg.advertiseRoute(key, route)
-			// Ensure route is added after config change
-		} else if staticRouteExists := rg.client.StaticRouteExists(route); !staticRouteExists {
-			rg.client.AddStaticRoutes([]string{route})
 		}
 	}
 }
@@ -417,11 +414,9 @@ func (rg *routeGenerator) advertiseThisService(svc *v1.Service, ep *v1.Endpoints
 	}
 
 	// we need to announce single IPs for services of type LoadBalancer and externalTrafficPolicy Cluster
-	if svc.Spec.Type == v1.ServiceTypeLoadBalancer && svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
-		if rg.isSingleLoadBalancerIP(svc.Spec.LoadBalancerIP) {
-			logc.Debug("Advertising load balancer of type cluster because of single IP definition")
-			return true
-		}
+	if svc.Spec.Type == v1.ServiceTypeLoadBalancer && svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster && rg.isSingleLoadBalancerIP(svc.Spec.LoadBalancerIP) {
+		logc.Debug("Advertising load balancer of type cluster because of single IP definition")
+		return true
 	}
 
 	// we only need to advertise local services, since we advertise the entire cluster IP range.


### PR DESCRIPTION
## Description
After this patch, single IPs are no longer announced as global routes.

The patch also fixes a bug related to config change, causing one or more route to be withdrawn if changing from
for example /32 to /29 in BGPConfiguration. Now setRoutesForKey() assures that routes it thinks are advertised
actually do exist.

I also built a version of the 3.21 release with this included:
docker.io/unifon/caliconode:v3.21.4-singleip2

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fixes https://github.com/projectcalico/calico/issues/6074

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that single-IP entries on BGPConfiguration LoadBalancerIPs were not advertised according to external traffic policy. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
