### PR TITLE
windows: create calico-node serviceaccount token secret if it doesn't exist

### DIFF
--- a/calico/getting-started/windows-calico/quickstart.md
+++ b/calico/getting-started/windows-calico/quickstart.md
@@ -58,23 +58,6 @@ The following steps install a Kubernetes cluster on a single Windows node with a
   The geeky details of what you get by default:
   {% include geek-details.html details='Policy:Calico,IPAM:Azure,CNI:Azure,Overlay:No,Routing:VPC Native,Datastore:Kubernetes' %}
 
-
->**Note**: If your Kubernetes version is v1.24.0 or higher, service account token secrets are no longer automatically created. Before continuing with the install, {% include open-new-window.html text='manually create' url='https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token' %} the calico-node service account token:
-```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Secret
-metadata:
-  name: calico-node-token
-  namespace: calico-system
-  annotations:
-    kubernetes.io/service-account.name: calico-node
-type: kubernetes.io/service-account-token
-EOF
-```
-Note: if {{site.prodname}} is installed in kube-system, update the `namespace` in the above command.
-{: .alert .alert-info}
-
 {% tabs %}
   <label:Kubernetes VXLAN,active:true>
   <%

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -33,6 +33,7 @@ Param(
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $DownloadOnly="no",
     [parameter(Mandatory = $false)] $StartCalico="yes",
+    [parameter(Mandatory = $false)] $AutoCreateServiceAccountTokenSecret="yes",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",
     [parameter(Mandatory = $false)] $EtcdEndpoints="",
     [parameter(Mandatory = $false)] $EtcdTlsSecretName="",
@@ -229,7 +230,7 @@ function GetCalicoKubeConfig()
 {
     param(
       [parameter(Mandatory=$true)] $CalicoNamespace,
-      [parameter(Mandatory=$false)] $SecretName = "calico-node",
+      [parameter(Mandatory=$false)] $SecretNamePrefix = "calico-node",
       [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
     )
 
@@ -266,22 +267,56 @@ function GetCalicoKubeConfig()
             exit 1
         }
     } else {
-        $ErrorActionPreference = 'Continue'
         $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretName | select -first 1
-        $ErrorActionPreference = 'Stop'
         if ([string]::IsNullOrEmpty($name)) {
             throw "$SecretName service account does not exist."
+        $ErrorActionPreference = 'Continue'
+        $secretName=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretNamePrefix | select -first 1
+        $ErrorActionPreference = 'Stop'
+        if ([string]::IsNullOrEmpty($secretName)) {
+            if (-Not $AutoCreateServiceAccountTokenSecret) {
+                throw "$SecretName service account token secret does not exist."
+            } else {
+                # Otherwise create the serviceaccount token secret.
+                $secretName = "calico-node-token"
+                CreateTokenAccountSecret -Name $secretName -Namespace $CalicoNamespace
+            }
         }
         # CA from the k8s secret is already base64-encoded.
-        $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
+        $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
         # Token from the k8s secret is base64-encoded but we need the jwt token.
-        $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.token}' -n $CalicoNamespace
+        $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.token}' -n $CalicoNamespace
         $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
 
         $server=findstr https:// $KubeConfigPath
     }
 
     (Get-Content $RootDir\calico-kube-config.template).replace('<ca>', $ca).replace('<server>', $server.Trim()).replace('<token>', $token) | Set-Content $RootDir\calico-kube-config -Force
+}
+
+function CreateTokenAccountSecret()
+{
+    param(
+      [parameter(Mandatory=$true)] $Name,
+      [parameter(Mandatory=$true)] $Namespace,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $tempFile = New-TemporaryFile
+    Write-Host "Created temp file ${tempFile}"
+
+    $yaml=@"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $Name
+  namespace: $Namespace
+  annotations:
+    kubernetes.io/service-account.name: calico-node
+type: kubernetes.io/service-account-token
+"@
+    Set-Content -Path $tempFile.FullName -value $yaml
+    c:\k\kubectl --kubeconfig $KubeConfigPath apply -f $tempFile.FullName
 }
 
 function EnableWinDsrForEKS()

--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -33,6 +33,8 @@ Param(
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $DownloadOnly="no",
     [parameter(Mandatory = $false)] $StartCalico="yes",
+    # As of Kubernetes version v1.24.0, service account token secrets are no longer automatically created. But this installation script uses that secret
+    # to generate a kubeconfig so default to creating the calico-node token secret if it doesn't exist.
     [parameter(Mandatory = $false)] $AutoCreateServiceAccountTokenSecret="yes",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",
     [parameter(Mandatory = $false)] $EtcdEndpoints="",
@@ -279,7 +281,7 @@ function GetCalicoKubeConfig()
             } else {
                 # Otherwise create the serviceaccount token secret.
                 $secretName = "calico-node-token"
-                CreateTokenAccountSecret -Name $secretName -Namespace $CalicoNamespace
+                CreateTokenAccountSecret -Name $secretName -Namespace $CalicoNamespace -KubeConfigPath $KubeConfigPath
             }
         }
         # CA from the k8s secret is already base64-encoded.


### PR DESCRIPTION
## Description

Since k8s 1.24, serviceaccount token secrets are no longer automatically
created. This is a problem for Calico for Windows since we use the token
secret to generate a kubeconfig.

This commit makes the script create a calico-node token secret if it doesn't exist.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Windows quickstart install script creates calico service account token secret if missing
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
