### PR TITLE
Fixing broken nested tab structure.

### DIFF
--- a/calico/reference/cni-plugin/configuration.md
+++ b/calico/reference/cni-plugin/configuration.md
@@ -4,18 +4,9 @@ description: Details for configuring the Calico CNI plugins.
 canonical_url: '/reference/cni-plugin/configuration'
 ---
 
-{% tabs %}
-  <label:Operator,active:true>
-<%
-
-The {{site.prodname}} CNI plugins do not need to be configured directly when installed by the operator. For a complete operator 
-configuration reference, see [the installation API reference documentation][installation].
-
-%>
-
-  <label:Manifest>
-<%
-
+>**Note**: The {{site.prodname}} CNI plugins do not need to be configured directly when installed by the operator.
+>For a complete operator configuration reference, see [the installation API reference documentation][installation].
+{: .alert .alert-info}
 
 The {{site.prodname}} CNI plugin is configured through the standard CNI
 [configuration mechanism](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration){:target="_blank"}
@@ -578,9 +569,5 @@ For example:
   "num_queues": 3,
 }
 ```
-
-%>
-
-{% endtabs %}
 
 [installation]: {{site.baseurl}}/reference/installation/api


### PR DESCRIPTION
This page has a nested tab structure that doesn't work. I've removed the page-wide tab and replaced that information with a note. Perhaps not the best way, but it allows the other information to display properly.

See what happens when you click the Operator tab at [Using host-local IPAM](https://projectcalico.docs.tigera.io/reference/cni-plugin/configuration#using-host-local-ipam)

Preview: https://deploy-preview-6576--calico-master.netlify.app/reference/cni-plugin/configuration

CC @alexeymagdich-tigera 