### PR TITLE
[Release v3.23] Cherry-pick: Pass proper EndPointType for l3 ipip devices. (#6373)

### DIFF
--- a/felix/bpf/tc/compiler.go
+++ b/felix/bpf/tc/compiler.go
@@ -101,11 +101,7 @@ func ProgFilename(epType EndpointType, toOrFrom ToOrFromEp, epToHostDrop, fib, d
 	case EpTypeHost:
 		epTypeShort = "hep"
 	case EpTypeTunnel:
-		if features.IPIPDeviceIsL3 {
-			epTypeShort = "l3"
-		} else {
-			epTypeShort = "tnl"
-		}
+		epTypeShort = "tnl"
 	case EpTypeL3Device:
 		epTypeShort = "l3"
 	}

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -984,7 +984,11 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection
 	if m.isWorkloadIface(ifaceName) {
 		endpointType = tc.EpTypeWorkload
 	} else if ifaceName == "tunl0" {
-		endpointType = tc.EpTypeTunnel
+		if m.Features.IPIPDeviceIsL3 {
+			endpointType = tc.EpTypeL3Device
+		} else {
+			endpointType = tc.EpTypeTunnel
+		}
 	} else if ifaceName == "wireguard.cali" {
 		endpointType = tc.EpTypeL3Device
 	} else if m.isDataIface(ifaceName) {


### PR DESCRIPTION
## Description
Cherry pick for PR: https://github.com/projectcalico/calico/pull/6373
Set EndPointType for l3 ipip devices to EpTypeL3Device

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
