### PR TITLE
[release-v3.23] cherry-pick: Add /proc and /var/run/calico to mount-bpffs volumes

### DIFF
--- a/node/pkg/nodeinit/calico-init_linux.go
+++ b/node/pkg/nodeinit/calico-init_linux.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 	"syscall"
 
@@ -89,14 +88,12 @@ func ensureBPFFilesystem() error {
 // with PID 1 running on a host to allow felix running in calico-node to access the root of cgroup namespace.
 // This is needed by felix to attach CTLB programs and implement k8s services correctly.
 func ensureCgroupV2Filesystem() error {
-	cgroupRootPath := "/initproc"
-
 	// Check if the Cgroup2 filesystem is mounted at the expected location.
-	logrus.Info("Checking if Cgroup2 filesystem is mounted.")
-	mountInfoFile := path.Join(cgroupRootPath, "mountinfo")
+	logrus.Info("Checking if cgroup2 filesystem is mounted.")
+	mountInfoFile := "/nodeproc/1/mountinfo"
 	mounts, err := os.Open(mountInfoFile)
 	if err != nil {
-		return fmt.Errorf("failed to open %s: %w", mountInfoFile, err)
+		return fmt.Errorf("failed to open %s. err: %w", mountInfoFile, err)
 	}
 	scanner := bufio.NewScanner(mounts)
 	for scanner.Scan() {
@@ -121,6 +118,12 @@ func ensureCgroupV2Filesystem() error {
 
 	// If we get here, the Cgroup2 filesystem is not mounted.  Try to mount it.
 	logrus.Info("Cgroup2 filesystem is not mounted. Trying to mount it...")
+
+	err = os.MkdirAll(bpf.CgroupV2Path, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to prepare mount point: %v. err: %w.", bpf.CgroupV2Path, err)
+	}
+	logrus.Infof("Mount point %s is ready for mounting root cgroup2 fs.", bpf.CgroupV2Path)
 
 	mountCmd := exec.Command("mountns", bpf.CgroupV2Path)
 	out, err := mountCmd.Output()


### PR DESCRIPTION
## Description
Back port for PR: https://github.com/projectcalico/calico/pull/6316
Operator PR: https://github.com/tigera/operator/pull/2072

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
