### PR TITLE
Install hping3 where needed in XDP FV tests

### DIFF
--- a/felix/fv/xdp_test.go
+++ b/felix/fv/xdp_test.go
@@ -86,8 +86,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ XDP tests with initialized 
 				"8055,8056,22,68",
 				protos[ii])
 
-			felix.Exec("apt-get", "install", "-y", "hping3")
-
 			hostEp := api.NewHostEndpoint()
 			hostEp.Name = fmt.Sprintf("host-endpoint-%d", ii)
 			hostEp.Labels = map[string]string{
@@ -100,6 +98,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ XDP tests with initialized 
 			hostEp.Spec.ExpectedIPs = []string{felix.IP}
 			_, err = client.HostEndpoints().Create(utils.Ctx, hostEp, utils.NoOptions)
 			Expect(err).NotTo(HaveOccurred())
+		}
+
+		if bpfEnabled {
+			ensureAllNodesBPFProgramsAttached(felixes)
 		}
 
 		ccTCP = &connectivity.Checker{Protocol: "tcp"}
@@ -363,6 +365,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ XDP tests with initialized 
 			It("should block packets smaller than UDP", func() {
 				client, server := clientServerIndexes("tcp")
 
+				felixes[client].Exec("apt-get", "install", "-y", "hping3")
 				err := utils.RunMayFail("docker", "exec", felixes[client].Name, "hping3", "--rawip", "-c", "1", "-H", "254", "-d", "1", hostW[server].IP)
 				Expect(err).To(HaveOccurred())
 				Expect(utils.LastRunOutput).To(ContainSubstring(`100% packet loss`))
@@ -395,6 +398,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ XDP tests with initialized 
 			It("should block ICMP too", func() {
 				client, server := clientServerIndexes("tcp")
 
+				time.Sleep(applyPeriod)
 				err := utils.RunMayFail("docker", "exec", felixes[client].Name, "ping", "-c", "1", "-w", "1", hostW[server].IP)
 				Expect(err).To(HaveOccurred())
 				Expect(utils.LastRunOutput).To(ContainSubstring(`100% packet loss`))


### PR DESCRIPTION
## Description
Fix the flakiness of XDP FV tests. `hping3` is installed in the main `BeforeEach()` while only needed by one test. The installation of package fails randomly because the package repository is not available. The failure could be due to different reasons including remote server rate limiting policies. Installing it when needed reduces the number of fetches, and fixes the issue. 

The delay as the result of installation allows many tests to sync, and removing it causes other test failure. This PR also fixes that.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
