### PR TITLE
Fix installation CRD to reflect operator API changes

### DIFF
--- a/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
@@ -4242,6 +4242,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              kubeletVolumePluginPath:
+                description: 'KubeletVolumePluginPath optionally specifies enablement
+                  of Calico CSI plugin. If not specified, CSI will be enabled by default.
+                  If set to "None", CSI will be disabled. Default: /var/lib/kubelet'
+                type: string
               kubernetesProvider:
                 description: KubernetesProvider specifies a particular provider of
                   the Kubernetes platform and enables provider-specific configuration.
@@ -10389,6 +10394,11 @@ spec:
                           type: string
                       type: object
                     type: array
+                  kubeletVolumePluginPath:
+                    description: 'KubeletVolumePluginPath optionally specifies enablement
+                      of Calico CSI plugin. If not specified, CSI will be enabled by default.
+                      If set to "None", CSI will be disabled. Default: /var/lib/kubelet'
+                    type: string
                   kubernetesProvider:
                     description: KubernetesProvider specifies a particular provider
                       of the Kubernetes platform and enables provider-specific configuration.

--- a/manifests/ocp/operator.tigera.io_installations_crd.yaml
+++ b/manifests/ocp/operator.tigera.io_installations_crd.yaml
@@ -4242,6 +4242,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              kubeletVolumePluginPath:
+                description: 'KubeletVolumePluginPath optionally specifies enablement
+                  of Calico CSI plugin. If not specified, CSI will be enabled by default.
+                  If set to "None", CSI will be disabled. Default: /var/lib/kubelet'
+                type: string
               kubernetesProvider:
                 description: KubernetesProvider specifies a particular provider of
                   the Kubernetes platform and enables provider-specific configuration.
@@ -10389,6 +10394,11 @@ spec:
                           type: string
                       type: object
                     type: array
+                  kubeletVolumePluginPath:
+                    description: 'KubeletVolumePluginPath optionally specifies enablement
+                      of Calico CSI plugin. If not specified, CSI will be enabled by default.
+                      If set to "None", CSI will be disabled. Default: /var/lib/kubelet'
+                    type: string
                   kubernetesProvider:
                     description: KubernetesProvider specifies a particular provider
                       of the Kubernetes platform and enables provider-specific configuration.

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -9686,6 +9686,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              kubeletVolumePluginPath:
+                description: 'KubeletVolumePluginPath optionally specifies enablement
+                  of Calico CSI plugin. If not specified, CSI will be enabled by default.
+                  If set to "None", CSI will be disabled. Default: /var/lib/kubelet'
+                type: string
               kubernetesProvider:
                 description: KubernetesProvider specifies a particular provider of
                   the Kubernetes platform and enables provider-specific configuration.
@@ -15833,6 +15838,11 @@ spec:
                           type: string
                       type: object
                     type: array
+                  kubeletVolumePluginPath:
+                    description: 'KubeletVolumePluginPath optionally specifies enablement
+                      of Calico CSI plugin. If not specified, CSI will be enabled by default.
+                      If set to "None", CSI will be disabled. Default: /var/lib/kubelet'
+                    type: string
                   kubernetesProvider:
                     description: KubernetesProvider specifies a particular provider
                       of the Kubernetes platform and enables provider-specific configuration.


### PR DESCRIPTION
## Description
Operator API changes introduced a new field "kubeletVolumePluginPath" to the Installation CRD. This commit ports those changes to the CRDs stored in the manifests directory to close a gap in newer versions of Calico.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- ~~[ ] Tests~~
- ~~[ ] Documentation~~
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update Installation CRD to include new CSI changes introduced by recent operator API changes.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
