### PR TITLE
Limit rate of logging 'Wireguard is not supported' to fix log spam

### DIFF
--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -36,6 +36,7 @@ import (
 	"github.com/projectcalico/calico/felix/routerule"
 	"github.com/projectcalico/calico/felix/routetable"
 	"github.com/projectcalico/calico/felix/timeshim"
+	lclogutils "github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 const (
@@ -166,7 +167,8 @@ type Wireguard struct {
 	// The write proc sys function.
 	writeProcSys func(path, value string) error
 
-	logCtx *log.Entry
+	logCtx            *log.Entry
+	rateLimitedLogger *lclogutils.RateLimitedLogger
 }
 
 func New(
@@ -282,6 +284,7 @@ func NewWithShims(
 		writeProcSys:         writeProcSys,
 		opRecorder:           opRecorder,
 		logCtx:               logCtx,
+		rateLimitedLogger:    lclogutils.NewRateLimitedLogger(lclogutils.OptInterval(4 * time.Hour)),
 	}
 }
 
@@ -661,7 +664,7 @@ func (w *Wireguard) Apply() (err error) {
 	}
 
 	if w.wireguardNotSupported {
-		w.logCtx.Info("Wireguard is not supported")
+		w.rateLimitedLogger.WithFields(w.logCtx.Data).Info("Wireguard is not supported")
 		return
 	}
 


### PR DESCRIPTION
## Description

Use libcalico-go logutils.RateLimitedLogger with a 4 hour interval
and use WithFields() with the same data as logCtx.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Limit rate of logging 'Wireguard is not supported' to fix log spam issues.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
