### PR TITLE
Let calico-bpf decide whether to fail when some counters error - XDP counters may not be present

### DIFF
--- a/calico/maintenance/ebpf/troubleshoot-ebpf.md
+++ b/calico/maintenance/ebpf/troubleshoot-ebpf.md
@@ -90,24 +90,24 @@ The tool is embedded in the {{site.nodecontainer}} container image. To run the t
   For example, to dump the BPF counters of `eth0` interface:
   ```
   $ kubectl exec -n calico-system calico-node-abcdef -- calico-node -bpf counters dump --iface=eth0
-  +----------+--------------------------------+---------+--------+
-  | CATEGORY |              TYPE              | INGRESS | EGRESS |
-  +----------+--------------------------------+---------+--------+
-  | Accepted | by another program             |       0 |      0 |
-  |          | by failsafe                    |       0 |      4 |
-  |          | by policy                      |      21 |      0 |
-  | Dropped  | by policy                      |       4 |      0 |
-  |          | failed decapsulation           |       0 |      0 |
-  |          | failed encapsulation           |       0 |      0 |
-  |          | incorrect checksum             |       0 |      0 |
-  |          | malformed IP packets           |       0 |      0 |
-  |          | packets with unknown route     |       0 |      0 |
-  |          | packets with unknown source    |       0 |      0 |
-  |          | packets with unsupported IP    |       0 |      0 |
-  |          | options                        |         |        |
-  |          | too short packets              |       0 |      0 |
-  | Total    | packets                        |    1593 |   1973 |
-  +----------+--------------------------------+---------+--------+
+  +----------+--------------------------------+---------+--------+-----+
+  | CATEGORY |              TYPE              | INGRESS | EGRESS | XDP |
+  +----------+--------------------------------+---------+--------+-----+
+  | Accepted | by another program             |       0 |      0 |   0 |
+  |          | by failsafe                    |       0 |      2 |  23 |
+  |          | by policy                      |       1 |      0 |   0 |
+  | Dropped  | by policy                      |       0 |      0 |   0 |
+  |          | failed decapsulation           |       0 |      0 |   0 |
+  |          | failed encapsulation           |       0 |      0 |   0 |
+  |          | incorrect checksum             |       0 |      0 |   0 |
+  |          | malformed IP packets           |       0 |      0 |   0 |
+  |          | packets with unknown route     |       0 |      0 |   0 |
+  |          | packets with unknown source    |       0 |      0 |   0 |
+  |          | packets with unsupported IP    |       0 |      0 |   0 |
+  |          | options                        |         |        |     |
+  |          | too short packets              |       0 |      0 |   0 |
+  | Total    | packets                        |      27 |    124 |  41 |
+  +----------+--------------------------------+---------+--------+-----+
   dumped eth0 counters.
   ```
 

--- a/felix/bpf/counters/counters.go
+++ b/felix/bpf/counters/counters.go
@@ -136,6 +136,8 @@ type Counters struct {
 	iface    string
 	numOfCpu int
 	maps     []bpf.Map
+	key      []byte
+	zeroVal  []byte
 }
 
 func NewCounters(iface string) *Counters {
@@ -144,6 +146,9 @@ func NewCounters(iface string) *Counters {
 		numOfCpu: bpf.NumPossibleCPUs(),
 		maps:     make([]bpf.Map, len(bpf.Hooks)),
 	}
+	// key is the key to the counters map, and it is set to 0 since there is only one entry
+	cntr.key = make([]byte, counterMapKeySize)
+	cntr.zeroVal = make([]byte, counterMapValueSize*MaxCounterNumber*cntr.numOfCpu)
 
 	for index, hook := range bpf.Hooks {
 		pinPath := bpf.MapPinPath(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
@@ -151,50 +156,22 @@ func NewCounters(iface string) *Counters {
 		cntr.maps[index] = Map(&bpf.MapContext{}, pinPath)
 		logrus.Debugf("%s counter map pin path: %v", hook, pinPath)
 	}
-
 	return &cntr
 }
 
-func (c Counters) Read() ([][]uint64, error) {
-	values := make([][]uint64, len(bpf.Hooks))
-	for i := range values {
-		values[i] = make([]uint64, MaxCounterNumber)
-	}
-
-	for hook, name := range bpf.Hooks {
-		val, err := c.read(c.maps[hook])
-		if err != nil {
-			if name == bpf.HookXDP {
-				logrus.Infof("Failed to read XDP bpf counters. err=%v", err)
-				continue
-			}
-			return values, fmt.Errorf("Failed to read bpf counters. hook=%s err=%w", name, err)
-		}
-		if len(values[hook]) < MaxCounterNumber {
-			return values, fmt.Errorf("Failed to read enough data from bpf counters. hook=%s", name)
-		}
-
-		values[hook] = val
-	}
-
-	return values, nil
-}
-
-func (c Counters) read(cMap bpf.Map) ([]uint64, error) {
-	err := cMap.Open()
+func (c Counters) Read(index int) ([]uint64, error) {
+	err := c.maps[index].Open()
 	if err != nil {
 		return []uint64{}, fmt.Errorf("failed to open counters map. err=%w", err)
 	}
 	defer func() {
-		err := cMap.Close()
+		err := c.maps[index].Close()
 		if err != nil {
 			logrus.WithError(err).Errorf("failed to close counters map.")
 		}
 	}()
 
-	// k is the key to the counters map, and it is set to 0 since there is only one entry
-	k := make([]byte, counterMapKeySize)
-	values, err := cMap.Get(k)
+	values, err := c.maps[index].Get(c.key)
 	if err != nil {
 		return []uint64{}, fmt.Errorf("failed to read counters map. err=%w", err)
 	}
@@ -210,37 +187,19 @@ func (c Counters) read(cMap bpf.Map) ([]uint64, error) {
 	return bpfCounters, nil
 }
 
-func (c *Counters) Flush() error {
-	for hook, name := range bpf.Hooks {
-		err := c.flush(c.maps[hook])
-		if err != nil {
-			if name == bpf.HookXDP {
-				logrus.Infof("Failed to flush XDP bpf counters. err=%v", err)
-				continue
-			}
-			return fmt.Errorf("Failed to flush bpf counters for interface=%s hook=%s. err=%w", c.iface, name, err)
-		}
-		logrus.Infof("Successfully flushed counters map for interface=%s hook=%s", c.iface, name)
-	}
-	return nil
-}
-
-func (c *Counters) flush(cMap bpf.Map) error {
-	err := cMap.Open()
+func (c *Counters) Flush(index int) error {
+	err := c.maps[index].Open()
 	if err != nil {
 		return fmt.Errorf("failed to open counters map. err=%v", err)
 	}
 	defer func() {
-		err := cMap.Close()
+		err := c.maps[index].Close()
 		if err != nil {
 			logrus.WithError(err).Errorf("failed to close counters map.")
 		}
 	}()
 
-	// k is the key to the counters map, and it is set to 0 since there is only one entry
-	k := make([]byte, counterMapKeySize)
-	v := make([]byte, counterMapValueSize*MaxCounterNumber*c.numOfCpu)
-	err = cMap.Update(k, v)
+	err = c.maps[index].Update(c.key, c.zeroVal)
 	if err != nil {
 		return fmt.Errorf("failed to update counters map. err=%v", err)
 	}

--- a/felix/bpf/counters/counters.go
+++ b/felix/bpf/counters/counters.go
@@ -136,7 +136,7 @@ type Counters struct {
 	iface    string
 	numOfCpu int
 	maps     []bpf.Map
-	key      []byte
+	zeroKey  []byte
 	zeroVal  []byte
 }
 
@@ -146,8 +146,8 @@ func NewCounters(iface string) *Counters {
 		numOfCpu: bpf.NumPossibleCPUs(),
 		maps:     make([]bpf.Map, len(bpf.Hooks)),
 	}
-	// key is the key to the counters map, and it is set to 0 since there is only one entry
-	cntr.key = make([]byte, counterMapKeySize)
+	// zeroKey is the key to the counters map, and it is set to 0 since there is only one entry
+	cntr.zeroKey = make([]byte, counterMapKeySize)
 	cntr.zeroVal = make([]byte, counterMapValueSize*MaxCounterNumber*cntr.numOfCpu)
 
 	for index, hook := range bpf.Hooks {
@@ -171,7 +171,7 @@ func (c Counters) Read(index int) ([]uint64, error) {
 		}
 	}()
 
-	values, err := c.maps[index].Get(c.key)
+	values, err := c.maps[index].Get(c.zeroKey)
 	if err != nil {
 		return []uint64{}, fmt.Errorf("failed to read counters map. err=%w", err)
 	}
@@ -199,7 +199,7 @@ func (c *Counters) Flush(index int) error {
 		}
 	}()
 
-	err = c.maps[index].Update(c.key, c.zeroVal)
+	err = c.maps[index].Update(c.zeroKey, c.zeroVal)
 	if err != nil {
 		return fmt.Errorf("failed to update counters map. err=%v", err)
 	}

--- a/felix/cmd/calico-bpf/commands/counters.go
+++ b/felix/cmd/calico-bpf/commands/counters.go
@@ -123,6 +123,7 @@ func dumpInterface(cmd *cobra.Command, iface string) error {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetCaption(true, fmt.Sprintf("dumped %s counters.", iface))
 	table.SetHeader([]string{"CATEGORY", "TYPE", "INGRESS", "EGRESS", "XDP"})
+
 	var rows [][]string
 	for _, c := range counters.Descriptions() {
 		newRow := []string{c.Category, c.Caption}

--- a/felix/cmd/calico-bpf/commands/counters.go
+++ b/felix/cmd/calico-bpf/commands/counters.go
@@ -129,7 +129,7 @@ func dumpInterface(cmd *cobra.Command, iface string) error {
 		newRow := []string{c.Category, c.Caption}
 		// Now add value related to each hook, i.e. ingress, egress and XDP
 		for index, hook := range bpf.Hooks {
-			if hook == bpf.HookXDP && !xdpOK {
+			if values[index] == nil {
 				newRow = append(newRow, "N/A")
 			} else {
 				newRow = append(newRow, fmt.Sprintf("%v", values[index][c.Counter]))

--- a/felix/cmd/calico-bpf/commands/counters.go
+++ b/felix/cmd/calico-bpf/commands/counters.go
@@ -102,12 +102,10 @@ func dumpInterface(cmd *cobra.Command, iface string) error {
 	bpfCounters := counters.NewCounters(iface)
 
 	values := make([][]uint64, len(bpf.Hooks))
-	xdpOK := true
 	for index, hook := range bpf.Hooks {
 		val, err := bpfCounters.Read(index)
 		if err != nil {
 			if hook == bpf.HookXDP {
-				xdpOK = false
 				log.Infof("Failed to read XDP bpf counters. err=%v", err)
 				continue
 			}
@@ -116,7 +114,6 @@ func dumpInterface(cmd *cobra.Command, iface string) error {
 		if len(val) < counters.MaxCounterNumber {
 			return fmt.Errorf("Failed to read enough data from bpf counters. iface=%v hook=%s", iface, hook)
 		}
-		values[index] = make([]uint64, counters.MaxCounterNumber)
 		values[index] = val
 	}
 

--- a/felix/cmd/calico-bpf/commands/counters.go
+++ b/felix/cmd/calico-bpf/commands/counters.go
@@ -125,7 +125,7 @@ func dumpInterface(cmd *cobra.Command, iface string) error {
 	for _, c := range counters.Descriptions() {
 		newRow := []string{c.Category, c.Caption}
 		// Now add value related to each hook, i.e. ingress, egress and XDP
-		for index, hook := range bpf.Hooks {
+		for index := range bpf.Hooks {
 			if values[index] == nil {
 				newRow = append(newRow, "N/A")
 			} else {


### PR DESCRIPTION
## Description
Failing in dumping or flushing a counter map should not prevent the operation for the rest of maps. So instead of returning an error, we just need to log and continue with the rest of maps.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
