### PR TITLE
Remove trailing whitespace from Tigera Operator manifest

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -166,7 +166,7 @@ rules:
     verbs:
       - list
       - watch
-      - create 
+      - create
       - update
   # Needed for operator lock
   - apiGroups:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -166,7 +166,7 @@ rules:
     verbs:
       - list
       - watch
-      - create 
+      - create
       - update
   # Needed for operator lock
   - apiGroups:

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -17980,7 +17980,7 @@ rules:
     verbs:
       - list
       - watch
-      - create 
+      - create
       - update
   # Needed for operator lock
   - apiGroups:


### PR DESCRIPTION
When this trailing whitespace is present, and the Tigera Operator
manifest is embedded as YAML within a Kubernetes ConfigMap or Secret,
all whitespace in the embedded YAML is escaped. This is discussed in
https://github.com/kubernetes/kubernetes/issues/36222.

I updated the template, then ran `make gen-manifests` to update the manifest.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
