### PR TITLE
Add some extra endpoint slice FVs to try to repro issue.

### DIFF
--- a/felix/calc/calc_graph_fv_test.go
+++ b/felix/calc/calc_graph_fv_test.go
@@ -402,6 +402,18 @@ var baseTests = []StateList{
 		endpointSliceActive,
 	},
 	{
+		// Service NetworkPolicy test updating endpoint slices.
+		endpointSliceActiveNewIPs,
+		endpointSliceActiveNewIPs2,
+		endpointSliceActiveNewIPs,
+	},
+	{
+		// Service NetworkPolicy test overlapping two endpoint slices with same IPs.
+		endpointSliceActiveNewIPs,
+		endpointSliceOverlap,
+		endpointSlice2ActiveNewIPs2,
+	},
+	{
 		encapWithIPIPPool,
 		encapWithVXLANPool,
 		encapWithIPIPAndVXLANPool,

--- a/felix/calc/resources_for_test.go
+++ b/felix/calc/resources_for_test.go
@@ -835,10 +835,44 @@ var localIPAMBlockWithBorrows = AllocationBlock{
 var p = int32(80)
 var tcp = v1.ProtocolTCP
 var endpointSliceKey1 = model.ResourceKey{Name: "eps", Namespace: "default", Kind: "KubernetesEndpointSlice"}
+var endpointSliceKey2 = model.ResourceKey{Name: "eps-2", Namespace: "default", Kind: "KubernetesEndpointSlice"}
 var endpointSlice1 = discovery.EndpointSlice{
 	ObjectMeta: metav1.ObjectMeta{Name: "eps", Namespace: "default", Labels: map[string]string{"kubernetes.io/service-name": "svc"}},
 	Endpoints: []discovery.Endpoint{
 		{Addresses: []string{"10.0.0.1"}},
+	},
+	Ports: []discovery.EndpointPort{
+		{Port: &p, Protocol: &tcp},
+	},
+}
+var endpointSlice1NewIPs = discovery.EndpointSlice{
+	ObjectMeta: metav1.ObjectMeta{Name: "eps", Namespace: "default", Labels: map[string]string{"kubernetes.io/service-name": "svc"}},
+	Endpoints: []discovery.Endpoint{
+		{Addresses: []string{"10.0.0.1"}},
+		{Addresses: []string{"10.0.0.2"}},
+		{Addresses: []string{"10.0.0.3"}},
+	},
+	Ports: []discovery.EndpointPort{
+		{Port: &p, Protocol: &tcp},
+	},
+}
+var endpointSlice1NewIPs2 = discovery.EndpointSlice{
+	ObjectMeta: metav1.ObjectMeta{Name: "eps", Namespace: "default", Labels: map[string]string{"kubernetes.io/service-name": "svc"}},
+	Endpoints: []discovery.Endpoint{
+		{Addresses: []string{"10.0.0.2"}},
+		{Addresses: []string{"10.0.0.3"}},
+		{Addresses: []string{"10.0.0.4"}},
+	},
+	Ports: []discovery.EndpointPort{
+		{Port: &p, Protocol: &tcp},
+	},
+}
+var endpointSlice2NewIPs2 = discovery.EndpointSlice{
+	ObjectMeta: metav1.ObjectMeta{Name: "eps-2", Namespace: "default", Labels: map[string]string{"kubernetes.io/service-name": "svc"}},
+	Endpoints: []discovery.Endpoint{
+		{Addresses: []string{"10.0.0.2"}},
+		{Addresses: []string{"10.0.0.3"}},
+		{Addresses: []string{"10.0.0.4"}},
 	},
 	Ports: []discovery.EndpointPort{
 		{Port: &p, Protocol: &tcp},

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -2398,6 +2398,40 @@ var endpointSliceActive = endpointSliceAndLocalWorkload.withKVUpdates(
 	},
 )
 
+// Change the endpoint slice
+var endpointSliceActiveNewIPs = endpointSliceActive.withName("EndpointSliceActiveNewIPs").withKVUpdates(
+	KVPair{Key: endpointSliceKey1, Value: &endpointSlice1NewIPs},
+).withIPSet("svc:Jhwii46PCMT5NlhWsUqZmv7al8TeHFbNQMhoVg", []string{
+	"10.0.0.1,tcp:80",
+	"10.0.0.2,tcp:80",
+	"10.0.0.3,tcp:80",
+})
+
+var endpointSliceActiveNewIPs2 = endpointSliceActive.withName("EndpointSliceActiveNewIPs").withKVUpdates(
+	KVPair{Key: endpointSliceKey1, Value: &endpointSlice1NewIPs2},
+).withIPSet("svc:Jhwii46PCMT5NlhWsUqZmv7al8TeHFbNQMhoVg", []string{
+	"10.0.0.2,tcp:80",
+	"10.0.0.3,tcp:80",
+	"10.0.0.4,tcp:80",
+})
+
+// Overlap two endpoint slices
+var endpointSliceOverlap = endpointSliceActiveNewIPs.withName("EndpointSliceOverlap").withKVUpdates(
+	KVPair{Key: endpointSliceKey2, Value: &endpointSlice2NewIPs2},
+).withIPSet("svc:Jhwii46PCMT5NlhWsUqZmv7al8TeHFbNQMhoVg", []string{
+	"10.0.0.1,tcp:80",
+	"10.0.0.2,tcp:80",
+	"10.0.0.3,tcp:80",
+	"10.0.0.4,tcp:80",
+})
+var endpointSlice2ActiveNewIPs2 = endpointSliceActive.withName("EndpointSliceActiveNewIPs").withKVUpdates(
+	KVPair{Key: endpointSliceKey2, Value: &endpointSlice2NewIPs2},
+).withIPSet("svc:Jhwii46PCMT5NlhWsUqZmv7al8TeHFbNQMhoVg", []string{
+	"10.0.0.2,tcp:80",
+	"10.0.0.3,tcp:80",
+	"10.0.0.4,tcp:80",
+})
+
 var encapWithIPIPPool = empty.withKVUpdates(
 	KVPair{Key: ipPoolKey, Value: &ipPoolWithIPIP},
 ).withExpectedEncapsulation(


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Trying to repro a customer issue where some IPs seemingly get lost from a service IP set.  Thought it might be due to some sort of churn of the EndpointSlices so I wrote some extra FVs that churn IPs and create slices with overlapping IPs.  No luck reproing the problem but seemed worth committing the tests.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
