### PR TITLE
Enhance XDP programs

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -25,13 +25,8 @@ struct bpf_map_def_extended {
 	__u32 value_size;
 	__u32 max_entries;
 	__u32 map_flags;
-#if defined(__BPFTOOL_LOADER__) || defined (__IPTOOL_LOADER__)
+#if defined(__BPFTOOL_LOADER__)
 	__u32 map_id;
-#endif
-#ifdef __IPTOOL_LOADER__
-	__u32 pinning_strategy;
-	__u32 unused1;
-	__u32 unused2;
 #endif
 };
 
@@ -245,7 +240,7 @@ static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)
 
 #define ip_ttl_exceeded(ip) (CALI_F_TO_HOST && !CALI_F_TUNNEL && (ip)->ttl <= 1)
 
-#if !defined(__BPFTOOL_LOADER__) && !defined (__IPTOOL_LOADER__)
+#if !defined(__BPFTOOL_LOADER__) && (!CALI_F_XDP)
 
 #if !CALI_F_CGROUP
 extern const volatile struct cali_tc_globals __globals;
@@ -322,7 +317,7 @@ static CALI_BPF_INLINE int name##_delete_elem(const void* key)	\
 	return bpf_map_delete_elem(&map_symbol(name, ver), key);	\
 }
 
-#if defined(__BPFTOOL_LOADER__) || defined (__IPTOOL_LOADER__)
+#if defined(__BPFTOOL_LOADER__)
 #define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags, pin)		\
 struct bpf_map_def_extended __attribute__((section("maps"))) map_symbol(name, ver) = {	\
 	.type = map_type,								\

--- a/felix/bpf-gpl/calculate-flags
+++ b/felix/bpf-gpl/calculate-flags
@@ -80,7 +80,7 @@ elif [[ "${filename}" =~ .*xdp.* ]]; then
   # XDP, so host endpoint.
   ((flags |= CALI_TC_HOST_EP))
   ((flags |= CALI_XDP_PROG))
-  args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO" "-D__IPTOOL_LOADER__")
+  args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="host"
 elif [[ "${filename}" =~ .*nat.* ]]; then
   ((flags |= CALI_TC_HOST_EP))

--- a/felix/bpf-gpl/connect_balancer.c
+++ b/felix/bpf-gpl/connect_balancer.c
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include <linux/bpf.h>
@@ -19,7 +19,7 @@
 
 #include "sendrecv.h"
 
-#if !defined(__BPFTOOL_LOADER__) && !defined (__IPTOOL_LOADER__)
+#if !defined(__BPFTOOL_LOADER__) && (!CALI_F_XDP)
 const volatile struct cali_ctlb_globals __globals;
 #define UDP_NOT_SEEN_TIMEO __globals.udp_not_seen_timeo
 #else

--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -24,10 +24,6 @@ struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump2 = {
 	.key_size = 4,
 	.value_size = 4,
 	.max_entries = 16,
-#if !defined(__BPFTOOL_LOADER__) && defined(__IPTOOL_LOADER__)
-	.map_id = 1,
-	.pinning_strategy = 1 /* object namespace */,
-#endif
 };
 
 #define CALI_JUMP_TO(ctx, index) bpf_tail_call(ctx, &map_symbol(cali_jump, 2), index)

--- a/felix/bpf-gpl/policy.h
+++ b/felix/bpf-gpl/policy.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #ifndef __CALI_POLICY_H__
@@ -44,9 +44,6 @@ struct bpf_map_def_extended __attribute__((section("maps"))) cali_v4_ip_sets = {
 	.value_size     = sizeof(__u32),
 	.max_entries    = 1024*1024,
 	.map_flags      = BPF_F_NO_PREALLOC,
-#if !defined(__BPFTOOL_LOADER__) && defined(__IPTOOL_LOADER__)
-	.pinning_strategy        = MAP_PIN_GLOBAL,
-#endif
 };
 
 #define RULE_START(id) \

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -42,7 +42,7 @@
 #include "metadata.h"
 #include "bpf_helpers.h"
 
-#if !defined(__BPFTOOL_LOADER__) && !defined (__IPTOOL_LOADER__)
+#if !defined(__BPFTOOL_LOADER__)
 const volatile struct cali_tc_globals __globals;
 #endif
 

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -19,7 +19,6 @@
 #include "skb.h"
 #include "routes.h"
 #include "reasons.h"
-#include "icmp.h"
 #include "parsing.h"
 #include "failsafe.h"
 #include "jump.h"
@@ -50,8 +49,9 @@ static CALI_BPF_INLINE int calico_xdp(struct xdp_md *xdp)
 		CALI_DEBUG("Counters map lookup failed: DROP\n");
 		// We don't want to drop packets just because counters initialization fails, but
 		// failing here normally should not happen.
-		return TC_ACT_SHOT;
+		return XDP_DROP;
 	}
+	COUNTER_INC(&ctx, COUNTER_TOTAL_PACKETS);
 
 	if (CALI_LOG_LEVEL >= CALI_LOG_LEVEL_INFO) {
 		ctx.state->prog_start_time = bpf_ktime_get_ns();
@@ -113,31 +113,82 @@ deny:
  * which ip will load for us when we're attaching a program to a xdp hook.
  * This allows us to control the behaviour in the window before Felix replaces
  * the policy program with its generated version.*/
-__attribute__((section("1/0")))
+SEC("xdp/policy")
 int calico_xdp_norm_pol_tail(struct xdp_md *xdp)
 {
 	CALI_DEBUG("Entering normal policy tail call: PASS\n");
 	return XDP_PASS;
 }
 
-__attribute__((section("1/1")))
+SEC("xdp/accept")
 int calico_xdp_accepted_entrypoint(struct xdp_md *xdp)
 {
 	CALI_DEBUG("Entering calico_xdp_accepted_entrypoint\n");
+	struct cali_tc_ctx ctx = {
+		.counters = counters_get(),
+		.fwd = {
+			.res = XDP_PASS,
+			.reason = CALI_REASON_UNKNOWN,
+		},
+	};
+
+	if (!ctx.counters) {
+		CALI_DEBUG("Counters map lookup failed: DROP\n");
+		return XDP_DROP;
+	}
+
 	// Share with TC the packet is already accepted and accept it there too.
 	if (xdp2tc_set_metadata(xdp, CALI_META_ACCEPTED_BY_XDP)) {
 		CALI_DEBUG("Failed to set metadata for TC\n");
 	}
+	COUNTER_INC(&ctx, CALI_REASON_ACCEPTED_BY_POLICY);
+
 	return XDP_PASS;
 }
 
+SEC("xdp/drop")
+int calico_xdp_drop(struct xdp_md *xdp)
+{
+	CALI_DEBUG("Entering calico_xdp_drop\n");
+	struct cali_tc_ctx ctx = {
+		.state = state_get(),
+		.counters = counters_get(),
+	};
+
+	if (!ctx.state) {
+		CALI_DEBUG("State map lookup failed: no event generated\n");
+		return XDP_DROP;
+	}
+
+	if (!ctx.counters) {
+		CALI_DEBUG("Counters map lookup failed: DROP\n");
+		return XDP_DROP;
+	}
+	COUNTER_INC(&ctx, CALI_REASON_DROPPED_BY_POLICY);
+
+	CALI_DEBUG("proto=%d\n", ctx.state->ip_proto);
+	CALI_DEBUG("src=%x dst=%x\n", bpf_ntohl(ctx.state->ip_src),
+			bpf_ntohl(ctx.state->ip_dst));
+	CALI_DEBUG("pre_nat=%x:%d\n", bpf_ntohl(ctx.state->pre_nat_ip_dst),
+			ctx.state->pre_nat_dport);
+	CALI_DEBUG("post_nat=%x:%d\n", bpf_ntohl(ctx.state->post_nat_ip_dst), ctx.state->post_nat_dport);
+	CALI_DEBUG("tun_ip=%x\n", ctx.state->tun_ip);
+	CALI_DEBUG("pol_rc=%d\n", ctx.state->pol_rc);
+	CALI_DEBUG("sport=%d\n", ctx.state->sport);
+	CALI_DEBUG("flags=0x%x\n", ctx.state->flags);
+	CALI_DEBUG("ct_rc=%d\n", ctx.state->ct_result.rc);
+
+	CALI_DEBUG("DENY due to policy");
+	return XDP_DROP;
+}
+
 #ifndef CALI_ENTRYPOINT_NAME_XDP
-#define CALI_ENTRYPOINT_NAME_XDP calico_entrypoint_xdp
+#define CALI_ENTRYPOINT_NAME_XDP calico_entrypoint
 #endif
 
 // Entrypoint with definable name.  It's useful to redefine the name for each entrypoint
 // because the name is exposed by bpftool et al.
-__attribute__((section(XSTR(CALI_ENTRYPOINT_NAME_XDP))))
+SEC("xdp/"XSTR(CALI_ENTRYPOINT_NAME_XDP))
 int xdp_calico_entry(struct xdp_md *xdp)
 {
 	return calico_xdp(xdp);

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -138,12 +138,64 @@ func (o *Obj) AttachClassifier(secName, ifName, hook string) (int, error) {
 
 	opts, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.int(isIngress))
 	if err != nil {
-		return -1, fmt.Errorf("Error attaching tc program %w", err)
+		return -1, fmt.Errorf("error attaching tc program %w", err)
 	}
 
 	progId, err := C.bpf_tc_query_iface(C.int(ifIndex), opts, C.int(isIngress))
 	if err != nil {
-		return -1, fmt.Errorf("Error querying interface %s: %w", ifName, err)
+		return -1, fmt.Errorf("error querying interface %s: %w", ifName, err)
+	}
+	return int(progId), nil
+}
+
+func (o *Obj) AttachXDP(ifName, progName string, oldID int, mode uint) (int, error) {
+	cProgName := C.CString(progName)
+	cIfName := C.CString(ifName)
+	defer C.free(unsafe.Pointer(cProgName))
+	defer C.free(unsafe.Pointer(cIfName))
+	ifIndex, err := C.if_nametoindex(cIfName)
+	if err != nil {
+		return -1, err
+	}
+
+	_, err = C.bpf_program_attach_xdp(o.obj, cProgName, C.int(ifIndex), C.int(oldID), C.uint(mode))
+	if err != nil {
+		return -1, fmt.Errorf("error attaching xdp program: %w", err)
+	}
+
+	progId, err := C.bpf_xdp_program_id(C.int(ifIndex))
+	if err != nil {
+		return -1, fmt.Errorf("error querying xdp information. interface %s: %w", ifName, err)
+	}
+	return int(progId), nil
+}
+
+func DetachXDP(ifName string, mode uint) error {
+	cIfName := C.CString(ifName)
+	defer C.free(unsafe.Pointer(cIfName))
+	ifIndex, err := C.if_nametoindex(cIfName)
+	if err != nil {
+		return err
+	}
+
+	_, err = C.bpf_set_link_xdp_fd(C.int(ifIndex), -1, C.uint(mode))
+	if err != nil {
+		return fmt.Errorf("failed to detach xdp program. interface %s: %w", ifName, err)
+	}
+
+	return nil
+}
+
+func GetXDPProgramID(ifName string) (int, error) {
+	cIfName := C.CString(ifName)
+	defer C.free(unsafe.Pointer(cIfName))
+	ifIndex, err := C.if_nametoindex(cIfName)
+	if err != nil {
+		return -1, err
+	}
+	progId, err := C.bpf_xdp_program_id(C.int(ifIndex))
+	if err != nil {
+		return -1, fmt.Errorf("error querying xdp information. interface %s: %w", ifName, err)
 	}
 	return int(progId), nil
 }
@@ -197,7 +249,7 @@ func (o *Obj) UpdateJumpMap(mapName, progName string, mapIndex int) error {
 	cProgName := C.CString(progName)
 	defer C.free(unsafe.Pointer(cMapName))
 	defer C.free(unsafe.Pointer(cProgName))
-	_, err := C.bpf_tc_update_jump_map(o.obj, cMapName, cProgName, C.int(mapIndex))
+	_, err := C.bpf_update_jump_map(o.obj, cMapName, cProgName, C.int(mapIndex))
 	if err != nil {
 		return fmt.Errorf("Error updating %s at index %d: %w", mapName, mapIndex, err)
 	}

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -39,7 +39,7 @@ void bpf_obj_load(struct bpf_object *obj) {
 	set_errno(bpf_object__load(obj));
 }
 
-struct bpf_tc_opts bpf_tc_program_attach (struct bpf_object *obj, char *secName, int ifIndex, int isIngress) {
+struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, int isIngress) {
 
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook, .attach_point = BPF_TC_EGRESS);
 	DECLARE_LIBBPF_OPTS(bpf_tc_opts, attach);
@@ -83,7 +83,7 @@ void bpf_tc_remove_qdisc (int ifIndex) {
         return;
 }
 
-int bpf_tc_update_jump_map(struct bpf_object *obj, char* mapName, char *progName, int progIndex) {
+int bpf_update_jump_map(struct bpf_object *obj, char* mapName, char *progName, int progIndex) {
 	struct bpf_program *prog_name = bpf_object__find_program_by_name(obj, progName);
 	if (prog_name == NULL) {
 		errno = ENOENT;
@@ -132,6 +132,43 @@ void bpf_tc_set_globals(struct bpf_map *map,
 	};
 
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
+}
+
+int bpf_xdp_program_id(int ifIndex) {
+	__u32 prog_id = 0, flags = 0;
+	int err;
+
+	err = bpf_get_link_xdp_id(ifIndex, &prog_id, flags);
+	set_errno(err);
+	return prog_id;
+}
+
+int bpf_program_attach_xdp(struct bpf_object *obj, char *name, int ifIndex, int old_id, __u32 flags)
+{
+	int err = 0;
+	struct bpf_link *link = NULL;
+	struct bpf_program *prog, *first_prog = NULL;
+	DECLARE_LIBBPF_OPTS(bpf_xdp_set_link_opts, opts,
+		.old_fd = bpf_prog_get_fd_by_id(old_id));
+
+	if (!(prog = bpf_object__find_program_by_name(obj, name))) {
+		err = ENOENT;
+		goto out;
+	}
+
+	int prog_fd = bpf_program__fd(prog);
+	if (prog_fd < 0) {
+		errno = -prog_fd;
+		return prog_fd;
+	}
+
+	err = bpf_set_link_xdp_fd_opts(ifIndex, prog_fd, flags, &opts);
+	set_errno(err);
+	return err;
+
+out:
+	set_errno(err);
+	return err;
 }
 
 struct bpf_link *bpf_program_attach_cgroup(struct bpf_object *obj, int cgroup_fd, char *name)

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -62,6 +62,18 @@ func (o *Obj) AttachClassifier(secName, ifName, hook string) (int, error) {
 	panic("LIBBPF syscall stub")
 }
 
+func (o *Obj) AttachXDP(ifName, progName string, oldFD int, mode uint) (int, error) {
+	panic("LIBBPF syscall stub")
+}
+
+func DetachXDP(ifName string, mode uint) error {
+	panic("LIBBPF syscall stub")
+}
+
+func GetXDPProgramID(ifName string) (int, error) {
+	panic("LIBBPF syscall stub")
+}
+
 func (o *Obj) AttachCGroup(_, _ string) (*Link, error) {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -305,18 +305,17 @@ func (p *Builder) writeProgramFooter(forXDP bool) {
 	p.b.MovImm32(R1, int32(state.PolicyDeny))
 	p.b.Store32(R9, R1, stateOffPolResult)
 
+	// Execute the tail call to drop program
+	p.b.Mov64(R1, R6)                      // First arg is the context.
+	p.b.LoadMapFD(R2, uint32(p.jumpMapFD)) // Second arg is the map.
+	p.b.MovImm32(R3, jumpIdxDrop)          // Third arg is the index (rather than a pointer to the index).
+	p.b.Call(HelperTailCall)
+
+	// Fall through if tail call fails.
+	p.b.LabelNextInsn("exit")
 	if forXDP {
-		p.b.LabelNextInsn("exit")
 		p.b.MovImm64(R0, 1 /* XDP_DROP */)
 	} else {
-		// Execute the tail call to drop program
-		p.b.Mov64(R1, R6)                      // First arg is the context.
-		p.b.LoadMapFD(R2, uint32(p.jumpMapFD)) // Second arg is the map.
-		p.b.MovImm32(R3, jumpIdxDrop)          // Third arg is the index (rather than a pointer to the index).
-		p.b.Call(HelperTailCall)
-
-		// Fall through if tail call fails.
-		p.b.LabelNextInsn("exit")
 		p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
 	}
 	p.b.Exit()
@@ -341,7 +340,11 @@ func (p *Builder) writeProgramFooter(forXDP bool) {
 		// Fall through if tail call fails.
 		p.b.MovImm32(R1, state.PolicyTailCallFailed)
 		p.b.Store32(R9, R1, stateOffPolResult)
-		p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
+		if forXDP {
+			p.b.MovImm64(R0, 1 /* XDP_DROP */)
+		} else {
+			p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
+		}
 		p.b.Exit()
 	}
 }

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -70,7 +70,7 @@ func TestReattachPrograms(t *testing.T) {
 	vethName3, veth3 := createVeth()
 	defer deleteLink(veth3)
 	ap3.Iface = vethName3
-	log.Debugf("Testing %v in %v", ap3.SectionName(), ap3.FileName())
+	log.Debugf("Testing %v in %v", ap3.ProgramName(), ap3.FileName())
 
 	// Start with a clean base state in case another test left something behind.
 	t.Log("Doing initial clean up")

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -511,7 +511,7 @@ func bpftoolProgLoadAll(fname, bpfFsDir string, forXDP bool, polProg bool, maps 
 	}
 
 	if polProg {
-		polProgPath := "1_0"
+		polProgPath := "xdp_policy"
 		if !forXDP {
 			polProgPath = "classifier_tc_policy"
 		}
@@ -543,7 +543,7 @@ func bpftoolProgLoadAll(fname, bpfFsDir string, forXDP bool, polProg bool, maps 
 			log.WithError(err).Info("failed to update jump map (deleting policy_v6 program)")
 		}
 	}
-	polProgPath := "1_1"
+	polProgPath := "xdp_accept"
 	if !forXDP {
 		polProgPath = "classifier_tc_accept"
 	}
@@ -552,14 +552,19 @@ func bpftoolProgLoadAll(fname, bpfFsDir string, forXDP bool, polProg bool, maps 
 		return errors.Wrap(err, "failed to update jump map (allowed program)")
 	}
 
+	dropProgPath := "xdp_drop"
+	if !forXDP {
+		dropProgPath = "classifier_tc_drop"
+	}
+	_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "3", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, dropProgPath))
+	if err != nil {
+		return errors.Wrap(err, "failed to update jump map (drop program)")
+	}
+
 	if !forXDP {
 		_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "2", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "classifier_tc_icmp"))
 		if err != nil {
 			return errors.Wrap(err, "failed to update jump map (icmp program)")
-		}
-		_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "3", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "classifier_tc_drop"))
-		if err != nil {
-			return errors.Wrap(err, "failed to update jump map (drop program)")
 		}
 		_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "4", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "classifier_tc_prologue_v6"))
 		if err != nil {

--- a/felix/bpf/ut/xdp_test.go
+++ b/felix/bpf/ut/xdp_test.go
@@ -249,7 +249,7 @@ func TestXDPPrograms(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, tc := range xdpTestCases {
-		runBpfTest(t, "calico_entrypoint_xdp", tc.Rules, func(bpfrun bpfProgRunFn) {
+		runBpfTest(t, "xdp_calico_entrypoint", tc.Rules, func(bpfrun bpfProgRunFn) {
 			_, _, _, _, pktBytes, err := testPacket(nil, tc.IPv4Header, tc.NextHeader, nil)
 			Expect(err).NotTo(HaveOccurred())
 			res, err := bpfrun(pktBytes)

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,20 +15,29 @@
 package xdp
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
-	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/libbpf"
 )
+
+type ProgName string
+
+var programNames = []ProgName{
+	"calico_xdp_norm_pol_tail",
+	"calico_xdp_accepted_entrypoint",
+	"", // This is a placeholder for icmp program, and only defined to align indexes with TC
+	"calico_xdp_drop",
+}
+
+const DetachedID = 0
 
 type AttachPoint struct {
 	Iface    string
@@ -60,8 +69,8 @@ func (ap AttachPoint) FileName() string {
 	return "xdp_" + logLevel + ".o"
 }
 
-func (ap AttachPoint) SectionName() string {
-	return "calico_entrypoint_xdp"
+func (ap AttachPoint) ProgramName() string {
+	return "xdp_calico_entry"
 }
 
 func (ap *AttachPoint) Log() *log.Entry {
@@ -98,10 +107,6 @@ func (ap *AttachPoint) AlreadyAttached(object string) (int, bool) {
 }
 
 func (ap *AttachPoint) AttachProgram() (int, error) {
-	preCompiledBinary := path.Join(bpf.ObjectDir, ap.FileName())
-	sectionName := ap.SectionName()
-
-	// Patch the binary so that its log prefix is like "eth0------X".
 	tempDir, err := ioutil.TempDir("", "calico-xdp")
 	if err != nil {
 		return -1, fmt.Errorf("failed to create temporary directory: %w", err)
@@ -109,82 +114,75 @@ func (ap *AttachPoint) AttachProgram() (int, error) {
 	defer func() {
 		_ = os.RemoveAll(tempDir)
 	}()
-	tempBinary := path.Join(tempDir, ap.FileName())
+
+	filename := ap.FileName()
+	preCompiledBinary := path.Join(bpf.ObjectDir, filename)
+	tempBinary := path.Join(tempDir, filename)
+
+	// Patch the binary so that its log prefix is like "eth0------X".
 	err = ap.patchBinary(preCompiledBinary, tempBinary)
 	if err != nil {
 		ap.Log().WithError(err).Error("Failed to patch binary")
 		return -1, err
 	}
 
+	obj, err := libbpf.OpenObject(tempBinary)
+	if err != nil {
+		return -1, err
+	}
+	defer obj.Close()
+
+	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
+		// TODO: We need to set map size here like tc.
+		pinPath := bpf.MapPinPath(m.Type(), m.Name(), ap.Iface, bpf.HookXDP)
+		if err := m.SetPinPath(pinPath); err != nil {
+			return -1, fmt.Errorf("error pinning map %s: %w", m.Name(), err)
+		}
+	}
+
 	// Check if the bpf object is already attached, and we should skip re-attaching it
 	progID, isAttached := ap.AlreadyAttached(preCompiledBinary)
 	if isAttached {
-		ap.Log().Infof("Programs already attached, skip reattaching %s", ap.FileName())
+		ap.Log().Infof("Programs already attached, skip reattaching %s", filename)
 		return progID, nil
 	}
-	ap.Log().Infof("Continue with attaching BPF program %s", ap.FileName())
+	ap.Log().Infof("Continue with attaching BPF program %s", filename)
 
-	// Note that there are a few considerations here.
-	//
-	// Firstly, we use -force when attaching, so as to minimise any flap in the XDP program when
-	// restarting or upgrading Felix.
-	//
-	// Secondly, we need to consider any other XDP programs that might be there at start of day.
-	// (Either 3rd party, or maybe some earlier version of Felix.)  We fundamentally have to
-	// clean those up, as our XDP usage cannot coexist with anyone else's.
-	//
-	// Thirdly, for a given host interface, is it possible for our best attachment mode to
-	// change, other than at start of day?  In principle it's possible if we do a patch that
-	// alters some conditionally included code.  We don't have that for XDP right now, but we
-	// conceivably could in future.  So safest to assume it's possible for the attachment mode
-	// to improve, which means needing to do `off` for subsequent modes.
-	//
-	// Hence this logic:
-	// - Loop through the modes.
-	//   - If we haven't yet successfully attached (for this loop), do the attachment (with
-	//     -force).
-	//   - If that failed, or we attached with an earlier mode, do `off` to remove any existing
-	//     program with this mode.
-	//   - Continue through remaining modes even if attachment already successful.
-	var errs []error
+	if err := obj.Load(); err != nil {
+		ap.Log().Warn("Failed to load program")
+		return -1, fmt.Errorf("error loading program: %w", err)
+	}
+
+	// TODO: Add support for IPv6
+	err = updateJumpMap(obj)
+	if err != nil {
+		ap.Log().Warn("Failed to update jump map")
+		return -1, fmt.Errorf("error updating jump map %v", err)
+	}
+
+	oldID, err := ap.ProgramID()
+	if err != nil {
+		return -1, fmt.Errorf("failed to get the attached XDP program ID: %w", err)
+	}
+
 	attachmentSucceeded := false
 	for _, mode := range ap.Modes {
-		ap.Log().Debugf("XDP remove/attach with mode %v", mode)
-
-		// We will need to do "ip link set dev <dev> xdp off" if we've successfully attached
-		// with an earlier mode, or if we fail to attach with this mode.  So we only _don't_
-		// need "off" if we successfully attach in this iteration.
-		offNeeded := true
-
-		if !attachmentSucceeded {
-			// Try to attach our XDP program in this mode.
-			cmd := exec.Command("ip", "-force", "link", "set", "dev", ap.Iface, mode.String(), "object", tempBinary, "section", sectionName)
-			ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
-			out, err := cmd.CombinedOutput()
-			ap.Log().WithField("mode", mode).Debugf("Result: err=%v out=\n%v", err, string(out))
-			if err == nil {
-				ap.Log().Infof("Successful XDP attachment with mode %v", mode)
-				attachmentSucceeded = true
-				offNeeded = false
-			} else {
-				errs = append(errs, err)
-			}
-		}
-
-		if offNeeded {
-			// Remove any existing program for this mode.
-			cmd := exec.Command("ip", "link", "set", "dev", ap.Iface, mode.String(), "off")
-			ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
-			out, err := cmd.CombinedOutput()
-			ap.Log().WithField("mode", mode).Debugf("Result: err=%v out=\n%v", err, string(out))
+		ap.Log().Debugf("Trying to attach XDP program in mode %v - old id: %v", mode, oldID)
+		// Force attach the program. If there is already a program attached, the replacement only
+		// succeed in the same mode of the current program.
+		progID, err = obj.AttachXDP(ap.Iface, ap.ProgramName(), oldID, unix.XDP_FLAGS_REPLACE|uint(mode))
+		if err != nil || progID == DetachedID || progID == oldID {
+			ap.Log().WithError(err).Warnf("Failed to attach to XDP program %s mode %v", ap.ProgramName(), mode)
+		} else {
+			ap.Log().Debugf("Successfully attached XDP program in mode %v. ID: %v", mode, progID)
+			attachmentSucceeded = true
+			break
 		}
 	}
+
 	if !attachmentSucceeded {
-		return -1, fmt.Errorf("Couldn't attach XDP program %v section %v to iface %v; modes=%v errs=%v", tempBinary, sectionName, ap.Iface, ap.Modes, errs)
-	}
-	progID, err = ap.ProgramID()
-	if err != nil {
-		return -1, fmt.Errorf("couldn't get the attached XDP program ID err=%v", err)
+		return -1, fmt.Errorf("failed to attach XDP program with program name %v to interface %v",
+			ap.ProgramName(), ap.Iface)
 	}
 
 	// program is now attached. Now we should store its information to prevent unnecessary reloads in future
@@ -199,69 +197,47 @@ func (ap AttachPoint) DetachProgram() error {
 	// Get the current XDP program ID, if any.
 	progID, err := ap.ProgramID()
 	if err != nil {
-		if errors.Is(err, ErrNoXDP) {
-			// Interface has no XDP attached - that's what we want.
-			return nil
-		}
-		// Some other error: return it to trigger a retry.
-		return fmt.Errorf("Couldn't get XDP program ID for %v: %w", ap.Iface, err)
+		return fmt.Errorf("failed to get the attached XDP program ID: %w", err)
 	}
-
-	// Get the map IDs that the program is using.
-	out, err := exec.Command("bpftool", "prog", "show", "id", strconv.Itoa(progID), "-j").CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("Couldn't query XDP prog id=%v iface=%v out=\n%v err=%w", progID, ap.Iface, string(out), err)
-	}
-	var progJSON struct {
-		Maps []int `json:"map_ids"`
-	}
-	err = json.Unmarshal(out, &progJSON)
-	if err != nil {
-		ap.Log().WithError(err).Debugf("Failed to parse bpftool output out=\n%v.  Assume not our XDP program.", string(out))
+	if progID == DetachedID {
+		ap.Log().Debugf("No XDP program attached.")
 		return nil
 	}
 
-	ourProgram := false
-	for _, mapID := range progJSON.Maps {
-		// Check if this map is one of ours.
-		ap.Log().Debugf("Check if map id %v is one of ours", mapID)
-		out, err = exec.Command("bpftool", "map", "show", "id", fmt.Sprintf("%v", mapID), "-j").CombinedOutput()
+	ourProg, err := bpf.AlreadyAttachedProg(ap, path.Join(bpf.ObjectDir, ap.FileName()), progID)
+	if err != nil || !ourProg {
+		return fmt.Errorf("XDP expected program ID does match with current one: %w", err)
+	}
+
+	// Try to remove our XDP program in all modes, until the program ID is 0
+	removalSucceeded := false
+	for _, mode := range ap.Modes {
+		err = libbpf.DetachXDP(ap.Iface, uint(mode))
+		ap.Log().Debugf("Trying to detach XDP program in mode %v.", mode)
 		if err != nil {
-			return fmt.Errorf("Couldn't query map id=%v iface=%v out=\n%v err=%w", progID, ap.Iface, string(out), err)
+			ap.Log().Debugf("Failed to detach XDP program in mode %v: %v.", mode, err)
+			continue
 		}
-		var mapJSON struct {
-			Name string `json:"name"`
-		}
-		err = json.Unmarshal(out, &mapJSON)
+		curProgId, err := ap.ProgramID()
 		if err != nil {
-			ap.Log().WithError(err).Debugf("Failed to parse bpftool output out=\n%v.  Assume not our map.", string(out))
-		} else if strings.HasPrefix(mapJSON.Name, "cali_") {
-			ourProgram = true
+			return fmt.Errorf("failed to get the attached XDP program ID: %w", err)
+		}
+
+		if curProgId == DetachedID {
+			removalSucceeded = true
+			ap.Log().Debugf("Successfully detached XDP program.")
 			break
 		}
 	}
-
-	if ourProgram {
-		// It's our XDP program; remove it.
-		ap.Log().Debug("Removing our XDP program")
-		removalSucceeded := false
-		for _, mode := range ap.Modes {
-			cmd := exec.Command("ip", "link", "set", "dev", ap.Iface, mode.String(), "off")
-			ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
-			out, err := cmd.CombinedOutput()
-			ap.Log().WithField("mode", mode).Debugf("Result: err=%v out=\n%v", err, string(out))
-			if err == nil {
-				removalSucceeded = true
-			}
-		}
-		if !removalSucceeded {
-			return fmt.Errorf("Couldn't remove our XDP program from iface %v", ap.Iface)
-		}
+	if !removalSucceeded {
+		return fmt.Errorf("couldn't remove our XDP program. program ID: %v", progID)
 	}
+
+	ap.Log().Infof("XDP program detached. program ID: %v", progID)
 
 	// Program is detached, now remove the json file we saved for it
 	if err = bpf.ForgetAttachedProg(ap.IfaceName(), "xdp"); err != nil {
-		return fmt.Errorf("Failed to delete hash of BPF program from disk. err=%w", err)
+		return fmt.Errorf("failed to delete hash of BPF program from disk: %w", err)
 	}
 	return nil
 }
@@ -287,32 +263,36 @@ func (ap *AttachPoint) IsAttached() (bool, error) {
 	return err == nil, err
 }
 
-var ErrNoXDP = errors.New("no XDP program attached")
-
-// TODO: we should try to not get the program ID via 'ip' binary and rather
-// we should use libbpf to obtain it.
 func (ap *AttachPoint) ProgramID() (int, error) {
-	cmd := exec.Command("ip", "link", "show", "dev", ap.Iface)
-	ap.Log().Debugf("Running: %v %v", cmd.Path, cmd.Args)
-	out, err := cmd.CombinedOutput()
-	ap.Log().Debugf("Result: err=%v out=\n%v", err, string(out))
+	progID, err := libbpf.GetXDPProgramID(ap.Iface)
 	if err != nil {
 		return -1, fmt.Errorf("Couldn't check for XDP program on iface %v: %w", ap.Iface, err)
 	}
-	s := strings.Fields(string(out))
-	for i := range s {
-		// Example of output:
-		//
-		// 196: test_A@test_B: <BROADCAST,MULTICAST> mtu 1500 xdpgeneric qdisc noop state DOWN mode DEFAULT group default qlen 1000
-		//    link/ether 1a:d0:df:a5:12:59 brd ff:ff:ff:ff:ff:ff
-		//    prog/xdp id 175 tag 5199fa060702bbff jited
-		if s[i] == "prog/xdp" && len(s) > i+2 && s[i+1] == "id" {
-			progID, err := strconv.Atoi(s[i+2])
-			if err != nil {
-				return -1, fmt.Errorf("Couldn't parse ID following 'prog/xdp' err=%w out=\n%v", err, string(out))
-			}
-			return progID, nil
+	return progID, nil
+}
+
+func updateJumpMap(obj *libbpf.Obj) error {
+	ipVersions := []string{"IPv4"}
+
+	for _, ipFamily := range ipVersions {
+		pIndex := 0
+		err := obj.UpdateJumpMap(bpf.JumpMapName(), string(programNames[pIndex]), pIndex)
+		if err != nil {
+			return fmt.Errorf("error updating %v policy program: %v", ipFamily, err)
+		}
+
+		eIndex := 1
+		err = obj.UpdateJumpMap(bpf.JumpMapName(), string(programNames[eIndex]), eIndex)
+		if err != nil {
+			return fmt.Errorf("error updating %v epilogue program: %v", ipFamily, err)
+		}
+
+		dIndex := 3
+		err = obj.UpdateJumpMap(bpf.JumpMapName(), string(programNames[dIndex]), dIndex)
+		if err != nil {
+			return fmt.Errorf("error updating %v drop program: %v", ipFamily, err)
 		}
 	}
-	return -1, fmt.Errorf("Couldn't find 'prog/xdp id <ID>' out=\n%v err=%w", string(out), ErrNoXDP)
+
+	return nil
 }


### PR DESCRIPTION
## Description
This PR includes 3 main changes:
- Load XDP programs using `libbpf` instead of using `ip`
- Add drop program to XDP objects
- Add bpf counters to XDP programs

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF: Add BPF counters to XDP programs, and also load XDP programs using Libbpf instead of iproute2.
```
## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
