### PR TITLE
felix/bpf: simplify programming jump maps

### DIFF
--- a/felix/bpf/bpf_defs.go
+++ b/felix/bpf/bpf_defs.go
@@ -77,16 +77,3 @@ var ErrIterationFinished = errors.New("iteration finished")
 // ErrVisitedTooManyKeys is returned by the MapIterator's Next() method if it sees many more keys than there should
 // be in the map.
 var ErrVisitedTooManyKeys = errors.New("visited 10x the max size of the map keys")
-
-const (
-	ProgIndexPolicy = iota
-	ProgIndexAllowed
-	ProgIndexICMP
-	ProgIndexDrop
-	ProgIndexHostCTConflict
-	ProgIndexV6Prologue
-	ProgIndexV6Policy
-	ProgIndexV6Allowed
-	ProgIndexV6ICMP
-	ProgIndexV6Drop
-)

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -28,6 +28,7 @@ import (
 
 	. "github.com/projectcalico/calico/felix/bpf/asm"
 	"github.com/projectcalico/calico/felix/bpf/state"
+	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
@@ -301,17 +302,17 @@ func (p *Builder) writeJumpIfToOrFromHost(label string) {
 
 func (p *Builder) indexOfDropProgram() int32 {
 	if p.forIPv6 {
-		return int32(bpf.ProgIndexV6Drop)
+		return int32(tcdefs.ProgIndexV6Drop)
 	} else {
-		return int32(bpf.ProgIndexDrop)
+		return int32(tcdefs.ProgIndexDrop)
 	}
 }
 
 func (p *Builder) indexOfAllowesProgram() int32 {
 	if p.forIPv6 {
-		return int32(bpf.ProgIndexV6Allowed)
+		return int32(tcdefs.ProgIndexV6Allowed)
 	} else {
-		return int32(bpf.ProgIndexAllowed)
+		return int32(tcdefs.ProgIndexAllowed)
 	}
 }
 

--- a/felix/bpf/tc/compiler.go
+++ b/felix/bpf/tc/compiler.go
@@ -40,21 +40,6 @@ const (
 	EpTypeNAT      EndpointType = "nat"
 )
 
-type ProgName string
-
-var programNames = []ProgName{
-	"calico_tc_norm_pol_tail",
-	"calico_tc_skb_accepted_entrypoint",
-	"calico_tc_skb_send_icmp_replies",
-	"calico_tc_skb_drop",
-	"calico_tc_host_ct_conflict",
-	"calico_tc_v6",
-	"calico_tc_v6_norm_pol_tail",
-	"calico_tc_v6_skb_accepted_entrypoint",
-	"calico_tc_v6_skb_send_icmp_replies",
-	"calico_tc_v6_skb_drop",
-}
-
 func SectionName(endpointType EndpointType, fromOrTo ToOrFromEp) string {
 	return fmt.Sprintf("calico_%s_%s_ep", fromOrTo, endpointType)
 }

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -47,6 +47,7 @@ const (
 	ProgIndexHostCtConflict
 	ProgIndexV6Prologue
 	ProgIndexV6Policy
+	ProgIndexV6Allowed
 	ProgIndexV6Icmp
 	ProgIndexV6Drop
 )
@@ -75,6 +76,7 @@ var JumpMapIndexes = map[string][]int{
 	"IPv6": []int{
 		ProgIndexV6Prologue,
 		ProgIndexV6Policy,
+		ProgIndexV6Allowed,
 		ProgIndexV6Icmp,
 		ProgIndexV6Drop,
 	},

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -38,3 +38,44 @@ const (
 
 	MarksMask uint32 = 0x1ff00000
 )
+
+const (
+	ProgIndexPolicy = iota
+	ProgIndexAllowed
+	ProgIndexIcmp
+	ProgIndexDrop
+	ProgIndexHostCtConflict
+	ProgIndexV6Prologue
+	ProgIndexV6Policy
+	ProgIndexV6Icmp
+	ProgIndexV6Drop
+)
+
+var ProgramNames = []string{
+	"calico_tc_norm_pol_tail",
+	"calico_tc_skb_accepted_entrypoint",
+	"calico_tc_skb_send_icmp_replies",
+	"calico_tc_skb_drop",
+	"calico_tc_host_ct_conflict",
+	"calico_tc_v6",
+	"calico_tc_v6_norm_pol_tail",
+	"calico_tc_v6_skb_accepted_entrypoint",
+	"calico_tc_v6_skb_send_icmp_replies",
+	"calico_tc_v6_skb_drop",
+}
+
+var JumpMapIndexes = map[string][]int{
+	"IPv4": []int{
+		ProgIndexPolicy,
+		ProgIndexAllowed,
+		ProgIndexIcmp,
+		ProgIndexDrop,
+		ProgIndexHostCtConflict,
+	},
+	"IPv6": []int{
+		ProgIndexV6Prologue,
+		ProgIndexV6Policy,
+		ProgIndexV6Icmp,
+		ProgIndexV6Drop,
+	},
+}


### PR DESCRIPTION
JumpMapIndexes defines which programs are to be loaded for each family and ProgIndex* together with ProgramNames dictate the indexes (order).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
