### PR TITLE
[release-v3.21] Automated cherry pick of #6528: windows: replace eol'd 20H2 with 1809 for FV tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -242,7 +242,7 @@ blocks:
     - name: K8S_VERSION
       value: 1.22.1
     - name: WINDOWS_VERSION
-      value: "20H2"
+      value: "1809"
     jobs:
     - name: VXLAN - Windows FV
       commands:

--- a/cni-plugin/.semaphore/run-win-fv.sh
+++ b/cni-plugin/.semaphore/run-win-fv.sh
@@ -40,7 +40,8 @@ ${SCP_CMD} -r ubuntu@${MASTER_IP}:/home/ubuntu/report /home/semaphore
 
 ls -ltr ./report
 mkdir /home/semaphore/fv.log
-mv /home/semaphore/report/*.log /home/semaphore/fv.log
+# check if *.log glob contains any files so that mv doesn't fail
+compgen -G /home/semaphore/report/*.log > /dev/null && mv /home/semaphore/report/*.log /home/semaphore/fv.log
 
 # Stop for debug
 echo "Check for pause file..."

--- a/felix/.semaphore/publish-artifacts
+++ b/felix/.semaphore/publish-artifacts
@@ -17,6 +17,9 @@
 # No set -e so that we continue to collect artifacts even if some fail.
 set -x
 
+# set nullglob so that '*' is not used literally if the artifacts dir is empty
+shopt -s nullglob
+
 my_dir=$(dirname "$0")
 repo_dir=$my_dir/..
 

--- a/felix/.semaphore/run-win-fv
+++ b/felix/.semaphore/run-win-fv
@@ -50,7 +50,8 @@ ${SCP_CMD} -r ubuntu@${MASTER_IP}:/home/ubuntu/report /home/semaphore
 
 ls -ltr ./report
 mkdir /home/semaphore/fv.log
-mv /home/semaphore/report/*.log /home/semaphore/fv.log
+# check if *.log glob contains any files so that mv doesn't fail
+compgen -G /home/semaphore/report/*.log > /dev/null && mv /home/semaphore/report/*.log /home/semaphore/fv.log
 
 # Stop for debug
 echo "Check for pause file..."


### PR DESCRIPTION
Cherry pick of #6528 on release-v3.21.

#6528: windows: replace eol'd 20H2 with 1809 for FV tests