### PR TITLE
Add missing permissions for certificates.k8s.io api

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -292,4 +292,5 @@ rules:
       - certificatesigningrequests
     verbs:
       - list
+      - watch  
 {{- end }}

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -5971,6 +5971,7 @@ rules:
       - certificatesigningrequests
     verbs:
       - list
+      - watch
 ---
 # Source: tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator.yaml
 kind: ClusterRoleBinding


### PR DESCRIPTION
Fixes watch permission errors in the operator logs.