### PR TITLE
Fix bug allowing pools to be split into invalid numbers

### DIFF
--- a/calicoctl/calicoctl/commands/ipam/split.go
+++ b/calicoctl/calicoctl/commands/ipam/split.go
@@ -208,7 +208,7 @@ Examples:
 func splitCIDR(oldCIDR string, parts int) ([]string, error) {
 	// Validate that we are trying to split the CIDR into a valid number of child CIDRs.
 	power := math.Log2(float64(parts))
-	if math.IsNaN(power) || power == 0 {
+	if math.IsNaN(power) || power == 0 || math.Trunc(power) != power {
 		return nil, fmt.Errorf("Number to split CIDR into is not a valid power of 2: %d", parts)
 	}
 

--- a/calicoctl/tests/st/calicoctl/test_ipam_split.py
+++ b/calicoctl/tests/st/calicoctl/test_ipam_split.py
@@ -21,7 +21,8 @@ from tests.st.test_base import TestBase
 from tests.st.utils.utils import log_and_run, calicoctl, \
     API_VERSION, name, namespace, ERROR_CONFLICT, NOT_FOUND, NOT_NAMESPACED, \
     SET_DEFAULT, NOT_SUPPORTED, KUBERNETES_NP, NOT_LOCKED_SPLIT, \
-    POOL_NOT_EXIST_CIDR, NOT_KUBERNETES, NO_IPAM, writeyaml
+    POOL_NOT_EXIST_CIDR, INVALID_SPLIT_NUM, POOL_TOO_SMALL, \
+    NOT_KUBERNETES, NO_IPAM, writeyaml
 from tests.st.utils.data import *
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
@@ -67,6 +68,14 @@ class TestCalicoctlIPAMSplit(TestBase):
         # Attempt to split a non-existent IP pool
         rc = calicoctl("ipam split --cidr=10.0.2.0/24 4")
         rc.assert_error(text=POOL_NOT_EXIST_CIDR)
+
+        # Attempt to split an IP pool into an invalid number of child pools
+        rc = calicoctl("ipam split --cidr=10.0.1.0/24 3")
+        rc.assert_error(text=INVALID_SPLIT_NUM)
+
+        # Attempt to split an IP pool into more pools than possible given the size
+        rc = calicoctl("ipam split --cidr=10.0.1.0/24 512")
+        rc.assert_error(text=POOL_TOO_SMALL)
 
         # Split the IP pool
         rc = calicoctl("ipam split --cidr=10.0.1.0/24 4")
@@ -142,6 +151,14 @@ class TestCalicoctlIPAMSplit(TestBase):
         # Attempt to split a non-existent IP pool
         rc = calicoctl("ipam split --name=%s 4" % name(ippool_name2_rev1_v6))
         rc.assert_error(text=POOL_NOT_EXIST_CIDR)
+
+        # Attempt to split an IP pool into an invalid number of child pools
+        rc = calicoctl("ipam split --name=%s 3" % name(ippool_name1_rev1_v4))
+        rc.assert_error(text=INVALID_SPLIT_NUM)
+
+        # Attempt to split an IP pool into more pools than possible given the size
+        rc = calicoctl("ipam split --name=%s 512" % name(ippool_name1_rev1_v4))
+        rc.assert_error(text=POOL_TOO_SMALL)
 
         # Split the IP pool
         rc = calicoctl("ipam split --name=%s 4" % name(ippool_name1_rev1_v4))

--- a/calicoctl/tests/st/utils/utils.py
+++ b/calicoctl/tests/st/utils/utils.py
@@ -53,6 +53,8 @@ NOT_KUBERNETES = "Invalid datastore type: etcdv3 to import to for datastore migr
 NO_IPAM = "No IPAM resources specified in file"
 NOT_LOCKED_SPLIT = "Datastore is not locked. Run the `calicoctl datastore migrate lock` command in order split the IP pools."
 POOL_NOT_EXIST_CIDR = "Unable to find IP pool"
+INVALID_SPLIT_NUM = "Number to split CIDR into is not a valid power of 2"
+POOL_TOO_SMALL = "is not large enough to be split into"
 
 class CalicoctlOutput:
     """


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes a bug that did not take into account that floats are truncated when converted to integers.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
