### PR TITLE
Match full interface names to exclude

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
@@ -16,7 +16,7 @@ package autodetection
 // Default interfaces to exclude for any logic following the first-found
 // auto detect IP method
 var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
-	"docker.*", "cbr.*", "dummy.*",
-	"virbr.*", "lxcbr.*", "veth.*", "lo",
-	"cali.*", "tunl.*", "flannel.*", "kube-ipvs.*", "cni.*",
+	"^docker.*", "^cbr.*", "^dummy.*",
+	"^virbr.*", "^lxcbr.*", "^veth.*", "^lo",
+	"^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*",
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fix bug where Calico `first-found` IP autodetection method ignores valid interfaces.

`DEFAULT_INTERFACES_TO_EXCLUDE` is a list of regular expressions for interface names to ignore when the IP autodetection method is set to `first-found`. These are mostly virtual interfaces, which are safe to ignore.

A lurking issue is that `regexp.MatchString()` returns true even for partial string matches. This means that any interface including these string parts will be matched and ignored. This is problematic for ppc64le, since a standard interface naming scheme is `ibmveth{a,b...}`.

In my attempt to preserve the spirit of the original author, I've changed the regular expressions to match at the start of the interface name only. This PR targets calico-node, and fixed the issue for me (test image for `ppc64le` is `cdkbot/calico-node:v3.23.3-dev1-ppc64le`)

Other options:
- Add `$` at the end of all strings to make the intent clear.
- Only change `veth.*` to `^veth.*$`
- Only change `veth.*` to `^!(ibm)veth.*$` (not sure about this regex, basically match `veth.*` but not `ibmveth.*`).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

References https://github.com/canonical/microk8s/issues/3458

## Todos

- [ ] Tests (it is not straightforward
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
