### PR TITLE
[release-v3.22] cherry-pick: Make sure cgroup2 fs default mount point exists on host

### DIFF
--- a/node/cmd/mountns/main.go
+++ b/node/cmd/mountns/main.go
@@ -64,10 +64,18 @@ func main() {
 	}
 	mountPoint := os.Args[1]
 	fmt.Println("Trying to mount root cgroup fs.")
-	err := syscall.Mount("none", mountPoint, "cgroup2", 0, "")
+
+	err := os.MkdirAll(mountPoint, 0700)
 	if err != nil {
-		fmt.Printf("Failed to mount Cgroup filesystem. err: %v\n", err)
+		fmt.Printf("Failed to prepare mount point: %v. err: %v.\n", mountPoint, err)
 		os.Exit(1)
 	}
-	fmt.Println("Successfully mounted root cgroup fs.")
+	fmt.Printf("Mount point %s is ready for mounting root cgroup2 fs.\n", mountPoint)
+
+	err = syscall.Mount("none", mountPoint, "cgroup2", 0, "")
+	if err != nil {
+		fmt.Printf("Failed to mount cgroup2 filesystem. err: %v.\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Successfully mounted root cgroup2 fs.")
 }

--- a/node/pkg/nodeinit/calico-init_linux.go
+++ b/node/pkg/nodeinit/calico-init_linux.go
@@ -124,8 +124,8 @@ func ensureCgroupV2Filesystem() error {
 
 	mountCmd := exec.Command("mountns", bpf.CgroupV2Path)
 	out, err := mountCmd.Output()
+	logrus.Debugf("Executed %v. err:%v out:\n%s", mountCmd, err, out)
 	if err != nil {
-		logrus.Errorf("Mouting cgroup2 fs failed. output: %v", out)
 		return fmt.Errorf("failed to mount cgroup2 filesystem: %w", err)
 	}
 


### PR DESCRIPTION
## Description
This is a back port of this PR: https://github.com/projectcalico/calico/pull/6305 to release v3.22

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
