### PR TITLE
Update manifests to work for node role label change

### DIFF
--- a/app-policy/config/install/05-calico.yaml
+++ b/app-policy/config/install/05-calico.yaml
@@ -190,10 +190,8 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       tolerations:
-        # Allow the pod to run on the master.  This is required for
+        # Allow the pod to run on the control-plane. This is required for
         # the master to communicate with pods.
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
         # Mark the pod as a critical add-on for rescheduling.

--- a/app-policy/config/install/05-calico.yaml
+++ b/app-policy/config/install/05-calico.yaml
@@ -194,6 +194,8 @@ spec:
         # the master to communicate with pods.
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         # Mark the pod as a critical add-on for rescheduling.
         - key: "CriticalAddonsOnly"
           operator: "Exists"

--- a/calico/getting-started/kubernetes/quickstart.md
+++ b/calico/getting-started/kubernetes/quickstart.md
@@ -103,7 +103,7 @@ The geeky details of what you get:
 1. Remove the taints on the master so that you can schedule pods on it.
 
    ```
-   kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
+   kubectl taint nodes --all node-role.kubernetes.io/control-plane-
    ```
 
    It should return the following.

--- a/calico/security/kubernetes-nodes.md
+++ b/calico/security/kubernetes-nodes.md
@@ -143,7 +143,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: ingress-k8s-masters
 spec:
-  selector: has(node-role.kubernetes.io/master)
+  selector: has(node-role.kubernetes.io/master || has(node-role.kubernetes.io/control-plane)
   # This rule allows ingress to the Kubernetes API server.
   ingress:
   - action: Allow
@@ -163,7 +163,7 @@ spec:
   - action: Allow
     protocol: TCP
     source:
-      selector: has(node-role.kubernetes.io/master)
+      selector: has(node-role.kubernetes.io/master) || has(node-role.kubernetes.io/control-plane)
     destination:
       ports:
       - 2380
@@ -171,14 +171,14 @@ spec:
 EOF
 ```
 
-Note that the above policy selects the standard **node-role.kubernetes.io/master** label that kubeadm sets on master nodes.
+Note that the above policy selects the standard **node-role.kubernetes.io/master** or **node-role.kubernetes.io/control-plane** labels that kubeadm sets on master nodes.
 
 Next, we need to apply policy to restrict ingress to the Kubernetes workers.
 Before adding the policy we will add a label to all of our worker nodes, which then gets added to its automatic host endpoint.
 For this tutorial we will use **kubernetes-worker**. An example command to add the label to worker nodes:
 
 ```bash
-kubectl get node -l '!node-role.kubernetes.io/master' -o custom-columns=NAME:.metadata.name | tail -n +2 | xargs -I{} kubectl label node {} kubernetes-worker=
+kubectl get node -l '!node-role.kubernetes.io/master' -l '!node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name | tail -n +2 | xargs -I{} kubectl label node {} kubernetes-worker=
 ```
 
 The workers' ingress policy consists of two rules. The first rule allows all traffic to localhost. As with the masters,
@@ -203,7 +203,7 @@ spec:
   - action: Allow
     protocol: TCP
     source:
-      selector: has(node-role.kubernetes.io/master)
+      selector: has(node-role.kubernetes.io/master) || has(node-role.kubernetes.io/control-plane)
     destination:
       ports:
       - 10250

--- a/calico/security/kubernetes-nodes.md
+++ b/calico/security/kubernetes-nodes.md
@@ -143,7 +143,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: ingress-k8s-masters
 spec:
-  selector: has(node-role.kubernetes.io/master || has(node-role.kubernetes.io/control-plane)
+  selector: has(node-role.kubernetes.io/control-plane)
   # This rule allows ingress to the Kubernetes API server.
   ingress:
   - action: Allow
@@ -163,7 +163,7 @@ spec:
   - action: Allow
     protocol: TCP
     source:
-      selector: has(node-role.kubernetes.io/master) || has(node-role.kubernetes.io/control-plane)
+      selector: has(node-role.kubernetes.io/control-plane)
     destination:
       ports:
       - 2380
@@ -171,14 +171,14 @@ spec:
 EOF
 ```
 
-Note that the above policy selects the standard **node-role.kubernetes.io/master** or **node-role.kubernetes.io/control-plane** labels that kubeadm sets on master nodes.
+Note that the above policy selects the standard **node-role.kubernetes.io/control-plane** label that kubeadm sets on master nodes.
 
 Next, we need to apply policy to restrict ingress to the Kubernetes workers.
 Before adding the policy we will add a label to all of our worker nodes, which then gets added to its automatic host endpoint.
 For this tutorial we will use **kubernetes-worker**. An example command to add the label to worker nodes:
 
 ```bash
-kubectl get node -l '!node-role.kubernetes.io/master' -l '!node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name | tail -n +2 | xargs -I{} kubectl label node {} kubernetes-worker=
+kubectl get node -l '!node-role.kubernetes.io/control-plane' -o custom-columns=NAME:.metadata.name | tail -n +2 | xargs -I{} kubectl label node {} kubernetes-worker=
 ```
 
 The workers' ingress policy consists of two rules. The first rule allows all traffic to localhost. As with the masters,
@@ -203,7 +203,7 @@ spec:
   - action: Allow
     protocol: TCP
     source:
-      selector: has(node-role.kubernetes.io/master) || has(node-role.kubernetes.io/control-plane)
+      selector: has(node-role.kubernetes.io/control-plane)
     destination:
       ports:
       - 10250

--- a/charts/calico/templates/calico-kube-controllers.yaml
+++ b/charts/calico/templates/calico-kube-controllers.yaml
@@ -27,8 +27,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/confd/tests/mock_data/kdd/nodes.yaml
+++ b/confd/tests/mock_data/kdd/nodes.yaml
@@ -9,6 +9,7 @@ metadata:
     beta.kubernetes.io/os: linux
     kubernetes.io/hostname: kube-master
     node-role.kubernetes.io/master: ""
+    node-role.kubernetes.io/control-plane: ""
   name: kube-master
   namespace: ""
 spec:

--- a/confd/tests/mock_data/kdd/nodes.yaml
+++ b/confd/tests/mock_data/kdd/nodes.yaml
@@ -8,7 +8,6 @@ metadata:
     beta.kubernetes.io/arch: amd64
     beta.kubernetes.io/os: linux
     kubernetes.io/hostname: kube-master
-    node-role.kubernetes.io/master: ""
     node-role.kubernetes.io/control-plane: ""
   name: kube-master
   namespace: ""

--- a/kube-controllers/tests/testutils/flannel_migration_utils.go
+++ b/kube-controllers/tests/testutils/flannel_migration_utils.go
@@ -110,7 +110,7 @@ func (f *FlannelCluster) Reset() {
 func (f *FlannelCluster) AddFlannelNode(nodeName, podCidr, backend, mac, ip string, labels map[string]string, isMaster bool) *v1.Node {
 	defaultLabels := map[string]string{"beta.kubernetes.io/os": "linux"}
 	if isMaster {
-		defaultLabels["node-role.kubernetes.io/master"] = ""
+		defaultLabels["node-role.kubernetes.io/control-plane"] = ""
 	}
 	for k, v := range labels {
 		defaultLabels[k] = v

--- a/manifests/apiserver.yaml
+++ b/manifests/apiserver.yaml
@@ -108,6 +108,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: calico-apiserver-certs
         secret:

--- a/manifests/apiserver.yaml
+++ b/manifests/apiserver.yaml
@@ -107,8 +107,6 @@ spec:
       serviceAccountName: calico-apiserver
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
       volumes:
       - name: calico-apiserver-certs

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -4732,8 +4732,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -567,8 +567,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -4629,8 +4629,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -4733,8 +4733,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -4689,8 +4689,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -4691,8 +4691,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -726,8 +726,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4703,8 +4703,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/manifests/csi-driver.yaml
+++ b/manifests/csi-driver.yaml
@@ -43,11 +43,6 @@ spec:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: NoSchedule
-      # Same as the above toleration except looks at the outdated node label since
-      # some installers may not have been updated to use the new terminology.
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
       containers:
       - name: calico-csi
         image: calico/csi:master

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -4691,8 +4691,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/node/tests/k8st/infra/apiserver.yaml
+++ b/node/tests/k8st/infra/apiserver.yaml
@@ -111,6 +111,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect:
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: calico-apiserver-certs
         secret:

--- a/node/tests/k8st/infra/apiserver.yaml
+++ b/node/tests/k8st/infra/apiserver.yaml
@@ -110,8 +110,6 @@ spec:
       serviceAccountName: calico-apiserver
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect:
         key: node-role.kubernetes.io/control-plane
       volumes:
       - name: calico-apiserver-certs

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -713,8 +713,6 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers

--- a/node/tests/k8st/infra/etcd.yaml
+++ b/node/tests/k8st/infra/etcd.yaml
@@ -41,6 +41,8 @@ spec:
         # Allow this pod to run on the master.
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
         # This, along with the annotation above marks this pod as a critical add-on.
         - key: CriticalAddonsOnly

--- a/node/tests/k8st/infra/etcd.yaml
+++ b/node/tests/k8st/infra/etcd.yaml
@@ -38,18 +38,16 @@ spec:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"
           effect: NoSchedule
-        # Allow this pod to run on the master.
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
+        # Allow this pod to run on the control plane node.
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
         # This, along with the annotation above marks this pod as a critical add-on.
         - key: CriticalAddonsOnly
           operator: Exists
-      # Only run this pod on the master.
+      # Only run this pod on the control-plane.
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       hostNetwork: true
       containers:
         - args:

--- a/node/tests/k8st/utils/utils.py
+++ b/node/tests/k8st/utils/utils.py
@@ -242,16 +242,16 @@ def node_info():
     ips = []
     ip6s = []
 
-    master_node = kubectl("get node --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[0].metadata.name}'")
+    master_node = kubectl("get node --selector='node-role.kubernetes.io/control-plane' -o jsonpath='{.items[0].metadata.name}'")
     nodes.append(master_node)
     ip6s.append(ipv6_map[master_node])
-    master_ip = kubectl("get node --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[0].status.addresses[0].address}'")
+    master_ip = kubectl("get node --selector='node-role.kubernetes.io/control-plane' -o jsonpath='{.items[0].status.addresses[0].address}'")
     ips.append(master_ip)
 
     for i in range(3):
-        node = kubectl("get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[%d].metadata.name}'" % i)
+        node = kubectl("get node --selector='!node-role.kubernetes.io/control-plane' -o jsonpath='{.items[%d].metadata.name}'" % i)
         nodes.append(node)
         ip6s.append(ipv6_map[node])
-        node_ip = kubectl("get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[%d].status.addresses[0].address}'" % i)
+        node_ip = kubectl("get node --selector='!node-role.kubernetes.io/control-plane' -o jsonpath='{.items[%d].status.addresses[0].address}'" % i)
         ips.append(node_ip)
     return nodes, ips, ip6s


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

With K8s 1.24, the old node label of `master` is phased out. These changes to the manifests and docs should keep the manifests up to date with the new node label `control-plane`.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
