### PR TITLE
[release-v3.24] Auto pick #6929: Add 'vxlan-v6.calico', 'wireguard.cali', 'wg-v6.cali' to IP

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
@@ -19,5 +19,5 @@ var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
 	"^docker.*", "^cbr.*", "^dummy.*",
 	"^virbr.*", "^lxcbr.*", "^veth.*", "^lo",
 	"^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*",
-	"^vxlan.calico.*",
+	"^vxlan\\.calico.*", "^vxlan-v6\\.calico.*", "^wireguard\\.cali.*", "^wg-v6\\.cali.*",
 }

--- a/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
+++ b/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
@@ -61,4 +61,22 @@ var _ = DescribeTable("GetInterfaces",
 		},
 		expectFound: false,
 	}),
+	Entry("should skip vxlan-v6.calico", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "vxlan-v6.calico"}}, nil
+		},
+		expectFound: false,
+	}),
+	Entry("should skip wireguard.cali", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "wireguard.cali"}}, nil
+		},
+		expectFound: false,
+	}),
+	Entry("should skip wg-v6.cali", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "wg-v6.cali"}}, nil
+		},
+		expectFound: false,
+	}),
 )


### PR DESCRIPTION
Cherry pick of #6929 on release-v3.24.

#6929: Add 'vxlan-v6.calico', 'wireguard.cali', 'wg-v6.cali' to IP