### PR TITLE
Increment Debian packaging epoch to "2:"

### DIFF
--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -187,7 +187,7 @@ function do_net_cal {
     pushd ${rootdir}/networking-calico
     PKG_NAME=networking-calico \
 	    NAME=networking-calico \
-	    DEB_EPOCH=1: \
+	    DEB_EPOCH=2: \
 	    ${rootdir}/hack/release/packaging/utils/make-packages.sh deb rpm
     # Packages are produced in rootDir/ - move them to the output dir.
     find ../ -type f -name 'networking-calico_*-*' -exec mv '{}' $outputDir \;
@@ -218,10 +218,11 @@ function do_felix {
 	    NAME=Felix \
 	    RPM_TAR_ARGS='--exclude=bin/calico-felix-* --exclude=.gitignore --exclude=*.d --exclude=*.ll --exclude=.go-pkg-cache --exclude=vendor --exclude=report' \
 	    DPKG_EXCL="-I'bin/calico-felix-*' -I.git -I.gitignore -I'*.d' -I'*.ll' -I.go-pkg-cache -I.git -Ivendor -Ireport" \
+	    DEB_EPOCH=2: \
 	    ${rootdir}/hack/release/packaging/utils/make-packages.sh deb rpm
     git checkout Makefile
 
-    
+
     # Packages are produced in rootDir/ - move them to the output dir.
     find ../ -type f -name 'felix_*-*' -exec mv '{}' $outputDir \;
     popd


### PR DESCRIPTION
We use `git cherry -v ${last_tag} | wc -l` to count the number of commits since the last `0.dev` development tag on master, and include that count in the Debian version so that it is always increasing.

For some reason, though, that number is now NOT increasing!  The current packages in our master PPA have a count of 295, but that command on the current monorepo gives 176.  Huh?

I don't really know why that is, but possibly connected with Semaphore using a shallow checkout previously?  I've fixed that in #6763, but now we also need to bump the epoch number so that we can start a new sequence of versions from 176.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
