### PR TITLE
Set IPIPMode and VXLANMode to the default "Never" if they are empty strings

### DIFF
--- a/felix/calc/encapsulation_resolver.go
+++ b/felix/calc/encapsulation_resolver.go
@@ -197,8 +197,26 @@ func (c *EncapsulationCalculator) handleAPIPool(p model.KVPair) error {
 		return fmt.Errorf("failed to convert %+v to *model.IPPool", p.Value)
 	}
 
+	// Validate pool's IPIPMode
+	switch pool.Spec.IPIPMode {
+	case apiv3.IPIPModeNever:
+	case apiv3.IPIPModeAlways:
+	case apiv3.IPIPModeCrossSubnet:
+	default:
+		return fmt.Errorf("invalid IPIPMode \"%v\" for %v", pool.Spec.IPIPMode, pool.Spec.CIDR)
+	}
+
+	// Validate pool's VXLANMode
+	switch pool.Spec.VXLANMode {
+	case apiv3.VXLANModeNever:
+	case apiv3.VXLANModeAlways:
+	case apiv3.VXLANModeCrossSubnet:
+	default:
+		return fmt.Errorf("invalid VXLANMode \"%v\" for %v", pool.Spec.VXLANMode, pool.Spec.CIDR)
+	}
+
 	poolKey := pool.Spec.CIDR
-	c.updatePool(poolKey, pool.Spec.IPIPMode != "" && pool.Spec.IPIPMode != apiv3.IPIPModeNever, pool.Spec.VXLANMode != "" && pool.Spec.VXLANMode != apiv3.VXLANModeNever)
+	c.updatePool(poolKey, pool.Spec.IPIPMode != apiv3.IPIPModeNever, pool.Spec.VXLANMode != apiv3.VXLANModeNever)
 
 	return nil
 }

--- a/felix/calc/encapsulation_resolver_test.go
+++ b/felix/calc/encapsulation_resolver_test.go
@@ -179,19 +179,6 @@ var _ = Describe("EncapsulationCalculator", func() {
 				[]model.KVPair{*getAPIPool("fe80::0/122", apiv3.IPIPModeNever, apiv3.VXLANModeCrossSubnet)},
 				nil, nil, nil, nil,
 				false, false, true),
-			Entry("Initialize with initPools with empty string for encaps",
-				nil, nil, nil, nil,
-				&model.KVPairList{
-					KVPairs: []*model.KVPair{
-						getAPIPool("192.168.1.0/24", "", ""),
-						getAPIPool("192.168.2.0/24", "", ""),
-					},
-				},
-				false, false, false),
-			Entry("API pool with empty string for encaps",
-				[]model.KVPair{*getAPIPool("192.168.1.0/24", "", "")},
-				nil, nil, nil, nil,
-				false, false, false),
 		)
 	})
 	Context("FelixConfig set", func() {
@@ -227,6 +214,13 @@ var _ = Describe("EncapsulationCalculator", func() {
 				[]model.KVPair{*getModelPool("192.168.3.0/24", encap.Undefined, encap.Always), *getModelPool("192.168.4.0/24", encap.CrossSubnet, encap.Undefined)},
 				false, false),
 		)
+	})
+	Describe("Invalid IPIPMode and/or VXLANMode", func() {
+		err := encapsulationCalculator.handlePool(*getAPIPool("192.168.11.0/24", "", ""))
+		Expect(err.Error()).To(Equal("invalid IPIPMode \"\" for 192.168.11.0/24"))
+
+		err = encapsulationCalculator.handlePool(*getAPIPool("192.168.12.0/24", apiv3.IPIPModeNever, ""))
+		Expect(err.Error()).To(Equal("invalid VXLANMode \"\" for 192.168.12.0/24"))
 	})
 })
 

--- a/libcalico-go/lib/clientv3/ippool.go
+++ b/libcalico-go/lib/clientv3/ippool.go
@@ -272,6 +272,17 @@ func convertIpPoolFromStorage(pool *apiv3.IPPool) error {
 	if pool.Spec.NodeSelector == "" {
 		pool.Spec.NodeSelector = "all()"
 	}
+
+	// Default IPIPMode to "Never" if not set.
+	if len(pool.Spec.IPIPMode) == 0 {
+		pool.Spec.IPIPMode = apiv3.IPIPModeNever
+	}
+
+	// Default VXLANMode to "Never" if not set.
+	if len(pool.Spec.VXLANMode) == 0 {
+		pool.Spec.VXLANMode = apiv3.VXLANModeNever
+	}
+
 	return nil
 }
 

--- a/libcalico-go/lib/clientv3/ippool_e2e_test.go
+++ b/libcalico-go/lib/clientv3/ippool_e2e_test.go
@@ -41,6 +41,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 	ctx := context.Background()
 	name1 := "ippool-1"
 	name2 := "ippool-2"
+	name3 := "ippool-3"
 	spec1 := apiv3.IPPoolSpec{
 		CIDR:         "1.2.3.0/24",
 		IPIPMode:     apiv3.IPIPModeAlways,
@@ -78,6 +79,22 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 		AllowedUses:      []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseWorkload, apiv3.IPPoolAllowedUseTunnel},
 		DisableBGPExport: false,
 	}
+	spec3 := apiv3.IPPoolSpec{
+		CIDR:         "1.2.3.0/24",
+		IPIPMode:     "",
+		VXLANMode:    "",
+		BlockSize:    26,
+		NodeSelector: "all()",
+		AllowedUses:  []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseWorkload, apiv3.IPPoolAllowedUseTunnel},
+	}
+	spec3_1 := apiv3.IPPoolSpec{
+		CIDR:         "1.2.3.0/24",
+		IPIPMode:     apiv3.IPIPModeNever,
+		VXLANMode:    apiv3.VXLANModeNever,
+		BlockSize:    26,
+		NodeSelector: "all()",
+		AllowedUses:  []apiv3.IPPoolAllowedUse{apiv3.IPPoolAllowedUseWorkload, apiv3.IPPoolAllowedUseTunnel},
+	}
 
 	It("should error when creating an IPPool with no name", func() {
 		c, err := clientv3.New(config)
@@ -93,7 +110,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 	})
 
 	DescribeTable("IPPool e2e CRUD tests",
-		func(name1, name2 string, spec1, spec1_2, spec2 apiv3.IPPoolSpec) {
+		func(name1, name2, name3 string, spec1, spec1_2, spec2, spec3, spec3_1 apiv3.IPPoolSpec) {
 			c, err := clientv3.New(config)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -318,10 +335,34 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			_, outError = c.IPPools().Get(ctx, name2, options.GetOptions{})
 			Expect(outError).To(HaveOccurred())
 			Expect(outError.Error()).To(ContainSubstring("resource does not exist: IPPool(" + name2 + ") with error:"))
+
+			By("Adding an IPPool with empty string for IPIPMode and VXLANMode and expecting it to be defaulted to 'Never'")
+			res, outError = c.IPPools().Create(ctx, &apiv3.IPPool{
+				ObjectMeta: metav1.ObjectMeta{Name: name3},
+				Spec:       spec3,
+			}, options.SetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res).To(MatchResource(apiv3.KindIPPool, testutils.ExpectNoNamespace, name3, spec3_1))
+
+			res, outError = c.IPPools().Get(ctx, name3, options.GetOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(res).To(MatchResource(apiv3.KindIPPool, testutils.ExpectNoNamespace, name3, spec3_1))
+
+			outList, outError = c.IPPools().List(ctx, options.ListOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			Expect(outList.Items).To(ConsistOf(
+				testutils.Resource(apiv3.KindIPPool, testutils.ExpectNoNamespace, name3, spec3_1),
+			))
+
+			By("Deleting IPPool (name3)")
+			dres, outError = c.IPPools().Delete(ctx, name3, options.DeleteOptions{})
+			Expect(outError).NotTo(HaveOccurred())
+			spec3_1.Disabled = true
+			Expect(dres).To(MatchResource(apiv3.KindIPPool, testutils.ExpectNoNamespace, name3, spec3_1))
 		},
 
 		// Test 1: Pass two fully populated IPPoolSpecs and expect the series of operations to succeed.
-		Entry("Two fully populated IPPoolSpecs", name1, name2, spec1, spec1_2, spec2),
+		Entry("Two fully populated IPPoolSpecs", name1, name2, name3, spec1, spec1_2, spec2, spec3, spec3_1),
 	)
 
 	Describe("IPPool watch functionality", func() {
@@ -590,7 +631,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			Expect(err).To(BeAssignableToTypeOf(errors.ErrorResourceDoesNotExist{}))
 		})
 
-		It("should enable VXLAN globally on an IPPool Update if the global setting is not configured", func() {
+		It("should not enable VXLAN globally on an IPPool Update if the global setting is not configured", func() {
 			By("Getting the current felix configuration - checking does not exist")
 			_, err = getGlobalSetting()
 			Expect(err).To(HaveOccurred())
@@ -664,7 +705,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			return cfg.Spec.IPIPEnabled, nil
 		}
 
-		It("should enable IPIP globally on an IPPool Create (IPIPModeAlways) if the global setting is not configured", func() {
+		It("should not enable IPIP globally on an IPPool Create (IPIPModeAlways) if the global setting is not configured", func() {
 			By("Getting the current felix configuration - checking does not exist")
 			_, err = getGlobalSetting()
 			Expect(err).To(HaveOccurred())
@@ -711,7 +752,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			Expect(err).To(BeAssignableToTypeOf(errors.ErrorResourceDoesNotExist{}))
 		})
 
-		It("should enable IPIP globally on an IPPool Create (IPIPModeNever) if the global setting is not configured", func() {
+		It("should not enable IPIP globally on an IPPool Create (IPIPModeNever) if the global setting is not configured", func() {
 			By("Getting the current felix configuration - checking does not exist")
 			_, err = getGlobalSetting()
 			Expect(err).To(HaveOccurred())
@@ -731,7 +772,7 @@ var _ = testutils.E2eDatastoreDescribe("IPPool tests", testutils.DatastoreAll, f
 			Expect(err).To(BeAssignableToTypeOf(errors.ErrorResourceDoesNotExist{}))
 		})
 
-		It("should enable IPIP globally on an IPPool Update if the global setting is not configured", func() {
+		It("should not enable IPIP globally on an IPPool Update if the global setting is not configured", func() {
 			By("Getting the current felix configuration - checking does not exist")
 			_, err = getGlobalSetting()
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Set IPIPMode and VXLANMode to the default "Never" if they are empty strings in convertIpPoolFromStorage() in clientv3/ippool.go (for when the IP pool was created by an older Calico version that did not have these fields).

Add tests for this to clientv3/ippool_e2e_test.go.

Roll back EncapsulationCalculator changes from https://github.com/projectcalico/calico/pull/6494 and add validation to EncapsulationCalculator.handleAPIPool in encapsulation_resolver.go. Also add tests for it in encapsulation_resolver_test.go.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
fixes https://github.com/projectcalico/calico/issues/6442
undoes https://github.com/projectcalico/calico/pull/6494


## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Set IPIPMode and VXLANMode to the default "Never" if they are empty strings in IPPools.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
