### PR TITLE
Tweak newly added test

### DIFF
--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -23,9 +23,8 @@ const (
 	externalIPRange2 = "172.217.3.5/32"
 	externalIP2      = "172.217.3.5"
 
-	// Range and specific IP for loadbalancer IP test.
-	loadBalancerIPRange1 = "172.217.4.10/16"
-	loadBalancerIP1      = "172.217.4.10"
+	// Specific IP for loadbalancer IP test.
+	loadBalancerIP1 = "172.217.4.10"
 )
 
 func addEndpointSubset(ep *v1.Endpoints, nodename string) {

--- a/confd/pkg/backends/calico/routes_test.go
+++ b/confd/pkg/backends/calico/routes_test.go
@@ -573,53 +573,48 @@ var _ = Describe("RouteGenerator", func() {
 			})
 
 			// This test simulates a situation where BGPConfiguration has a /32 route that exactly matches
-			// a LoadBalancer with ExternalTrafficPolicy set to Local. Should result in one route advertised.
+			// a LoadBalancer with ExternalTrafficPolicy set to Local. The route should only be advertised
+			// when the Service is created, and not when the BGPConfiguration is created.
 			It("should handle /32 routes for LoadBalancerIPs", func() {
+				// BeforeEach creates a service. Remove it before the test, since we want to start
+				// this test without the service in place. svc3 is a LoadBalancer service with external traffic
+				// policy of Local.
+				err := rg.epIndexer.Delete(ep3)
+				Expect(err).NotTo(HaveOccurred())
+				err = rg.svcIndexer.Delete(svc3)
+				Expect(err).NotTo(HaveOccurred())
 
-				// Create a /32 CIDR for the services loadBalancerIP.
-				loadBalancerIPRangeSingle := fmt.Sprintf("%s/32", loadBalancerIP1)
+				// The key we expect to be used for the LB IP.
 				key := "/calico/staticroutes/" + loadBalancerIP1 + "-32"
 
 				// Trigger programming of valid routes from the route generator for any known services.
-				// We don't have a BGPConfiguration update yet, so we shouldn't receive any routes.
+				// We don't have a BGPConfiguration update or services yet, so we shouldn't receive any routes.
 				By("Resyncing routes at start of test")
 				rg.resyncKnownRoutes()
 				Expect(rg.client.cache[key]).To(Equal(""))
 				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(0))
 
 				// Simulate an event from the syncer which sets the LoadBalancer IP range containing only the service's loadBalancerIP.
+				// We use a /32 route to trigger the situation under test.
+				loadBalancerIPRangeSingle := fmt.Sprintf("%s/32", loadBalancerIP1)
 				By("onLoadBalancerIPsUpdate to include /32 route")
 				rg.client.onLoadBalancerIPsUpdate([]string{loadBalancerIPRangeSingle})
 				rg.resyncKnownRoutes()
 
-				// Expect that we advertise the /32 given to us via BGPConfiguration.
-				Expect(rg.client.cache[key]).To(Equal(loadBalancerIP1 + "/32"))
-				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
+				// No routes should be advertised yet.
+				Expect(rg.client.cache[key]).To(Equal(""))
+				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(0))
 
-				// Trigger programming of routes from the route generator again. This time, the service's loadBalancerIP
-				// will be allowed by BGPConfiguration and so it should be programmed.
+				// Now add the service.
+				err = rg.epIndexer.Add(ep3)
+				Expect(err).NotTo(HaveOccurred())
+				err = rg.svcIndexer.Add(svc3)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect that we advertise the /32 LB IP from the Service.
 				By("Resyncing routes from route generator")
 				rg.resyncKnownRoutes()
-
-				// Expect that we continue to advertise the route and the refcount should indicate a route received
-				// from the RouteGenerator only.
 				Expect(rg.client.cache[key]).To(Equal(loadBalancerIP1 + "/32"))
-				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
-
-				// Simulate an event from the syncer which updates the range. It still includes the original IP,
-				// to ensure we don't trigger the route generator to withdraw its route.
-				By("onLoadBalancerIPsUpdate to include /16 route")
-				rg.client.onLoadBalancerIPsUpdate([]string{loadBalancerIPRange1})
-				rg.resyncKnownRoutes()
-
-				// The route should still exist, since the RouteGenerator's route is still valid.
-				Expect(rg.client.cache[key]).To(Equal(loadBalancerIP1 + "/32"))
-				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
-
-				// Revert the BGPConfiguration change.
-				By("onLoadBalancerIPsUpdate to include /32 route again")
-				rg.client.onLoadBalancerIPsUpdate([]string{loadBalancerIPRangeSingle})
-				rg.resyncKnownRoutes()
 				Expect(rg.client.programmedRouteRefCount[key]).To(Equal(1))
 
 				// Finally, remove BGPConfiguration. It should withdraw the route


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

I realized after merging https://github.com/projectcalico/calico/pull/6282 that the test added
wasn't guaranteed to catch the situation originally intended to be fixed
by that PR.

This PR makes some minor tweaks to that test to more accurately simulate
the original problem situation fixed by that PR.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.