### PR TITLE
[release-v3.24] Auto pick #6679: Fix population of IPAM handle UID field.

### DIFF
--- a/calicoctl/tests/fv/ipam_test.go
+++ b/calicoctl/tests/fv/ipam_test.go
@@ -272,6 +272,9 @@ func TestIPAMCleanup(t *testing.T) {
 		Expect(report.LeakedHandles).To(HaveLen(1))
 		Expect(report.LeakedHandles[0].ID).To(Equal("leaked-handle"))
 		Expect(report.LeakedHandles[0].Revision).ToNot(BeEmpty())
+		if kdd {
+			Expect(report.LeakedHandles[0].UID).ToNot(BeNil())
+		}
 
 		out, err = CalicoctlMayFail(kdd, "ipam", "release", "--from-report=/tmp/ipam_report.json")
 		Expect(err).To(HaveOccurred(), "calicoctl ipam release should fail if datastore is not locked")

--- a/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
+++ b/libcalico-go/lib/backend/k8s/resources/ipam_handle.go
@@ -69,20 +69,21 @@ type ipamHandleClient struct {
 }
 
 func (c ipamHandleClient) toV1(kvpv3 *model.KVPair) *model.KVPair {
-	handle := kvpv3.Value.(*libapiv3.IPAMHandle).Spec.HandleID
-	block := kvpv3.Value.(*libapiv3.IPAMHandle).Spec.Block
-	del := kvpv3.Value.(*libapiv3.IPAMHandle).Spec.Deleted
+	v3Handle := kvpv3.Value.(*libapiv3.IPAMHandle)
+	handleID := v3Handle.Spec.HandleID
+	block := v3Handle.Spec.Block
+	del := v3Handle.Spec.Deleted
 	return &model.KVPair{
 		Key: model.IPAMHandleKey{
-			HandleID: handle,
+			HandleID: handleID,
 		},
 		Value: &model.IPAMHandle{
-			HandleID: handle,
+			HandleID: handleID,
 			Block:    block,
 			Deleted:  del,
 		},
 		Revision: kvpv3.Revision,
-		UID:      kvpv3.UID,
+		UID:      &v3Handle.UID,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #6679 on release-v3.24.

#6679: Fix population of IPAM handle UID field.

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
`calicoctl ipam check` needs to read the IPAM handle UID but it wasn't being populated in the KVPair.  It was being copied from the wrong field.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.