### PR TITLE
Update kubernetes-upgrade.md

### DIFF
--- a/calico/maintenance/kubernetes-upgrade.md
+++ b/calico/maintenance/kubernetes-upgrade.md
@@ -116,7 +116,7 @@ ownership of the helm resources to the new chart location.
    `<manifest-file-name>` with the file name of your {{page.version}} manifest.
 
    ```
-   kubectl apply -f <manifest-file-name>
+   kubectl replace -f <manifest-file-name>
    ```
 
 1. Watch the status of the upgrade as follows.


### PR DESCRIPTION
Use kubectl replace instead of applying when upgrading. This avoids the possibility of a 2-way merge leaving behind unwanted fields as described in https://github.com/projectcalico/calico/issues/6848

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This is a documentation change to use kubectl replace instead of kubectl apply when upgrading using manifests.

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/6848

<!-- If appropriate, include a link to the issue this fixes.


If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
