### PR TITLE
Swap Typha's Ctrie for Google's B-Tree library. Add snapshot size gauge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/BurntSushi/toml v1.2.0
 	github.com/Microsoft/hcsshim v0.8.22
-	github.com/Workiva/go-datastructures v1.0.53
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go-v2 v1.11.0
 	github.com/aws/aws-sdk-go-v2/config v1.10.0
@@ -27,6 +26,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/protobuf v1.5.2
+	github.com/google/btree v1.1.2
 	github.com/google/gopacket v1.1.19
 	github.com/google/netstack v0.0.0-20191123085552-55fcc16cd0eb
 	github.com/google/uuid v1.2.0
@@ -165,7 +165,6 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
-	github.com/google/btree v1.0.1 // indirect
 	github.com/google/cadvisor v0.44.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 h1:UUppSQnhf4Yc6xGxSkoQpPhb7RVzuv5Nb1mwJ5VId9s=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/Workiva/go-datastructures v1.0.53 h1:J6Y/52yX10Xc5JjXmGtWoSSxs3mZnGSaq37xZZh7Yig=
-github.com/Workiva/go-datastructures v1.0.53/go.mod h1:1yZL+zfsztete+ePzZz/Zb1/t5BnDuE2Ya2MMGhzP6A=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
@@ -406,8 +404,9 @@ github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
+github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
+github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/cadvisor v0.44.1 h1:hsAxDZOY+5xSCXH12d/G9cxYTfP+32cMT3J7aatrgDY=
 github.com/google/cadvisor v0.44.1/go.mod h1:GQ9KQfz0iNHQk3D6ftzJWK4TXabfIgM10Oy3FkR+Gzg=
 github.com/google/cel-go v0.10.1 h1:MQBGSZGnDwh7T/un+mzGKOMz3x+4E/GDPprWjDL+1Jg=
@@ -737,7 +736,6 @@ github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -876,11 +874,9 @@ github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BG
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae h1:vgGSvdW5Lqg+I1aZOlG32uyE6xHpLdKhZzcTEktz5wM=
 github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae/go.mod h1:quDq6Se6jlGwiIKia/itDZxqC5rj6/8OdFyMMAwTxCs=
-github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
@@ -1299,7 +1295,6 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
-golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -358,7 +358,7 @@ func (t *TyphaDaemon) addSyncerPipeline(
 	cache := snapcache.New(snapcache.Config{
 		MaxBatchSize:     t.ConfigParams.SnapshotCacheMaxBatchSize,
 		HealthAggregator: t.healthAggregator,
-		HealthName:       string(syncerType),
+		Name:             string(syncerType),
 	})
 
 	pipeline := &syncerPipeline{

--- a/typha/pkg/snapcache/cache.go
+++ b/typha/pkg/snapcache/cache.go
@@ -21,13 +21,12 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/Workiva/go-datastructures/trie/ctrie"
-	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
-
+	"github.com/google/btree"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
 	cprometheus "github.com/projectcalico/calico/libcalico-go/lib/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/typha/pkg/jitter"
 	"github.com/projectcalico/calico/typha/pkg/syncproto"
@@ -74,7 +73,7 @@ func init() {
 	prometheus.MustRegister(counterUpdatesSkipped)
 }
 
-// SnapshotCache consumes updates from the Syncer API and caches them in the form of a series of
+// Cache consumes updates from the Syncer API and caches them in the form of a series of
 // Breadcrumb objects.  Each Breadcrumb (conceptually) contains the complete snapshot of the
 // datastore at the revision it was created as well as a list of deltas from the previous snapshot.
 // A client that wants to keep in sync can get the current Breadcrumb, process the key-value pairs
@@ -89,10 +88,10 @@ func init() {
 //
 // Implementation
 //
-// To avoid the overhead of taking a complete copy of the state for each Breadcrumb, we use a Ctrie,
+// To avoid the overhead of taking a complete copy of the state for each Breadcrumb, we use a B-tree,
 // which supports efficient, concurrent-read-safe snapshots.  The main thread of the SnapshotCache
-// processes updates sequentially, updating the Ctrie.  After processing a batch of updates, the
-// main thread generates a new Breadcrumb object with a read-only snapshot of the Ctrie along with
+// processes updates sequentially, updating the B-tree.  After processing a batch of updates, the
+// main thread generates a new Breadcrumb object with a snapshot of the B-tree along with
 // the list of deltas.
 //
 // Each Breadcrumb object contains a pointer to the next Breadcrumb, which is filled in using an
@@ -103,7 +102,7 @@ func init() {
 //
 // Why not use channels to fan out to the clients?  I think it'd be more tricky to make robust and
 // non-blocking:  We'd need to keep a list of channels to send to (one per client); the
-// book-keeping around adding/removing from that list is a little fiddly and we'd need to
+// bookkeeping around adding/removing from that list is a little fiddly and we'd need to
 // iterate over the list (which may be slow) to send the updates to each client.  If any of the
 // clients were blocked, we'd need to selectively skip channels (else we'd block all clients due
 // to one slow client) and keep track of what we'd sent to each channel.  All doable but, I think,
@@ -119,7 +118,7 @@ type Cache struct {
 
 	// kvs contains the current state of the datastore.  Its keys are the serialized form of our model keys
 	// and the values are SerializedUpdate objects.
-	kvs *ctrie.Ctrie
+	kvs *btree.BTreeG[syncproto.SerializedUpdate]
 	// breadcrumbCond is the condition variable used to signal when a new breadcrumb is available.
 	breadcrumbCond *sync.Cond
 	// currentBreadcrumb points to the most recent Breadcrumb, which contains the most recent snapshot of kvs.
@@ -170,12 +169,12 @@ func (config *Config) ApplyDefaults() {
 
 func New(config Config) *Cache {
 	config.ApplyDefaults()
-	kvs := ctrie.New(nil /*default hash factory*/)
+	kvs := btree.NewG[syncproto.SerializedUpdate](2, func(a, b syncproto.SerializedUpdate) bool { return a.Key < b.Key })
 	cond := sync.NewCond(&sync.Mutex{})
 	snap := &Breadcrumb{
 		Timestamp: time.Now(),
 		nextCond:  cond,
-		KVs:       kvs.ReadOnlySnapshot(),
+		KVs:       kvs.Clone(),
 	}
 	c := &Cache{
 		config:            config,
@@ -304,8 +303,8 @@ func (c *Cache) publishBreadcrumbs() {
 	}
 }
 
-// publishBreadcrumb updates the master Ctrie and publishes a new Breadcrumb containing a read-only
-// snapshot of the Ctrie and the deltas from this batch.
+// publishBreadcrumb updates the master tree and publishes a new Breadcrumb containing a read-only
+// snapshot of the tree and the deltas from this batch.
 func (c *Cache) publishBreadcrumb() {
 	var somethingChanged bool
 	var updates []api.Update
@@ -347,8 +346,7 @@ func (c *Cache) publishBreadcrumb() {
 			continue
 		}
 		// Update the master KV map.
-		keyAsBytes := []byte(newUpd.Key)
-		oldUpd, exists := c.kvs.Lookup(keyAsBytes)
+		oldUpd, exists := c.kvs.Get(newUpd)
 		log.WithFields(log.Fields{
 			"oldUpd": oldUpd,
 			"newUpd": newUpd,
@@ -357,9 +355,9 @@ func (c *Cache) publishBreadcrumb() {
 			// This is either a deletion or a validation failure.  We can't skip deletions even if we
 			// didn't have that key before because we need to pass through the UpdateType for Felix to
 			// correctly calculate its stats.
-			c.kvs.Remove(keyAsBytes)
+			c.kvs.Delete(newUpd)
 		} else {
-			if exists && newUpd.WouldBeNoOp(oldUpd.(syncproto.SerializedUpdate)) {
+			if exists && newUpd.WouldBeNoOp(oldUpd) {
 				log.WithField("key", newUpd.Key).Debug("Skipping update to unchanged key")
 				counterUpdatesSkipped.Inc()
 				continue
@@ -369,7 +367,7 @@ func (c *Cache) publishBreadcrumb() {
 			// the KV and adjust it before storing it in the snapshot.
 			updToStore := newUpd
 			updToStore.UpdateType = api.UpdateTypeKVNew
-			c.kvs.Insert(keyAsBytes, updToStore)
+			c.kvs.ReplaceOrInsert(updToStore)
 		}
 
 		// Record the update in the new Breadcrumb so that clients following the chain of
@@ -385,7 +383,7 @@ func (c *Cache) publishBreadcrumb() {
 
 	summaryUpdateSize.Observe(float64(len(newCrumb.Deltas)))
 	// Add the new read-only snapshot to the new crumb.
-	newCrumb.KVs = c.kvs.ReadOnlySnapshot()
+	newCrumb.KVs = c.kvs.Clone()
 
 	// Replace the Breadcrumb and link the old Breadcrumb to the new so that clients can follow
 	// the trail.
@@ -406,7 +404,7 @@ type Breadcrumb struct {
 	SequenceNumber uint64
 	Timestamp      time.Time
 
-	KVs        *ctrie.Ctrie
+	KVs        *btree.BTreeG[syncproto.SerializedUpdate]
 	Deltas     []syncproto.SerializedUpdate
 	SyncStatus api.SyncStatus
 

--- a/typha/pkg/snapcache/cache.go
+++ b/typha/pkg/snapcache/cache.go
@@ -22,11 +22,12 @@ import (
 	"unsafe"
 
 	"github.com/google/btree"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
 	cprometheus "github.com/projectcalico/calico/libcalico-go/lib/prometheus"
-	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/typha/pkg/jitter"
 	"github.com/projectcalico/calico/typha/pkg/syncproto"
@@ -38,6 +39,7 @@ const (
 )
 
 var (
+	// FIXME All of these should be upgraded to vectors so that each syncer has its own stats.
 	summaryUpdateSize = cprometheus.NewSummary(prometheus.SummaryOpts{
 		Name: "typha_breadcrumb_size",
 		Help: "Number of KVs recorded in each breadcrumb.",
@@ -62,11 +64,17 @@ var (
 		Name: "typha_updates_skipped",
 		Help: "Total number of updates skipped as duplicates.",
 	})
+
+	gaugeVecSnapshotSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "typha_snapshot_size",
+		Help: "Current number of key/value pairs contained in the cache of the datastore.",
+	}, []string{"syncer"})
 )
 
 func init() {
 	prometheus.MustRegister(summaryUpdateSize)
 	prometheus.MustRegister(gaugeCurrentSequenceNumber)
+	prometheus.MustRegister(gaugeVecSnapshotSize)
 	prometheus.MustRegister(counterBreadcrumbNonBlock)
 	prometheus.MustRegister(counterBreadcrumbBlock)
 	prometheus.MustRegister(counterUpdatesTotal)
@@ -128,11 +136,13 @@ type Cache struct {
 
 	wakeUpTicker *jitter.Ticker
 	healthTicks  <-chan time.Time
+
+	gaugeSnapSize prometheus.Gauge
 }
 
 const (
-	healthNameDefault = "cache"
-	healthInterval    = 10 * time.Second
+	nameDefault    = "cache"
+	healthInterval = 10 * time.Second
 )
 
 type healthAggregator interface {
@@ -144,7 +154,7 @@ type Config struct {
 	MaxBatchSize     int
 	WakeUpInterval   time.Duration
 	HealthAggregator healthAggregator
-	HealthName       string
+	Name             string
 }
 
 func (config *Config) ApplyDefaults() {
@@ -162,8 +172,8 @@ func (config *Config) ApplyDefaults() {
 		}).Info("Defaulting WakeUpInterval.")
 		config.WakeUpInterval = defaultWakeUpInterval
 	}
-	if config.HealthName == "" {
-		config.HealthName = healthNameDefault
+	if config.Name == "" {
+		config.Name = nameDefault
 	}
 }
 
@@ -185,8 +195,15 @@ func New(config Config) *Cache {
 		wakeUpTicker:      jitter.NewTicker(config.WakeUpInterval, config.WakeUpInterval/10),
 		healthTicks:       time.NewTicker(healthInterval).C,
 	}
+
+	var err error
+	c.gaugeSnapSize, err = gaugeVecSnapshotSize.GetMetricWithLabelValues(config.Name)
+	if err != nil {
+		log.WithError(err).Panic("Bug: failed to get Prometheus gauge.")
+	}
+
 	if config.HealthAggregator != nil {
-		config.HealthAggregator.RegisterReporter(config.HealthName, &health.HealthReport{Live: true, Ready: true}, healthInterval*2)
+		config.HealthAggregator.RegisterReporter(config.Name, &health.HealthReport{Live: true, Ready: true}, healthInterval*2)
 	}
 	c.reportHealth()
 	return c
@@ -286,7 +303,7 @@ func (c *Cache) fillBatchFromInputQueue(ctx context.Context) error {
 
 func (c *Cache) reportHealth() {
 	if c.config.HealthAggregator != nil {
-		c.config.HealthAggregator.Report(c.config.HealthName, &health.HealthReport{
+		c.config.HealthAggregator.Report(c.config.Name, &health.HealthReport{
 			Live:  true,
 			Ready: c.pendingStatus == api.InSync,
 		})
@@ -382,6 +399,7 @@ func (c *Cache) publishBreadcrumb() {
 	}
 
 	summaryUpdateSize.Observe(float64(len(newCrumb.Deltas)))
+	c.gaugeSnapSize.Set(float64(c.kvs.Len()))
 	// Add the new read-only snapshot to the new crumb.
 	newCrumb.KVs = c.kvs.Clone()
 

--- a/typha/pkg/snapcache/cache_test.go
+++ b/typha/pkg/snapcache/cache_test.go
@@ -82,11 +82,13 @@ func (r *healthRecorder) LastReport() (rep health.HealthReport) {
 
 func crumbToSnapshotUpdates(crumb *snapcache.Breadcrumb) []api.Update {
 	var snapshotUpdates []api.Update
-	for entry := range crumb.KVs.Iterator(nil) {
-		upd, err := entry.Value.(syncproto.SerializedUpdate).ToUpdate()
+	crumb.KVs.Ascend(func(entry syncproto.SerializedUpdate) bool {
+		upd, err := entry.ToUpdate()
 		Expect(err).NotTo(HaveOccurred())
 		snapshotUpdates = append(snapshotUpdates, upd)
-	}
+		return true // Keep iterating.
+	})
+
 	return snapshotUpdates
 }
 
@@ -144,13 +146,9 @@ var _ = Describe("Snapshot cache FV tests", func() {
 			// Wait for the update to flow through...
 			Eventually(func() bool {
 				crumb = cache.CurrentBreadcrumb()
-				crumbSize := crumb.KVs.Size()
-				// Check snapshot is read-only.
-				Expect(func() {
-					crumb.KVs.Insert([]byte("abcd"), "unused")
-				}).To(Panic())
+				crumbSize := crumb.KVs.Len()
 				log.WithField("crumb", crumb).WithField("size", crumbSize).Info("Current crumb now...")
-				Consistently(func() uint { return crumb.KVs.Size() }).Should(Equal(crumbSize))
+				Consistently(crumb.KVs.Len).Should(Equal(crumbSize))
 				return crumbSize > 0
 			}).Should(BeTrue())
 			log.WithField("crumb", crumb).Info("Got initial crumb")
@@ -227,13 +225,9 @@ var _ = Describe("Snapshot cache FV tests", func() {
 			// Wait for the update to flow through...
 			Eventually(func() bool {
 				crumb = cache.CurrentBreadcrumb()
-				crumbSize := crumb.KVs.Size()
-				// Check snapshot is read-only.
-				Expect(func() {
-					crumb.KVs.Insert([]byte("abcd"), "unused")
-				}).To(Panic())
+				crumbSize := crumb.KVs.Len()
 				log.WithField("crumb", crumb).WithField("size", crumbSize).Info("Current crumb now...")
-				Consistently(func() uint { return crumb.KVs.Size() }).Should(Equal(crumbSize))
+				Consistently(crumb.KVs.Len).Should(Equal(crumbSize))
 				return crumbSize > 0
 			}).Should(BeTrue())
 			log.WithField("crumb", crumb).Info("Got initial crumb")
@@ -583,14 +577,16 @@ func (f *follower) Loop(cxt context.Context) {
 	crumb := f.cache.CurrentBreadcrumb()
 	logCxt.WithField("crumb", crumb.SequenceNumber).Info("Got first crumb")
 	done := false
-	for item := range crumb.KVs.Iterator(cxt.Done()) {
-		upd := item.Value.(syncproto.SerializedUpdate)
-		f.storeKV(upd)
+
+	crumb.KVs.Ascend(func(update syncproto.SerializedUpdate) bool {
+		f.storeKV(update)
 		if crumb.SyncStatus == api.InSync {
 			f.inSyncAt = f.maxRev
 			done = true
 		}
-	}
+		return true // Keep iterating.
+	})
+
 	var minSleepCrumbSeqNo uint64
 	for !done && cxt.Err() == nil {
 		var err error

--- a/typha/pkg/snapcache/cache_test.go
+++ b/typha/pkg/snapcache/cache_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Snapshot cache FV tests", func() {
 			MaxBatchSize:     10,
 			WakeUpInterval:   10 * time.Second,
 			HealthAggregator: mockHealth,
-			HealthName:       "my-cache",
+			Name:             "my-cache",
 		}
 		cache = snapcache.New(cacheConfig)
 		cxt, cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- The B-tree's `Len()` operation is `O(1)` whereas Ctrie was `O(n)` so we can add a gauge to monitor snapshot size.
- The B-tree lib supports generics.
- The B-tree lib supports mutable updates in between snapshots (should perform better under load).
- B-tree's aren't so "exotic".  The Ctrie we were using before was a really unusual datastructure that was optimised for other use cases (concurrent insert/remove); it was very hard to understand and debug when it went wrong.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Typha now uses a B-tree for its internal cache, which allows it to export a Prometheus metric, typha_snapshot_size, that gives the total size of its current snapshot of the Calico datastore.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
