### PR TITLE
[release-v3.23] Auto pick #6671: felix/encap: ignore vxlanEnabled for ipv6

### DIFF
--- a/api/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/api/pkg/apis/projectcalico/v3/felixconfig.go
@@ -207,7 +207,7 @@ type FelixConfigurationSpec struct {
 	// IPIPMTU is the MTU to set on the tunnel device. See Configuring MTU [Default: 1440]
 	IPIPMTU *int `json:"ipipMTU,omitempty" confignamev1:"IpInIpMtu"`
 
-	// VXLANEnabled overrides whether Felix should create the VXLAN tunnel device for VXLAN networking. Optional as Felix determines this based on the existing IP pools. [Default: nil (unset)]
+	// VXLANEnabled overrides whether Felix should create the VXLAN tunnel device for IPv4 VXLAN networking. Optional as Felix determines this based on the existing IP pools. [Default: nil (unset)]
 	VXLANEnabled *bool `json:"vxlanEnabled,omitempty" confignamev1:"VXLANEnabled"`
 	// VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel device. See Configuring MTU [Default: 1410]
 	VXLANMTU *int `json:"vxlanMTU,omitempty"`

--- a/api/pkg/openapi/openapi_generated.go
+++ b/api/pkg/openapi/openapi_generated.go
@@ -1987,7 +1987,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 					},
 					"vxlanEnabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "VXLANEnabled overrides whether Felix should create the VXLAN tunnel device for VXLAN networking. Optional as Felix determines this based on the existing IP pools. [Default: nil (unset)]",
+							Description: "VXLANEnabled overrides whether Felix should create the VXLAN tunnel device for IPv4 VXLAN networking. Optional as Felix determines this based on the existing IP pools. [Default: nil (unset)]",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/felix/calc/encapsulation_resolver.go
+++ b/felix/calc/encapsulation_resolver.go
@@ -267,9 +267,5 @@ func (c *EncapsulationCalculator) VXLANEnabled() bool {
 }
 
 func (c *EncapsulationCalculator) VXLANEnabledV6() bool {
-	if c.config != nil && c.config.VXLANEnabled != nil {
-		return *c.config.VXLANEnabled
-	}
-
 	return len(c.vxlanPoolsv6) > 0
 }

--- a/felix/fv/mtu_test.go
+++ b/felix/fv/mtu_test.go
@@ -115,6 +115,14 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 					fc.Spec.VXLANEnabled = &f
 					_, err := client.FelixConfigurations().Create(context.Background(), fc, options.SetOptions{})
 					Expect(err).NotTo(HaveOccurred())
+					// To disable vxlan for ipv6, set VXLANModeNever on the IPv6 pool
+					if enableIPv6 {
+						poolV6, err := client.IPPools().Get(context.Background(), infrastructure.DefaultIPv6PoolName, options.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						poolV6.Spec.VXLANMode = api.VXLANModeNever
+						_, err = client.IPPools().Update(context.Background(), poolV6, options.SetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+					}
 
 					// It should now have an MTU of 1460 since there is no encap.
 					for _, felix := range felixes {

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -642,13 +642,31 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 				_, err := client.FelixConfigurations().Create(context.Background(), felixConfig, options.SetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				// Expect the VXLAN device to be deleted.
+				// Expect the ipv4 VXLAN device to be deleted.
 				for _, felix := range felixes {
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
 					}, "10s", "100ms").ShouldNot(ContainSubstring(mtuStr))
+					// IPv6 ignores the VXLAN enabled flag and must be disabled at the pool level. As such the ipv6
+					// interfaces should still exist at this point
 					if enableIPv6 {
+						Eventually(func() string {
+							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
+							return out
+						}, "10s", "100ms").Should(ContainSubstring(mtuStrV6))
+					}
+				}
+
+				if enableIPv6 {
+					ip6pool, err := client.IPPools().Get(context.Background(), infrastructure.DefaultIPv6PoolName, options.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					ip6pool.Spec.VXLANMode = "Never"
+					_, err = client.IPPools().Update(context.Background(), ip6pool, options.SetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Expect the ipv6 VXLAN device to be deleted.
+					for _, felix := range felixes {
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out

--- a/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/libcalico-go/config/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -622,8 +622,8 @@ spec:
                 type: boolean
               vxlanEnabled:
                 description: 'VXLANEnabled overrides whether Felix should create the
-                  VXLAN tunnel device for VXLAN networking. Optional as Felix determines
-                  this based on the existing IP pools. [Default: nil (unset)]'
+                  VXLAN tunnel device for IPv4 VXLAN networking. Optional as Felix
+                  determines this based on the existing IP pools. [Default: nil (unset)]'
                 type: boolean
               vxlanMTU:
                 description: 'VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel


### PR DESCRIPTION
Cherry pick of #6671 on release-v3.23.

#6671: felix/encap: ignore vxlanEnabled for ipv6