### PR TITLE
Fix patch commands overwriting metadata

### DIFF
--- a/calicoctl/tests/st/calicoctl/test_crud.py
+++ b/calicoctl/tests/st/calicoctl/test_crud.py
@@ -1159,11 +1159,11 @@ class TestCalicoctlCommands(TestBase):
         self.assertEqual("192.168.0.1",node1_rev1['spec']['bgp']['routeReflectorClusterID'])
 
         # test patching an ippool
-        rc = calicoctl("create", data=ippool_name1_rev1_v4)
+        rc = calicoctl("create", data=ippool_name1_rev4_v4)
         rc.assert_no_error()
 
         rc = calicoctl(
-                "patch ippool %s -p '{\"spec\":{\"natOutgoing\": true}}'" % name(ippool_name1_rev1_v4))
+                "patch ippool %s -p '{\"spec\":{\"natOutgoing\": true}}'" % name(ippool_name1_rev4_v4))
         rc.assert_no_error()
 
         rc = calicoctl(
@@ -1171,6 +1171,9 @@ class TestCalicoctlCommands(TestBase):
         rc.assert_no_error()
         ippool1_rev1 = rc.decoded
         self.assertEqual(True,ippool1_rev1['spec']['natOutgoing'])
+        # Ensure that labels and annotations were merged properly
+        self.assertEqual('label-1',ippool1_rev1['metadata']['labels']['test-label'])
+        self.assertEqual('annotation-1',ippool1_rev1['metadata']['annotations']['test-annotation'])
 
         # test patching invalid networkpolicy
         rc = calicoctl('create', data=networkpolicy_name2_rev1)

--- a/calicoctl/tests/st/utils/data.py
+++ b/calicoctl/tests/st/utils/data.py
@@ -77,6 +77,25 @@ ippool_name1_rev2_v4 = {
     }
 }
 
+ippool_name1_rev4_v4 = {
+    'apiVersion': API_VERSION,
+    'kind': 'IPPool',
+    'metadata': {
+        'name': 'ippool-name1',
+        'labels': {'test-label': 'label-1'},
+        'annotations': {'test-annotation': 'annotation-1'},
+    },
+    'spec': {
+        'cidr': "10.0.1.0/24",
+        'ipipMode': 'Always',
+        'vxlanMode': 'Never',
+        'blockSize': 27,
+        'allowedUses': ["Workload", "Tunnel"],
+        'nodeSelector': "foo == 'bar'",
+        'disabled': True,
+    }
+}
+
 ippool_name2_rev1_v6 = {
     'apiVersion': API_VERSION,
     'kind': 'IPPool',


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Cherry-pick of https://github.com/projectcalico/calico/pull/6791

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix an issue that caused annotations and labels to be overwritten during a calicoctl patch command
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
