### PR TITLE
Change prog ID to int and define hooks in BPF

### DIFF
--- a/felix/bpf/attach.go
+++ b/felix/bpf/attach.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import (
 type AttachedProgInfo struct {
 	Object string `json:"object"`
 	Hash   string `json:"hash"`
-	ID     string `json:"id"`
+	ID     int    `json:"id"`
 	Config string `json:"config"`
 }
 
@@ -47,15 +47,9 @@ type AttachPointInfo interface {
 	Config() string
 }
 
-var (
-	// These are possible hooks for a bpf program. "ingress" and "egress" imply TC program
-	// and each one reflects traffic direction. "xdp" implies xdp programs.
-	runtimeJSONsuffixes = []string{"ingress", "egress", "xdp"}
-)
-
 // AlreadyAttachedProg checks that the program we are going to attach has the
 // same parameters as what we remembered about the currently attached.
-func AlreadyAttachedProg(a AttachPointInfo, object, id string) (bool, error) {
+func AlreadyAttachedProg(a AttachPointInfo, object string, id int) (bool, error) {
 	bytesToRead, err := ioutil.ReadFile(RuntimeJSONFilename(a.IfaceName(), a.HookName()))
 	if err != nil {
 		// If file does not exist, just ignore the err code, and return false
@@ -96,7 +90,7 @@ func AlreadyAttachedProg(a AttachPointInfo, object, id string) (bool, error) {
 }
 
 // RememberAttachedProg stores the attached programs parameters in a file.
-func RememberAttachedProg(a AttachPointInfo, object, id string) error {
+func RememberAttachedProg(a AttachPointInfo, object string, id int) error {
 	hash, err := sha256OfFile(object)
 	if err != nil {
 		return err
@@ -139,8 +133,8 @@ func ForgetAttachedProg(iface, hook string) error {
 // ForgetIfaceAttachedProg removes information we store about any programs
 // associated with an iface.
 func ForgetIfaceAttachedProg(iface string) error {
-	for _, hook := range runtimeJSONsuffixes {
-		err := ForgetAttachedProg(iface, hook)
+	for _, hook := range Hooks {
+		err := ForgetAttachedProg(iface, string(hook))
 		if err != nil {
 			return err
 		}
@@ -162,8 +156,8 @@ func CleanAttachedProgDir() {
 
 	expectedJSONFiles := set.New[string]()
 	for _, iface := range interfaces {
-		for _, hook := range runtimeJSONsuffixes {
-			expectedJSONFiles.Add(RuntimeJSONFilename(iface.Name, hook))
+		for _, hook := range Hooks {
+			expectedJSONFiles.Add(RuntimeJSONFilename(iface.Name, string(hook)))
 		}
 	}
 

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -46,12 +46,24 @@ import (
 	"github.com/projectcalico/calico/felix/labelindex"
 )
 
+// Hook is the hook to which a BPF program should be attached. This is relative to
+// the host namespace so workload PolDirnIngress policy is attached to the HookEgress.
+type Hook string
+
+const (
+	HookIngress Hook = "ingress"
+	HookEgress  Hook = "egress"
+	HookXDP     Hook = "xdp"
+)
+
+var Hooks = []Hook{HookIngress, HookEgress, HookXDP}
+
 type XDPMode int
 
 const (
-	XDPDriver XDPMode = iota
-	XDPOffload
-	XDPGeneric
+	XDPDriver  XDPMode = unix.XDP_FLAGS_DRV_MODE
+	XDPOffload XDPMode = unix.XDP_FLAGS_HW_MODE
+	XDPGeneric XDPMode = unix.XDP_FLAGS_SKB_MODE
 )
 
 type FindObjectMode uint32
@@ -2267,4 +2279,25 @@ const countersMapVersion = 1
 
 func CountersMapName() string {
 	return fmt.Sprintf("cali_counters%d", countersMapVersion)
+}
+
+func MapPinPath(typ int, name, iface string, hook Hook) string {
+	PinBaseDir := path.Join(DefaultBPFfsPath, "tc")
+	subDir := "globals"
+	if (typ == unix.BPF_MAP_TYPE_PROG_ARRAY && strings.Contains(name, JumpMapName())) ||
+		(typ == unix.BPF_MAP_TYPE_PERCPU_ARRAY && strings.Contains(name, CountersMapName())) {
+		// Remove period in the interface name if any
+		ifName := strings.ReplaceAll(iface, ".", "")
+		switch hook {
+		case HookXDP:
+			subDir = ifName + "_xdp"
+		case HookIngress:
+			subDir = ifName + "_igr/"
+		case HookEgress:
+			subDir = ifName + "_egr"
+		default:
+			panic("Invalid hook")
+		}
+	}
+	return path.Join(PinBaseDir, subDir, name)
 }

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -2284,6 +2284,8 @@ func CountersMapName() string {
 func MapPinPath(typ int, name, iface string, hook Hook) string {
 	PinBaseDir := path.Join(DefaultBPFfsPath, "tc")
 	subDir := "globals"
+	// We need one jump map and one counter map for each program, thus we need to pin those
+	// to a unique path, which is /sys/fs/bpf/tc/[iface]_[igr|egr|xdp]/[map_name].
 	if (typ == unix.BPF_MAP_TYPE_PROG_ARRAY && strings.Contains(name, JumpMapName())) ||
 		(typ == unix.BPF_MAP_TYPE_PERCPU_ARRAY && strings.Contains(name, CountersMapName())) {
 		// Remove period in the interface name if any

--- a/felix/bpf/counters/counters.go
+++ b/felix/bpf/counters/counters.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/calico/felix/bpf"
-	"github.com/projectcalico/calico/felix/bpf/tc"
 )
 
 const (
@@ -153,13 +152,13 @@ func NewCounters(iface string) *Counters {
 		maps:     make([]bpf.Map, len(HooksName)),
 	}
 
-	pinPath := tc.MapPinPath(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
-		bpf.CountersMapName(), iface, tc.HookIngress)
+	pinPath := bpf.MapPinPath(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
+		bpf.CountersMapName(), iface, bpf.HookIngress)
 	cntr.maps[HookIngress] = Map(&bpf.MapContext{}, pinPath)
 	logrus.Debugf("ingress counter map pin path: %v", pinPath)
 
-	pinPath = tc.MapPinPath(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
-		bpf.CountersMapName(), iface, tc.HookEgress)
+	pinPath = bpf.MapPinPath(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
+		bpf.CountersMapName(), iface, bpf.HookEgress)
 	cntr.maps[HookEgress] = Map(&bpf.MapContext{}, pinPath)
 	logrus.Debugf("egress counter map pin path: %v", pinPath)
 

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -44,7 +44,7 @@ import (
 type AttachPoint struct {
 	Type                 EndpointType
 	ToOrFrom             ToOrFromEp
-	Hook                 Hook
+	Hook                 bpf.Hook
 	Iface                string
 	LogLevel             string
 	HostIP               net.IP
@@ -78,39 +78,39 @@ func (ap AttachPoint) Log() *log.Entry {
 	})
 }
 
-func (ap AttachPoint) AlreadyAttached(object string) (string, bool) {
+func (ap AttachPoint) AlreadyAttached(object string) (int, bool) {
 	logCxt := log.WithField("attachPoint", ap)
 	progID, err := ap.ProgramID()
 	if err != nil {
 		logCxt.WithError(err).Debugf("Couldn't get the attached TC program ID.")
-		return "", false
+		return -1, false
 	}
 
 	progsToClean, err := ap.listAttachedPrograms()
 	if err != nil {
 		logCxt.WithError(err).Debugf("Couldn't get the list of already attached TC programs")
-		return "", false
+		return -1, false
 	}
 
 	isAttached, err := bpf.AlreadyAttachedProg(ap, object, progID)
 	if err != nil {
 		logCxt.WithError(err).Debugf("Failed to check if BPF program was already attached.")
-		return "", false
+		return -1, false
 	}
 
 	if isAttached && len(progsToClean) == 1 {
 		return progID, true
 	}
-	return "", false
+	return -1, false
 }
 
 // AttachProgram attaches a BPF program from a file to the TC attach point
-func (ap AttachPoint) AttachProgram() (string, error) {
+func (ap AttachPoint) AttachProgram() (int, error) {
 	logCxt := log.WithField("attachPoint", ap)
 
 	tempDir, err := ioutil.TempDir("", "calico-tc")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temporary directory: %w", err)
+		return -1, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
 	defer func() {
 		_ = os.RemoveAll(tempDir)
@@ -123,7 +123,7 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	err = ap.patchLogPrefix(logCxt, preCompiledBinary, tempBinary)
 	if err != nil {
 		logCxt.WithError(err).Error("Failed to patch binary")
-		return "", err
+		return -1, err
 	}
 
 	// Using the RLock allows multiple attach calls to proceed in parallel unless
@@ -135,11 +135,11 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 
 	progsToClean, err := ap.listAttachedPrograms()
 	if err != nil {
-		return "", err
+		return -1, err
 	}
 	obj, err := libbpf.OpenObject(tempBinary)
 	if err != nil {
-		return "", err
+		return -1, err
 	}
 	defer obj.Close()
 
@@ -149,17 +149,17 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 		// userspace before the program is loaded.
 		if m.IsMapInternal() {
 			if err := ap.ConfigureProgram(m); err != nil {
-				return "", fmt.Errorf("failed to configure %s: %w", filename, err)
+				return -1, fmt.Errorf("failed to configure %s: %w", filename, err)
 			}
 			continue
 		}
 
 		if err := ap.setMapSize(m); err != nil {
-			return "", fmt.Errorf("error setting map size %s : %w", m.Name(), err)
+			return -1, fmt.Errorf("error setting map size %s : %w", m.Name(), err)
 		}
-		pinPath := MapPinPath(m.Type(), m.Name(), ap.Iface, ap.Hook)
+		pinPath := bpf.MapPinPath(m.Type(), m.Name(), ap.Iface, ap.Hook)
 		if err := m.SetPinPath(pinPath); err != nil {
-			return "", fmt.Errorf("error pinning map %s: %w", m.Name(), err)
+			return -1, fmt.Errorf("error pinning map %s: %w", m.Name(), err)
 		}
 	}
 
@@ -167,14 +167,14 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	// re-attaching it if the binary and its configuration are the same.
 	progID, isAttached := ap.AlreadyAttached(preCompiledBinary)
 	if isAttached {
-		logCxt.Infof("Program already attached to TC, skip reattaching %s", ap.FileName())
+		logCxt.Infof("Program already attached to TC, skip reattaching %s", filename)
 		return progID, nil
 	}
-	logCxt.Debugf("Continue with attaching BPF program %s", ap.FileName())
+	logCxt.Debugf("Continue with attaching BPF program %s", filename)
 
 	if err := obj.Load(); err != nil {
 		logCxt.Warn("Failed to load program")
-		return "", fmt.Errorf("error loading program: %w", err)
+		return -1, fmt.Errorf("error loading program: %w", err)
 	}
 
 	isHost := false
@@ -185,13 +185,13 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	err = updateJumpMap(obj, isHost, ap.IPv6Enabled)
 	if err != nil {
 		logCxt.Warn("Failed to update jump map")
-		return "", fmt.Errorf("error updating jump map %v", err)
+		return -1, fmt.Errorf("error updating jump map %v", err)
 	}
 
 	progId, err := obj.AttachClassifier(SectionName(ap.Type, ap.ToOrFrom), ap.Iface, string(ap.Hook))
 	if err != nil {
 		logCxt.Warnf("Failed to attach to TC section %s", SectionName(ap.Type, ap.ToOrFrom))
-		return "", err
+		return -1, err
 	}
 	logCxt.Info("Program attached to TC.")
 
@@ -218,18 +218,18 @@ func (ap AttachPoint) AttachProgram() (string, error) {
 	}
 
 	if len(progErrs) != 0 {
-		return "", fmt.Errorf("failed to clean up one or more old calico programs: %v", progErrs)
+		return -1, fmt.Errorf("failed to clean up one or more old calico programs: %v", progErrs)
 	}
 
 	// Store information of object in a json file so in future we can skip reattaching it.
 	// If the process fails, the json file with the correct name and program details
 	// is not stored on disk, and during Felix restarts the same program will be reattached
 	// which leads to an unnecessary load time
-	if err = bpf.RememberAttachedProg(ap, preCompiledBinary, strconv.Itoa(progId)); err != nil {
+	if err = bpf.RememberAttachedProg(ap, preCompiledBinary, progId); err != nil {
 		logCxt.WithError(err).Error("Failed to record hash of BPF program on disk; ignoring.")
 	}
 
-	return strconv.Itoa(progId), nil
+	return progId, nil
 }
 
 func (ap AttachPoint) patchLogPrefix(logCtx *log.Entry, ifile, ofile string) error {
@@ -338,10 +338,10 @@ var ErrNoTC = errors.New("no TC program attached")
 
 // TODO: we should try to not get the program ID via 'tc' binary and rather
 // we should use libbpf to obtain it.
-func (ap *AttachPoint) ProgramID() (string, error) {
+func (ap *AttachPoint) ProgramID() (int, error) {
 	out, err := ExecTC("filter", "show", "dev", ap.IfaceName(), string(ap.Hook))
 	if err != nil {
-		return "", fmt.Errorf("Failed to check interface %s program ID: %w", ap.Iface, err)
+		return -1, fmt.Errorf("Failed to check interface %s program ID: %w", ap.Iface, err)
 	}
 
 	s := strings.Fields(string(out))
@@ -351,14 +351,15 @@ func (ap *AttachPoint) ProgramID() (string, error) {
 		// filter protocol all pref 49152 bpf chain 0
 		// filter protocol all pref 49152 bpf chain 0 handle 0x1 calico_from_hos:[61] direct-action not_in_hw id 61 tag 4add0302745d594c jited
 		if s[i] == "id" && len(s) > i+1 {
-			_, err := strconv.Atoi(s[i+1])
+			progID, err := strconv.Atoi(s[i+1])
 			if err != nil {
-				return "", fmt.Errorf("Couldn't parse ID in 'tc filter' command err=%w out=\n%v", err, string(out))
+				return -1, fmt.Errorf("Couldn't parse ID in 'tc filter' command err=%w out=\n%v", err, string(out))
 			}
-			return s[i+1], nil
+
+			return progID, nil
 		}
 	}
-	return "", fmt.Errorf("Couldn't find 'id <ID> in 'tc filter' command out=\n%v err=%w", string(out), ErrNoTC)
+	return -1, fmt.Errorf("Couldn't find 'id <ID> in 'tc filter' command out=\n%v err=%w", string(out), ErrNoTC)
 }
 
 // FileName return the file the AttachPoint will load the program from
@@ -381,9 +382,9 @@ func (ap AttachPoint) IsAttached() (bool, error) {
 	return len(progs) > 0, nil
 }
 
-// tcDirRegex matches tc's auto-created directory names, directories created when using libbpf
+// tcDirRegex matches tc's and xdp's auto-created directory names, directories created when using libbpf
 // so we can clean them up when removing maps without accidentally removing other user-created dirs..
-var tcDirRegex = regexp.MustCompile(`([0-9a-f]{40})|(.*_(igr|egr))`)
+var tcDirRegex = regexp.MustCompile(`([0-9a-f]{40})|(.*_(igr|egr|xdp))`)
 
 // CleanUpMaps scans for cali_jump maps that are still pinned to the filesystem but no longer referenced by
 // our BPF programs.

--- a/felix/bpf/tc/compiler.go
+++ b/felix/bpf/tc/compiler.go
@@ -16,23 +16,11 @@ package tc
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sys/unix"
 
-	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/environment"
-)
-
-// TCHook is the hook to which a BPF program should be attached.  This is relative to the host namespace
-// so workload PolDirnIngress policy is attached to the HookEgress.
-type Hook string
-
-const (
-	HookIngress Hook = "ingress"
-	HookEgress  Hook = "egress"
 )
 
 type ToOrFromEp string
@@ -119,23 +107,4 @@ func ProgFilename(epType EndpointType, toOrFrom ToOrFromEp, epToHostDrop, fib, d
 	oFileName := fmt.Sprintf("%v_%v_%s%s%s%v%s.o",
 		toOrFrom, epTypeShort, hostDropPart, fibPart, dsrPart, logLevel, corePart)
 	return oFileName
-}
-
-const (
-	PinBaseDir = "/sys/fs/bpf/tc/"
-)
-
-func MapPinPath(typ int, name, iface string, hook Hook) string {
-	subDir := "globals"
-	if (typ == unix.BPF_MAP_TYPE_PROG_ARRAY && strings.Contains(name, bpf.JumpMapName())) ||
-		(typ == unix.BPF_MAP_TYPE_PERCPU_ARRAY && strings.Contains(name, bpf.CountersMapName())) {
-		// Remove period in the interface name if any
-		ifName := strings.ReplaceAll(iface, ".", "")
-		if hook == HookIngress {
-			subDir = ifName + "_igr/"
-		} else {
-			subDir = ifName + "_egr/"
-		}
-	}
-	return path.Join(PinBaseDir, subDir, name)
 }

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -40,7 +40,7 @@ func TestReattachPrograms(t *testing.T) {
 	ap1 := tc.AttachPoint{
 		Type:     tc.EpTypeWorkload,
 		ToOrFrom: tc.ToEp,
-		Hook:     tc.HookIngress,
+		Hook:     bpf.HookIngress,
 		DSR:      true,
 		LogLevel: "DEBUG",
 	}
@@ -53,7 +53,7 @@ func TestReattachPrograms(t *testing.T) {
 	ap2 := tc.AttachPoint{
 		Type:     tc.EpTypeWorkload,
 		ToOrFrom: tc.ToEp,
-		Hook:     tc.HookEgress,
+		Hook:     bpf.HookEgress,
 		DSR:      false,
 		LogLevel: "DEBUG",
 	}

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -91,7 +91,7 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 								ap := tc.AttachPoint{
 									Type:       epType,
 									ToOrFrom:   toOrFrom,
-									Hook:       tc.HookIngress,
+									Hook:       bpf.HookIngress,
 									ToHostDrop: epToHostDrop,
 									FIB:        fibEnabled,
 									DSR:        dsr,

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1883,7 +1883,7 @@ func FindJumpMap(progID int, ifaceName string) (mapFD bpf.MapFD, err error) {
 		}
 	}
 
-	return 0, fmt.Errorf("failed to find jump map for iface=%v progID=%v", ifaceName, progID)
+	return 0, fmt.Errorf("failed to find jump map for iface=%s progID=%d", ifaceName, progID)
 }
 
 func (m *bpfEndpointManager) getInterfaceIP(ifaceName string) (*net.IP, error) {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -99,7 +99,7 @@ type attachPoint interface {
 	IfaceName() string
 	JumpMapFDMapKey() string
 	IsAttached() (bool, error)
-	AttachProgram() (string, error)
+	AttachProgram() (int, error)
 	DetachProgram() error
 	Log() *log.Entry
 }
@@ -587,8 +587,8 @@ func (m *bpfEndpointManager) onWorkloadEnpdointRemove(msg *proto.WorkloadEndpoin
 		return false
 	})
 	// Remove policy debug info if any
-	m.removePolicyDebugInfo(oldWEP.Name, tc.HookIngress)
-	m.removePolicyDebugInfo(oldWEP.Name, tc.HookEgress)
+	m.removePolicyDebugInfo(oldWEP.Name, bpf.HookIngress)
+	m.removePolicyDebugInfo(oldWEP.Name, bpf.HookEgress)
 }
 
 // onPolicyUpdate stores the policy in the cache and marks any endpoints using it dirty.
@@ -1196,22 +1196,22 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection
 	if endpointType == tc.EpTypeWorkload {
 		// Policy direction is relative to the workload so, from the host namespace it's flipped.
 		if policyDirection == PolDirnIngress {
-			ap.Hook = tc.HookEgress
+			ap.Hook = bpf.HookEgress
 		} else {
-			ap.Hook = tc.HookIngress
+			ap.Hook = bpf.HookIngress
 		}
 	} else {
 		ap.WgPort = m.wgPort
 		// Host endpoints have the natural relationship between policy direction and hook.
 		if policyDirection == PolDirnIngress {
-			ap.Hook = tc.HookIngress
+			ap.Hook = bpf.HookIngress
 		} else {
-			ap.Hook = tc.HookEgress
+			ap.Hook = bpf.HookEgress
 		}
 	}
 
 	var toOrFrom tc.ToOrFromEp
-	if ap.Hook == tc.HookIngress {
+	if ap.Hook == bpf.HookIngress {
 		toOrFrom = tc.FromEp
 	} else {
 		toOrFrom = tc.ToEp
@@ -1746,7 +1746,7 @@ func (m *bpfEndpointManager) setJumpMapFD(ap attachPoint, fd bpf.MapFD) {
 	})
 }
 
-func (m *bpfEndpointManager) removePolicyDebugInfo(ifaceName string, hook tc.Hook) {
+func (m *bpfEndpointManager) removePolicyDebugInfo(ifaceName string, hook bpf.Hook) {
 	if !m.bpfPolicyDebugEnabled {
 		return
 	}
@@ -1757,7 +1757,7 @@ func (m *bpfEndpointManager) removePolicyDebugInfo(ifaceName string, hook tc.Hoo
 	}
 }
 
-func (m *bpfEndpointManager) writePolicyDebugInfo(insns asm.Insns, ifaceName string, tcHook tc.Hook, polErr error) error {
+func (m *bpfEndpointManager) writePolicyDebugInfo(insns asm.Insns, ifaceName string, tcHook bpf.Hook, polErr error) error {
 	if !m.bpfPolicyDebugEnabled {
 		return nil
 	}
@@ -1769,7 +1769,7 @@ func (m *bpfEndpointManager) writePolicyDebugInfo(insns asm.Insns, ifaceName str
 	// is in reference with the host. Workload's ingress is host's egress and
 	// vice versa.
 	polDir := "ingress"
-	if tcHook == tc.HookIngress {
+	if tcHook == bpf.HookIngress {
 		polDir = "egress"
 	}
 
@@ -1839,10 +1839,11 @@ func (m *bpfEndpointManager) removePolicyProgram(jumpMapFD bpf.MapFD) error {
 	return nil
 }
 
-func FindJumpMap(progIDStr, ifaceName string) (mapFD bpf.MapFD, err error) {
-	logCtx := log.WithField("progID", progIDStr).WithField("iface", ifaceName)
+func FindJumpMap(progID int, ifaceName string) (mapFD bpf.MapFD, err error) {
+	logCtx := log.WithField("progID", progID).WithField("iface", ifaceName)
 	logCtx.Debugf("Looking up jump map")
-	bpftool := exec.Command("bpftool", "prog", "show", "id", progIDStr, "--json")
+	bpftool := exec.Command("bpftool", "prog", "show", "id",
+		fmt.Sprintf("%d", progID), "--json")
 	output, err := bpftool.Output()
 	if err != nil {
 		// We can hit this case if the interface was deleted underneath us; check that it's still there.
@@ -1882,7 +1883,7 @@ func FindJumpMap(progIDStr, ifaceName string) (mapFD bpf.MapFD, err error) {
 		}
 	}
 
-	return 0, fmt.Errorf("failed to find jump map for iface=%v progID=%v", ifaceName, progIDStr)
+	return 0, fmt.Errorf("failed to find jump map for iface=%v progID=%v", ifaceName, progID)
 }
 
 func (m *bpfEndpointManager) getInterfaceIP(ifaceName string) (*net.IP, error) {


### PR DESCRIPTION
## Description
This PR includes two changes:
- Use `int` for program ID.
- Define bpf hooks in BPF package and use it for all other ones.
- Move `MapPinPath` function to bpf package to use it in XDP.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
