### PR TITLE
Add CSI node-driver-registrar to image list for private registry use

### DIFF
--- a/calico/_config.yml
+++ b/calico/_config.yml
@@ -95,3 +95,4 @@ defaults:
         pilot-webhook: calico/pilot-webhook
         flexvol: calico/pod2daemon-flexvol
         csi-driver: calico/csi
+        csi-node-driver-registrar: calico/node-driver-registrar

--- a/calico/_data/versions.yml
+++ b/calico/_data/versions.yml
@@ -33,3 +33,5 @@
       version: v3.24.0
      csi-driver:
       version: v3.24.0
+     csi-node-driver-registrar:
+      version: v3.24.0


### PR DESCRIPTION
## Description
The documentation containing instructions for downloading all of the necessary images to deploy Calico from a private registry was missing the node-driver-registrar image. This PR corrects that oversight.

Verified manually via inspection of the relevant documentation page after executing make serve

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

cherry-pick of [6812](https://github.com/projectcalico/calico/pull/6812)

## Todos

- ~~[ ] Tests~~
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Updated documentation list of images to pull for deploying from private registry (now includes node-driver-registrar)
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
