### PR TITLE
Allow dnsmasq to start when there's a race with no ports

### DIFF
--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -260,7 +260,7 @@ class DnsmasqUpdater(object):
 
     def start(self):
         while True:
-            LOG.info("DnsmasqUpdater: wait until updates needed")
+            LOG.debug("DnsmasqUpdater: wait until updates needed")
             dirty_network_ids = set()
             dirty_network_ids.add(self.updates_needed.get())
             try:
@@ -268,7 +268,7 @@ class DnsmasqUpdater(object):
                     dirty_network_ids.add(self.updates_needed.get_nowait())
             except Empty:
                 pass
-            LOG.info("DnsmasqUpdater: updating now for %r", dirty_network_ids)
+            LOG.debug("DnsmasqUpdater: updating now for %r", dirty_network_ids)
             for network_id in dirty_network_ids:
                 self.really_update_dnsmasq(network_id)
 
@@ -298,11 +298,14 @@ class DnsmasqUpdater(object):
             # Requirements have changed, so start, restart or stop Dnsmasq for
             # that network ID.
             if ports_needed:
+                LOG.info("Restart dnsmasq for network %s with %d port(s)",
+                         network_id, len(ports_needed))
                 self.agent.call_driver('restart', net)
             else:
                 # No ports left, so also remove this network from the cache.
                 _fix_network_cache_port_lookup(self.agent, net.id)
                 self.agent.cache.remove(net)
+                LOG.info("Disable dnsmasq for network %s", network_id)
                 self.agent.call_driver('disable', net)
 
             # Remember what we've asked Dnsmasq for.

--- a/networking-calico/networking_calico/agent/linux/dhcp.py
+++ b/networking-calico/networking_calico/agent/linux/dhcp.py
@@ -190,12 +190,15 @@ class DnsmasqRouted(dhcp.Dnsmasq):
         cmd.remove('--interface=tap*')
         cmd.remove('--bridge-interface=%s,tap*' % self.interface_name)
         bridge_option = '--bridge-interface=%s' % self.interface_name
+        bridge_ports_added = False
         for port in self.network.ports:
             if port.device_id.startswith('tap'):
                 LOG.debug('Listen on %s', port.device_id)
                 cmd.append('--interface=%s' % port.device_id)
                 bridge_option = bridge_option + ',' + port.device_id
-        cmd.append(bridge_option)
+                bridge_ports_added = True
+        if bridge_ports_added:
+            cmd.append(bridge_option)
 
         return cmd
 


### PR DESCRIPTION
## Description

https://github.com/projectcalico/calico/commit/9a8a6c9bc2bd083c95c8adf209a74c4ac2506fc8 introduced a
race by decoupling the threads ("A") that can update the network model from the thread ("B") that
restarts dnsmasq with configuration for the network model.

The result is that:
- thread A can say "update dnsmasq for network X, which definitely has at least one port"
- this means that a trigger is queued for thread B
- thread A handles an endpoint deletion which means that network X now has no ports
- thread B runs and generates invalid dnsmasq options because there are now no ports.

It would be fine if that happened just once, but this Neutron code causes the situation to persist
for 5 minutes:

    def enable(self):
        """Enables DHCP for this network by spawning a local process."""
        try:
            common_utils.wait_until_true(self._enable, timeout=300)
        except common_utils.WaitTimeout:
            LOG.error("Failed to start DHCP process for network %s",
                      self.network.id)

It would still be fine if another thread updated the network concerned during those 5 minutes, and
if the updated network object was the same object as the one that the `enable` thread has a
reference to.  However there are a couple of cases where our DHCP agent deliberately creates a new
network object for an existing network ID:

1. When resyncing against the data store, which happens every 10 minutes.

2. If it sees an endpoint with a new subnet.

In those cases the `enable` thread keeps referencing the old network object with no ports, and hence
it blocks actual dnsmasq updating for 5 minutes.

So, what to do about this?  Possibly the best fix would be to take a deep copy of the network model
when passing it to the dnsmasq update thread.  But unfortunately the model (aka NetworkCache) object
appears to have no support for that.  Or perhaps we could add more locking, but that feels complex
and risky.  Instead, for now, let's just ensure that the dnsmasq configuration is valid even when
there are unexpectedly no ports on the network.  Then dnsmasq should start up, and `enable` return
and unblock the update thread, and shortly after there will be a further trigger that either stops
dnsmasq or restarts it again with correct config.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
