### PR TITLE
Reinstate DevStack testing (for OpenStack)

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -625,6 +625,10 @@ blocks:
     when: "true or change_in(['/networking-calico/'])"
   dependencies: ["Prerequisites"]
   task:
+    agent:
+      machine:
+        type: e1-standard-4
+        os_image: ubuntu1804
     prologue:
       commands:
       - cd networking-calico

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -642,6 +642,8 @@ blocks:
           # message for more context.
           - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
           - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -632,18 +632,17 @@ blocks:
       - name: 'Unit and FV tests (tox)'
         commands:
           - ../.semaphore/run-and-monitor tox.log make tox
-      # TODO: Re-enable
-      # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
-      #   commands:
-      #     - git checkout -b devstack-test
-      #     - export LIBVIRT_TYPE=qemu
-      #     - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
-      #     # Use proposed fix at
-      #     # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
-      #     # message for more context.
-      #     - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
-      #     - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
-      #     - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
+      - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
+        commands:
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
+          # Use proposed fix at
+          # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
+          # message for more context.
+          - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
+          - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -642,6 +642,8 @@ blocks:
           # message for more context.
           - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
           - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -632,18 +632,17 @@ blocks:
       - name: 'Unit and FV tests (tox)'
         commands:
           - ../.semaphore/run-and-monitor tox.log make tox
-      # TODO: Re-enable
-      # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
-      #   commands:
-      #     - git checkout -b devstack-test
-      #     - export LIBVIRT_TYPE=qemu
-      #     - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
-      #     # Use proposed fix at
-      #     # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
-      #     # message for more context.
-      #     - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
-      #     - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
-      #     - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
+      - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
+        commands:
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
+          # Use proposed fix at
+          # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
+          # message for more context.
+          - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
+          - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -625,6 +625,10 @@ blocks:
     when: "false or change_in(['/networking-calico/'])"
   dependencies: ["Prerequisites"]
   task:
+    agent:
+      machine:
+        type: e1-standard-4
+        os_image: ubuntu1804
     prologue:
       commands:
       - cd networking-calico

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -640,6 +640,8 @@ blocks:
           # message for more context.
           - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
           - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
           - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -630,18 +630,17 @@ blocks:
       - name: 'Unit and FV tests (tox)'
         commands:
           - ../.semaphore/run-and-monitor tox.log make tox
-      # TODO: Re-enable
-      # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
-      #   commands:
-      #     - git checkout -b devstack-test
-      #     - export LIBVIRT_TYPE=qemu
-      #     - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
-      #     # Use proposed fix at
-      #     # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
-      #     # message for more context.
-      #     - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
-      #     - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
-      #     - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
+      - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
+        commands:
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
+          # Use proposed fix at
+          # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
+          # message for more context.
+          - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
+          - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -623,6 +623,10 @@ blocks:
     when: "${FORCE_RUN} or change_in(['/networking-calico/'])"
   dependencies: ["Prerequisites"]
   task:
+    agent:
+      machine:
+        type: e1-standard-4
+        os_image: ubuntu1804
     prologue:
       commands:
       - cd networking-calico

--- a/devstack
+++ b/devstack
@@ -1,0 +1,1 @@
+networking-calico/devstack

--- a/networking-calico/devstack/README.rst
+++ b/networking-calico/devstack/README.rst
@@ -2,6 +2,6 @@
 DevStack plugin for Calico
 ==========================
 
-Welcome to networking-calico's DevStack plugin!  For how to use this, please
+Welcome to Calico's DevStack plugin!  For how to use this, please
 see
 http://docs.projectcalico.org/master/getting-started/openstack/installation/devstack.

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -121,6 +121,8 @@ disable_service horizon
 LOGFILE=stack.log
 LOG_COLOR=False
 
+TEMPEST_BRANCH=29.0.0
+
 EOF
 
 if ! ${TEMPEST:-false}; then

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -33,7 +33,7 @@ set -ex
 #
 #     If the SERVICE_HOST environment variable is already set when ./stack.sh
 #     is run, and is _different_ from the local machine's hostname, the
-#     networking-calico DevStack plugin will interpret that as a request to set
+#     Calico DevStack plugin will interpret that as a request to set
 #     up a compute-only node, that points to $SERVICE_HOST as its controller.
 #
 #     On the other hand, if SERVICE_HOST is not set, or is the _same_ as the
@@ -62,30 +62,33 @@ set -ex
 #     set to 'true', Tempest will be installed and the required initial
 #     networks created, ready for a Tempest run after the stack setup has
 #     completed.
+#
+# NC_PLUGIN_REPO
+#
+#     Repository for the Calico devstack plugin.  By default this is
+#     https://github.com/projectcalico/calico.
+#
+# NC_PLUGIN_REF
+#
+#     Git ref for the Calico devstack plugin.  By default this is master.
+#
 # ------------------------------------------------------------------------------
+
+: ${NC_PLUGIN_REPO:=https://github.com/projectcalico/calico}
+: ${NC_PLUGIN_REF:=master}
 
 # Assume that we are starting from the home directory of a non-root
 # user that can sudo, and hence is suitable for running DevStack.  For
 # example, the 'ubuntu' user on Ubuntu.
 cd
 
-# Create a directory for Calico stuff.
-mkdir -p calico
-cd calico
+# Create a directory for DevStack bootstrap and testing.
+mkdir -p devstack-bootstrap
+cd devstack-bootstrap
 
 # Ensure that Git is installed.
 sudo apt-get update
 sudo apt-get -y install git
-
-# Prepare networking-calico tree - the following lines will check out
-# the master branch of networking-calico (if not already present).
-test -e networking-calico
-pushd networking-calico
-
-# Remember the current directory.
-ncdir=`pwd`
-ncref=`git rev-parse --abbrev-ref HEAD`
-popd
 
 # Enable IPv4 and IPv6 forwarding.
 sudo sysctl -w net.ipv4.ip_forward=1
@@ -112,7 +115,7 @@ RABBIT_PASSWORD=6366743536a8216bde26
 SERVICE_PASSWORD=91eb72bcafb4ddf246ab
 SERVICE_TOKEN=c5680feca5e2c9c8f820
 
-enable_plugin networking-calico $ncdir $ncref
+enable_plugin calico $NC_PLUGIN_REPO $NC_PLUGIN_REF
 disable_service horizon
 
 LOGFILE=stack.log
@@ -164,7 +167,7 @@ if ! ${TEMPEST:-false}; then
     fi
 else
     # Run mainline Tempest tests.
-    source ../networking-calico/devstack/devstackgaterc
+    source ../calico/devstack/devstackgaterc
     cd /opt/stack/tempest
     tox -eall -- $DEVSTACK_GATE_TEMPEST_REGEX --concurrency=$TEMPEST_CONCURRENCY
 fi

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -62,7 +62,7 @@ EOF
 		    install_package calico-common
 
 		    # Install networking-calico.
-		    pip_install "${GITDIR['networking-calico']}"
+		    pip_install "${GITDIR['calico']}/networking-calico"
 
 		    ;;
 
@@ -132,7 +132,7 @@ EOF
 		    export ETCDCTL_API=3
 		    export ETCDCTL_ENDPOINTS=http://$SERVICE_HOST:$ETCD_PORT
 		    run_process calico-bird \
-                      "${DEST}/networking-calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl"
+                      "${DEST}/calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl"
 
 		    # Run the Calico DHCP agent.
 		    sudo mkdir /var/log/neutron || true


### PR DESCRIPTION
Yay, we have DevStack testing again.  Changes needed were as follows:

- Use e1-standard-4 instead of e1-standard-2.  With e1-standard-2 we get OOM killing during the test run.
- Tweaked method for passing in the location and ref of the networking-calico code to use as a DevStack plugin, now that networking-calico is part of the monorepo.
- Top-level `devstack` -> `networking-calico/devstack` symbolic link, needed for the monorepo as a whole to function as a DevStack plugin.
- Pin to Tempest code similar to what we were using (from Tempest master) when this test was last running and passing.