### PR TITLE
beta.kubernetes.io/arch|os haven been deprecated

### DIFF
--- a/calico/getting-started/windows-calico/demo.md
+++ b/calico/getting-started/windows-calico/demo.md
@@ -46,7 +46,7 @@ spec:
     imagePullPolicy: Always
     name: busybox
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
 ---
 
@@ -64,7 +64,7 @@ spec:
     ports:
     - containerPort: 80
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 EOF
 ```
 
@@ -314,7 +314,7 @@ spec:
     imagePullPolicy: Always
     name: busybox
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
 ---
 
@@ -332,7 +332,7 @@ spec:
     ports:
     - containerPort: 80
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
 ```
 

--- a/calico/getting-started/windows-calico/kubernetes/standard.md
+++ b/calico/getting-started/windows-calico/kubernetes/standard.md
@@ -68,7 +68,7 @@ To get around this for `kube-proxy`:
      ...
        spec:
          nodeSelector:
-           beta.kubernetes.io/os: linux
+           kubernetes.io/os: linux
          containers:
    ```
 1. Apply the updated manifest.

--- a/confd/tests/mock_data/kdd/nodes.yaml
+++ b/confd/tests/mock_data/kdd/nodes.yaml
@@ -5,8 +5,8 @@ metadata:
     node.alpha.kubernetes.io/ttl: "0"
     volumes.kubernetes.io/controller-managed-attach-detach: "true"
   labels:
-    beta.kubernetes.io/arch: amd64
-    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux
     kubernetes.io/hostname: kube-master
     node-role.kubernetes.io/master: ""
   name: kube-master
@@ -24,8 +24,8 @@ metadata:
     node.alpha.kubernetes.io/ttl: "0"
     volumes.kubernetes.io/controller-managed-attach-detach: "true"
   labels:
-    beta.kubernetes.io/arch: amd64
-    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux
     kubernetes.io/hostname: kube-node-1
   name: kube-node-1
   namespace: ""
@@ -42,8 +42,8 @@ metadata:
     node.alpha.kubernetes.io/ttl: "0"
     volumes.kubernetes.io/controller-managed-attach-detach: "true"
   labels:
-    beta.kubernetes.io/arch: amd64
-    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux
     kubernetes.io/hostname: kube-node-2
   name: kube-node-2
   namespace: ""

--- a/confd/tests/test_suite_common.sh
+++ b/confd/tests/test_suite_common.sh
@@ -294,8 +294,8 @@ metadata:
     node.alpha.kubernetes.io/ttl: "0"
     volumes.kubernetes.io/controller-managed-attach-detach: "true"
   labels:
-    beta.kubernetes.io/arch: amd64
-    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/os: linux
     kubernetes.io/hostname: node$ii
   name: node$ii
   namespace: ""

--- a/kube-controllers/tests/testutils/flannel_migration_utils.go
+++ b/kube-controllers/tests/testutils/flannel_migration_utils.go
@@ -108,7 +108,7 @@ func (f *FlannelCluster) Reset() {
 }
 
 func (f *FlannelCluster) AddFlannelNode(nodeName, podCidr, backend, mac, ip string, labels map[string]string, isMaster bool) *v1.Node {
-	defaultLabels := map[string]string{"beta.kubernetes.io/os": "linux"}
+	defaultLabels := map[string]string{"kubernetes.io/os": "linux"}
 	if isMaster {
 		defaultLabels["node-role.kubernetes.io/master"] = ""
 	}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
beta.kubernetes.io/arch and beta.kubernetes.io/os haven been deprecated in k8s 1.14

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
