### PR TITLE
fix: update template test cases

### DIFF
--- a/confd/pkg/resource/template/template_funcs_test.go
+++ b/confd/pkg/resource/template/template_funcs_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 var _ = Describe("Template", func() {
-	Describe("validate hashToIPv4 method,", func() {
-		It("should get valid multicast ip address", func() {
+	Describe("to validate hashToIPv4 method,", func() {
+		It("It should validate router_id from the invalid range", func() {
 			expectedRouterId := "207.94.5.27"
 			nodeName := "Testrobin123"
-			actualRouterId := hashToIPv4(nodeName)
+			actualRouterId := hashToIPv4(nodeName) //invalid router_id 239.94.5.27
 			Expect(expectedRouterId).To(Equal(actualRouterId))
 		})
-		It("should get valid ip address", func() {
+		It("It should validate router_id from the valid range", func() {
 			expectedRouterId := "109.174.215.226"
 			nodeName := "nodeTest"
 			actualRouterId := hashToIPv4(nodeName)

--- a/confd/pkg/resource/template/template_suite_test.go
+++ b/confd/pkg/resource/template/template_suite_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 )
 
-func TestCalico(t *testing.T) {
+func TestTemplate(t *testing.T) {
 	testutils.HookLogrusForGinkgo()
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../../../report/template_suite.xml")


### PR DESCRIPTION
## Description
Updating test name and add comments for the test cases hashToIPv4 method
For bug fix: https://github.com/projectcalico/calico/issues/5146


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
https://github.com/projectcalico/calico/issues/5146

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>
https://github.com/projectcalico/calico/pull/6674

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [X] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.
docs-not-required
- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.
release-note-not-required
- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
