### PR TITLE
Fix calicoctl IPAM handle release in KDD mode

### DIFF
--- a/calicoctl/calicoctl/commands/ipam/check.go
+++ b/calicoctl/calicoctl/commands/ipam/check.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	docopt "github.com/docopt/docopt-go"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
@@ -287,6 +288,7 @@ func (c *IPAMChecker) checkIPAM(ctx context.Context) error {
 			handleKey := kv.Key.(model.IPAMHandleKey)
 			handles[handleKey.HandleID] = HandleInfo{
 				ID:       handleKey.HandleID,
+				UID:      kv.UID,
 				Revision: kv.Revision,
 			}
 		}
@@ -634,6 +636,7 @@ func (a *Allocation) GetAttrString() string {
 
 type HandleInfo struct {
 	ID       string
+	UID      *types.UID
 	Revision string
 }
 

--- a/calicoctl/test-data/kubeconfig.yaml
+++ b/calicoctl/test-data/kubeconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+  name: main-cluster
+contexts:
+- context:
+    cluster: main-cluster
+    user: default
+  name: main
+current-context: "main"
+kind: Config
+preferences: {}
+users: null

--- a/calicoctl/tests/fv/ipam_test.go
+++ b/calicoctl/tests/fv/ipam_test.go
@@ -26,17 +26,17 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
-
-	log "github.com/sirupsen/logrus"
-
-	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	ipamcmd "github.com/projectcalico/calico/calicoctl/calicoctl/commands/ipam"
 	. "github.com/projectcalico/calico/calicoctl/tests/fv/utils"
-	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	libapi "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/calico/libcalico-go/lib/ipam"
@@ -51,298 +51,293 @@ func init() {
 }
 
 func TestIPAM(t *testing.T) {
-	RegisterTestingT(t)
+	RunDatastoreTest(t, func(t *testing.T, kdd bool, client clientv3.Interface) {
+		ctx := context.Background()
 
-	ctx := context.Background()
-
-	// Create a Calico client.
-	config := apiconfig.NewCalicoAPIConfig()
-	config.Spec.DatastoreType = "etcdv3"
-	config.Spec.EtcdEndpoints = "http://127.0.0.1:2379"
-	client, err := clientv3.New(*config)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Create an IPv4 pool.
-	pool := v3.NewIPPool()
-	pool.Name = "ipam-test-v4"
-	pool.Spec.CIDR = "10.65.0.0/16"
-	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	// Create an IPv6 pool.
-	pool = v3.NewIPPool()
-	pool.Name = "ipam-test-v6"
-	pool.Spec.CIDR = "fd5f:abcd:64::0/48"
-	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	// Create a Node resource for this host.
-	node := libapi.NewNode()
-	node.Name, err = os.Hostname()
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.Nodes().Create(ctx, node, options.SetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	// Set Calico version in ClusterInformation
-	out, err := SetCalicoVersion(false)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(out).To(ContainSubstring("Calico version set to"))
-
-	// ipam show with specific unallocated IP.
-	out = Calicoctl(false, "ipam", "show", "--ip=10.65.0.2")
-	Expect(out).To(ContainSubstring("10.65.0.2 is not assigned"))
-
-	// ipam show, with no allocations yet.
-	out = Calicoctl(false, "ipam", "show")
-	Expect(out).To(ContainSubstring("IPS IN USE"))
-
-	// Assign some IPs.
-	var v4, v6 []cnet.IPNet
-	v4Assignments, v6Assignments, err := client.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
-		Num4:        5,
-		Num6:        7,
-		Attrs:       map[string]string{"note": "reserved by ipam_test.go"},
-		IntendedUse: v3.IPPoolAllowedUseWorkload,
-	})
-	Expect(err).NotTo(HaveOccurred())
-	if v4Assignments != nil {
-		v4 = v4Assignments.IPs
-	}
-	if v6Assignments != nil {
-		v6 = v6Assignments.IPs
-	}
-
-	// ipam show, pools only.
-	out = Calicoctl(false, "ipam", "show")
-	Expect(out).To(ContainSubstring("IPS IN USE"))
-	Expect(out).To(ContainSubstring("10.65.0.0/16"))
-	Expect(out).To(ContainSubstring("5 (0%)"))
-	Expect(out).To(ContainSubstring("65531 (100%)"))
-	Expect(out).To(ContainSubstring("fd5f:abcd:64::/48"))
-
-	// ipam show, including blocks.
-	out = Calicoctl(false, "ipam", "show", "--show-blocks")
-	Expect(out).To(ContainSubstring("Block"))
-	Expect(out).To(ContainSubstring("5 (8%)"))
-	Expect(out).To(ContainSubstring("59 (92%)"))
-
-	// Find out the allocation block.
-	var allocatedIP string
-	r, err := regexp.Compile(`(10\.65\.[0-9]+\.)([0-9]+)/26`)
-	Expect(err).NotTo(HaveOccurred())
-	for _, line := range strings.Split(out, "\n") {
-		sm := r.FindStringSubmatch(line)
-		if len(sm) > 0 {
-			ordinalBase, err := strconv.Atoi(sm[2])
-			Expect(err).NotTo(HaveOccurred())
-			allocatedIP = sm[1] + strconv.Itoa(ordinalBase+2)
-			break
-		}
-	}
-	Expect(allocatedIP).NotTo(BeEmpty())
-
-	// ipam show with specific IP that is now allocated.
-	out = Calicoctl(false, "ipam", "show", "--ip="+allocatedIP)
-	Expect(out).To(ContainSubstring(allocatedIP + " is in use"))
-	Expect(out).To(ContainSubstring("Attributes:"))
-	Expect(out).To(ContainSubstring("note: reserved by ipam_test.go"))
-
-	// ipam show with an invalid IP.
-	out, err = CalicoctlMayFail(false, "ipam", "show", "--ip=10.240.0.300")
-	Expect(err).To(HaveOccurred())
-	Expect(out).To(ContainSubstring("invalid IP address"))
-
-	// Create a pool with blocksize 29, so we can easily allocate
-	// an entire block.
-	pool = v3.NewIPPool()
-	pool.Name = "ipam-test-v4-b29"
-	pool.Spec.CIDR = "10.66.0.0/16"
-	pool.Spec.BlockSize = 29
-	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	// Allocate more than one block's worth (8) of IPs from that
-	// pool.
-	// Assign some IPs.
-	var v4More, v6More []cnet.IPNet
-	v4MoreAssignments, v6MoreAssignments, err := client.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
-		Num4:        11,
-		IPv4Pools:   []cnet.IPNet{cnet.MustParseNetwork(pool.Spec.CIDR)},
-		IntendedUse: v3.IPPoolAllowedUseWorkload,
-	})
-	Expect(err).NotTo(HaveOccurred())
-	if v4MoreAssignments != nil {
-		v4More = v4MoreAssignments.IPs
-	}
-	if v6MoreAssignments != nil {
-		v6More = v6MoreAssignments.IPs
-	}
-
-	// ipam show, including blocks.
-	//
-	// Example output here:
-	// +----------+-------------------------------------------+------------+------------+-------------------+
-	// | GROUPING |                   CIDR                    | IPS TOTAL  | IPS IN USE |     IPS FREE      |
-	// +----------+-------------------------------------------+------------+------------+-------------------+
-	// | IP Pool  | 10.65.0.0/16                              |      65536 | 5 (0%)     | 65531 (100%)      |
-	// | Block    | 10.65.79.0/26                             |         64 | 5 (8%)     | 59 (92%)          |
-	// | IP Pool  | 10.66.0.0/16                              |      65536 | 11 (0%)    | 65525 (100%)      |
-	// | Block    | 10.66.137.224/29                          |          8 | 8 (100%)   | 0 (0%)            |
-	// | Block    | 10.66.137.232/29                          |          8 | 3 (38%)    | 5 (62%)           |
-	// | IP Pool  | fd5f:abcd:64::/48                         | 1.2089e+24 | 7 (0%)     | 1.2089e+24 (100%) |
-	// | Block    | fd5f:abcd:64:4f2c:ec1b:27b9:1989:77c0/122 |         64 | 7 (11%)    | 57 (89%)          |
-	// +----------+-------------------------------------------+------------+------------+-------------------+
-	outLines := strings.Split(Calicoctl(false, "ipam", "show", "--show-blocks"), "\n")
-	Expect(outLines).To(ContainElement(And(ContainSubstring("Block"), ContainSubstring("10.66"), ContainSubstring("8 (100%)"), ContainSubstring("0 (0%)"))))
-	Expect(outLines).To(ContainElement(And(ContainSubstring("IP Pool"), ContainSubstring("fd5f"), ContainSubstring("7 (0%)"))))
-
-	// Clean up resources
-	cidrs := append(v4, v4More...)
-	cidrs = append(cidrs, v6...)
-	cidrs = append(cidrs, v6More...)
-	nodename, err := os.Hostname()
-	Expect(err).NotTo(HaveOccurred())
-	var ips []ipam.ReleaseOptions
-	for _, cidr := range cidrs {
-		err = client.IPAM().ReleaseAffinity(ctx, cidr, nodename, false)
+		// Create an IPv4 pool.
+		pool := v3.NewIPPool()
+		pool.Name = "ipam-test-v4"
+		pool.Spec.CIDR = "10.65.0.0/16"
+		_, err := client.IPPools().Create(ctx, pool, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		ip := cnet.ParseIP(cidr.IP.String())
-		ips = append(ips, ipam.ReleaseOptions{Address: ip.IP.String()})
-	}
-	// Release the IPs
-	_, err = client.IPAM().ReleaseIPs(ctx, ips...)
-	Expect(err).NotTo(HaveOccurred())
 
-	_, err = client.IPPools().Delete(ctx, "ipam-test-v4", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.IPPools().Delete(ctx, "ipam-test-v6", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.Nodes().Delete(ctx, nodename, options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.IPPools().Delete(ctx, "ipam-test-v4-b29", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
+		// Create an IPv6 pool.
+		pool = v3.NewIPPool()
+		pool.Name = "ipam-test-v6"
+		pool.Spec.CIDR = "fd5f:abcd:64::0/48"
+		_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a Node resource for this host.
+		cleanupNode := createNodeForLocalhost(t, ctx, client)
+		defer cleanupNode()
+
+		// Set Calico version in ClusterInformation
+		out, err := SetCalicoVersion(kdd)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("Calico version set to"))
+
+		// ipam show with specific unallocated IP.
+		out = Calicoctl(kdd, "ipam", "show", "--ip=10.65.0.2")
+		Expect(out).To(ContainSubstring("10.65.0.2 is not assigned"))
+
+		// ipam show, with no allocations yet.
+		out = Calicoctl(kdd, "ipam", "show")
+		Expect(out).To(ContainSubstring("IPS IN USE"))
+
+		// Assign some IPs.
+		var v4, v6 []cnet.IPNet
+		v4Assignments, v6Assignments, err := client.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+			Num4:        5,
+			Num6:        7,
+			Attrs:       map[string]string{"note": "reserved by ipam_test.go"},
+			IntendedUse: v3.IPPoolAllowedUseWorkload,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		if v4Assignments != nil {
+			v4 = v4Assignments.IPs
+		}
+		if v6Assignments != nil {
+			v6 = v6Assignments.IPs
+		}
+
+		// ipam show, pools only.
+		out = Calicoctl(kdd, "ipam", "show")
+		Expect(out).To(ContainSubstring("IPS IN USE"))
+		Expect(out).To(ContainSubstring("10.65.0.0/16"))
+		Expect(out).To(ContainSubstring("5 (0%)"))
+		Expect(out).To(ContainSubstring("65531 (100%)"))
+		Expect(out).To(ContainSubstring("fd5f:abcd:64::/48"))
+
+		// ipam show, including blocks.
+		out = Calicoctl(kdd, "ipam", "show", "--show-blocks")
+		Expect(out).To(ContainSubstring("Block"))
+		Expect(out).To(ContainSubstring("5 (8%)"))
+		Expect(out).To(ContainSubstring("59 (92%)"))
+
+		// Find out the allocation block.
+		var allocatedIP string
+		r, err := regexp.Compile(`(10\.65\.[0-9]+\.)([0-9]+)/26`)
+		Expect(err).NotTo(HaveOccurred())
+		for _, line := range strings.Split(out, "\n") {
+			sm := r.FindStringSubmatch(line)
+			if len(sm) > 0 {
+				ordinalBase, err := strconv.Atoi(sm[2])
+				Expect(err).NotTo(HaveOccurred())
+				allocatedIP = sm[1] + strconv.Itoa(ordinalBase+2)
+				break
+			}
+		}
+		Expect(allocatedIP).NotTo(BeEmpty())
+
+		// ipam show with specific IP that is now allocated.
+		out = Calicoctl(kdd, "ipam", "show", "--ip="+allocatedIP)
+		Expect(out).To(ContainSubstring(allocatedIP + " is in use"))
+		Expect(out).To(ContainSubstring("Attributes:"))
+		Expect(out).To(ContainSubstring("note: reserved by ipam_test.go"))
+
+		// ipam show with an invalid IP.
+		out, err = CalicoctlMayFail(kdd, "ipam", "show", "--ip=10.240.0.300")
+		Expect(err).To(HaveOccurred())
+		Expect(out).To(ContainSubstring("invalid IP address"))
+
+		// Create a pool with blocksize 29, so we can easily allocate
+		// an entire block.
+		pool = v3.NewIPPool()
+		pool.Name = "ipam-test-v4-b29"
+		pool.Spec.CIDR = "10.66.0.0/16"
+		pool.Spec.BlockSize = 29
+		_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Allocate more than one block's worth (8) of IPs from that
+		// pool.
+		// Assign some IPs.
+		var v4More, v6More []cnet.IPNet
+		v4MoreAssignments, v6MoreAssignments, err := client.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+			Num4:        11,
+			IPv4Pools:   []cnet.IPNet{cnet.MustParseNetwork(pool.Spec.CIDR)},
+			IntendedUse: v3.IPPoolAllowedUseWorkload,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		if v4MoreAssignments != nil {
+			v4More = v4MoreAssignments.IPs
+		}
+		if v6MoreAssignments != nil {
+			v6More = v6MoreAssignments.IPs
+		}
+
+		// ipam show, including blocks.
+		//
+		// Example output here:
+		// +----------+-------------------------------------------+------------+------------+-------------------+
+		// | GROUPING |                   CIDR                    | IPS TOTAL  | IPS IN USE |     IPS FREE      |
+		// +----------+-------------------------------------------+------------+------------+-------------------+
+		// | IP Pool  | 10.65.0.0/16                              |      65536 | 5 (0%)     | 65531 (100%)      |
+		// | Block    | 10.65.79.0/26                             |         64 | 5 (8%)     | 59 (92%)          |
+		// | IP Pool  | 10.66.0.0/16                              |      65536 | 11 (0%)    | 65525 (100%)      |
+		// | Block    | 10.66.137.224/29                          |          8 | 8 (100%)   | 0 (0%)            |
+		// | Block    | 10.66.137.232/29                          |          8 | 3 (38%)    | 5 (62%)           |
+		// | IP Pool  | fd5f:abcd:64::/48                         | 1.2089e+24 | 7 (0%)     | 1.2089e+24 (100%) |
+		// | Block    | fd5f:abcd:64:4f2c:ec1b:27b9:1989:77c0/122 |         64 | 7 (11%)    | 57 (89%)          |
+		// +----------+-------------------------------------------+------------+------------+-------------------+
+		outLines := strings.Split(Calicoctl(kdd, "ipam", "show", "--show-blocks"), "\n")
+		Expect(outLines).To(ContainElement(And(ContainSubstring("Block"), ContainSubstring("10.66"), ContainSubstring("8 (100%)"), ContainSubstring("0 (0%)"))))
+		Expect(outLines).To(ContainElement(And(ContainSubstring("IP Pool"), ContainSubstring("fd5f"), ContainSubstring("7 (0%)"))))
+
+		// Clean up resources
+		cidrs := append(v4, v4More...)
+		cidrs = append(cidrs, v6...)
+		cidrs = append(cidrs, v6More...)
+		nodename, err := os.Hostname()
+		Expect(err).NotTo(HaveOccurred())
+		var ips []ipam.ReleaseOptions
+		for _, cidr := range cidrs {
+			err = client.IPAM().ReleaseAffinity(ctx, cidr, nodename, false)
+			Expect(err).NotTo(HaveOccurred())
+			ip := cnet.ParseIP(cidr.IP.String())
+			ips = append(ips, ipam.ReleaseOptions{Address: ip.IP.String()})
+		}
+		// Release the IPs
+		_, err = client.IPAM().ReleaseIPs(ctx, ips...)
+		Expect(err).NotTo(HaveOccurred())
+	})
 }
 
 func TestIPAMCleanup(t *testing.T) {
-	RegisterTestingT(t)
+	RunDatastoreTest(t, func(t *testing.T, kdd bool, client clientv3.Interface) {
+		ctx := context.Background()
 
-	ctx := context.Background()
+		out, err := SetCalicoVersion(kdd)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("Calico version set to"))
 
-	// Create a Calico client.
-	config := apiconfig.NewCalicoAPIConfig()
-	config.Spec.DatastoreType = "etcdv3"
-	config.Spec.EtcdEndpoints = "http://127.0.0.1:2379"
-	client, err := clientv3.New(*config)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Set Calico version in ClusterInformation
-	out, err := SetCalicoVersion(false)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(out).To(ContainSubstring("Calico version set to"))
-
-	// Create an IPv4 pool.
-	pool := v3.NewIPPool()
-	pool.Name = "ipam-test-v4-handle-clean"
-	pool.Spec.CIDR = "10.66.0.0/16"
-	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	defer func() {
-		_, err = client.IPPools().Delete(ctx, "ipam-test-v4-handle-clean", options.DeleteOptions{})
+		// Create an IPv4 pool.
+		pool := v3.NewIPPool()
+		pool.Name = "ipam-test-v4-handle-clean"
+		pool.Spec.CIDR = "10.66.0.0/16"
+		_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-	}()
 
-	// Create a Node resource for this host.
-	node := libapi.NewNode()
-	node.Name, err = os.Hostname()
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.Nodes().Create(ctx, node, options.SetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	defer func() {
-		_, err = client.Nodes().Delete(ctx, node.Name, options.DeleteOptions{})
+		// Create a Node resource for this host.
+		cleanupNode := createNodeForLocalhost(t, ctx, client)
+		defer cleanupNode()
+
+		// Assign some IPs.
+		myHandle := "TestIPAMCleanup"
+		v4Assignments, _, err := client.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
+			Num4:        1,
+			Attrs:       map[string]string{"note": "reserved by ipam_test.go"},
+			HandleID:    &myHandle,
+			IntendedUse: v3.IPPoolAllowedUseWorkload,
+		})
+		_ = v4Assignments
 		Expect(err).NotTo(HaveOccurred())
-	}()
 
-	// Assign some IPs.
-	myHandle := "TestIPAMCleanup"
-	v4Assignments, _, err := client.IPAM().AutoAssign(ctx, ipam.AutoAssignArgs{
-		Num4:        1,
-		Attrs:       map[string]string{"note": "reserved by ipam_test.go"},
-		HandleID:    &myHandle,
-		IntendedUse: v3.IPPoolAllowedUseWorkload,
+		// Make a raw, leaked handle for IPAM check to find.
+		type accessor interface {
+			Backend() bapi.Client
+		}
+		bc := client.(accessor).Backend()
+		createLeakedHandle := func() *model.KVPair {
+			kv, err := bc.Create(ctx, &model.KVPair{
+				Key: model.IPAMHandleKey{
+					HandleID: "leaked-handle",
+				},
+				Value: &model.IPAMHandle{
+					HandleID: "leaked-handle",
+					Block: map[string]int{
+						"10.65.79.0/26": 1,
+					},
+					Deleted: false,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return kv
+		}
+		createLeakedHandle()
+
+		// Run calicoctl ipam check and parse the resulting report.
+		out = Calicoctl(kdd, "ipam", "check", "--show-all-ips", "-o", "/tmp/ipam_report.json")
+		t.Log("IPAM check output:", out)
+		reportFile, err := ioutil.ReadFile("/tmp/ipam_report.json")
+		Expect(err).NotTo(HaveOccurred())
+		t.Log("IPAM check report (raw JSON):", string(reportFile))
+		var report ipamcmd.Report
+		err = json.Unmarshal(reportFile, &report)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check that handles were reported correctly.
+		Expect(out).To(ContainSubstring("Found 1 handles with no matching IPs (and 1 handles with matches)."))
+		Expect(report.LeakedHandles).To(HaveLen(1))
+		Expect(report.LeakedHandles[0].ID).To(Equal("leaked-handle"))
+		Expect(report.LeakedHandles[0].Revision).ToNot(BeEmpty())
+
+		out, err = CalicoctlMayFail(kdd, "ipam", "release", "--from-report=/tmp/ipam_report.json")
+		Expect(err).To(HaveOccurred(), "calicoctl ipam release should fail if datastore is not locked")
+		Expect(out).To(ContainSubstring("not locked"))
+
+		out, err = CalicoctlMayFail(kdd, "ipam", "release", "--from-report=/tmp/ipam_report.json", "--force")
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run calicoctl ipam release: %s", out))
+		t.Log("calicoctl ipam release output:", out)
+		Expect(out).To(ContainSubstring("Released 1 IPs successfully"))
+		Expect(out).To(ContainSubstring("Released 1 handles; 0 skipped; 0 errors."))
+
+		// Both handles should now be gone.
+		handles, err := bc.List(ctx, model.IPAMHandleListOptions{}, "")
+		Expect(err).NotTo(HaveOccurred())
+		for _, kv := range handles.KVPairs {
+			hk := kv.Key.(model.IPAMHandleKey)
+			Expect(hk.HandleID).NotTo(Equal("leaked-handle"))
+			Expect(hk.HandleID).NotTo(Equal(myHandle))
+		}
+
+		// Recreate the handle and try running the same report again.  Should skip that handle due to change of revision.
+		createLeakedHandle()
+		out, err = CalicoctlMayFail(kdd, "ipam", "release", "--from-report=/tmp/ipam_report.json", "--force")
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run calicoctl ipam release: %s", out))
+		t.Log("calicoctl ipam release output:", out)
+		Expect(out).ToNot(MatchRegexp(`.*Released \d+ IPs.*`), "No IPs should be released")
+		Expect(out).To(ContainSubstring("Released 0 handles; 1 skipped; 0 errors."))
+
+		// Run with missing handle, should skip.
+		out, err = CalicoctlMayFail(kdd, "ipam", "release", "--from-report=/tmp/ipam_report.json", "--force")
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run calicoctl ipam release: %s", out))
+		t.Log("calicoctl ipam release output:", out)
+		Expect(out).To(ContainSubstring("Released 0 handles; 1 skipped; 0 errors."))
 	})
-	_ = v4Assignments
-	Expect(err).NotTo(HaveOccurred())
+}
 
-	// Make a raw, leaked handle for IPAM check to find.
+func createNodeForLocalhost(t *testing.T, ctx context.Context, client clientv3.Interface) (cleanup func()) {
 	type accessor interface {
 		Backend() bapi.Client
 	}
 	bc := client.(accessor).Backend()
-	createLeakedHandle := func() *model.KVPair {
-		kv, err := bc.Create(ctx, &model.KVPair{
-			Key: model.IPAMHandleKey{
-				HandleID: "leaked-handle",
+	nodeName, err := os.Hostname()
+	if k8sClient, ok := bc.(*k8s.KubeClient); ok {
+		t.Log("Creating Kubernetes Node")
+		cs := k8sClient.ClientSet
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
 			},
-			Value: &model.IPAMHandle{
-				HandleID: "leaked-handle",
-				Block: map[string]int{
-					"10.65.79.0/26": 1,
-				},
-				Deleted: false,
-			},
-		})
+		}
+		node, err := cs.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		return kv
+		return func() {
+			err := cs.CoreV1().Nodes().Delete(ctx, node.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+	} else {
+		t.Log("Creating etcd Node")
+		node := libapi.NewNode()
+		node.Name = nodeName
+		Expect(err).NotTo(HaveOccurred())
+		_, err = client.Nodes().Create(ctx, node, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		return func() {
+			_, err = client.Nodes().Delete(ctx, node.Name, options.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
 	}
-	createLeakedHandle()
-
-	// Run calicoctl ipam check and parse the resulting report.
-	out = Calicoctl(false, "ipam", "check", "--show-all-ips", "-o", "/tmp/ipam_report.json")
-	t.Log("IPAM check output:", out)
-	reportFile, err := ioutil.ReadFile("/tmp/ipam_report.json")
-	Expect(err).NotTo(HaveOccurred())
-	t.Log("IPAM check report (raw JSON):", string(reportFile))
-	var report ipamcmd.Report
-	err = json.Unmarshal(reportFile, &report)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Check that handles were reported correctly.
-	Expect(out).To(ContainSubstring("Found 1 handles with no matching IPs (and 1 handles with matches)."))
-	Expect(report.LeakedHandles).To(HaveLen(1))
-	Expect(report.LeakedHandles[0].ID).To(Equal("leaked-handle"))
-	Expect(report.LeakedHandles[0].Revision).ToNot(BeEmpty())
-
-	out, err = CalicoctlMayFail(false, "ipam", "release", "--from-report=/tmp/ipam_report.json")
-	Expect(err).To(HaveOccurred(), "calicoctl ipam release should fail if datastore is not locked")
-	Expect(out).To(ContainSubstring("not locked"))
-
-	out, err = CalicoctlMayFail(false, "ipam", "release", "--from-report=/tmp/ipam_report.json", "--force")
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run calicoctl ipam release: %s", out))
-	t.Log("calicoctl ipam release output:", out)
-	Expect(out).To(ContainSubstring("Released 1 IPs successfully"))
-	Expect(out).To(ContainSubstring("Released 1 handles; 0 skipped; 0 errors."))
-
-	// Both handles should now be gone.
-	handles, err := bc.List(ctx, model.IPAMHandleListOptions{}, "")
-	Expect(err).NotTo(HaveOccurred())
-	for _, kv := range handles.KVPairs {
-		hk := kv.Key.(model.IPAMHandleKey)
-		Expect(hk.HandleID).NotTo(Equal("leaked-handle"))
-		Expect(hk.HandleID).NotTo(Equal(myHandle))
-	}
-
-	// Recreate the handle and try running the same report again.  Should skip that handle due to change of revision.
-	createLeakedHandle()
-	out, err = CalicoctlMayFail(false, "ipam", "release", "--from-report=/tmp/ipam_report.json", "--force")
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run calicoctl ipam release: %s", out))
-	t.Log("calicoctl ipam release output:", out)
-	Expect(out).ToNot(MatchRegexp(`.*Released \d+ IPs.*`), "No IPs should be released")
-	Expect(out).To(ContainSubstring("Released 0 handles; 1 skipped; 0 errors."))
-
-	// Run with missing handle, should skip.
-	out, err = CalicoctlMayFail(false, "ipam", "release", "--from-report=/tmp/ipam_report.json", "--force")
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to run calicoctl ipam release: %s", out))
-	t.Log("calicoctl ipam release output:", out)
-	Expect(out).To(ContainSubstring("Released 0 handles; 1 skipped; 0 errors."))
 }

--- a/calicoctl/tests/fv/migrate_ipam_test.go
+++ b/calicoctl/tests/fv/migrate_ipam_test.go
@@ -62,6 +62,10 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 	pool.Spec.CIDR = "10.65.0.0/16"
 	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_, err = client.IPPools().Delete(ctx, "ipam-test-v4", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	// Create an IPv6 pool.
 	pool = v3.NewIPPool()
@@ -69,6 +73,10 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 	pool.Spec.CIDR = "fd5f:abcd:64::0/48"
 	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_, err = client.IPPools().Delete(ctx, "ipam-test-v6", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	// Create a Node resource for this host.
 	node := libapiv3.NewNode()
@@ -81,6 +89,10 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 	}
 	_, err = client.Nodes().Create(ctx, node, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_, err = client.Nodes().Delete(ctx, "node4", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	// Assign some IPs.
 	var v4, v6 []cnet.IPNet
@@ -107,6 +119,10 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 	pool.Spec.BlockSize = 29
 	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_, err = client.IPPools().Delete(ctx, "ipam-test-v4-b29", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	// Allocate more than one block's worth (8) of IPs from that
 	// pool.
@@ -218,14 +234,5 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 	}
 	// Release the IPs
 	_, err = client.IPAM().ReleaseIPs(ctx, ips...)
-	Expect(err).NotTo(HaveOccurred())
-
-	_, err = client.IPPools().Delete(ctx, "ipam-test-v4", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.IPPools().Delete(ctx, "ipam-test-v6", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.Nodes().Delete(ctx, "node4", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	_, err = client.IPPools().Delete(ctx, "ipam-test-v4-b29", options.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/calicoctl/tests/fv/multi_context_test.go
+++ b/calicoctl/tests/fv/multi_context_test.go
@@ -15,7 +15,6 @@
 package fv_test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -35,10 +34,12 @@ func init() {
 func TestMultiCluster(t *testing.T) {
 	RegisterTestingT(t)
 
-	os.Setenv("KUBECONFIG", strings.Join([]string{
+	unpatchEnv, err := PatchEnv("KUBECONFIG", strings.Join([]string{
 		"/go/src/github.com/projectcalico/calico/calicoctl/test-data/multi-context/kubectl-config.yaml",
 		"/go/src/github.com/projectcalico/calico/calicoctl/test-data/multi-context/kubectl-config-second.yaml",
 	}, ":"))
+	Expect(err).NotTo(HaveOccurred())
+	defer unpatchEnv()
 
 	// Set Calico version in ClusterInformation for both contexts
 	out, err := SetCalicoVersion(true, "--context", "main")

--- a/calicoctl/tests/fv/namespace_option_test.go
+++ b/calicoctl/tests/fv/namespace_option_test.go
@@ -53,17 +53,29 @@ func TestMultiOption(t *testing.T) {
 	pool.Spec.CIDR = "10.65.0.0/16"
 	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_, err = client.IPPools().Delete(ctx, "ipam-test-v4", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	np := v3.NewNetworkPolicy()
 	np.Name = "policy1"
 	np.Namespace = "firstns"
 	_, err = client.NetworkPolicies().Create(ctx, np, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_, err = client.NetworkPolicies().Delete(ctx, "firstns", "policy1", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	np.Name = "policy2"
 	np.Namespace = "secondns"
 	_, err = client.NetworkPolicies().Create(ctx, np, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		_, err = client.NetworkPolicies().Delete(ctx, "secondns", "policy2", options.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}()
 
 	// Set Calico version in ClusterInformation
 	out, err := SetCalicoVersion(false)
@@ -83,14 +95,4 @@ func TestMultiOption(t *testing.T) {
 
 	out = Calicoctl(false, "get", "networkPolicy", "-a")
 	Expect(out).To(Equal("NAMESPACE   NAME      \nfirstns     policy1   \nsecondns    policy2   \n\n"))
-
-	// Clean up resources
-	_, err = client.IPPools().Delete(ctx, "ipam-test-v4", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	_, err = client.NetworkPolicies().Delete(ctx, "firstns", "policy1", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
-
-	_, err = client.NetworkPolicies().Delete(ctx, "secondns", "policy2", options.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
 }

--- a/calicoctl/tests/fv/utils/calicoctl.go
+++ b/calicoctl/tests/fv/utils/calicoctl.go
@@ -15,6 +15,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -44,7 +45,7 @@ func getEnv(kdd bool) []string {
 
 func Calicoctl(kdd bool, args ...string) string {
 	out, err := CalicoctlMayFail(kdd, args...)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to run calicoctl (kdd:%v) %v", kdd, args))
 	return out
 }
 

--- a/calicoctl/tests/fv/utils/datastore.go
+++ b/calicoctl/tests/fv/utils/datastore.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+)
+
+func RunDatastoreTest(t *testing.T, testFn func(t *testing.T, kdd bool, client clientv3.Interface)) {
+	t.Run("etcd", func(t *testing.T) {
+		RegisterTestingT(t)
+		config := apiconfig.NewCalicoAPIConfig()
+		config.Spec.DatastoreType = apiconfig.EtcdV3
+		config.Spec.EtcdEndpoints = "http://127.0.0.1:2379"
+		client, err := clientv3.New(*config)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			err := client.(interface {
+				Backend() bapi.Client
+			}).Backend().Clean()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		testFn(t, false, client)
+	})
+	t.Run("kubernetes", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		// When we run Calicoctl, it picks up our environment.
+		unpatchEnv, err := PatchEnv("KUBECONFIG", "/go/src/github.com/projectcalico/calico/calicoctl/test-data/kubeconfig.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		defer unpatchEnv()
+
+		// Inline configuration for a local calico client.
+		config := apiconfig.NewCalicoAPIConfig()
+		config.Spec.DatastoreType = apiconfig.Kubernetes
+		config.Spec.Kubeconfig = "/go/src/github.com/projectcalico/calico/calicoctl/test-data/kubeconfig.yaml"
+		config.Spec.K8sInsecureSkipTLSVerify = true
+		client, err := clientv3.New(*config)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			err := client.(interface {
+				Backend() bapi.Client
+			}).Backend().Clean()
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		testFn(t, true, client)
+	})
+}

--- a/calicoctl/tests/fv/utils/env.go
+++ b/calicoctl/tests/fv/utils/env.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"os"
+
+	. "github.com/onsi/gomega"
+)
+
+func PatchEnv(key, value string) (unpatch func(), err error) {
+	oldKC, oldKCSet := os.LookupEnv(key)
+	err = os.Setenv(key, value)
+	if err != nil {
+		return
+	}
+	if oldKCSet {
+		unpatch = func() {
+			Expect(os.Setenv(key, oldKC)).NotTo(HaveOccurred())
+		}
+	} else {
+		unpatch = func() {
+			Expect(os.Unsetenv(key)).NotTo(HaveOccurred())
+		}
+	}
+	return
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

* Fix that `calicoctl ipam release` could only release IPAM handles when running in etcd mode.
* Rework the calicoctl FV tests so they run against both etcd and kubernetes.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that `calicoctl ipam release` could only release IPAM handles when running in etcd mode.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
