### PR TITLE
[release-v3.23] Auto pick #6512: Limit rate of logging 'Wireguard is not supported' to fix log #6518: Fix construction of rateLimitedLogger in wireguard

### DIFF
--- a/felix/wireguard/wireguard.go
+++ b/felix/wireguard/wireguard.go
@@ -36,6 +36,7 @@ import (
 	"github.com/projectcalico/calico/felix/routerule"
 	"github.com/projectcalico/calico/felix/routetable"
 	"github.com/projectcalico/calico/felix/timeshim"
+	lclogutils "github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 const (
@@ -162,7 +163,8 @@ type Wireguard struct {
 	opRecorder     logutils.OpRecorder
 
 	// The write proc sys function.
-	writeProcSys func(path, value string) error
+	writeProcSys      func(path, value string) error
+	rateLimitedLogger *lclogutils.RateLimitedLogger
 }
 
 func New(
@@ -254,6 +256,7 @@ func NewWithShims(
 		localCIDRs:           set.New(),
 		writeProcSys:         writeProcSys,
 		opRecorder:           opRecorder,
+		rateLimitedLogger:    lclogutils.NewRateLimitedLogger(lclogutils.OptInterval(4 * time.Hour)),
 	}
 }
 
@@ -634,7 +637,7 @@ func (w *Wireguard) Apply() (err error) {
 	}
 
 	if w.wireguardNotSupported {
-		log.Info("Wireguard is not supported")
+		w.rateLimitedLogger.Info("Wireguard is not supported")
 		return
 	}
 


### PR DESCRIPTION
Cherry pick of #6512 #6518 on release-v3.23.

#6512: Limit rate of logging 'Wireguard is not supported' to fix log
#6518: Fix construction of rateLimitedLogger in wireguard