### PR TITLE
Ensure calico-kube-controllers runs with non root user

### DIFF
--- a/charts/calico/templates/calico-kube-controllers.yaml
+++ b/charts/calico/templates/calico-kube-controllers.yaml
@@ -91,6 +91,8 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
       volumes:
         # Mount in the etcd TLS secrets with mode 400.
         # See https://kubernetes.io/docs/concepts/configuration/secret/
@@ -124,6 +126,8 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
 {{- end }}
 
 ---

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -4763,3 +4763,5 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -627,6 +627,8 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
       volumes:
         # Mount in the etcd TLS secrets with mode 400.
         # See https://kubernetes.io/docs/concepts/configuration/secret/

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -4660,6 +4660,8 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
 ---
 # Source: calico/templates/calico-typha.yaml
 # This manifest creates a Deployment of Typha to back the above service.

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -4764,6 +4764,8 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
 ---
 # Source: calico/templates/calico-typha.yaml
 # This manifest creates a Deployment of Typha to back the above service.

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -4720,3 +4720,5 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -4722,3 +4722,5 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -786,6 +786,8 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
       volumes:
         # Mount in the etcd TLS secrets with mode 400.
         # See https://kubernetes.io/docs/concepts/configuration/secret/

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4734,3 +4734,5 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -4722,3 +4722,5 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -744,3 +744,5 @@ spec:
               - /usr/bin/check-status
               - -r
             periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The `amd64` and `arm64` images of calico-kube-controllers run with non root user:
https://github.com/projectcalico/calico/blob/bf32bb49e455ae25229b6ee19d61b898e827fcbd/kube-controllers/Dockerfile.amd64#L55

https://github.com/projectcalico/calico/blob/bf32bb49e455ae25229b6ee19d61b898e827fcbd/kube-controllers/Dockerfile.arm64#L37

We can enhance the securityContext of the calico-kube-controllers container to specify
```yaml
          securityContext:
            runAsNonRoot: true
```

to force the running image to run as a non-root user to ensure least privilege. 

This will fail for the `armv7`, `ppc64le` and `s390x` images of calico-kube-controllers as they still run with the default root user and don't specify an `USER` in the Dockerfile

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>
N/A


If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The calico-kube-controllers container now runs with `securityContext.runAsNonRoot=true`.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
