### PR TITLE
Update the ipsec.yaml file's location

### DIFF
--- a/calico/getting-started/kubernetes/vpp/getting-started.md
+++ b/calico/getting-started/kubernetes/vpp/getting-started.md
@@ -94,7 +94,7 @@ Before you get started, make sure you have downloaded and configured the {% incl
 1. Now that you have an empty cluster configured, you can install the Tigera operator. 
 
    ```bash
-   kubectl apply -f {{site.data.versions.manifests_url}}/manifests/tigera-operator.yaml
+   kubectl apply -f {{site.data.versions.first.manifests_url}}/manifests/tigera-operator.yaml
    ```
 
 1. Then, you need to configure the {{site.prodname}} installation for the VPP dataplane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference]({{site.baseurl}}/reference/installation/api).
@@ -155,7 +155,7 @@ DPDK provides better performance compared to the standard install but it require
 1. Now that you have an empty cluster configured, you can install the Tigera operator. 
 
    ```bash
-   kubectl apply -f {{site.data.versions.manifests_url}}/manifests/tigera-operator.yaml
+   kubectl apply -f {{site.data.versions.first.manifests_url}}/manifests/tigera-operator.yaml
    ```
 
 2. Then, you need to configure the {{site.prodname}} installation for the VPP dataplane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference]({{site.baseurl}}/reference/installation/api).
@@ -243,7 +243,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
 1. Start by installing the Tigera operator on your cluster. 
 
    ```bash
-   kubectl apply -f {{site.data.versions.manifests_url}}/manifests/tigera-operator.yaml
+   kubectl apply -f {{site.data.versions.first.manifests_url}}/manifests/tigera-operator.yaml
    ```
 
 1. Then, you need to configure the {{site.prodname}} installation for the VPP dataplane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the installation reference]({{site.baseurl}}/reference/installation/api).

--- a/calico/getting-started/kubernetes/vpp/ipsec.md
+++ b/calico/getting-started/kubernetes/vpp/ipsec.md
@@ -35,7 +35,7 @@ kubectl -n calico-vpp-dataplane create secret generic calicovpp-ipsec-secret \
 
 To enable IPsec, you need to configure two environment variables on the `calico-vpp-node` pod. You can do so with the following kubectl command:
 ````bash
-kubectl -n calico-vpp-dataplane patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/patches/ipsec.yaml)"
+kubectl -n calico-vpp-dataplane patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/components/ipsec/ipsec.yaml)"
 ````
 
 Once IPsec is enabled, all the traffic that uses IP-in-IP encapsulation in the cluster will be automatically encrypted.


### PR DESCRIPTION
## Description

Updates to Calico/VPP docs:

1. The `ipsec.yaml` file's location changed from `vpp-dataplane/yaml/patches/ipsec.yaml` to `vpp-dataplane/yaml/components/ipsec/ipsec.yaml `but it was not updated in the `ipsec.md` doc.
2. Correct the URL for `tigera-operator.yaml` in `getting-started.md`



## Related issues/PRs

https://github.com/projectcalico/calico/pull/6776

## Todos


## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
