### PR TITLE
Fix EncapsulationCalculator behavior when encapsulation is empty string

### DIFF
--- a/felix/calc/encapsulation_resolver.go
+++ b/felix/calc/encapsulation_resolver.go
@@ -198,7 +198,7 @@ func (c *EncapsulationCalculator) handleAPIPool(p model.KVPair) error {
 	}
 
 	poolKey := pool.Spec.CIDR
-	c.updatePool(poolKey, pool.Spec.IPIPMode != apiv3.IPIPModeNever, pool.Spec.VXLANMode != apiv3.VXLANModeNever)
+	c.updatePool(poolKey, pool.Spec.IPIPMode != "" && pool.Spec.IPIPMode != apiv3.IPIPModeNever, pool.Spec.VXLANMode != "" && pool.Spec.VXLANMode != apiv3.VXLANModeNever)
 
 	return nil
 }

--- a/felix/calc/encapsulation_resolver_test.go
+++ b/felix/calc/encapsulation_resolver_test.go
@@ -179,6 +179,19 @@ var _ = Describe("EncapsulationCalculator", func() {
 				[]model.KVPair{*getAPIPool("fe80::0/122", apiv3.IPIPModeNever, apiv3.VXLANModeCrossSubnet)},
 				nil, nil, nil, nil,
 				false, false, true),
+			Entry("Initialize with initPools with empty string for encaps",
+				nil, nil, nil, nil,
+				&model.KVPairList{
+					KVPairs: []*model.KVPair{
+						getAPIPool("192.168.1.0/24", "", ""),
+						getAPIPool("192.168.2.0/24", "", ""),
+					},
+				},
+				false, false, false),
+			Entry("API pool with empty string for encaps",
+				[]model.KVPair{*getAPIPool("192.168.1.0/24", "", "")},
+				nil, nil, nil, nil,
+				false, false, false),
 		)
 	})
 	Context("FelixConfig set", func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
https://github.com/projectcalico/calico/issues/6442

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix EncapsulationCalculator behavior when IP pool encapsulation is empty (when the pool was created by an older Calico version, for example).
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
