### PR TITLE
DOCS-716: Added missing title metadata to index files

### DIFF
--- a/calico/getting-started/bare-metal/installation/index.md
+++ b/calico/getting-started/bare-metal/installation/index.md
@@ -1,4 +1,5 @@
 ---
+title: Install on non-cluster hosts
 description: Install Calico on hosts to secure host communications.
 show_read_time: false
 show_toc: false

--- a/calico/getting-started/kubernetes/hardway/index.md
+++ b/calico/getting-started/kubernetes/hardway/index.md
@@ -1,4 +1,5 @@
 ---
+Title: Calico the hard way
 description: Up for the challenge? Calico the hard way takes you under the covers of an end-to-end Calico installation.
 show_read_time: false
 show_toc: false

--- a/calico/getting-started/openstack/index.md
+++ b/calico/getting-started/openstack/index.md
@@ -1,4 +1,5 @@
 ---
+title: OpenStack
 description: Install Calico networking and network policy for OpenStack.
 show_read_time: false
 show_toc: false

--- a/calico/getting-started/openstack/installation/index.md
+++ b/calico/getting-started/openstack/installation/index.md
@@ -1,5 +1,6 @@
 ---
-description: Install Calico for OpenStack.
+title: Install Calico on OpenStack
+description: Install Calico on OpenStack
 show_read_time: false
 show_toc: false
 ---

--- a/calico/reference/calicoctl/datastore/index.md
+++ b/calico/reference/calicoctl/datastore/index.md
@@ -1,4 +1,5 @@
 ---
+title: datastore
 description: calicoctl datastore commands.
 show_read_time: false
 show_toc: false

--- a/calico/reference/calicoctl/datastore/migrate/index.md
+++ b/calico/reference/calicoctl/datastore/migrate/index.md
@@ -1,4 +1,5 @@
 ---
+title: Migrate
 description: calicoctl datastore migrate commands.
 show_read_time: false
 show_toc: false

--- a/calico/reference/calicoctl/index.md
+++ b/calico/reference/calicoctl/index.md
@@ -1,4 +1,5 @@
 ---
+title: calicoctl
 show_read_time: false
 description: Optional command line interface (CLI) to manage Calico resources.
 show_toc: false

--- a/calico/reference/calicoctl/ipam/index.md
+++ b/calico/reference/calicoctl/ipam/index.md
@@ -1,4 +1,5 @@
 ---
+title: ipam
 description: calicoctl IPAM commands for Calico-assigned IP addresses.
 show_read_time: false
 show_toc: false

--- a/calico/reference/calicoctl/node/index.md
+++ b/calico/reference/calicoctl/node/index.md
@@ -1,4 +1,5 @@
 ---
+title: node
 description: calicoctl node commands.
 show_read_time: false
 show_toc: false

--- a/calico/reference/etcd-rbac/index.md
+++ b/calico/reference/etcd-rbac/index.md
@@ -1,4 +1,5 @@
 ---
+title: Configuring etcd RBAC
 description: Tasks for protecting your etcd datastore.
 show_read_time: false
 show_toc: false

--- a/calico/reference/host-endpoints/index.md
+++ b/calico/reference/host-endpoints/index.md
@@ -1,4 +1,5 @@
 ---
+title: Host endpoints
 description: Protect host endpoints with Calico network policy.
 show_read_time: false
 show_toc: false

--- a/calico/reference/resources/index.md
+++ b/calico/reference/resources/index.md
@@ -1,4 +1,5 @@
 ---
+title: Resource definitions
 description: APIs for all Calico networking and network policy resources. 
 show_read_time: false
 show_toc: false

--- a/calico/security/calico-policy.md
+++ b/calico/security/calico-policy.md
@@ -1,4 +1,5 @@
 ---
+title: Calico policy
 description: Calico network policy lets you secure both workloads and hosts.
 show_read_time: false
 show_toc: false

--- a/calico/security/kubernetes-policy.md
+++ b/calico/security/kubernetes-policy.md
@@ -1,4 +1,5 @@
 ---
+title: Kubernetes policy
 description: Manage your Kubernetes network policies right alongside the more powerful Calico network policies.
 show_read_time: false
 show_toc: false


### PR DESCRIPTION
For https://tigera.atlassian.net/browse/DOCS-716

This PR adds title metadata where it was missing in 14 index files.