### PR TITLE
bpf fix tunnels default drop

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1362,6 +1362,16 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 			})
 		}
 
+		// Accept any SEEN packets that go to the host. What remains here should be from
+		// host interfaces. This should accept packets in default-DROP iptable
+		// environments.  Such packets go through BPF on host iface but must go through
+		// the INPUT of iptables too. default-DROP would block IPIP/VXLAN/WG/etc. traffic
+		// without explicit ACCEPT.
+		inputRules = append(inputRules, iptables.Rule{
+			Match:  iptables.Match().MarkMatchesWithMask(tcdefs.MarkSeen, tcdefs.MarkSeenMask),
+			Action: iptables.AcceptAction{},
+		})
+
 		if t.IPVersion == 6 {
 			for _, prefix := range rulesConfig.WorkloadIfacePrefixes {
 				// In BPF mode, we don't support IPv6 yet.  Drop it.

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -445,14 +445,32 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 			Eventually(checkConn, "10s", "100ms").ShouldNot(HaveOccurred())
 		})
 
-		for _, ai := range []bool{true, false} {
-			allInterfaces := ai
-			desc := "wireguard traffic is allowed with a blocking host endpoint policy"
-			if ai {
-				desc += " (using * HostEndpoint)"
-			} else {
-				desc += " (using eth0 HostEndpoint)"
-			}
+		tests := []struct {
+			hep            string
+			iptablesPolicy string
+		}{
+			{
+				hep:            "*",
+				iptablesPolicy: "ACCEPT",
+			},
+			{
+				hep:            "*",
+				iptablesPolicy: "DROP",
+			},
+			{
+				hep:            "eth0",
+				iptablesPolicy: "ACCEPT",
+			},
+			{
+				hep:            "eth0",
+				iptablesPolicy: "DROP",
+			},
+		}
+
+		for _, xtc := range tests {
+			tc := xtc
+			desc := "wireguard traffic is allowed with a blocking host endpoint policy" +
+				" (using " + tc.hep + " HostEndpoint, " + tc.iptablesPolicy + ")"
 			It(desc, func() {
 				By("Creating policy to deny wireguard port on main felix host endpoint.")
 				policy := api.NewGlobalNetworkPolicy()
@@ -498,12 +516,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 					}
 					hep.Spec.Node = f.Hostname
 					hep.Spec.ExpectedIPs = []string{f.IP}
-					if allInterfaces {
-						hep.Spec.InterfaceName = "*"
-					} else {
-						hep.Spec.InterfaceName = "eth0"
-					}
+					hep.Spec.InterfaceName = tc.hep
 					_, err := client.HostEndpoints().Create(utils.Ctx, hep, options.SetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				By("Setting iptables INPUT chain policy to " + tc.iptablesPolicy)
+				for _, felix := range felixes {
+					_, err := felix.ExecOutput("iptables", "-w", "10", "-W", "100000", "-P", "INPUT", tc.iptablesPolicy)
 					Expect(err).NotTo(HaveOccurred())
 				}
 


### PR DESCRIPTION
## Description
    felix/bpf: explicitly ACCEPT in INPUT
    
    This avoids packets being dropped when the default policy is DROP

    felix/fv: test wg iptables -P INPUT DROP

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: explicitly ACCEPT approved traffic in INPUT to avoid drops in default-DROP environments.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
