### PR TITLE
Dont use ProgramIptablesDNAT for BPF tests

### DIFF
--- a/felix/fv/hostendpoints_test.go
+++ b/felix/fv/hostendpoints_test.go
@@ -127,29 +127,31 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 		cc.ExpectSome(felixes[1], w[1])
 	}
 	expectHostToOwnPodViaServiceTraffic := func() {
+		port := 8055
+		tgtPort := 8055
 		// host to own pod always allowed, even via a service IP
 		for i := range felixes {
 			// Allocate a service IP.
-			serviceIP := fmt.Sprintf("10.96.0.%v", i+1)
+			serviceIP := fmt.Sprintf("10.101.0.%v", i+10)
 
-			// Add a NAT rule for the service IP.
-			felixes[i].ProgramIptablesDNAT(serviceIP, w[i].IP, "OUTPUT")
+			createK8sService(infra, felixes[i], w[i], serviceIP, w[i].IP, port, tgtPort, "OUTPUT")
 
 			// Expect connectivity to the service IP.
-			cc.ExpectSome(felixes[i], connectivity.TargetIP(serviceIP), 8055)
+			cc.ExpectSome(felixes[i], connectivity.TargetIP(serviceIP), uint16(port))
 		}
 	}
 	expectDenyHostToRemotePodViaServiceTraffic := func() {
+		port := 8055
+		tgtPort := 8055
 		// host to remote pod always denied, even via a service IP
 		for i := range felixes {
 			// Allocate a service IP.
-			serviceIP := fmt.Sprintf("10.96.10.%v", i+1)
+			serviceIP := fmt.Sprintf("10.101.0.%v", i+10)
 
-			// Add a NAT rule for the service IP.
-			felixes[i].ProgramIptablesDNAT(serviceIP, w[1-i].IP, "OUTPUT")
+			createK8sService(infra, felixes[i], w[1-i], serviceIP, w[1-i].IP, port, tgtPort, "OUTPUT")
 
 			// Expect not to be able to connect to the service IP.
-			cc.ExpectNone(felixes[i], connectivity.TargetIP(serviceIP), 8055)
+			cc.ExpectNone(felixes[i], connectivity.TargetIP(serviceIP), uint16(port))
 		}
 	}
 	expectPodToPodTraffic := func() {
@@ -157,15 +159,16 @@ func describeHostEndpointTests(getInfra infrastructure.InfraFactory, allInterfac
 		cc.ExpectSome(w[1], w[0])
 	}
 	expectLocalPodToRemotePodViaServiceTraffic := func() {
+		port := 8055
+		tgtPort := 8055
 		for i := range felixes {
 			// Allocate a service IP.
-			serviceIP := fmt.Sprintf("10.96.10.%v", i+1)
+			serviceIP := fmt.Sprintf("10.101.0.%v", i+10)
 
-			// Add a NAT rule for the service IP.
-			felixes[i].ProgramIptablesDNAT(serviceIP, w[1-i].IP, "PREROUTING")
+			createK8sService(infra, felixes[i], w[1-i], serviceIP, w[1-i].IP, port, tgtPort, "PREROUTING")
 
 			// Expect to connect from local pod to the service IP.
-			cc.ExpectSome(w[i], connectivity.TargetIP(serviceIP), 8055)
+			cc.ExpectSome(w[i], connectivity.TargetIP(serviceIP), uint16(port))
 		}
 	}
 	expectDenyHostToHostTraffic := func() {

--- a/felix/fv/infrastructure/infra_etcd.go
+++ b/felix/fv/infrastructure/infra_etcd.go
@@ -97,6 +97,10 @@ func (eds *EtcdDatastoreInfra) GetCalicoClient() client.Interface {
 	return utils.GetEtcdClient(eds.etcdContainer.IP)
 }
 
+func (eds *EtcdDatastoreInfra) GetDataStoreType() string {
+	return "etcdv3"
+}
+
 func (eds *EtcdDatastoreInfra) GetClusterGUID() string {
 	ci, err := eds.GetCalicoClient().ClusterInformation().Get(
 		context.Background(),

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -557,6 +557,10 @@ func (kds *K8sDatastoreInfra) GetCalicoClient() client.Interface {
 	return kds.calicoClient
 }
 
+func (kds *K8sDatastoreInfra) GetDataStoreType() string {
+	return "kubernetes"
+}
+
 func (kds *K8sDatastoreInfra) GetClusterGUID() string {
 	ci, err := kds.GetCalicoClient().ClusterInformation().Get(
 		context.Background(),

--- a/felix/fv/infrastructure/infrastructure.go
+++ b/felix/fv/infrastructure/infrastructure.go
@@ -41,6 +41,8 @@ type DatastoreInfra interface {
 	GetCalicoClient() client.Interface
 	// GetClusterGUID will return the cluster GUID.
 	GetClusterGUID() string
+	// GetDataStoreType will return the datastore type (etcdv3/kubernetes)
+	GetDataStoreType() string
 	// SetExpectedIPIPTunnelAddr will set the Felix object's
 	// ExpectedIPIPTunnelAddr field, if we expect Felix to see that field being
 	// set after it has started up for the first time.

--- a/felix/fv/ipip_test.go
+++ b/felix/fv/ipip_test.go
@@ -42,6 +42,8 @@ import (
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/workload"
@@ -61,6 +63,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 
 	BeforeEach(func() {
 		infra = getInfra()
+		if BPFMode() && infra.GetDataStoreType() == "etcdv3" {
+			Skip("Skipping BPF test for etcdv3 backend.")
+		}
 		felixes, client = infrastructure.StartNNodeTopology(2, infrastructure.DefaultTopologyOptions(), infra)
 
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
@@ -311,13 +316,13 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 			// existing case to pass for a different reason.
 			It("allows host0 to remote Calico-networked workload via service IP", func() {
 				// Allocate a service IP.
-				serviceIP := "10.96.10.1"
+				serviceIP := "10.101.0.11"
+				port := 8055
+				tgtPort := 8055
 
-				// Add a NAT rule for the service IP.
-				felixes[0].ProgramIptablesDNAT(serviceIP, w[1].IP, "OUTPUT")
-
+				createK8sService(infra, felixes[0], w[1], serviceIP, w[1].IP, port, tgtPort, "OUTPUT")
 				// Expect to connect to the service IP.
-				cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)
+				cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), uint16(port))
 				cc.CheckConnectivity()
 			})
 		})
@@ -468,4 +473,18 @@ func getIPSetCounts(c *containers.Container) map[string]int {
 		}
 	}
 	return numMembers
+}
+
+func createK8sService(infra infrastructure.DatastoreInfra, felix *infrastructure.Felix, w *workload.Workload, serviceIP, targetIP string, port, tgtPort int, chain string) {
+	if BPFMode() {
+		k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient
+		testSvc := k8sService("test-svc", serviceIP, w, port, tgtPort, 0, "tcp")
+		testSvcNamespace := testSvc.ObjectMeta.Namespace
+		_, err := k8sClient.CoreV1().Services(testSvcNamespace).Create(context.Background(), testSvc, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(k8sGetEpsForServiceFunc(k8sClient, testSvc), "10s").Should(HaveLen(1),
+			"Service endpoints didn't get created? Is controller-manager happy?")
+	} else {
+		felix.ProgramIptablesDNAT(serviceIP, targetIP, chain)
+	}
 }

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -85,6 +85,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 				// tested but we can verify the state with ethtool.
 				topologyOptions.ExtraEnvVars["FELIX_FeatureDetectOverride"] = fmt.Sprintf("ChecksumOffloadBroken=%t", brokenXSum)
 
+				if infra.GetDataStoreType() == "etcdv3" && BPFMode() {
+					Skip("Skipping BPF tests for etcdv3 backend.")
+				}
 				felixes, client = infrastructure.StartNNodeTopology(3, topologyOptions, infra)
 
 				// Install a default profile that allows all ingress and egress, in the absence of any Policy.
@@ -419,13 +422,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					// existing case to pass for a different reason.
 					It("allows host0 to remote Calico-networked workload via service IP", func() {
 						// Allocate a service IP.
-						serviceIP := "10.96.10.1"
+						serviceIP := "10.111.0.11"
+						port := 8055
+						tgtPort := 8055
 
-						// Add a NAT rule for the service IP.
-						felixes[0].ProgramIptablesDNAT(serviceIP, w[1].IP, "OUTPUT")
+						createK8sService(infra, felixes[0], w[1], serviceIP, w[1].IP, port, tgtPort, "OUTPUT")
 
 						// Expect to connect to the service IP.
-						cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), 8055)
+						cc.ExpectSome(felixes[0], connectivity.TargetIP(serviceIP), uint16(port))
 						cc.CheckConnectivity()
 					})
 				})


### PR DESCRIPTION
## Description

```ProgramIptablesDNAT``` is used for both IPtables and BPF dataplane tests. This should be avoided for BPF tests. In case of BPF a proper k8s service is created. Further etcdv3 mode is skipped for bpf tests.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
