### PR TITLE
fix error log format

### DIFF
--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -591,7 +591,7 @@ func (m *vxlanManager) getParentInterface(localVTEP *proto.VXLANTunnelEndpointUp
 		}
 		for _, addr := range addrs {
 			if addr.IPNet.IP.String() == parentDeviceIP {
-				m.logCtx.Debugf("Found parent interface: %s", link)
+				m.logCtx.Debugf("Found parent interface: %+v", link)
 				return link, nil
 			}
 		}
@@ -692,19 +692,19 @@ func (m *vxlanManager) configureVXLANDevice(mtu int, localVTEP *proto.VXLANTunne
 
 	// Make sure the IP address is configured.
 	if err := m.ensureAddressOnLink(addr, link); err != nil {
-		return fmt.Errorf("failed to ensure address of interface: %s", err)
+		return fmt.Errorf("failed to ensure address of interface: %v", err)
 	}
 
 	// If required, disable checksum offload.
 	if xsumBroken {
 		if err := ethtool.EthtoolTXOff(m.vxlanDevice); err != nil {
-			return fmt.Errorf("failed to disable checksum offload: %s", err)
+			return fmt.Errorf("failed to disable checksum offload: %v", err)
 		}
 	}
 
 	// And the device is up.
 	if err := m.nlHandle.LinkSetUp(link); err != nil {
-		return fmt.Errorf("failed to set interface up: %s", err)
+		return fmt.Errorf("failed to set interface up: %v", err)
 	}
 
 	return nil
@@ -738,7 +738,7 @@ func (m *vxlanManager) ensureAddressOnLink(ipStr string, link netlink.Link) erro
 		}
 		m.logCtx.WithFields(logrus.Fields{"address": existing, "link": link.Attrs().Name}).Warn("Removing unwanted IP from VXLAN device")
 		if err := m.nlHandle.AddrDel(link, &existing); err != nil {
-			return fmt.Errorf("failed to remove IP address %s", existing)
+			return fmt.Errorf("failed to remove IP address %s: %v", existing.String(), err)
 		}
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
fix some log print format error.

`
2022-10-11 10:22:08.063 [DEBUG][112] felix/vxlan_mgr.go 588: Found parent interface: &{{%!s(int=9) %!s(int=1500) %!s(int=1000) eth0 aa:bb:cc:dd:88:16 up|broadcast|multicast %!s(uint32=69699) %!s(int=8) %!s(int=0) <nil>  %!s(*netlink.LinkStatistics=&{3516861 3367420 2645954856 1278274451 0 0 0 0 3772 0 0 0 0 0 0 0 0 0 0 0 0 0 0}) %!s(int=0) %!s(int=0) %!s(int=1) %!s(*netlink.LinkXdp=&{0 false 0 0 0}) ether <nil> up %!s(int=0) %!s(int=-1) %!s(int=1) %!s(int=1) %!s(uint32=65536) %!s(uint32=65535) [] %!s(uint32=0) <nil>} %!s(int=1210) 802.1q} ipVersion=0x6
`

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
