### PR TITLE
felix/fv: fix flake in BPF affinity tests

### DIFF
--- a/felix/cmd/calico-bpf/commands/nat.go
+++ b/felix/cmd/calico-bpf/commands/nat.go
@@ -90,7 +90,7 @@ func dumpAff(cmd *cobra.Command) (err error) {
 	}
 
 	for k, v := range affMap {
-		cmd.Printf("%-40s %s", k, v)
+		cmd.Printf("%-40s %s\n", k, v)
 	}
 
 	cmd.Printf("\n")

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -2180,6 +2180,26 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							ip := testSvc.Spec.ClusterIP
 							port := uint16(testSvc.Spec.Ports[0].Port)
 
+							if setAffinity {
+								// Sync with NAT tables to prevent creating extra entry when
+								// CTLB misses but regulat DNAT hits, but connection fails and
+								// then CTLB succeeds.
+								natFtKey := nat.NewNATKey(net.ParseIP(ip), port, numericProto)
+								Eventually(func() bool {
+									m := dumpNATMap(felixes[0])
+									v, ok := m[natFtKey]
+									if !ok || v.Count() == 0 {
+										return false
+									}
+
+									beKey := nat.NewNATBackendKey(v.ID(), 0)
+
+									be := dumpEPMap(felixes[0])
+									_, ok = be[beKey]
+									return ok
+								}, 5*time.Second).Should(BeTrue())
+							}
+
 							cc.ExpectSome(w[0][1], TargetIP(ip), port)
 							cc.CheckConnectivity()
 

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -2182,7 +2182,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 							if setAffinity {
 								// Sync with NAT tables to prevent creating extra entry when
-								// CTLB misses but regulat DNAT hits, but connection fails and
+								// CTLB misses but regular DNAT hits, but connection fails and
 								// then CTLB succeeds.
 								natFtKey := nat.NewNATKey(net.ParseIP(ip), port, numericProto)
 								Eventually(func() bool {


### PR DESCRIPTION
When CTLB is in use two entries instead of 1 may get created if CTLB
misses on NAT the first time, but the regular DNAT, which then executes
hits. The connection may fail and the next time CTLB won't miss,
creating new affinity entry with 0.0.0.0 client IP (the correct,
expected entry)


```
          should have connectivity from a workload to a service with multiple backends [It]
          /go/src/github.com/projectcalico/calico/felix/fv/bpf_test.go:2165

          Expected
              <nat.AffinityMapMem | len:2>: {
                  [10, 101, 0, 10, 80, 0, 6, 0, 10, 65, 0, 3, 0, 0, 0, 0]: [10, 65, 0, 2, 119, 31, 0, 0, 235, 74, 248, 39, 235, 3, 0, 0],
                  [10, 101, 0, 10, 80, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0]: [10, 65, 0, 2, 119, 31, 0, 0, 202, 173, 54, 48, 235, 3, 0, 0],
              }
          to have length 1

          /go/src/github.com/projectcalico/calico/felix/fv/bpf_test.go:2186
```

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
