### PR TITLE
Fix issues in config_params_test.go and static-checks

### DIFF
--- a/felix/config/config_params_test.go
+++ b/felix/config/config_params_test.go
@@ -57,7 +57,6 @@ var _ = Describe("FelixConfig vs ConfigParams parity", func() {
 		"VXLANTunnelMACAddr",
 		"VXLANTunnelMACAddrV6",
 		"loadClientConfigFromEnvironment",
-		"RouteSyncDisabled",
 
 		"loadClientConfigFromEnvironment",
 		"useNodeResourceUpdates",

--- a/felix/routetable/dummy_table.go
+++ b/felix/routetable/dummy_table.go
@@ -9,11 +9,9 @@ type DummyTable struct {
 }
 
 func (_ *DummyTable) OnIfaceStateChanged(_ string, _ ifacemonitor.State) {
-	return
 }
 
 func (_ *DummyTable) QueueResync() {
-
 }
 
 func (_ *DummyTable) Apply() error {
@@ -21,17 +19,13 @@ func (_ *DummyTable) Apply() error {
 }
 
 func (_ *DummyTable) SetRoutes(_ string, _ []Target) {
-	return
 }
 
 func (_ *DummyTable) SetL2Routes(_ string, _ []L2Target) {
-	return
 }
 
 func (_ *DummyTable) RouteRemove(_ string, _ ip.CIDR) {
-	return
 }
 
 func (_ *DummyTable) RouteUpdate(_ string, _ Target) {
-	return
 }


### PR DESCRIPTION
## Description

Fix RouteSyncDisabled issue in config_params_test.go and static-checks issue in dummy_table.go
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
