### PR TITLE
Openstack watch mtu v3.24

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -627,27 +627,30 @@ blocks:
     when: "true or change_in(['/networking-calico/'])"
   dependencies: ["Prerequisites"]
   task:
+    agent:
+      machine:
+        type: e1-standard-4
+        os_image: ubuntu1804
     prologue:
       commands:
       - cd networking-calico
-      - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
-      - sudo pip3 install tox
     jobs:
       - name: 'Unit and FV tests (tox)'
         commands:
-          - ../.semaphore/run-and-monitor tox.log tox
-      # TODO: Re-enable
-      # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
-      #   commands:
-      #     - git checkout -b devstack-test
-      #     - export LIBVIRT_TYPE=qemu
-      #     - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
-      #     # Use proposed fix at
-      #     # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
-      #     # message for more context.
-      #     - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
-      #     - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
-      #     - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
+          - ../.semaphore/run-and-monitor tox.log make tox
+      - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
+        commands:
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
+          # Use proposed fix at
+          # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
+          # message for more context.
+          - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
+          - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -625,7 +625,7 @@ blocks:
 - name: 'networking-calico'
   run:
     when: "false or change_in(['/networking-calico/'])"
-  dependencies: []
+  dependencies: ["Prerequisites"]
   task:
     agent:
       machine:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -655,6 +655,42 @@ blocks:
           - sudo journalctl > logs/journalctl.txt
           - artifact push job --expire-in 1d logs
 
+- name: 'networking-calico'
+  run:
+    when: "false or change_in(['/networking-calico/'])"
+  dependencies: []
+  task:
+    agent:
+      machine:
+        type: e1-standard-4
+        os_image: ubuntu1804
+    prologue:
+      commands:
+      - cd networking-calico
+    jobs:
+      - name: 'Unit and FV tests (tox)'
+        commands:
+          - ../.semaphore/run-and-monitor tox.log make tox
+      - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
+        commands:
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
+          # Use proposed fix at
+          # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
+          # message for more context.
+          - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
+          - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
+    epilogue:
+      on_fail:
+        commands:
+          - mkdir logs
+          - sudo journalctl > logs/journalctl.txt
+          - artifact push job --expire-in 1d logs
+
 - name: "Documentation"
   run:
     when: "false or change_in(['/*', '/calico/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -625,39 +625,6 @@ blocks:
 - name: 'networking-calico'
   run:
     when: "false or change_in(['/networking-calico/'])"
-  dependencies: ["Prerequisites"]
-  task:
-    prologue:
-      commands:
-      - cd networking-calico
-      - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
-      - sudo pip3 install tox
-    jobs:
-      - name: 'Unit and FV tests (tox)'
-        commands:
-          - ../.semaphore/run-and-monitor tox.log tox
-      # TODO: Re-enable
-      # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
-      #   commands:
-      #     - git checkout -b devstack-test
-      #     - export LIBVIRT_TYPE=qemu
-      #     - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
-      #     # Use proposed fix at
-      #     # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
-      #     # message for more context.
-      #     - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
-      #     - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
-      #     - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
-    epilogue:
-      on_fail:
-        commands:
-          - mkdir logs
-          - sudo journalctl > logs/journalctl.txt
-          - artifact push job --expire-in 1d logs
-
-- name: 'networking-calico'
-  run:
-    when: "false or change_in(['/networking-calico/'])"
   dependencies: []
   task:
     agent:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -625,27 +625,30 @@ blocks:
     when: "${FORCE_RUN} or change_in(['/networking-calico/'])"
   dependencies: ["Prerequisites"]
   task:
+    agent:
+      machine:
+        type: e1-standard-4
+        os_image: ubuntu1804
     prologue:
       commands:
       - cd networking-calico
-      - sudo apt-get install -y python-all-dev python3-all-dev python3-pip
-      - sudo pip3 install tox
     jobs:
       - name: 'Unit and FV tests (tox)'
         commands:
-          - ../.semaphore/run-and-monitor tox.log tox
-      # TODO: Re-enable
-      # - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
-      #   commands:
-      #     - git checkout -b devstack-test
-      #     - export LIBVIRT_TYPE=qemu
-      #     - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
-      #     # Use proposed fix at
-      #     # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
-      #     # message for more context.
-      #     - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
-      #     - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
-      #     - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
+          - ../.semaphore/run-and-monitor tox.log make tox
+      - name: 'Mainline ST (DevStack + Tempest) on Ussuri'
+        commands:
+          - git checkout -b devstack-test
+          - export LIBVIRT_TYPE=qemu
+          - export UPPER_CONSTRAINTS_FILE=https://releases.openstack.org/constraints/upper/ussuri
+          # Use proposed fix at
+          # https://review.opendev.org/c/openstack/requirements/+/810859.  See commit
+          # message for more context.
+          - export REQUIREMENTS_REPO=https://review.opendev.org/openstack/requirements
+          - export REQUIREMENTS_BRANCH=refs/changes/59/810859/1
+          - export NC_PLUGIN_REPO=$(dirname $(pwd))
+          - export NC_PLUGIN_REF=$(git rev-parse --abbrev-ref HEAD)
+          - TEMPEST=true DEVSTACK_BRANCH=stable/ussuri ./devstack/bootstrap.sh
     epilogue:
       on_fail:
         commands:

--- a/devstack
+++ b/devstack
@@ -1,0 +1,1 @@
+networking-calico/devstack

--- a/networking-calico/.testr.conf
+++ b/networking-calico/.testr.conf
@@ -2,8 +2,11 @@
 test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-0} \
              OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/tests $LISTOPT $IDOPTION
-             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/plugins/ml2/drivers/calico/test $LISTOPT $IDOPTION
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/tests
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_election
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_plugin_etcd
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_compaction
+
 test_id_option=--load-list $IDFILE
 test_list_option=--list
 test_run_concurrency=echo 1

--- a/networking-calico/Dockerfile
+++ b/networking-calico/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/coreos/etcd:v3.3.11 as etcd
+
+FROM python:3.8
+
+COPY --from=etcd /usr/local/bin/etcd /usr/local/bin/etcd
+
+RUN pip3 install tox

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -3,3 +3,7 @@ include ../metadata.mk
 ###############################################################################
 # TODO: Release
 ###############################################################################
+
+tox:
+	docker build -t networking-calico-test .
+	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code --rm networking-calico-test tox

--- a/networking-calico/devstack/README.rst
+++ b/networking-calico/devstack/README.rst
@@ -2,6 +2,6 @@
 DevStack plugin for Calico
 ==========================
 
-Welcome to networking-calico's DevStack plugin!  For how to use this, please
+Welcome to Calico's DevStack plugin!  For how to use this, please
 see
 http://docs.projectcalico.org/master/getting-started/openstack/installation/devstack.

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -62,7 +62,7 @@ EOF
 		    install_package calico-common
 
 		    # Install networking-calico.
-		    pip_install "${GITDIR['networking-calico']}"
+		    pip_install "${GITDIR['calico']}/networking-calico"
 
 		    ;;
 
@@ -132,7 +132,7 @@ EOF
 		    export ETCDCTL_API=3
 		    export ETCDCTL_ENDPOINTS=http://$SERVICE_HOST:$ETCD_PORT
 		    run_process calico-bird \
-                      "${DEST}/networking-calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl"
+                      "${DEST}/calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl"
 
 		    # Run the Calico DHCP agent.
 		    sudo mkdir /var/log/neutron || true

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -1,6 +1,6 @@
 # Copyright 2012 OpenStack Foundation
 # Copyright 2015 Metaswitch Networks
-# Copyright 2016, 2018 Tigera, Inc.
+# Copyright 2016, 2018, 2022 Tigera, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -18,8 +18,11 @@
 import logging
 import netaddr
 import os
+import re
 import socket
+import subprocess
 import sys
+import time
 
 import eventlet
 eventlet.monkey_patch()
@@ -50,6 +53,10 @@ from networking_calico import datamodel_v3
 from networking_calico import etcdutils
 
 from etcd3gw.exceptions import Etcd3Exception
+
+from eventlet.event import Event
+from eventlet.queue import Empty
+from eventlet.queue import LightQueue
 
 LOG = logging.getLogger(__name__)
 
@@ -148,6 +155,164 @@ def split_endpoint_name(name):
     return tuple([p.replace('#', '-') for p in parts])
 
 
+class MTUWatcher(object):
+
+    # -----------------------------------------------------------------
+    # Methods called from DHCP agent's main thread.
+    # -----------------------------------------------------------------
+
+    def __init__(self, agent, port_handler):
+        self.agent = agent
+        self.port_handler = port_handler
+        self.mtu_by_if_name = {}
+        self.port_id_by_if_name = {}
+        self.rx_up = re.compile('[0-9]+: (tap[a-z0-9-]+).* mtu ([0-9]+) .* state UP')
+        self.rx_del = re.compile('Deleted [0-9]+: (tap[a-z0-9-]+)')
+
+    def get_mtu(self, if_name):
+        # Note, returns None if we haven't yet seen an MTU for the given
+        # interface name.
+        return self.mtu_by_if_name.get(if_name)
+
+    def watch_port(self, id, if_name):
+        self.port_id_by_if_name[if_name] = id
+
+    def unwatch_port(self, id, if_name):
+        if if_name in self.port_id_by_if_name:
+            del self.port_id_by_if_name[if_name]
+
+    def run(self):
+        while True:
+            # Start 'ip monitor link' running on a separate thread.
+            running_event = Event()
+            exited_event = Event()
+            eventlet.spawn(self.process_command, ['ip', 'monitor', 'link'],
+                           running_event=running_event,
+                           exited_event=exited_event)
+
+            # Wait until we can be sure that 'ip monitor link' is really
+            # running (or has exited), and hence that we will see all
+            # further link transitions.
+            while not (running_event.ready() or exited_event.ready()):
+                # Create and delete a dummy interface.
+                os.system("ip link add calico-dhcp-dmy type dummy")
+                os.system("ip link del calico-dhcp-dmy type dummy")
+                time.sleep(0.5)
+
+            if not exited_event.ready():
+                # Now run 'ip link', to find MTU of all pre-existing interfaces.
+                self.process_command(['ip', 'link'])
+
+            # Wait for the 'ip monitor link' thread to exit, so that we
+            # can then restart it.
+            exited_event.wait()
+
+    # -----------------------------------------------------------------
+    # Methods called from MTU watcher's own thread, or from agent thread.
+    # -----------------------------------------------------------------
+
+    def process_command(self, command, running_event=None, exited_event=None):
+        process = subprocess.Popen(command, stdout=subprocess.PIPE)
+        while True:
+            line = process.stdout.readline()
+            if not line:
+                LOG.info("command %r exited", command)
+                break
+            if running_event:
+                running_event.send()
+                running_event = None
+            match_data = self.rx_up.match(line.decode('utf-8'))
+            if match_data:
+                self.record_mtu(match_data.group(1), int(match_data.group(2)))
+                continue
+            match_data = self.rx_del.match(line.decode('utf-8'))
+            if match_data:
+                self.if_deleted(match_data.group(1))
+
+        if exited_event:
+            exited_event.send()
+
+    def record_mtu(self, if_name, mtu):
+        LOG.debug("MTU for %s is now %d", if_name, mtu)
+        old_mtu = self.mtu_by_if_name.get(if_name)
+        self.mtu_by_if_name[if_name] = mtu
+        if if_name in self.port_id_by_if_name and mtu != old_mtu:
+            # MTU changing for a watched port.
+            self.port_handler.on_mtu_change(self.port_id_by_if_name[if_name], mtu)
+
+    def if_deleted(self, if_name):
+        LOG.debug("Interface %s deleted", if_name)
+        if if_name in self.mtu_by_if_name:
+            del self.mtu_by_if_name[if_name]
+
+
+class DnsmasqUpdater(object):
+    def __init__(self, agent):
+        self.agent = agent
+        self.updates_needed = LightQueue()
+
+        # Cache of the ports that we've asked Dnsmasq to handle, for each
+        # network ID.
+        self._last_dnsmasq_ports = {}
+
+    def update_network(self, network_id):
+        self.updates_needed.put(network_id)
+
+    def start(self):
+        while True:
+            LOG.debug("DnsmasqUpdater: wait until updates needed")
+            dirty_network_ids = set()
+            dirty_network_ids.add(self.updates_needed.get())
+            try:
+                while True:
+                    dirty_network_ids.add(self.updates_needed.get_nowait())
+            except Empty:
+                pass
+            LOG.debug("DnsmasqUpdater: updating now for %r", dirty_network_ids)
+            for network_id in dirty_network_ids:
+                self.really_update_dnsmasq(network_id)
+
+    def really_update_dnsmasq(self, network_id):
+        # Get NetModel for that network ID.
+        net = self.agent.cache.get_network_by_id(network_id)
+        LOG.debug("Net: %s", net)
+
+        # Compute the set of ports that we need Dnsmasq to handle for this
+        # network ID.
+        ports_needed = [
+            port for port in net.ports if port.device_id.startswith('tap')
+        ]
+        ports_needed.sort(key=lambda port: port.id)
+        for p in ports_needed:
+            LOG.debug("Port %s", p)
+            for edo in p.extra_dhcp_opts:
+                LOG.debug("DHCP option %s", edo)
+
+        # Compare `str(p)` for each needed port, instead of just `p`
+        # (which is really just a pointer), so that we can spot when
+        # DHCP options change within the same port DictModel.
+        ports_needed_as_string = ' //// '.join([str(p) for p in ports_needed])
+
+        # Compare that against what we've last asked Dnsmasq to handle.
+        if ports_needed_as_string != self._last_dnsmasq_ports.get(network_id):
+            # Requirements have changed, so start, restart or stop Dnsmasq for
+            # that network ID.
+            if ports_needed:
+                LOG.info("Restart dnsmasq for network %s with %d port(s)",
+                         network_id, len(ports_needed))
+                self.agent.call_driver('restart', net)
+            else:
+                # No ports left, so also remove this network from the cache.
+                _fix_network_cache_port_lookup(self.agent, net.id)
+                self.agent.cache.remove(net)
+                LOG.info("Disable dnsmasq for network %s", network_id)
+                self.agent.call_driver('disable', net)
+
+            # Remember what we've asked Dnsmasq for.
+            self._last_dnsmasq_ports[network_id] = ports_needed_as_string
+        else:
+            LOG.debug("No change")
+
 class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
 
     def __init__(self, agent, hostname):
@@ -174,6 +339,13 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Networks for which Dnsmasq needs updating.
         self.dirty_networks = set()
 
+        # Use a separate thread for dnsmasq updating, so that we can
+        # also trigger that for MTU changes.
+        self.dnsmasq_updater = DnsmasqUpdater(agent)
+
+        # Create MTU watcher.
+        self.mtu_watcher = MTUWatcher(agent, self)
+
         # Also watch the etcd subnet trees: both the new region-aware
         # one, and the old pre-region one, so as to support a VM
         # renewing its DHCP lease while an upgrade is still in
@@ -184,14 +356,12 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
             self,
             datamodel_v2.subnet_dir(self.region_string))
 
-        # Cache of the ports that we've asked Dnsmasq to handle, for each
-        # network ID.
-        self._last_dnsmasq_ports = {}
-
         # Cache of current local endpoint IDs.
         self.local_endpoint_ids = set()
 
     def start(self):
+        eventlet.spawn(self.dnsmasq_updater.start)
+        eventlet.spawn(self.mtu_watcher.run)
         eventlet.spawn(self.v1_subnet_watcher.start)
         eventlet.spawn(self.subnet_watcher.start)
         super(CalicoEtcdWatcher, self).start()
@@ -309,16 +479,22 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
             LOG.warning("Endpoint has no DHCP-served IPs: %s", endpoint)
             return
 
+        extra_dhcp_opts = []
+        mtu = self.mtu_watcher.get_mtu(endpoint['interfaceName'])
+        self.mtu_watcher.watch_port(endpoint_id, endpoint['interfaceName'])
+        if mtu:
+            extra_dhcp_opts.append(self.get_mtu_option(mtu))
+
         port = {'id': endpoint_id,
                 'device_owner': 'calico',
                 'device_id': endpoint['interfaceName'],
                 'fixed_ips': fixed_ips,
                 'mac_address': endpoint['mac'],
-                # FIXME: Calico currently does not pass through extra DHCP
-                # options, but it would be nice if it did.  Perhaps we could
-                # use an endpoint annotation, similarly as we do for the FQDN.
+                # FIXME: Calico currently does not handle extra DHCP
+                # options, other than MTU, but there might be use cases
+                # where it should handle further options.
                 # https://bugs.launchpad.net/networking-calico/+bug/1553348
-                'extra_dhcp_opts': []}
+                'extra_dhcp_opts': extra_dhcp_opts}
         if fqdn:
             port['dns_assignment'] = dns_assignments
 
@@ -342,8 +518,30 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         # Add this port into the NetModel.
         self.agent.cache.put_port(dhcp.DictModel(port))
 
-        # Schedule updating Dnsmasq.
-        self._update_dnsmasq(port['network_id'])
+        # If we have seen the TAP interface, schedule updating Dnsmasq;
+        # otherwise wait until we do see the TAP interface, whereupon
+        # _update_dnsmasq will be called again.  Dnsmasq updates can
+        # take a little time, and they run in series, so it's best to
+        # wait if we don't have the information we need yet, to avoid
+        # delaying the correct Dnsmasq update that we really want.
+        if mtu:
+            self._update_dnsmasq(port['network_id'])
+
+    def get_mtu_option(self, mtu):
+        return dhcp.DictModel({
+            'opt_name': 'mtu',
+            'opt_value': str(mtu),
+            'ip_version': 4,
+        })
+
+    # Note, on_mtu_change is called from MTU watcher's thread.
+    def on_mtu_change(self, id, mtu):
+        port = self.agent.cache.get_port_by_id(id)
+        if port:
+            LOG.info("MTU changed to %s for %s (%s)", mtu, port.device_id, id)
+            port.extra_dhcp_opts = [self.get_mtu_option(mtu)]
+            self.agent.cache.put_port(port)
+            self._update_dnsmasq(port.network_id)
 
     def _ensure_net_and_subnets(self, port):
         """Ensure that the cache has a NetModel and subnets for PORT."""
@@ -407,33 +605,10 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
 
             # Add (or update) the NetModel in the cache.
             LOG.debug("Net: %s", net)
-            self._fix_network_cache_port_lookup(net.id)
+            _fix_network_cache_port_lookup(self.agent, net.id)
             self.agent.cache.put(net)
 
         return net.id
-
-    def _fix_network_cache_port_lookup(self, network_id):
-        """Fix NetworkCache before removing or replacing a network.
-
-        neutron.agent.dhcp.agent is bugged in that it adds the DHCP port into
-        the cache without updating the cache's port_lookup dict, but then
-        NetworkCache.remove() barfs if there is a port in network.ports but not
-        in that dict...
-
-        NetworkCache.put() implicitly does a remove() first if there is already
-        a NetModel in the cache with the same ID.  So a put() to update or
-        replace a network also hits this problem.
-
-        This method avoids that problem by ensuring that all of a network's
-        ports are in the port_lookup dict.  A caller should call this
-        immediately before a remove() or a put().
-        """
-
-        # If there is an existing NetModel for this network ID, ensure that all
-        # its ports are in the port_lookup dict.
-        if network_id in self.agent.cache.cache:
-            for port in self.agent.cache.cache[network_id].ports:
-                self.agent.cache.port_lookup[port.id] = network_id
 
     def _update_dnsmasq(self, network_id):
         """Start/stop/restart Dnsmasq for NETWORK_ID."""
@@ -445,31 +620,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
             self.dirty_networks.add(network_id)
             return
 
-        # Get NetModel for that network ID.
-        net = self.agent.cache.get_network_by_id(network_id)
-        LOG.debug("Net: %s", net)
-
-        # Compute the set of ports that we need Dnsmasq to handle for this
-        # network ID.
-        ports_needed = [
-            port for port in net.ports if port.device_id.startswith('tap')
-        ]
-        ports_needed.sort(key=lambda port: port.id)
-
-        # Compare that against what we've last asked Dnsmasq to handle.
-        if ports_needed != self._last_dnsmasq_ports.get(network_id):
-            # Requirements have changed, so start, restart or stop Dnsmasq for
-            # that network ID.
-            if ports_needed:
-                self.agent.call_driver('restart', net)
-            else:
-                # No ports left, so also remove this network from the cache.
-                self._fix_network_cache_port_lookup(net.id)
-                self.agent.cache.remove(net)
-                self.agent.call_driver('disable', net)
-
-            # Remember what we've asked Dnsmasq for.
-            self._last_dnsmasq_ports[network_id] = ports_needed
+        self.dnsmasq_updater.update_network(network_id)
 
     def on_endpoint_delete(self, response_ignored, name):
         """Handler for endpoint deletion."""
@@ -491,6 +642,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         port = self.agent.cache.get_port_by_id(endpoint_id)
         if port:
             LOG.debug("deleted port: %s", port)
+            self.mtu_watcher.unwatch_port(endpoint_id, port.device_id)
             self.agent.cache.remove_port(port)
             self._update_dnsmasq(port.network_id)
 
@@ -503,7 +655,7 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         LOG.debug("Reset cache for new snapshot")
         for network_id in list(self.agent.cache.get_network_ids()):
             self.dirty_networks.add(network_id)
-            self._fix_network_cache_port_lookup(network_id)
+            _fix_network_cache_port_lookup(self.agent, network_id)
             self.agent.cache.put(empty_network(network_id))
 
         # Suppress Dnsmasq updates until we've processed the whole snapshot.
@@ -518,6 +670,30 @@ class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
         for network_id in self.dirty_networks:
             self._update_dnsmasq(network_id)
         self.dirty_networks = set()
+
+
+def _fix_network_cache_port_lookup(agent, network_id):
+    """Fix NetworkCache before removing or replacing a network.
+
+    neutron.agent.dhcp.agent is bugged in that it adds the DHCP port into
+    the cache without updating the cache's port_lookup dict, but then
+    NetworkCache.remove() barfs if there is a port in network.ports but not
+    in that dict...
+
+    NetworkCache.put() implicitly does a remove() first if there is already
+    a NetModel in the cache with the same ID.  So a put() to update or
+    replace a network also hits this problem.
+
+    This method avoids that problem by ensuring that all of a network's
+    ports are in the port_lookup dict.  A caller should call this
+    immediately before a remove() or a put().
+    """
+
+    # If there is an existing NetModel for this network ID, ensure that all
+    # its ports are in the port_lookup dict.
+    if network_id in agent.cache.cache:
+        for port in agent.cache.cache[network_id].ports:
+            agent.cache.port_lookup[port.id] = network_id
 
 
 class SubnetIDNotFound(Exception):

--- a/networking-calico/networking_calico/agent/linux/dhcp.py
+++ b/networking-calico/networking_calico/agent/linux/dhcp.py
@@ -190,12 +190,15 @@ class DnsmasqRouted(dhcp.Dnsmasq):
         cmd.remove('--interface=tap*')
         cmd.remove('--bridge-interface=%s,tap*' % self.interface_name)
         bridge_option = '--bridge-interface=%s' % self.interface_name
+        bridge_ports_added = False
         for port in self.network.ports:
             if port.device_id.startswith('tap'):
                 LOG.debug('Listen on %s', port.device_id)
                 cmd.append('--interface=%s' % port.device_id)
                 bridge_option = bridge_option + ',' + port.device_id
-        cmd.append(bridge_option)
+                bridge_ports_added = True
+        if bridge_ports_added:
+            cmd.append(bridge_option)
 
         return cmd
 

--- a/networking-calico/networking_calico/agent/linux/interface.py
+++ b/networking-calico/networking_calico/agent/linux/interface.py
@@ -61,6 +61,9 @@ class RoutedInterfaceDriver(interface.LinuxInterfaceDriver):
 
         ns_dummy.link.set_up()
 
+    def set_mtu(self, device_name, mtu, namespace=None, prefix=None):
+        pass
+
     def init_l3(self, device_name, ip_cidrs, namespace=None,
                 preserve_ips=[], gateway=None, extra_subnets=[]):
         """L3 initialization for RoutedInterfaceDriver.

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_election.py
@@ -180,10 +180,7 @@ class TestElection(unittest.TestCase):
     def test_exception_detail_logging(self):
         LOG.debug("test_exception_detail_logging")
 
-        with mock.patch.object(
-                log.getLogger(
-                    'networking_calico.plugins.ml2.drivers.calico.election'),
-                'warning') as mock_lw:
+        with mock.patch.object(election.LOG, 'warning') as mock_lw:
             etcdv3._client = client = stub_etcd.Client()
             exc = e3e.Etcd3Exception(detail_text="Unauthorised user")
             client.add_read_exception(exc)

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -20,3 +20,5 @@ neutron>=16,<17
 neutron-lib==2.3.0
 mock>=3.0.0 # BSD
 pyroute2<0.6.0 # Apache v2
+
+nose2


### PR DESCRIPTION
This is a backport of #6725 + related work for the v3.24 branch.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Allow Calico to set MTU in OpenStack
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
