### PR TITLE
Update docs for DisableBGPExport

### DIFF
--- a/calico/reference/installation/_api.html
+++ b/calico/reference/installation/_api.html
@@ -1248,6 +1248,19 @@ the main IP pool CIDR.
 Default: 26 (IPv4), 122 (IPv6)</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>disableBGPExport</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableBGPExport specifies whether routes from this IP pool&rsquo;s CIDR are exported over BGP.
+Default: false</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="operator.tigera.io/v1.Image">Image
@@ -1694,6 +1707,21 @@ InstallationSpec
 <p>Computed is the final installation including overlaid resources.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>conditions</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#condition-v1-meta">
+[]Kubernetes meta/v1.Condition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions represents the latest observed set of conditions for the component. A component may be one or more of
+Ready, Progressing, Degraded or other customer types.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
@@ -2016,7 +2044,7 @@ One of: None, Login, Consent, SelectAccount.</p>
 <a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>Provider represents a particular provider or flavor of Kubernetes. Valid options
-are: EKS, GKE, AKS, OpenShift, DockerEnterprise.</p>
+are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise.</p>
 <h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
@@ -2100,8 +2128,25 @@ string
 <p>Optionally, a detailed message providing additional context.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>observedGeneration</code><br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>observedGeneration represents the generation that the condition was set based upon.
+For instance, if generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+with respect to the current state of the instance.</p>
+</td>
+</tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+(<code>string</code> alias)</h3>
+<p>TigeraStatusReason represents the reason for a particular condition.</p>
 <h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec
 </h3>
 <p>

--- a/calico/reference/node/configuration.md
+++ b/calico/reference/node/configuration.md
@@ -52,6 +52,8 @@ exist in the cluster. The following options control the parameters on the create
 | CALICO_IPV6POOL_VXLAN | VXLAN Mode to use for the IPv6 Pool created at start up. [Default: `Never`] | Always, CrossSubnet, Never |
 | CALICO_IPV6POOL_NAT_OUTGOING | Controls NAT Outgoing for the IPv6 Pool created at start up. [Default: `false`] | boolean |
 | CALICO_IPV6POOL_NODE_SELECTOR | Controls the NodeSelector for the IPv6 Pool created at start up. [Default: `all()`] | [selector]({{site.baseurl}}/reference/resources/ippool#node-selector) |
+| CALICO_IPV4POOL_DISABLE_BGP_EXPORT | Disable exporting routes over BGP for the IPv4 Pool created at start up. [Default: `false`] | boolean |
+| CALICO_IPV6POOL_DISABLE_BGP_EXPORT | Disable exporting routes over BGP for the IPv6 Pool created at start up. [Default: `false`] | boolean |
 | NO_DEFAULT_POOLS | Prevents  {{site.prodname}} from creating a default pool if one does not exist. [Default: `false`] | boolean |
 
 ### Configuring BGP Networking


### PR DESCRIPTION
## Description

This PR is a follow-up to #6391 and https://github.com/tigera/operator/pull/2083 which added more ways to configure `DisableBGPExport` on an IP pool.

- Document the new env vars to control `DisableBGPExport` on default IP pools.
- Update the installation API reference.



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
