### PR TITLE
[release-v3.24] Auto pick #6606: Bump K8S_VERSION and KUBECTL_VERSION to v1.24.3 in

### DIFF
--- a/hack/test/kind/kind-single.config
+++ b/hack/test/kind/kind-single.config
@@ -14,12 +14,10 @@ nodes:
     hostPort: 8080
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta2
+  apiVersion: kubeadm.k8s.io/v1beta3
   kind: ClusterConfiguration
   metadata:
     name: config
-  featureGates:
-    IPv6DualStack: true
   controllerManager:
     extraArgs:
       cluster-cidr: "192.168.0.0/16"

--- a/hack/test/kind/kind.config
+++ b/hack/test/kind/kind.config
@@ -16,8 +16,6 @@ kubeadmConfigPatches:
   kind: ClusterConfiguration
   metadata:
     name: config
-  featureGates:
-    IPv6DualStack: true
   controllerManager:
     extraArgs:
       cluster-cidr: "192.168.0.0/16"

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1225,7 +1225,7 @@ kind-cluster-destroy: $(KIND) $(KUBECTL)
 
 kind $(KIND):
 	mkdir -p $(KIND_DIR)
-	$(DOCKER_GO_BUILD) sh -c "GOBIN=/go/src/github.com/projectcalico/calico/hack/test/kind go install sigs.k8s.io/kind@v0.11.1"
+	$(DOCKER_GO_BUILD) sh -c "GOBIN=/go/src/github.com/projectcalico/calico/hack/test/kind go install sigs.k8s.io/kind@v0.14.0"
 
 kubectl $(KUBECTL):
 	mkdir -p $(KIND_DIR)

--- a/metadata.mk
+++ b/metadata.mk
@@ -6,9 +6,9 @@
 GO_BUILD_VER = v0.73
 
 # Version of Kubernetes to use for tests.
-K8S_VERSION     = v1.23.3
+K8S_VERSION     = v1.24.3
 # This is used for lachlanevenson/k8s-kubectl and kubectl binary release.
-KUBECTL_VERSION = v1.23.2
+KUBECTL_VERSION = v1.24.3
 
 # Version of various tools used in the build and tests.
 COREDNS_VERSION=1.5.2

--- a/node/tests/k8st/infra/apiserver.yaml
+++ b/node/tests/k8st/infra/apiserver.yaml
@@ -111,6 +111,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: calico-apiserver-certs
         secret:

--- a/node/tests/k8st/infra/etcd.yaml
+++ b/node/tests/k8st/infra/etcd.yaml
@@ -41,13 +41,15 @@ spec:
         # Allow this pod to run on the master.
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
         # This, along with the annotation above marks this pod as a critical add-on.
         - key: CriticalAddonsOnly
           operator: Exists
       # Only run this pod on the master.
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       hostNetwork: true
       containers:
         - args:

--- a/node/tests/k8st/utils/utils.py
+++ b/node/tests/k8st/utils/utils.py
@@ -242,16 +242,16 @@ def node_info():
     ips = []
     ip6s = []
 
-    master_node = kubectl("get node --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[0].metadata.name}'")
+    master_node = kubectl("get node --selector='node-role.kubernetes.io/control-plane' -o jsonpath='{.items[0].metadata.name}'")
     nodes.append(master_node)
     ip6s.append(ipv6_map[master_node])
-    master_ip = kubectl("get node --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[0].status.addresses[0].address}'")
+    master_ip = kubectl("get node --selector='node-role.kubernetes.io/control-plane' -o jsonpath='{.items[0].status.addresses[0].address}'")
     ips.append(master_ip)
 
     for i in range(3):
-        node = kubectl("get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[%d].metadata.name}'" % i)
+        node = kubectl("get node --selector='!node-role.kubernetes.io/control-plane' -o jsonpath='{.items[%d].metadata.name}'" % i)
         nodes.append(node)
         ip6s.append(ipv6_map[node])
-        node_ip = kubectl("get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[%d].status.addresses[0].address}'" % i)
+        node_ip = kubectl("get node --selector='!node-role.kubernetes.io/control-plane' -o jsonpath='{.items[%d].status.addresses[0].address}'" % i)
         ips.append(node_ip)
     return nodes, ips, ip6s


### PR DESCRIPTION
Cherry pick of #6606 on release-v3.24.

#6606: Bump K8S_VERSION and KUBECTL_VERSION to v1.24.3 in

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Bump K8S_VERSION and KUBECTL_VERSION to v1.24.3 in metadata.mk
```