### PR TITLE
[release-v3.24] Automated cherry pick of #6528: windows: replace eol'd 20H2 with 1809 for FV tests

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -310,7 +310,7 @@ blocks:
     - name: K8S_VERSION
       value: 1.22.1
     - name: WINDOWS_VERSION
-      value: "20H2"
+      value: "1809"
     jobs:
     - name: VXLAN - Windows FV
       commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -310,7 +310,7 @@ blocks:
     - name: K8S_VERSION
       value: 1.22.1
     - name: WINDOWS_VERSION
-      value: "20H2"
+      value: "1809"
     jobs:
     - name: VXLAN - Windows FV
       commands:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -308,7 +308,7 @@ blocks:
     - name: K8S_VERSION
       value: 1.22.1
     - name: WINDOWS_VERSION
-      value: "20H2"
+      value: "1809"
     jobs:
     - name: VXLAN - Windows FV
       commands:


### PR DESCRIPTION
Cherry pick of #6528 on release-v3.24.

#6528: windows: replace eol'd 20H2 with 1809 for FV tests