### PR TITLE
Optimise KeyFromDefaultPath.

### DIFF
--- a/libcalico-go/lib/backend/model/block_affinity.go
+++ b/libcalico-go/lib/backend/model/block_affinity.go
@@ -100,6 +100,10 @@ func (options BlockAffinityListOptions) KeyFromDefaultPath(path string) Key {
 	}
 	cidrStr := strings.Replace(r[0][2], "-", "/", 1)
 	_, cidr, _ := net.ParseCIDR(cidrStr)
+	if cidr == nil {
+		log.Debugf("Failed to parse CIDR in block affinity path: %q", path)
+		return nil
+	}
 	host := r[0][1]
 
 	if options.Host != "" && options.Host != host {

--- a/libcalico-go/lib/backend/model/keys_test.go
+++ b/libcalico-go/lib/backend/model/keys_test.go
@@ -15,16 +15,161 @@
 package model_test
 
 import (
-	. "github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"reflect"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	. "github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
+
+// interestingPaths contains seed data for the KeyFromDefaultPath fuzzer.
+//
+// Some of these inputs are junk (they test that bad keys are ignored and that nothing panics) and
+// some are not really valid in the "global" sense.  For example, we include strings with percent
+// encoding even though the objects they describe have other naming validation that should prevent
+// that. The parser was intended to be generic and to support a range of possible orchestrator
+// environments where we may need to be more permissive.
+//
+// Note: go test will run the Fuzz target as an ordinary unit test feeding in these inputs, so we don't
+// need to duplicate all of these as extra UTs.
+var interestingPaths = []string{
+	"/calico/v1/config/foobar",
+	"/calico/v1/config/foobar/bazz",
+	"/calico/v1/policy/profile/foo%2fbar/rules",
+	"/calico/v1/policy/profile/foo%2fbar/labels",
+	"/calico/v1/policy/tier/default/policy/biff%2fbop",
+	"/calico/v1/policy/tier",
+	"/calico/v1/host/foobar/workload/open%2fstack/work%2fload/endpoint/end%2fpoint",
+	"/calico/v1/host/foobar/endpoint",
+	"/calico/v1/host/foobar/endpoint/biff",
+	"/calico/v1/host/foobar/metadata",
+	"/calico/v1/host/foobar/wireguard",
+	"/calico/v1/host/foobar/config/biff/bopp",
+	"/calico/v1/host/foobar/bird_ip",
+	"/calico/v1/host/foobar",
+	"/calico/v1/netset",
+	"/calico/v1/netset/foo",
+	"/calico/v1/Ready",
+	"/calico/v1/Ready/garbage",
+	"/calico/v1/policy/tier",
+	"/calico/v1/policy/tier/foo",
+	"/calico/v1/policy/tier/foo/policy",
+	"/calico/v1/policy/tier/foo/policy/bar",
+	"/calico/v1/policy/profile",
+	"/calico/bgp/v1/global",
+	"/calico/bgp/v1/global/peer_v4",
+	"/calico/bgp/v1/global/peer_v4/name",
+	"/calico/bgp/v1/global/peer_v4/name",
+	"/calico/bgp/v1/global/peer_v4/10.0.0.5",
+	"/calico/bgp/v1/global/peer_v4/10.0.0.5-500",
+	"/calico/bgp/v1/global/peer_v6",
+	"/calico/bgp/v1/global/peer_v6/name",
+	"/calico/bgp/v1/host",
+	"/calico/bgp/v1/host/peer_v4",
+	"/calico/bgp/v1/host/peer_v4/name",
+	"/calico/bgp/v1/host/peer_v6",
+	"/calico/bgp/v1/host/peer_v6/name",
+	"/calico/bgp/v1/host/random-node-2/peer_v6/aabb:aabb::ffff-123",
+	"/calico/v1",
+	"/calico/v1/ipam",
+	"/calico/ipam/v2/assignment/ipv4/1.2.3.4-26",
+	"/calico/ipam/v2/handle/foobar",
+	"/calico/ipam/v2/handle/foobar/baz",
+	"/calico/ipam/v2",
+	"/calico/ipam/v2/host/foobar/ipv4/block/1.2.3.4-5",
+	"calico/ipam/v2/host/0/ipv0/block/0",
+	"/calico/felix/v1/host",
+	"/calico/felix/v1/host/foo/endpoint/bar",
+	"/calico/felix/v1/endpoint",
+	"/calico/felix/v2/foo/host",
+	"/calico/felix/v2//foo/host",
+	"/calico/felix/v2/region-Europe/host/h1/status",
+	"/calico/resources/v3/projectcalico.org/foo/bar/baz",
+	// Note: using % encoding in some areas where we don't really expect it here, but the parser
+	// does handle it, and it helps to prime the fuzzer.
+	"/bar/v1/host/foobar/workload/open%2fstack/work%2fload/endpoint/end%2fpoint",
+	"/calico/v1/host/foobar/workload/open%2fstack/work%2fload/endpoint/end%2fpoint",
+	"/calico/resources/v3/projectcalico.org/felixconfigurations/default",
+	"/calico/resources/v3/projectcalico.org/networkpolicies",
+	"/calico/resources/v3/projectcalico.org/networkpolicies/default/my-network-policy",
+	"/calico/resources/v3/projectcalico.org/felixconfigurations/default/my-network-policy",
+	"/calico/felix/v2/region-Europe/host/h1/workload/o1/w1/endpoint/e1",
+}
+
+// FuzzKeyFromDefaultPath fuzzes KeyFromDefaultPath, makings sure it doesn't panic and comparing its
+// output and behaviour with the older implementation.
+//
+// Note: once we're sure of the new implementation we might want to remove the old implementation
+// next time we need to touch path parsing (or if the old impl panics in fuzzing, and we want to stop
+// maintaining it!).  If we do that, we should keep the test so that it continues to check the new
+// implementation doesn't panic with garbage input.
+func FuzzKeyFromDefaultPath(f *testing.F) {
+	for _, k := range interestingPaths {
+		f.Add(k)
+		f.Add(k[1:])
+		f.Add(k + "/")
+		f.Add("/" + k + "//")
+		f.Add("/cluster/cluster-1" + k)
+	}
+	f.Fuzz(func(t *testing.T, path string) {
+		// Parse with old and new, neither should panic!
+		oldKey := OldKeyFromDefaultPath(path)
+		newKey := KeyFromDefaultPath(path)
+		if oldKey == nil {
+			// Ignoring keys that the old parser couldn't handle.  The new parser is a little more permissive
+			// and consistent in some areas of escaping.
+			return
+		}
+		// If the old can parse it the new should parse it too (and get the same Key).
+		if !safeKeysEqual(oldKey, newKey) {
+			t.Fatalf("%q -> (new output) %v != (old output) %v", path, newKey, oldKey)
+		}
+
+		// Any key that we get out should support conversion back to a path.
+		serialised, err := KeyToDefaultPath(newKey)
+		if err != nil {
+			t.Fatalf("Failed to reserialise %q -> %v -> %s", path, newKey, err)
+		}
+
+		// All our canonical paths start with a / but some key types are permissive to a missing leading
+		// slash (for historical reasons around supporting older etcd versions).  Check that old and new
+		// are equally permissive by removing the slash and parsing the key again.
+		if len(path) > 0 && path[0] == '/' {
+			serialised = serialised[1:]
+		}
+		newKey2 := KeyFromDefaultPath(serialised)
+		oldKey2 := OldKeyFromDefaultPath(serialised)
+		if !safeKeysEqual(newKey2, oldKey2) {
+			t.Fatalf("%q -> (new output) %v != (old output) %v", serialised, newKey2, oldKey2)
+		}
+		if newKey2 != nil && !safeKeysEqual(newKey, newKey2) {
+			t.Fatalf("%q -> %v but %q -> %v", path, newKey, serialised, newKey2)
+		}
+	})
+}
+
+func safeKeysEqual(a, b Key) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+
+	// Due to an unfortunate historical mistake some of our keys embed non-comparable types net.IP and friends.
+	if !reflect.ValueOf(a).Type().Comparable() || !reflect.ValueOf(b).Type().Comparable() {
+		return reflect.DeepEqual(a, b)
+	}
+	return a == b
+}
 
 var _ = Describe("keys with region component", func() {
 
@@ -334,4 +479,54 @@ func mustParseCIDR(s string) net.IPNet {
 		panic(err)
 	}
 	return *ipNet
+}
+
+var benchResult any
+var _ = benchResult
+var benchKeys = []Key{
+	WorkloadEndpointKey{
+		Hostname:       "ip-12-23-24-52.cloud.foo.bar.baz",
+		OrchestratorID: "kubernetes",
+		WorkloadID:     "some-pod-name-12346",
+		EndpointID:     "eth0",
+	},
+	WireguardKey{NodeName: "ip-12-23-24-53.cloud.foo.bar.baz"},
+	HostEndpointKey{
+		Hostname:   "ip-12-23-24-52.cloud.foo.bar.baz",
+		EndpointID: "eth0",
+	},
+	ResourceKey{
+		Name:      "projectcalico-default-allow",
+		Namespace: "default",
+		Kind:      apiv3.KindNetworkPolicy,
+	},
+}
+
+func BenchmarkOldKeyFromDefaultPath(b *testing.B) {
+	benchmarkKeyFromDefaultPathImpl(b, OldKeyFromDefaultPath)
+}
+
+func BenchmarkKeyFromDefaultPath(b *testing.B) {
+	benchmarkKeyFromDefaultPathImpl(b, KeyFromDefaultPath)
+}
+
+func benchmarkKeyFromDefaultPathImpl(b *testing.B, keyFromDefaultPath func(path string) Key) {
+	var benchPaths []string
+	for _, k := range benchKeys {
+		p, err := KeyToDefaultPath(k)
+		if err != nil {
+			b.Fatal("Failed to parse keys:", err)
+		}
+		benchPaths = append(benchPaths, p)
+	}
+	defer logrus.SetLevel(logrus.GetLevel())
+	logrus.SetLevel(logrus.PanicLevel)
+
+	b.ResetTimer()
+	var key any
+	for i := 0; i <= b.N; i++ {
+		p := benchPaths[i%len(benchPaths)]
+		key = keyFromDefaultPath(p)
+	}
+	benchResult = key
 }


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The old version was linear, trying one key type after another. As the number of key types has grown this now causes noticable CPU usage when benchmarking. This commit reworks the algorithm to parse keys using a tree of switch statements and other conditions.

I considered making this a bit more generic but there are a lot of exceptions and special cases (for example, Felix config keys allow slashes in the name of the key), and, this should be a one-off since all new resources will go through the "resources/v3" path.

Add a Fuzz test that compares with the old implementation.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Reduce parsing overhead when parsing key/value pairs from Typha.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
