### PR TITLE
Stagger felix start in wireguard tests.

### DIFF
--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -169,6 +169,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 					routeEntriesV6[0], routeEntriesV6[1] = routeEntriesV6[1], routeEntriesV6[0]
 				}
 				for i := 0; i < nodeCount; i++ {
+					if i > 0 {
+						// Stagger Felix starts to reduce chance of synchronising the Wireguard handshake (which
+						// makes it back off/retry).
+						time.Sleep(2 * time.Second)
+					}
 					wgBootstrapEvents = felixes[i].WatchStdoutFor(
 						regexp.MustCompile(".*(Cleared wireguard public key from datastore|Wireguard public key not set in datastore).+"),
 					)
@@ -1126,7 +1131,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3 node 
 	)
 
 	BeforeEach(func() {
-		//TODO: add IPv6 coverage when enabling this back
+		// TODO: add IPv6 coverage when enabling this back
 		Skip("Skipping WireGuard tests for now due to unreliability.")
 
 		// Run these tests only when the Host has Wireguard kernel module available.
@@ -1169,6 +1174,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3 node 
 			felixes[0])
 
 		for i := range felixes {
+			if i > 0 {
+				// Stagger Felix starts to reduce chance of synchronising the Wireguard handshake (which
+				// makes it back off/retry).
+				time.Sleep(2 * time.Second)
+			}
 			felixes[i].TriggerDelayedStart()
 		}
 
@@ -1394,7 +1404,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 	)
 
 	BeforeEach(func() {
-		//TODO: add IPv6 coverage when enabling this back
+		// TODO: add IPv6 coverage when enabling this back
 		Skip("Skipping WireGuard tests for now due to unreliability.")
 
 		// Run these tests only when the Host has Wireguard kernel module available.
@@ -1432,6 +1442,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported 3-node 
 		externalClient.Exec("ip", "route", "add", wlsByHost[0][0].IP, "via", felixes[0].IP)
 
 		for i := range felixes {
+			if i > 0 {
+				// Stagger Felix starts to reduce chance of synchronising the Wireguard handshake (which
+				// makes it back off/retry).
+				time.Sleep(2 * time.Second)
+			}
 			felixes[i].TriggerDelayedStart()
 		}
 


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Hoping this will avoid accidental wireguard handshake sync. If the handshakes sync then they back off and retry but it takes 5s for one retry, so if they sync twice in a row we exceed our connectivity check timeout.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
