### PR TITLE
felix/bpf: CTLB workaround for host and nodeports

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -58,6 +58,7 @@ struct bpf_map_def_extended {
 // CALI_XDP_PROG is set for programs attached to the XDP hook
 #define CALI_XDP_PROG 	(1<<6)
 #define CALI_TC_NAT_IF	(1<<7)
+#define CALI_TC_LO	(1<<8)
 
 #ifndef CALI_DROP_WORKLOAD_TO_HOST
 #define CALI_DROP_WORKLOAD_TO_HOST false
@@ -75,6 +76,9 @@ struct bpf_map_def_extended {
 #define CALI_F_TUNNEL  	 ((CALI_COMPILE_FLAGS) & CALI_TC_TUNNEL)
 #define CALI_F_L3_DEV    ((CALI_COMPILE_FLAGS) & CALI_TC_L3_DEV)
 #define CALI_F_NAT_IF    (((CALI_COMPILE_FLAGS) & CALI_TC_NAT_IF) != 0)
+#define CALI_F_LO        (((CALI_COMPILE_FLAGS) & CALI_TC_LO) != 0)
+
+#define CALI_F_MAIN	(CALI_F_HEP && !CALI_F_TUNNEL && !CALI_F_L3_DEV && !CALI_F_NAT_IF && !CALI_F_LO)
 
 #define CALI_F_XDP ((CALI_COMPILE_FLAGS) & CALI_XDP_PROG)
 
@@ -105,7 +109,7 @@ struct bpf_map_def_extended {
 #define CALI_FIB_LOOKUP_ENABLED true
 #endif
 
-#define CALI_FIB_ENABLED (!CALI_F_L3 && CALI_FIB_LOOKUP_ENABLED && CALI_F_TO_HOST)
+#define CALI_FIB_ENABLED (!CALI_F_L3 && CALI_FIB_LOOKUP_ENABLED && (CALI_F_TO_HOST || CALI_F_TO_HEP))
 
 #define COMPILE_TIME_ASSERT(expr) {typedef char array[(expr) ? 1 : -1];}
 static CALI_BPF_INLINE void __compile_asserts(void) {
@@ -272,6 +276,7 @@ CALI_CONFIGURABLE_DEFINE(psnat_len, 0x4c545250) /* be 0x4c545250 = ACSII(PRTL) *
 CALI_CONFIGURABLE_DEFINE(flags, 0x00000001)
 CALI_CONFIGURABLE_DEFINE(host_tunnel_ip, 0x4c4e5554) /* be 0x4c4e5554 = ACSII(TUNL) */
 CALI_CONFIGURABLE_DEFINE(wg_port, 0x54504757) /* be 0x54504757 = ASCII(WGPT) */
+CALI_CONFIGURABLE_DEFINE(natin_idx, 0xdeadbeef)
 
 #define HOST_IP		CALI_CONFIGURABLE(host_ip)
 #define TUNNEL_MTU 	CALI_CONFIGURABLE(tunnel_mtu)
@@ -283,6 +288,7 @@ CALI_CONFIGURABLE_DEFINE(wg_port, 0x54504757) /* be 0x54504757 = ASCII(WGPT) */
 #define GLOBAL_FLAGS 	CALI_CONFIGURABLE(flags)
 #define HOST_TUNNEL_IP	CALI_CONFIGURABLE(host_tunnel_ip)
 #define WG_PORT		CALI_CONFIGURABLE(wg_port)
+#define NATIN_IFACE	CALI_CONFIGURABLE(natin_idx)
 
 #ifdef UNITTEST
 CALI_CONFIGURABLE_DEFINE(__skb_mark, 0x4d424b53) /* be 0x4d424b53 = ASCII(SKBM) */

--- a/felix/bpf-gpl/calculate-flags
+++ b/felix/bpf-gpl/calculate-flags
@@ -52,6 +52,7 @@ flags=0
 ((CALI_TC_L3_DEV = 1 << 5))
 ((CALI_XDP_PROG = 1 << 6))
 ((CALI_TC_NAT_IF = 1 << 7))
+((CALI_TC_LO = 1 << 8))
 
 if [[ "${filename}" =~ .*hep.* ]]; then
   # Host endpoint.
@@ -87,6 +88,12 @@ elif [[ "${filename}" =~ .*nat.* ]]; then
   ((flags |= CALI_TC_NAT_IF))
   args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO")
   ep_type="nat"
+elif [[ "${filename}" =~ .*lo.* ]]; then
+  # loopback, so host endpoint.
+  ((flags |= CALI_TC_HOST_EP))
+  ((flags |= CALI_TC_LO))
+  args+=("-DCALI_NO_DEFAULT_POLICY_PROG" "-DCALI_LOG_PFX=CALICOLO")
+  ep_type="lo"
 else
   echo "Can't recognise endpoint type"
   exit 2

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -34,6 +34,8 @@ enum cali_ct_type {
 #define CALI_CT_FLAG_BA		0x100 /* marks that src->dst is the B->A leg */
 #define CALI_CT_FLAG_HOST_PSNAT 0x200 /* marks that this is from host port collision resolution */
 #define CALI_CT_FLAG_SVC_SELF	0x400 /* marks connections from a pod via service to self */
+#define CALI_CT_FLAG_NP_LOOP	0x800 /* marks connections that were turned around when accessing nodeport on a local IP */
+#define CALI_CT_FLAG_NP_REMOTE	0x1000 /* marks connections from local host to remote backend of a nodeport */
 
 struct calico_ct_leg {
 	__u64 bytes;

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -299,7 +299,7 @@ cancel_fib:
 		}
 
 		CALI_DEBUG("Setting mark to 0x%x\n", mark);
-		ctx->skb->mark = mark;
+		skb_set_mark(ctx->skb, mark);
 	}
 
 skip_fib:
@@ -330,7 +330,7 @@ skip_fib:
 		 * can do a 16-bit store instead of a 32-bit load/modify/store,
 		 * which trips up the validator.
 		 */
-		ctx->skb->mark = ctx->fwd.mark; /* make sure that each pkt has SEEN mark */
+		skb_set_mark(ctx->skb, ctx->fwd.mark); /* make sure that each pkt has SEEN mark */
 	}
 
 	if (CALI_LOG_LEVEL >= CALI_LOG_LEVEL_INFO) {

--- a/felix/bpf-gpl/fib.h
+++ b/felix/bpf-gpl/fib.h
@@ -25,7 +25,7 @@ static CALI_BPF_INLINE bool fib_approve(struct cali_tc_ctx *ctx, __u32 ifindex)
 	/* Let's assume that unittest is setup so that WEP's are ready - for UT simplicity */
 	return true;
 #else
-	/* If we are turnign packets around on lo to a remote pod, approve the
+	/* If we are turning packets around on lo to a remote pod, approve the
 	 * fib as it does not concern a possibly not ready local WEP.
 	 */
 	if (CALI_F_TO_HEP && ctx->state->flags & CALI_ST_CT_NP_REMOTE) {

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -16,6 +16,8 @@ struct cali_tc_globals {
 	__be32 host_tunnel_ip;
 	__be32 flags;
 	__be16 wg_port;
+	__u32 natin_idx;
+	__u32 natout_idx;
 };
 
 enum cali_globals_flags {

--- a/felix/bpf-gpl/list-objs
+++ b/felix/bpf-gpl/list-objs
@@ -30,11 +30,15 @@ for core_support in co-re legacy;do
 	# The workload-to-host drop setting only applies to the from-workload hook.
 	ep_types="wep"
       else
-	ep_types="wep hep tnl l3 nat"
+	ep_types="wep hep tnl l3 nat lo"
       fi
       for fib in "" "fib_"; do
 	for ep_type in $ep_types; do
-	  if [ "${host_drop}" = "host_drop_" ] || [ "${fib}" = "fib_" ]; then
+          if [ "${fib}" = "fib_" ] && [ "${ep_type}" = "lo" ]; then
+	    directions="from to"
+	  elif [ "${fib}" = "fib_" ] && [ ${ep_type} = "hep" ]; then
+            directions="from to"
+          elif [ "${host_drop}" = "host_drop_" ] || [ "${fib}" = "fib_" ]; then
 	    # The workload-to-host drop setting only applies to the from-workload hook.
 	    # The FIB only applies in the from-endpoint hooks.
 	    directions="from"

--- a/felix/bpf-gpl/reasons.h
+++ b/felix/bpf-gpl/reasons.h
@@ -24,6 +24,7 @@ enum calico_reason {
 	CALI_REASON_RT_UNKNOWN,
 	CALI_REASON_ACCEPTED_BY_XDP, // Not used by countres map
 	CALI_REASON_WEP_NOT_READY,
+	CALI_REASON_NATIFACE,
 };
 
 #define DENY_REASON(ctx, res) 	\

--- a/felix/bpf-gpl/routes.h
+++ b/felix/bpf-gpl/routes.h
@@ -66,6 +66,7 @@ static CALI_BPF_INLINE enum cali_rt_flags cali_rt_lookup_flags(__be32 addr)
 #define cali_rt_is_local(rt)	((rt)->flags & CALI_RT_LOCAL)
 #define cali_rt_is_host(rt)	((rt)->flags & CALI_RT_HOST)
 #define cali_rt_is_workload(rt)	((rt)->flags & CALI_RT_WORKLOAD)
+#define cali_rt_is_tunneled(rt)	((rt)->flags & CALI_RT_TUNNELED)
 
 #define cali_rt_flags_local_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST)) == (CALI_RT_LOCAL | CALI_RT_HOST))
 #define cali_rt_flags_local_workload(t) (((t) & CALI_RT_LOCAL) && ((t) & CALI_RT_WORKLOAD))

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -59,6 +59,9 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx, bool relax)
 		case BPF_FIB_LKUP_RET_NO_NEIGH:
 			if (!relax) {
 				ret = ctx->skb->ingress_ifindex == fib_params.ifindex;
+				CALI_DEBUG("Host RPF check src=%x skb iface=%d strict if %d\n",
+						bpf_ntohl(ctx->state->ip_src), ctx->skb->ifindex,
+						fib_params.ifindex);
 			} else {
 				ret = fib_params.ifindex != CT_INVALID_IFINDEX;
 				CALI_DEBUG("Host RPF check src=%x skb iface=%d loose if %d\n",

--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -162,4 +162,14 @@ static CALI_BPF_INLINE bool skb_is_gso(struct __sk_buff *skb) {
 	return (skb->gso_segs > 1);
 }
 
+static CALI_BPF_INLINE void skb_set_mark(struct __sk_buff *skb, __u32 mark)
+{
+	asm volatile (\
+		"*(u32 *)(%[skb] + %[offset]) = %[mark]" \
+		: /*out*/ : [skb] "r" (skb), [mark] "r" (mark),
+		  [offset] "i" (offsetof(struct __sk_buff, mark)) /*in*/ \
+		: /*clobber*/ \
+	);
+}
+
 #endif /* __SKB_H__ */

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -64,9 +64,35 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 
 	/* Optimisation: if another BPF program has already pre-approved the packet,
 	 * skip all processing. */
-	if (!CALI_F_TO_HOST && skb->mark == CALI_SKB_MARK_BYPASS) {
-		CALI_INFO("Final result=ALLOW (%d). Bypass mark bit set.\n", CALI_REASON_BYPASS);
+	if (CALI_F_FROM_HOST && skb->mark == CALI_SKB_MARK_BYPASS) {
+		CALI_INFO("Final result=ALLOW (%d). Bypass mark set.\n", CALI_REASON_BYPASS);
 		return TC_ACT_UNSPEC;
+	}
+
+	if (CALI_F_NAT_IF) {
+		switch (skb->mark) {
+		case CALI_SKB_MARK_BYPASS:
+			/* We are turning a packet around to a local WEP using bpfnat
+			 * iface, the WEP should do normal processing.
+			 */
+			{
+				__u32 mark = 0;
+				skb->mark = mark;
+			}
+			CALI_INFO("Final result=ALLOW (%d). Bypass mark set at bpfnat local WL\n", CALI_REASON_BYPASS);
+			return TC_ACT_UNSPEC;
+		case CALI_SKB_MARK_BYPASS_FWD:
+			/* We are turning a packet around from lo to a remote WEP using
+			 * bpfnat iface. Next hop is a HEP and it should just forward the
+			 * packet.
+			 */
+			{
+				__u32 mark = CALI_SKB_MARK_BYPASS;
+				skb->mark = mark;
+			}
+			CALI_INFO("Final result=ALLOW (%d). Bypass mark set at bpfnat remote WL\n", CALI_REASON_BYPASS);
+			return TC_ACT_UNSPEC;
+		}
 	}
 
 	/* Optimisation: if XDP program has already accepted the packet,
@@ -355,8 +381,7 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 	/* No conntrack entry, check if we should do NAT */
 	nat_lookup_result nat_res = NAT_LOOKUP_ALLOW;
 
-	/* Skip NAT lookup for traffic leaving the host namespace */
-	if (CALI_F_TO_HOST) {
+	if (CALI_F_TO_HOST || (CALI_F_FROM_HOST && !skb_seen(ctx->skb) && !ctx->nat_dest /* no sport conflcit */)) {
 		ctx->nat_dest = calico_v4_nat_lookup2(ctx->state->ip_src, ctx->state->ip_dst,
 						      ctx->state->ip_proto, ctx->state->dport,
 						      ctx->state->tun_ip != 0, &nat_res);
@@ -384,7 +409,7 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 syn_force_policy:
 	/* DNAT in state is set correctly now */
 
-	if ((!(ctx->state->tun_ip) && CALI_F_FROM_HEP) && !CALI_F_NAT_IF) {
+	if ((!(ctx->state->tun_ip) && CALI_F_FROM_HEP) && !CALI_F_NAT_IF && !CALI_F_LO) {
 		if (!hep_rpf_check(ctx, false)) {
 			goto deny;
 		}
@@ -467,15 +492,6 @@ syn_force_policy:
 		}
 	}
 
-	if (rt_addr_is_local_host(ctx->state->post_nat_ip_dst)) {
-		CALI_DEBUG("Post-NAT dest IP is local host.\n");
-		if (CALI_F_FROM_HEP && is_failsafe_in(ctx->state->ip_proto, ctx->state->post_nat_dport, ctx->state->ip_src)) {
-			CALI_DEBUG("Inbound failsafe port: %d. Skip policy.\n", ctx->state->post_nat_dport);
-			COUNTER_INC(ctx, CALI_REASON_ACCEPTED_BY_FAILSAFE);
-			goto skip_policy;
-		}
-		ctx->state->flags |= CALI_ST_DEST_IS_HOST;
-	}
 	if (rt_addr_is_local_host(ctx->state->ip_src)) {
 		CALI_DEBUG("Source IP is local host.\n");
 		if (CALI_F_TO_HEP && is_failsafe_out(ctx->state->ip_proto, ctx->state->post_nat_dport, ctx->state->post_nat_ip_dst)) {
@@ -486,6 +502,47 @@ syn_force_policy:
 		ctx->state->flags |= CALI_ST_SRC_IS_HOST;
 	}
 
+	struct cali_rt *dest_rt = cali_rt_lookup(ctx->state->post_nat_ip_dst);
+
+	if (!dest_rt) {
+		CALI_DEBUG("No route for post DNAT dest %x\n", ctx->state->post_nat_ip_dst);
+		goto do_policy;
+	}
+
+	if (cali_rt_flags_local_host(dest_rt->flags)) {
+		CALI_DEBUG("Post-NAT dest IP is local host.\n");
+		if (CALI_F_FROM_HEP && is_failsafe_in(ctx->state->ip_proto, ctx->state->post_nat_dport, ctx->state->ip_src)) {
+			CALI_DEBUG("Inbound failsafe port: %d. Skip policy.\n", ctx->state->post_nat_dport);
+			COUNTER_INC(ctx, CALI_REASON_ACCEPTED_BY_FAILSAFE);
+			goto skip_policy;
+		}
+		ctx->state->flags |= CALI_ST_DEST_IS_HOST;
+	}
+
+	if (CALI_F_TO_HEP && ctx->nat_dest && !skb_seen(ctx->skb) && !(ctx->state->flags & CALI_ST_HOST_PSNAT)) {
+		CALI_DEBUG("Host accesses nodeport backend %x:%d state->flags 0x%x\n",
+			   bpf_htonl(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport,
+			   ctx->state->flags);
+		if (cali_rt_flags_local_workload(dest_rt->flags)) {
+			CALI_DEBUG("NP redir on HEP - skip policy\n");
+			ctx->state->flags |= CALI_ST_CT_NP_LOOP;
+			ctx->state->pol_rc = CALI_POL_ALLOW;
+			goto skip_policy;
+		} else if (cali_rt_flags_remote_workload(dest_rt->flags)) {
+			if (CALI_F_LO) {
+				CALI_DEBUG("NP redir remote on LO\n");
+				ctx->state->flags |= CALI_ST_CT_NP_LOOP;
+			} else if (CALI_F_MAIN && cali_rt_is_tunneled(dest_rt)) {
+				CALI_DEBUG("NP redir remote on HEP to tunnel\n");
+				ctx->state->flags |= CALI_ST_CT_NP_LOOP;
+			}
+			ctx->state->flags |= CALI_ST_CT_NP_REMOTE;
+			ctx->state->pol_rc = CALI_POL_ALLOW;
+			/* XXX We need to do HEP policy here, where we do NAT. */
+		}
+	}
+
+do_policy:
 	CALI_DEBUG("About to jump to policy program.\n");
 	CALI_JUMP_TO(ctx->skb, PROG_INDEX_POLICY);
 	if (CALI_F_HEP) {
@@ -566,8 +623,8 @@ int calico_tc_skb_accepted_entrypoint(struct __sk_buff *skb)
 	update_rule_counters(ctx.state);
 	struct calico_nat_dest *nat_dest = NULL;
 	struct calico_nat_dest nat_dest_2 = {
-		.addr=ctx.state->nat_dest.addr,
-		.port=ctx.state->nat_dest.port,
+		.addr = ctx.state->nat_dest.addr,
+		.port = ctx.state->nat_dest.port,
 	};
 	if (ctx.state->nat_dest.addr != 0) {
 		nat_dest = &nat_dest_2;
@@ -776,6 +833,12 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		if (CALI_F_TO_HOST && CALI_F_NAT_IF) {
 			ct_ctx_nat.flags |= CALI_CT_FLAG_VIA_NAT_IF;
 		}
+		if (CALI_F_TO_HEP && !CALI_F_NAT_IF && state->flags & CALI_ST_CT_NP_LOOP) {
+			ct_ctx_nat.flags |= CALI_CT_FLAG_NP_LOOP;
+		}
+		if (CALI_F_TO_HEP && !CALI_F_NAT_IF && state->flags & CALI_ST_CT_NP_REMOTE) {
+			ct_ctx_nat.flags |= CALI_CT_FLAG_NP_REMOTE;
+		}
 		if (state->flags & CALI_ST_HOST_PSNAT) {
 			ct_ctx_nat.flags |= CALI_CT_FLAG_HOST_PSNAT;
 		}
@@ -822,10 +885,11 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		state->ct_result.nat_sport = ct_ctx_nat.sport;
 		/* fall through as DNAT is now established */
 
-		if (CALI_F_TO_HOST && CALI_F_NAT_IF) {
+		if ((CALI_F_TO_HOST && CALI_F_NAT_IF) || (CALI_F_TO_HEP && (CALI_F_LO || CALI_F_MAIN))) {
 			struct cali_rt *r = cali_rt_lookup(state->post_nat_ip_dst);
-			if (r && cali_rt_flags_remote_workload(r->flags) && r->flags & CALI_RT_TUNNELED) {
-				CALI_DEBUG("remote wl %x tunneled\n", bpf_htonl(state->post_nat_ip_dst));
+			if (r && cali_rt_flags_remote_workload(r->flags) && cali_rt_is_tunneled(r)) {
+				CALI_DEBUG("remote wl %x tunneled via %x\n",
+						bpf_htonl(state->post_nat_ip_dst), bpf_htonl(HOST_TUNNEL_IP));
 				ct_ctx_nat.src = HOST_TUNNEL_IP;
 				/* This would be the place to set a new source port if we
 				 * had a way how to allocate it. Instead we rely on source
@@ -1218,6 +1282,8 @@ nat_encap:
 		rc = CALI_RES_REDIR_IFINDEX;
 	}
 
+	goto encap_allow;
+
 allow:
 	if (state->ct_result.flags & CALI_CT_FLAG_SVC_SELF) {
 		CALI_DEBUG("Loopback SNAT\n");
@@ -1226,6 +1292,33 @@ allow:
 		fib = false; /* Disable FIB because we want to drop to iptables */
 	}
 
+	if (CALI_F_TO_HEP && !skb_seen(skb)) {
+		CALI_DEBUG("Host accesses nodeport backend %x:%d\n",
+			   bpf_htonl(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
+
+		struct cali_rt *r = cali_rt_lookup(state->post_nat_ip_dst);
+
+		if (r) {
+			if (cali_rt_flags_local_workload(r->flags)) {
+				state->ct_result.ifindex_fwd = r->if_index;
+				CALI_DEBUG("NP local WL on HEP\n");
+				ctx->state->flags |= CALI_ST_CT_NP_LOOP;
+				fib = true; /* Enforce FIB since we want to redirect */
+			} else if (cali_rt_flags_remote_workload(r->flags)) {
+				if (CALI_F_LO || CALI_F_MAIN) {
+					state->ct_result.ifindex_fwd = NATIN_IFACE  ;
+					CALI_DEBUG("NP remote WL on LO or main HEP\n");
+					ctx->state->flags |= CALI_ST_CT_NP_LOOP;
+				}
+				ctx->state->flags |= CALI_ST_CT_NP_REMOTE;
+				fib = true; /* Enforce FIB since we want to redirect */
+			}
+		} else {
+			/* might go outside the cluster */
+		}
+	}
+
+encap_allow:
 	{
 		struct fwd fwd = {
 			.res = rc,
@@ -1351,9 +1444,9 @@ int calico_tc_host_ct_conflict(struct __sk_buff *skb)
 
 	switch (ct_result_rc(ctx.state->ct_result.rc)) {
 	case CALI_CT_ESTABLISHED:
-		/* Because we are on the "from host" path, conntrack gives us
-		 * CALI_CT_ESTABLISHED only. Better to fix the corner case here than on
-		 * the generic path.
+		/* Because we are on the "from host" path, conntrack may give us
+		 * CALI_CT_ESTABLISHED only if traffic targets pod without DNAT. Better to
+		 * fix the corner case here than on the generic path.
 		 */
 		ct_result_set_rc(ctx.state->ct_result.rc, CALI_CT_ESTABLISHED_DNAT);
 		/* fallthrough */
@@ -1391,12 +1484,12 @@ int calico_tc_skb_drop(struct __sk_buff *skb)
 		.counters = counters_get(),
 		.ipheader_len = IP_SIZE,
 	};
-	
+
 	if (!ctx.state) {
 		CALI_DEBUG("State map lookup failed: no event generated\n");
 		return TC_ACT_SHOT;
 	}
-	
+
 	if (!ctx.counters) {
 		CALI_DEBUG("Counters map lookup failed: DROP\n");
 		return TC_ACT_SHOT;

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -537,8 +537,6 @@ syn_force_policy:
 				ctx->state->flags |= CALI_ST_CT_NP_LOOP;
 			}
 			ctx->state->flags |= CALI_ST_CT_NP_REMOTE;
-			ctx->state->pol_rc = CALI_POL_ALLOW;
-			/* XXX We need to do HEP policy here, where we do NAT. */
 		}
 	}
 

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -75,10 +75,7 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			/* We are turning a packet around to a local WEP using bpfnat
 			 * iface, the WEP should do normal processing.
 			 */
-			{
-				__u32 mark = 0;
-				skb->mark = mark;
-			}
+			skb->mark = 0UL;
 			CALI_INFO("Final result=ALLOW (%d). Bypass mark set at bpfnat local WL\n", CALI_REASON_BYPASS);
 			return TC_ACT_UNSPEC;
 		case CALI_SKB_MARK_BYPASS_FWD:

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -82,7 +82,7 @@ struct cali_tc_state {
 	/* Packet IP proto; updated to UDP when we encap. */
 	__u8 ip_proto;
 	/* Flags from enum cali_state_flags. */
-	__u8 flags;
+	__u8 __pad;
 	/* Packet size filled from iphdr->tot_len in tc_state_fill_from_iphdr(). */
 	__be16 ip_size;
 	/* Count of rules that were hit while processing policy. */
@@ -91,11 +91,12 @@ struct cali_tc_state {
 	__u64 rule_ids[MAX_RULE_IDS];
 
 	/* Result of the conntrack lookup. */
-	struct calico_ct_result ct_result;
+	struct calico_ct_result ct_result; /* 28 bytes */
 
 	/* Result of the NAT calculation.  Zeroed if there is no DNAT. */
-	struct calico_nat_dest nat_dest;
+	struct calico_nat_dest nat_dest; /* 8 bytes */
 	__u64 prog_start_time;
+	__u64 flags;
 };
 
 enum cali_state_flags {
@@ -114,9 +115,14 @@ enum cali_state_flags {
 	/* CALI_ST_SUPPRESS_CT_STATE prevents the creation of any new CT state. */
 	CALI_ST_SUPPRESS_CT_STATE = 0x10,
 	/* CALI_ST_SKIP_POLICY is set when the policy program is skipped. */
-	CALI_ST_SKIP_POLICY = 0x20,
+	CALI_ST_SKIP_POLICY	  = 0x20,
 	/* CALI_ST_HOST_PSNAT is set when we are resolving host source port collision. */
-	CALI_ST_HOST_PSNAT = 0x40,
+	CALI_ST_HOST_PSNAT	  = 0x40,
+	/* CALI_ST_CT_NP_LOOP tells CT when creating an entry that we are
+	 * turnign this packet around from a nodeport to a local pod. */
+	CALI_ST_CT_NP_LOOP	  = 0x80,
+	/* CALI_ST_CT_NP_REMOTE is set when host is accessing a remote nodeport. */
+	CALI_ST_CT_NP_REMOTE	  = 0x100,
 };
 
 struct fwd {

--- a/felix/bpf/arp/map.go
+++ b/felix/bpf/arp/map.go
@@ -68,11 +68,15 @@ func (k Key) String() string {
 	return fmt.Sprintf("ip %s ifindex %d", k.IP(), k.IfIndex())
 }
 
+func (k Key) AsBytes() []byte {
+	return k[:]
+}
+
 const ValueSize = 12
 
 type Value [ValueSize]byte
 
-func NewValue(macSrc, macDst []byte) Value {
+func NewValue(macSrc, macDst net.HardwareAddr) Value {
 	var v Value
 
 	copy(v[0:6], macSrc)
@@ -91,6 +95,10 @@ func (v Value) DstMAC() net.HardwareAddr {
 
 func (v Value) String() string {
 	return fmt.Sprintf("src: %s dst %s", v.SrcMAC(), v.DstMAC())
+}
+
+func (v Value) AsBytes() []byte {
+	return v[:]
 }
 
 type MapMem map[Key]Value

--- a/felix/bpf/conntrack/v3/map.go
+++ b/felix/bpf/conntrack/v3/map.go
@@ -191,6 +191,8 @@ const (
 	FlagSrcDstBA  uint16 = (1 << 8)
 	FlagHostPSNAT uint16 = (1 << 9)
 	FlagSvcSelf   uint16 = (1 << 10)
+	FlagNPLoop    uint16 = (1 << 11)
+	FlagNPRemote  uint16 = (1 << 12)
 )
 
 func (e Value) ReverseNATKey() Key {
@@ -454,6 +456,14 @@ func (e Value) String() string {
 
 		if flags&FlagSvcSelf != 0 {
 			flagsStr += " svc-self"
+		}
+
+		if flags&FlagNPLoop != 0 {
+			flagsStr += " np-loop"
+		}
+
+		if flags&FlagNPRemote != 0 {
+			flagsStr += " np-remote"
 		}
 	}
 

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -307,6 +307,7 @@ func TcSetGlobals(
 	hostTunnelIP uint32,
 	flags uint32,
 	wgPort uint16,
+	natin, natout uint32,
 ) error {
 	_, err := C.bpf_tc_set_globals(m.bpfMap,
 		C.uint(hostIP),
@@ -319,6 +320,8 @@ func TcSetGlobals(
 		C.uint(hostTunnelIP),
 		C.uint(flags),
 		C.ushort(wgPort),
+		C.uint(natin),
+		C.uint(natout),
 	)
 
 	return err

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -116,7 +116,9 @@ void bpf_tc_set_globals(struct bpf_map *map,
 			ushort psnat_len,
 			uint host_tunnel_ip,
 			uint flags,
-			ushort wg_port)
+			ushort wg_port,
+			uint natin,
+			uint natout)
 {
 	struct cali_tc_globals data = {
 		.host_ip = host_ip,
@@ -129,6 +131,8 @@ void bpf_tc_set_globals(struct bpf_map *map,
 		.host_tunnel_ip = host_tunnel_ip,
 		.flags = flags,
 		.wg_port = wg_port,
+		.natin_idx = natin,
+		.natout_idx = natout,
 	};
 
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -103,7 +103,7 @@ const (
 	GlobalsRPFStrictEnabled uint32 = 16
 )
 
-func TcSetGlobals(_ *Map, _, _, _ uint32, _, _, _, _ uint16, _, _ uint32, _ uint16) error {
+func TcSetGlobals(_ *Map, _, _, _ uint32, _, _, _, _ uint16, _, _ uint32, _ uint16, _, _ uint32) error {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -104,12 +104,13 @@ var (
 	_                      = stateOffPreNATDstPort
 	stateOffPostNATDstPort = FieldOffset{Offset: stateEventHdrSize + 94, Field: "state->post_nat_dport"}
 	stateOffIPProto        = FieldOffset{Offset: stateEventHdrSize + 96, Field: "state->ip_proto"}
-	stateOffFlags          = FieldOffset{Offset: stateEventHdrSize + 97, Field: "state->flags"}
 	stateOffIPSize         = FieldOffset{Offset: stateEventHdrSize + 98, Field: "state->ip_size"}
 	_                      = stateOffIPSize
 
 	stateOffRulesHit = FieldOffset{Offset: stateEventHdrSize + 100, Field: "state->rules_hit"}
 	stateOffRuleIDs  = FieldOffset{Offset: stateEventHdrSize + 104, Field: "state->rule_ids"}
+
+	stateOffFlags = FieldOffset{Offset: stateEventHdrSize + 408, Field: "state->flags"}
 
 	// Compile-time check that IPSetEntrySize hasn't changed; if it changes, the code will need to change.
 	_ = [1]struct{}{{}}[20-ipsets.IPSetEntrySize]
@@ -125,8 +126,8 @@ var (
 	ipsKeyPad    int16 = 19
 
 	// Bits in the state flags field.
-	FlagDestIsHost uint8 = 1 << 2
-	FlagSrcIsHost  uint8 = 1 << 3
+	FlagDestIsHost uint64 = 1 << 2
+	FlagSrcIsHost  uint64 = 1 << 3
 )
 
 type Rule struct {
@@ -291,10 +292,10 @@ func (p *Builder) writeProgramHeader() {
 
 func (p *Builder) writeJumpIfToOrFromHost(label string) {
 	// Load state flags.
-	p.b.Load8(R1, R9, stateOffFlags)
+	p.b.Load64(R1, R9, stateOffFlags)
 
 	// Mask against host bits.
-	p.b.AndImm32(R1, int32(FlagDestIsHost|FlagSrcIsHost))
+	p.b.AndImm64(R1, int32(FlagDestIsHost|FlagSrcIsHost))
 
 	// If non-zero, jump to specified label.
 	p.b.JumpNEImm64(R1, 0, label)

--- a/felix/bpf/state/map.go
+++ b/felix/bpf/state/map.go
@@ -60,13 +60,14 @@ const (
 //    __u16 pre_nat_dport;
 //    __u16 post_nat_dport;
 //    __u8 ip_proto;
-//    __u8 flags;
+//    __u8 __pad;
 //    __be16 ip_size;
 //    __u32 rules_hit;
 //    __u64 rule_ids[MAX_RULE_IDS];
 //    struct calico_ct_result ct_result;
 //    struct calico_nat_dest nat_dest;
 //    __u64 prog_start_time;
+//    __u64 flags;
 // };
 type State struct {
 	SrcAddr             uint32
@@ -96,7 +97,7 @@ type State struct {
 	PreNATDstPort       uint16
 	PostNATDstPort      uint16
 	IPProto             uint8
-	Flags               uint8
+	pad                 uint8
 	IPSize              uint16
 	RulesHit            uint32
 	RuleIDs             [MaxRuleIDs]uint64
@@ -109,9 +110,10 @@ type State struct {
 	_                   uint32
 	NATData             uint64
 	ProgStartTime       uint64
+	Flags               uint64
 }
 
-const expectedSize = 408
+const expectedSize = 416
 
 func (s *State) AsBytes() []byte {
 	size := unsafe.Sizeof(State{})

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -62,6 +62,8 @@ type AttachPoint struct {
 	IPv6Enabled          bool
 	MapSizes             map[string]uint32
 	RPFStrictEnabled     bool
+	NATin                uint32
+	NATout               uint32
 }
 
 var tcLock sync.RWMutex
@@ -177,7 +179,7 @@ func (ap AttachPoint) AttachProgram() (int, error) {
 	}
 
 	isHost := false
-	if ap.Type == "host" || ap.Type == "nat" {
+	if ap.Type == "host" || ap.Type == "nat" || ap.Type == "lo" {
 		isHost = true
 	}
 
@@ -631,7 +633,8 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 
 	return libbpf.TcSetGlobals(m, hostIP, intfIP,
 		ap.ExtToServiceConnmark, ap.TunnelMTU, vxlanPort, ap.PSNATStart, ap.PSNATEnd, hostTunnelIP,
-		flags, ap.WgPort)
+		flags, ap.WgPort, ap.NATin, ap.NATout,
+	)
 }
 
 func (ap *AttachPoint) setMapSize(m *libbpf.Map) error {

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	conntrack3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
+	v3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/routes"
@@ -1519,6 +1520,9 @@ func TestNormalSYNRetryForcePolicy(t *testing.T) {
 func TestNATSYNRetryGoesToSameBackend(t *testing.T) {
 	RegisterTestingT(t)
 
+	cleanUpMaps()
+	defer cleanUpMaps()
+
 	mc := &bpf.MapContext{}
 	natMap := nat.FrontendMap(mc)
 	err := natMap.EnsureExists()
@@ -2205,4 +2209,152 @@ func TestNATSourceCollision(t *testing.T) {
 
 		return nil
 	}, "120s").Should(Succeed())
+}
+
+func TestNATHostRemoteNPLocalPod(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer resetCTMap(ctMap)
+
+	bpfIfaceName = "NPrm"
+	defer func() { bpfIfaceName = "" }()
+
+	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefaultNP(node2ip)
+	Expect(err).NotTo(HaveOccurred())
+	udp := l4.(*layers.UDP)
+	mc := &bpf.MapContext{}
+	natMap := nat.FrontendMap(mc)
+	err = natMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
+	natBEMap := nat.BackendMap(mc)
+	err = natBEMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
+	// local workload
+	err = natMap.Update(
+		nat.NewNATKey(net.IPv4(255, 255, 255, 255), uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
+		nat.NewNATValue(0 /* count */, 1 /* local */, 1, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	natIP := net.IPv4(8, 8, 8, 8)
+	natPort := uint16(666)
+
+	err = natBEMap.Update(
+		nat.NewNATBackendKey(0, 0).AsBytes(),
+		nat.NewNATBackendValue(natIP, natPort).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	wCIDR := net.IPNet{
+		IP:   natIP,
+		Mask: net.IPv4Mask(255, 255, 255, 0),
+	}
+
+	ctMap := conntrack.Map(mc)
+	err = ctMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+	resetCTMap(ctMap) // ensure it is clean
+
+	var recvPkt []byte
+
+	hostIP = node1ip
+	skbMark = 0
+
+	// Setup routing
+	rtMap := routes.Map(mc)
+	err = rtMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
+	// backend it is a local workload
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&wCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalWorkload).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	// destination is remote host
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	dumpRTMap(rtMap)
+
+	// Arriving at the egress HEP
+	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(pktBytes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_REDIRECT))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(ipv4.SrcIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(natIP.String()))
+
+		udpL := pktR.Layer(layers.LayerTypeUDP)
+		Expect(udpL).NotTo(BeNil())
+		udpR := udpL.(*layers.UDP)
+		Expect(udpR.SrcPort).To(Equal(layers.UDPPort(udp.SrcPort)))
+		Expect(udpR.DstPort).To(Equal(layers.UDPPort(natPort)))
+
+		recvPkt = res.dataOut
+	}, withHostNetworked())
+
+	dumpCTMap(ctMap)
+
+	hostIP = net.IPv4(0, 0, 0, 0) // workloads do not have it set
+
+	expectMark(tcdefs.MarkSeen)
+
+	ct, err := conntrack.LoadMapMem(ctMap)
+	Expect(err).NotTo(HaveOccurred())
+	v, ok := ct[conntrack.NewKey(uint8(ipv4.Protocol), ipv4.SrcIP, uint16(udp.SrcPort), natIP.To4(), natPort)]
+	Expect(ok).To(BeTrue())
+	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
+	Expect(v.Flags()).To(Equal(v3.FlagNPLoop))
+
+	// Arriving at workload
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(recvPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		Expect(res.dataOut).To(Equal(recvPkt))
+	})
+
+	skbMark = 0
+	var respPkt []byte
+
+	// Response leaving workload
+	runBpfTest(t, "calico_from_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		respPkt = udpResponseRaw(recvPkt)
+		res, err := bpfrun(respPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(ipv4.DstIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(ipv4.SrcIP.String()))
+
+		udpL := pktR.Layer(layers.LayerTypeUDP)
+		Expect(udpL).NotTo(BeNil())
+		udpR := udpL.(*layers.UDP)
+		Expect(udpR.SrcPort).To(Equal(layers.UDPPort(udp.DstPort)))
+		Expect(udpR.DstPort).To(Equal(layers.UDPPort(udp.SrcPort)))
+	})
+
+	// Packet supposed to be delivered to the local host.
+
+	dumpCTMap(ctMap)
 }

--- a/felix/bpf/ut/pol_prog_test.go
+++ b/felix/bpf/ut/pol_prog_test.go
@@ -2296,7 +2296,7 @@ func (p packet) StateIn() state.State {
 		preNATDstAddr = p.preNATDstAddr
 		preNATDstPort = p.preNATDstPort
 	}
-	flags := uint8(0)
+	flags := uint64(0)
 	if p.fromHostFlag {
 		flags |= polprog.FlagSrcIsHost
 	}

--- a/felix/bpf/ut/snat_test.go
+++ b/felix/bpf/ut/snat_test.go
@@ -129,7 +129,7 @@ func TestSNATHostServiceRemotePod(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	// Out via host iface. We should use a L3 tunnel, but that is not supported
+	// Out via host iface. We should use an L3 tunnel, but that is not supported
 	// by the test infra. Host interface does pretty much the same for what we
 	// need. It creates extra CT entries of type 0.
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
@@ -229,7 +229,7 @@ func TestSNATHostServiceRemotePod(t *testing.T) {
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(hostConflictPkt)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		Expect(res.Retval).To(Or(Equal(resTC_ACT_UNSPEC), Equal(resTC_ACT_REDIRECT)))
 
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)
@@ -251,7 +251,7 @@ func TestSNATHostServiceRemotePod(t *testing.T) {
 	runBpfTest(t, "calico_to_host_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(hostConflictPkt)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+		Expect(res.Retval).To(Or(Equal(resTC_ACT_UNSPEC), Equal(resTC_ACT_REDIRECT)))
 
 		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)

--- a/felix/cmd/calico-bpf/commands/policy_debug.go
+++ b/felix/cmd/calico-bpf/commands/policy_debug.go
@@ -44,7 +44,8 @@ func init() {
 }
 
 var policyDumpCmd = &cobra.Command{
-	Use:   "dump <interface> <hook>",
+	Use: "dump <interface> <hook>\n" +
+		"\n\thook - can be 'ingress', 'egress' or 'all'.",
 	Short: "dumps policy",
 	Run: func(cmd *cobra.Command, args []string) {
 		iface, hook, err := parseArgs(args)

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -52,6 +52,7 @@ import (
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/felix/bpf"
+	bpfarp "github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/asm"
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/counters"
@@ -238,6 +239,11 @@ type bpfEndpointManager struct {
 	// Maps for policy rule counters
 	polNameToMatchIDs map[string]set.Set[polprog.RuleMatchID]
 	dirtyRules        set.Set[polprog.RuleMatchID]
+
+	natInIdx  int
+	natOutIdx int
+
+	arpMap bpf.Map
 }
 
 type serviceKey struct {
@@ -312,6 +318,7 @@ func newBPFEndpointManager(
 		bpfPolicyDebugEnabled: config.BPFPolicyDebugEnabled,
 		polNameToMatchIDs:     map[string]set.Set[polprog.RuleMatchID]{},
 		dirtyRules:            set.New[polprog.RuleMatchID](),
+		arpMap:                bpfMapContext.ArpMap,
 	}
 
 	// Calculate allowed XDP attachment modes.  Note, in BPF mode untracked ingress policy is
@@ -892,6 +899,9 @@ func (m *bpfEndpointManager) updateWEPsInDataplane() {
 			defer wg.Done()
 			defer sem.Release(1)
 			err := m.applyPolicy(ifaceName)
+			if err == nil {
+				err = m.dp.setAcceptLocal(ifaceName, true)
+			}
 			mutex.Lock()
 			errs[ifaceName] = err
 			mutex.Unlock()
@@ -1157,6 +1167,8 @@ func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, ep *proto.
 	} else {
 		ap.IntfIP = *ip
 	}
+	ap.NATin = uint32(m.natInIdx)
+	ap.NATout = uint32(m.natOutIdx)
 
 	jumpMapFD, err := m.dp.ensureProgramAttached(&ap)
 	if err != nil {
@@ -1234,6 +1246,10 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection
 	// Determine endpoint type.
 	if m.isWorkloadIface(ifaceName) {
 		endpointType = tc.EpTypeWorkload
+	} else if ifaceName == "lo" {
+		endpointType = tc.EpTypeLO
+		ap.HostTunnelIP = m.tunnelIP
+		log.Debugf("Setting tunnel ip %s on ap %s", m.tunnelIP, ifaceName)
 	} else if ifaceName == "tunl0" {
 		if m.Features.IPIPDeviceIsL3 {
 			endpointType = tc.EpTypeL3Device
@@ -1248,6 +1264,8 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection
 		log.Debugf("Setting tunnel ip %s on ap %s", m.tunnelIP, ifaceName)
 	} else if m.isDataIface(ifaceName) {
 		endpointType = tc.EpTypeHost
+		ap.HostTunnelIP = m.tunnelIP
+		log.Debugf("Setting tunnel ip %s on ap %s", m.tunnelIP, ifaceName)
 	} else {
 		log.Panicf("Unsupported ifaceName %v", ifaceName)
 	}
@@ -1398,7 +1416,8 @@ func (m *bpfEndpointManager) isWorkloadIface(iface string) bool {
 }
 
 func (m *bpfEndpointManager) isDataIface(iface string) bool {
-	return m.dataIfaceRegex.MatchString(iface) || iface == bpfOutDev
+	return m.dataIfaceRegex.MatchString(iface) ||
+		(m.ctlbWorkaroundEnabled && (iface == bpfOutDev || iface == "lo"))
 }
 
 func (m *bpfEndpointManager) isL3Iface(iface string) bool {
@@ -1658,24 +1677,32 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 		if err != nil {
 			return fmt.Errorf("missing %s after add: %w", bpfInDev, err)
 		}
+	}
+	if state := bpfin.Attrs().OperState; state != netlink.OperUp {
+		log.WithField("state", state).Info(bpfInDev)
 		if err := netlink.LinkSetUp(bpfin); err != nil {
 			return fmt.Errorf("failed to set %s up: %w", bpfInDev, err)
 		}
-		bpfout, err = netlink.LinkByName(bpfOutDev)
-		if err != nil {
-			return fmt.Errorf("missing %s after add: %w", bpfOutDev, err)
-		}
+	}
+	bpfout, err = netlink.LinkByName(bpfOutDev)
+	if err != nil {
+		return fmt.Errorf("missing %s after add: %w", bpfOutDev, err)
+	}
+	if state := bpfout.Attrs().OperState; state != netlink.OperUp {
+		log.WithField("state", state).Info(bpfOutDev)
 		if err := netlink.LinkSetUp(bpfout); err != nil {
 			return fmt.Errorf("failed to set %s up: %w", bpfOutDev, err)
 		}
 	}
 
-	if bpfout == nil {
-		bpfout, err = netlink.LinkByName(bpfOutDev)
-		if err != nil {
-			return fmt.Errorf("miss %s after add: %w", bpfOutDev, err)
-		}
-	}
+	m.natInIdx = bpfin.Attrs().Index
+	m.natOutIdx = bpfout.Attrs().Index
+
+	anyV4, _ := ip.CIDRFromString("0.0.0.0/0")
+	_ = m.arpMap.Update(
+		bpfarp.NewKey(anyV4.Addr().AsNetIP(), uint32(m.natInIdx)).AsBytes(),
+		bpfarp.NewValue(bpfin.Attrs().HardwareAddr, bpfout.Attrs().HardwareAddr).AsBytes(),
+	)
 
 	// Add a permanent ARP entry to point to the other side of the veth to avoid
 	// ARP requests that would not be proxied if .all.rp_filter == 1
@@ -1699,6 +1726,11 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 	err = m.ensureQdisc(bpfInDev)
 	if err != nil {
 		return fmt.Errorf("failed to set qdisc on %s: %w", bpfOutDev, err)
+	}
+
+	err = m.ensureQdisc("lo")
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to set qdisc on lo.")
 	}
 
 	// Setup a link local route to a non-existent link local address that would
@@ -2044,14 +2076,13 @@ func (m *bpfEndpointManager) onServiceUpdate(update *proto.ServiceUpdate) {
 		"Namespace": update.Namespace,
 	}).Info("Service Update")
 
-	ips := make([]string, 0, 2+len(update.ExternalIps))
+	ips := make([]string, 0, 2)
 	if update.ClusterIp != "" {
 		ips = append(ips, update.ClusterIp)
 	}
 	if update.LoadbalancerIp != "" {
 		ips = append(ips, update.LoadbalancerIp)
 	}
-	ips = append(ips, update.ExternalIps...)
 
 	key := serviceKey{name: update.Name, namespace: update.Namespace}
 

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -667,11 +667,9 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			})
 			err = bpfEpMgr.CompleteDeferredWork()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(dp.routes).To(HaveLen(4))
+			Expect(dp.routes).To(HaveLen(2))
 			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.2.3.4")))
 			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("5.6.7.8")))
-			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.0.0.1")))
-			Expect(dp.routes).To(HaveKey(ip.MustParseCIDROrIP("1.0.0.2")))
 
 			bpfEpMgr.OnUpdate(&proto.ServiceUpdate{
 				Name:      "service",

--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -87,6 +87,7 @@ type bpfRouteManager struct {
 
 func newBPFRouteManager(config *Config, mc *bpf.MapContext,
 	opReporter logutils.OpRecorder) *bpfRouteManager {
+
 	// Record the external node CIDRs and pre-mark them as dirty.  These can only change with a config update,
 	// which would restart Felix.
 	extCIDRs := set.New[ip.V4CIDR]()

--- a/felix/fv/bpf_attach_test.go
+++ b/felix/fv/bpf_attach_test.go
@@ -73,7 +73,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		// This should not happen at initial execution of felix, since there is no program attached
 		firstRunBase := felix.WatchStdoutFor(regexp.MustCompile("Program already attached, skip reattaching"))
 		// These should happen at first execution of felix, since there is no program attached
-		firstRunProg1 := felix.WatchStdoutFor(regexp.MustCompile(`Continue with attaching BPF program to_hep_debug(|_co-re)\.o`))
+		firstRunProg1 := felix.WatchStdoutFor(regexp.MustCompile(`Continue with attaching BPF program to_hep_fib_debug(|_co-re)\.o`))
 		firstRunProg2 := felix.WatchStdoutFor(regexp.MustCompile(`Continue with attaching BPF program from_hep_fib_debug(|_co-re)\.o`))
 		By("Starting Felix")
 		felix.TriggerDelayedStart()
@@ -84,7 +84,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		// This should not happen at initial execution of felix, since there is no program attached
 		secondRunBase := felix.WatchStdoutFor(regexp.MustCompile(`Continue with attaching BPF program (to|from)_hep`))
 		// These should happen after restart of felix, since BPF programs are already attached
-		secondRunProg1 := felix.WatchStdoutFor(regexp.MustCompile(`Program already attached to TC, skip reattaching to_hep_debug(|_co-re)\.o`))
+		secondRunProg1 := felix.WatchStdoutFor(regexp.MustCompile(`Program already attached to TC, skip reattaching to_hep_fib_debug(|_co-re)\.o`))
 		secondRunProg2 := felix.WatchStdoutFor(regexp.MustCompile(`Program already attached to TC, skip reattaching from_hep_fib_debug(|_co-re)\.o`))
 		By("Restarting Felix")
 		felix.Restart()

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3933,3 +3933,20 @@ func bpfCheckIfPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polNam
 
 	return (startOfPolicy && endOfPolicy && actionMatch)
 }
+
+func bpfDumpPolicy(felix *infrastructure.Felix, iface, hook, policy string) string {
+	out, err := felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook)
+	Expect(err).NotTo(HaveOccurred())
+	return out
+}
+
+func bpfWaitForPolicy(felix *infrastructure.Felix, iface, hook, policy string) string {
+	search := fmt.Sprintf("Start of policy %s", policy)
+	out := ""
+	Eventually(func() string {
+		out = bpfDumpPolicy(felix, iface, hook, policy)
+		return out
+	}, "5s", "200ms").Should(ContainSubstring(search))
+
+	return out
+}

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -557,7 +557,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						numHostIfaces := 1
 						specialIfaces := 0
 						if ctlbWorkaround {
-							specialIfaces = 1
+							specialIfaces = 2 /* nat + lo */
 						}
 						expectedNumMaps := 2*numWorkloads + 2*numHostIfaces + 2*specialIfaces
 						return expectedNumMaps
@@ -776,9 +776,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			err := infra.AddDefaultDeny()
 			Expect(err).NotTo(HaveOccurred())
 			if !options.TestManagesBPF {
-				for _, felix := range felixes {
-					ensureBPFProgramsAttached(felix)
-				}
+				ensureAllNodesBPFProgramsAttached(felixes)
 			}
 		}
 
@@ -2373,11 +2371,14 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					)
 
 					testSvcName := "test-service"
+					testSvcExtIP0 := "10.123.0.0"
+					testSvcExtIP1 := "10.123.0.1"
 
 					BeforeEach(func() {
 						k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient
 						testSvc = k8sService(testSvcName, "10.101.0.10",
 							w[0][0], 80, 8055, int32(npPort), testOpts.protocol)
+						testSvc.Spec.ExternalIPs = []string{testSvcExtIP0, testSvcExtIP1}
 						if extLocal {
 							testSvc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 						}
@@ -2426,7 +2427,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								By("checking correct NAT entries for remote nodeports")
 
 								ipOK := []string{"255.255.255.255", "10.101.0.1", /* API server */
-									testSvc.Spec.ClusterIP,
+									testSvc.Spec.ClusterIP, testSvcExtIP0, testSvcExtIP1,
 									felixes[0].IP, felixes[1].IP, felixes[2].IP}
 
 								if testOpts.tunnel == "ipip" {
@@ -2494,6 +2495,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 											Selector: "ep-type=='host'",
 										},
 									},
+									{
+										Action: "Allow",
+										Source: api.EntityRule{
+											Nets: []string{testSvcExtIP0 + "/32", testSvcExtIP1 + "/32"},
+										},
+									},
 								}
 								w00Slector := fmt.Sprintf("name=='%s'", w[0][0].Name)
 								pol.Spec.Selector = w00Slector
@@ -2501,36 +2508,103 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								pol = createPolicy(pol)
 							})
 
-							if testOpts.connTimeEnabled {
-								It("should have connectivity from all host-networked workloads to workload 0", func() {
-									node0IP := felixes[0].IP
-									node1IP := felixes[1].IP
+							It("should have connectivity from all host-networked workloads to workload 0 via nodeport", func() {
+								node0IP := felixes[0].IP
+								node1IP := felixes[1].IP
 
-									hostW0SrcIP := ExpectWithSrcIPs(node0IP)
-									hostW1SrcIP := ExpectWithSrcIPs(node1IP)
+								hostW0SrcIP := ExpectWithSrcIPs(node0IP)
+								hostW1SrcIP := ExpectWithSrcIPs(node1IP)
 
-									switch testOpts.tunnel {
-									case "ipip":
+								switch testOpts.tunnel {
+								case "ipip":
+									if testOpts.connTimeEnabled {
 										hostW0SrcIP = ExpectWithSrcIPs(felixes[0].ExpectedIPIPTunnelAddr)
-										hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedIPIPTunnelAddr)
-									case "wireguard":
-										hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedWireguardTunnelAddr)
-									case "vxlan":
-										hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedVXLANTunnelAddr)
 									}
+									hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedIPIPTunnelAddr)
+								case "wireguard":
+									hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedWireguardTunnelAddr)
+								case "vxlan":
+									hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedVXLANTunnelAddr)
+								}
 
-									ports := ExpectWithPorts(npPort)
+								ports := ExpectWithPorts(npPort)
 
-									// Also try host networked pods, both on a local and remote node.
-									// N.B. it cannot work without the connect time balancer
-									// cc.Expect(Some, hostW[0], TargetIP(node0IP), ports, hostW0SrcIP)
-									// cc.Expect(Some, hostW[1], TargetIP(node0IP), ports, hostW1SrcIP)
-									cc.Expect(Some, hostW[0], TargetIP(node1IP), ports, hostW0SrcIP)
-									cc.Expect(Some, hostW[1], TargetIP(node1IP), ports, hostW1SrcIP)
+								cc.Expect(Some, hostW[0], TargetIP(node0IP), ports, hostW0SrcIP)
+								cc.Expect(Some, hostW[0], TargetIP(node1IP), ports, hostW0SrcIP)
+								cc.Expect(Some, hostW[1], TargetIP(node0IP), ports, hostW1SrcIP)
+								cc.Expect(Some, hostW[1], TargetIP(node1IP), ports, hostW1SrcIP)
 
-									cc.CheckConnectivity()
+								cc.CheckConnectivity()
+							})
+
+							It("should have connectivity from all host-networked workloads to workload 0 via ExternalIP", func() {
+								if testOpts.connTimeEnabled {
+									// not valid for CTLB as it is just and approx.
+									return
+								}
+								// This test is primarily to make sure that the external
+								// IPs do not interfere with the workaround and vise
+								// versa.
+								By("Setting ExternalIPs")
+								felixes[0].Exec("ip", "addr", "add", testSvcExtIP0+"/32", "dev", "eth0")
+								felixes[1].Exec("ip", "addr", "add", testSvcExtIP1+"/32", "dev", "eth0")
+
+								// The external IPs must be routable
+								By("Setting routes for the ExternalIPs")
+								felixes[0].Exec("ip", "route", "add", testSvcExtIP1+"/32", "via", felixes[1].IP)
+								felixes[1].Exec("ip", "route", "add", testSvcExtIP0+"/32", "via", felixes[0].IP)
+								externalClient.Exec("ip", "route", "add", testSvcExtIP1+"/32", "via", felixes[1].IP)
+								externalClient.Exec("ip", "route", "add", testSvcExtIP0+"/32", "via", felixes[0].IP)
+
+								By("Allow ingress from external client", func() {
+									pol = api.NewGlobalNetworkPolicy()
+									pol.Namespace = "fv"
+									pol.Name = "policy-ext-client"
+									pol.Spec.Ingress = []api.Rule{
+										{
+											Action: "Allow",
+											Source: api.EntityRule{
+												Nets: []string{externalClient.IP + "/32"},
+											},
+										},
+									}
+									w00Slector := fmt.Sprintf("name=='%s'", w[0][0].Name)
+									pol.Spec.Selector = w00Slector
+
+									pol = createPolicy(pol)
 								})
-							}
+
+								node0IP := felixes[0].IP
+								node1IP := felixes[1].IP
+
+								hostW0SrcIP := ExpectWithSrcIPs(node0IP)
+								hostW1SrcIP := ExpectWithSrcIPs(node1IP)
+								hostW11SrcIP := ExpectWithSrcIPs(testSvcExtIP1)
+
+								switch testOpts.tunnel {
+								case "ipip":
+									hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedIPIPTunnelAddr)
+									hostW11SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedIPIPTunnelAddr)
+								case "wireguard":
+									hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedWireguardTunnelAddr)
+									hostW11SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedWireguardTunnelAddr)
+								case "vxlan":
+									hostW1SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedVXLANTunnelAddr)
+									hostW11SrcIP = ExpectWithSrcIPs(felixes[1].ExpectedVXLANTunnelAddr)
+								}
+
+								ports := ExpectWithPorts(80)
+
+								cc.Expect(Some, hostW[0], TargetIP(testSvcExtIP0), ports, ExpectWithSrcIPs(testSvcExtIP0))
+								cc.Expect(Some, hostW[1], TargetIP(testSvcExtIP0), ports, hostW1SrcIP)
+								cc.Expect(Some, hostW[0], TargetIP(testSvcExtIP1), ports, hostW0SrcIP)
+								cc.Expect(Some, hostW[1], TargetIP(testSvcExtIP1), ports, hostW11SrcIP)
+
+								cc.Expect(Some, externalClient, TargetIP(testSvcExtIP0), ports)
+								cc.Expect(Some, externalClient, TargetIP(testSvcExtIP1), ports)
+
+								cc.CheckConnectivity()
+							})
 
 							_ = testIfNotUDPUConnected && // two app with two sockets cannot conflict
 								Context("with conflict from host-networked workloads via clusterIP and directly", func() {
@@ -2651,7 +2725,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								ports := ExpectWithPorts(uint16(testSvc.Spec.Ports[0].Port))
 
 								// Also try host networked pods, both on a local and remote node.
-								// N.B. it cannot work without the connect time balancer
 								cc.Expect(Some, hostW[0], TargetIP(clusterIP), ports, hostW0SrcIP)
 								cc.Expect(Some, hostW[1], TargetIP(clusterIP), ports, hostW1SrcIP)
 
@@ -3281,51 +3354,16 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				fc, err = calicoClient.FelixConfigurations().Create(context.Background(), fc, options2.SetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				counts := make([]int, len(felixes))
-				ifaceCnt := 4 // eth0, bpfout.cali, 2xcali*
-				if testOpts.tunnel != "none" {
-					ifaceCnt++ // the tunnel device
-				}
 				// Wait for BPF to be active.
-				readyIfaces := func() (total int) {
-					var wg sync.WaitGroup
-					for i := range felixes {
-						if counts[i] != ifaceCnt {
-							wg.Add(1)
-							go func(i int) {
-								defer wg.Done()
-								c := 0
-								for _, s := range felixes[i].BPFIfState() {
-									if s.Ready {
-										c++
-									}
-								}
-								counts[i] = c
-							}(i)
-						}
-					}
-
-					wg.Wait()
-
-					for _, c := range counts {
-						total += c
-					}
-
-					return
-				}
-
-				// We need to make sure that host as well as workload ifaces are
-				// ready, that is their tc programs are loaded. The test matrix
-				// checks all of these options and we do not want to get false
-				// positives.
-				Eventually(readyIfaces, "15s", "300ms").Should(Equal(len(felixes) * ifaceCnt))
+				ensureAllNodesBPFProgramsAttached(felixes)
 			}
 
 			expectPongs := func() {
-				EventuallyWithOffset(1, pc.SinceLastPong, "5s").Should(
-					BeNumerically("<", time.Second),
+				count := pc.PongCount()
+				EventuallyWithOffset(1, pc.PongCount, "5s").Should(
+					BeNumerically(">", count),
 					"Expected to see pong responses on the connection but didn't receive any")
-				log.Info("Pongs received within last 1s")
+				log.Info("Pongs received")
 			}
 
 			if testOpts.protocol == "tcp" && testOpts.dsr {
@@ -3337,7 +3375,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 					By("having initial connectivity", expectPongs)
 					By("enabling BPF mode", enableBPF) // Waits for BPF programs to be installed
-					time.Sleep(2 * time.Second)        // pongs time out after 1s, make sure we look for fresh pongs.
 					By("still having connectivity on the existing connection", expectPongs)
 				}
 
@@ -3469,7 +3506,7 @@ func dumpBPFMap(felix *infrastructure.Felix, m bpf.Map, iter bpf.IterCallback) {
 	// might fail a test that was retrying this dump anyway.
 	Eventually(func() bool {
 		return felix.FileExists(m.Path())
-	}).Should(BeTrue(), fmt.Sprintf("dumpBPFMap: map %s didn't show up inside container", m.Path()))
+	}, "10s", "300ms").Should(BeTrue(), fmt.Sprintf("dumpBPFMap: map %s didn't show up inside container", m.Path()))
 	cmd, err := bpf.DumpMapCmd(m)
 	Expect(err).NotTo(HaveOccurred(), "Failed to get BPF map dump command: "+m.Path())
 	log.WithField("cmd", cmd).Debug("dumpBPFMap")

--- a/felix/fv/ipip_test.go
+++ b/felix/fv/ipip_test.go
@@ -110,6 +110,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 				felix.Exec("ipset", "list")
 				felix.Exec("ip", "r")
 				felix.Exec("ip", "a")
+				if BPFMode() {
+					felix.Exec("calico-bpf", "policy", "dump", "eth0", "all")
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description   
    Packets from the host are intercepted at the first device they hit. If
    it is towards the same host, it is the loopback device, otherwise it is
    the main device on the cluster network. At that point we do the DNAT -
    select the backed pod for the nodeport. We assume that there is a
    default route so it hits a device. Otherwise we cannot do much.
    
    We either use FIB to redirect the packet to an outgoing device (if on lo
    or if it should go to a different one than the default) or we redirect
    the packet to the bpfin.cali iface to turn the packet around into the
    host address namespace that can route the packet. If an overlay is used,
    we SNAT the packet so that it has the tunnel's source and we redirect it
    to the tunnel.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

refs https://github.com/projectcalico/calico/issues/4509

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
