### PR TITLE
[release-v3.23] Auto pick #6513: kube-controllers health check: timeout, and report any errors

### DIFF
--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -267,10 +267,14 @@ func runHealthChecks(ctx context.Context, s *status.Status, k8sClientset *kubern
 				)
 			}
 		}(k8sCheckDone)
-		k8sClientset.Discovery().RESTClient().Get().AbsPath("/healthz").Do(ctx).StatusCode(&healthStatus)
+
+		// Call the /healthz endpoint using the same clientset as our main controllers. This allows us to share a connection
+		// and gives us a good idea of whether or not the other controllers are currently experiencing issues accessing the apiserver.
+		result := k8sClientset.Discovery().RESTClient().Get().Timeout(20 * time.Second).AbsPath("/healthz").Do(ctx).StatusCode(&healthStatus)
 		k8sCheckDone <- nil
+
 		if healthStatus != http.StatusOK {
-			log.WithError(err).Errorf("Failed to reach apiserver")
+			log.WithError(result.Error()).WithField("status", healthStatus).Errorf("Received bad status code from apiserver")
 			s.SetReady(
 				"KubeAPIServer",
 				false,


### PR DESCRIPTION
Cherry pick of #6513 on release-v3.23.

#6513: kube-controllers health check: timeout, and report any errors

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- We never timeout the /healthz call, meaning it might take a while before we retry if the connection gets blackholed.
- We were logging out a nil error - instead, get the error from the HTTP call.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix nil error logged from kube-controllers health reporter
```

```release-note
Fix that kube-controllers health checks didn't include a timeout on HTTP calls
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.