### PR TITLE
Split Typha metrics by syncer type

### DIFF
--- a/calico/reference/typha/prometheus.md
+++ b/calico/reference/typha/prometheus.md
@@ -16,31 +16,40 @@ are tied to particular implementation choices inside Typha we can't make any har
 metrics will persist across releases. However, we aim not to make any spurious changes to
 existing metrics.
 
-Many of Typha's metrics are now parameterised by "syncer type"; Typha runs one "syncer" for each
+##### Terminology
+
+**Syncer:** Many of Typha's metrics are now parameterised by "syncer type"; Typha runs one "syncer" for each
 type of client that it supports. The "syncer" is the component that synchronises Typha's local cache
 of the datastore with the upstream datastore. The syncer type is attached to the metrics via a
 Prometheus label `syncer="..."`.
 
-| Name                                 | Description                                                                                             |
-|--------------------------------------|---------------------------------------------------------------------------------------------------------|
-| `typha_cache_size`                   | The total number of key/value pairs in Typha's in-memory cache.                                         |
-| `typha_breadcrumb_block`             | Count of the number of times Typha got the next Breadcrumb after blocking.                              |
-| `typha_breadcrumb_non_block`         | typha_breadcrumb_non_block Count of the number of times Typha got the next Breadcrumb without blocking. |
-| `typha_breadcrumb_seq_number`        | Current (server-local) sequence number; number of snapshot deltas processed.                            |
-| `typha_breadcrumb_size`              | Number of KVs recorded in each breadcrumb.                                                              |
-| `typha_client_latency_secs`          | Per-client latency. I.e. how far behind the current state is each client.                               |
-| `typha_client_snapshot_send_secs`    | How long it took to send the initial snapshot to each client.                                           |
-| `typha_client_write_latency_secs`    | Per-client write. How long each write call is taking.                                                   |
-| `typha_connections_accepted`         | Total number of connections accepted over time.                                                         |
-| `typha_connections_active`           | Number of open client connections.                                                                      |
-| `typha_connections_dropped`          | Total number of connections dropped due to rebalancing.                                                 |
-| `typha_kvs_per_msg`                  | Number of KV pairs sent in each message.                                                                |
-| `typha_log_errors`                   | Number of errors encountered while logging.                                                             |
-| `typha_logs_dropped`                 | Number of logs dropped because the output stream was blocked.                                           |
-| `typha_next_breadcrumb_latency_secs` | Time to retrieve next breadcrumb when already behind.                                                   |
-| `typha_ping_latency`                 | Round-trip ping latency to client.                                                                      |
-| `typha_updates_skipped`              | Total number of updates skipped as duplicates.                                                          |
-| `typha_updates_total`                | Total number of updates received from the Syncer.                                                       |
+**Breadcrumb:** Typha's internal cache stores a series of snapshots of the state of the datastore along with
+a list of changes when compared to the previous snapshot.  We call the combination of a snapshot and the list of 
+changes a "breadcrumb".  Breadcrumbs are linked together into a linked list as they are created.  When a client
+connects, Typha sends the snapshot from the most recent breadcrumb to the client; then, it "follows the breadcrumbs"
+on behalf of that client, sending it the change list from each breadcrumb.
+
+| Name                                 | Description                                                                                                                                                             |
+|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `typha_cache_size`                   | The total number of key/value pairs in Typha's in-memory cache.                                                                                                         |
+| `typha_breadcrumb_block`             | Count of the number of times Typha got the next Breadcrumb after blocking.                                                                                              |
+| `typha_breadcrumb_non_block`         | typha_breadcrumb_non_block Count of the number of times Typha got the next Breadcrumb without blocking.                                                                 |
+| `typha_breadcrumb_seq_number`        | Current (server-local) sequence number; number of snapshot deltas processed.                                                                                            |
+| `typha_breadcrumb_size`              | Number of KVs recorded in each breadcrumb.                                                                                                                              |
+| `typha_client_latency_secs`          | Per-client latency. I.e. how far behind the current state is each client.                                                                                               |
+| `typha_client_snapshot_send_secs`    | How long it took to send the initial snapshot to each client.                                                                                                           |
+| `typha_client_write_latency_secs`    | Per-client write. How long each write call is taking.                                                                                                                   |
+| `typha_connections_accepted`         | Total number of connections accepted over time.                                                                                                                         |
+| `typha_connections_active`           | Number of open client connections (including connections that have not completed the handshake).                                                                        |
+| `typha_connections_streaming`        | Number of client connections that are actively streaming (i.e. connections that successfully completed the handshake).                                                  |
+| `typha_connections_dropped`          | Total number of connections dropped due to rebalancing.                                                                                                                 |
+| `typha_kvs_per_msg`                  | Number of KV pairs sent in each message.                                                                                                                                |
+| `typha_log_errors`                   | Number of errors encountered while logging.                                                                                                                             |
+| `typha_logs_dropped`                 | Number of logs dropped because the output stream was blocked.                                                                                                           |
+| `typha_next_breadcrumb_latency_secs` | Time to retrieve next breadcrumb when already behind.                                                                                                                   |
+| `typha_ping_latency`                 | Round-trip ping/pong latency to client.  Typha's protocol includes a regular ping/pong keepalive to verify that the connection is still up.                             |
+| `typha_updates_skipped`              | Total number of updates skipped because the datastore change was not relevant. (For example, an update to a Kubernetes Pod field that {{site.prodname}} does not read.) |
+| `typha_updates_total`                | Total number of updates received from the datastore.                                                                                                                    |
 
 Prometheus metrics are self-documenting, with metrics turned on, `curl` can be used to list the
 metrics along with their help text and type information.

--- a/calico/reference/typha/prometheus.md
+++ b/calico/reference/typha/prometheus.md
@@ -1,40 +1,46 @@
 ---
 title: Prometheus statistics
-description: Review metrics for the Typha component if you are using Prometheus. 
+description: Review metrics for the Typha component if you are using Prometheus.
 canonical_url: '/reference/typha/prometheus'
 ---
 
-Typha can be configured to report a number of metrics through Prometheus.  See the
+Typha can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration) for how to enable metrics reporting.
 
 ## Metric reference
 
 #### Typha specific
 
-Typha exports a number of Prometheus metrics.  The current set is as follows.  Since some metrics
+Typha exports a number of Prometheus metrics. The current set is as follows. Since some metrics
 are tied to particular implementation choices inside Typha we can't make any hard guarantees that
-metrics will persist across releases.  However, we aim not to make any spurious changes to
+metrics will persist across releases. However, we aim not to make any spurious changes to
 existing metrics.
 
-| Name          | Description     |
-| ------------- | --------------- |
-| `typha_breadcrumb_block` | Count of the number of times Typha got the next Breadcrumb after blocking. |
-| `typha_breadcrumb_non_block` | typha_breadcrumb_non_block Count of the number of times Typha got the next Breadcrumb without blocking. |
-| `typha_breadcrumb_seq_number` | Current (server-local) sequence number; number of snapshot deltas processed. |
-| `typha_breadcrumb_size` | Number of KVs recorded in each breadcrumb. |
-| `typha_client_latency_secs` | Per-client latency.  I.e. how far behind the current state is each client. |
-| `typha_client_snapshot_send_secs` | How long it took to send the initial snapshot to each client. |
-| `typha_client_write_latency_secs` | Per-client write.  How long each write call is taking. |
-| `typha_connections_accepted` | Total number of connections accepted over time. |
-| `typha_connections_active` | Number of open client connections. |
-| `typha_connections_dropped` | Total number of connections dropped due to rebalancing. |
-| `typha_kvs_per_msg` | Number of KV pairs sent in each message. |
-| `typha_log_errors` | Number of errors encountered while logging. |
-| `typha_logs_dropped` | Number of logs dropped because the output stream was blocked. |
-| `typha_next_breadcrumb_latency_secs` | Time to retrieve next breadcrumb when already behind. |
-| `typha_ping_latency` | Round-trip ping latency to client. |
-| `typha_updates_skipped` | Total number of updates skipped as duplicates. |
-| `typha_updates_total` | Total number of updates received from the Syncer. |
+Many of Typha's metrics are now parameterised by "syncer type"; Typha runs one "syncer" for each
+type of client that it supports. The "syncer" is the component that synchronises Typha's local cache
+of the datastore with the upstream datastore. The syncer type is attached to the metrics via a
+Prometheus label `syncer="..."`.
+
+| Name                                 | Description                                                                                             |
+|--------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `typha_cache_size`                   | The total number of key/value pairs in Typha's in-memory cache.                                         |
+| `typha_breadcrumb_block`             | Count of the number of times Typha got the next Breadcrumb after blocking.                              |
+| `typha_breadcrumb_non_block`         | typha_breadcrumb_non_block Count of the number of times Typha got the next Breadcrumb without blocking. |
+| `typha_breadcrumb_seq_number`        | Current (server-local) sequence number; number of snapshot deltas processed.                            |
+| `typha_breadcrumb_size`              | Number of KVs recorded in each breadcrumb.                                                              |
+| `typha_client_latency_secs`          | Per-client latency. I.e. how far behind the current state is each client.                               |
+| `typha_client_snapshot_send_secs`    | How long it took to send the initial snapshot to each client.                                           |
+| `typha_client_write_latency_secs`    | Per-client write. How long each write call is taking.                                                   |
+| `typha_connections_accepted`         | Total number of connections accepted over time.                                                         |
+| `typha_connections_active`           | Number of open client connections.                                                                      |
+| `typha_connections_dropped`          | Total number of connections dropped due to rebalancing.                                                 |
+| `typha_kvs_per_msg`                  | Number of KV pairs sent in each message.                                                                |
+| `typha_log_errors`                   | Number of errors encountered while logging.                                                             |
+| `typha_logs_dropped`                 | Number of logs dropped because the output stream was blocked.                                           |
+| `typha_next_breadcrumb_latency_secs` | Time to retrieve next breadcrumb when already behind.                                                   |
+| `typha_ping_latency`                 | Round-trip ping latency to client.                                                                      |
+| `typha_updates_skipped`              | Total number of updates skipped as duplicates.                                                          |
+| `typha_updates_total`                | Total number of updates received from the Syncer.                                                       |
 
 Prometheus metrics are self-documenting, with metrics turned on, `curl` can be used to list the
 metrics along with their help text and type information.
@@ -57,11 +63,12 @@ typha_breadcrumb_non_block 0
 typha_breadcrumb_seq_number 22215
 ...
 ```
+
 {: .no-select-button}
 
 #### CPU / memory metrics
 
-Typha also exports the default set of metrics that Prometheus makes available.  Currently, those
+Typha also exports the default set of metrics that Prometheus makes available. Currently, those
 include:
 
 | Name          | Description     |

--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -525,12 +525,12 @@ var _ = Describe("With an in-process Server", func() {
 		})
 
 		It("should report the correct number of connections", func() {
-			expectGaugeValue("typha_connections_active", 1.0)
+			expectGlobalGaugeValue("typha_connections_active", 1.0)
 		})
 
 		It("should report the correct number of connections after killing the client", func() {
 			clientCancel()
-			expectGaugeValue("typha_connections_active", 0.0)
+			expectGlobalGaugeValue("typha_connections_active", 0.0)
 		})
 	})
 
@@ -583,7 +583,7 @@ var _ = Describe("With an in-process Server", func() {
 			}
 			// After the timeout we should have dropped exactly the right number of connections.
 			Expect(numFinished).To(Equal(40))
-			expectGaugeValue("typha_connections_active", 60.0)
+			expectGlobalGaugeValue("typha_connections_active", 60.0)
 		})
 
 		It("should pass through a KV and status", func() {
@@ -604,14 +604,14 @@ var _ = Describe("With an in-process Server", func() {
 		})
 
 		It("should report the correct number of connections", func() {
-			expectGaugeValue("typha_connections_active", 100.0)
+			expectGlobalGaugeValue("typha_connections_active", 100.0)
 		})
 
 		It("should report the correct number of connections after killing the clients", func() {
 			for _, c := range clientStates {
 				c.clientCancel()
 			}
-			expectGaugeValue("typha_connections_active", 0.0)
+			expectGlobalGaugeValue("typha_connections_active", 0.0)
 		})
 
 		It("with churn, it should report the correct number of connections after killing the clients", func() {
@@ -627,7 +627,7 @@ var _ = Describe("With an in-process Server", func() {
 				c.clientCancel()
 				time.Sleep(100 * time.Microsecond)
 			}
-			expectGaugeValue("typha_connections_active", 0.0)
+			expectGlobalGaugeValue("typha_connections_active", 0.0)
 		})
 	})
 })
@@ -790,14 +790,14 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 				Fail("client wasn't disconnected within expected time")
 			case <-disconnected:
 			}
-			expectGaugeValue("typha_connections_active", 0.0)
+			expectGlobalGaugeValue("typha_connections_active", 0.0)
 		}
 
 		It("should clean up if the hello doesn't get sent", func() {
-			expectGaugeValue("typha_connections_active", 1.0)
+			expectGlobalGaugeValue("typha_connections_active", 1.0)
 			err := rawConn.Close()
 			Expect(err).ToNot(HaveOccurred())
-			expectGaugeValue("typha_connections_active", 0.0)
+			expectGlobalGaugeValue("typha_connections_active", 0.0)
 		})
 
 		Describe("After sending Hello with bad syncer type", func() {
@@ -1082,7 +1082,7 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			clientCxt, clientCancel := context.WithCancel(context.Background())
 			recorder := NewRecorder()
 
-			origGaugeValue, err := getCounter("typha_connections_grace_used")
+			origGaugeValue, err := getPerSyncerCounter("typha_connections_grace_used", syncproto.SyncerTypeFelix)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Make the client block after it reads the first update.  This means the server will have started
@@ -1124,14 +1124,14 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			sendNUpdates(1)
 
 			Eventually(recorder.Len, 2*time.Second).Should(BeNumerically("==", initialSnapshotSize+3))
-			Expect(getCounter("typha_connections_grace_used")).To(BeNumerically("==", origGaugeValue+1))
+			Expect(getPerSyncerCounter("typha_connections_grace_used", syncproto.SyncerTypeFelix)).To(BeNumerically("==", origGaugeValue+1))
 		})
 
 		It("client should get disconnected if it falls behind after the grace period", func() {
 			clientCxt, clientCancel := context.WithCancel(context.Background())
 			recorder := NewRecorder()
 
-			origGaugeValue, err := getCounter("typha_connections_grace_used")
+			origGaugeValue, err := getPerSyncerCounter("typha_connections_grace_used", syncproto.SyncerTypeFelix)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Make the client block after it reads the first update.  This means the server will have started
@@ -1187,12 +1187,12 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			Expect(recorder.Len()).To(BeNumerically("<=", initialSnapshotSize*2))
 
 			// Should not use the grace period at all.
-			Expect(getCounter("typha_connections_grace_used")).To(BeNumerically("==", origGaugeValue))
+			Expect(getPerSyncerCounter("typha_connections_grace_used", syncproto.SyncerTypeFelix)).To(BeNumerically("==", origGaugeValue))
 		})
 	})
 })
 
-func getGauge(name string) (float64, error) {
+func getGlobalGauge(name string) (float64, error) {
 	mfs, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
 		return 0, err
@@ -1205,23 +1205,31 @@ func getGauge(name string) (float64, error) {
 	return 0, errors.New("not found")
 }
 
-func getCounter(name string) (float64, error) {
+func expectGlobalGaugeValue(name string, value float64) {
+	Eventually(func() (float64, error) {
+		return getGlobalGauge(name)
+	}).Should(Equal(value))
+}
+
+func getPerSyncerCounter(name string, syncer syncproto.SyncerType) (float64, error) {
 	mfs, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
 		return 0, err
 	}
 	for _, mf := range mfs {
 		if mf.GetName() == name {
-			return mf.Metric[0].GetCounter().GetValue(), nil
+			for _, m := range mf.Metric {
+				for _, l := range m.Label {
+					if l.GetName() == "syncer" && l.GetValue() == string(syncer) {
+						return m.GetCounter().GetValue(), nil
+					}
+				}
+			}
+			// Found the metric but no value for that syncer yet.
+			return 0, nil
 		}
 	}
-	return 0, errors.New("not found")
-}
-
-func expectGaugeValue(name string, value float64) {
-	Eventually(func() (float64, error) {
-		return getGauge(name)
-	}).Should(Equal(value))
+	return 0, errors.New("metric not found")
 }
 
 // TLS connection tests.

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/projectcalico/calico/typha/pkg/daemon"
 	"github.com/projectcalico/calico/typha/pkg/discovery"
 	"github.com/projectcalico/calico/typha/pkg/syncproto"

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -15,21 +15,20 @@
 package daemon_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"strconv"
 	"sync"
 	"time"
 
-	. "github.com/projectcalico/calico/typha/pkg/daemon"
-	"github.com/projectcalico/calico/typha/pkg/discovery"
-
-	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/projectcalico/calico/typha/pkg/daemon"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
+	"github.com/projectcalico/calico/typha/pkg/syncproto"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
@@ -136,7 +135,7 @@ var _ = Describe("Daemon", func() {
 
 			It("should create the server components", func() {
 				d.CreateServer()
-				Expect(d.SyncerPipelines).To(HaveLen(4))
+				Expect(d.CachesBySyncerType).To(HaveLen(syncproto.NumSyncerTypes))
 				for _, p := range d.SyncerPipelines {
 					Expect(p.SyncerToValidator).ToNot(BeNil())
 					Expect(p.Syncer).ToNot(BeNil())

--- a/typha/pkg/k8s/rebalance.go
+++ b/typha/pkg/k8s/rebalance.go
@@ -54,7 +54,7 @@ func PollK8sForConnectionLimit(
 				logCxt.WithError(tErr).WithField("numTyphas", numTyphas).Warn(
 					"Failed to get number of Typhas")
 			}
-			// Get the number of nodes as an estimate for the number of Felix connections we should expect.
+			// Get the number of nodes.  We expect one syncer connection of each type per node.
 			numNodes, nErr := k8sAPI.GetNumNodes()
 			if nErr != nil || numNodes <= 0 {
 				logCxt.WithError(nErr).WithField("numNodes", numNodes).Warn(

--- a/typha/pkg/promutils/registration.go
+++ b/typha/pkg/promutils/registration.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promutils
+
+import (
+	"github.com/projectcalico/calico/typha/pkg/syncproto"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+// GetOrRegister tries to register the given collector with Prometheus' DefaultRegisterer.  If the registration fails
+// because an identical collector is already registered then it returns the existing collector.  Otherwise, it
+// returns the input collector.  Panics on other errors.
+func GetOrRegister[T prometheus.Collector](collector T) T {
+	err := prometheus.DefaultRegisterer.Register(collector)
+	if err != nil {
+		if err, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			return err.ExistingCollector.(T)
+		} else {
+			logrus.WithError(err).WithField("collector", collector).Panic("Failed to register prometheus collector.")
+		}
+	}
+	return collector
+}
+
+func PreCreateCounterPerSyncer(cv *prometheus.CounterVec) {
+	for _, st := range syncproto.AllSyncerTypes {
+		cv.WithLabelValues(string(st))
+	}
+}
+
+func PreCreateGaugePerSyncer(cv *prometheus.GaugeVec) {
+	for _, st := range syncproto.AllSyncerTypes {
+		cv.WithLabelValues(string(st))
+	}
+}

--- a/typha/pkg/promutils/registration.go
+++ b/typha/pkg/promutils/registration.go
@@ -15,9 +15,10 @@
 package promutils
 
 import (
-	"github.com/projectcalico/calico/typha/pkg/syncproto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/typha/pkg/syncproto"
 )
 
 // GetOrRegister tries to register the given collector with Prometheus' DefaultRegisterer.  If the registration fails

--- a/typha/pkg/snapcache/cache.go
+++ b/typha/pkg/snapcache/cache.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/google/btree"
+	"github.com/projectcalico/calico/typha/pkg/promutils"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
@@ -39,46 +40,47 @@ const (
 )
 
 var (
-	// FIXME All of these should be upgraded to vectors so that each syncer has its own stats.
-	summaryUpdateSize = cprometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "typha_breadcrumb_size",
-		Help: "Number of KVs recorded in each breadcrumb.",
-	})
-	gaugeCurrentSequenceNumber = prometheus.NewGauge(prometheus.GaugeOpts{
+	syncerLabel = []string{"syncer"}
+
+	gaugeVecCurrentSequenceNumber = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "typha_breadcrumb_seq_number",
 		Help: "Current (server-local) sequence number; number of snapshot deltas processed.",
-	})
-	counterBreadcrumbNonBlock = prometheus.NewCounter(prometheus.CounterOpts{
+	}, syncerLabel)
+	counterVecBreadcrumbNonBlock = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "typha_breadcrumb_non_block",
 		Help: "Count of the number of times Typha got the next Breadcrumb without blocking.",
-	})
-	counterBreadcrumbBlock = prometheus.NewCounter(prometheus.CounterOpts{
+	}, syncerLabel)
+	counterVecBreadcrumbBlock = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "typha_breadcrumb_block",
 		Help: "Count of the number of times Typha got the next Breadcrumb after blocking.",
-	})
-	counterUpdatesTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	}, syncerLabel)
+	counterVecUpdatesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "typha_updates_total",
 		Help: "Total number of updates received from the Syncer.",
-	})
-	counterUpdatesSkipped = prometheus.NewCounter(prometheus.CounterOpts{
+	}, syncerLabel)
+	counterVecUpdatesSkipped = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "typha_updates_skipped",
 		Help: "Total number of updates skipped as duplicates.",
-	})
-
+	}, syncerLabel)
 	gaugeVecSnapshotSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "typha_snapshot_size",
 		Help: "Current number of key/value pairs contained in the cache of the datastore.",
-	}, []string{"syncer"})
+	}, syncerLabel)
 )
 
 func init() {
-	prometheus.MustRegister(summaryUpdateSize)
-	prometheus.MustRegister(gaugeCurrentSequenceNumber)
+	prometheus.MustRegister(gaugeVecCurrentSequenceNumber)
+	promutils.PreCreateGaugePerSyncer(gaugeVecCurrentSequenceNumber)
 	prometheus.MustRegister(gaugeVecSnapshotSize)
-	prometheus.MustRegister(counterBreadcrumbNonBlock)
-	prometheus.MustRegister(counterBreadcrumbBlock)
-	prometheus.MustRegister(counterUpdatesTotal)
-	prometheus.MustRegister(counterUpdatesSkipped)
+	promutils.PreCreateGaugePerSyncer(gaugeVecSnapshotSize)
+	prometheus.MustRegister(counterVecBreadcrumbNonBlock)
+	promutils.PreCreateCounterPerSyncer(counterVecBreadcrumbNonBlock)
+	prometheus.MustRegister(counterVecBreadcrumbBlock)
+	promutils.PreCreateCounterPerSyncer(counterVecBreadcrumbBlock)
+	prometheus.MustRegister(counterVecUpdatesTotal)
+	promutils.PreCreateCounterPerSyncer(counterVecUpdatesTotal)
+	prometheus.MustRegister(counterVecUpdatesSkipped)
+	promutils.PreCreateCounterPerSyncer(counterVecUpdatesSkipped)
 }
 
 // Cache consumes updates from the Syncer API and caches them in the form of a series of
@@ -137,7 +139,13 @@ type Cache struct {
 	wakeUpTicker *jitter.Ticker
 	healthTicks  <-chan time.Time
 
-	gaugeSnapSize prometheus.Gauge
+	gaugeSnapSize              prometheus.Gauge
+	counterUpdatesTotal        prometheus.Counter
+	counterUpdatesSkipped      prometheus.Counter
+	gaugeCurrentSequenceNumber prometheus.Gauge
+	counterBreadcrumbBlock     prometheus.Counter
+	counterBreadcrumbNonBlock  prometheus.Counter
+	summaryUpdateSize          prometheus.Summary
 }
 
 const (
@@ -181,19 +189,14 @@ func New(config Config) *Cache {
 	config.ApplyDefaults()
 	kvs := btree.NewG[syncproto.SerializedUpdate](2, func(a, b syncproto.SerializedUpdate) bool { return a.Key < b.Key })
 	cond := sync.NewCond(&sync.Mutex{})
-	snap := &Breadcrumb{
-		Timestamp: time.Now(),
-		nextCond:  cond,
-		KVs:       kvs.Clone(),
-	}
+
 	c := &Cache{
-		config:            config,
-		inputC:            make(chan interface{}, config.MaxBatchSize*2),
-		breadcrumbCond:    cond,
-		kvs:               kvs,
-		currentBreadcrumb: (unsafe.Pointer)(snap),
-		wakeUpTicker:      jitter.NewTicker(config.WakeUpInterval, config.WakeUpInterval/10),
-		healthTicks:       time.NewTicker(healthInterval).C,
+		config:         config,
+		inputC:         make(chan interface{}, config.MaxBatchSize*2),
+		breadcrumbCond: cond,
+		kvs:            kvs,
+		wakeUpTicker:   jitter.NewTicker(config.WakeUpInterval, config.WakeUpInterval/10),
+		healthTicks:    time.NewTicker(healthInterval).C,
 	}
 
 	var err error
@@ -201,6 +204,29 @@ func New(config Config) *Cache {
 	if err != nil {
 		log.WithError(err).Panic("Bug: failed to get Prometheus gauge.")
 	}
+	c.counterUpdatesTotal = counterVecUpdatesTotal.WithLabelValues(config.Name)
+	c.counterUpdatesSkipped = counterVecUpdatesSkipped.WithLabelValues(config.Name)
+	c.gaugeCurrentSequenceNumber = gaugeVecCurrentSequenceNumber.WithLabelValues(config.Name)
+	c.counterBreadcrumbNonBlock = counterVecBreadcrumbNonBlock.WithLabelValues(config.Name)
+	c.counterBreadcrumbBlock = counterVecBreadcrumbBlock.WithLabelValues(config.Name)
+	// No vector version of summary so we use an explicit label.   promutils.GetOrRegister avoids panics in UT
+	// where the same cache is recreated.
+	c.summaryUpdateSize = promutils.GetOrRegister(cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "typha_breadcrumb_size",
+		Help: "Number of KVs recorded in each breadcrumb.",
+		ConstLabels: map[string]string{
+			"syncer": config.Name,
+		},
+	}))
+
+	snap := &Breadcrumb{
+		Timestamp:                 time.Now(),
+		nextCond:                  cond,
+		KVs:                       kvs.Clone(),
+		counterBreadcrumbBlock:    c.counterBreadcrumbBlock,
+		counterBreadcrumbNonBlock: c.counterBreadcrumbNonBlock,
+	}
+	c.currentBreadcrumb = (unsafe.Pointer)(snap)
 
 	if config.HealthAggregator != nil {
 		config.HealthAggregator.RegisterReporter(config.Name, &health.HealthReport{Live: true, Ready: true}, healthInterval*2)
@@ -343,6 +369,9 @@ func (c *Cache) publishBreadcrumb() {
 		SyncStatus:     oldCrumb.SyncStatus,
 		nextCond:       c.breadcrumbCond,
 		Deltas:         make([]syncproto.SerializedUpdate, 0, len(updates)),
+
+		counterBreadcrumbBlock:    c.counterBreadcrumbBlock,
+		counterBreadcrumbNonBlock: c.counterBreadcrumbNonBlock,
 	}
 	if lastUpdate && c.pendingStatus != newCrumb.SyncStatus {
 		// Only update the status if this is the last message in the batch, otherwise
@@ -353,7 +382,7 @@ func (c *Cache) publishBreadcrumb() {
 	// Update the main trie and record the updates in the new crumb.
 	for _, upd := range updates {
 		// Update stats.
-		counterUpdatesTotal.Inc()
+		c.counterUpdatesTotal.Inc()
 		// Pre-serialise the KV so that we only serialise once per update instead of once
 		// for each client.
 		newUpd, err := syncproto.SerializeUpdate(upd)
@@ -376,7 +405,7 @@ func (c *Cache) publishBreadcrumb() {
 		} else {
 			if exists && newUpd.WouldBeNoOp(oldUpd) {
 				log.WithField("key", newUpd.Key).Debug("Skipping update to unchanged key")
-				counterUpdatesSkipped.Inc()
+				c.counterUpdatesSkipped.Inc()
 				continue
 			}
 			// Since the purpose of the snapshot is to hold the initial set of updates to send to Felix at start-of-day,
@@ -398,7 +427,7 @@ func (c *Cache) publishBreadcrumb() {
 		return
 	}
 
-	summaryUpdateSize.Observe(float64(len(newCrumb.Deltas)))
+	c.summaryUpdateSize.Observe(float64(len(newCrumb.Deltas)))
 	c.gaugeSnapSize.Set(float64(c.kvs.Len()))
 	// Add the new read-only snapshot to the new crumb.
 	newCrumb.KVs = c.kvs.Clone()
@@ -415,7 +444,7 @@ func (c *Cache) publishBreadcrumb() {
 	// while calling Broadcast.
 	log.WithField("seqNo", newCrumb.SequenceNumber).Debug("Broadcasting new Breadcrumb")
 	c.breadcrumbCond.Broadcast()
-	gaugeCurrentSequenceNumber.Set(float64(newCrumb.SequenceNumber))
+	c.gaugeCurrentSequenceNumber.Set(float64(newCrumb.SequenceNumber))
 }
 
 type Breadcrumb struct {
@@ -428,6 +457,9 @@ type Breadcrumb struct {
 
 	nextCond *sync.Cond
 	next     unsafe.Pointer
+
+	counterBreadcrumbNonBlock prometheus.Counter
+	counterBreadcrumbBlock    prometheus.Counter
 }
 
 func (b *Breadcrumb) Next(ctx context.Context) (*Breadcrumb, error) {
@@ -435,7 +467,7 @@ func (b *Breadcrumb) Next(ctx context.Context) (*Breadcrumb, error) {
 	// contention if the next Breadcrumb is already available.
 	next := b.loadNext()
 	if next != nil {
-		counterBreadcrumbNonBlock.Inc()
+		b.counterBreadcrumbNonBlock.Inc()
 		return next, nil
 	}
 
@@ -452,7 +484,7 @@ func (b *Breadcrumb) Next(ctx context.Context) (*Breadcrumb, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	counterBreadcrumbBlock.Inc()
+	b.counterBreadcrumbBlock.Inc()
 	return next, nil
 }
 

--- a/typha/pkg/snapcache/cache.go
+++ b/typha/pkg/snapcache/cache.go
@@ -22,9 +22,10 @@ import (
 	"unsafe"
 
 	"github.com/google/btree"
-	"github.com/projectcalico/calico/typha/pkg/promutils"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/typha/pkg/promutils"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
@@ -63,7 +64,7 @@ var (
 		Help: "Total number of updates skipped as duplicates.",
 	}, syncerLabel)
 	gaugeVecSnapshotSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "typha_snapshot_size",
+		Name: "typha_cache_size",
 		Help: "Current number of key/value pairs contained in the cache of the datastore.",
 	}, syncerLabel)
 )

--- a/typha/pkg/syncproto/sync_proto.go
+++ b/typha/pkg/syncproto/sync_proto.go
@@ -200,6 +200,21 @@ const (
 	SyncerTypeBGP                SyncerType = "bgp"
 	SyncerTypeTunnelIPAllocation SyncerType = "tunnel-ip-allocation"
 	SyncerTypeNodeStatus         SyncerType = "node-status"
+
+	// NumSyncerTypes is the number of SyncerType constants above.  For iota to pick up the correct value, all
+	// new consts must be added to this block and NumSyncerTypes must be the last entry.
+	NumSyncerTypes = iota
+)
+
+var (
+	// AllSyncerTypes contains each of the SyncerType constants. We use an array rather than a slice for a
+	// compile-time length check.
+	AllSyncerTypes = [NumSyncerTypes]SyncerType{
+		SyncerTypeFelix,
+		SyncerTypeBGP,
+		SyncerTypeTunnelIPAllocation,
+		SyncerTypeNodeStatus,
+	}
 )
 
 type MsgClientHello struct {

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -28,9 +28,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/projectcalico/calico/typha/pkg/promutils"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/typha/pkg/promutils"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/projectcalico/calico/typha/pkg/promutils"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
@@ -49,6 +50,7 @@ var (
 )
 
 var (
+	// Global Prometheus metrics, not specific to any particular syncer type.
 	counterNumConnectionsAccepted = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "typha_connections_accepted",
 		Help: "Total number of connections accepted over time.",
@@ -57,55 +59,27 @@ var (
 		Name: "typha_connections_dropped",
 		Help: "Total number of connections dropped due to rebalancing.",
 	})
-	counterGracePeriodUsed = prometheus.NewCounter(prometheus.CounterOpts{
+
+	// Counters with per-syncer-type values.
+	gaugeVecNumConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "typha_connections_active",
+		Help: "Number of open client connections.",
+	}, []string{"syncer"})
+	counterVecGracePeriodUsed = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "typha_connections_grace_used",
 		Help: "Total number of connections that made use of the grace period to catch up after sending the initial " +
 			"snapshot.",
-	})
-	gaugeNumConnections = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "typha_connections_active",
-		Help: "Number of open client connections.",
-	})
-	summarySnapshotSendTime = cprometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "typha_client_snapshot_send_secs",
-		Help: "How long it took to send the initial snapshot to each client.",
-	})
-	summaryClientLatency = cprometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "typha_client_latency_secs",
-		Help: "Per-client latency.  I.e. how far behind the current state is each client.",
-		// Reduce the time window so the stat is more useful after a spike.
-		MaxAge:     1 * time.Minute,
-		AgeBuckets: 2,
-	})
-	summaryWriteLatency = cprometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "typha_client_write_latency_secs",
-		Help: "Per-client write.  How long each write call is taking.",
-	})
-	summaryNextCatchupLatency = cprometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "typha_next_breadcrumb_latency_secs",
-		Help: "Time to retrieve next breadcrumb when already behind.",
-	})
-	summaryPingLatency = cprometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "typha_ping_latency",
-		Help: "Round-trip ping latency to client.",
-	})
-	summaryNumKVsPerMsg = cprometheus.NewSummary(prometheus.SummaryOpts{
-		Name: "typha_kvs_per_msg",
-		Help: "Number of KV pairs sent in each message.",
-	})
+	}, []string{"syncer"})
 )
 
 func init() {
 	prometheus.MustRegister(counterNumConnectionsAccepted)
 	prometheus.MustRegister(counterNumConnectionsDropped)
-	prometheus.MustRegister(counterGracePeriodUsed)
-	prometheus.MustRegister(gaugeNumConnections)
-	prometheus.MustRegister(summarySnapshotSendTime)
-	prometheus.MustRegister(summaryClientLatency)
-	prometheus.MustRegister(summaryNextCatchupLatency)
-	prometheus.MustRegister(summaryWriteLatency)
-	prometheus.MustRegister(summaryPingLatency)
-	prometheus.MustRegister(summaryNumKVsPerMsg)
+
+	prometheus.MustRegister(gaugeVecNumConnections)
+	promutils.PreCreateGaugePerSyncer(gaugeVecNumConnections)
+	prometheus.MustRegister(counterVecGracePeriodUsed)
+	promutils.PreCreateCounterPerSyncer(counterVecGracePeriodUsed)
 }
 
 const (
@@ -131,6 +105,8 @@ type Server struct {
 	connTrackingLock sync.Mutex
 	maxConns         int
 	connIDToConn     map[uint64]*connection
+
+	perSyncerConnMetrics map[syncproto.SyncerType]perSyncerConnMetrics
 
 	Finished sync.WaitGroup
 }
@@ -246,13 +222,18 @@ func New(caches map[syncproto.SyncerType]BreadcrumbProvider, config Config) *Ser
 	config.ApplyDefaults()
 	log.WithField("config", config).Info("Creating server")
 	s := &Server{
-		config:       config,
-		caches:       caches,
-		maxConnsC:    make(chan int),
-		dropInterval: config.DropInterval,
-		maxConns:     config.MaxConns,
-		connIDToConn: map[uint64]*connection{},
-		listeningC:   make(chan struct{}),
+		config:               config,
+		caches:               caches,
+		maxConnsC:            make(chan int),
+		dropInterval:         config.DropInterval,
+		maxConns:             config.MaxConns,
+		connIDToConn:         map[uint64]*connection{},
+		listeningC:           make(chan struct{}),
+		perSyncerConnMetrics: map[syncproto.SyncerType]perSyncerConnMetrics{},
+	}
+
+	for st := range caches {
+		s.perSyncerConnMetrics[st] = makePerSyncerConnMetrics(st)
 	}
 
 	// Register that we will report liveness.
@@ -410,6 +391,8 @@ func (s *Server) serve(cxt context.Context) {
 
 			encoder: gob.NewEncoder(conn),
 			readC:   make(chan interface{}),
+
+			allMetrics: s.perSyncerConnMetrics,
 		}
 		// Track the connection's lifetime in connIDToConn so we can kill it later if needed.
 		s.recordConnection(connection)
@@ -534,6 +517,11 @@ type connection struct {
 	readC   chan interface{}
 
 	logCxt *log.Entry
+
+	// Similarly to allCaches, allMetrics contains all the metrics relevant to a particular syncer.  We copy one
+	// of them to the unnamed field after the handshake.
+	allMetrics map[syncproto.SyncerType]perSyncerConnMetrics
+	perSyncerConnMetrics
 }
 
 func (h *connection) handle(finishedWG *sync.WaitGroup) (err error) {
@@ -550,13 +538,14 @@ func (h *connection) handle(finishedWG *sync.WaitGroup) (err error) {
 		}
 		// Wait for the background threads to shut down.
 		h.shutDownWG.Wait()
-		gaugeNumConnections.Dec()
+		if h.gaugeNumConnections != nil {
+			h.gaugeNumConnections.Dec()
+		}
 		h.logCxt.Info("Client connection shut down.")
 		finishedWG.Done()
 	}()
 
 	h.logCxt.Info("Per-connection goroutine started")
-	gaugeNumConnections.Inc()
 
 	// Start goroutine to read messages from client and put them on a channel for this goroutine to process.
 	h.shutDownWG.Add(1)
@@ -566,6 +555,7 @@ func (h *connection) handle(finishedWG *sync.WaitGroup) (err error) {
 	if err = h.doHandshake(); err != nil {
 		return // Error already logged.
 	}
+	h.gaugeNumConnections.Inc()
 
 	// Start a goroutine to stream the snapshot and then the deltas to the client.
 	h.shutDownWG.Add(1)
@@ -598,7 +588,7 @@ func (h *connection) handle(finishedWG *sync.WaitGroup) (err error) {
 			case syncproto.MsgPong:
 				h.logCxt.Debug("Pong from client")
 				lastPongReceived = time.Now()
-				summaryPingLatency.Observe(time.Since(msg.PingTimestamp).Seconds())
+				h.summaryPingLatency.Observe(time.Since(msg.PingTimestamp).Seconds())
 			default:
 				h.logCxt.WithField("msg", msg).Error("Unknown message from client")
 				return errors.New("Unknown message type")
@@ -688,6 +678,8 @@ func (h *connection) doHandshake() error {
 		h.logCxt.Info("Client didn't provide a SyncerType, assuming SyncerTypeFelix for back-compatibility.")
 		syncerType = syncproto.SyncerTypeFelix
 	}
+	h.logCxt = h.logCxt.WithField("type", syncerType)
+	h.perSyncerConnMetrics = h.allMetrics[syncerType]
 	desiredSyncerCache := h.allCaches[syncerType]
 	if desiredSyncerCache == nil {
 		h.logCxt.WithField("requestedType", syncerType).Info("Client requested unknown SyncerType.")
@@ -725,7 +717,7 @@ func (h *connection) sendMsg(msg interface{}) error {
 		h.logCxt.WithError(err).Info("Failed to write to client")
 		return err
 	}
-	summaryWriteLatency.Observe(time.Since(startTime).Seconds())
+	h.summaryWriteLatency.Observe(time.Since(startTime).Seconds())
 	return nil
 }
 
@@ -791,7 +783,7 @@ func (h *connection) sendSnapshotAndUpdatesToClient(logCxt *log.Entry) {
 			// Take a peek at the very latest breadcrumb to see how far behind we are...
 			latestCrumb := h.cache.CurrentBreadcrumb()
 			crumbAge := latestCrumb.Timestamp.Sub(breadcrumb.Timestamp)
-			summaryClientLatency.Observe(crumbAge.Seconds())
+			h.summaryClientLatency.Observe(crumbAge.Seconds())
 			logCxt.WithFields(log.Fields{
 				"seqNo":     breadcrumb.SequenceNumber,
 				"timestamp": breadcrumb.Timestamp,
@@ -827,7 +819,7 @@ func (h *connection) sendSnapshotAndUpdatesToClient(logCxt *log.Entry) {
 					}).Warn("Client is a long way behind after sending snapshot; " +
 						"allowing grace period for it to catch up.")
 					loggedClientBehind = true
-					counterGracePeriodUsed.Add(1.0)
+					h.counterGracePeriodUsed.Inc()
 				}
 			} else if loggedClientBehind && time.Now().After(gracePeriodEndTime) {
 				// Client caught up after being behind when we sent it a snapshot.
@@ -850,7 +842,7 @@ func (h *connection) sendSnapshotAndUpdatesToClient(logCxt *log.Entry) {
 			// Either we're already batching up updates or we're behind.  Append the deltas to the
 			// buffer.
 			deltas = append(deltas, breadcrumb.Deltas...)
-			summaryNextCatchupLatency.Observe(timeSpentInNext.Seconds())
+			h.summaryNextCatchupLatency.Observe(timeSpentInNext.Seconds())
 
 			if crumbAge < h.config.MinBatchingAgeThreshold {
 				// Caught up, stop batching.
@@ -861,7 +853,7 @@ func (h *connection) sendSnapshotAndUpdatesToClient(logCxt *log.Entry) {
 		if len(deltas) > 0 {
 			// Send the deltas relative to the previous snapshot.
 			logCxt.WithField("num", len(deltas)).Debug("Sending deltas")
-			summaryNumKVsPerMsg.Observe(float64(len(deltas)))
+			h.summaryNumKVsPerMsg.Observe(float64(len(deltas)))
 			err := h.sendMsg(syncproto.MsgKVs{
 				KVs: deltas,
 			})
@@ -896,7 +888,7 @@ func (h *connection) streamSnapshotToClient(logCxt *log.Entry, breadcrumb *snapc
 		}
 		logCxt.WithField("numKVs", len(kvs)).Debug("Sending snapshot KVs to client.")
 		numKeys += len(kvs)
-		summaryNumKVsPerMsg.Observe(float64(len(kvs)))
+		h.summaryNumKVsPerMsg.Observe(float64(len(kvs)))
 		err := h.sendMsg(syncproto.MsgKVs{
 			KVs: kvs,
 		})
@@ -931,7 +923,7 @@ func (h *connection) streamSnapshotToClient(logCxt *log.Entry, breadcrumb *snapc
 		return
 	}
 	logCxt.WithField("numKeys", numKeys).Info("Finished sending snapshot to client")
-	summarySnapshotSendTime.Observe(time.Since(startTime).Seconds())
+	h.summarySnapshotSendTime.Observe(time.Since(startTime).Seconds())
 	return
 }
 
@@ -963,4 +955,60 @@ func (h *connection) sendPingsToClient(logCxt *log.Entry) {
 			return
 		}
 	}
+}
+
+// perSyncerConnMetrics contains a set of Prometheus metrics that each connection needs to update.  There is one
+// set per syncer type.
+type perSyncerConnMetrics struct {
+	counterGracePeriodUsed    prometheus.Counter
+	summarySnapshotSendTime   prometheus.Summary
+	summaryClientLatency      prometheus.Summary
+	summaryWriteLatency       prometheus.Summary
+	summaryNextCatchupLatency prometheus.Summary
+	summaryPingLatency        prometheus.Summary
+	summaryNumKVsPerMsg       prometheus.Summary
+	gaugeNumConnections       prometheus.Gauge
+}
+
+func makePerSyncerConnMetrics(syncerType syncproto.SyncerType) perSyncerConnMetrics {
+	var c perSyncerConnMetrics
+	syncerLabels := map[string]string{
+		"syncer": string(syncerType),
+	}
+	c.summarySnapshotSendTime = promutils.GetOrRegister(cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name:        "typha_client_snapshot_send_secs",
+		Help:        "How long it took to send the initial snapshot to each client.",
+		ConstLabels: syncerLabels,
+	}))
+	c.summaryClientLatency = promutils.GetOrRegister(cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "typha_client_latency_secs",
+		Help: "Per-client latency.  I.e. how far behind the current state is each client.",
+		// Reduce the time window so the stat is more useful after a spike.
+		MaxAge:      1 * time.Minute,
+		AgeBuckets:  2,
+		ConstLabels: syncerLabels,
+	}))
+	c.summaryWriteLatency = promutils.GetOrRegister(cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name:        "typha_client_write_latency_secs",
+		Help:        "Per-client write.  How long each write call is taking.",
+		ConstLabels: syncerLabels,
+	}))
+	c.summaryNextCatchupLatency = promutils.GetOrRegister(cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name:        "typha_next_breadcrumb_latency_secs",
+		Help:        "Time to retrieve next breadcrumb when already behind.",
+		ConstLabels: syncerLabels,
+	}))
+	c.summaryPingLatency = promutils.GetOrRegister(cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name:        "typha_ping_latency",
+		Help:        "Round-trip ping latency to client.",
+		ConstLabels: syncerLabels,
+	}))
+	c.summaryNumKVsPerMsg = promutils.GetOrRegister(cprometheus.NewSummary(prometheus.SummaryOpts{
+		Name:        "typha_kvs_per_msg",
+		Help:        "Number of KV pairs sent in each message.",
+		ConstLabels: syncerLabels,
+	}))
+	c.counterGracePeriodUsed = counterVecGracePeriodUsed.WithLabelValues(string(syncerType))
+	c.gaugeNumConnections = gaugeVecNumConnections.WithLabelValues(string(syncerType))
+	return c
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This PR splits Typha's Prometheus metrics by syncer type. Many of Typha's statistics are only meaningful within the scope of a syncer but previously, all the syncers wrote to the same metrics resulting in metrics that would bounce around between the values associated with the different syncers.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Many of Typha's Prometheus metrics are now split by syncer (client) type, represented by a label "syncer" on the metrics. This prevents cross-talk where the syncers would all share the same metrics and the last writer to the metric would "win".
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
