### PR TITLE
Tune conntrack timeout behaviour

### DIFF
--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -278,7 +278,7 @@ func (c *Checker) CheckConnectivityWithTimeout(timeout time.Duration, opts ...in
 }
 
 func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout time.Duration, opts ...interface{}) {
-
+	log.Info("Starting connectivity check...")
 	for _, o := range opts {
 		switch v := o.(type) {
 		case string:
@@ -299,7 +299,8 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 	var actualConnPretty []string
 	var finalErr error
 
-	for time.Since(start) < timeout || completedAttempts < 2 {
+	for {
+		checkStartTime := time.Now()
 		actualConn, actualConnPretty = c.ActualConnectivity()
 		failed := false
 		finalErr = nil
@@ -314,6 +315,8 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 			}
 		}
 
+		completedAttempts++
+
 		if !failed {
 			if c.finalTest != nil {
 				finalErr = c.finalTest()
@@ -323,6 +326,7 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 			}
 			if !failed {
 				// Success!
+				log.WithField("attempts", completedAttempts).Info("Connectivity check passed.")
 				return
 			}
 		}
@@ -331,7 +335,15 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 			break
 		}
 
-		completedAttempts++
+		// Check the timeout before we execute the retry function since the retry function might take a while,
+		// effectively cutting down the timeout.  Since one check should take ~2s we also check that we started
+		// the iteration close to the end of the.  Better to be a little permissive than flaky!
+		if time.Since(start) > timeout &&
+			checkStartTime.Sub(start) > timeout-2*time.Second &&
+			completedAttempts >= 2 {
+			break
+		}
+
 		if c.beforeRetry != nil {
 			log.Debug("calling beforeRetry")
 			c.beforeRetry()
@@ -352,6 +364,7 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 		message += "\nDescription:\n" + c.description
 	}
 
+	log.Warn("Connectivity check failed: " + message)
 	message += fmt.Sprintf("\n\n Test took %s and %d tries.\n", time.Since(start), completedAttempts)
 
 	if c.OnFail != nil {

--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -299,7 +299,7 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 	var actualConnPretty []string
 	var finalErr error
 
-	for !c.RetriesDisabled && time.Since(start) < timeout || completedAttempts < 2 {
+	for time.Since(start) < timeout || completedAttempts < 2 {
 		actualConn, actualConnPretty = c.ActualConnectivity()
 		failed := false
 		finalErr = nil
@@ -326,6 +326,11 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 				return
 			}
 		}
+
+		if c.RetriesDisabled {
+			break
+		}
+
 		completedAttempts++
 		if c.beforeRetry != nil {
 			log.Debug("calling beforeRetry")
@@ -346,6 +351,8 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 	if c.description != "" {
 		message += "\nDescription:\n" + c.description
 	}
+
+	message += fmt.Sprintf("\n\n Test took %s and %d tries.\n", time.Since(start), completedAttempts)
 
 	if c.OnFail != nil {
 		c.OnFail(message)

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -1294,10 +1294,6 @@ func wireguardTopologyOptions(routeSource string, ipipEnabled bool, extraEnvs ..
 	felixConfig.Spec.WireguardEnabled = &enabled
 	topologyOptions.InitialFelixConfiguration = felixConfig
 
-	// Debugging.
-	// topologyOptions.ExtraEnvVars["FELIX_DebugUseShortPollIntervals"] = "true"
-	topologyOptions.FelixLogSeverity = "debug"
-
 	return topologyOptions
 }
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Building on #6315 after finding a further issue with the timeouts.  If the pre-retry function takes a long time (for example, cleaning conntrack in every felix...) then we can end up with an effectively short timeout.  For example, suppose the intended timeout was 10s, we might get:

- T=0s Check runs, takes 1-2s
- T=2s Pre-retry runs, takes 2-3 seconds
- T=5s Check attempt 2 runs, takes 1-2s
- T=7s Pre-retry runs, takes 2-3 seconds
- T=10s timeout, even though the last check started at T=5s

This change moves the timeout check to before the pre-retry function and allows extra leeway if the check itself took >2s.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
