### PR TITLE
Fix syncing calico node labels for Kubernetes CRD mode

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/kubecontrollersconfig_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/kubecontrollersconfig_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+)
+
+var _ = Describe("k8s sync label validation tests", func() {
+	client := NewKubeControllersConfigClient(nil, nil).(*customK8sResourceClient)
+	It("should accept enabled sync labels", func() {
+		res := &apiv3.KubeControllersConfiguration{
+			Spec: apiv3.KubeControllersConfigurationSpec{
+				Controllers: apiv3.ControllersConfig{
+					Node: &apiv3.NodeControllerConfig{
+						SyncLabels: apiv3.Enabled,
+					},
+				},
+			},
+		}
+		err := client.validator.Validate(res)
+		Expect(err).To(BeNil())
+	})
+
+	It("should not accept disabled sync labels", func() {
+		res := &apiv3.KubeControllersConfiguration{
+			Spec: apiv3.KubeControllersConfigurationSpec{
+				Controllers: apiv3.ControllersConfig{
+					Node: &apiv3.NodeControllerConfig{
+						SyncLabels: apiv3.Disabled,
+					},
+				},
+			},
+		}
+		err := client.validator.Validate(res)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
For Kubernetes CRD mode, sync labels should always be set to enabled.
This PR adds a validation rule for `syncLabels`. When the datastore type is Kubernetes, it does not allow disabling sync labels.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
https://github.com/projectcalico/calico/issues/5594
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed SyncLabels validation for Kubernetes datastore.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
