### PR TITLE
Fix misspelling of variant in several places

### DIFF
--- a/calico/reference/installation/_api.html
+++ b/calico/reference/installation/_api.html
@@ -198,7 +198,7 @@ ApplicationLayerStatus
 <h3 id="operator.tigera.io/v1.ImageSet">ImageSet
 </h3>
 <p>ImageSet is used to specify image digests for the images that the operator deploys.
-The name of the ImageSet is expected to be in the format <code>&lt;variang&gt;-&lt;release&gt;</code>.
+The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
 The <code>variant</code> used is <code>enterprise</code> if the InstallationSpec Variant is
 <code>TigeraSecureEnterprise</code> otherwise it is <code>calico</code>.
 The <code>release</code> must match the version of the variant that the operator is built to deploy,

--- a/charts/tigera-operator/crds/operator.tigera.io_imagesets_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_imagesets_crd.yaml
@@ -20,7 +20,7 @@ spec:
       openAPIV3Schema:
         description: ImageSet is used to specify image digests for the images that
           the operator deploys. The name of the ImageSet is expected to be in the
-          format `<variang>-<release>`. The `variant` used is `enterprise` if the
+          format `<variant>-<release>`. The `variant` used is `enterprise` if the
           InstallationSpec Variant is `TigeraSecureEnterprise` otherwise it is `calico`.
           The `release` must match the version of the variant that the operator is
           built to deploy, this version can be obtained by passing the `--version`

--- a/manifests/ocp/operator.tigera.io_imagesets_crd.yaml
+++ b/manifests/ocp/operator.tigera.io_imagesets_crd.yaml
@@ -20,7 +20,7 @@ spec:
       openAPIV3Schema:
         description: ImageSet is used to specify image digests for the images that
           the operator deploys. The name of the ImageSet is expected to be in the
-          format `<variang>-<release>`. The `variant` used is `enterprise` if the
+          format `<variant>-<release>`. The `variant` used is `enterprise` if the
           InstallationSpec Variant is `TigeraSecureEnterprise` otherwise it is `calico`.
           The `release` must match the version of the variant that the operator is
           built to deploy, this version can be obtained by passing the `--version`

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -70,7 +70,7 @@ spec:
       openAPIV3Schema:
         description: ImageSet is used to specify image digests for the images that
           the operator deploys. The name of the ImageSet is expected to be in the
-          format `<variang>-<release>`. The `variant` used is `enterprise` if the
+          format `<variant>-<release>`. The `variant` used is `enterprise` if the
           InstallationSpec Variant is `TigeraSecureEnterprise` otherwise it is `calico`.
           The `release` must match the version of the variant that the operator is
           built to deploy, this version can be obtained by passing the `--version`

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -5384,7 +5384,7 @@ spec:
       openAPIV3Schema:
         description: ImageSet is used to specify image digests for the images that
           the operator deploys. The name of the ImageSet is expected to be in the
-          format `<variang>-<release>`. The `variant` used is `enterprise` if the
+          format `<variant>-<release>`. The `variant` used is `enterprise` if the
           InstallationSpec Variant is `TigeraSecureEnterprise` otherwise it is `calico`.
           The `release` must match the version of the variant that the operator is
           built to deploy, this version can be obtained by passing the `--version`


### PR DESCRIPTION
## Description

PR can be summed up from the subject. I mainly noticed this misspelling when looking at the [installation reference](https://projectcalico.docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ImageSet), but it appears some of the schema yaml contained the misspelled word as well.