### PR TITLE
feat: add imagePullSecrets to tigera-operator ServiceAccount

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-serviceaccount-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-serviceaccount-tigera-operator.yaml
@@ -1,5 +1,12 @@
+{{ $secrets := list }}
+{{ range $name := keys .Values.imagePullSecrets -}}
+{{ $item := dict "name" $name }}
+{{ $secrets = append $secrets $item }}
+{{ end }}
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: {{.Release.Namespace}}
+imagePullSecrets: {{- $secrets | toYaml | nindent 2 }}

--- a/manifests/ocp/02-serviceaccount-tigera-operator.yaml
+++ b/manifests/ocp/02-serviceaccount-tigera-operator.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: tigera-operator
+imagePullSecrets:
+  []

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -17798,6 +17798,8 @@ kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: tigera-operator
+imagePullSecrets:
+  []
 ---
 # Source: tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
 # Permissions required when running the operator for a Calico cluster.


### PR DESCRIPTION
## Description

This will fix #6530 and add the add the defined imagePullSecrets to the tigera-operator ServiceAccount. The logic is essentially borrowed from templates/crs/custom-resources.yaml :)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Helm: imagePullSecrets now also applied to tigera-operator serviceaccount 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
