### PR TITLE
felix/bpf: service routes maintenance fixed

### DIFF
--- a/felix/cachingmap/caching_map.go
+++ b/felix/cachingmap/caching_map.go
@@ -24,7 +24,6 @@ import (
 // CachingMap. It implements interaction with the dataplane.
 type DataplaneMap[K comparable, V comparable] interface {
 	Update(K, V) error
-	Get(K) (V, error)
 	Delete(K) error
 	Load() (map[K]V, error)
 	ErrIsNotExists(error) bool

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -669,10 +669,6 @@ func (m *bpfEndpointManager) markExistingWEPDirty(wlID proto.WorkloadEndpointID,
 }
 
 func (m *bpfEndpointManager) CompleteDeferredWork() error {
-	start := time.Now()
-	defer func() {
-		log.Infof("CompleteDeferredWork took %v", time.Since(start))
-	}()
 	// Do one-off initialisation.
 	m.dp.ensureStarted()
 
@@ -1956,7 +1952,7 @@ func (m *bpfEndpointManager) onServiceUpdate(update *proto.ServiceUpdate) {
 
 	ips4 := make([]ip.V4CIDR, 0, len(ips))
 	for _, i := range ips {
-		cidr, err := ip.CIDRFromString(i + "/32")
+		cidr, err := ip.ParseCIDROrIP(i)
 		if err != nil {
 			log.WithFields(log.Fields{"service": key, "ip": i}).Warn("Not a valid CIDR.")
 		} else if cidrv4, ok := cidr.(ip.V4CIDR); !ok {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1585,15 +1585,9 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 		return nil
 	}
 
-	nl, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
-	if err != nil {
-		return fmt.Errorf("failed to create nelink: %w", err)
-	}
-	defer nl.Close()
-
 	var bpfout, bpfin netlink.Link
 
-	bpfin, err = nl.LinkByName(bpfInDev)
+	bpfin, err := netlink.LinkByName(bpfInDev)
 	if err != nil {
 		nat := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{
@@ -1601,27 +1595,27 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 			},
 			PeerName: bpfOutDev,
 		}
-		if err := nl.LinkAdd(nat); err != nil {
+		if err := netlink.LinkAdd(nat); err != nil {
 			return fmt.Errorf("failed to add %s: %w", bpfInDev, err)
 		}
-		bpfin, err = nl.LinkByName(bpfInDev)
+		bpfin, err = netlink.LinkByName(bpfInDev)
 		if err != nil {
 			return fmt.Errorf("missing %s after add: %w", bpfInDev, err)
 		}
-		if err := nl.LinkSetUp(bpfin); err != nil {
+		if err := netlink.LinkSetUp(bpfin); err != nil {
 			return fmt.Errorf("failed to set %s up: %w", bpfInDev, err)
 		}
-		bpfout, err = nl.LinkByName(bpfOutDev)
+		bpfout, err = netlink.LinkByName(bpfOutDev)
 		if err != nil {
 			return fmt.Errorf("missing %s after add: %w", bpfOutDev, err)
 		}
-		if err := nl.LinkSetUp(bpfout); err != nil {
+		if err := netlink.LinkSetUp(bpfout); err != nil {
 			return fmt.Errorf("failed to set %s up: %w", bpfOutDev, err)
 		}
 	}
 
 	if bpfout == nil {
-		bpfout, err = nl.LinkByName(bpfOutDev)
+		bpfout, err = netlink.LinkByName(bpfOutDev)
 		if err != nil {
 			return fmt.Errorf("miss %s after add: %w", bpfOutDev, err)
 		}
@@ -1635,7 +1629,7 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 		HardwareAddr: bpfout.Attrs().HardwareAddr,
 		LinkIndex:    bpfin.Attrs().Index,
 	}
-	if err := nl.NeighAdd(arp); err != nil && err != syscall.EEXIST {
+	if err := netlink.NeighAdd(arp); err != nil && err != syscall.EEXIST {
 		return fmt.Errorf("failed to update neight for %s: %w", bpfOutDev, err)
 	}
 
@@ -2030,18 +2024,12 @@ func (m *bpfEndpointManager) GetRouteTableSyncers() []routeTableSyncer {
 }
 
 func (m *bpfEndpointManager) invalidateServiceRoutes() error {
-	nl, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
-	if err != nil {
-		return fmt.Errorf("failed to create nelink to load service routes: %w", err)
-	}
-	defer nl.Close()
-
-	bpfin, err := nl.LinkByName(bpfInDev)
+	bpfin, err := netlink.LinkByName(bpfInDev)
 	if err != nil {
 		return fmt.Errorf("couldn't get %s link, device may not exist yet: %w", bpfInDev, err)
 	}
 
-	rts, err := nl.RouteList(bpfin, 4)
+	rts, err := netlink.RouteList(bpfin, 4)
 	if err != nil {
 		return fmt.Errorf("failed to get routes on %s: %w", bpfInDev, err)
 	}

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -61,7 +61,6 @@ import (
 	"github.com/projectcalico/calico/felix/ifacemonitor"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/iptables"
-	"github.com/projectcalico/calico/felix/netlinkshim"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/ratelimited"
 	"github.com/projectcalico/calico/felix/routetable"
@@ -114,8 +113,8 @@ type bpfDataplane interface {
 	removePolicyProgram(jumpMapFD bpf.MapFD) error
 	setAcceptLocal(iface string, val bool) error
 	setRPFilter(iface string, val int) error
-	setRoute(ip string) error
-	delRoute(ip string) error
+	setRoute(ip.V4CIDR)
+	delRoute(ip.V4CIDR)
 }
 
 type bpfInterface struct {
@@ -218,8 +217,8 @@ type bpfEndpointManager struct {
 	bpfPolicyDebugEnabled bool
 
 	routeTable    *routetable.RouteTable
-	services      map[serviceKey][]string
-	dirtyServices map[serviceKey][]string
+	services      map[serviceKey][]ip.V4CIDR
+	dirtyServices map[serviceKey]struct{}
 }
 
 type serviceKey struct {
@@ -331,8 +330,14 @@ func newBPFEndpointManager(
 			254,
 			opReporter,
 		)
-		m.services = make(map[serviceKey][]string)
-		m.dirtyServices = make(map[serviceKey][]string)
+		// Since we do not know what the state of services is at the start, mark
+		// the routes to be all cleaned up. As the service update will arrive,
+		// we will update the state.
+		if err := m.invalidateServiceRoutes(); err != nil {
+			log.WithError(err).Warn("Failed to invalidate existing service routes, unused ones may be left over.")
+		}
+		m.services = make(map[serviceKey][]ip.V4CIDR)
+		m.dirtyServices = make(map[serviceKey]struct{})
 
 		// Anything else would prevent packets being accepted from the special
 		// service veth. It does not create a security hole since BPF does the RPF
@@ -664,15 +669,27 @@ func (m *bpfEndpointManager) markExistingWEPDirty(wlID proto.WorkloadEndpointID,
 }
 
 func (m *bpfEndpointManager) CompleteDeferredWork() error {
+	start := time.Now()
+	defer func() {
+		log.Infof("CompleteDeferredWork took %v", time.Since(start))
+	}()
 	// Do one-off initialisation.
 	m.dp.ensureStarted()
 
 	m.applyProgramsToDirtyDataInterfaces()
 	m.updateWEPsInDataplane()
-	m.reconcileServices()
 
 	bpfEndpointsGauge.Set(float64(len(m.nameToIface)))
 	bpfDirtyEndpointsGauge.Set(float64(m.dirtyIfaceNames.Len()))
+
+	if m.ctlbWorkaroundEnabled {
+		// Update all existing IPs of dirty services
+		for svc := range m.dirtyServices {
+			for _, ip := range m.services[svc] {
+				m.dp.setRoute(ip)
+			}
+		}
+	}
 
 	if err := m.ifStateMap.ApplyAllChanges(); err != nil {
 		log.WithError(err).Warn("Failed to write updates to ifstate BPF map.")
@@ -1572,10 +1589,11 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 		return nil
 	}
 
-	nl, err := netlinkshim.NewRealNetlink()
+	nl, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
 	if err != nil {
 		return fmt.Errorf("failed to create nelink: %w", err)
 	}
+	defer nl.Close()
 
 	var bpfout, bpfin netlink.Link
 
@@ -1935,7 +1953,35 @@ func (m *bpfEndpointManager) onServiceUpdate(update *proto.ServiceUpdate) {
 	ips = append(ips, update.ExternalIps...)
 
 	key := serviceKey{name: update.Name, namespace: update.Namespace}
-	m.dirtyServices[key] = ips
+
+	ips4 := make([]ip.V4CIDR, 0, len(ips))
+	for _, i := range ips {
+		cidr, err := ip.CIDRFromString(i + "/32")
+		if err != nil {
+			log.WithFields(log.Fields{"service": key, "ip": i}).Warn("Not a valid CIDR.")
+		} else if cidrv4, ok := cidr.(ip.V4CIDR); !ok {
+			log.WithFields(log.Fields{"service": key, "ip": i}).Debug("Not a valid V4 CIDR.")
+		} else {
+			ips4 = append(ips4, cidrv4)
+		}
+	}
+
+	// Check which IPs have been removed (no-op if we haven't seen it yet)
+	for _, old := range m.services[key] {
+		exists := false
+		for _, svcIP := range ips4 {
+			if old == svcIP {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			m.dp.delRoute(old)
+		}
+	}
+
+	m.services[key] = ips4
+	m.dirtyServices[key] = struct{}{}
 }
 
 func (m *bpfEndpointManager) onServiceRemove(update *proto.ServiceRemove) {
@@ -1949,79 +1995,32 @@ func (m *bpfEndpointManager) onServiceRemove(update *proto.ServiceRemove) {
 	}).Info("Service Remove")
 
 	key := serviceKey{name: update.Name, namespace: update.Namespace}
-	m.dirtyServices[key] = nil
-}
 
-func (m *bpfEndpointManager) reconcileServices() {
-	for svc, ips := range m.dirtyServices {
-		errored := false
-		for _, ip := range ips {
-			if err := m.dp.setRoute(ip); err != nil {
-				log.WithError(err).Errorf("Failed to set route to %s via bpfnatin.", ip)
-				errored = true
-			}
-		}
-
-		known := m.services[svc]
-
-		for _, old := range known {
-			exist := false
-			for _, ip := range ips {
-				if ip == old {
-					exist = true
-					break
-				}
-			}
-
-			if !exist {
-				if err := m.dp.delRoute(old); err != nil {
-					log.WithError(err).Errorf("Failed to delete route to %s via bpfnatin.", old)
-					errored = true
-				}
-			}
-		}
-
-		if !errored {
-			if len(ips) > 0 {
-				m.services[svc] = ips
-			} else {
-				delete(m.services, svc)
-			}
-			delete(m.dirtyServices, svc)
-		}
+	for _, svcIP := range m.services[key] {
+		m.dp.delRoute(svcIP)
 	}
+
+	delete(m.services, key)
 }
 
 var bpfnatGW = ip.FromNetIP(net.IPv4(169, 254, 1, 1))
 
-func (m *bpfEndpointManager) setRoute(dst string) error {
-	cidr, err := ip.CIDRFromString(dst + "/32")
-	if err != nil {
-		return err
-	}
-
+func (m *bpfEndpointManager) setRoute(cidr ip.V4CIDR) {
 	m.routeTable.RouteUpdate(bpfInDev, routetable.Target{
 		Type: routetable.TargetTypeGlobalUnicast,
 		CIDR: cidr,
 		GW:   bpfnatGW,
 	})
 	log.WithFields(log.Fields{
-		"cidr": dst + "/32",
+		"cidr": cidr,
 	}).Debug("setRoute")
-	return nil
 }
 
-func (m *bpfEndpointManager) delRoute(dst string) error {
-	cidr, err := ip.CIDRFromString(dst + "/32")
-	if err != nil {
-		return err
-	}
-
+func (m *bpfEndpointManager) delRoute(cidr ip.V4CIDR) {
 	m.routeTable.RouteRemove(bpfInDev, cidr)
 	log.WithFields(log.Fields{
-		"cidr": dst + "/32",
+		"cidr": cidr,
 	}).Debug("delRoute")
-	return nil
 }
 
 func (m *bpfEndpointManager) GetRouteTableSyncers() []routeTableSyncer {
@@ -2032,4 +2031,31 @@ func (m *bpfEndpointManager) GetRouteTableSyncers() []routeTableSyncer {
 	tables := []routeTableSyncer{m.routeTable}
 
 	return tables
+}
+
+func (m *bpfEndpointManager) invalidateServiceRoutes() error {
+	nl, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
+	if err != nil {
+		return fmt.Errorf("failed to create nelink to load service routes: %w", err)
+	}
+	defer nl.Close()
+
+	bpfin, err := nl.LinkByName(bpfInDev)
+	if err != nil {
+		return fmt.Errorf("couldn't get %s link, device may not exist yet: %w", bpfInDev, err)
+	}
+
+	rts, err := nl.RouteList(bpfin, 4)
+	if err != nil {
+		return fmt.Errorf("failed to get routes on %s: %w", bpfInDev, err)
+	}
+
+	for _, rt := range rts {
+		if rt.Scope == netlink.SCOPE_UNIVERSE /*global*/ && rt.Dst != nil {
+			cidr := ip.CIDRFromIPNet(rt.Dst)
+			m.delRoute(cidr.(ip.V4CIDR))
+		}
+	}
+
+	return nil
 }

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -218,7 +218,7 @@ type bpfEndpointManager struct {
 
 	routeTable    *routetable.RouteTable
 	services      map[serviceKey][]ip.V4CIDR
-	dirtyServices map[serviceKey]struct{}
+	dirtyServices set.Set[serviceKey]
 }
 
 type serviceKey struct {
@@ -337,7 +337,7 @@ func newBPFEndpointManager(
 			log.WithError(err).Warn("Failed to invalidate existing service routes, unused ones may be left over.")
 		}
 		m.services = make(map[serviceKey][]ip.V4CIDR)
-		m.dirtyServices = make(map[serviceKey]struct{})
+		m.dirtyServices = set.New[serviceKey]()
 
 		// Anything else would prevent packets being accepted from the special
 		// service veth. It does not create a security hole since BPF does the RPF
@@ -680,11 +680,12 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 
 	if m.ctlbWorkaroundEnabled {
 		// Update all existing IPs of dirty services
-		for svc := range m.dirtyServices {
+		m.dirtyServices.Iter(func(svc serviceKey) error {
 			for _, ip := range m.services[svc] {
 				m.dp.setRoute(ip)
 			}
-		}
+			return set.RemoveItem
+		})
 	}
 
 	if err := m.ifStateMap.ApplyAllChanges(); err != nil {
@@ -1971,7 +1972,7 @@ func (m *bpfEndpointManager) onServiceUpdate(update *proto.ServiceUpdate) {
 	}
 
 	m.services[key] = ips4
-	m.dirtyServices[key] = struct{}{}
+	m.dirtyServices.Add(key)
 }
 
 func (m *bpfEndpointManager) onServiceRemove(update *proto.ServiceRemove) {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -330,12 +330,6 @@ func newBPFEndpointManager(
 			254,
 			opReporter,
 		)
-		// Since we do not know what the state of services is at the start, mark
-		// the routes to be all cleaned up. As the service update will arrive,
-		// we will update the state.
-		if err := m.invalidateServiceRoutes(); err != nil {
-			log.WithError(err).Warn("Failed to invalidate existing service routes, unused ones may be left over.")
-		}
 		m.services = make(map[serviceKey][]ip.V4CIDR)
 		m.dirtyServices = set.New[serviceKey]()
 
@@ -2022,25 +2016,4 @@ func (m *bpfEndpointManager) GetRouteTableSyncers() []routeTableSyncer {
 	tables := []routeTableSyncer{m.routeTable}
 
 	return tables
-}
-
-func (m *bpfEndpointManager) invalidateServiceRoutes() error {
-	bpfin, err := netlink.LinkByName(bpfInDev)
-	if err != nil {
-		return fmt.Errorf("couldn't get %s link, device may not exist yet: %w", bpfInDev, err)
-	}
-
-	rts, err := netlink.RouteList(bpfin, 4)
-	if err != nil {
-		return fmt.Errorf("failed to get routes on %s: %w", bpfInDev, err)
-	}
-
-	for _, rt := range rts {
-		if rt.Scope == netlink.SCOPE_UNIVERSE /*global*/ && rt.Dst != nil {
-			cidr := ip.CIDRFromIPNet(rt.Dst)
-			m.delRoute(cidr.(ip.V4CIDR))
-		}
-	}
-
-	return nil
 }

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -530,7 +530,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			err := bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dp.routes).To(HaveLen(1))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("1.2.3.4/32")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.2.3.4")))
 
 			bpfEpMgr.OnUpdate(&proto.ServiceUpdate{
 				Name:           "service",
@@ -541,8 +541,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			err = bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dp.routes).To(HaveLen(2))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("1.2.3.4/32")))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("5.6.7.8/32")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.2.3.4")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("5.6.7.8")))
 
 			bpfEpMgr.OnUpdate(&proto.ServiceUpdate{
 				Name:           "service",
@@ -554,10 +554,10 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			err = bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dp.routes).To(HaveLen(4))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("1.2.3.4/32")))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("5.6.7.8/32")))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("1.0.0.1/32")))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("1.0.0.2/32")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.2.3.4")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("5.6.7.8")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.0.0.1")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.0.0.2")))
 
 			bpfEpMgr.OnUpdate(&proto.ServiceUpdate{
 				Name:      "service",
@@ -567,7 +567,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			err = bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dp.routes).To(HaveLen(1))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("1.2.3.4/32")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.2.3.4")))
 
 			bpfEpMgr.OnUpdate(&proto.ServiceRemove{
 				Name:      "service",
@@ -586,8 +586,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			err = bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dp.routes).To(HaveLen(2))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("1.2.3.4/32")))
-			Expect(dp.routes).To(HaveKey(ip.CIDRFromStringMust("5.6.7.8/32")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.2.3.4")))
+			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("5.6.7.8")))
 
 			bpfEpMgr.OnUpdate(&proto.ServiceRemove{
 				Name:      "service",

--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -255,14 +255,6 @@ func CIDRFromString(cidrStr string) (CIDR, error) {
 	return CIDRFromIPNet(cidr), nil
 }
 
-func CIDRFromStringMust(cidrStr string) CIDR {
-	cidr, err := CIDRFromString(cidrStr)
-	if err != nil {
-		panic(err)
-	}
-	return cidr
-}
-
 func CIDRFromCalicoNet(ipNet calinet.IPNet) CIDR {
 	return CIDRFromIPNet(&ipNet.IPNet)
 }

--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -255,6 +255,14 @@ func CIDRFromString(cidrStr string) (CIDR, error) {
 	return CIDRFromIPNet(cidr), nil
 }
 
+func CIDRFromStringMust(cidrStr string) CIDR {
+	cidr, err := CIDRFromString(cidrStr)
+	if err != nil {
+		panic(err)
+	}
+	return cidr
+}
+
 func CIDRFromCalicoNet(ipNet calinet.IPNet) CIDR {
 	return CIDRFromIPNet(&ipNet.IPNet)
 }

--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -175,6 +175,11 @@ const (
 	updateTypeDelta
 )
 
+// RouteTable manages calico routes for a specific table. It reconciles the
+// routes that we desire to have for calico managed devices with what is the
+// current status in the dataplane. That is, it removes any routes that we do
+// not desire and adds those that we do. It skips over devices that we do not
+// manage not to interfare with other users of the route tables.
 type RouteTable struct {
 	logCxt *log.Entry
 


### PR DESCRIPTION
## Description

    This fix ensures that if a service IP is recycled during the same calc
    graph iteration, then we endup with the IP being present in the route
    table.
    
    Previously, it was possible to be programmed and then deleted by a service
    that was being removed if iterating over the dirtyServices was done in a
    wrong order.
    
    We remove all IPs immediately when they are deleted, while we add IPs
    of dirtyServices that should exist at the end of the iteration.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
