### PR TITLE
Skip vxlan.calico in IP auto-detection

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2022 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,4 +19,5 @@ var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
 	"^docker.*", "^cbr.*", "^dummy.*",
 	"^virbr.*", "^lxcbr.*", "^veth.*", "^lo",
 	"^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*",
+	"^vxlan.calico.*",
 }

--- a/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
+++ b/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
@@ -43,16 +43,22 @@ var _ = DescribeTable("GetInterfaces",
 		getInterfaces: net.Interfaces,
 		expectFound:   true,
 	}),
-	Entry("ibmveth", getInterfacesTestCase{
+	Entry("should not skip ibmveth", getInterfacesTestCase{
 		getInterfaces: func() ([]net.Interface, error) {
 			return []net.Interface{{Index: 0, Name: "lo"}, {Index: 1, Name: "ibmvetha"}}, nil
 		},
 		expectFound:         true,
 		expectInterfaceName: "ibmvetha",
 	}),
-	Entry("veth", getInterfacesTestCase{
+	Entry("should skip veth", getInterfacesTestCase{
 		getInterfaces: func() ([]net.Interface, error) {
 			return []net.Interface{{Index: 0, Name: "veth123126312783"}}, nil
 		},
+	}),
+	Entry("should skip vxlan.calico", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "vxlan.calico"}}, nil
+		},
+		expectFound: false,
 	}),
 )


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/6901

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Calico would try to use the VXLAN tunnel device for its BGP connections. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.