### PR TITLE
Update api reference

### DIFF
--- a/calico/reference/installation/_api.html
+++ b/calico/reference/installation/_api.html
@@ -8,6 +8,8 @@
 <p>API Schema definitions for configuring the installation of Calico and Calico Enterprise</p>
 Resource Types:
 <ul><li>
+<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+</li><li>
 <a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
 </li><li>
 <a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
@@ -18,6 +20,96 @@ Resource Types:
 </li><li>
 <a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
 </li></ul>
+<h3 id="operator.tigera.io/v1.APIServer">APIServer
+</h3>
+<p>APIServer installs the Tigera API server and related resources. At most one instance
+of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br>
+string
+</td>
+<td><code>APIServer</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerSpec">
+APIServerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Specification of the desired state for the Tigera API server.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>apiServerDeployment</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">
+APIServerDeployment
+</a>
+</em>
+</td>
+<td>
+<p>APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If
+used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides
+take precedence.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerStatus">
+APIServerStatus
+</a>
+</em>
+</td>
+<td>
+<p>Most recently observed status for the Tigera API server.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer
 </h3>
 <p>ApplicationLayer is the Schema for the applicationlayers API</p>
@@ -382,7 +474,8 @@ TyphaAffinity
 </td>
 <td>
 <em>(Optional)</em>
-<p>TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
+<p>Deprecated. Please use Installation.Spec.TyphaDeployment instead.
+TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
 </td>
 </tr>
 <tr>
@@ -492,7 +585,8 @@ field.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>ComponentResources can be used to customize the resource requirements for each component.
+<p>Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment.
+ComponentResources can be used to customize the resource requirements for each component.
 Node, Typha, and KubeControllers are supported for installations.</p>
 </td>
 </tr>
@@ -524,6 +618,61 @@ NonPrivilegedType
 <td>
 <em>(Optional)</em>
 <p>NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeDaemonSet</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+CalicoNodeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoKubeControllersDeployment</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+CalicoKubeControllersDeployment
+</a>
+</em>
+</td>
+<td>
+<p>CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaDeployment</code><br>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeployment">
+TyphaDeployment
+</a>
+</em>
+</td>
+<td>
+<p>TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated
+ComponentResources or TyphaAffinity, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoWindowsUpgradeDaemonSet</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+CalicoWindowsUpgradeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
 </td>
 </tr>
 </table>
@@ -689,6 +838,401 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+</p>
+<p>APIServerDeployment is the configuration for the API server Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+APIServerDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the API server Deployment.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+</p>
+<p>APIServerDeploymentContainer is an API server Deployment container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the API server Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named API server Deployment container&rsquo;s resources.
+If omitted, the API server Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+</p>
+<p>APIServerDeploymentInitContainer is an API server Deployment init container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the API server Deployment init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named API server Deployment init container&rsquo;s resources.
+If omitted, the API server Deployment will use its default value for this init container&rsquo;s resources.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+</p>
+<p>APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+[]APIServerDeploymentInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of API server init containers.
+If specified, this overrides the specified API server Deployment init containers.
+If omitted, the API server Deployment will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+[]APIServerDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of API server containers.
+If specified, this overrides the specified API server Deployment containers.
+If omitted, the API server Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the API server pods.
+If specified, this overrides any affinity that may be set on the API server Deployment.
+If omitted, the API server Deployment will use its default value for affinity.
+WARNING: Please note that this field will override the default API server Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the API server pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the API server Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the API server Deployment
+and each of this field&rsquo;s key/value pairs are added to the API server Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the API server Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default API server Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the API server pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the API server Deployment.
+If omitted, the API server Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default API server Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+</p>
+<p>APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+APIServerDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the API server Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+</p>
+<p>APIServerDeploymentSpec defines configuration for the API server Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the API server Deployment.
+If omitted, the API server Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+APIServerDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the API server Deployment pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+</p>
+<p>APIServerSpec defines the desired state of Tigera API server.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiServerDeployment</code><br>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">
+APIServerDeployment
+</a>
+</em>
+</td>
+<td>
+<p>APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If
+used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides
+take precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+</p>
+<p>APIServerStatus defines the observed state of Tigera API server.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>State provides user-readable status.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec
 </h3>
 <p>
@@ -813,6 +1357,281 @@ IPAMSpec
 <em>(Optional)</em>
 <p>IPAM specifies the pod IP address management that will be used in the Calico or
 Calico Enterprise installation.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>CalicoKubeControllersDeployment is the configuration for the calico-kube-controllers Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+CalicoKubeControllersDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-kube-controllers Deployment.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+</p>
+<p>CalicoKubeControllersDeploymentContainer is a calico-kube-controllers Deployment container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-kube-controllers Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-kube-controllers Deployment container&rsquo;s resources.
+If omitted, the calico-kube-controllers Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+</p>
+<p>CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+[]CalicoKubeControllersDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-kube-controllers containers.
+If specified, this overrides the specified calico-kube-controllers Deployment containers.
+If omitted, the calico-kube-controllers Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-kube-controllers pods.
+If specified, this overrides any affinity that may be set on the calico-kube-controllers Deployment.
+If omitted, the calico-kube-controllers Deployment will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-kube-controllers Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the calico-kube-controllers pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the calico-kube-controllers Deployment
+and each of this field&rsquo;s key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-kube-controllers Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-kube-controllers Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-kube-controllers pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-kube-controllers Deployment.
+If omitted, the calico-kube-controllers Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-kube-controllers Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+</p>
+<p>CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers Deployment&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+CalicoKubeControllersDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+</p>
+<p>CalicoKubeControllersDeploymentSpec defines configuration for the calico-kube-controllers Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-kube-controllers Deployment.
+If omitted, the calico-kube-controllers Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+CalicoKubeControllersDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-kube-controllers Deployment pod that will be created.</p>
 </td>
 </tr>
 </tbody>
@@ -969,6 +1788,612 @@ Default: Disabled</p>
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+CalicoNodeDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-node DaemonSet.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeDaemonSetContainer is a calico-node DaemonSet container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node DaemonSet container&rsquo;s resources.
+If omitted, the calico-node DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeDaemonSetInitContainer is a calico-node DaemonSet init container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node DaemonSet init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node DaemonSet init container&rsquo;s resources.
+If omitted, the calico-node DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+</p>
+<p>CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+[]CalicoNodeDaemonSetInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of calico-node init containers.
+If specified, this overrides the specified calico-node DaemonSet init containers.
+If omitted, the calico-node DaemonSet will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+[]CalicoNodeDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-node containers.
+If specified, this overrides the specified calico-node DaemonSet containers.
+If omitted, the calico-node DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-node pods.
+If specified, this overrides any affinity that may be set on the calico-node DaemonSet.
+If omitted, the calico-node DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-node DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is the calico-node pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-node DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-node DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-node pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-node DaemonSet.
+If omitted, the calico-node DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-node DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+</p>
+<p>CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+CalicoNodeDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-node DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+</p>
+<p>CalicoNodeDaemonSetSpec defines configuration for the calico-node DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-node DaemonSet.
+If omitted, the calico-node DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+CalicoNodeDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-node DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+CalicoWindowsUpgradeDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-windows-upgrade DaemonSet.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+</p>
+<p>CalicoWindowsUpgradeDaemonSetContainer is a calico-windows-upgrade DaemonSet container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-windows-upgrade DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-windows-upgrade DaemonSet container&rsquo;s resources.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for this container&rsquo;s resources.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+</p>
+<p>CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+[]CalicoWindowsUpgradeDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-windows-upgrade containers.
+If specified, this overrides the specified calico-windows-upgrade DaemonSet containers.
+If omitted, the calico-windows-upgrade DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-windows-upgrade pods.
+If specified, this overrides any affinity that may be set on the calico-windows-upgrade DaemonSet.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is the calico-windows-upgrade pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-windows-upgrade DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-windows-upgrade DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-windows-upgrade pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-windows-upgrade DaemonSet.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+</p>
+<p>CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade DaemonSet&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+CalicoWindowsUpgradeDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+</p>
+<p>CalicoWindowsUpgradeDaemonSetSpec defines configuration for the calico-windows-upgrade DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-windows-upgrade DaemonSet.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+CalicoWindowsUpgradeDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-windows-upgrade DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement
 </h3>
 <p>
@@ -1054,7 +2479,8 @@ Default: SHA256WithRSA</p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<p>The ComponentResource struct associates a ResourceRequirements with a component by name</p>
+<p>Deprecated. Please use component resource config fields in Installation.Spec instead.
+The ComponentResource struct associates a ResourceRequirements with a component by name</p>
 <table>
 <thead>
 <tr>
@@ -1494,7 +2920,8 @@ TyphaAffinity
 </td>
 <td>
 <em>(Optional)</em>
-<p>TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
+<p>Deprecated. Please use Installation.Spec.TyphaDeployment instead.
+TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
 </td>
 </tr>
 <tr>
@@ -1604,7 +3031,8 @@ field.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>ComponentResources can be used to customize the resource requirements for each component.
+<p>Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment.
+ComponentResources can be used to customize the resource requirements for each component.
 Node, Typha, and KubeControllers are supported for installations.</p>
 </td>
 </tr>
@@ -1636,6 +3064,61 @@ NonPrivilegedType
 <td>
 <em>(Optional)</em>
 <p>NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeDaemonSet</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+CalicoNodeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoKubeControllersDeployment</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+CalicoKubeControllersDeployment
+</a>
+</em>
+</td>
+<td>
+<p>CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaDeployment</code><br>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeployment">
+TyphaDeployment
+</a>
+</em>
+</td>
+<td>
+<p>TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated
+ComponentResources or TyphaAffinity, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoWindowsUpgradeDaemonSet</code><br>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+CalicoWindowsUpgradeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
 </td>
 </tr>
 </tbody>
@@ -1805,6 +3288,60 @@ Default: -1</p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
 </p>
+<h3 id="operator.tigera.io/v1.Metadata">Metadata
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+</p>
+<p>Metadata contains the standard Kubernetes labels and annotations fields.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels is a map of string keys and values that may match replicaset and
+service selectors. Each of these key/value pairs are added to the
+object&rsquo;s labels provided the key does not already exist in the object&rsquo;s labels.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Annotations is a map of arbitrary non-identifying metadata. Each of these
+key/value pairs are added to the object&rsquo;s annotations provided the key does not
+already exist in the object&rsquo;s annotations.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec
 </h3>
 <p>
@@ -2191,7 +3728,8 @@ Available, Progressing, or Degraded.</p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<p>TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
+<p>Deprecated. Please use TyphaDeployment instead.
+TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
 <table>
 <thead>
 <tr>
@@ -2212,6 +3750,340 @@ NodeAffinity
 <td>
 <em>(Optional)</em>
 <p>NodeAffinity describes node affinity scheduling rules for typha.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>TyphaDeployment is the configuration for the typha Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+TyphaDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the typha Deployment.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+</p>
+<p>TyphaDeploymentContainer is a typha Deployment container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the typha Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named typha Deployment container&rsquo;s resources.
+If omitted, the typha Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+</p>
+<p>TyphaDeploymentInitContainer is a typha Deployment init container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the typha Deployment init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named typha Deployment init container&rsquo;s resources.
+If omitted, the typha Deployment will use its default value for this init container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+</p>
+<p>TyphaDeploymentDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+[]TyphaDeploymentInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of typha init containers.
+If specified, this overrides the specified typha Deployment init containers.
+If omitted, the typha Deployment will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+[]TyphaDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of typha containers.
+If specified, this overrides the specified typha Deployment containers.
+If omitted, the typha Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the typha pods.
+If specified, this overrides any affinity that may be set on the typha Deployment.
+If omitted, the typha Deployment will use its default value for affinity.
+If used in conjunction with the deprecated TyphaAffinity, then this value takes precedence.
+WARNING: Please note that this field will override the default calico-typha Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the calico-typha pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-typha Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-typha Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-typha Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the typha pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the typha Deployment.
+If omitted, the typha Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-typha Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+</p>
+<p>TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+TyphaDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the typha Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+</p>
+<p>TyphaDeploymentSpec defines configuration for the typha Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the typha Deployment.
+If omitted, the typha Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+TyphaDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the typha Deployment pod that will be created.</p>
 </td>
 </tr>
 </tbody>

--- a/calico/reference/installation/config.json
+++ b/calico/reference/installation/config.json
@@ -7,7 +7,6 @@
         "List$",
         "AmazonCloudIntegration",
         "MetadataAccessAllowedType",
-        "APIServer",
         "Authentication",
         "Auth",
         "AuthMethod",


### PR DESCRIPTION
## Description

The changes from `make build-operator-reference` but with the WAFStatusType manually removed (not sure how the config is supposed to be updated to filter that field out)

Deploy preview: https://deploy-preview-6431--calico-master.netlify.app/reference/installation/api
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
