### PR TITLE
[release-v3.22] Auto pick #6326: Include hostname configuration from UBI base image where

### DIFF
--- a/apiserver/docker-image/Dockerfile.amd64
+++ b/apiserver/docker-image/Dockerfile.amd64
@@ -16,6 +16,10 @@ COPY  --from=ubi /tmp /tmp
 COPY  --from=ubi /lib /lib
 COPY  --from=ubi /lib64 /lib64
 
+# Copy hostname configuration files from UBI so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 ADD  bin/apiserver-amd64 /code/apiserver
 ADD  bin/filecheck-amd64 /code/filecheck
 

--- a/app-policy/Dockerfile.amd64
+++ b/app-policy/Dockerfile.amd64
@@ -42,6 +42,10 @@ ADD bin/healthz-amd64 /healthz
 COPY --from=ubi /lib64 /lib64
 COPY --from=ubi /lib /lib
 
+# Copy hostname configuration files from UBI so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 # Typical Linux systems start numbering human users at 1000, reserving 1-999
 # for services, so we pick 999 to be least likely to overlap.  It's not a big
 # deal if we happen to overlap, as it would take a container escape for

--- a/calicoctl/Dockerfile.amd64
+++ b/calicoctl/Dockerfile.amd64
@@ -30,6 +30,10 @@ LABEL name="Calico CLI tool" \
       description="calicoctl(1) is a command line tool used to interface with the Calico datastore " \
       maintainer="maintainers@projectcalico.org"
 
+# Copy hostname configuration files from UBI so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 COPY --from=ubi /licenses /licenses
 ADD bin/calicoctl-linux-amd64 /calicoctl
 

--- a/cni-plugin/Dockerfile.amd64
+++ b/cni-plugin/Dockerfile.amd64
@@ -37,6 +37,10 @@ COPY --from=ubi /lib /lib
 
 ADD bin/amd64/ /opt/cni/bin/
 
+# Copy hostname configuration files from UBI so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 ENV PATH=$PATH:/opt/cni/bin
 WORKDIR /opt/cni/bin
 CMD ["/opt/cni/bin/install"]

--- a/kube-controllers/Dockerfile.amd64
+++ b/kube-controllers/Dockerfile.amd64
@@ -45,6 +45,10 @@ COPY --from=ubi /usr/include /usr/include
 COPY --from=ubi /lib64 /lib64
 COPY --from=ubi /lib /lib
 
+# Copy hostname configuration files from UBI so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ADD bin/check-status-linux-amd64 /usr/bin/check-status
 USER 999

--- a/kube-controllers/docker-images/flannel-migration/Dockerfile.amd64
+++ b/kube-controllers/docker-images/flannel-migration/Dockerfile.amd64
@@ -40,6 +40,10 @@ COPY --from=ubi /usr/include /usr/include
 COPY --from=ubi /lib64 /lib64
 COPY --from=ubi /lib /lib
 
+# Copy hostname configuration files from UBI so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 ADD bin/kubectl-amd64 /usr/bin/kubectl
 ADD bin/kube-controllers-linux-amd64 /usr/bin/kube-controllers
 ADD bin/check-status-linux-amd64 /usr/bin/check-status

--- a/pod2daemon/Dockerfile.amd64
+++ b/pod2daemon/Dockerfile.amd64
@@ -48,6 +48,10 @@ COPY --from=ubi /usr/lib64 /usr/lib64
 COPY --from=ubi /usr/bin /usr/bin
 COPY --from=ubi /usr/local/bin/flexvol.sh /usr/local/bin/flexvol.sh
 
+# Copy hostname configuration files from the UBI image so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 ADD bin/flexvol-amd64 /usr/local/bin/flexvol
 
 ENTRYPOINT ["/usr/local/bin/flexvol.sh"]

--- a/typha/docker-image/Dockerfile.amd64
+++ b/typha/docker-image/Dockerfile.amd64
@@ -44,6 +44,10 @@ COPY --from=ubi /usr/include /usr/include
 COPY --from=ubi /lib64 /lib64
 COPY --from=ubi /lib /lib
 
+# Copy hostname configuration files from the UBI image so glibc hostname lookups work.
+COPY --from=ubi /etc/host.conf /etc/host.conf
+COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.
 ADD bin/calico-typha-amd64 /code/calico-typha


### PR DESCRIPTION
Cherry pick of #6326 on release-v3.22.

#6326: Include hostname configuration from UBI base image where

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

When we switched to CGO / BoringSSL a few releases ago, we introduced an
issue where glibc hostname lookups were failing due to a few missing
configuration files in the container filesystem.

This PR adds those configuration files from the UBI base image so that
glibc can appropriately perform hostname lookups.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix lookups of locally defined hostnames from within Calico containers due to missing nsswitch.conf
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.