### PR TITLE
Adjust how kube-controllers timeout works

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -88,7 +88,7 @@ The default values.yaml should be suitable for most basic deployments.
 
 ```
 # Image pull secrets to provision for pulling images from private registries.
-# If provided, references to the secrets must also be provided in the installation section.
+# This field is a map of desired Secret name to .dockerconfigjson formatted data to use for the secret.
 imagePullSecrets: {}
 
 # Configures general installation parameters for Calico. Schema is based

--- a/kube-controllers/pkg/controllers/node/hostendpoints.go
+++ b/kube-controllers/pkg/controllers/node/hostendpoints.go
@@ -92,8 +92,6 @@ func (c *autoHostEndpointController) onUpdate(update bapi.Update) {
 					}
 				}
 			}
-		default:
-			logrus.Warnf("Unexpected kind received over syncer: %s", update.KVPair.Key)
 		}
 	} else {
 		switch update.KVPair.Key.(type) {
@@ -109,8 +107,6 @@ func (c *autoHostEndpointController) onUpdate(update bapi.Update) {
 						logrus.WithError(err).Fatal()
 					}
 				}
-			default:
-				logrus.Warnf("Unexpected kind received over syncer: %s", update.KVPair.Key)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Remove 2 second timeout for healthz call 
- Replace with exponential backoff timeout using a context
- Retry sooner if we encounter an error

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Use exponential backoff for kube-controllers health check timeout, retry sooner if failed.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.