### PR TITLE
Include policy counters in policy dump

### DIFF
--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -457,6 +457,7 @@ func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string
 	for ruleIdx, rule := range policy.Rules {
 		log.Debugf("Start of rule %d", ruleIdx)
 		p.b.AddComment(fmt.Sprintf("Start of rule %s", rule))
+		p.b.AddComment(fmt.Sprintf("Rule MatchID: %d", rule.MatchID))
 		action := strings.ToLower(rule.Action)
 		if action == "log" {
 			log.Debug("Skipping log rule.  Not supported in BPF mode.")

--- a/felix/cmd/calico-bpf/commands/policy_debug.go
+++ b/felix/cmd/calico-bpf/commands/policy_debug.go
@@ -96,19 +96,18 @@ func printInsn(cmd *cobra.Command, insn asm.Insn) {
 	cmd.Println()
 }
 
-func getRuleMatchID(comment string) (uint64, error) {
+func getRuleMatchID(comment string) uint64 {
 	matchID := strings.Split(comment, "Rule MatchID:")[1]
 	matchID = strings.Trim(matchID, " ")
 	id, err := strconv.ParseUint(matchID, 0, 64)
 	if err != nil {
-		return 0, err
+		return 0
 	}
-	return id, nil
+	return id
 }
 
 func dumpPolicyInfo(cmd *cobra.Command, iface, hook string, m counters.PolicyMapMem) error {
 	var policyDbg bpf.PolicyDebugInfo
-	var count uint64
 	filename := bpf.PolicyDebugJSONFileName(iface, hook)
 	_, err := os.Stat(filename)
 	if err != nil {
@@ -134,14 +133,8 @@ func dumpPolicyInfo(cmd *cobra.Command, iface, hook string, m counters.PolicyMap
 	for _, insn := range policyDbg.PolicyInfo {
 		for _, comment := range insn.Comments {
 			if strings.Contains(comment, "Rule MatchID") {
-				count = 0
-				matchId, err := getRuleMatchID(comment)
-				if err == nil {
-					if val, ok := m[matchId]; ok {
-						count = val
-					}
-				}
-				cmd.Printf("// count = %d\n", count)
+				matchId := getRuleMatchID(comment)
+				cmd.Printf("// count = %d\n", m[matchId])
 			} else {
 				cmd.Printf("// %s\n", comment)
 			}


### PR DESCRIPTION
## Description

This PR has the changes to dump policy counters.
1. Write the rule matchID into the json
2. when reading the json, find the match ID, get the dump of the policyCounters bpfmap and get the count value of the match ID.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
