### PR TITLE
[release-v3.23] cherry-pick #6287: Support ppc64le image

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -62,10 +62,8 @@ else
 CGO_ENABLED=0
 endif
 
-ifeq ($(ARCH),arm64)
-# Forces ARM64 build image to be used in a crosscompilation run.
+# Use ARCH specific build image.
 CALICO_BUILD:=$(CALICO_BUILD)-$(ARCH)
-endif
 
 ###############################################################################
 # Static checks
@@ -124,7 +122,7 @@ check-boring-ssl: $(BINDIR)/apiserver-$(ARCH)
 		go tool nm $(BINDIR)/apiserver-$(ARCH) > $(BINDIR)/tags.txt && grep '_Cfunc__goboringcrypto_' $(BINDIR)/tags.txt 1> /dev/null
 	-rm -f $(BINDIR)/tags.txt
 
-.PHONY: ut 
+.PHONY: ut
 ut: lint-cache-dir run-etcd
 	$(DOCKER_RUN) $(CALICO_BUILD) \
 		sh -c '$(GIT_CONFIG_SSH) ETCD_ENDPOINTS="http://127.0.0.1:2379" DATASTORE_TYPE="etcdv3" go test $(UNIT_TEST_FLAGS) \
@@ -216,7 +214,7 @@ clean-hack-lib:
 # Release
 ###############################################################################
 ## Produces a clean build of release artifacts at the specified version.
-release-build: .release-$(VERSION).created 
+release-build: .release-$(VERSION).created
 .release-$(VERSION).created:
 	$(MAKE) clean image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries IMAGETAG=$(VERSION) RELEASE=true

--- a/apiserver/docker-image/Dockerfile.ppc64le
+++ b/apiserver/docker-image/Dockerfile.ppc64le
@@ -1,0 +1,30 @@
+ARG QEMU_IMAGE
+ARG UBI_IMAGE
+
+FROM ${QEMU_IMAGE} as qemu
+
+FROM --platform=linux/ppc64le ${UBI_IMAGE} as ubi
+
+COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+
+RUN microdnf update
+
+# At runtime, apiserver generate certificates in /code directory
+# hence, provide RW permission for user 1001
+RUN mkdir /code
+RUN rm -rf /tmp
+RUN mkdir /tmp
+
+FROM scratch
+COPY  --from=ubi /code /code
+COPY  --from=ubi /tmp /tmp
+# copies the shared linux libs requred by apiserver
+COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
+COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
+
+ADD  bin/apiserver-ppc64le /code/apiserver
+ADD  bin/filecheck-ppc64le /code/filecheck
+
+WORKDIR /code
+
+ENTRYPOINT ["./apiserver"]

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -224,13 +224,16 @@ endif
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 CERTS_PATH := $(REPO_ROOT)/hack/test/certs
 
-# Set the platform correctly for building docker images so that 
+# Set the platform correctly for building docker images so that
 # cross-builds get the correct architecture set in the produced images.
 ifeq ($(ARCH),arm64)
 TARGET_PLATFORM=--platform=linux/arm64/v8
 endif
 ifeq ($(ARCH),armv7)
 TARGET_PLATFORM=--platform=linux/arm/v7
+endif
+ifeq ($(ARCH),ppc64le)
+TARGET_PLATFORM=--platform=linux/ppc64le
 endif
 
 # DOCKER_BUILD is the base build command used for building all images.


### PR DESCRIPTION
Signed-off-by: Yussuf Shaikh <yussuf.shaikh1@ibm.com>

## Description

Add support for ppc64le apiserver build image.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Build ppc64le image for calico/apiserver.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
