### PR TITLE
Tweak TLS config wherever used and make it FIPS compliant.

### DIFF
--- a/apiserver/cmd/apiserver/server/options.go
+++ b/apiserver/cmd/apiserver/server/options.go
@@ -121,6 +121,7 @@ func (o *CalicoServerOptions) Config() (*apiserver.Config, error) {
 		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 	}
 	serverConfig.SecureServing.CipherSuites = cipherSuites
+	serverConfig.SecureServing.MinTLSVersion = tls.VersionTLS12
 
 	if o.PrintSwagger {
 		o.DisableAuth = true

--- a/crypto/pkg/tls/tls.go
+++ b/crypto/pkg/tls/tls.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tls
+
+import (
+	"crypto/tls"
+)
+
+// NewTLSConfig returns a tls.Config with the recommended default settings for Calico.
+// Read more recommendations here:
+// https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4095
+func NewTLSConfig(fipsMode bool) *tls.Config {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if fipsMode {
+		cfg.CipherSuites = []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		}
+		cfg.CurvePreferences = []tls.CurveID{tls.CurveP384, tls.CurveP256}
+		// Our certificate for FIPS does not mention validation for v1.3.
+		cfg.MaxVersion = tls.VersionTLS12
+		cfg.Renegotiation = tls.RenegotiateNever
+	}
+	return cfg
+}

--- a/go.mod
+++ b/go.mod
@@ -298,7 +298,9 @@ replace (
 	k8s.io/api => k8s.io/api v0.24.0
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.0
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.0
-	k8s.io/apiserver => k8s.io/apiserver v0.24.0
+
+	// Our fork is identical to k8s.io with the exception of an added tls-max-version flag.
+	k8s.io/apiserver => github.com/projectcalico/kubernetes-apiserver v0.24.0-calico
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.24.0
 	k8s.io/client-go => k8s.io/client-go v0.24.0
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -762,6 +762,8 @@ github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 h1:J
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54/go.mod h1:UgC0aTQ2KMDxlX3lU/stndk7DMUBJqzN40yFiILHgxc=
 github.com/projectcalico/hcsshim v0.8.9-calico h1:aRrOWouDTzKwaIoRGMV/I1QikR+ikwj1G9T9h3wD090=
 github.com/projectcalico/hcsshim v0.8.9-calico/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg38RRsjT5y8=
+github.com/projectcalico/kubernetes-apiserver v0.24.0-calico h1:uCS2NO12VUxPJgxoWa5n8cOPU/KGZVTCsIcK1984hXU=
+github.com/projectcalico/kubernetes-apiserver v0.24.0-calico/go.mod h1:WFx2yiOMawnogNToVvUYT9nn1jaIkMKj41ZYCVycsBA=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=

--- a/libcalico-go/lib/apiconfig/apiconfig.go
+++ b/libcalico-go/lib/apiconfig/apiconfig.go
@@ -62,6 +62,9 @@ type EtcdConfig struct {
 	EtcdKey    string `json:"etcdKey" ignored:"true"`
 	EtcdCert   string `json:"etcdCert" ignored:"true"`
 	EtcdCACert string `json:"etcdCACert" ignored:"true"`
+
+	// EtcdFIPSModeEnabled uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
+	EtcdFIPSModeEnabled bool `json:"etcdFIPSModeEnabled" envconfig:"ETCD_FIPS_MODE_ENABLED"`
 }
 
 type KubeConfig struct {

--- a/typha/pkg/config/config_params.go
+++ b/typha/pkg/config/config_params.go
@@ -147,6 +147,9 @@ type Config struct {
 	K8sServiceName                        string        `config:"string;calico-typha"`
 	K8sPortName                           string        `config:"string;calico-typha"`
 
+	// FIPSModeEnabled Enables FIPS 140-2 verified crypto mode.
+	FIPSModeEnabled bool `config:"bool;false"`
+
 	// State tracking.
 
 	// nameToSource tracks where we loaded each config param from.

--- a/typha/pkg/syncclientutils/config.go
+++ b/typha/pkg/syncclientutils/config.go
@@ -42,6 +42,9 @@ type TyphaConfig struct {
 	CAFile   string
 	CN       string
 	URISAN   string
+
+	// FIPSModeEnabled Enables FIPS 140-2 verified crypto mode.
+	FIPSModeEnabled bool
 }
 
 // ReadTyphaConfig reads the TyphaConfig from environment variables.
@@ -65,6 +68,8 @@ func ReadTyphaConfig(supportedPrefixes []string) TyphaConfig {
 					}
 					duration := time.Duration(seconds * float64(time.Second))
 					reflect.ValueOf(typhaConfig).Elem().FieldByName(field.Name).Set(reflect.ValueOf(duration))
+				} else if field.Type.Name() == "bool" {
+					reflect.ValueOf(typhaConfig).Elem().FieldByName(field.Name).SetBool(value == "true")
 				} else {
 					reflect.ValueOf(typhaConfig).Elem().FieldByName(field.Name).Set(reflect.ValueOf(value))
 				}

--- a/typha/pkg/syncclientutils/config_test.go
+++ b/typha/pkg/syncclientutils/config_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncclientutils_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/typha/pkg/syncclientutils"
+)
+
+var _ = Describe("Test TyphaConfig", func() {
+
+	BeforeEach(func() {
+		os.Setenv("FELIX_TYPHACAFILE", "cafile")
+		os.Setenv("FELIX_TYPHAFIPSMODEENABLED", "true")
+		os.Setenv("FELIX_TYPHAREADTIMEOUT", "100")
+
+	})
+
+	It("should be able to read all types", func() {
+		typhaConfig := syncclientutils.ReadTyphaConfig([]string{"FELIX_"})
+		Expect(typhaConfig.CAFile).To(Equal("cafile"))
+		Expect(typhaConfig.FIPSModeEnabled).To(BeTrue())
+		Expect(typhaConfig.ReadTimeout.Seconds()).To(Equal(100.))
+	})
+})

--- a/typha/pkg/syncclientutils/startsyncerclient.go
+++ b/typha/pkg/syncclientutils/startsyncerclient.go
@@ -59,14 +59,15 @@ func MustStartSyncerClientIfTyphaConfigured(
 		myVersion, myHostname, myInfo,
 		cbs,
 		&syncclient.Options{
-			SyncerType:   syncerType,
-			ReadTimeout:  typhaConfig.ReadTimeout,
-			WriteTimeout: typhaConfig.WriteTimeout,
-			KeyFile:      typhaConfig.KeyFile,
-			CertFile:     typhaConfig.CertFile,
-			CAFile:       typhaConfig.CAFile,
-			ServerCN:     typhaConfig.CN,
-			ServerURISAN: typhaConfig.URISAN,
+			SyncerType:      syncerType,
+			ReadTimeout:     typhaConfig.ReadTimeout,
+			WriteTimeout:    typhaConfig.WriteTimeout,
+			KeyFile:         typhaConfig.KeyFile,
+			CertFile:        typhaConfig.CertFile,
+			CAFile:          typhaConfig.CAFile,
+			ServerCN:        typhaConfig.CN,
+			ServerURISAN:    typhaConfig.URISAN,
+			FIPSModeEnabled: typhaConfig.FIPSModeEnabled,
 		},
 	)
 	if err := typhaConnection.Start(context.Background()); err != nil {

--- a/typha/pkg/syncclientutils/startsyncerclient_suite_test.go
+++ b/typha/pkg/syncclientutils/startsyncerclient_suite_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncclientutils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
+
+	"testing"
+)
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+}
+
+func TestSyncClientUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../report/startsyncerclient_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "TestSyncClientUtils Suite", []Reporter{junitReporter})
+}

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -30,17 +30,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/libcalico-go/lib/writelogger"
+	"github.com/golang/snappy"
 
-	"github.com/projectcalico/calico/typha/pkg/promutils"
-
+	calicotls "github.com/projectcalico/calico/crypto/pkg/tls"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/health"
 	cprometheus "github.com/projectcalico/calico/libcalico-go/lib/prometheus"
+	"github.com/projectcalico/calico/libcalico-go/lib/writelogger"
+	"github.com/projectcalico/calico/typha/pkg/promutils"
 
 	"github.com/projectcalico/calico/typha/pkg/buildinfo"
 	"github.com/projectcalico/calico/typha/pkg/jitter"
@@ -153,6 +153,9 @@ type Config struct {
 	// DebugLogWrites tells the server to wrap each connection with a Writer that
 	// logs every write.  Intended only for use in tests!
 	DebugLogWrites bool
+
+	// FIPSModeEnabled Enables FIPS 140-2 verified crypto mode.
+	FIPSModeEnabled bool
 }
 
 const (
@@ -318,7 +321,10 @@ func (s *Server) serve(cxt context.Context) {
 	)
 	if s.config.requiringTLS() {
 		pwd, _ := os.Getwd()
-		logCxt.WithField("pwd", pwd).Info("Opening TLS listen socket")
+		logCxt.WithFields(log.Fields{
+			"pwd":             pwd,
+			"fipsModeEnabled": s.config.FIPSModeEnabled,
+		}).Info("Opening TLS listen socket")
 		cert, tlsErr := tls.LoadX509KeyPair(s.config.CertFile, s.config.KeyFile)
 		if tlsErr != nil {
 			logCxt.WithFields(log.Fields{
@@ -326,13 +332,8 @@ func (s *Server) serve(cxt context.Context) {
 				"keyFile":  s.config.KeyFile,
 			}).WithError(tlsErr).Panic("Failed to load certificate and key")
 		}
-		tlsConfig := tls.Config{Certificates: []tls.Certificate{cert}}
-		// Typha API is a private binary API so we can enforce a recent TLS variant without
-		// worrying about back-compatibility with old browsers (for example).
-		tlsConfig.MinVersion = tls.VersionTLS12
-
-		// Set allowed cipher suites.
-		tlsConfig.CipherSuites = s.allowedCiphers()
+		tlsConfig := calicotls.NewTLSConfig(s.config.FIPSModeEnabled)
+		tlsConfig.Certificates = []tls.Certificate{cert}
 
 		// Arrange for server to verify the clients' certificates.
 		logCxt.Info("Will verify client certificates")
@@ -354,7 +355,7 @@ func (s *Server) serve(cxt context.Context) {
 		)
 
 		laddr := fmt.Sprintf("0.0.0.0:%v", s.config.ListenPort())
-		l, err = tls.Listen("tcp", laddr, &tlsConfig)
+		l, err = tls.Listen("tcp", laddr, tlsConfig)
 	} else {
 		logCxt.Info("Opening listen socket")
 		l, err = net.ListenTCP("tcp", &net.TCPAddr{Port: s.config.ListenPort()})
@@ -618,19 +619,6 @@ func (s *Server) TerminateRandomConnection(logCtx *log.Entry, reason string) boo
 		return true
 	}
 	return false
-}
-
-// allowedCiphers returns the set of allowed cipher suites for the server.
-// The list is taken from https://github.com/golang/go/blob/dev.boringcrypto.go1.13/src/crypto/tls/boring.go#L54
-func (s *Server) allowedCiphers() []uint16 {
-	return []uint16{
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-	}
 }
 
 func (s *Server) reportHealth() {


### PR DESCRIPTION
- Apiserver will always use the recommended ciphers to make it fips compliant, the operator will add the tls-max-version flag.
- Replace tls.Config creation with our own convenience function that sets recommended settings.
- Go mod uses our fork of k8s.io/apiserver, which is identical to v0.24.0, with an added flag. We will submit a PR upstream to get this into Kubernetes.