### PR TITLE
[release-v3.23] Auto pick #6296: Fix namespacing of endpoint slice objects

### DIFF
--- a/libcalico-go/lib/namespace/namespace_suite_test.go
+++ b/libcalico-go/lib/namespace/namespace_suite_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/ginkgo/reporters"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
+)
+
+func TestClient(t *testing.T) {
+	testutils.HookLogrusForGinkgo()
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../report/lib_namespace_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "lib/namespace suite", []Reporter{junitReporter})
+}

--- a/libcalico-go/lib/namespace/resource.go
+++ b/libcalico-go/lib/namespace/resource.go
@@ -39,6 +39,7 @@ func IsNamespaced(kind string) bool {
 	case KindKubernetesEndpointSlice:
 		// KindKubernetesEndpointSlice is a special-case resource. We don't expose it over the
 		// v3 API, but it is used in the felix syncer.
+		return true
 	case KindKubernetesService:
 		return true
 	}

--- a/libcalico-go/lib/namespace/resource_test.go
+++ b/libcalico-go/lib/namespace/resource_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/namespace"
+)
+
+var _ = Describe("lib/namespace tests", func() {
+	DescribeTable("Namespaced resources",
+		func(kind string, isNamespaced bool) {
+			Expect(namespace.IsNamespaced(kind)).To(Equal(isNamespaced))
+		},
+
+		Entry(namespace.KindKubernetesNetworkPolicy, namespace.KindKubernetesNetworkPolicy, true),
+		Entry(namespace.KindKubernetesService, namespace.KindKubernetesService, true),
+		Entry(namespace.KindKubernetesEndpointSlice, namespace.KindKubernetesEndpointSlice, true),
+		Entry("BGPConfiguration", "BGPConfiguration", false),
+	)
+})


### PR DESCRIPTION
Cherry pick of #6296 on release-v3.23.

#6296: Fix namespacing of endpoint slice objects

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/6294

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix calico/node and typha version skew bug between Calico v3.22 and v3.23
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.