### PR TITLE
Fix gce nodename

### DIFF
--- a/calico/scripts/install-calico-windows.ps1
+++ b/calico/scripts/install-calico-windows.ps1
@@ -484,8 +484,7 @@ if ($platform -EQ "ec2") {
 if ($platform -EQ "gce") {
     $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
     Write-Host "Setup Calico for Windows for GCE, node name $gceNodeName ..."
-    $gceNodeNameQuote = """$gceNodeName"""
-    Set-ConfigParameters -var 'NODENAME' -value $gceNodeNameQuote
+    Set-ConfigParameters -var 'NODENAME' -value $gceNodeName
 
     $calicoNs = GetCalicoNamespace
     GetCalicoKubeConfig -CalicoNamespace $calicoNs


### PR DESCRIPTION
## Description

```
Set-EnvVarIfNotSet : A positional parameter cannot be found that accepts argument 
'bz-calico-8sdn-windows-0.c.unique-caldron-775.internal'.
At C:\CalicoWindows\config.ps1:73 char:1
+ Set-EnvVarIfNotSet -var "NODENAME" -defaultValue ""bz-calico-8sdn-win ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-EnvVarIfNotSet], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Set-EnvVarIfNotSet
 
Set-EnvVarIfNotSet : Cannot bind argument to parameter 'defaultValue' because it is null.
At C:\CalicoWindows\config.ps1:77 char:61
+ ... EnvVarIfNotSet -var "CALICO_K8S_NODE_REF" -defaultValue $env:NODENAME
+                                                             ~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Set-EnvVarIfNotSet], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Set-EnvVarIfNotSet
 
```


I think we still need to figure out why kubelet is not setting the FQDN node name we're specifuying with `--hostname-override=$env:NODENAME`

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
