### PR TITLE
Add get/secrets permissions to calico-node rbac template.

### DIFF
--- a/charts/calico/templates/calico-node-rbac.yaml
+++ b/charts/calico/templates/calico-node-rbac.yaml
@@ -45,6 +45,14 @@ rules:
       # Used to discover Typhas.
       - get
 {{- end }}
+  # This permission is needed to get bgp password for BGPPeer resource.
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
   # Pod CIDR auto-detection on kubeadm needs access to config maps.
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
Hi,
We faced with issue that calico-node couldn't read bgp password from secrets since there is no appropriate permissions for this role [1]. This PR adds get/secrets permission to calico-node rbac template.  There is the same issue in tigera-operator [2]. I found similar PR [3] and it was merged long time ago, but now i don't see this changes in master. 

Thanks!
[1] https://projectcalico.docs.tigera.io/reference/resources/bgppeer#bgppassword
[2] https://github.com/tigera/operator/issues/2006
[3] https://github.com/projectcalico/calico/pull/4043

