### PR TITLE
pod-service-self should not rely on src==dst

### DIFF
--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -33,6 +33,7 @@ enum cali_ct_type {
 #define CALI_CT_FLAG_VIA_NAT_IF	0x80 /* marks connection first seen on the service veth */
 #define CALI_CT_FLAG_BA		0x100 /* marks that src->dst is the B->A leg */
 #define CALI_CT_FLAG_HOST_PSNAT 0x200 /* marks that this is from host port collision resolution */
+#define CALI_CT_FLAG_SVC_SELF	0x400 /* marks connections from a pod via service to self */
 
 struct calico_ct_leg {
 	__u64 bytes;

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -910,6 +910,12 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				}
 			}
 
+			if (CALI_F_FROM_WEP && state->ip_src == state->post_nat_ip_dst) {
+				CALI_DEBUG("New loopback SNAT\n");
+				ct_ctx_nat.flags |= CALI_CT_FLAG_SVC_SELF;
+				ctx->state->ct_result.flags |= CALI_CT_FLAG_SVC_SELF;
+			}
+
 			ct_ctx_nat.type = CALI_CT_TYPE_NAT_REV;
 			int err;
 			if ((err = conntrack_create(ctx, &ct_ctx_nat))) {
@@ -1215,7 +1221,7 @@ nat_encap:
 	}
 
 allow:
-	if (CALI_F_FROM_WEP && state->ip_src == state->ip_dst) {
+	if (state->ct_result.flags & CALI_CT_FLAG_SVC_SELF) {
 		CALI_DEBUG("Loopback SNAT\n");
 		seen_mark |=  CALI_SKB_MARK_MASQ;
 		CALI_DEBUG("marking CALI_SKB_MARK_MASQ\n");

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -44,16 +44,6 @@ const (
 	TypeNormal uint8 = iota
 	TypeNATForward
 	TypeNATReverse
-
-	FlagNATOut    uint16 = (1 << 0)
-	FlagNATFwdDsr uint16 = (1 << 1)
-	FlagNATNPFwd  uint16 = (1 << 2)
-	FlagSkipFIB   uint16 = (1 << 3)
-	FlagReserved4 uint16 = (1 << 4)
-	FlagReserved5 uint16 = (1 << 5)
-	FlagExtLocal  uint16 = (1 << 6)
-	FlagViaNATIf  uint16 = (1 << 7)
-	FlagSrcDstBA  uint16 = (1 << 8)
 )
 
 // NewValueNormal creates a new Value of type TypeNormal based on the given parameters

--- a/felix/bpf/conntrack/v3/map.go
+++ b/felix/bpf/conntrack/v3/map.go
@@ -189,6 +189,8 @@ const (
 	FlagExtLocal  uint16 = (1 << 6)
 	FlagViaNATIf  uint16 = (1 << 7)
 	FlagSrcDstBA  uint16 = (1 << 8)
+	FlagHostPSNAT uint16 = (1 << 9)
+	FlagSvcSelf   uint16 = (1 << 10)
 )
 
 func (e Value) ReverseNATKey() Key {
@@ -444,6 +446,14 @@ func (e Value) String() string {
 
 		if flags&FlagSrcDstBA != 0 {
 			flagsStr += " B-A"
+		}
+
+		if flags&FlagHostPSNAT != 0 {
+			flagsStr += " host-psnat"
+		}
+
+		if flags&FlagSvcSelf != 0 {
+			flagsStr += " svc-self"
 		}
 	}
 

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	conntrack3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/routes"
@@ -431,7 +432,7 @@ func TestNATNodePort(t *testing.T) {
 	v, ok := ct[conntrack.NewKey(uint8(ipv4.Protocol), ipv4.SrcIP, uint16(udp.SrcPort), natIP.To4(), natPort)]
 	Expect(ok).To(BeTrue())
 	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
-	Expect(v.Flags()).To(Equal(conntrack.FlagNATNPFwd))
+	Expect(v.Flags()).To(Equal(conntrack3.FlagNATNPFwd))
 
 	expectMark(tcdefs.MarkSeenBypassForwardSourceFixup)
 	// Leaving node 1
@@ -544,7 +545,7 @@ func TestNATNodePort(t *testing.T) {
 	v, ok = ct[conntrack.NewKey(uint8(ipv4.Protocol), ipv4.SrcIP, uint16(udp.SrcPort), natIP.To4(), natPort)]
 	Expect(ok).To(BeTrue())
 	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
-	Expect(v.Flags()).To(Equal(conntrack.FlagExtLocal))
+	Expect(v.Flags()).To(Equal(conntrack3.FlagExtLocal))
 
 	dumpARPMap(arpMap)
 
@@ -1008,7 +1009,7 @@ func TestNATNodePortNoFWD(t *testing.T) {
 	v, ok := ct[conntrack.NewKey(uint8(ipv4.Protocol), ipv4.SrcIP, uint16(udp.SrcPort), natIP.To4(), natPort)]
 	Expect(ok).To(BeTrue())
 	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
-	Expect(v.Flags()).To(Equal(conntrack.FlagExtLocal))
+	Expect(v.Flags()).To(Equal(conntrack3.FlagExtLocal))
 
 	// Arriving at workload
 	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
@@ -1899,7 +1900,7 @@ func TestNATNodePortIngressDSR(t *testing.T) {
 	v, ok := ct[conntrack.NewKey(uint8(ipv4.Protocol), ipv4.SrcIP, uint16(udp.SrcPort), natIP.To4(), natPort)]
 	Expect(ok).To(BeTrue())
 	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
-	Expect(v.Flags()).To(Equal(conntrack.FlagNATFwdDsr | conntrack.FlagNATNPFwd))
+	Expect(v.Flags()).To(Equal(conntrack3.FlagNATFwdDsr | conntrack3.FlagNATNPFwd))
 }
 
 func TestNATSourceCollision(t *testing.T) {


### PR DESCRIPTION
## Description  
    Mark the connections if the post dnat dst is the same as src when
    resolving on WEP and reuse that information for subsequent packets.
    
    src==dst may be equal in other scenarious like host talking to a pod on
    the same host via its own ip (nodeport). Than the communication is
    host-host on one leg.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: pod-service-self connections without CTLB have a svc-self mark
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
