### PR TITLE
s390x: mtuIfacePattern default value supports s390x worker interfaces

### DIFF
--- a/calico/reference/felix/configuration.md
+++ b/calico/reference/felix/configuration.md
@@ -93,7 +93,7 @@ The full list of parameters which can be set is as follows.
 | `TyphaK8sServiceName`             | `FELIX_TYPHAK8SSERVICENAME`             | Name of the Typha Kubernetes service | string |
 | `Ipv6Support`                     | `FELIX_IPV6SUPPORT`                     | Enable {{site.prodname}} networking and security for IPv6 traffic as well as for IPv4. | boolean |
 | `RouteSource`                     | `FELIX_ROUTESOURCE`                     | Where Felix gets is routing information from for VXLAN and the BPF dataplane. The CalicoIPAM setting is more efficient because it supports route aggregation, but it only works when Calico's IPAM or host-local IPAM is in use. Use the WorkloadIPs setting if you are using Calico's VXLAN or BPF dataplane and not using Calico IPAM or host-local IPAM. [Default: "CalicoIPAM"] | 'CalicoIPAM', or 'WorkloadIPs' |
-| `mtuIfacePattern`                 | `FELIX_MTUIFACEPATTERN`                 | Pattern used to discover the host's interface for MTU auto-detection. [Default: `^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)` | regex |
+| `mtuIfacePattern`                 | `FELIX_MTUIFACEPATTERN`                 | Pattern used to discover the host's interface for MTU auto-detection. [Default: `^((en|wl|ww|sl|ib)[copsx].*|(eth|wlan|wwan).*)` | regex |
 | `FeatureDetectOverride`           | `FELIX_FEATUREDETECTOVERRIDE`           | Is used to override the feature detection. Values are specified in a comma separated list with no spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=true,IPIPDeviceIsL3=true. "true" or "false" will force the feature, empty or omitted values are auto-detected. [Default: `""`] | string |
 
 #### etcd datastore configuration

--- a/calico/reference/resources/felixconfig.md
+++ b/calico/reference/resources/felixconfig.md
@@ -130,7 +130,7 @@ spec:
 | bpfMapSizeRoute | In eBPF dataplane mode, controls the size of the route map. | int | int | 262144 |
 | bpfPolicyDebugEnabled              | In eBPF dataplane mode, controls whether felix will collect policy dump for each interface. | true, false | boolean | true |
 | routeSource                        | Where Felix gets is routing information from for VXLAN and the BPF dataplane. The CalicoIPAM setting is more efficient because it supports route aggregation, but it only works when Calico's IPAM or host-local IPAM is in use. Use the WorkloadIPs setting if you are using Calico's VXLAN or BPF dataplane and not using Calico IPAM or host-local IPAM. | CalicoIPAM,WorkloadIPs | string | `CalicoIPAM` |
-| mtuIfacePattern                    | Pattern used to discover the host's interface for MTU auto-detection. | regex | string | `^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)` |
+| mtuIfacePattern                    | Pattern used to discover the host's interface for MTU auto-detection. | regex | string | `^((en|wl|ww|sl|ib)[copsx].*|(eth|wlan|wwan).*)` |
 
 <br>
 

--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -372,7 +372,7 @@ type Config struct {
 	Variant string `config:"string;Calico"`
 
 	// Configures MTU auto-detection.
-	MTUIfacePattern *regexp.Regexp `config:"regexp;^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)"`
+	MTUIfacePattern *regexp.Regexp `config:"regexp;^((en|wl|ww|sl|ib)[copsx].*|(eth|wlan|wwan).*)"`
 
 	// Encapsulation information calculated from IP Pools and FelixConfiguration (VXLANEnabled and IpInIpEnabled)
 	Encapsulation Encapsulation


### PR DESCRIPTION
Signed-off-by: huoqifeng <huoqif@cn.ibm.com>

mtuIfacePattern has default pattern `^((en|wl|ww|sl|ib)[opsx].*|(eth|wlan|wwan).*)` which does not match the network interface in `s390x` worker as the interface name is assigned by systemd depending on the interface type and bus address. On x86 it's virtio-pci while s390x uses virtio-ccw. The latter will receive a name enc<n> where n is the CCW bus address (in this example the devno is 0).

So, s390x worker has network interface `enc0`, `enc1` etc. I want to change the pattern to `^((en|wl|ww|sl|ib)[copsx].*|(eth|wlan|wwan).*)` to add `c` in `[opsx]`.

I know `FELIX_MTUIFACEPATTERN` can be used to overwrite the default value `mtuIfacePattern`, but I'd like also change the default value so that it still works in s390x worker even user forget to overwrite the value via `FELIX_MTUIFACEPATTERN`