### PR TITLE
revise doc of calico-network-policy

### DIFF
--- a/calico/security/calico-network-policy.md
+++ b/calico/security/calico-network-policy.md
@@ -212,7 +212,7 @@ spec:
   types:
     - Egress
   egress:    
-    - action: Deny
+    - action: Allow
       destination:
         nets:
         - 1.2.3.0/24


### PR DESCRIPTION
## Description

documentation

According to the context, I think the `action` field of this example should be "Allow" instead of "Deny".