### PR TITLE
Fix L3RouteResolver "some nodes share IP address" log messages

### DIFF
--- a/felix/calc/l3_route_resolver.go
+++ b/felix/calc/l3_route_resolver.go
@@ -85,6 +85,11 @@ type l3rrNodeInfo struct {
 	Addresses []ip.Addr
 }
 
+var (
+	emptyV4Addr ip.V4Addr
+	emptyV6Addr ip.V6Addr
+)
+
 func (i l3rrNodeInfo) Equal(b l3rrNodeInfo) bool {
 	if i.V4Addr == b.V4Addr &&
 		i.V4CIDR == b.V4CIDR &&
@@ -92,6 +97,7 @@ func (i l3rrNodeInfo) Equal(b l3rrNodeInfo) bool {
 		i.V6CIDR == b.V6CIDR &&
 		i.IPIPAddr == b.IPIPAddr &&
 		i.VXLANAddr == b.VXLANAddr &&
+		i.VXLANV6Addr == b.VXLANV6Addr &&
 		i.WireguardAddr == b.WireguardAddr {
 
 		if len(i.Addresses) != len(b.Addresses) {
@@ -132,6 +138,13 @@ func (i l3rrNodeInfo) AddressesAsCIDRs() []ip.CIDR {
 
 	for _, a := range i.Addresses {
 		addrs[a] = struct{}{}
+	}
+
+	// Clean up empty (uninitialized) addresses
+	for a := range addrs {
+		if a == emptyV4Addr || a == emptyV6Addr {
+			delete(addrs, a)
+		}
 	}
 
 	cidrs := make([]ip.CIDR, len(addrs))
@@ -458,7 +471,7 @@ func (c *L3RouteResolver) onNodeUpdate(nodeName string, newNodeInfo *l3rrNodeInf
 		}
 		if oldNodeInfo.V4CIDR != myNewV4CIDR {
 			// This node's CIDR has changed; some routes may now have an incorrect value for same-subnet.
-			c.visitAllRoutes(c.trie.v4T, func(r nodenameRoute) {
+			c.visitAllRoutes(c.trie.trieForCIDR(myNewV4CIDR), func(r nodenameRoute) {
 				if r.nodeName == c.myNodeName {
 					return // Ignore self.
 				}
@@ -477,7 +490,7 @@ func (c *L3RouteResolver) onNodeUpdate(nodeName string, newNodeInfo *l3rrNodeInf
 		}
 		if oldNodeInfo.V6CIDR != myNewV6CIDR {
 			// This node's CIDR has changed; some routes may now have an incorrect value for same-subnet.
-			c.visitAllRoutes(c.trie.v4T, func(r nodenameRoute) {
+			c.visitAllRoutes(c.trie.trieForCIDR(myNewV6CIDR), func(r nodenameRoute) {
 				if r.nodeName == c.myNodeName {
 					return // Ignore self.
 				}
@@ -766,9 +779,6 @@ func (c *L3RouteResolver) flush() {
 				}
 			}
 		}
-
-		var emptyV4Addr ip.V4Addr
-		var emptyV6Addr ip.V6Addr
 
 		if rt.DstNodeName != "" {
 			dstNodeInfo, exists := c.nodeNameToNodeInfo[rt.DstNodeName]

--- a/felix/calc/l3_route_resolver_test.go
+++ b/felix/calc/l3_route_resolver_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/ip"
+)
+
+var _ = Describe("L3RouteResolver", func() {
+	Describe("L3RouteResolver UTs", func() {
+		var l3RR *L3RouteResolver
+		var eventBuf *EventSequencer
+
+		BeforeEach(func() {
+			eventBuf = NewEventSequencer(nil)
+			l3RR = NewL3RouteResolver("test-hostname", eventBuf, true, "CalicoIPAM")
+		})
+
+		It("onNodeUpdate should add entries to the correct IP version tries", func() {
+			Expect(l3RR.trie.v4T).To(Equal(&ip.CIDRTrie{}))
+			Expect(l3RR.trie.v6T).To(Equal(&ip.CIDRTrie{}))
+
+			nodeInfo := &l3rrNodeInfo{
+				V4Addr: ip.FromString("192.168.0.1").(ip.V4Addr),
+				V6Addr: ip.FromString("dead:beef::1").(ip.V6Addr),
+			}
+
+			l3RR.onNodeUpdate("nodeName1", nodeInfo)
+
+			ri := RouteInfo{}
+			ri.Host.NodeNames = []string{"nodeName1"}
+
+			expectedV4T := &ip.CIDRTrie{}
+			cidrV4, _ := ip.CIDRFromString("192.168.0.1/32")
+			expectedV4T.Update(cidrV4, ri)
+			Expect(l3RR.trie.v4T).To(Equal(expectedV4T))
+
+			expectedV6T := &ip.CIDRTrie{}
+			cidrV6, _ := ip.CIDRFromString("dead:beef::1/128")
+			expectedV6T.Update(cidrV6, ri)
+			Expect(l3RR.trie.v6T).To(Equal(expectedV6T))
+		})
+	})
+	Describe("l3rrNodeInfo UTs", func() {
+		It("should not return empty IP addresses in AddressesAsCIDRs()", func() {
+			var (
+				emptyV4Addr ip.V4Addr
+				emptyV6Addr ip.V6Addr
+			)
+			info := l3rrNodeInfo{
+				V4Addr: emptyV4Addr,
+				V6Addr: emptyV6Addr,
+			}
+			Expect(info.AddressesAsCIDRs()).To(Equal([]ip.CIDR{}))
+		})
+		It("should consider VXLANV6Addr in Equal() method", func() {
+			info1 := l3rrNodeInfo{
+				VXLANV6Addr: ip.FromString("dead:beef::1"),
+			}
+			info2 := l3rrNodeInfo{
+				VXLANV6Addr: ip.FromString("dead:beef::2"),
+			}
+			Expect(info1.Equal(info1)).To(BeTrue())
+			Expect(info1.Equal(info2)).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Description

Don't export empty (uninitialized) IP addresses in L3RouteResolver, to fix incorrectly outputting "Some nodes share IP address, route calculation may choose wrong node." log messages for those IPs (e.g.: '::/128' when IPv6 is disabled).

ref: https://calicousers.slack.com/archives/CPTH1KS00/p1654705701097149

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix L3RouteResolver incorrectly outputting "Some nodes share IP address, route calculation may choose wrong node." log messages.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
