### PR TITLE
calico-kube-controllers: Run as non-root by default for the armv7, ppc64le and s390x images

### DIFF
--- a/kube-controllers/Dockerfile.armv7
+++ b/kube-controllers/Dockerfile.armv7
@@ -11,9 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+ARG QEMU_IMAGE
+
+FROM ${QEMU_IMAGE} as qemu
+
+FROM arm32v7/alpine:3.12 as base
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin/
+
+# Make sure the status file is owned by our user.
+RUN mkdir /status
+RUN touch /status/status.json && chown 999 /status/status.json
+
 FROM scratch
 LABEL maintainer "Marc Crebassa <aalaesar@gmail.com>"
 
+COPY --from=base /status /status
+
 ADD bin/kube-controllers-linux-armv7 /usr/bin/kube-controllers
 ADD bin/check-status-linux-armv7 /usr/bin/check-status
+USER 999
 ENTRYPOINT ["/usr/bin/kube-controllers"]

--- a/kube-controllers/Dockerfile.ppc64le
+++ b/kube-controllers/Dockerfile.ppc64le
@@ -11,9 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+ARG QEMU_IMAGE
+ARG UBI_IMAGE
+
+FROM ${QEMU_IMAGE} as qemu
+
+FROM --platform=linux/ppc64le ${UBI_IMAGE} as ubi
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-ppc64le-static /usr/bin/
+
+# Make sure the status file is owned by our user.
+RUN mkdir /status
+RUN touch /status/status.json && chown 999 /status/status.json
+
 FROM scratch
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 
+COPY --from=ubi /status /status
+
 ADD bin/kube-controllers-linux-ppc64le /usr/bin/kube-controllers
 ADD bin/check-status-linux-ppc64le /usr/bin/check-status
+USER 999
 ENTRYPOINT ["/usr/bin/kube-controllers"]

--- a/kube-controllers/Dockerfile.s390x
+++ b/kube-controllers/Dockerfile.s390x
@@ -11,9 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+ARG QEMU_IMAGE
+ARG UBI_IMAGE
+
+FROM ${QEMU_IMAGE} as qemu
+
+FROM --platform=linux/s390x ${UBI_IMAGE} as ubi
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/
+
+# Make sure the status file is owned by our user.
+RUN mkdir /status
+RUN touch /status/status.json && chown 999 /status/status.json
+
 FROM scratch
 LABEL maintainer "LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
 
+COPY --from=ubi /status /status
+
 ADD bin/kube-controllers-linux-s390x /usr/bin/kube-controllers
 ADD bin/check-status-linux-s390x /usr/bin/check-status
+USER 999
 ENTRYPOINT ["/usr/bin/kube-controllers"]


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This PR adapts the armv7, ppc64le and s390x images of calico-kube-controllers to run as non-root by default. Similar to https://github.com/projectcalico/kube-controllers/pull/565 and https://github.com/projectcalico/calico/pull/6346 (the changes that adapted the amd64 and arm64 images to run as non-root).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Not applicable

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The armv7, ppc64le and s390x images of calico-kube-controllers now runs as non-root by default (similar to the amd64 and arm64 imagaes).
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
