### PR TITLE
Containerize OpenStack UT + FV testing

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -628,12 +628,10 @@ blocks:
     prologue:
       commands:
       - cd networking-calico
-      - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
-      - sudo pip3 install tox
     jobs:
       - name: 'Unit and FV tests (tox)'
         commands:
-          - ../.semaphore/run-and-monitor tox.log tox
+          - ../.semaphore/run-and-monitor tox.log make tox
       # TODO: Re-enable
       # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
       #   commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -628,12 +628,10 @@ blocks:
     prologue:
       commands:
       - cd networking-calico
-      - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
-      - sudo pip3 install tox
     jobs:
       - name: 'Unit and FV tests (tox)'
         commands:
-          - ../.semaphore/run-and-monitor tox.log tox
+          - ../.semaphore/run-and-monitor tox.log make tox
       # TODO: Re-enable
       # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
       #   commands:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -626,12 +626,10 @@ blocks:
     prologue:
       commands:
       - cd networking-calico
-      - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
-      - sudo pip3 install tox
     jobs:
       - name: 'Unit and FV tests (tox)'
         commands:
-          - ../.semaphore/run-and-monitor tox.log tox
+          - ../.semaphore/run-and-monitor tox.log make tox
       # TODO: Re-enable
       # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
       #   commands:

--- a/networking-calico/.testr.conf
+++ b/networking-calico/.testr.conf
@@ -2,8 +2,8 @@
 test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-0} \
              OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/tests $LISTOPT $IDOPTION
-             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/plugins/ml2/drivers/calico/test $LISTOPT $IDOPTION
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/tests
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/plugins/ml2/drivers/calico/test
 test_id_option=--load-list $IDFILE
 test_list_option=--list
 test_run_concurrency=echo 1

--- a/networking-calico/.testr.conf
+++ b/networking-calico/.testr.conf
@@ -3,7 +3,10 @@ test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-0} \
              OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
              ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/tests
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/plugins/ml2/drivers/calico/test
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_election
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_plugin_etcd
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_compaction
+
 test_id_option=--load-list $IDFILE
 test_list_option=--list
 test_run_concurrency=echo 1

--- a/networking-calico/Dockerfile
+++ b/networking-calico/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/coreos/etcd:v3.3.11 as etcd
+
+FROM python:3.8
+
+COPY --from=etcd /usr/local/bin/etcd /usr/local/bin/etcd
+
+RUN pip3 install tox

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -3,3 +3,7 @@ include ../metadata.mk
 ###############################################################################
 # TODO: Release
 ###############################################################################
+
+tox:
+	docker build -t networking-calico-test .
+	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code --rm networking-calico-test tox

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
@@ -180,10 +180,7 @@ class TestElection(unittest.TestCase):
     def test_exception_detail_logging(self):
         LOG.debug("test_exception_detail_logging")
 
-        with mock.patch.object(
-                log.getLogger(
-                    'networking_calico.plugins.ml2.drivers.calico.election'),
-                'warning') as mock_lw:
+        with mock.patch.object(election.LOG, 'warning') as mock_lw:
             etcdv3._client = client = stub_etcd.Client()
             exc = e3e.Etcd3Exception(detail_text="Unauthorised user")
             client.add_read_exception(exc)

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -20,3 +20,5 @@ neutron>=16,<17
 neutron-lib==2.3.0
 mock>=3.0.0 # BSD
 pyroute2<0.6.0 # Apache v2
+
+nose2


### PR DESCRIPTION
#### Use nose2 instead of subunit to discover and run tests

- subunit.run appears to be undocumented
- with nose2 I can add `-v` to get the name of each test printed before it runs

#### Use Python 3.8 container to run UT and FV tests

Allows any developer to run these tests, without dependence on their Linux install.  Specifically,
on my current Ubuntu, "python3" is now 3.10 and I don't know if it's possible to get a 3.8 install
via apt.

Also adds a handy `make tox` target.

Since the tests then run in a container, we can't use `docker run ...` to run an etcd server.
Instead we add etcd into the Python 3.8 container.

#### Use `election.LOG` to mock the election module's logging

I don't understand why `log.getLogger('networking_calico.plugins.ml2.drivers.calico.election')` no
longer works, given the other changes in this PR, but anyway using `election.LOG` feels more
elegant.

#### Update Semaphore to use 'make tox'

#### Run ML2 driver tests separately

I was seeing failures when running all of these together in a single test run.  I guess that's
because the ordering is different than it was with subunit, and there is mocking left over from one
file that affects a following file.  It has never been intended to have mocking interactions between
test files, and so we can avoid this problem just by running each test file in its own run.
