### PR TITLE
mark CALI_ST_SKIP_FIB packets on ingress of heps

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -525,6 +525,16 @@ syn_force_policy:
 
 	if (!dest_rt) {
 		CALI_DEBUG("No route for post DNAT dest %x\n", bpf_ntohl(ctx->state->post_nat_ip_dst));
+		if (CALI_F_FROM_HEP) {
+			/* Disable FIB, let the packet go through the host after it is
+			 * policed. It is ingress into the system and we do not know what
+			 * exactly is the packet's destination. It may be a local VM or
+			 * something similar and we let the host to route it or dump it.
+			 *
+			 * https://github.com/projectcalico/calico/issues/6450
+			 */
+			ctx->state->flags |= CALI_ST_SKIP_FIB;
+		}
 		goto do_policy;
 	}
 

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -993,6 +993,7 @@ var payloadDefault = []byte("ABCDEABCDEXXXXXXXXXXXX")
 var srcIP = net.IPv4(1, 1, 1, 1)
 var dstIP = net.IPv4(2, 2, 2, 2)
 var srcV4CIDR = ip.CIDRFromNetIP(srcIP).(ip.V4CIDR)
+var dstV4CIDR = ip.CIDRFromNetIP(dstIP).(ip.V4CIDR)
 
 var ipv4Default = &layers.IPv4{
 	Version:  4,

--- a/felix/bpf/ut/icmp_related_test.go
+++ b/felix/bpf/ut/icmp_related_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 var rulesAllowUDP = &polprog.Rules{
+	SuppressNormalHostPolicy: true,
 	Tiers: []polprog.Tier{{
 		Name: "base tier",
 		Policies: []polprog.Policy{{
@@ -173,6 +174,11 @@ func TestICMPRelatedFromHost(t *testing.T) {
 	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
+
+	rtKey := routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal := routes.NewValue(routes.FlagsLocalHost).AsBytes()
+	err = rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
 
 	skbMark = 0
 	runBpfTest(t, "calico_from_host_ep", rulesAllowUDP, func(bpfrun bpfProgRunFn) {

--- a/felix/bpf/ut/whitelist_test.go
+++ b/felix/bpf/ut/whitelist_test.go
@@ -115,13 +115,14 @@ func TestAllowEnterHostToWorkload(t *testing.T) {
 
 	// Insert a reverse route for the source workload.
 	rtKey := routes.NewKey(srcV4CIDR).AsBytes()
-	rtVal := routes.NewValueWithIfIndex(routes.FlagsLocalWorkload|routes.FlagInIPAMPool, 1).AsBytes()
+	rtVal := routes.NewValue(routes.FlagsRemoteWorkload | routes.FlagInIPAMPool).AsBytes()
 	err = rtMap.Update(rtKey, rtVal)
-	defer func() {
-		err := rtMap.Delete(rtKey)
-		Expect(err).NotTo(HaveOccurred())
-	}()
 	Expect(err).NotTo(HaveOccurred())
+	rtKey = routes.NewKey(dstV4CIDR).AsBytes()
+	rtVal = routes.NewValueWithIfIndex(routes.FlagsRemoteWorkload|routes.FlagInIPAMPool, 1).AsBytes()
+	err = rtMap.Update(rtKey, rtVal)
+	Expect(err).NotTo(HaveOccurred())
+	defer resetRTMap(rtMap)
 
 	ctKey := conntrack.NewKey(uint8(ipv4.Protocol),
 		ipv4.SrcIP, uint16(udp.SrcPort), ipv4.DstIP, uint16(udp.DstPort))


### PR DESCRIPTION
## Description
    felix/bpf: mark CALI_ST_SKIP_FIB packets on ingress of heps
    
    Disable FIB, let the packet go through the host after it is
    policed. It is ingress into the system and we do not know what
    exactly is the packet's destination. It may be a local VM or
    something similar and we let the host to route it or dump it.
    
    Fixes https://github.com/projectcalico/calico/issues/6450

    felix/bpf: log packet properties when CALI_SKB_MARK_BYPASS
    
    We want to be able to confirm which packet it is when logging. We skip
    the packet parsing otherwise.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
fixes https://github.com/projectcalico/calico/issues/6450

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Fixes https://github.com/projectcalico/calico/issues/6450
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
