### PR TITLE
[release-v3.24] Retain OpenSSL FIPS dependent files in calico-node image

### DIFF
--- a/node/clean-up-filesystem.sh
+++ b/node/clean-up-filesystem.sh
@@ -221,6 +221,16 @@ while read -r path; do
     libs_to_keep[$path]=true
     continue
   fi
+  # These libraries and hmac files under /usr/lib64 are needed when ubi container
+  # is running in FIPS mode. They are not directly linked by the allowed binaries.
+  # * /usr/lib64/.libcrypto.so.x.y.z.hmac
+  # * /usr/lib64/.libssl.so.x.y.z.hmac
+  # * /usr/lib64/libssl.so.x.y.z
+  if [[ "$path" =~ .libcrypto|.libssl|libssl ]]; then
+    echo "FIPS PLUGIN: $path"
+    libs_to_keep[$path]=true
+    continue
+  fi
 done < <(find /usr/lib64 \( -type f -or -type l \))
 
 # Now remove all but a keep-list of RPM packages.  Cleaning up packages with rpm itself updates the


### PR DESCRIPTION
## Description

The current calico-node cleanup script removes certain files from the base image that FIPS mode relies on. When FIPS is enabled, OpenSSL gives internal error `FATAL FIPS SELFTEST FAILURE`. It also causes calico-node readiness probe to fail with the same error and become not ready. The checkup script is modified to not remove libssl.so and hidden hmac files.

## Related issues/PRs

Pick https://github.com/projectcalico/calico/pull/6852 into release-v3.24 branch

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Retain OpenSSL FIPS dependent files in calico-node image.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
