### PR TITLE
Built stripped binaries when release

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -45,7 +45,8 @@ APISERVER_GIT_DESCRIPTION?=$(shell git describe --tags)
 LDFLAGS = -X $(PACKAGE_NAME)/cmd/apiserver/server.VERSION=$(APISERVER_VERSION) \
 	-X $(PACKAGE_NAME)/cmd/apiserver/server.BUILD_DATE=$(APISERVER_BUILD_DATE) \
 	-X $(PACKAGE_NAME)/cmd/apiserver/server.GIT_DESCRIPTION=$(APISERVER_GIT_DESCRIPTION) \
-	-X $(PACKAGE_NAME)/cmd/apiserver/server.GIT_REVISION=$(APISERVER_GIT_REVISION)
+	-X $(PACKAGE_NAME)/cmd/apiserver/server.GIT_REVISION=$(APISERVER_GIT_REVISION) \
+	$(RELEASE_LDFLAGS)
 
 ##############################################################################
 # Download and include ../lib.Makefile before anything else
@@ -85,7 +86,7 @@ ifeq ($(ARCH),amd64)
 	$(call build_cgo_boring_binary, $(PACKAGE_NAME)/cmd/apiserver, $@)
 else
 	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) \
-		sh -c '$(GIT_CONFIG_SSH) go build -v -o $@ -ldflags "$(VERSION_FLAGS)" $(PACKAGE_NAME)/cmd/apiserver'
+		sh -c '$(GIT_CONFIG_SSH) go build -v -o $@ -ldflags "$(LDFLAGS)" $(PACKAGE_NAME)/cmd/apiserver'
 endif
 
 $(BINDIR)/filecheck-$(ARCH): $(K8SAPISERVER_GO_FILES)

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -19,10 +19,10 @@ DIKASTES_IMAGE ?=dikastes
 BUILD_IMAGES ?= $(DIKASTES_IMAGE)
 
 LDFLAGS = -X $(PACKAGE_NAME)/buildinfo.GitVersion=$(GIT_DESCRIPTION) \
-			-X $(PACKAGE_NAME)/buildinfo.BuildDate=$(DATE) \
-			-X $(PACKAGE_NAME)/buildinfo.GitRevision=$(GIT_COMMIT) \
-			-B 0x$(BUILD_ID)
-
+	-X $(PACKAGE_NAME)/buildinfo.BuildDate=$(DATE) \
+	-X $(PACKAGE_NAME)/buildinfo.GitRevision=$(GIT_COMMIT) \
+	-B 0x$(BUILD_ID) \
+	$(RELEASE_LDFLAGS)
 ##############################################################################
 # Download and include ../lib.Makefile before anything else
 #   Additions to EXTRA_DOCKER_ARGS need to happen before the include since

--- a/calicoctl/Makefile
+++ b/calicoctl/Makefile
@@ -32,10 +32,11 @@ TEST_CONTAINER_NAME ?= calico/test
 
 CALICOCTL_GIT_REVISION?=$(shell git rev-parse --short HEAD)
 
-LDFLAGS=-X $(PACKAGE_NAME)/calicoctl/commands.VERSION=$(GIT_VERSION) \
+LDFLAGS= -X $(PACKAGE_NAME)/calicoctl/commands.VERSION=$(GIT_VERSION) \
 	-X $(PACKAGE_NAME)/calicoctl/commands.GIT_REVISION=$(CALICOCTL_GIT_REVISION) \
 	-X $(PACKAGE_NAME)/calicoctl/commands/common.VERSION=$(GIT_VERSION) \
-	-X main.VERSION=$(GIT_VERSION)
+	-X main.VERSION=$(GIT_VERSION) \
+	$(RELEASE_LDFLAGS)
 
 .PHONY: clean
 ## Clean enough that a new release build will be clean

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -18,7 +18,7 @@ BUILD_IMAGES   ?=$(CNI_PLUGIN_IMAGE)
 include ../lib.Makefile
 
 ###############################################################################
-LDFLAGS = -X main.VERSION=$(GIT_VERSION)
+LDFLAGS = -X main.VERSION=$(GIT_VERSION) $(RELEASE_LDFLAGS)
 
 SRC_FILES=$(shell find pkg cmd internal -name '*.go')
 TEST_SRC_FILES=$(shell find tests -name '*.go')

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -42,7 +42,7 @@ clean:
 ###############################################################################
 # Building the binary
 ###############################################################################
-LDFLAGS = -X main.VERSION=$(GIT_VERSION)
+LDFLAGS= -X main.VERSION=$(GIT_VERSION) $(RELEASE_LDFLAGS)
 
 build: bin/kube-controllers-linux-$(ARCH) bin/check-status-linux-$(ARCH)
 build-all: $(addprefix sub-build-,$(VALIDARCHES))

--- a/node/Makefile
+++ b/node/Makefile
@@ -153,7 +153,8 @@ DATE:=$(shell date -u +'%FT%T%z')
 LDFLAGS= -X $(PACKAGE_NAME)/pkg/lifecycle/startup.VERSION=$(GIT_VERSION) \
 	-X $(PACKAGE_NAME)/buildinfo.GitVersion=$(GIT_DESCRIPTION) \
 	-X $(PACKAGE_NAME)/buildinfo.BuildDate=$(DATE) \
-	-X $(PACKAGE_NAME)/buildinfo.GitRevision=$(GIT_COMMIT)
+	-X $(PACKAGE_NAME)/buildinfo.GitRevision=$(GIT_COMMIT) \
+	$(RELEASE_LDFLAGS)
 
 # Source golang files on which compiling the calico-node binary depends.
 SRC_FILES=$(shell find ./pkg -name '*.go') \

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -15,6 +15,7 @@ BUILD_IMAGES    ?=$(FLEXVOL_IMAGE) $(CSI_IMAGE) $(REGISTRAR_IMAGE)
 
 include ../lib.Makefile
 
+LDFLAGS= $(RELEASE_LDFLAGS)
 ###############################################################################
 
 
@@ -58,14 +59,14 @@ bin/flexvol-armv7: ARCH=armv7
 bin/flexvol-ppc64le: ARCH=ppc64le
 bin/flexvol-s390x: ARCH=s390x
 bin/flexvol-%: $(SRC_FILES)
-	$(DOCKER_RUN) -e CGO_ENABLED=0 $(CALICO_BUILD) go build -buildvcs=false -v -o bin/flexvol-$(ARCH) flexvol/flexvoldriver.go
+	$(DOCKER_RUN) -e CGO_ENABLED=0 $(CALICO_BUILD) go build -buildvcs=false -v -o bin/flexvol-$(ARCH) -ldflags "$(LDFLAGS)" flexvol/flexvoldriver.go
 
 bin/csi-driver-arm64: ARCH=arm64
 bin/csi-driver-armv7: ARCH=armv7
 bin/csi-driver-ppc64le: ARCH=ppc64le
 bin/csi-driver-s390x: ARCH=s390x
 bin/csi-driver-%: $(SRC_FILES)
-	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) go build -buildvcs=false -v -o bin/csi-driver-$(ARCH) csidriver/main.go
+	$(DOCKER_RUN) -e CGO_ENABLED=$(CGO_ENABLED) $(CALICO_BUILD) go build -buildvcs=false -v -o bin/csi-driver-$(ARCH) -ldflags "$(LDFLAGS)" csidriver/main.go
 
 bin/csi-driver-amd64: $(SRC_FILES)
 	$(call build_static_cgo_boring_binary, csidriver/main.go, $@)

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -29,7 +29,8 @@ include ../lib.Makefile
 LDFLAGS := -X $(PACKAGE_NAME)/pkg/buildinfo.GitVersion=$(GIT_DESCRIPTION) \
 			-X $(PACKAGE_NAME)/pkg/buildinfo.BuildDate=$(DATE) \
 			-X $(PACKAGE_NAME)/pkg/buildinfo.GitRevision=$(GIT_COMMIT) \
-			-B 0x$(BUILD_ID)
+			-B 0x$(BUILD_ID) \
+			$(RELEASE_LDFLAGS)
 
 # All Typha go files.
 SRC_FILES:=$(shell find . $(foreach dir,$(NON_TYPHA_DIRS),-path ./$(dir) -prune -o) -type f -name '*.go' -print)


### PR DESCRIPTION
Signed-off-by: Afshin Paydar <afshin.paydar@binary.com>

## Description
- Built binaries as small as possible to reduce docker images size, by stripping symbols from binaries only when release.
- type of fix: `kind/enhancement`
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
- https://github.com/projectcalico/calico/issues/6649
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
