### PR TITLE
Add missing DNS libraries to typha image

### DIFF
--- a/typha/docker-image/Dockerfile.amd64
+++ b/typha/docker-image/Dockerfile.amd64
@@ -46,6 +46,8 @@ COPY --from=ubi /usr/include /usr/include
 COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
 COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
 COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=ubi /lib64/libnss_dns.so.2 /lib64/libnss_dns.so.2
+COPY --from=ubi /lib64/libresolv.so.2 /lib64/libresolv.so.2
 
 # Copy hostname configuration files from the UBI image so glibc hostname lookups work.
 COPY --from=ubi /etc/host.conf /etc/host.conf


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Looks like these libraries were missed in commit d95bd0b71b9998d3f34fb038b66979ed0d94eb96

Not sure the exact mechanism (they don't show up in the ldd output for
typha) but was seeing problems with the image as-is, that manifested
like so:

```
2022-07-12 22:11:45.843 [ERROR][7] health.go 296: Health endpoint failed, trying to restart it... error=listen tcp: lookup localhost: device or resource busy
```

Was given a clue by this post: https://stackoverflow.com/questions/64823495/device-or-resource-busy-in-container-from-scratch-and-alpine-but-not-on-ubuntu

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.