### PR TITLE
docs: fix jekyll issues

### DIFF
--- a/calico/Gemfile
+++ b/calico/Gemfile
@@ -4,13 +4,14 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'jekyll', '~>4.0.0'
+gem 'jekyll' # jekyll/jekyll:pages is currently version 3.8.5, but specifying '~>3.8.5' here results in an error
 
 group :jekyll_plugins do
   gem 'jekyll-redirect-from'
   gem 'jekyll-seo-tag'
   gem 'jekyll-sitemap'
   gem 'jekyll-include-cache'
-  gem 'webrick'
+  gem 'webrick' # needed when running on ruby3+
+  gem 'kramdown-parser-gfm' # needed when not specifying jekyll version
 end
 

--- a/calico/Makefile
+++ b/calico/Makefile
@@ -83,7 +83,7 @@ clean:
 	# Clean .created files which indicate images / releases have been built.
 	find . -name '.*.created*' -type f -delete
 	find . -name '.*.published*' -type f -delete
-	rm -rf _output _site .jekyll-metadata pinned_versions.yaml _includes/charts/*/values.yaml
+	rm -rf _output _site .jekyll-metadata .jekyll-cache pinned_versions.yaml _includes/charts/*/values.yaml Gemfile.lock
 
 ###############################################################################
 # CI / test targets

--- a/calico/netlify/Gemfile
+++ b/calico/netlify/Gemfile
@@ -4,12 +4,13 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'jekyll', '~>4.0.0'
+gem 'jekyll', '~>3.8.5' # jekyll/jekyll:pages is currently version 3.8.5
 
 group :jekyll_plugins do
   gem 'jekyll-redirect-from'
   gem 'jekyll-seo-tag'
   gem 'jekyll-sitemap'
   gem 'jekyll-include-cache'
+  gem 'webrick' # needed when running on ruby3+
 end
 


### PR DESCRIPTION
Use version 3.8.5 for jekyll in Gemfile (as jekyll/jekyll:pages is currently version 3.8.5).

Prepend 'bundle exec' to jekyll commands to fix dependency versioning issues (namely 'make _site' and 'make serve').

Add Gemfile.lock and .jekyll-cache to 'make clean' target.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
