### PR TITLE
[Backport 3.24] Match full interface names to exclude

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
@@ -16,7 +16,7 @@ package autodetection
 // Default interfaces to exclude for any logic following the first-found
 // auto detect IP method
 var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
-	"docker.*", "cbr.*", "dummy.*",
-	"virbr.*", "lxcbr.*", "veth.*", "lo",
-	"cali.*", "tunl.*", "flannel.*", "kube-ipvs.*", "cni.*",
+	"^docker.*", "^cbr.*", "^dummy.*",
+	"^virbr.*", "^lxcbr.*", "^veth.*", "^lo",
+	"^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*",
 }

--- a/node/pkg/lifecycle/startup/autodetection/filtered.go
+++ b/node/pkg/lifecycle/startup/autodetection/filtered.go
@@ -16,7 +16,7 @@ package autodetection
 import (
 	"errors"
 	"fmt"
-	gnet "net"
+	gonet "net"
 
 	log "github.com/sirupsen/logrus"
 
@@ -28,7 +28,7 @@ import (
 //
 // The incl and excl slice of regex strings may be nil.
 func FilteredEnumeration(incl, excl []string, cidrs []net.IPNet, version int) (*Interface, *net.IPNet, error) {
-	interfaces, err := GetInterfaces(incl, excl, version)
+	interfaces, err := GetInterfaces(gonet.Interfaces, incl, excl, version)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,7 +54,7 @@ func FilteredEnumeration(incl, excl []string, cidrs []net.IPNet, version int) (*
 
 // matchCIDRs matches an IP address against a list of cidrs.
 // If the list is empty, it always matches.
-func matchCIDRs(ip gnet.IP, cidrs []net.IPNet) bool {
+func matchCIDRs(ip gonet.IP, cidrs []net.IPNet) bool {
 	if len(cidrs) == 0 {
 		return true
 	}

--- a/node/pkg/lifecycle/startup/autodetection/interfaces.go
+++ b/node/pkg/lifecycle/startup/autodetection/interfaces.go
@@ -32,8 +32,8 @@ type Interface struct {
 // GetInterfaces returns a list of all interfaces, skipping any interfaces whose
 // name matches any of the exclusion list regexes, and including those on the
 // inclusion list.
-func GetInterfaces(includeRegexes []string, excludeRegexes []string, version int) ([]Interface, error) {
-	netIfaces, err := net.Interfaces()
+func GetInterfaces(getSystemInterfaces func() ([]net.Interface, error), includeRegexes []string, excludeRegexes []string, version int) ([]Interface, error) {
+	netIfaces, err := getSystemInterfaces()
 	if err != nil {
 		log.WithError(err).Warnf("Failed to enumerate interfaces")
 		return nil, err

--- a/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
+++ b/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package autodetection
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+type getInterfacesTestCase struct {
+	getInterfaces       func() ([]net.Interface, error)
+	expectFound         bool
+	expectInterfaceName string
+}
+
+var _ = DescribeTable("GetInterfaces",
+	func(tc getInterfacesTestCase) {
+		found, err := GetInterfaces(tc.getInterfaces, nil, DEFAULT_INTERFACES_TO_EXCLUDE, 4)
+		Expect(err).NotTo(HaveOccurred())
+		if tc.expectFound {
+			Expect(found).NotTo(BeEmpty())
+		} else {
+			Expect(found).To(BeEmpty())
+		}
+		if name := tc.expectInterfaceName; name != "" {
+			Expect(found[0].Name).To(Equal(name))
+		}
+	},
+	Entry("default interface", getInterfacesTestCase{
+		getInterfaces: net.Interfaces,
+		expectFound:   true,
+	}),
+	Entry("ibmveth", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "lo"}, {Index: 1, Name: "ibmvetha"}}, nil
+		},
+		expectFound:         true,
+		expectInterfaceName: "ibmvetha",
+	}),
+	Entry("veth", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "veth123126312783"}}, nil
+		},
+	}),
+)

--- a/node/pkg/lifecycle/startup/autodetection/reachaddr.go
+++ b/node/pkg/lifecycle/startup/autodetection/reachaddr.go
@@ -48,7 +48,7 @@ func ReachDestination(dest string, version int) (*net.IPNet, error) {
 
 	// Get a full list of interface and IPs and find the CIDR matching the
 	// found IP.
-	ifaces, err := GetInterfaces(nil, nil, version)
+	ifaces, err := GetInterfaces(gonet.Interfaces, nil, nil, version)
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -601,7 +601,7 @@ func validateIP(ipn string) {
 
 	// Get a complete list of interfaces with their addresses and check if
 	// the IP address can be found.
-	ifaces, err := autodetection.GetInterfaces(nil, nil, ipAddr.Version())
+	ifaces, err := autodetection.GetInterfaces(net.Interfaces, nil, nil, ipAddr.Version())
 	if err != nil {
 		log.WithError(err).Error("Unable to query host interfaces")
 		utils.Terminate()

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -259,7 +259,9 @@ func getMonitorPollInterval() time.Duration {
 
 func configureAndCheckIPAddressSubnets(ctx context.Context, cli client.Interface, node *libapi.Node, k8sNode *v1.Node) bool {
 	// Configure and verify the node IP addresses and subnets.
-	checkConflicts, err := configureIPsAndSubnets(node, k8sNode, autodetection.GetInterfaces)
+	checkConflicts, err := configureIPsAndSubnets(node, k8sNode, func(incl []string, excl []string, version int) ([]autodetection.Interface, error) {
+		return autodetection.GetInterfaces(net.Interfaces, incl, excl, version)
+	})
 	if err != nil {
 		// If this is auto-detection error, do a cleanup before returning
 		clearv4 := os.Getenv("IP") == "autodetect"


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Backport https://github.com/projectcalico/calico/pull/6760 to 3.24 branch

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

https://github.com/projectcalico/calico/pull/6760

## Todos

- [X] Tests
- [ ] Documentation
- [X] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Match full interface names in IP auto-detection default exclude list.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
