### PR TITLE
[Release 3.23] Cherry-pick: BPF support for 3rd party iptables DNAT rules that redirect host->pod 

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -146,6 +146,8 @@ static CALI_BPF_INLINE void __compile_asserts(void) {
      . . . .  . 1 0 1  . . . .       FALLTHROUGH => SEEN but no BPF CT state; need to check
                                      against Linux CT state
 
+	 . . . .  . . . .  1 . . .		 SKIP_FIB => skip fib and send packet to host
+
      . . . .  1 . . .  . . . .       CT_ESTABLISHED: set by iptables to indicate match
                                      against Linux CT state
 

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -756,6 +756,13 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 		if (CALI_F_FROM_WEP && state->flags & CALI_ST_SKIP_FIB) {
 			ct_ctx_nat.flags |= CALI_CT_FLAG_SKIP_FIB;
 		}
+		/* Packets received at WEP with CALI_CT_FLAG_SKIP_FIB mark signal
+		 * that all traffic on this connection must flow via host namespace as it was
+		 * originally meant for host, but got redirected to a WEP by a 3rd party DNAT rule.
+		 */
+		if (CALI_F_TO_WEP && ((ctx->skb->mark & CALI_SKB_MARK_SKIP_FIB) == CALI_SKB_MARK_SKIP_FIB)) {
+			ct_ctx_nat.flags |= CALI_CT_FLAG_SKIP_FIB;
+		}
 
 		if (state->ip_proto == IPPROTO_TCP) {
 			if (skb_refresh_validate_ptrs(ctx, TCP_SIZE)) {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3040,7 +3040,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 				hostIP0 := TargetIP(felixes[0].IP)
 				hostPort := uint16(8080)
-				target := fmt.Sprintf("%s:8055", w[0][0].GetIP())
+				target := fmt.Sprintf("%s:8055", w[0][0].IP)
 
 				policy := api.NewNetworkPolicy()
 				policy.Name = "allow-all"

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3031,6 +3031,64 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					})
 				})
 			})
+
+			It("should have connectivity when DNAT redirects to-host traffic to a local pod.", func() {
+				protocol := "tcp"
+				if testOpts.protocol == "udp" {
+					protocol = "udp"
+				}
+
+				hostIP0 := TargetIP(felixes[0].IP)
+				hostPort := uint16(8080)
+				target := fmt.Sprintf("%s:8055", w[0][0].GetIP())
+
+				policy := api.NewNetworkPolicy()
+				policy.Name = "allow-all"
+				policy.Namespace = "default"
+				one := float64(1)
+				policy.Spec.Order = &one
+				policy.Spec.Ingress = []api.Rule{{Action: api.Allow}}
+				policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
+				policy.Spec.Selector = "all()"
+				_, err := calicoClient.NetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+				Expect(err).NotTo(HaveOccurred())
+
+				expectNormalConnectivity := func() {
+					cc.ResetExpectations()
+					cc.ExpectNone(felixes[1], hostIP0, hostPort)
+					cc.ExpectNone(externalClient, hostIP0, hostPort)
+					cc.ExpectNone(w[1][0], hostIP0, hostPort)
+					cc.CheckConnectivity()
+					cc.ResetExpectations()
+				}
+
+				By("checking initial connectivity", func() {
+					expectNormalConnectivity()
+				})
+
+				By("installing 3rd party DNAT rules", func() {
+					// Install a DNAT in first felix
+					felixes[0].Exec(
+						"iptables", "-w", "10", "-W", "100000", "-t", "nat", "-A", "PREROUTING", "-p", protocol, "-m", protocol,
+						"--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", target)
+
+					cc.ResetExpectations()
+					cc.ExpectSome(felixes[1], hostIP0, hostPort)
+					cc.ExpectSome(externalClient, hostIP0, hostPort)
+					cc.ExpectSome(w[1][0], hostIP0, hostPort)
+					cc.CheckConnectivity()
+					cc.ResetExpectations()
+				})
+
+				By("removing 3rd party rules and check connectivity is back to normal again", func() {
+					felixes[0].Exec(
+						"iptables", "-w", "10", "-W", "100000", "-t", "nat", "-D", "PREROUTING", "-p", protocol, "-m", protocol,
+						"--dport", fmt.Sprintf("%d", hostPort), "-j", "DNAT", "--to-destination", target)
+
+					expectNormalConnectivity()
+				})
+			})
+
 		})
 
 		Describe("with BPF disabled to begin with", func() {

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1087,14 +1087,20 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 
 	rawRules = append(rawRules,
 		Rule{
-			Match:  Match().NotDestAddrType(AddrTypeLocal),
-			Action: GotoAction{Target: ChainRawUntrackedFlows},
-		},
-		Rule{
 			// Return, i.e. no-op, if bypass mark is not set.
 			Match:   Match().MarkMatchesWithMask(tcdefs.MarkSeenBypass, 0xffffffff),
 			Action:  GotoAction{Target: ChainRawBPFUntrackedPolicy},
 			Comment: []string{"Jump to target for packets with Bypass mark"},
+		},
+		Rule{
+			Match:   Match().DestAddrType(AddrTypeLocal),
+			Action:  SetMaskedMarkAction{Mark: tcdefs.MarkSeenSkipFIB, Mask: tcdefs.MarkSeenSkipFIB},
+			Comment: []string{"Mark traffic towards the host - it is TRACKed"},
+		},
+		Rule{
+			Match:   Match().NotDestAddrType(AddrTypeLocal),
+			Action:  GotoAction{Target: ChainRawUntrackedFlows},
+			Comment: []string{"Check if forwarded traffic needs to be TRACKed"},
 		},
 	)
 


### PR DESCRIPTION
## Description
Back port of PR https://github.com/projectcalico/calico/pull/6766 which include fix for GH issue https://github.com/projectcalico/calico/issues/6522

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
