### PR TITLE
networking_calico: Fix spurious endpoint delete

### DIFF
--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/mech_calico.py
@@ -790,8 +790,10 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             endpoint_should_already_exist = port_bound(original)
 
             # Check for migration so that we can reliably delete the
-            # WorkloadEndpoint on the old host.
-            if original['binding:host_id'] != port['binding:host_id']:
+            # WorkloadEndpoint on the old host. That happens when the host
+            # formerly had a binding, and it doesn't match the current one.
+            if original['binding:host_id'] and \
+                    original['binding:host_id'] != port['binding:host_id']:
                 LOG.info("Migration, delete WorkloadEndpoint on old host %s",
                          original['binding:host_id'])
                 self.endpoint_syncer.delete_endpoint(original)


### PR DESCRIPTION
## Description
A port which is created and subsequently updated may race into code which was meant to delete the WorkloadEndpoint on the source hypervisor during a live-migration.

When the mechanism driver gets a port-update, first check that the binding existed to begin with before deleting the WorkloadEndpoint. If no such binding exists on the original port, then the port just came into existence and was updated just very shortly after.

When this happens, logs like the following are printed: "Migration, delete WorkloadEndpoint on old host"
(rather than a message with an actual hostname to which the original port was bound).

The fact that this was happening should have been harmless and just resulted in some confusing log messages, but fix it nonetheless.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico for OpenStack: suppress spurious attempted endpoint deletions (which aren't needed because the endpoint does not exist at that point) and associated logging, in some port update scenarios
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
