### PR TITLE
Remove previous HNS networks while first kubelet run after node reboot

### DIFF
--- a/calico/scripts/PrepareNode.ps1
+++ b/calico/scripts/PrepareNode.ps1
@@ -131,6 +131,7 @@ if ($global:containerRuntime -eq "Docker") {
                 Write-Host "Waiting for network deletion to complete."
                 Start-Sleep 1
             } while ((Get-HNSNetwork | ? Type -NE nat))
+            Remove-Item c:\etc\cni\net.d\**
         }
     }
 }

--- a/calico/scripts/PrepareNode.ps1
+++ b/calico/scripts/PrepareNode.ps1
@@ -103,9 +103,7 @@ function Get-LastBootTime()
         throw "Failed to get last boot time"
     }
  
-    # This function is used in conjunction with Get-StoredLastBootTime, which
-    # returns a string, so convert the datetime value to a string using the "general" standard format.
-    return $bootTime.ToString("G")
+    return $bootTime.ToUniversalTime().ToString("O")
 }
 
 


### PR DESCRIPTION
## Description

https://github.com/projectcalico/calico/pull/6656 fixes https://github.com/projectcalico/calico/issues/5828 when Calico installed as windows services.

This PR fixes the same issue but when Calico starts as hostprocess daemonsets.

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/5828

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Remove previous HNS networks while first kubelet run after node reboot
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
