### PR TITLE
DHCP agent: Fix check for linux interface being up

### DIFF
--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -166,7 +166,7 @@ class MTUWatcher(object):
         self.port_handler = port_handler
         self.mtu_by_if_name = {}
         self.port_id_by_if_name = {}
-        self.rx_up = re.compile('[0-9]+: (tap[a-z0-9-]+).*: <(?:UP|.+,UP)[,>].* mtu ([0-9]+)')
+        self.rx_up = re.compile('^[0-9]+: (tap[a-z0-9-]+).*:.* mtu ([0-9]+)')
         self.rx_del = re.compile('Deleted [0-9]+: (tap[a-z0-9-]+)')
 
     def get_mtu(self, if_name):

--- a/networking-calico/networking_calico/agent/dhcp_agent.py
+++ b/networking-calico/networking_calico/agent/dhcp_agent.py
@@ -166,7 +166,7 @@ class MTUWatcher(object):
         self.port_handler = port_handler
         self.mtu_by_if_name = {}
         self.port_id_by_if_name = {}
-        self.rx_up = re.compile('[0-9]+: (tap[a-z0-9-]+).* mtu ([0-9]+) .* state UP')
+        self.rx_up = re.compile('[0-9]+: (tap[a-z0-9-]+).*: <(?:UP|.+,UP)[,>].* mtu ([0-9]+)')
         self.rx_del = re.compile('Deleted [0-9]+: (tap[a-z0-9-]+)')
 
     def get_mtu(self, if_name):
@@ -235,6 +235,8 @@ class MTUWatcher(object):
     def record_mtu(self, if_name, mtu):
         LOG.debug("MTU for %s is now %d", if_name, mtu)
         old_mtu = self.mtu_by_if_name.get(if_name)
+        if mtu != old_mtu:
+            LOG.info("MTU for %s changed from %s to %s", if_name, old_mtu, mtu)
         self.mtu_by_if_name[if_name] = mtu
         if if_name in self.port_id_by_if_name and mtu != old_mtu:
             # MTU changing for a watched port.
@@ -243,6 +245,7 @@ class MTUWatcher(object):
     def if_deleted(self, if_name):
         LOG.debug("Interface %s deleted", if_name)
         if if_name in self.mtu_by_if_name:
+            LOG.info("Discard MTU for deleted interface %s", if_name)
             del self.mtu_by_if_name[if_name]
 
 


### PR DESCRIPTION
We were looking for "state UP" in the output from `ip monitor link`, but that's not the right thing to look for, and in practice often shows as "state UNKNOWN" when the interface is actually up.

According to https://superuser.com/questions/1463162/unknown-state-of-network-interface, the correct thing is to look for "UP" in the set of flags between < and >, as for example here:

    3: wlp59s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DORMANT group default qlen 1000

I've adjusted the rx_up regexp to do that.

This could impact in practice when a VM is rebooted, because it appears that when that happens, the TAP interface is deleted and then recreated with "state UNKNOWN".  Then, if the VM is also supposed to have a non-default MTU, the DHCP agent would fail to spot that, and so the rebooting VM would internally set a default MTU of 1500 instead of what it ought to have.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
