### PR TITLE
Remove Enterprise-only fields from operator installation API reference

### DIFF
--- a/calico/reference/installation/_api.html
+++ b/calico/reference/installation/_api.html
@@ -167,20 +167,6 @@ ApplicationLayerSpec
 <table>
 <tr>
 <td>
-<code>webApplicationFirewall</code><br>
-<em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
-WAFStatusType
-</a>
-</em>
-</td>
-<td>
-<p>WebApplicationFirewall controls whether or not ModSecurity enforcement is enabled for the cluster.
-When enabled, Services may opt-in to having ingress traffic examed by ModSecurity.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>logCollection</code><br>
 <em>
 <a href="#operator.tigera.io/v1.LogCollectionSpec">
@@ -1291,20 +1277,6 @@ string
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>
-<code>webApplicationFirewall</code><br>
-<em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
-WAFStatusType
-</a>
-</em>
-</td>
-<td>
-<p>WebApplicationFirewall controls whether or not ModSecurity enforcement is enabled for the cluster.
-When enabled, Services may opt-in to having ingress traffic examed by ModSecurity.</p>
-</td>
-</tr>
 <tr>
 <td>
 <code>logCollection</code><br>
@@ -4217,10 +4189,4 @@ TyphaDeploymentPodTemplateSpec
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
-</p>
 <hr/>


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- ~~[ ] Tests~~
- [x] Documentation
- ~~[ ] Release note~~

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
