### PR TITLE
fix: pods lost ip addreses after windows node reboot.

### DIFF
--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -22,6 +22,8 @@ $baseDir = "$PSScriptRoot\.."
 ipmo $baseDir\libs\calico\calico.psm1 -Force
 
 Write-Host "Running kubelet service."
+Wait-ForCalicoInit
+
 Write-Host "Using configured nodename: $env:NODENAME DNS: $env:DNS_NAME_SERVERS"
 
 Write-Host "Auto-detecting node IP, looking for interface named like '$InterfaceName' ..."

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -22,6 +22,10 @@ $baseDir = "$PSScriptRoot\.."
 ipmo $baseDir\libs\calico\calico.psm1 -Force
 
 Write-Host "Running kubelet service."
+
+# After restart of node network adapter goes to the wrong state. So, CalicoNode service recreates it.
+# But kubelet can start some pods using broken adapter before CalicoNode complete initialization.
+# So, we need to wait for complete Calico initialization.
 Wait-ForCalicoInit
 
 Write-Host "Using configured nodename: $env:NODENAME DNS: $env:DNS_NAME_SERVERS"


### PR DESCRIPTION
## Description

Currently pods (on Windows nodes) lost network adapters after node reboot. 
It happens because after node reboot kubelet starts when calico is not ready yet and restart pods using network adapters that will be deleted during CalicoNode startup.

Health checks don't solve the issue because network adapter doesn't recreated in this case. We can't delete this pods normally (without --force key).

This PR change startup of kubelet ensure that it starts after the calico network initialized.

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/5828

## Todos

- [x] Release note
- [x] Rebase
- [ ] Squash commits

## Release Note

```release-note
windows: ensure calico-managed kubelet starts after the calico network has been initialized
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
