### PR TITLE
felix/netlinkshim: separate MockNetlinkDataplane and MockWireguard

### DIFF
--- a/felix/netlinkshim/mocknetlink/wireguard.go
+++ b/felix/netlinkshim/mocknetlink/wireguard.go
@@ -70,12 +70,17 @@ func (d *MockNetlinkDataplane) NewMockWireguard() (netlinkshim.Wireguard, error)
 	}
 	Expect(d.WireguardOpen).To(BeFalse())
 	d.WireguardOpen = true
-	return d, nil
+
+	return &MockWireguard{d}, nil
 }
 
 // ----- Wireguard API -----
 
-func (d *MockNetlinkDataplane) Close() error {
+type MockWireguard struct {
+	*MockNetlinkDataplane
+}
+
+func (d *MockWireguard) Close() error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	defer GinkgoRecover()
@@ -89,7 +94,7 @@ func (d *MockNetlinkDataplane) Close() error {
 	return nil
 }
 
-func (d *MockNetlinkDataplane) DeviceByName(name string) (*wgtypes.Device, error) {
+func (d *MockWireguard) DeviceByName(name string) (*wgtypes.Device, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	defer GinkgoRecover()
@@ -121,7 +126,7 @@ func (d *MockNetlinkDataplane) DeviceByName(name string) (*wgtypes.Device, error
 	return device, nil
 }
 
-func (d *MockNetlinkDataplane) Devices() ([]*wgtypes.Device, error) {
+func (d *MockWireguard) Devices() ([]*wgtypes.Device, error) {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	defer GinkgoRecover()
@@ -148,7 +153,7 @@ func (d *MockNetlinkDataplane) Devices() ([]*wgtypes.Device, error) {
 	return links, nil
 }
 
-func (d *MockNetlinkDataplane) ConfigureDevice(name string, cfg wgtypes.Config) error {
+func (d *MockWireguard) ConfigureDevice(name string, cfg wgtypes.Config) error {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	defer GinkgoRecover()


### PR DESCRIPTION
We need different Close() methods at the least. dp needs to do some
accounting in MockNetlinkDataplane for wg, but wg should be its own
struct.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
