### PR TITLE
Calico for OpenStack: Handle changing MTU in the scenarios where Nova and libvirt successfully handle that

### DIFF
--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -234,10 +234,11 @@ class MTUWatcher(object):
 
     def record_mtu(self, if_name, mtu):
         LOG.debug("MTU for %s is now %d", if_name, mtu)
-        if if_name in self.port_id_by_if_name and mtu != self.mtu_by_if_name.get(if_name):
+        old_mtu = self.mtu_by_if_name.get(if_name)
+        self.mtu_by_if_name[if_name] = mtu
+        if if_name in self.port_id_by_if_name and mtu != old_mtu:
             # MTU changing for a watched port.
             self.port_handler.on_mtu_change(self.port_id_by_if_name[if_name], mtu)
-        self.mtu_by_if_name[if_name] = mtu
 
     def if_deleted(self, if_name):
         LOG.debug("Interface %s deleted", if_name)

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -190,8 +190,8 @@ class MTUWatcher(object):
         # transitions.
         while not self.ip_monitor_running:
             # Create and delete a dummy interface.
-            os.system("ip link add calico-dhcp-dummy type dummy")
-            os.system("ip link del calico-dhcp-dummy type dummy")
+            os.system("ip link add calico-dhcp-dmy type dummy")
+            os.system("ip link del calico-dhcp-dmy type dummy")
             time.sleep(0.5)
 
         # Now run 'ip link', to find MTU of all pre-existing interfaces.

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -499,8 +499,14 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Add this port into the NetModel.
         self.agent.cache.put_port(dhcp.DictModel(port))
 
-        # Schedule updating Dnsmasq.
-        self._update_dnsmasq(port['network_id'])
+        # If we have seen the TAP interface, schedule updating Dnsmasq;
+        # otherwise wait until we do see the TAP interface, whereupon
+        # _update_dnsmasq will be called again.  Dnsmasq updates can
+        # take a little time, and they run in series, so it's best to
+        # wait if we don't have the information we need yet, to avoid
+        # delaying the correct Dnsmasq update that we really want.
+        if mtu:
+            self._update_dnsmasq(port['network_id'])
 
     def get_mtu_option(self, mtu):
         return dhcp.DictModel({

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -165,8 +165,8 @@ class MTUWatcher(object):
         self.port_handler = port_handler
         self.mtu_by_if_name = {}
         self.port_id_by_if_name = {}
-        self.rx_up = re.compile('[0-9]+: ([a-z0-9-]+).* mtu ([0-9]+) .* state UP')
-        self.rx_del = re.compile('Deleted [0-9]+: ([a-z0-9-]+)')
+        self.rx_up = re.compile('[0-9]+: (tap[a-z0-9-]+).* mtu ([0-9]+) .* state UP')
+        self.rx_del = re.compile('Deleted [0-9]+: (tap[a-z0-9-]+)')
 
     def get_mtu(self, if_name):
         # Note, returns None if we haven't yet seen an MTU for the given

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -51,6 +51,9 @@ from networking_calico import etcdutils
 
 from etcd3gw.exceptions import Etcd3Exception
 
+from eventlet.queue import Empty
+from eventlet.queue import LightQueue
+
 LOG = logging.getLogger(__name__)
 
 NETWORK_ID = 'calico'
@@ -148,6 +151,60 @@ def split_endpoint_name(name):
     return tuple([p.replace('#', '-') for p in parts])
 
 
+class DnsmasqUpdater(object):
+    def __init__(self, agent):
+        self.agent = agent
+        self.updates_needed = LightQueue()
+
+        # Cache of the ports that we've asked Dnsmasq to handle, for each
+        # network ID.
+        self._last_dnsmasq_ports = {}
+
+    def update_network(self, network_id):
+        self.updates_needed.put(network_id)
+
+    def start(self):
+        while True:
+            LOG.info("DnsmasqUpdater: wait until updates needed")
+            dirty_network_ids = set()
+            dirty_network_ids.add(self.updates_needed.get())
+            try:
+                while True:
+                    dirty_network_ids.add(self.updates_needed.get_nowait())
+            except Empty:
+                pass
+            LOG.info("DnsmasqUpdater: updating now for %r", dirty_network_ids)
+            for network_id in dirty_network_ids:
+                self.really_update_dnsmasq(network_id)
+
+    def really_update_dnsmasq(self, network_id):
+        # Get NetModel for that network ID.
+        net = self.agent.cache.get_network_by_id(network_id)
+        LOG.debug("Net: %s", net)
+
+        # Compute the set of ports that we need Dnsmasq to handle for this
+        # network ID.
+        ports_needed = [
+            port for port in net.ports if port.device_id.startswith('tap')
+        ]
+        ports_needed.sort(key=lambda port: port.id)
+
+        # Compare that against what we've last asked Dnsmasq to handle.
+        if ports_needed != self._last_dnsmasq_ports.get(network_id):
+            # Requirements have changed, so start, restart or stop Dnsmasq for
+            # that network ID.
+            if ports_needed:
+                self.agent.call_driver('restart', net)
+            else:
+                # No ports left, so also remove this network from the cache.
+                _fix_network_cache_port_lookup(self.agent, net.id)
+                self.agent.cache.remove(net)
+                self.agent.call_driver('disable', net)
+
+            # Remember what we've asked Dnsmasq for.
+            self._last_dnsmasq_ports[network_id] = ports_needed
+
+
 class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
 
     def __init__(self, agent, hostname):
@@ -174,6 +231,10 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Networks for which Dnsmasq needs updating.
         self.dirty_networks = set()
 
+        # Use a separate thread for dnsmasq updating, so that we can
+        # also trigger that for MTU changes.
+        self.dnsmasq_updater = DnsmasqUpdater(agent)
+
         # Also watch the etcd subnet trees: both the new region-aware
         # one, and the old pre-region one, so as to support a VM
         # renewing its DHCP lease while an upgrade is still in
@@ -184,14 +245,11 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
             self,
             datamodel_v2.subnet_dir(self.region_string))
 
-        # Cache of the ports that we've asked Dnsmasq to handle, for each
-        # network ID.
-        self._last_dnsmasq_ports = {}
-
         # Cache of current local endpoint IDs.
         self.local_endpoint_ids = set()
 
     def start(self):
+        eventlet.spawn(self.dnsmasq_updater.start)
         eventlet.spawn(self.v1_subnet_watcher.start)
         eventlet.spawn(self.subnet_watcher.start)
         super(CalicoEtcdWatcher, self).start()
@@ -407,33 +465,10 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
 
             # Add (or update) the NetModel in the cache.
             LOG.debug("Net: %s", net)
-            self._fix_network_cache_port_lookup(net.id)
+            _fix_network_cache_port_lookup(self.agent, net.id)
             self.agent.cache.put(net)
 
         return net.id
-
-    def _fix_network_cache_port_lookup(self, network_id):
-        """Fix NetworkCache before removing or replacing a network.
-
-        neutron.agent.dhcp.agent is bugged in that it adds the DHCP port into
-        the cache without updating the cache's port_lookup dict, but then
-        NetworkCache.remove() barfs if there is a port in network.ports but not
-        in that dict...
-
-        NetworkCache.put() implicitly does a remove() first if there is already
-        a NetModel in the cache with the same ID.  So a put() to update or
-        replace a network also hits this problem.
-
-        This method avoids that problem by ensuring that all of a network's
-        ports are in the port_lookup dict.  A caller should call this
-        immediately before a remove() or a put().
-        """
-
-        # If there is an existing NetModel for this network ID, ensure that all
-        # its ports are in the port_lookup dict.
-        if network_id in self.agent.cache.cache:
-            for port in self.agent.cache.cache[network_id].ports:
-                self.agent.cache.port_lookup[port.id] = network_id
 
     def _update_dnsmasq(self, network_id):
         """Start/stop/restart Dnsmasq for NETWORK_ID."""
@@ -445,31 +480,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
             self.dirty_networks.add(network_id)
             return
 
-        # Get NetModel for that network ID.
-        net = self.agent.cache.get_network_by_id(network_id)
-        LOG.debug("Net: %s", net)
-
-        # Compute the set of ports that we need Dnsmasq to handle for this
-        # network ID.
-        ports_needed = [
-            port for port in net.ports if port.device_id.startswith('tap')
-        ]
-        ports_needed.sort(key=lambda port: port.id)
-
-        # Compare that against what we've last asked Dnsmasq to handle.
-        if ports_needed != self._last_dnsmasq_ports.get(network_id):
-            # Requirements have changed, so start, restart or stop Dnsmasq for
-            # that network ID.
-            if ports_needed:
-                self.agent.call_driver('restart', net)
-            else:
-                # No ports left, so also remove this network from the cache.
-                self._fix_network_cache_port_lookup(net.id)
-                self.agent.cache.remove(net)
-                self.agent.call_driver('disable', net)
-
-            # Remember what we've asked Dnsmasq for.
-            self._last_dnsmasq_ports[network_id] = ports_needed
+        self.dnsmasq_updater.update_network(network_id)
 
     def on_endpoint_delete(self, response_ignored, name):
         """Handler for endpoint deletion."""
@@ -503,7 +514,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         LOG.debug("Reset cache for new snapshot")
         for network_id in list(self.agent.cache.get_network_ids()):
             self.dirty_networks.add(network_id)
-            self._fix_network_cache_port_lookup(network_id)
+            _fix_network_cache_port_lookup(self.agent, network_id)
             self.agent.cache.put(empty_network(network_id))
 
         # Suppress Dnsmasq updates until we've processed the whole snapshot.
@@ -518,6 +529,30 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         for network_id in self.dirty_networks:
             self._update_dnsmasq(network_id)
         self.dirty_networks = set()
+
+
+def _fix_network_cache_port_lookup(agent, network_id):
+    """Fix NetworkCache before removing or replacing a network.
+
+    neutron.agent.dhcp.agent is bugged in that it adds the DHCP port into
+    the cache without updating the cache's port_lookup dict, but then
+    NetworkCache.remove() barfs if there is a port in network.ports but not
+    in that dict...
+
+    NetworkCache.put() implicitly does a remove() first if there is already
+    a NetModel in the cache with the same ID.  So a put() to update or
+    replace a network also hits this problem.
+
+    This method avoids that problem by ensuring that all of a network's
+    ports are in the port_lookup dict.  A caller should call this
+    immediately before a remove() or a put().
+    """
+
+    # If there is an existing NetModel for this network ID, ensure that all
+    # its ports are in the port_lookup dict.
+    if network_id in agent.cache.cache:
+        for port in agent.cache.cache[network_id].ports:
+            agent.cache.port_lookup[port.id] = network_id
 
 
 class SubnetIDNotFound(Exception):

--- a/networking-calico/networking_calico/agent/linux/interface.py
+++ b/networking-calico/networking_calico/agent/linux/interface.py
@@ -61,6 +61,9 @@ class RoutedInterfaceDriver(interface.LinuxInterfaceDriver):
 
         ns_dummy.link.set_up()
 
+    def set_mtu(self, device_name, mtu, namespace=None, prefix=None):
+        pass
+
     def init_l3(self, device_name, ip_cidrs, namespace=None,
                 preserve_ips=[], gateway=None, extra_subnets=[]):
         """L3 initialization for RoutedInterfaceDriver.


### PR DESCRIPTION
## Description

The OpenStack API allows MTU to be changed on a Neutron network.  Given related Nova/libvirt support (or not) for changing MTU, we believe there are two scenarios where the new MTU value should take effect:

1. If a new VM is created on that network, after changing its MTU, the VM has the new MTU value.
2. If an existing VM is hard-rebooted, it has the new MTU value after reboot.

And two scenarios where the new MTU does not take effect:

3. If a pre-existing VM is not rebooted, it keeps the same MTU as it had before.
4. If a pre-existing VM is live-migrated to a new host, it keeps the same MTU as it had before.

With Calico as the Neutron driver, Calico is involved insofar as it configures the DHCP server (dnsmasq) which tells the VM guest OS what its internal MTU should be.  Prior to this PR, Calico did not set the DHCP MTU option, so a VM guest would always internally have MTU 1500, even if Nova had set a different MTU on the host side of the VM's TAP interface.

This PR enhances the Calico DHCP agent to configure the DHCP MTU option to match what Nova sets on the host side.  In other words Calico entirely defers to the MTU value that Nova and libvirt have decided to program - which derives from the Neutron network MTU, but with caveats as noted above - instead of monitoring the Neutron network MTU value itself.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
