### PR TITLE
[release-v3.24] Auto pick #6460: Properly round-trip metadata on internal IPAMConfig API

### DIFF
--- a/apiserver/pkg/storage/calico/converter.go
+++ b/apiserver/pkg/storage/calico/converter.go
@@ -106,7 +106,7 @@ func convertToAAPI(libcalicoObject runtime.Object) (res runtime.Object) {
 		aapi := &aapi.CalicoNodeStatus{}
 		CalicoNodeStatusConverter{}.convertToAAPI(lcg, aapi)
 		return aapi
-	case *api.IPAMConfiguration:
+	case *libapi.IPAMConfig:
 		lcg := libcalicoObject.(*libapi.IPAMConfig)
 		aapi := &aapi.IPAMConfiguration{}
 		IPAMConfigConverter{}.convertToAAPI(lcg, aapi)

--- a/apiserver/pkg/storage/calico/ipamconfig_storage.go
+++ b/apiserver/pkg/storage/calico/ipamconfig_storage.go
@@ -102,6 +102,10 @@ func (gc IPAMConfigConverter) convertToAAPI(libcalicoObject resourceObject, aapi
 	aapiIPAMConfig.Spec.MaxBlocksPerHost = int32(lcgIPAMConfig.Spec.MaxBlocksPerHost)
 	aapiIPAMConfig.TypeMeta = lcgIPAMConfig.TypeMeta
 	aapiIPAMConfig.ObjectMeta = lcgIPAMConfig.ObjectMeta
+
+	// libcalico uses a different Kind for these resources - IPAMConfig.
+	aapiIPAMConfig.TypeMeta.APIVersion = aapi.GroupVersionCurrent
+	aapiIPAMConfig.Kind = aapi.KindIPAMConfiguration
 }
 
 func (gc IPAMConfigConverter) convertToAAPIList(libcalicoListObject resourceListObject, aapiListObj runtime.Object, pred storage.SelectionPredicate) {
@@ -112,6 +116,7 @@ func (gc IPAMConfigConverter) convertToAAPIList(libcalicoListObject resourceList
 		return
 	}
 	aapiIPAMConfigList.TypeMeta = lcgIPAMConfigList.TypeMeta
+	aapiIPAMConfigList.TypeMeta.Kind = aapi.KindIPAMConfigurationList
 	aapiIPAMConfigList.ListMeta = lcgIPAMConfigList.ListMeta
 	for _, item := range lcgIPAMConfigList.Items {
 		aapiIPAMConfig := aapi.IPAMConfiguration{}

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -2035,8 +2035,9 @@ var _ = testutils.E2eDatastoreDescribe("Test Syncer API for Kubernetes backend",
 			Expect(fc.Value.(*apiv3.FelixConfiguration).GetObjectMeta().GetResourceVersion()).To(Equal(""))
 			fc.Value.(*apiv3.FelixConfiguration).GetObjectMeta().SetResourceVersion(updFC.Value.(*apiv3.FelixConfiguration).GetObjectMeta().GetResourceVersion())
 
-			// UID is auto-generated, make sure we don't fail the assertion based on it.
+			// UID and CreationTimestamp are auto-generated, make sure we don't fail the assertion based on it.
 			fc.Value.(*apiv3.FelixConfiguration).ObjectMeta.UID = updFC.Value.(*apiv3.FelixConfiguration).ObjectMeta.UID
+			fc.Value.(*apiv3.FelixConfiguration).ObjectMeta.CreationTimestamp = updFC.Value.(*apiv3.FelixConfiguration).ObjectMeta.CreationTimestamp
 
 			// Assert the created object matches what we created.
 			Expect(updFC.Value.(*apiv3.FelixConfiguration)).To(Equal(fc.Value.(*apiv3.FelixConfiguration)))

--- a/libcalico-go/lib/backend/k8s/resources/ipam_config.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_config.go
@@ -50,7 +50,7 @@ func NewIPAMConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourc
 				APIVersion: apiv3.GroupVersionCurrent,
 			},
 			k8sListType:  reflect.TypeOf(libapiv3.IPAMConfigList{}),
-			resourceKind: libapiv3.KindIPAMConfig,
+			resourceKind: apiv3.KindIPAMConfiguration,
 		},
 	}
 }

--- a/libcalico-go/lib/backend/k8s/resources/ipam_config.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_config.go
@@ -50,7 +50,7 @@ func NewIPAMConfigClient(c *kubernetes.Clientset, r *rest.RESTClient) K8sResourc
 				APIVersion: apiv3.GroupVersionCurrent,
 			},
 			k8sListType:  reflect.TypeOf(libapiv3.IPAMConfigList{}),
-			resourceKind: apiv3.KindIPAMConfiguration,
+			resourceKind: libapiv3.KindIPAMConfig,
 		},
 	}
 }

--- a/libcalico-go/lib/backend/k8s/resources/ipam_config.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_config.go
@@ -69,14 +69,8 @@ type ipamConfigClient struct {
 func (c ipamConfigClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
 	v3obj := kvpv3.Value.(*libapiv3.IPAMConfig)
 
-	// Copy across any object metadata fields that we need to properly
-	// round-trip on the v1 API. v1 API users are expected to leave this
-	// metadata untouched.
-	m := metav1.ObjectMeta{}
-	m.SetCreationTimestamp(v3obj.GetCreationTimestamp())
-
 	return &model.KVPair{
-		Key: model.IPAMConfigKey{Metadata: m},
+		Key: model.IPAMConfigKey{},
 		Value: &model.IPAMConfig{
 			StrictAffinity:     v3obj.Spec.StrictAffinity,
 			AutoAllocateBlocks: v3obj.Spec.AutoAllocateBlocks,
@@ -90,12 +84,9 @@ func (c ipamConfigClient) toV1(kvpv3 *model.KVPair) (*model.KVPair, error) {
 // For the first point, toV3 takes the given v1 KVPair and converts it into a v3 representation, suitable
 // for writing as a CRD to the Kubernetes API.
 func (c ipamConfigClient) toV3(kvpv1 *model.KVPair) *model.KVPair {
-	// Build object meta, starting with the key's Metadata field,
-	// which may include round-tripped fields if this KVP is being
-	// updated rather than created.
-	m := kvpv1.Key.(model.IPAMConfigKey).Metadata
-
+	// Build object meta.
 	// We only support a singleton resource with name "default".
+	m := metav1.ObjectMeta{}
 	m.SetName(model.IPAMConfigGlobalName)
 	m.SetResourceVersion(kvpv1.Revision)
 

--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -124,7 +124,7 @@ func SetCalicoMetadataFromK8sAnnotations(calicoRes Resource, k8sRes Resource) {
 	}
 }
 
-// Store Calico Metadata in the in the k8s resource annotations for CRD backed resources.
+// Store Calico Metadata in the k8s resource annotations for CRD backed resources.
 // This should store all Metadata except for those stored in Annotations and Labels and
 // store them in annotations.
 func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
@@ -203,6 +203,14 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.Labels = rom.GetLabels()
 	meta.Annotations = annotations
 	meta.UID = rom.GetUID()
+
+	// If no creation timestamp was stored in the metadata annotation, use the one from the CR.
+	// The timestamp is normally set in the clientv3 code. However, for objects that bypass
+	// the v3 client (e.g., IPAM), we won't have generated a creation timestamp and the field
+	// is required on update calls.
+	if meta.GetCreationTimestamp().Time.IsZero() {
+		meta.SetCreationTimestamp(rom.GetCreationTimestamp())
+	}
 
 	// Overwrite the K8s metadata with the Calico metadata.
 	meta.DeepCopyInto(rom.(*metav1.ObjectMeta))

--- a/libcalico-go/lib/backend/model/ipam_config.go
+++ b/libcalico-go/lib/backend/model/ipam_config.go
@@ -16,8 +16,6 @@ package model
 
 import (
 	"reflect"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -26,12 +24,7 @@ const (
 
 var typeIPAMConfig = reflect.TypeOf(IPAMConfig{})
 
-type IPAMConfigKey struct {
-	// Metadata stores information that needs to be round-tripped
-	// with an IPAMConfig resource over the v1 API. It is not stored in the data store.
-	// This includes v3 metadata that we don't want to lose as part of a get / update cycle.
-	Metadata metav1.ObjectMeta `json:"-"`
-}
+type IPAMConfigKey struct{}
 
 func (key IPAMConfigKey) defaultPath() (string, error) {
 	return "/calico/ipam/v2/config", nil

--- a/libcalico-go/lib/backend/model/ipam_config.go
+++ b/libcalico-go/lib/backend/model/ipam_config.go
@@ -16,17 +16,22 @@ package model
 
 import (
 	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	IPAMConfigGlobalName = "default"
 )
 
-var (
-	typeIPAMConfig = reflect.TypeOf(IPAMConfig{})
-)
+var typeIPAMConfig = reflect.TypeOf(IPAMConfig{})
 
-type IPAMConfigKey struct{}
+type IPAMConfigKey struct {
+	// Metadata stores information that needs to be round-tripped
+	// with an IPAMConfig resource over the v1 API. It is not stored in the data store.
+	// This includes v3 metadata that we don't want to lose as part of a get / update cycle.
+	Metadata metav1.ObjectMeta `json:"-"`
+}
 
 func (key IPAMConfigKey) defaultPath() (string, error) {
 	return "/calico/ipam/v2/config", nil

--- a/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
@@ -16,12 +16,12 @@ package clientv3_test
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	libapiv3 "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 
@@ -99,7 +99,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(res1).To(MatchResource(libapiv3.KindIPAMConfig, testutils.ExpectNoNamespace, name, spec1))
-			fmt.Printf("Created res1 %v", res1)
+			Expect(res1.GroupVersionKind).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfiguration"}))
 
 			By("Attempting to create the same IPAMConfig but with spec2")
 			_, outError = c.IPAMConfig().Create(ctx, &libapiv3.IPAMConfig{
@@ -114,7 +114,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(res).To(MatchResource(libapiv3.KindIPAMConfig, testutils.ExpectNoNamespace, name, spec1))
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
-			fmt.Printf("Getting res %v", res)
+			Expect(res.GroupVersionKind).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfiguration"}))
 
 			By("Updating IPAMConfig with spec2")
 			res1.Spec = spec2
@@ -146,8 +146,11 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 			Expect(dres).To(testutils.MatchResource(libapiv3.KindIPAMConfig, testutils.ExpectNoNamespace, name, spec2))
 
 			By("Listing IPAMConfig and expecting error")
-			_, outError = c.IPAMConfig().List(ctx, options.ListOptions{})
+			l, outError := c.IPAMConfig().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
+			for _, res := range l.Items {
+				Expect(res.GroupVersionKind).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfiguration"}))
+			}
 		},
 
 		// Test 1: Pass two fully populated IPAMConfigSpecs and expect the series of operations to succeed.

--- a/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ipamconfig_e2e_test.go
@@ -99,7 +99,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 			}, options.SetOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(res1).To(MatchResource(libapiv3.KindIPAMConfig, testutils.ExpectNoNamespace, name, spec1))
-			Expect(res1.GroupVersionKind).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfiguration"}))
+			Expect(res1.GroupVersionKind()).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfig"}))
 
 			By("Attempting to create the same IPAMConfig but with spec2")
 			_, outError = c.IPAMConfig().Create(ctx, &libapiv3.IPAMConfig{
@@ -114,7 +114,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 			Expect(outError).NotTo(HaveOccurred())
 			Expect(res).To(MatchResource(libapiv3.KindIPAMConfig, testutils.ExpectNoNamespace, name, spec1))
 			Expect(res.ResourceVersion).To(Equal(res1.ResourceVersion))
-			Expect(res.GroupVersionKind).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfiguration"}))
+			Expect(res.GroupVersionKind()).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfig"}))
 
 			By("Updating IPAMConfig with spec2")
 			res1.Spec = spec2
@@ -149,7 +149,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAMConfig tests", testutils.DatastoreAl
 			l, outError := c.IPAMConfig().List(ctx, options.ListOptions{})
 			Expect(outError).NotTo(HaveOccurred())
 			for _, res := range l.Items {
-				Expect(res.GroupVersionKind).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfiguration"}))
+				Expect(res.GroupVersionKind()).To(Equal(schema.GroupVersionKind{Group: "projectcalico.org", Version: "v3", Kind: "IPAMConfig"}))
 			}
 		},
 

--- a/libcalico-go/lib/clientv3/resources.go
+++ b/libcalico-go/lib/clientv3/resources.go
@@ -314,7 +314,6 @@ func (c *resources) kvPairToResource(kvp *model.KVPair) resource {
 
 // checkNamespace checks that the namespace is supplied on a namespaced resource type.
 func (c *resources) checkNamespace(ns, kind string) error {
-
 	if namespace.IsNamespaced(kind) && len(ns) == 0 {
 		return cerrors.ErrorValidation{
 			ErroredFields: []cerrors.ErroredField{{


### PR DESCRIPTION
Cherry pick of #6460 on release-v3.24.

#6460: Properly round-trip metadata on internal IPAMConfig API

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This one is a tiny bit confusing. Our client machinery has a few quirks.

- The internal ("v1", "model") API doesn't include all of the metadata that Kubernetes objects expect.
- Our clientv3 code does, and it defaults some of them itself rather than relying on the Kubernetes API server to do so (UID, CreationTimestamp)
- When serializing a resource to a CRD, we store UID and CreationTimestamp allocated in the clientv3 layer as annotations on the CR, rather than use the "real" metadata for that CR, leading to different values for the CR and the projectcalico.org/v3 resource.

So:
- Objects created on the v1 API never receive a CreationTimestamp
- Objects created on the v3 API do, but as soon as they are modified using a v1 client that metadata is lost.

The fix is:

- Update our CRD layer to populate metadata with the CRD's creation timestamp if none has been provided.

This PR has a couple other fixes as well:
- Fixes watch bug caused by wrong kind in converter logic.
- Fixes wrong Kind showing up on some API calls

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.