### PR TITLE
Fix off-by-one error in NthBit() in felix/ip/ip_addr.go

### DIFF
--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -110,7 +110,7 @@ func (a V6Addr) AsUint64Pair() (uint64, uint64) {
 
 func (a V6Addr) NthBit(n uint) int {
 	h, l := a.AsUint64Pair()
-	if n < 64 {
+	if n <= 64 {
 		return int(h >> (64 - n) & 1)
 	}
 

--- a/felix/ip/trie.go
+++ b/felix/ip/trie.go
@@ -45,7 +45,7 @@ func (t *CIDRTrie) Delete(cidr CIDR) {
 
 func deleteInternal(n *CIDRNode, cidr CIDR) *CIDRNode {
 	if n.cidr.Version() != cidr.Version() {
-		logrus.WithField("n.cidr", n.cidr).WithField("cidr", cidr).Panic("Mismatched CIDR IP versions")
+		logrus.WithFields(logrus.Fields{"n.cidr": n.cidr, "cidr": cidr}).Panic("Mismatched CIDR IP versions")
 	}
 
 	if !n.cidr.Contains(cidr.Addr()) {
@@ -153,7 +153,7 @@ func (n *CIDRNode) lookupPath(buffer []CIDRTrieEntry, cidr CIDR) []CIDRTrieEntry
 	}
 
 	if n.cidr.Version() != cidr.Version() {
-		logrus.WithField("n.cidr", n.cidr).WithField("cidr", cidr).Panic("Mismatched CIDR IP versions")
+		logrus.WithFields(logrus.Fields{"n.cidr": n.cidr, "cidr": cidr}).Panic("Mismatched CIDR IP versions")
 	}
 
 	if !n.cidr.Contains(cidr.Addr()) {
@@ -186,7 +186,7 @@ func (n *CIDRNode) get(cidr CIDR) interface{} {
 	}
 
 	if n.cidr.Version() != cidr.Version() {
-		logrus.WithField("n.cidr", n.cidr).WithField("cidr", cidr).Panic("Mismatched CIDR IP versions")
+		logrus.WithFields(logrus.Fields{"n.cidr": n.cidr, "cidr": cidr}).Panic("Mismatched CIDR IP versions")
 	}
 
 	if !n.cidr.Contains(cidr.Addr()) {
@@ -378,7 +378,7 @@ func (t *CIDRTrie) Update(cidr CIDR, value interface{}) {
 
 func CommonPrefix(a, b CIDR) CIDR {
 	if a.Version() != b.Version() {
-		logrus.WithField("a", a).WithField("b", b).Panic("Mismatched CIDR IP versions")
+		logrus.WithFields(logrus.Fields{"a": a, "b": b}).Panic("Mismatched CIDR IP versions")
 	}
 
 	var cidr CIDR


### PR DESCRIPTION
## Description

This was causing problems in Get() for an IPv6 CIDRTrie. Also add
test case to felix/ip/trie_test.go to test the fix.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix issue in L3RouteResolver CIDRTrie which could result in crashes when the IPv6 trie had a node with a /63 prefix.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
