### PR TITLE
Wait for BPF programs to be attached to interfaces - FV tests

### DIFF
--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -125,3 +125,21 @@ func ValueFromBytes(b []byte) Value {
 	copy(v[:], b)
 	return v
 }
+
+type MapMem map[Key]Value
+
+func MapMemIter(m MapMem) bpf.IterCallback {
+	ks := len(Key{})
+	vs := len(Value{})
+
+	return func(k, v []byte) bpf.IteratorAction {
+		var key Key
+		copy(key[:ks], k[:ks])
+
+		var val Value
+		copy(val[:vs], v[:vs])
+
+		m[key] = val
+		return bpf.IterNone
+	}
+}

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -189,7 +189,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 		return true
 	}
 
-	ifaces := []string{"eth0"}
 	testOpts := bpfTestOptions{
 		bpfLogLevel: "debug",
 		tunnel:      "none",
@@ -289,10 +288,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 			if ctlbWorkaround {
 				options.ExtraEnvVars["FELIX_FeatureDetectOverride"] = "BPFConnectTimeLoadBalancingWorkaround=enabled"
-			}
-			tunIf := getTunIfName(testOpts.tunnel)
-			if tunIf != "" {
-				ifaces = append(ifaces, tunIf)
 			}
 		})
 
@@ -397,8 +392,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				err := infra.AddDefaultDeny()
 				Expect(err).NotTo(HaveOccurred())
 
-				expectedIfaces := append(ifaces, w[0].InterfaceName)
+				expectedIfaces := []string{"eth0"}
+				expectedIfaces = append(expectedIfaces, w[0].InterfaceName)
 				expectedIfaces = append(expectedIfaces, w[1].InterfaceName)
+				tunIf := getTunIfName(testOpts.tunnel)
+				if tunIf != "" {
+					expectedIfaces = append(expectedIfaces, tunIf)
+				}
 				ensureProgramAttached(felixes[0], expectedIfaces)
 
 				pol := api.NewGlobalNetworkPolicy()
@@ -775,7 +775,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			Expect(err).NotTo(HaveOccurred())
 			if !options.TestManagesBPF {
 				for ii, felix := range felixes {
-					expectedIfaces := append(ifaces, w[ii][0].InterfaceName)
+					expectedIfaces := []string{"eth0"}
+					tunIf := getTunIfName(testOpts.tunnel)
+					if tunIf != "" {
+						expectedIfaces = append(expectedIfaces, tunIf)
+					}
+					expectedIfaces = append(expectedIfaces, w[ii][0].InterfaceName)
 					expectedIfaces = append(expectedIfaces, w[ii][1].InterfaceName)
 					ensureProgramAttached(felix, expectedIfaces)
 				}


### PR DESCRIPTION
## Description

For now, BPF tests are flaking with a lot of timing issues. BPF endpoint manager is spending a lot of time attaching the programs. By this time, the test starts resulting in timeouts and failures.

Fix - Wait for BPF programs to be attached to interfaces mainly (eth0, workload interfaces, tunnel interfaces(ipip, vxlan and wireguard) before proceeding with the test. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
