### PR TITLE
Add ability to set MTU of Calico OpenStack nets

### DIFF
--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -15,6 +15,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from collections import defaultdict
 import logging
 import netaddr
 import os
@@ -114,13 +115,14 @@ class FakePlugin(object):
     get_networks = None
 
 
-def empty_network(network_id=NETWORK_ID):
+def empty_network(network_id=NETWORK_ID,
+                  network_mtu=neutron_constants.DEFAULT_NETWORK_MTU):
     """Construct and return an empty network model."""
     return make_net_model({"id": network_id,
                            "subnets": [],
                            "ports": [],
                            "tenant_id": "calico",
-                           "mtu": neutron_constants.DEFAULT_NETWORK_MTU})
+                           "mtu": network_mtu})
 
 
 def copy_network(source_net):
@@ -187,6 +189,8 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Cache of the ports that we've asked Dnsmasq to handle, for each
         # network ID.
         self._last_dnsmasq_ports = {}
+        mtu_dict = defaultdict(lambda: neutron_constants.DEFAULT_NETWORK_MTU)
+        self._last_dnsmasq_mtu = mtu_dict
 
         # Cache of current local endpoint IDs.
         self.local_endpoint_ids = set()
@@ -282,6 +286,11 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         dns_assignments = []
         fqdn = annotations.get(datamodel_v3.ANN_KEY_FQDN)
         network_id = annotations.get(datamodel_v3.ANN_KEY_NETWORK_ID)
+        # The MTU annotation was retroactively added to the datamodel after the
+        # spec existed. To ensure that we do not break users who have endpoints
+        # in etcd without the MTU annotation, fallback to the previous default.
+        network_mtu = int(annotations.get(datamodel_v3.ANN_KEY_NETWORK_MTU,
+                          neutron_constants.DEFAULT_NETWORK_MTU))
         allowedIps = [e.split('/')[0] for e in endpoint.get('allowedIps', [])]
         for addrm in endpoint['ipNetworks']:
             ip_addr = addrm.split('/')[0]
@@ -325,7 +334,8 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Ensure that the cache includes the network and subnets for this port,
         # and set the port's network ID correctly.
         try:
-            port['network_id'] = self._ensure_net_and_subnets(port)
+            port['network_id'] = self._ensure_net_and_subnets(port,
+                                                              network_mtu)
         except SubnetIDNotFound:
             LOG.warning("Missing data for one of port's subnets")
             return
@@ -345,7 +355,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Schedule updating Dnsmasq.
         self._update_dnsmasq(port['network_id'])
 
-    def _ensure_net_and_subnets(self, port):
+    def _ensure_net_and_subnets(self, port, network_mtu):
         """Ensure that the cache has a NetModel and subnets for PORT."""
 
         # Gather the subnet IDs that we need for this port, and get the
@@ -389,7 +399,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
             # We still have no NetModel for the relevant network ID, so create
             # a new one.  In this case we _must_ be adding new subnets.
             assert new_subnets
-            net = empty_network(network_id)
+            net = empty_network(network_id, network_mtu)
             LOG.debug("New network %s", net)
         elif new_subnets:
             # We have a NetModel that was already in the cache and are about to
@@ -408,6 +418,10 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
             # Add (or update) the NetModel in the cache.
             LOG.debug("Net: %s", net)
             self._fix_network_cache_port_lookup(net.id)
+
+        # Flush any changes realized out to the NetCache.
+        if new_subnets or network_mtu != net.mtu:
+            net.mtu = network_mtu
             self.agent.cache.put(net)
 
         return net.id
@@ -457,10 +471,12 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         ports_needed.sort(key=lambda port: port.id)
 
         # Compare that against what we've last asked Dnsmasq to handle.
-        if ports_needed != self._last_dnsmasq_ports.get(network_id):
+        last_ports = self._last_dnsmasq_ports.get(network_id)
+        mtu_changing = self._last_dnsmasq_mtu.get(network_id) != net.mtu
+        if ports_needed != last_ports or mtu_changing:
             # Requirements have changed, so start, restart or stop Dnsmasq for
             # that network ID.
-            if ports_needed:
+            if ports_needed or mtu_changing:
                 self.agent.call_driver('restart', net)
             else:
                 # No ports left, so also remove this network from the cache.
@@ -470,6 +486,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
 
             # Remember what we've asked Dnsmasq for.
             self._last_dnsmasq_ports[network_id] = ports_needed
+            self._last_dnsmasq_mtu[network_id] = net.mtu
 
     def on_endpoint_delete(self, response_ignored, name):
         """Handler for endpoint deletion."""
@@ -502,9 +519,10 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # information.
         LOG.debug("Reset cache for new snapshot")
         for network_id in list(self.agent.cache.get_network_ids()):
+            network = self.agent.cache.get_network_by_id(network_id)
             self.dirty_networks.add(network_id)
             self._fix_network_cache_port_lookup(network_id)
-            self.agent.cache.put(empty_network(network_id))
+            self.agent.cache.put(empty_network(network_id, network.mtu))
 
         # Suppress Dnsmasq updates until we've processed the whole snapshot.
         self.suppress_dnsmasq_updates = True

--- a/networking-calico/networking_calico/datamodel_v3.py
+++ b/networking-calico/networking_calico/datamodel_v3.py
@@ -33,6 +33,7 @@ INTERFACE_PREFIX = 'interfacePrefix'
 ANN_KEY_PREFIX = 'openstack.projectcalico.org/'
 ANN_KEY_FQDN = ANN_KEY_PREFIX + 'fqdn'
 ANN_KEY_NETWORK_ID = ANN_KEY_PREFIX + 'network-id'
+ANN_KEY_NETWORK_MTU = ANN_KEY_PREFIX + 'network-mtu'
 
 # Namespace constants.
 NO_REGION_NAMESPACE = 'openstack'


### PR DESCRIPTION
 ## Description

Add an annotation to the etcd datamodel used to describe
WorkloadEndpoints for Calico OpenStack VMs that specifies
 the MTU of the OpenStack network.

This effectively adds non-default (>1500) MTU support to
 Calico OpenStack.

## Related issues/PRs

none

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
networking-calico and thus calico-dhcp-agent now respect the MTU property of OpenStack networks. Upon requesting a DHCP lease, an option for interface-mtu is provided that corresponds to that of the OpenStack network in which the port resides.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.