### PR TITLE
[release-v3.24] Auto pick #6454: Fix validation for maxblocksperhost

### DIFF
--- a/libcalico-go/config/crd/crd.projectcalico.org_ipamconfigs.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_ipamconfigs.yaml
@@ -37,6 +37,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/libcalico-go/lib/apis/v3/ipam_config.go
+++ b/libcalico-go/lib/apis/v3/ipam_config.go
@@ -47,6 +47,8 @@ type IPAMConfigSpec struct {
 
 	// MaxBlocksPerHost, if non-zero, is the max number of blocks that can be
 	// affine to each host.
+	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Maximum:=2147483647
 	// +optional
 	MaxBlocksPerHost int `json:"maxBlocksPerHost,omitempty"`
 }

--- a/libcalico-go/lib/clientv3/ipamconfig.go
+++ b/libcalico-go/lib/clientv3/ipamconfig.go
@@ -39,15 +39,20 @@ type IPAMConfigs struct {
 	client client
 }
 
+func validateMetadata(res *libapiv3.IPAMConfig) error {
+	if res.ObjectMeta.GetName() != libapiv3.GlobalIPAMConfigName {
+		return errors.New("Cannot create a IPAMConfiguration resource with a name other than \"default\"")
+	}
+	return nil
+}
+
 // Create takes the representation of a IPAMConfig and creates it.  Returns the stored
 // representation of the IPAMConfig, and an error, if there is any.
 func (r IPAMConfigs) Create(ctx context.Context, res *libapiv3.IPAMConfig, opts options.SetOptions) (*libapiv3.IPAMConfig, error) {
 	if err := validator.Validate(res); err != nil {
 		return nil, err
-	}
-
-	if res.ObjectMeta.GetName() != libapiv3.GlobalIPAMConfigName {
-		return nil, errors.New("Cannot create a IPAMConfiguration resource with a name other than \"default\"")
+	} else if err := validateMetadata(res); err != nil {
+		return nil, err
 	}
 
 	out, err := r.client.resources.Create(ctx, opts, libapiv3.KindIPAMConfig, res)
@@ -61,6 +66,8 @@ func (r IPAMConfigs) Create(ctx context.Context, res *libapiv3.IPAMConfig, opts 
 // representation of the IPAMConfig, and an error, if there is any.
 func (r IPAMConfigs) Update(ctx context.Context, res *libapiv3.IPAMConfig, opts options.SetOptions) (*libapiv3.IPAMConfig, error) {
 	if err := validator.Validate(res); err != nil {
+		return nil, err
+	} else if err := validateMetadata(res); err != nil {
 		return nil, err
 	}
 

--- a/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
@@ -153,4 +153,15 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 		// Test 1: Pass two fully populated IPAMConfigSpecs and expect the series of operations to succeed.
 		Entry("Two fully populated IPAMConfigSpecs", name, spec1, spec2),
 	)
+
+	It("should reject MaxBlocksPerHost less than zero", func() {
+		_, err := c.IPAMConfig().Create(ctx, &libapiv3.IPAMConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec: libapiv3.IPAMConfigSpec{
+				MaxBlocksPerHost: -1,
+			},
+		}, options.SetOptions{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("error with field MaxBlocksPerHost = '-1' (must be greater than or equal to 0)"))
+	})
 })

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -2682,6 +2682,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -2692,6 +2692,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -2693,6 +2693,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -2677,6 +2677,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -2677,6 +2677,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -2694,6 +2694,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -2594,6 +2594,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -2677,6 +2677,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/ocp/crd.projectcalico.org_ipamconfigs.yaml
+++ b/manifests/ocp/crd.projectcalico.org_ipamconfigs.yaml
@@ -37,6 +37,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -2609,6 +2609,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean


### PR DESCRIPTION
Cherry pick of #6454 on release-v3.24.

#6454: Fix validation for maxblocksperhost

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.