### PR TITLE
Add command to split IP pools

### DIFF
--- a/calicoctl/calicoctl/commands/common/resources.go
+++ b/calicoctl/calicoctl/commands/common/resources.go
@@ -32,6 +32,7 @@ import (
 	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	calicoErrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
 type action int
@@ -377,4 +378,17 @@ func handleNamespace(resource resourcemgr.ResourceObject, rm resourcemgr.Resourc
 	}
 
 	return nil
+}
+
+// CheckLocked checks if the datastore is locked. This is important for
+// datastore migrations and splitting up IP pools so that the underlying
+// data is not changed while the operations are being carried out.
+func CheckLocked(ctx context.Context, c client.Interface) (bool, error) {
+	// Get the cluster information resource
+	clusterinfo, err := c.ClusterInformation().Get(ctx, "default", options.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("Error retrieving ClusterInformation: %s", err)
+	}
+
+	return !*clusterinfo.Spec.DatastoreReady, nil
 }

--- a/calicoctl/calicoctl/commands/datastore/migrate/export.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/export.go
@@ -147,7 +147,7 @@ Description:
 
 	// Check that the datastore is locked.
 	ctx := context.Background()
-	locked, err := checkLocked(ctx, client)
+	locked, err := common.CheckLocked(ctx, client)
 	if err != nil {
 		return fmt.Errorf("Error while checking if datastore was locked: %s", err)
 	} else if !locked {

--- a/calicoctl/calicoctl/commands/datastore/migrate/import.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/import.go
@@ -121,7 +121,7 @@ Description:
 
 	// Make sure that the datastore is locked. Since the call to EnsureInitialized
 	// should initialize it to unlocked, lock it before we continue.
-	locked, err := checkLocked(ctx, client)
+	locked, err := common.CheckLocked(ctx, client)
 	if err != nil {
 		return fmt.Errorf("Error while checking if datastore was locked: %s", err)
 	} else if !locked {

--- a/calicoctl/calicoctl/commands/datastore/migrate/lock.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/lock.go
@@ -25,7 +25,6 @@ import (
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
-	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
@@ -92,14 +91,4 @@ Description:
 
 	fmt.Print("Datastore locked.\n")
 	return nil
-}
-
-func checkLocked(ctx context.Context, c clientv3.Interface) (bool, error) {
-	// Get the cluster information resource
-	clusterinfo, err := c.ClusterInformation().Get(ctx, "default", options.GetOptions{})
-	if err != nil {
-		return false, fmt.Errorf("Error retrieving ClusterInformation: %s", err)
-	}
-
-	return !*clusterinfo.Spec.DatastoreReady, nil
 }

--- a/calicoctl/calicoctl/commands/ipam.go
+++ b/calicoctl/calicoctl/commands/ipam.go
@@ -34,6 +34,8 @@ func IPAM(args []string) error {
     release          Release a Calico assigned IP address.
     show             Show details of a Calico configuration,
                      assigned IP address, or of overall IP usage.
+    split            Split the IP pool specified by the CIDR into
+                     the specified number of smaller IPPools.
     configure        Configure IPAM
 
 Options:
@@ -73,6 +75,8 @@ Description:
 		return ipam.Show(args)
 	case "configure":
 		return ipam.Configure(args)
+	case "split":
+		return ipam.Split(args)
 	default:
 		fmt.Println(doc)
 	}

--- a/calicoctl/calicoctl/commands/ipam/split.go
+++ b/calicoctl/calicoctl/commands/ipam/split.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/clientmgr"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
+	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+func Split(args []string) error {
+	doc := constants.DatastoreIntro + `Usage:
+  <BINARY_NAME> ipam split <NUMBER> [--cidr=<CIDR>] [--name=<POOL_NAME>] [--config=<CONFIG>] [--allow-version-mismatch]
+
+Options:
+  -h --help                    Show this screen.
+  -c --config=<CONFIG>         Path to the file containing connection configuration in
+                               YAML or JSON format.
+                               [default: ` + constants.DefaultConfigPath + `]
+     --cidr=<CIDR>             CIDR of the IP pool to split.
+     --name=<POOL_NAME>        Name of the IP pool to split.
+     --allow-version-mismatch  Allow client and cluster versions mismatch.
+
+Description:
+  The ipam split command splits an IP pool specified by the specified CIDR or name
+  into the specified number of smaller IP pools. Each child IP pool will be of equal
+  size. IP pools can only be split into a number of smaller pools that is a power
+  of 2.
+
+Examples:
+  # Split the IP pool specified by 172.0.0.0/8 into 2 smaller pools
+  <BINARY_NAME> ipam split --cidr=172.0.0.0/8 2
+`
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	parsedArgs, err := docopt.ParseArgs(doc, args, "")
+	if err != nil {
+		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))
+	}
+	if len(parsedArgs) == 0 {
+		return nil
+	}
+
+	err = common.CheckVersionMismatch(parsedArgs["--config"], parsedArgs["--allow-version-mismatch"])
+	if err != nil {
+		return err
+	}
+
+	// Validate that a name or CIDR is provided to search for the IP pool.
+	var oldPoolCIDR, oldPoolName string
+	if cidr := parsedArgs["--cidr"]; cidr != nil {
+		oldPoolCIDR = parsedArgs["--cidr"].(string)
+	}
+	if name := parsedArgs["--name"]; name != nil {
+		oldPoolName = parsedArgs["--name"].(string)
+	}
+	if oldPoolCIDR == "" && oldPoolName == "" {
+		return fmt.Errorf("No name or CIDR provided. Provide a name or CIDR to denote the IP pool to split.")
+	}
+
+	cf := parsedArgs["--config"].(string)
+	// Get the backend client.
+	client, err := clientmgr.NewClient(cf)
+	if err != nil {
+		return err
+	}
+
+	// Check that the datastore is locked
+	ctx := context.Background()
+	locked, err := common.CheckLocked(ctx, client)
+	if err != nil {
+		return fmt.Errorf("Error while checking if datastore was locked: %s", err)
+	} else if !locked {
+		return fmt.Errorf("Datastore is not locked. Run the `calicoctl datastore migrate lock` command in order split the IP pools.")
+	}
+
+	// Find the IP pool to split
+	var oldPool *apiv3.IPPool
+	if oldPoolName != "" {
+		oldPool, err = client.IPPools().Get(ctx, oldPoolName, options.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("Unable to find IP pool with name %s: %v", oldPoolName, err)
+		}
+	} else if oldPoolCIDR != "" {
+		poolList, err := client.IPPools().List(ctx, options.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("Unable to list IP pools to find the pool specified by %s", oldPoolCIDR)
+		}
+
+		for _, pool := range poolList.Items {
+			if pool.Spec.CIDR == oldPoolCIDR {
+				oldPool = &pool
+			}
+		}
+	}
+
+	if oldPool == nil {
+		return fmt.Errorf("Unable to find IP pool %s covering the specified CIDR %s", oldPoolName, oldPoolCIDR)
+	}
+
+	// Disable the specified IP pool.
+	oldPool.Spec.Disabled = true
+	oldPool, err = client.IPPools().Update(ctx, oldPool, options.SetOptions{})
+	if err != nil {
+		return fmt.Errorf("Error disabling IP pool %s", oldPoolCIDR)
+	}
+
+	// Calculate the split pool CIDRs.
+	numString := parsedArgs["<NUMBER>"].(string)
+	splitNum, err := strconv.Atoi(numString)
+	if err != nil {
+		return fmt.Errorf("Error reading number to split IP pools into. %s is not a valid number: %v", numString, err)
+	}
+
+	splitCIDRs, err := splitCIDR(oldPool.Spec.CIDR, splitNum)
+	if err != nil {
+		return fmt.Errorf("Error splitting the CIDR %s into %d CIDRs: %v", oldPool.Spec.CIDR, splitNum, err)
+	}
+
+	// Create the new split pools using UnsafeCreate.
+	poolsCreated := make([]*apiv3.IPPool, splitNum)
+	for i, cidr := range splitCIDRs {
+		poolCopy := oldPool.DeepCopyObject()
+		splitPool, ok := poolCopy.(*apiv3.IPPool)
+		if !ok {
+			return fmt.Errorf("Error copying metadata out from old IP pool: %s", oldPool.GetObjectMeta().GetName())
+		}
+
+		// Clear out unneeded metadata
+		splitPool.GetObjectMeta().SetUID("")
+		splitPool.GetObjectMeta().SetResourceVersion("")
+		splitPool.GetObjectMeta().SetGeneration(0)
+		splitPool.GetObjectMeta().SetSelfLink("")
+		splitPool.GetObjectMeta().SetCreationTimestamp(metav1.Time{})
+
+		// Set the new name
+		newName := fmt.Sprintf("split-%s-%d", oldPool.GetObjectMeta().GetName(), i)
+		// Max K8s resource name is 253 characters
+		// TODO: Think of a better way of naming split pools.
+		if len(newName) > 253 {
+			// The split name adds 8 additional characters, modify the old pool name to fit with those additional 8 characters.
+			newName = fmt.Sprintf("split-%s-%d", oldPool.GetObjectMeta().GetName()[:245], i)
+		}
+		splitPool.GetObjectMeta().SetName(newName)
+		splitPool.GetObjectMeta().SetGenerateName("")
+
+		// Set the new CIDR
+		splitPool.Spec.CIDR = cidr
+
+		// Enable the IP pool
+		splitPool.Spec.Disabled = false
+
+		_, err = client.IPPools().UnsafeCreate(ctx, splitPool, options.SetOptions{})
+		if err != nil {
+			return fmt.Errorf("Error using unsafe create to make split pool with cidr %s: %v", cidr, err)
+		}
+
+		poolsCreated[i] = splitPool
+	}
+
+	// Delete the old IP pool.
+	// Use UnsafeDelete which will do everything Delete does except for removing the associated affinities.
+	_, err = client.IPPools().UnsafeDelete(ctx, oldPool.GetObjectMeta().GetName(), options.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("Error removing the IP pool that was split %s: %v", oldPool.GetObjectMeta().GetName(), err)
+	}
+
+	// Output follow-up directions.
+	fmt.Printf("IP Pool %s was successfully split into %d smaller pools.", oldPool.GetObjectMeta().GetName(), splitNum)
+	for _, splitPool := range poolsCreated {
+		fmt.Printf("Created %s with CIDR %s.\n", splitPool.GetObjectMeta().GetName(), splitPool.Spec.CIDR)
+	}
+	fmt.Print("Please refer to the documentation for final steps.")
+
+	return nil
+}
+
+func splitCIDR(oldCIDR string, parts int) ([]string, error) {
+	// Validate that we are trying to split the CIDR into a valid number of child CIDRs.
+	power := math.Log2(float64(parts))
+	if math.IsNaN(power) || power == 0 {
+		return nil, fmt.Errorf("Number to split CIDR into is not a valid power of 2: %d", parts)
+	}
+
+	// Convert the string version of the CIDR into a CIDR object.
+	_, cidr, err := cnet.ParseCIDR(oldCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading CIDR %s before attempting to split it", oldCIDR)
+	}
+
+	ones, bits := cidr.Mask.Size()
+	if int(power)+ones > bits {
+		return nil, fmt.Errorf("The CIDR %s is not large enough to be split into %d parts", oldCIDR, parts)
+	}
+
+	// Find the block size to increment over.
+	newPoolSize := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(bits-ones-int(power))), nil)
+
+	// Mask the IP in case the CIDR isn't formatted nicely.
+	mask := net.CIDRMask(ones, bits)
+	maskedIP := cnet.IP{IP: cidr.IP.Mask(mask)}
+
+	// Create the child CIDRs
+	splitCIDRs := make([]string, parts)
+	for i := 0; i < parts; i++ {
+		splitCIDR := cnet.IPNet{
+			IPNet: net.IPNet{
+				IP:   maskedIP.IP,
+				Mask: net.CIDRMask(ones+int(power), bits),
+			},
+		}
+
+		splitCIDRs[i] = splitCIDR.String()
+		maskedIP = cnet.IncrementIP(maskedIP, newPoolSize)
+	}
+
+	return splitCIDRs, nil
+}

--- a/calicoctl/tests/st/calicoctl/test_ipam_split.py
+++ b/calicoctl/tests/st/calicoctl/test_ipam_split.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2022 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import copy
+import os
+
+from nose_parameterized import parameterized
+
+from tests.st.test_base import TestBase
+from tests.st.utils.utils import log_and_run, calicoctl, \
+    API_VERSION, name, namespace, ERROR_CONFLICT, NOT_FOUND, NOT_NAMESPACED, \
+    SET_DEFAULT, NOT_SUPPORTED, KUBERNETES_NP, NOT_LOCKED_SPLIT, \
+    POOL_NOT_EXIST_CIDR, NOT_KUBERNETES, NO_IPAM, writeyaml
+from tests.st.utils.data import *
+
+logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+class TestCalicoctlIPAMSplit(TestBase):
+    """
+    Test splitting IPAM pools works
+    1) Test splitting an ippool 10.0.1.0/24 into 4 ippools:
+       10.0.1.128/26, 10.0.1.64/26, 10.0.1.0/26, and 10.0.1.192/26.
+    """
+
+    def test_ipam_split_by_cidr(self):
+        """
+        Test that splitting IP pools works properly by CIDR
+        """
+
+        # Create the ipv4 pool using calicoctl, and read it out using an
+        # exact get and a list query.
+        rc = calicoctl("create", data=ippool_name1_rev1_v4)
+        rc.assert_no_error()
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_v4))
+        rc.assert_data(ippool_name1_rev1_v4)
+        rc = calicoctl("get ippool -o yaml")
+        rc.assert_list("IPPool", [ippool_name1_rev1_v4])
+
+        # Create a Node, this should also trigger auto-creation of a cluster info
+        rc = calicoctl("create", data=node_name4_rev1)
+        rc.assert_no_error()
+        rc = calicoctl("get node %s -o yaml" % name(node_name4_rev1))
+        rc.assert_data(node_name4_rev1)
+        rc = calicoctl("get clusterinfo %s -o yaml" % name(clusterinfo_name1_rev1))
+        rc.assert_no_error()
+
+        # Attempt to split the IP pool before locking the datastore
+        rc = calicoctl("ipam split --cidr=10.0.1.0/24 4")
+        rc.assert_error(text=NOT_LOCKED_SPLIT)
+
+        # Lock the data
+        rc = calicoctl("datastore migrate lock")
+        rc.assert_no_error()
+
+        # Attempt to split a non-existent IP pool
+        rc = calicoctl("ipam split --cidr=10.0.2.0/24 4")
+        rc.assert_error(text=POOL_NOT_EXIST_CIDR)
+
+        # Split the IP pool
+        rc = calicoctl("ipam split --cidr=10.0.1.0/24 4")
+        rc.assert_no_error()
+
+        # Check that the original IP pool no longer exists
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_v4))
+        rc.assert_error(text=NOT_FOUND)
+
+        # Check that the split IP pools exist
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split1_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split1_v4)
+
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split2_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split2_v4)
+
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split3_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split3_v4)
+
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split4_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split4_v4)
+
+        # Unlock the datastore
+        rc = calicoctl("datastore migrate unlock")
+        rc.assert_no_error()
+
+        # Clean up
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split1_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split2_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split3_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split4_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete node %s" % name(node_name4_rev1))
+        rc.assert_no_error()
+
+    def test_ipam_split_by_name(self):
+        """
+        Test that splitting IP pools works properly by IP pool name
+        """
+
+        # Create the ipv4 pool using calicoctl, and read it out using an
+        # exact get and a list query.
+        rc = calicoctl("create", data=ippool_name1_rev1_v4)
+        rc.assert_no_error()
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_v4))
+        rc.assert_data(ippool_name1_rev1_v4)
+        rc = calicoctl("get ippool -o yaml")
+        rc.assert_list("IPPool", [ippool_name1_rev1_v4])
+
+        # Create a Node, this should also trigger auto-creation of a cluster info
+        rc = calicoctl("create", data=node_name4_rev1)
+        rc.assert_no_error()
+        rc = calicoctl("get node %s -o yaml" % name(node_name4_rev1))
+        rc.assert_data(node_name4_rev1)
+        rc = calicoctl("get clusterinfo %s -o yaml" % name(clusterinfo_name1_rev1))
+        rc.assert_no_error()
+
+        # Attempt to split the IP pool before locking the datastore
+        rc = calicoctl("ipam split --name=%s 4" % name(ippool_name1_rev1_v4))
+        rc.assert_error(text=NOT_LOCKED_SPLIT)
+
+        # Lock the data
+        rc = calicoctl("datastore migrate lock")
+        rc.assert_no_error()
+
+        # Attempt to split a non-existent IP pool
+        rc = calicoctl("ipam split --name=%s 4" % name(ippool_name2_rev1_v6))
+        rc.assert_error(text=POOL_NOT_EXIST_CIDR)
+
+        # Split the IP pool
+        rc = calicoctl("ipam split --name=%s 4" % name(ippool_name1_rev1_v4))
+        rc.assert_no_error()
+
+        # Check that the original IP pool no longer exists
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_v4))
+        rc.assert_error(text=NOT_FOUND)
+
+        # Check that the split IP pools exist
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split1_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split1_v4)
+
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split2_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split2_v4)
+
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split3_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split3_v4)
+
+        rc = calicoctl("get ippool %s -o yaml" % name(ippool_name1_rev1_split4_v4))
+        rc.assert_no_error()
+        rc.assert_data(ippool_name1_rev1_split4_v4)
+
+        # Unlock the datastore
+        rc = calicoctl("datastore migrate unlock")
+        rc.assert_no_error()
+
+        # Clean up
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split1_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split2_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split3_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_split4_v4))
+        rc.assert_no_error()
+        rc = calicoctl("delete node %s" % name(node_name4_rev1))
+        rc.assert_no_error()

--- a/calicoctl/tests/st/utils/data.py
+++ b/calicoctl/tests/st/utils/data.py
@@ -77,6 +77,87 @@ ippool_name1_rev2_v4 = {
     }
 }
 
+ippool_name1_rev3_v4 = {
+    'apiVersion': API_VERSION,
+    'kind': 'IPPool',
+    'metadata': {
+        'name': 'ippool-name1'
+    },
+    'spec': {
+        'cidr': "10.0.1.0/24",
+        'ipipMode': 'Always',
+        'vxlanMode': 'Never',
+        'blockSize': 27,
+        'allowedUses': ["Workload", "Tunnel"],
+        'nodeSelector': "foo == 'bar'",
+        'disabled': True,
+    }
+}
+
+ippool_name1_rev1_split1_v4 = {
+    'apiVersion': API_VERSION,
+    'kind': 'IPPool',
+    'metadata': {
+        'name': 'split-ippool-name1-0'
+    },
+    'spec': {
+        'cidr': "10.0.1.0/26",
+        'ipipMode': 'Always',
+        'vxlanMode': 'Never',
+        'blockSize': 27,
+        'allowedUses': ["Workload", "Tunnel"],
+        'nodeSelector': "foo == 'bar'",
+    }
+}
+
+ippool_name1_rev1_split2_v4 = {
+    'apiVersion': API_VERSION,
+    'kind': 'IPPool',
+    'metadata': {
+        'name': 'split-ippool-name1-1'
+    },
+    'spec': {
+        'cidr': "10.0.1.64/26",
+        'ipipMode': 'Always',
+        'vxlanMode': 'Never',
+        'blockSize': 27,
+        'allowedUses': ["Workload", "Tunnel"],
+        'nodeSelector': "foo == 'bar'",
+    }
+}
+
+ippool_name1_rev1_split3_v4 = {
+    'apiVersion': API_VERSION,
+    'kind': 'IPPool',
+    'metadata': {
+        'name': 'split-ippool-name1-2'
+    },
+    'spec': {
+        'cidr': "10.0.1.128/26",
+        'ipipMode': 'Always',
+        'vxlanMode': 'Never',
+        'blockSize': 27,
+        'allowedUses': ["Workload", "Tunnel"],
+        'nodeSelector': "foo == 'bar'",
+    }
+}
+
+ippool_name1_rev1_split4_v4 = {
+    'apiVersion': API_VERSION,
+    'kind': 'IPPool',
+    'metadata': {
+        'name': 'split-ippool-name1-3'
+    },
+    'spec': {
+        'cidr': "10.0.1.192/26",
+        'ipipMode': 'Always',
+        'vxlanMode': 'Never',
+        'blockSize': 27,
+        'allowedUses': ["Workload", "Tunnel"],
+        'nodeSelector': "foo == 'bar'",
+    }
+}
+
 ippool_name2_rev1_v6 = {
     'apiVersion': API_VERSION,
     'kind': 'IPPool',

--- a/calicoctl/tests/st/utils/utils.py
+++ b/calicoctl/tests/st/utils/utils.py
@@ -51,6 +51,8 @@ KUBERNETES_NP = "kubernetes network policies must be managed through the kuberne
 NOT_LOCKED = "Datastore is not locked. Run the `calicoctl datastore migrate lock` command in order to begin migration."
 NOT_KUBERNETES = "Invalid datastore type: etcdv3 to import to for datastore migration. Datastore type must be kubernetes"
 NO_IPAM = "No IPAM resources specified in file"
+NOT_LOCKED_SPLIT = "Datastore is not locked. Run the `calicoctl datastore migrate lock` command in order split the IP pools."
+POOL_NOT_EXIST_CIDR = "Unable to find IP pool"
 
 class CalicoctlOutput:
     """

--- a/libcalico-go/lib/clientv3/ippool.go
+++ b/libcalico-go/lib/clientv3/ippool.go
@@ -40,6 +40,8 @@ type IPPoolInterface interface {
 	Get(ctx context.Context, name string, opts options.GetOptions) (*apiv3.IPPool, error)
 	List(ctx context.Context, opts options.ListOptions) (*apiv3.IPPoolList, error)
 	Watch(ctx context.Context, opts options.ListOptions) (watch.Interface, error)
+	UnsafeCreate(ctx context.Context, res *apiv3.IPPool, opts options.SetOptions) (*apiv3.IPPool, error)
+	UnsafeDelete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.IPPool, error)
 }
 
 // ipPools implements IPPoolInterface
@@ -57,7 +59,7 @@ func (r ipPools) Create(ctx context.Context, res *apiv3.IPPool, opts options.Set
 		res = &resCopy
 	}
 	// Validate the IPPool before creating the resource.
-	if err := r.validateAndSetDefaults(ctx, res, nil); err != nil {
+	if err := r.validateAndSetDefaults(ctx, res, nil, false); err != nil {
 		return nil, err
 	}
 
@@ -129,7 +131,7 @@ func (r ipPools) Update(ctx context.Context, res *apiv3.IPPool, opts options.Set
 	}
 
 	// Validate the IPPool updating the resource.
-	if err := r.validateAndSetDefaults(ctx, res, old); err != nil {
+	if err := r.validateAndSetDefaults(ctx, res, old, false); err != nil {
 		return nil, err
 	}
 
@@ -282,7 +284,7 @@ func (r ipPools) Watch(ctx context.Context, opts options.ListOptions) (watch.Int
 // validateAndSetDefaults validates IPPool fields and sets default values that are
 // not assigned.
 // The old pool will be unassigned for a Create.
-func (r ipPools) validateAndSetDefaults(ctx context.Context, new, old *apiv3.IPPool) error {
+func (r ipPools) validateAndSetDefaults(ctx context.Context, new, old *apiv3.IPPool, skipCIDROverlap bool) error {
 	errFields := []cerrors.ErroredField{}
 
 	// Spec.CIDR field must not be empty.
@@ -384,7 +386,7 @@ func (r ipPools) validateAndSetDefaults(ctx context.Context, new, old *apiv3.IPP
 
 	// If there was no previous pool then this must be a Create.  Check that the CIDR
 	// does not overlap with any other pool CIDRs.
-	if old == nil {
+	if old == nil && !skipCIDROverlap {
 		allPools, err := r.List(ctx, options.ListOptions{})
 		if err != nil {
 			return err
@@ -485,4 +487,74 @@ func (r ipPools) validateAndSetDefaults(ctx context.Context, new, old *apiv3.IPP
 	}
 
 	return nil
+}
+
+// UnsafeCreate takes the representation of an IPPool and creates it the same as Create.
+// It is unsafe because it will skip checks against overlapping blocks. This is only
+// used to create child pools during operations to split IP pools.
+func (r ipPools) UnsafeCreate(ctx context.Context, res *apiv3.IPPool, opts options.SetOptions) (*apiv3.IPPool, error) {
+	if res != nil {
+		// Since we're about to default some fields, take a (shallow) copy of the input data
+		// before we do so.
+		resCopy := *res
+		res = &resCopy
+	}
+	// Validate the IPPool before creating the resource.
+	if err := r.validateAndSetDefaults(ctx, res, nil, true); err != nil {
+		return nil, err
+	}
+
+	if err := validator.Validate(res); err != nil {
+		return nil, err
+	}
+
+	out, err := r.client.resources.Create(ctx, opts, apiv3.KindIPPool, res)
+	if out != nil {
+		return out.(*apiv3.IPPool), err
+	}
+	return nil, err
+}
+
+// UnsafeDelete deletes the IP pool similar to Delete except it does not delete the associated
+// block affinities. This should only be used to remove an old IP pool after the split IP pools
+// operations are complete.
+func (r ipPools) UnsafeDelete(ctx context.Context, name string, opts options.DeleteOptions) (*apiv3.IPPool, error) {
+	// Get the pool so that we can find the CIDR associated with it.
+	pool, err := r.Get(ctx, name, options.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	logCxt := log.WithFields(log.Fields{
+		"CIDR": pool.Spec.CIDR,
+		"Name": name,
+	})
+
+	// If the pool is active, set the disabled flag to ensure we stop allocating from this pool.
+	if !pool.Spec.Disabled {
+		logCxt.Debug("Disabling pool to release affinities")
+		pool.Spec.Disabled = true
+
+		// If the Delete has been called with a ResourceVersion then use that to perform the
+		// update - that way we'll catch update conflicts (we could actually check here, but
+		// the most likely scenario is there isn't one - so just pass it through and let the
+		// Update handle any conflicts).
+		if opts.ResourceVersion != "" {
+			pool.ResourceVersion = opts.ResourceVersion
+		}
+		if _, err := r.Update(ctx, pool, options.SetOptions{}); err != nil {
+			return nil, err
+		}
+
+		// Reset the resource version before the actual delete since the version of that resource
+		// will now have been updated.
+		opts.ResourceVersion = ""
+	}
+
+	// And finally, delete the pool.
+	out, err := r.client.resources.Delete(ctx, opts, apiv3.KindIPPool, noNamespace, name)
+	if out != nil {
+		return out.(*apiv3.IPPool), err
+	}
+	return nil, err
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add calicoctl command to split IP pools by CIDR.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add calicoctl command to split IP pools.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
