### PR TITLE
Fix BPF enablement flake

### DIFF
--- a/felix/bpf/asm/asm.go
+++ b/felix/bpf/asm/asm.go
@@ -613,10 +613,6 @@ type OffsetFixer func(origInsn Insn) Insn
 func (b *Block) addInsnWithOffsetFixup(insn Insn, targetLabel string) {
 	insnLabel := strings.Join(b.insnIdxToLabels[len(b.insns)], ",")
 	if !b.nextInsnReachble() {
-		if targetLabel == "allow" {
-			log.Infof("Asm: %v UU:    %v [UNREACHABLE]", insnLabel, insn)
-		}
-
 		log.Debugf("Asm: %v UU:    %v [UNREACHABLE]", insnLabel, insn)
 		for _, l := range b.insnIdxToLabels[len(b.insns)] {
 			delete(b.labelToInsnIdx, l)

--- a/felix/bpf/maps.go
+++ b/felix/bpf/maps.go
@@ -249,7 +249,7 @@ func MapDeleteKeyCmd(m Map, key []byte) ([]string, error) {
 	return nil, errors.Errorf("unrecognized map type %T", m)
 }
 
-//IterPerCpuMapCmdOutput iterates over the output of the dump of per-cpu map
+// IterPerCpuMapCmdOutput iterates over the output of the dump of per-cpu map
 func IterPerCpuMapCmdOutput(output []byte, f IterCallback) error {
 	var mp perCpuMapEntry
 	var v []byte
@@ -374,7 +374,7 @@ func (b *PinnedMap) Delete(k []byte) error {
 	valueSize := b.ValueSize
 	if b.perCPU {
 		valueSize = b.ValueSize * NumPossibleCPUs()
-		logrus.Infof("Set value size to %v for deleting an entry from Per-CPU map", valueSize)
+		logrus.Debugf("Set value size to %v for deleting an entry from Per-CPU map", valueSize)
 	}
 	return DeleteMapEntry(b.fd, k, valueSize)
 }

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -714,15 +714,16 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 				w := workload.New(felixes[ii], wName, "default",
 					wIP, strconv.Itoa(port), testOpts.protocol)
-				if run {
-					w.Start()
-				}
 
 				labels["name"] = w.Name
 				labels["workload"] = "regular"
 
 				w.WorkloadEndpoint.Labels = labels
-				w.ConfigureInInfra(infra)
+				if run {
+					err := w.Start()
+					Expect(err).NotTo(HaveOccurred())
+					w.ConfigureInInfra(infra)
+				}
 				if options.UseIPPools {
 					// Assign the workload's IP in IPAM, this will trigger calculation of routes.
 					err := calicoClient.IPAM().AssignIP(context.Background(), ipam.AssignIPArgs{
@@ -757,7 +758,6 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					testOpts.protocol)
 
 				hostW[ii].WorkloadEndpoint.Labels = map[string]string{"name": hostW[ii].Name}
-				hostW[ii].ConfigureInInfra(infra)
 
 				// Two workloads on each host so we can check the same host and other host cases.
 				w[ii][0] = addWorkload(true, ii, 0, 8055, map[string]string{"port": "8055"})
@@ -2225,14 +2225,14 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							cc.ExpectSome(w[0][1], TargetIP(ip), port)
 							cc.CheckConnectivity()
 
-							_, v1 := affKV()
+							_, val1 := affKV()
 
 							cc.CheckConnectivity()
 
 							_, v2 := affKV()
 
 							// This should happen consistently, but that may take quite some time.
-							Expect(v1.Backend()).To(Equal(v2.Backend()))
+							Expect(val1.Backend()).To(Equal(v2.Backend()))
 
 							cc.ResetExpectations()
 
@@ -2243,7 +2243,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							cc.CheckConnectivity()
 
 							mkey, mVal := affKV()
-							Expect(v1.Backend()).To(Equal(mVal.Backend()))
+							Expect(val1.Backend()).To(Equal(mVal.Backend()))
 
 							netIP := net.ParseIP(ip)
 							Expect(mkey.FrontendAffinityKey().AsBytes()).
@@ -3040,12 +3040,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 											Protocol:      testOpts.protocol,
 											InterfaceName: "eth20",
 										}
-										eth20.Start()
+										err := eth20.Start()
+										Expect(err).NotTo(HaveOccurred())
 
 										// assign address to eth20 and add route to the .20 network
 										felixes[1].Exec("ip", "route", "add", "192.168.20.0/24", "dev", "eth20")
 										felixes[1].Exec("ip", "addr", "add", "10.0.0.20/32", "dev", "eth20")
-										_, err := eth20.RunCmd("ip", "route", "add", "10.0.0.20/32", "dev", "eth0")
+										_, err = eth20.RunCmd("ip", "route", "add", "10.0.0.20/32", "dev", "eth0")
 										Expect(err).NotTo(HaveOccurred())
 										// Add a route to felix[1] to be able to reach the nodeport
 										_, err = eth20.RunCmd("ip", "route", "add", felixes[1].IP+"/32", "via", "10.0.0.20")
@@ -3496,7 +3497,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 			expectPongs := func() {
 				count := pc.PongCount()
-				EventuallyWithOffset(1, pc.PongCount, "5s").Should(
+				EventuallyWithOffset(1, pc.PongCount, "60s").Should(
 					BeNumerically(">", count),
 					"Expected to see pong responses on the connection but didn't receive any")
 				log.Info("Pongs received")
@@ -3507,6 +3508,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					By("Starting persistent connection")
 					pc = from.StartPersistentConnection(to.IP, 8055, workload.PersistentConnectionOpts{
 						MonitorConnectivity: true,
+						Timeout:             60 * time.Second,
 					})
 
 					By("having initial connectivity", expectPongs)
@@ -3883,10 +3885,10 @@ func k8sCreateLBServiceWithEndPoints(k8sClient kubernetes.Interface, name, clust
 		epslen           int
 	)
 	if w != nil {
-		testSvc = k8sLBService(name, clusterIP, w.Name, 80, tgtPort, protocol, externalIPs, srcRange)
+		testSvc = k8sLBService(name, clusterIP, w.Name, port, tgtPort, protocol, externalIPs, srcRange)
 		epslen = 1
 	} else {
-		testSvc = k8sLBService(name, clusterIP, "nobackend", 80, tgtPort, protocol, externalIPs, srcRange)
+		testSvc = k8sLBService(name, clusterIP, "nobackend", port, tgtPort, protocol, externalIPs, srcRange)
 		epslen = 0
 	}
 	testSvcNamespace = testSvc.ObjectMeta.Namespace
@@ -3900,9 +3902,9 @@ func k8sCreateLBServiceWithEndPoints(k8sClient kubernetes.Interface, name, clust
 func checkNodeConntrack(felixes []*infrastructure.Felix) error {
 
 	for i, felix := range felixes {
-		conntrack, err := felix.ExecOutput("conntrack", "-L")
+		conntrackOut, err := felix.ExecOutput("conntrack", "-L")
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "conntrack -L failed")
-		lines := strings.Split(conntrack, "\n")
+		lines := strings.Split(conntrackOut, "\n")
 	lineLoop:
 		for _, line := range lines {
 			line = strings.Trim(line, " ")
@@ -3970,7 +3972,7 @@ func setRPF(felixes []*infrastructure.Felix, tunnel string, all, main int) {
 
 	for _, felix := range felixes {
 		wg.Add(1)
-		go func() {
+		go func(felix *infrastructure.Felix) {
 			defer wg.Done()
 			Eventually(func() error {
 				// N.B. we only support environment with not so strict RPF - can be
@@ -3999,7 +4001,7 @@ func setRPF(felixes []*infrastructure.Felix, tunnel string, all, main int) {
 
 				return nil
 			}, "5s", "200ms").Should(Succeed())
-		}()
+		}(felix)
 	}
 
 	wg.Wait()

--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -935,7 +935,7 @@ func (pc *PersistentConnection) Start() error {
 		"docker",
 		args...,
 	)
-	logName := fmt.Sprintf("permanent connection %s", n)
+	logName := fmt.Sprintf("persistent connection %s", n)
 	stdout, err := runCmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("failed to start output logging for %s", logName)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

* Extend the timeout for test "should keep a connection up between hosts and remote workloads when BPF is enable".  The programs are taking a bit longer to attach and, with no timeout specified, we were timing out at 10s.
* Fix various minor issues in the BPF tests:
 
  * Don't access loop variable from goroutine.
  * Add missing error checks.
  * Don't provision WorkloadEndpoint resources for host-networked workloads.  (They make log spam as Felix tries to program the non-existent interfaces.)

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
