### PR TITLE
Update the ipsec.yaml file's location

### DIFF
--- a/calico/getting-started/kubernetes/vpp/ipsec.md
+++ b/calico/getting-started/kubernetes/vpp/ipsec.md
@@ -35,7 +35,7 @@ kubectl -n calico-vpp-dataplane create secret generic calicovpp-ipsec-secret \
 
 To enable IPsec, you need to configure two environment variables on the `calico-vpp-node` pod. You can do so with the following kubectl command:
 ````bash
-kubectl -n calico-vpp-dataplane patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/patches/ipsec.yaml)"
+kubectl -n calico-vpp-dataplane patch daemonset calico-vpp-node --patch "$(curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/{{page.vppbranch}}/yaml/components/ipsec/ipsec.yaml)"
 ````
 
 Once IPsec is enabled, all the traffic that uses IP-in-IP encapsulation in the cluster will be automatically encrypted.


### PR DESCRIPTION
## Description

The ipsec.yaml file's location changed from vpp-dataplane/yaml/patches/ipsec.yaml to vpp-dataplane/yaml/components/ipsec/ipsec.yaml but it was not updated in the ipsec.md doc.
## Related issues/PRs

## Related issues/PRs

https://github.com/projectcalico/calico/pull/6774

## Todos


## Release Note

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
