### PR TITLE
Set seccomp profile to RuntimeDefault for calico-kube-controllers and calico-typha

### DIFF
--- a/charts/calico/templates/calico-kube-controllers.yaml
+++ b/charts/calico/templates/calico-kube-controllers.yaml
@@ -32,6 +32,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
 {{- if eq .Values.datastore "etcd" }}
       # The controllers must run in the host network namespace so that

--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -38,6 +38,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: {{include "nodeName" . }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0

--- a/charts/calico/templates/calico-typha.yaml
+++ b/charts/calico/templates/calico-typha.yaml
@@ -62,6 +62,8 @@ spec:
       # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
       securityContext:
         fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - image: {{ .Values.typha.image }}:{{.Values.version }}
         imagePullPolicy: {{.Values.imagePullPolicy}}

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -4381,6 +4381,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -4737,6 +4740,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -258,6 +258,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -572,6 +575,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -4378,6 +4378,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -4634,6 +4637,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
@@ -4704,6 +4710,8 @@ spec:
       # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
       securityContext:
         fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - image: docker.io/calico/typha:master
         imagePullPolicy: IfNotPresent

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -4412,6 +4412,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -4738,6 +4741,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
@@ -4808,6 +4814,8 @@ spec:
       # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
       securityContext:
         fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - image: docker.io/calico/typha:master
         imagePullPolicy: IfNotPresent

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -4376,6 +4376,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -4694,6 +4697,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -4376,6 +4376,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -4696,6 +4699,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -337,6 +337,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: canal-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -731,6 +734,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4400,6 +4400,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: canal
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -4708,6 +4711,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -4378,6 +4378,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -4696,6 +4699,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -398,6 +398,9 @@ spec:
         - effect: NoExecute
           operator: Exists
       serviceAccountName: calico-node
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -718,6 +721,9 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers


### PR DESCRIPTION
## Description
We can enhance the `securityContext` of `calico-node`, `calico-kube-controllers`, `calico-typha` by explicitly adding a "RuntimeDefault" seccomp profile.

```yaml
      securityContext:
        seccompProfile:
          type: RuntimeDefault
```
By default Kubernetes runs the pods with profile "Unconfined". Privileged containers always run with `Unconfined` profile ([reference](https://kubernetes.io/docs/tutorials/security/seccomp/#before-you-begin)). Having said that this change will only affect `calico-kube-controllers` and `calico-typha` since all the containers in `calico-node` are ran as privileged. The specifying of the seccomp profile there acts as a guardrails against:
1. Adding a new container and running it as `Unconfined`
2. Removing `privileged: true` from a container definition and still running as `Unconfined`

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The calico-node, calico-kube-controllers and calico-typha pods now run with `securityContext.seccompProfile.type=RuntimeDefault`.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
