### PR TITLE
Disable VXLAN checksum offload by default.

### DIFF
--- a/felix/environment/feature_detect.go
+++ b/felix/environment/feature_detect.go
@@ -47,8 +47,6 @@ var (
 	v3Dot10Dot0 = MustParseVersion("3.10.0")
 	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
 	v3Dot14Dot0 = MustParseVersion("3.14.0")
-	// v5Dot7Dot0 contains a fix for checksum offloading.
-	v5Dot7Dot0 = MustParseVersion("5.7.0")
 	// v5Dot14Dot0 is the fist kernel version that IPIP tunnels acts like other L3
 	// devices where bpf programs only see inner IP header. In RHEL based distros,
 	// kernel 4.18.0 (v4Dot18Dot0_330) is the first one with this behavior.
@@ -122,7 +120,7 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 		SNATFullyRandom:       iptV.Compare(v1Dot6Dot0) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		MASQFullyRandom:       iptV.Compare(v1Dot6Dot2) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		RestoreSupportsLock:   iptV.Compare(v1Dot6Dot2) >= 0,
-		ChecksumOffloadBroken: kerV.Compare(v5Dot7Dot0) < 0,
+		ChecksumOffloadBroken: true, // Was supposed to be fixed in v5.7 but still seems to be broken.
 		IPIPDeviceIsL3:        d.ipipDeviceIsL3(),
 	}
 

--- a/felix/environment/feature_detect_test.go
+++ b/felix/environment/feature_detect_test.go
@@ -125,7 +125,7 @@ func TestFeatureDetection(t *testing.T) {
 				RestoreSupportsLock:   true,
 				SNATFullyRandom:       true,
 				MASQFullyRandom:       true,
-				ChecksumOffloadBroken: false,
+				ChecksumOffloadBroken: true,
 			},
 		},
 	} {
@@ -419,28 +419,32 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.10.0 - ubuntu",
 			Features{
-				IPIPDeviceIsL3: false,
+				IPIPDeviceIsL3:        false,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.14.0 - something else",
 			Features{
-				IPIPDeviceIsL3: true,
+				IPIPDeviceIsL3:        true,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.15.0",
 			Features{
-				IPIPDeviceIsL3: true,
+				IPIPDeviceIsL3:        true,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.10.0 - Default",
 			Features{
-				IPIPDeviceIsL3: true,
+				IPIPDeviceIsL3:        true,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "true",
@@ -449,7 +453,8 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.14.0",
 			Features{
-				IPIPDeviceIsL3: false,
+				IPIPDeviceIsL3:        false,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",
@@ -458,7 +463,8 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.16.0 - Ubuntu",
 			Features{
-				IPIPDeviceIsL3: false,
+				IPIPDeviceIsL3:        false,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Reports of the kernel bug being fixed seem to have been greatly exaggerated.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Fixes #4727

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Disable VXLAN checksum offload by default for all kernels.  If this was fixed, it has since been regressed.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
