### PR TITLE
Properly refcount routes, fix accidental withdrawal of routes

### DIFF
--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -135,6 +135,15 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 		nodeIPs:                 make(map[string]struct{}),
 		programmedRouteRefCount: make(map[string]int),
 
+		// Track which routes we have sent, and which we have not. We need maps for
+		// each of the three types of routes we track.
+		programmedRejectRoutesExt: make(map[string]bool),
+		programmedRoutesExt:       make(map[string]bool),
+		programmedRejectRoutesLB:  make(map[string]bool),
+		programmedRoutesLB:        make(map[string]bool),
+		programmedRejectRoutesCIP: make(map[string]bool),
+		programmedRoutesCIP:       make(map[string]bool),
+
 		// This channel, for the syncer calling OnUpdates and OnStatusUpdated, has 0
 		// capacity so that the caller blocks in the same way as it did before when its
 		// calls were processed synchronously.
@@ -285,6 +294,13 @@ type client struct {
 	// sources to track - k8s Services, and BGPConfiguration - and they can
 	// provide duplicate routes.
 	programmedRouteRefCount map[string]int
+
+	programmedRoutesExt       map[string]bool
+	programmedRejectRoutesExt map[string]bool
+	programmedRoutesLB        map[string]bool
+	programmedRejectRoutesLB  map[string]bool
+	programmedRoutesCIP       map[string]bool
+	programmedRejectRoutesCIP map[string]bool
 
 	// Readiness signals for individual data sources.
 	sourceReady map[string]bool
@@ -1323,7 +1339,7 @@ func getCommunitiesArray(communitiesSet set.Set[string]) []string {
 }
 
 func (c *client) onExternalIPsUpdate(externalIPs []string) {
-	if err := c.updateGlobalRoutes(c.externalIPs, externalIPs); err == nil {
+	if err := c.updateGlobalRoutes(externalIPs, c.programmedRejectRoutesExt, c.programmedRoutesExt); err == nil {
 		c.externalIPs = externalIPs
 		c.externalIPNets = parseIPNets(c.externalIPs)
 		log.Infof("Updated with new external IP CIDRs: %s", externalIPs)
@@ -1333,16 +1349,17 @@ func (c *client) onExternalIPsUpdate(externalIPs []string) {
 }
 
 func (c *client) onClusterIPsUpdate(clusterCIDRs []string) {
-	if err := c.updateGlobalRoutes(c.clusterCIDRs, clusterCIDRs); err == nil {
+	if err := c.updateGlobalRoutes(clusterCIDRs, c.programmedRejectRoutesCIP, c.programmedRoutesCIP); err == nil {
 		c.clusterCIDRs = clusterCIDRs
 		log.Infof("Updated with new cluster IP CIDRs: %s", clusterCIDRs)
+		c.printRefCounts()
 	} else {
 		log.WithError(err).Error("Failed to update cluster CIDR routes")
 	}
 }
 
 func (c *client) onLoadBalancerIPsUpdate(lbIPs []string) {
-	if err := c.updateGlobalRoutes(c.loadBalancerIPs, lbIPs); err == nil {
+	if err := c.updateGlobalRoutes(lbIPs, c.programmedRejectRoutesLB, c.programmedRoutesLB); err == nil {
 		c.loadBalancerIPs = lbIPs
 		c.loadBalancerIPNets = parseIPNets(c.loadBalancerIPs)
 		log.Infof("Updated with new Loadbalancer IP CIDRs: %s", lbIPs)
@@ -1371,8 +1388,8 @@ func (c *client) GetLoadBalancerIPs() []*net.IPNet {
 
 // "Global" here means the routes for cluster IP and external IP CIDRs that are advertised from
 // every node in the cluster.
-func (c *client) updateGlobalRoutes(current, new []string) error {
-	for _, n := range new {
+func (c *client) updateGlobalRoutes(routes []string, programmedRejectRoutes, programmedRoutes map[string]bool) error {
+	for _, n := range routes {
 		_, _, err := net.ParseCIDR(n)
 		if err != nil {
 			// Shouldn't ever happen, given prior validation.
@@ -1380,29 +1397,58 @@ func (c *client) updateGlobalRoutes(current, new []string) error {
 		}
 	}
 
-	// Find any currently advertised CIDRs that we should withdraw.
-	withdraws := []string{}
-	for _, existing := range current {
-		if !contains(new, existing) {
-			withdraws = append(withdraws, existing)
-		}
-	}
-
 	if !c.ExcludeServiceAdvertisement() {
-		// Withdraw the old CIDRs and add the new.
 		log.Info("Advertise global service ranges from this node")
-		c.addRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, new)
-		c.addRoutesLockHeld(routeKeyPrefix, routeKeyPrefixV6, new)
-		c.deleteRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, withdraws)
-		c.deleteRoutesLockHeld(routeKeyPrefix, routeKeyPrefixV6, withdraws)
+		for _, r := range routes {
+			if !programmedRejectRoutes[r] {
+				c.addRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, []string{r})
+				programmedRejectRoutes[r] = true
+			}
+			if !programmedRoutes[r] {
+				c.addRoutesLockHeld(routeKeyPrefix, routeKeyPrefixV6, []string{r})
+				programmedRoutes[r] = true
+			}
+		}
+
+		for r := range programmedRoutes {
+			if !contains(routes, r) {
+				c.deleteRoutesLockHeld(routeKeyPrefix, routeKeyPrefixV6, []string{r})
+				delete(programmedRoutes, r)
+			}
+		}
+		for r := range programmedRejectRoutes {
+			if !contains(routes, r) {
+				c.deleteRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, []string{r})
+				delete(programmedRejectRoutes, r)
+			}
+		}
 	} else {
 		// If this node is excluded from service advertisement, we should not advertise any
 		// routes. However, we should still program reject rules for the CIDR range so we do not
 		// program any learned routes into the data plane.
 		log.Info("Do not advertise global service ranges from this node")
-		c.deleteRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, current)
-		c.deleteRoutesLockHeld(routeKeyPrefix, routeKeyPrefixV6, current)
-		c.addRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, new)
+
+		// c.addRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, adds)
+		for _, r := range routes {
+			if !programmedRejectRoutes[r] {
+				c.addRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, []string{r})
+				programmedRejectRoutes[r] = true
+			}
+		}
+
+		// c.deleteRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, withdraws)
+		for r := range programmedRejectRoutes {
+			if !contains(routes, r) {
+				c.deleteRoutesLockHeld(rejectKeyPrefix, rejectKeyPrefixV6, []string{r})
+				delete(programmedRejectRoutes, r)
+			}
+		}
+
+		// Delete all programmed routes.
+		for r := range programmedRoutes {
+			c.deleteRoutesLockHeld(routeKeyPrefix, routeKeyPrefixV6, []string{r})
+			delete(programmedRoutes, r)
+		}
 	}
 
 	return nil
@@ -1674,7 +1720,7 @@ func (c *client) deleteRoutesLockHeld(prefixV4, prefixV6 string, cidrs []string)
 			k = prefixV4 + strings.Replace(cidr, "/", "-", 1)
 		}
 
-		if c.programmedRouteRefCount[k] == 1 {
+		if c.programmedRouteRefCount[k] <= 1 {
 			// This is the last reference for this route. We can remove it.
 			// We only delete from the cache if there are no other users of this route.
 			delete(c.cache, k)

--- a/confd/pkg/backends/calico/client.go
+++ b/confd/pkg/backends/calico/client.go
@@ -1352,7 +1352,6 @@ func (c *client) onClusterIPsUpdate(clusterCIDRs []string) {
 	if err := c.updateGlobalRoutes(clusterCIDRs, c.programmedRejectRoutesCIP, c.programmedRoutesCIP); err == nil {
 		c.clusterCIDRs = clusterCIDRs
 		log.Infof("Updated with new cluster IP CIDRs: %s", clusterCIDRs)
-		c.printRefCounts()
 	} else {
 		log.WithError(err).Error("Failed to update cluster CIDR routes")
 	}

--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -444,7 +444,7 @@ func (rg *routeGenerator) advertiseRoute(key, route string) {
 	// trigger advertisement of this prefix, however we only ever want to send
 	// a single static route advertisement as a result.
 	if rg.routeAdvertisementRefCount[route] == 0 {
-		// First time we've seend this route - advertise it.
+		// First time we've seen this route - advertise it.
 		rg.client.AddStaticRoutes([]string{route})
 	}
 

--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -63,11 +63,11 @@ func NewRouteGenerator(c *client) (rg *routeGenerator, err error) {
 
 	// initialize empty route generator
 	rg = &routeGenerator{
-		client:                   c,
-		nodeName:                 nodename,
-		svcRouteMap:              make(map[string]map[string]bool),
-		routeAdvertisementRefCount:  make(map[string]int),
-		resyncKnownRoutesTrigger: make(chan struct{}, 1),
+		client:                     c,
+		nodeName:                   nodename,
+		svcRouteMap:                make(map[string]map[string]bool),
+		routeAdvertisementRefCount: make(map[string]int),
+		resyncKnownRoutesTrigger:   make(chan struct{}, 1),
 	}
 
 	// set up k8s client

--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -41,13 +41,13 @@ const (
 // valid service ips to advertise
 type routeGenerator struct {
 	sync.Mutex
-	client                   *client
-	nodeName                 string
-	svcInformer, epInformer  cache.Controller
-	svcIndexer, epIndexer    cache.Indexer
-	svcRouteMap              map[string]map[string]bool
-	routeAdvertisementCount  map[string]int
-	resyncKnownRoutesTrigger chan struct{}
+	client                     *client
+	nodeName                   string
+	svcInformer, epInformer    cache.Controller
+	svcIndexer, epIndexer      cache.Indexer
+	svcRouteMap                map[string]map[string]bool
+	routeAdvertisementRefCount map[string]int
+	resyncKnownRoutesTrigger   chan struct{}
 }
 
 // NewRouteGenerator initializes a kube-api client and the informers
@@ -260,7 +260,6 @@ func (rg *routeGenerator) getAllRoutesForService(svc *v1.Service) []string {
 				routes = append(routes, lbIngress.IP)
 			}
 		}
-
 	}
 
 	return addFullIPLength(routes)
@@ -269,7 +268,6 @@ func (rg *routeGenerator) getAllRoutesForService(svc *v1.Service) []string {
 // getAdvertisedRoutes returns the routes that are currently advertised and
 // associated with the given key.
 func (rg *routeGenerator) getAdvertisedRoutes(key string) []string {
-
 	routes := make([]string, 0)
 
 	if rg.svcRouteMap[key] != nil {
@@ -279,14 +277,12 @@ func (rg *routeGenerator) getAdvertisedRoutes(key string) []string {
 	}
 
 	return routes
-
 }
 
 // setRoutesForKey associates only the given routes with the given key,
 // and advertises the given routes. It also withdraws any routes that are no
 // longer associated with the given key.
 func (rg *routeGenerator) setRoutesForKey(key string, routes []string) {
-
 	advertisedRoutes := rg.svcRouteMap[key]
 	if advertisedRoutes == nil {
 		advertisedRoutes = make(map[string]bool)
@@ -303,20 +299,16 @@ func (rg *routeGenerator) setRoutesForKey(key string, routes []string) {
 
 	// Advertise all routes that are not already advertised.
 	for _, route := range routes {
-
-		// Advertise route if not already advertised
+		// Advertise route if not already advertised for this key.
 		if _, ok := advertisedRoutes[route]; !ok {
 			rg.advertiseRoute(key, route)
 		}
-
 	}
-
 }
 
 // isAllowedExternalIP determines if the given IP is in the list of
 // whitelisted External IP CIDRs given in the default bgpconfiguration.
 func (rg *routeGenerator) isAllowedExternalIP(externalIP string) bool {
-
 	ip := net.ParseIP(externalIP)
 	if ip == nil {
 		log.Errorf("Could not parse service External IP: %s", externalIP)
@@ -336,7 +328,6 @@ func (rg *routeGenerator) isAllowedExternalIP(externalIP string) bool {
 // isAllowedLoadBalancerIP determines if the given IP is in the list of
 // whitelisted LoadBalancer CIDRs given in the default bgpconfiguration.
 func (rg *routeGenerator) isAllowedLoadBalancerIP(loadBalancerIP string) bool {
-
 	ip := net.ParseIP(loadBalancerIP)
 	if ip == nil {
 		log.Errorf("Could not parse service LB IP: %s", loadBalancerIP)
@@ -447,11 +438,19 @@ func (rg *routeGenerator) advertiseRoute(key, route string) {
 	if _, hasKey := rg.svcRouteMap[key]; !hasKey {
 		rg.svcRouteMap[key] = make(map[string]bool)
 	}
-
-	rg.client.AddStaticRoutes([]string{route})
 	rg.svcRouteMap[key][route] = true
 
-	rg.routeAdvertisementCount[route]++
+	// We need to reference count routes. We may have multiple services that
+	// trigger advertisement of this prefix, however we only ever want to send
+	// a single static route advertisement as a result.
+	if rg.routeAdvertisementRefCount[route] == 0 {
+		// First time we've seend this route - advertise it.
+		rg.client.AddStaticRoutes([]string{route})
+	} else {
+		// We've already advertised this prefix. Increment the counter
+		// to mark that we have multiple users of the route.
+		rg.routeAdvertisementRefCount[route]++
+	}
 }
 
 // withdrawRoute withdraws a route associated with the given key and
@@ -464,11 +463,11 @@ func (rg *routeGenerator) withdrawRoute(key, route string) {
 	// and assign the same External IP twice to a service. In all of these
 	// scenarios, you would end up in a situation where the same route is
 	// "legitimately" being advertised twice from a node.
-	if rg.routeAdvertisementCount[route] == 1 {
+	if rg.routeAdvertisementRefCount[route] == 1 {
 		rg.client.DeleteStaticRoutes([]string{route})
-		delete(rg.routeAdvertisementCount, route)
+		delete(rg.routeAdvertisementRefCount, route)
 	} else {
-		rg.routeAdvertisementCount[route]--
+		rg.routeAdvertisementRefCount[route]--
 	}
 
 	if rg.svcRouteMap[key] != nil {

--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -92,16 +92,13 @@ var _ = Describe("RouteGenerator", func() {
 			svcRouteMap:                make(map[string]map[string]bool),
 			routeAdvertisementRefCount: make(map[string]int),
 			client: &client{
-				cache:                     make(map[string]string),
-				syncedOnce:                true,
-				clusterCIDRs:              []string{"10.0.0.0/16"},
-				programmedRouteRefCount:   make(map[string]int),
-				programmedRejectRoutesExt: make(map[string]bool),
-				programmedRoutesExt:       make(map[string]bool),
-				programmedRejectRoutesLB:  make(map[string]bool),
-				programmedRoutesLB:        make(map[string]bool),
-				programmedRejectRoutesCIP: make(map[string]bool),
-				programmedRoutesCIP:       make(map[string]bool),
+				cache:                    make(map[string]string),
+				syncedOnce:               true,
+				clusterCIDRs:             []string{"10.0.0.0/16"},
+				programmedRouteRefCount:  make(map[string]int),
+				ExternalIPRouteIndex:     NewRouteIndex(),
+				ClusterIPRouteIndex:      NewRouteIndex(),
+				LoadBalancerIPRouteIndex: NewRouteIndex(),
 
 				externalIPs: []string{
 					ipNet1.String(),

--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -27,8 +27,11 @@ const (
 func addEndpointSubset(ep *v1.Endpoints, nodename string) {
 	ep.Subsets = append(ep.Subsets, v1.EndpointSubset{
 		Addresses: []v1.EndpointAddress{
-			v1.EndpointAddress{
-				NodeName: &nodename}}})
+			{
+				NodeName: &nodename,
+			},
+		},
+	})
 }
 
 func buildSimpleService() (svc *v1.Service, ep *v1.Endpoints) {
@@ -40,7 +43,8 @@ func buildSimpleService() (svc *v1.Service, ep *v1.Endpoints) {
 			ClusterIP:             "127.0.0.1",
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 			ExternalIPs:           []string{externalIP1, externalIP2},
-		}}
+		},
+	}
 	ep = &v1.Endpoints{
 		ObjectMeta: meta,
 	}
@@ -56,7 +60,8 @@ func buildSimpleService2() (svc *v1.Service, ep *v1.Endpoints) {
 			ClusterIP:             "127.0.0.5",
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 			ExternalIPs:           []string{externalIP1, externalIP2},
-		}}
+		},
+	}
 	ep = &v1.Endpoints{
 		ObjectMeta: meta,
 	}
@@ -69,7 +74,6 @@ var _ = Describe("RouteGenerator", func() {
 	var expectedSvc2RouteMap map[string]bool
 
 	BeforeEach(func() {
-
 		_, ipNet1, _ := net.ParseCIDR("104.244.42.129/32")
 		_, ipNet2, _ := net.ParseCIDR("172.217.3.0/24")
 
@@ -82,15 +86,16 @@ var _ = Describe("RouteGenerator", func() {
 		expectedSvc2RouteMap["172.217.3.5/32"] = true
 
 		rg = &routeGenerator{
-			nodeName:                "foobar",
-			svcIndexer:              cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			epIndexer:               cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			svcRouteMap:             make(map[string]map[string]bool),
-			routeAdvertisementCount: make(map[string]int),
+			nodeName:                   "foobar",
+			svcIndexer:                 cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			epIndexer:                  cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			svcRouteMap:                make(map[string]map[string]bool),
+			routeAdvertisementRefCount: make(map[string]int),
 			client: &client{
-				cache:        make(map[string]string),
-				syncedOnce:   true,
-				clusterCIDRs: []string{"10.0.0.0/16"},
+				cache:                   make(map[string]string),
+				syncedOnce:              true,
+				clusterCIDRs:            []string{"10.0.0.0/16"},
+				programmedRouteRefCount: make(map[string]int),
 				externalIPs: []string{
 					ipNet1.String(),
 					ipNet2.String(),
@@ -220,8 +225,8 @@ var _ = Describe("RouteGenerator", func() {
 			rg.onSvcAdd(svc)
 			Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 			Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
-			Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-			Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
@@ -232,8 +237,8 @@ var _ = Describe("RouteGenerator", func() {
 			rg.onEPAdd(ep)
 			Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 			Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
-			Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
-			Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal(""))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal(""))
 			Expect(rg.client.cache).To(Equal(map[string]string{}))
@@ -251,8 +256,8 @@ var _ = Describe("RouteGenerator", func() {
 			rg.onEPAdd(ep)
 			Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 			Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
-			Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
-			Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal(""))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal(""))
 			Expect(rg.client.cache).To(Equal(map[string]string{}))
@@ -270,8 +275,8 @@ var _ = Describe("RouteGenerator", func() {
 			rg.onEPAdd(ep)
 			Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 			Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
-			Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-			Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+			Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+			Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 		})
@@ -283,8 +288,8 @@ var _ = Describe("RouteGenerator", func() {
 				rg.onSvcAdd(svc)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
@@ -293,8 +298,8 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1/32"))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
@@ -304,23 +309,29 @@ var _ = Describe("RouteGenerator", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onSvcAdd(svc)
 				rg.onSvcAdd(svc2)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 3))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.svcRouteMap["foo/rem"]).To(Equal(expectedSvc2RouteMap))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-				Expect(rg.routeAdvertisementCount["127.0.0.5/32"]).To(Equal(1))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(2))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.5/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(2))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.5-32"]).To(Equal("127.0.0.5/32"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
+				// We expect the client refcounter to have a single reference for each generated route, as
+				// the route generator deduplicates route updates itself for duplicate service IPs.
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/127.0.0.5-32"]).To(Equal(1))
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/127.0.0.1-32"]).To(Equal(1))
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/172.217.3.5-32"]).To(Equal(1))
+
 				// delete one of the services, and make sure the duplicate route is still advertised
 				// and we handle the counting logic correctly
 				rg.onSvcDelete(svc2)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 5))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-				Expect(rg.routeAdvertisementCount["127.0.0.5/32"]).To(Equal(0))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.svcRouteMap["foo/rem"]).ToNot(HaveKey("127.0.0.5/32"))
 				Expect(rg.svcRouteMap["foo/rem"]).ToNot(HaveKey("172.217.3.5/32"))
@@ -328,15 +339,25 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.5-32"))
 
+				// The client refcount should be updated as well.
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/127.0.0.1-32"]).To(Equal(1))
+				Expect(rg.client.programmedRouteRefCount["/calico/staticroutes/172.217.3.5-32"]).To(Equal(1))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/127.0.0.5-32"))
+
 				// delete the other service and check that both routes are withdrawn and their counts are 0
 				rg.onSvcDelete(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 7))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 6))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1/32"))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+
+				// The client refcount should be updated as well.
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/172.217.3.5-32"))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey("/calico/staticroutes/127.0.0.5-32"))
 			})
 		})
 
@@ -346,8 +367,8 @@ var _ = Describe("RouteGenerator", func() {
 				rg.onSvcUpdate(nil, svc)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
@@ -357,8 +378,8 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1-32"))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
@@ -371,8 +392,8 @@ var _ = Describe("RouteGenerator", func() {
 				rg.onEPAdd(ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
@@ -380,8 +401,8 @@ var _ = Describe("RouteGenerator", func() {
 				rg.onEPDelete(ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcRouteMap).ToNot(HaveKey("foo/bar"))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 			})
@@ -393,8 +414,8 @@ var _ = Describe("RouteGenerator", func() {
 				rg.onEPUpdate(nil, ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(1))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
@@ -403,8 +424,8 @@ var _ = Describe("RouteGenerator", func() {
 				rg.onEPUpdate(nil, ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
-				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
-				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementRefCount["172.217.3.5/32"]).To(Equal(0))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
@@ -447,6 +468,72 @@ var _ = Describe("RouteGenerator", func() {
 
 				// We should no longer see cluster CIDRs to be advertised.
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(BeEmpty())
+			})
+
+			// This test simulates a situation where BGPConfiguration has a /32 route that exactly matches
+			// a Service route, resulting in two references to said route. It asserts that when the BGPConfiguration
+			// is modified to remove that route, the service entry is still properly advertised.
+			It("should handle duplicate prefixes BGPConfiguration and Service generated routes", func() {
+				// Create a /32 CIDR for the services first externalIP.
+				externalIPRangeSingle := fmt.Sprintf("%s/32", externalIP1)
+				key := "/calico/staticroutes/" + externalIP1 + "-32"
+
+				// Trigger programming of valid routes from the route generator for any known services.
+				// We don't have a BGPConfiguration update yet, so we shouldn't receive any routes.
+				By("Resyncing routes at start of test")
+				rg.resyncKnownRoutes()
+				Expect(rg.client.cache[key]).To(Equal(""))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(0))
+
+				// Simulate an event from the syncer which sets the External IP range containing only the service's externalIP.
+				By("onExternalIPsUpdate to include /32 route")
+				rg.client.onExternalIPsUpdate([]string{externalIPRangeSingle})
+
+				// Expect that we advertise the /32 given to us via BGPConfiguration.
+				Expect(rg.client.cache[key]).To(Equal(externalIP1 + "/32"))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
+
+				// Trigger programming of routes from the route generator again. This time, the service's externalIP
+				// will be allowed by BGPConfiguration and so it should be programmed.
+				By("Resyncing routes from route generator")
+				rg.resyncKnownRoutes()
+
+				// Expect that we continue to advertise the route, but the refcount should indicate a route received
+				// from both the RouteGenerator and BGPConfiguration.
+				Expect(rg.client.cache[key]).To(Equal(externalIP1 + "/32"))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(2))
+
+				// Simulate an event from the syncer which updates the range. It still includes the original IP,
+				// to ensure we don't trigger the route generator to withdraw its route.
+				By("onExternalIPsUpdate to include /16 route")
+				rg.client.onExternalIPsUpdate([]string{externalIPRange1})
+				rg.resyncKnownRoutes()
+
+				// The route should still exist, since the RouteGenerator's route is still valid. However,
+				// its reference count should be decremented back to one.
+				Expect(rg.client.cache[key]).To(Equal(externalIP1 + "/32"))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
+
+				// Revert the BGPConfiguration change.
+				By("onExternalIPsUpdate to include /32 route again")
+				rg.client.onExternalIPsUpdate([]string{externalIPRangeSingle})
+				rg.resyncKnownRoutes()
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(2))
+
+				// Now, remove both services (since both contribute externalIP). Ensure that the route is still programmed
+				// (via BGPConfiguration), but the ref count should once again drop to 1.
+				By("Deleting svc")
+				rg.onSvcDelete(svc)
+				By("Deleting svc2")
+				rg.onSvcDelete(svc2)
+				Expect(rg.client.cache[key]).To(Equal(externalIP1 + "/32"))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
+
+				// Finally, remove BGPConfiguration. It should withdraw the route
+				// and delete the refcount entry.
+				rg.client.onExternalIPsUpdate([]string{})
+				Expect(rg.client.cache).NotTo(HaveKey(key))
+				Expect(rg.client.programmedRouteRefCount).NotTo(HaveKey(key))
 			})
 		})
 	})

--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -92,10 +92,17 @@ var _ = Describe("RouteGenerator", func() {
 			svcRouteMap:                make(map[string]map[string]bool),
 			routeAdvertisementRefCount: make(map[string]int),
 			client: &client{
-				cache:                   make(map[string]string),
-				syncedOnce:              true,
-				clusterCIDRs:            []string{"10.0.0.0/16"},
-				programmedRouteRefCount: make(map[string]int),
+				cache:                     make(map[string]string),
+				syncedOnce:                true,
+				clusterCIDRs:              []string{"10.0.0.0/16"},
+				programmedRouteRefCount:   make(map[string]int),
+				programmedRejectRoutesExt: make(map[string]bool),
+				programmedRoutesExt:       make(map[string]bool),
+				programmedRejectRoutesLB:  make(map[string]bool),
+				programmedRoutesLB:        make(map[string]bool),
+				programmedRejectRoutesCIP: make(map[string]bool),
+				programmedRoutesCIP:       make(map[string]bool),
+
 				externalIPs: []string{
 					ipNet1.String(),
 					ipNet2.String(),


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Discovered in https://github.com/projectcalico/calico/issues/6074 and
https://github.com/projectcalico/calico/pull/6282.

BGPConfiguration and Services both provide static routes. Should they
provide the same route, we need to properly reference count them in
order to prevent accidental route withdrawals.

Example:

- BGPConfiguration contributes 10.0.0.1/32 
- Service A contributes 10.0.0.1/32 
- BGPConfiguration withdraws 10.0.0.1/32, replaces with 10.0.0.0/24 

We need to make sure we keep advertising 10.0.0.1/32, as contributed by the Service, even 
though BGPConfiguration no longer contributes that prefix. 

We actually have two layers of reference counting involved here - the
RouteGenerator reference counts prefixes since multiple services can
contribute the same CIDR, and the client further reference counts
prefixes from the RouteGenerator and BGPConfiguration. 

It's possible we could consolidate to a single layer, but it seems
conceptually correct and easier to test if we do this in two stages.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix occasional incorrect withdrawal of Service IPs over BGP when changing BGPConfiguration.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.