### PR TITLE
[release-v3.23] cherry-pick: Fix allowed source prefix annotation validation

### DIFF
--- a/libcalico-go/lib/apis/v3/workloadendpoint.go
+++ b/libcalico-go/lib/apis/v3/workloadendpoint.go
@@ -81,7 +81,7 @@ type WorkloadEndpointSpec struct {
 	Ports []WorkloadEndpointPort `json:"ports,omitempty" validate:"dive,omitempty"`
 	// AllowSpoofedSourcePrefixes is a list of CIDRs that the endpoint should be able to send traffic from,
 	// bypassing the RPF check.
-	AllowSpoofedSourcePrefixes []string `json:"allowSpoofedSourcePrefixes,omitempty" validate:"omitempty,dive,ip"`
+	AllowSpoofedSourcePrefixes []string `json:"allowSpoofedSourcePrefixes,omitempty" validate:"omitempty,dive,cidr"`
 }
 
 // WorkloadEndpointPort represents one endpoint's named or mapped port

--- a/libcalico-go/lib/validator/v3/validator_test.go
+++ b/libcalico-go/lib/validator/v3/validator_test.go
@@ -250,6 +250,20 @@ func init() {
 			},
 			false,
 		),
+		Entry("should reject WorkloadEndpointSpec with an invalid source spoofing config (m)",
+			libapiv3.WorkloadEndpointSpec{
+				InterfaceName:              "eth0",
+				AllowSpoofedSourcePrefixes: []string{"10.abcd"},
+			},
+			false,
+		),
+		Entry("should accept WorkloadEndpointSpec with an ip or prefix in the source spoofing config (m)",
+			libapiv3.WorkloadEndpointSpec{
+				InterfaceName:              "eth0",
+				AllowSpoofedSourcePrefixes: []string{"10.0.0.1", "192.168.0.0/16"},
+			},
+			true,
+		),
 
 		// (API) HostEndpointSpec.
 		Entry("should accept HostEndpointSpec with a port (m)",


### PR DESCRIPTION
## Description

This is a cherry pick of #6611 for the 3.23 release.

## Related issues/PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
