### PR TITLE
Try to improve robustness of veth deletion.

### DIFF
--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -512,42 +512,63 @@ func writeProcSys(path, value string) error {
 
 func (d *linuxDataplane) CleanUpNamespace(args *skel.CmdArgs) error {
 	// Only try to delete the device if a namespace was passed in.
-	if args.Netns != "" {
-		d.logger.WithFields(logrus.Fields{
-			"netns": args.Netns,
-			"iface": args.IfName,
-		}).Debug("Checking namespace & device exist.")
-		devErr := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
-			_, err := netlink.LinkByName(args.IfName)
-			return err
-		})
+	logCtx := d.logger.WithFields(logrus.Fields{
+		"netns": args.Netns,
+		"iface": args.IfName,
+	})
+	if args.Netns == "" {
+		logCtx.Info("CleanUpNamespace called with no netns name, ignoring.")
+		return nil
+	}
 
-		if devErr == nil {
-			d.logger.Infof("Calico CNI deleting device in netns %s", args.Netns)
-			// Deleting the veth has been seen to hang on some kernel version. Timeout the command if it takes too long.
-			ch := make(chan error, 1)
+	logCtx.Info("Deleting workload's device in netns.")
 
-			go func() {
-				err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
-					return ip.DelLinkByName(args.IfName)
-				})
+	// We've seen veth deletion hang on some very old kernels so we do it from a background goroutine.
+	startTime := time.Now()
+	done := make(chan struct{})
 
-				ch <- err
-			}()
+	var nsErr, linkErr error
 
-			select {
-			case err := <-ch:
-				if err != nil {
-					return err
-				} else {
-					d.logger.Infof("Calico CNI deleted device in netns %s", args.Netns)
-				}
-			case <-time.After(5 * time.Second):
-				return fmt.Errorf("Calico CNI timed out deleting device in netns %s", args.Netns)
+	go func() {
+		defer close(done)
+		nsErr = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+			logCtx.Info("Entered netns, deleting veth.")
+			ifName := args.IfName
+			var iface netlink.Link
+			iface, linkErr = netlink.LinkByName(ifName)
+			if linkErr == nil {
+				linkErr = netlink.LinkDel(iface)
 			}
-		} else {
-			d.logger.WithField("ifName", args.IfName).Info("veth does not exist, no need to clean up.")
+
+			// Always return nil so that we can tell the difference between an error from WithNetNSPath itself
+			// and an error deleting the link.
+			return nil
+		})
+	}()
+
+	select {
+	case <-done:
+		if nsErr != nil {
+			if _, ok := nsErr.(ns.NSPathNotExistErr); ok {
+				logCtx.Info("Workload's netns already gone.  Nothing to do.")
+				return nil
+			}
+			logCtx.WithError(nsErr).Error("Failed to enter workloads netns.")
+			return fmt.Errorf("failed to enter netns: %w", nsErr)
 		}
+
+		if linkErr != nil {
+			if _, ok := linkErr.(netlink.LinkNotFoundError); ok {
+				logCtx.Info("Workload's veth was already gone.  Nothing to do.")
+				return nil
+			}
+			logCtx.WithError(linkErr).Error("Failed to clean up workload's veth.")
+			return fmt.Errorf("failed to clean up workload's veth inside netns: %w", linkErr)
+		}
+
+		logCtx.WithField("after", time.Since(startTime)).Infof("Deleted device in netns.")
+	case <-time.After(20 * time.Second):
+		return fmt.Errorf("timed out deleting device in netns %s", args.Netns)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
* 5s timeout has fired spuriously in some scale tests; increse
  to 20s.  I believe the buggy kernels that required the timeout
  due to a hang are few and far between so we're now seeing more
  false positives.

* Avoid dipping in and out of the namespace twice to reduce
  number of netlink operations.  Instead, check for the error
  when the netns doesn't exist.

* Generally beef up logging in that area and include duration.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Increase timeout when deleting workloads veth device in order to avoid false positives under heavy load.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
