### PR TITLE
calico node arm64 dockerfile update

### DIFF
--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -101,9 +101,10 @@ RUN rpm -i ${IPSET_SOURCERPM_URL} && \
     rpmbuild -bb /root/rpmbuild/SPECS/ipset.spec
 
 # runit is not available in ubi or CentOS repos so build it.
-RUN wget -P /tmp http://smarden.org/runit/runit-${RUNIT_VER}.tar.gz && \
-    gunzip /tmp/runit-${RUNIT_VER}.tar.gz && \
-    tar -xpf /tmp/runit-${RUNIT_VER}.tar -C /tmp && \
+# get it from the debian repos as the official website doesn't support https
+RUN wget -P /tmp https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz && \
+    gunzip /tmp/runit_${RUNIT_VER}.orig.tar.gz && \
+    tar -xpf /tmp/runit_${RUNIT_VER}.orig.tar -C /tmp && \
     cd /tmp/admin/runit-${RUNIT_VER}/ && \
     # runit compilation trigger a false positive error halting the process.
     sed -i "s/runit-init/\/tmp\/admin\/runit-2.1.2\/compile\/runit-init/" src/runit-init.dist && \
@@ -137,6 +138,13 @@ COPY --from=centos  /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
 
 # Copy in our rpms
 COPY --from=centos  /root/rpmbuild/RPMS/${ARCH}/* /tmp/rpms/
+
+# Install a subset of packages from UBI prior to removing the UBI repo below.
+# We do this because the UBI repo has updated versions with CVE fixes. We can remove
+# this once the CentOS repo updates the version of these packages.
+# gzip >= 1.9-13.el8_5
+# cryptsetup-libs >= 2.3.3-4.el8_5.1
+RUN microdnf install gzip cryptsetup-libs
 
 # Install the necessary packages, making sure that we're using only CentOS repos.
 # Since the ubi repos do not contain all the packages we need (they're missing conntrack-tools),
@@ -189,8 +197,20 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
 # This can be removed once we update to ubi:8.1
 RUN systemctl disable systemd-resolved
 
+# Change the permissions for ipset so it can be run by any container user.
+RUN chgrp 0 /usr/sbin/ipset && \
+    chmod g=u /usr/sbin/ipset
+
+# Change the permissions for iptables so it can be run by any container user.
+RUN chgrp 0 /usr/sbin/iptables && \
+    chmod g=u /usr/sbin/iptables
+
 # Copy our bird binaries in
 COPY --from=bird /bird* /bin/
+
+# Set the suid bit on bird to allow our user to execute them with root permissions.
+RUN chmod u+s /bin/bird
+RUN chmod u+s /bin/bird6
 
 # Copy in the filesystem - this contains licenses, etc...
 COPY filesystem/etc/ /etc
@@ -199,10 +219,18 @@ COPY filesystem/licenses/ /licenses
 COPY filesystem/usr/ /usr
 COPY filesystem/sbin/* /usr/sbin/
 
+# Change permissions to make confd templates and output available in /etc/calico
+# to all container users.
+RUN chgrp -R 0 /etc/calico && \
+    chmod -R g=u /etc/calico
+
 COPY --from=bpftool /bpftool /bin
 
 # Copy in the calico-node binary
 COPY dist/bin/calico-node-arm64 /bin/calico-node
+
+# Set the suid bit on calico-node
+RUN chmod u+s /bin/calico-node
 
 # Copy in the moutnns binary
 COPY dist/bin/mountns-arm64 /bin/mountns


### PR DESCRIPTION
This PR updates the calico node arm64 docker manifest with the latest changes that were implemented in AMD64.

Add: set suid for ipset.
Add: bird executable can be run as root.
Add: Adjusted /etc/calico folder permissions to be accessible for all container users.
Add: Set suid for calico-node binary.
Add: Changed the run-init source mirror to debian.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
