### PR TITLE
felix/bpf: bpf_attr_setup_load_prog takes prog name

### DIFF
--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -21,7 +21,7 @@
 #define CALI_USE_LINUX_FIB true
 
 #define CALI_LOG(__fmt, ...) do { \
-		static const char fmt[] = __fmt; \
+		char fmt[] = __fmt; \
 		bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
 } while (0)
 

--- a/felix/bpf/bpf_syscall.go
+++ b/felix/bpf/bpf_syscall.go
@@ -71,7 +71,7 @@ func GetMapFDByID(mapID int) (MapFD, error) {
 const defaultLogSize = 1024 * 1024
 const maxLogSize = 128 * 1024 * 1024
 
-func LoadBPFProgramFromInsns(insns asm.Insns, license string, progType uint32) (fd ProgFD, err error) {
+func LoadBPFProgramFromInsns(insns asm.Insns, name, license string, progType uint32) (fd ProgFD, err error) {
 	log.Debugf("LoadBPFProgramFromInsns(%v, %v, %v)", insns, license, progType)
 	bpfutils.IncreaseLockedMemoryQuota()
 
@@ -80,7 +80,7 @@ func LoadBPFProgramFromInsns(insns asm.Insns, license string, progType uint32) (
 	for retries := 10; retries > 0; retries-- {
 		// By default, try to load the program with logging disabled.  This has two advantages: better performance
 		// and the fact that the log cannot overflow.
-		fd, err = tryLoadBPFProgramFromInsns(insns, license, 0, progType)
+		fd, err = tryLoadBPFProgramFromInsns(insns, name, license, 0, progType)
 		if err == nil {
 			log.WithField("fd", fd).Debug("Loaded program successfully")
 			return fd, nil
@@ -94,7 +94,7 @@ func LoadBPFProgramFromInsns(insns asm.Insns, license string, progType uint32) (
 	log.WithError(err).Warn("Failed to load BPF program; collecting diagnostics...")
 	var logSize uint = defaultLogSize
 	for {
-		fd, err2 := tryLoadBPFProgramFromInsns(insns, license, logSize, progType)
+		fd, err2 := tryLoadBPFProgramFromInsns(insns, name, license, logSize, progType)
 		if err2 == nil {
 			// Unexpected but we'll take it.
 			log.Warn("Retry succeeded.")
@@ -113,7 +113,7 @@ func LoadBPFProgramFromInsns(insns asm.Insns, license string, progType uint32) (
 	}
 }
 
-func tryLoadBPFProgramFromInsns(insns asm.Insns, license string, logSize uint, progType uint32) (ProgFD, error) {
+func tryLoadBPFProgramFromInsns(insns asm.Insns, name, license string, logSize uint, progType uint32) (ProgFD, error) {
 	log.Debugf("tryLoadBPFProgramFromInsns(..., %v, %v, %v)", license, logSize, progType)
 	bpfAttr := C.bpf_attr_alloc()
 	defer C.free(unsafe.Pointer(bpfAttr))
@@ -122,6 +122,8 @@ func tryLoadBPFProgramFromInsns(insns asm.Insns, license string, logSize uint, p
 	defer C.free(cInsnBytes)
 	cLicense := C.CString(license)
 	defer C.free(unsafe.Pointer(cLicense))
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
 
 	var logBuf unsafe.Pointer
 	var logLevel uint
@@ -131,7 +133,9 @@ func tryLoadBPFProgramFromInsns(insns asm.Insns, license string, logSize uint, p
 		defer C.free(logBuf)
 	}
 
-	C.bpf_attr_setup_load_prog(bpfAttr, (C.uint)(progType), C.uint(len(insns)), cInsnBytes, cLicense, (C.uint)(logLevel), (C.uint)(logSize), logBuf)
+	C.bpf_attr_setup_load_prog(bpfAttr, cName,
+		(C.uint)(progType), C.uint(len(insns)), cInsnBytes, cLicense,
+		(C.uint)(logLevel), (C.uint)(logSize), logBuf)
 	fd, _, errno := unix.Syscall(unix.SYS_BPF, unix.BPF_PROG_LOAD, uintptr(unsafe.Pointer(bpfAttr)), C.sizeof_union_bpf_attr)
 
 	if errno != 0 && errno != unix.ENOSPC /* log buffer too small */ {

--- a/felix/bpf/bpf_syscall.h
+++ b/felix/bpf/bpf_syscall.h
@@ -74,7 +74,16 @@ void bpf_attr_setup_map_elem_for_delete(union bpf_attr *attr, __u32 map_fd, void
 
 // bpf_attr_setup_load_prog sets up the bpf_attr union for use with BPF_PROG_LOAD.
 // A C function makes this easier because unions aren't easy to access from Go.
-void bpf_attr_setup_load_prog(union bpf_attr *attr, __u32 prog_type, __u32 insn_count, void *insns, char *license, __u32 log_level, __u32 log_size, void *log_buf) {
+void bpf_attr_setup_load_prog(union bpf_attr *attr,
+			      const char *name,
+			      __u32 prog_type,
+			      __u32 insn_count,
+			      void *insns,
+			      char *license,
+			      __u32 log_level,
+			      __u32 log_size,
+			      void *log_buf)
+{
    attr->prog_type = prog_type;
    attr->insn_cnt = insn_count;
    attr->insns = (__u64)(unsigned long)insns;
@@ -83,7 +92,26 @@ void bpf_attr_setup_load_prog(union bpf_attr *attr, __u32 prog_type, __u32 insn_
    attr->log_size = log_size;
    attr->log_buf = (__u64)(unsigned long)log_buf;
    attr->kern_version = 0;
-   if (log_size > 0) ((char *)log_buf)[0] = 0;
+
+   if (log_size > 0) {
+	   ((char *)log_buf)[0] = 0;
+   }
+
+   if (name) {
+	   int sz = sizeof(attr->prog_name);
+
+	   int i;
+	   for (i = 0; i < sz; i++) {
+		   attr->prog_name[i] = name[i];
+		   if (name[i] == '\0') {
+			   break;
+		   }
+	   }
+
+	   if (i == sz) {
+		   attr->prog_name[sz - 1] = '\0';
+	   }
+   }
 }
 
 // bpf_attr_setup_prog_run sets up the bpf_attr union for use with BPF_PROG_TEST_RUN.

--- a/felix/bpf/bpf_syscall_stub.go
+++ b/felix/bpf/bpf_syscall_stub.go
@@ -34,7 +34,7 @@ func GetMapFDByID(mapID int) (MapFD, error) {
 	panic("BPF syscall stub")
 }
 
-func LoadBPFProgramFromInsns(insns asm.Insns, license string, progType uint32) (ProgFD, error) {
+func LoadBPFProgramFromInsns(insns asm.Insns, name, license string, progType uint32) (ProgFD, error) {
 	panic("BPF syscall stub")
 }
 

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -170,7 +170,7 @@ func TestCompileTemplateRun(t *testing.T) {
 
 func TestLoadZeroProgram(t *testing.T) {
 	RegisterTestingT(t)
-	fd, err := bpf.LoadBPFProgramFromInsns(nil, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	fd, err := bpf.LoadBPFProgramFromInsns(nil, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	if err == nil {
 		_ = fd.Close()
 	}
@@ -303,9 +303,9 @@ outer:
 		Expect(err).NotTo(HaveOccurred())
 		var polProgFD bpf.ProgFD
 		if topts.xdp {
-			polProgFD, err = bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_XDP)
+			polProgFD, err = bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_XDP)
 		} else {
-			polProgFD, err = bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+			polProgFD, err = bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 		}
 		Expect(err).NotTo(HaveOccurred(), "Failed to load rules program.")
 		defer func() { _ = polProgFD.Close() }()
@@ -1310,7 +1310,7 @@ func TestJumpMap(t *testing.T) {
 	rules := polprog.Rules{}
 	insns, err := pg.Instructions(rules)
 	Expect(err).NotTo(HaveOccurred())
-	progFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	progFD, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).NotTo(HaveOccurred())
 
 	k := make([]byte, 4)

--- a/felix/bpf/ut/pol_prog_test.go
+++ b/felix/bpf/ut/pol_prog_test.go
@@ -45,7 +45,7 @@ func TestLoadAllowAllProgram(t *testing.T) {
 	insns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
 
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(fd).NotTo(BeZero())
 	defer func() {
@@ -79,7 +79,7 @@ func TestLoadProgramWithMapAccess(t *testing.T) {
 	insns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
 
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(fd).NotTo(BeZero())
 	defer func() {
@@ -154,7 +154,7 @@ func TestLoadKitchenSinkPolicy(t *testing.T) {
 		}}})
 
 	Expect(err).NotTo(HaveOccurred())
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(fd).NotTo(BeZero())
 	Expect(fd.Close()).NotTo(HaveOccurred())
@@ -169,7 +169,7 @@ func TestLoadGarbageProgram(t *testing.T) {
 		insns = append(insns, asm.Insn{Instruction: [8]uint8{i, i, i, i, i, i, i, i}})
 	}
 
-	fd, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	fd, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).To(HaveOccurred())
 	Expect(fd).To(BeZero())
 }
@@ -2412,7 +2412,7 @@ func runTest(t *testing.T, tp testPolicy) {
 
 	// Load the program into the kernel.  We don't pin it so it'll be removed when the
 	// test process exits (or by the defer).
-	polProgFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	polProgFD, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).NotTo(HaveOccurred(), "failed to load program into the kernel")
 	Expect(polProgFD).NotTo(BeZero())
 	defer func() {
@@ -2473,7 +2473,7 @@ func installAllowedProgram(jumpMap bpf.Map, jumpMapindex int) bpf.ProgFD {
 
 	epiInsns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
-	epiFD, err := bpf.LoadBPFProgramFromInsns(epiInsns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	epiFD, err := bpf.LoadBPFProgramFromInsns(epiInsns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).NotTo(HaveOccurred(), "failed to load program into the kernel")
 	Expect(epiFD).NotTo(BeZero())
 
@@ -2496,7 +2496,7 @@ func installDropProgram(jumpMap bpf.Map, jumpMapindex int) bpf.ProgFD {
 
 	epiInsns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
-	dropFD, err := bpf.LoadBPFProgramFromInsns(epiInsns, "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
+	dropFD, err := bpf.LoadBPFProgramFromInsns(epiInsns, "calico_policy", "Apache-2.0", unix.BPF_PROG_TYPE_SCHED_CLS)
 	Expect(err).NotTo(HaveOccurred(), "failed to load program into the kernel")
 	Expect(dropFD).NotTo(BeZero())
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1908,7 +1908,7 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(jumpMapFD bpf.MapFD, rules po
 	if rules.ForXDP {
 		progType = unix.BPF_PROG_TYPE_XDP
 	}
-	progFD, err := bpf.LoadBPFProgramFromInsns(insns, "Apache-2.0", uint32(progType))
+	progFD, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", uint32(progType))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load BPF policy program v%v: %w", ipFamily, err)
 	}

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1875,7 +1875,7 @@ func (m *bpfEndpointManager) updatePolicyProgram(jumpMapFD bpf.MapFD, rules polp
 	}
 
 	for _, ipFamily := range ipVersions {
-		insns, err := m.doUpdatePolicyProgram(jumpMapFD, rules, ipFamily)
+		insns, err := m.doUpdatePolicyProgram(ap.IfaceName(), jumpMapFD, rules, ipFamily)
 		perr := m.writePolicyDebugInfo(insns, ap.IfaceName(), ipFamily, polDir, ap.HookName(), err)
 		if perr != nil {
 			log.WithError(perr).Warn("error writing policy debug information")
@@ -1895,8 +1895,11 @@ func jumpPolicyKey(ipFamily proto.IPVersion) []byte {
 	}
 }
 
-func (m *bpfEndpointManager) doUpdatePolicyProgram(jumpMapFD bpf.MapFD, rules polprog.Rules, ipFamily proto.IPVersion) (asm.Insns, error) {
-	pg := polprog.NewBuilder(m.ipSetIDAlloc, m.bpfMapContext.IpsetsMap.MapFD(), m.bpfMapContext.StateMap.MapFD(), jumpMapFD, m.bpfPolicyDebugEnabled)
+func (m *bpfEndpointManager) doUpdatePolicyProgram(iface string, jumpMapFD bpf.MapFD, rules polprog.Rules,
+	ipFamily proto.IPVersion) (asm.Insns, error) {
+
+	pg := polprog.NewBuilder(m.ipSetIDAlloc, m.bpfMapContext.IpsetsMap.MapFD(),
+		m.bpfMapContext.StateMap.MapFD(), jumpMapFD, m.bpfPolicyDebugEnabled)
 	if ipFamily == proto.IPVersion_IPV6 {
 		pg.EnableIPv6Mode()
 	}
@@ -1908,7 +1911,7 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(jumpMapFD bpf.MapFD, rules po
 	if rules.ForXDP {
 		progType = unix.BPF_PROG_TYPE_XDP
 	}
-	progFD, err := bpf.LoadBPFProgramFromInsns(insns, "calico_policy", "Apache-2.0", uint32(progType))
+	progFD, err := bpf.LoadBPFProgramFromInsns(insns, fmt.Sprintf("pol_%s", iface), "Apache-2.0", uint32(progType))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load BPF policy program v%v: %w", ipFamily, err)
 	}


### PR DESCRIPTION
Allows to name programs when loading using the syscall directly, like policy programs.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
