### PR TITLE
Fix serviceaccount token generation for canal

### DIFF
--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -99,6 +99,14 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
+{{- if eq .Values.network "flannel" }}
+            # Set the serviceaccount name to use for the Calico CNI plugin.
+            # We use canal-node instead of calico-node when using flannel networking.
+            - name: CALICO_CNI_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+{{- end }}
 {{- if .Values.bpf }}
             # Overrides for kubernetes API server host/port. Needed in BPF mode.
             - name: KUBERNETES_SERVICE_HOST

--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -326,6 +326,12 @@ spec:
                   name: {{include "variant_name" . | lower}}-config
                   key: veth_mtu
 {{- else if eq .Values.network "flannel" }}
+            # Set the serviceaccount name to use for the Calico CNI plugin.
+            # We use canal-node instead of calico-node when using flannel networking.
+            - name: CALICO_CNI_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -486,7 +486,7 @@ current-context: calico-context`
 	if err != nil {
 		logrus.WithError(err).Fatal("Unable to create client for generating CNI token")
 	}
-	tr := cni.NewTokenRefresher(clientset, cni.NamespaceOfUsedServiceAccount(), cni.DefaultServiceAccountName)
+	tr := cni.NewTokenRefresher(clientset, cni.NamespaceOfUsedServiceAccount(), cni.CNIServiceAccountName())
 	tu, err := tr.UpdateToken()
 	if err != nil {
 		logrus.WithError(err).Fatal("Unable to create token for CNI kubeconfig")

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -459,6 +459,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Set the serviceaccount name to use for the Calico CNI plugin.
+            # We use canal-node instead of calico-node when using flannel networking.
+            - name: CALICO_CNI_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -346,6 +346,12 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
+            # Set the serviceaccount name to use for the Calico CNI plugin.
+            # We use canal-node instead of calico-node when using flannel networking.
+            - name: CALICO_CNI_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-canal.conflist"

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4448,6 +4448,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Set the serviceaccount name to use for the Calico CNI plugin.
+            # We use canal-node instead of calico-node when using flannel networking.
+            - name: CALICO_CNI_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             # Don't enable BGP.
             - name: CALICO_NETWORKING_BACKEND
               value: "none"

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4371,6 +4371,12 @@ spec:
               name: kubernetes-services-endpoint
               optional: true
           env:
+            # Set the serviceaccount name to use for the Calico CNI plugin.
+            # We use canal-node instead of calico-node when using flannel networking.
+            - name: CALICO_CNI_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             # Name of the CNI config file to create.
             - name: CNI_CONF_NAME
               value: "10-canal.conflist"

--- a/node/pkg/cni/token_watch.go
+++ b/node/pkg/cni/token_watch.go
@@ -217,7 +217,7 @@ func Run() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create in cluster client set")
 	}
-	tr := NewTokenRefresher(clientset, NamespaceOfUsedServiceAccount(), cniServiceAccountName())
+	tr := NewTokenRefresher(clientset, NamespaceOfUsedServiceAccount(), CNIServiceAccountName())
 	tokenChan := tr.TokenChan()
 	go tr.Run()
 
@@ -237,9 +237,9 @@ func Run() {
 	}
 }
 
-// cniServiceAccountName returns the name of the serviceaccount to use for the CNI plugin token request.
+// CNIServiceAccountName returns the name of the serviceaccount to use for the CNI plugin token request.
 // This can be set via the CALICO_CNI_SERVICE_ACCOUNT environment variable, and defaults to "calico-node" otherwise.
-func cniServiceAccountName() string {
+func CNIServiceAccountName() string {
 	if sa := os.Getenv("CALICO_CNI_SERVICE_ACCOUNT"); sa != "" {
 		logrus.WithField("name", sa).Debug("Using service account from CALICO_CNI_SERVICE_ACCOUNT")
 		return sa

--- a/node/pkg/cni/token_watch.go
+++ b/node/pkg/cni/token_watch.go
@@ -21,12 +21,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const DefaultServiceAccountName = "calico-node"
-const serviceAccountNamespace = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-const tokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-const defaultCNITokenValiditySeconds = 24 * 60 * 60
-const minTokenRetryDuration = 5 * time.Second
-const defaultRefreshFraction = 4
+const (
+	defaultServiceAccountName      = "calico-node"
+	serviceAccountNamespace        = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	tokenFile                      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultCNITokenValiditySeconds = 24 * 60 * 60
+	minTokenRetryDuration          = 5 * time.Second
+	defaultRefreshFraction         = 4
+)
 
 var kubeconfigPath string = "/host/etc/cni/net.d/calico-kubeconfig"
 
@@ -215,7 +217,7 @@ func Run() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create in cluster client set")
 	}
-	tr := NewTokenRefresher(clientset, NamespaceOfUsedServiceAccount(), DefaultServiceAccountName)
+	tr := NewTokenRefresher(clientset, NamespaceOfUsedServiceAccount(), cniServiceAccountName())
 	tokenChan := tr.TokenChan()
 	go tr.Run()
 
@@ -233,6 +235,16 @@ func Run() {
 		}
 		writeKubeconfig(cfg, tu.Token)
 	}
+}
+
+// cniServiceAccountName returns the name of the serviceaccount to use for the CNI plugin token request.
+// This can be set via the CALICO_CNI_SERVICE_ACCOUNT environment variable, and defaults to "calico-node" otherwise.
+func cniServiceAccountName() string {
+	if sa := os.Getenv("CALICO_CNI_SERVICE_ACCOUNT"); sa != "" {
+		logrus.WithField("name", sa).Debug("Using service account from CALICO_CNI_SERVICE_ACCOUNT")
+		return sa
+	}
+	return defaultServiceAccountName
 }
 
 // writeKubeconfig writes an updated kubeconfig file to disk that the CNI plugin can use to access the Kubernetes API.


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->


We missed that Canal uses a different service account name than vanilla
Calico. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix serviceaccount token generation for canal (introduced in v3.23.2)
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.