### PR TITLE
[release-v3.22] Auto pick #6380: Include UBI repos for CVE fixes

### DIFF
--- a/metadata.mk
+++ b/metadata.mk
@@ -22,7 +22,7 @@ ORGANIZATION = projectcalico
 GIT_USE_SSH = true
 
 # The version of BIRD to use for calico/node builds and confd tests.
-BIRD_VERSION=v0.3.3-184-g202a2186
+BIRD_VERSION=v0.3.3-188-g0196eee4
 
 # DEV_REGISTRIES configures the container image registries which are built from this
 # repository. By default, just build images with calico/. Allow this variable to be overridden,

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -122,6 +122,13 @@ COPY --from=centos  /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
 # Copy in our rpms
 COPY --from=centos  /root/rpmbuild/RPMS/${ARCH}/* /tmp/rpms/
 
+# Install a subset of packages from UBI prior to removing the UBI repo below.
+# We do this because the UBI repo has updated versions with CVE fixes. We can remove
+# this once the CentOS repo updates the version of these packages.
+# gzip >= 1.9-13.el8_5
+# cryptsetup-libs >= 2.3.3-4.el8_5.1
+RUN microdnf install gzip cryptsetup-libs
+
 # Install the necessary packages, making sure that we're using only CentOS repos.
 # Since the ubi repos do not contain all the packages we need (they're missing conntrack-tools),
 # we're using CentOS repos for all our packages. Using packages from a single source (CentOS) makes

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -122,15 +122,15 @@ COPY --from=centos  /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
 # Copy in our rpms
 COPY --from=centos  /root/rpmbuild/RPMS/${ARCH}/* /tmp/rpms/
 
-# Install the necessary packages, making sure that we're using only CentOS repos.
+# Install the necessary packages, making sure that we're also including CentOS repos.
 # Since the ubi repos do not contain all the packages we need (they're missing conntrack-tools),
-# we're using CentOS repos for all our packages. Using packages from a single source (CentOS) makes
-# it less likely we'll run into package dependency version mismatches.
+# we need to use CentOS repos for some packages. Using packages from a single source (CentOS) would make 
+# it less likely we'll run into package dependency version mismatches, but we include UBI sources anyway
+# since they generally are updated with CVE fixes sooner.
 #
 # NOTE: new packages need to be added to the keep-list in clean-up-filesystem.sh.
 COPY centos.repo /etc/yum.repos.d/
-RUN rm /etc/yum.repos.d/ubi.repo && \
-    touch /in-the-container && \
+RUN touch /in-the-container && \
     microdnf install \
     # Don't install copious docs.
     --setopt=tsflags=nodocs \

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -122,15 +122,15 @@ COPY --from=centos  /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
 # Copy in our rpms
 COPY --from=centos  /root/rpmbuild/RPMS/${ARCH}/* /tmp/rpms/
 
-# Install the necessary packages, making sure that we're also including CentOS repos.
+# Install the necessary packages, making sure that we're using only CentOS repos.
 # Since the ubi repos do not contain all the packages we need (they're missing conntrack-tools),
-# we need to use CentOS repos for some packages. Using packages from a single source (CentOS) would make 
-# it less likely we'll run into package dependency version mismatches, but we include UBI sources anyway
-# since they generally are updated with CVE fixes sooner.
+# we're using CentOS repos for all our packages. Using packages from a single source (CentOS) makes
+# it less likely we'll run into package dependency version mismatches.
 #
 # NOTE: new packages need to be added to the keep-list in clean-up-filesystem.sh.
 COPY centos.repo /etc/yum.repos.d/
-RUN touch /in-the-container && \
+RUN rm /etc/yum.repos.d/ubi.repo && \
+    touch /in-the-container && \
     microdnf install \
     # Don't install copious docs.
     --setopt=tsflags=nodocs \


### PR DESCRIPTION
Cherry pick of #6380 on release-v3.22.

#6380: Include UBI repos for CVE fixes

Also updates BIRD version to fix our tests, and as a consequence includes the following BIRD fixes:

- https://github.com/projectcalico/bird/pull/100
- https://github.com/projectcalico/bird/pull/101


```release-note
Update pacakges from UBI repo for CVE fixes
```

```release-note
Fix a bug where the check for treating the 240/4 CIDR like RFC 1918 ranges caught the broadcast address 255.255.255.255
```

```release-note
Fix race condition in BIRD that could potentially cause missed config updates
```
