### PR TITLE
felix/bpf: load calico_tc_host_ct_conflict only if needed

### DIFF
--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -585,9 +585,10 @@ func bpftoolProgLoadAll(fname, bpfFsDir string, forXDP bool, polProg bool, maps 
 	}
 
 	if !forXDP {
-		_, err = bpftool("map", "update", "pinned", jumpMap.Path(), "key", "4", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "classifier_tc_host_ct_conflict"))
-		if err != nil {
-			return errors.Wrap(err, "failed to update jump map (icmp program)")
+		out, err := bpftool("map", "update", "pinned", jumpMap.Path(), "key", "4", "0", "0", "0", "value", "pinned", path.Join(bpfFsDir, "classifier_tc_host_ct_conflict"))
+		if err != nil && !strings.Contains(string(out), "classifier_tc_host_ct_conflict): No such file or directory") {
+			fmt.Printf("err.Error() = %+v\n", err.Error())
+			return errors.Wrap(err, "failed to update jump map (host tc conflict program)")
 		}
 	}
 


### PR DESCRIPTION
We only need this program when CALI_F_TO_HEP is set. We redefine the need as HAS_HOST_CONFLICT_PROG.

If we do not need it, there is no point in loading and verifying the program. We do no need it for workloads and thus we save load/verify for every workload endpoint whenever it is created.

Programs that do not make the jump do not need to have the entry in the jump map filled.

felix/bpf-gpl/bin/to_hep_no_log_co-re.o:	file format elf64-bpf

Sections:
Idx Name                               Size     VMA              Type
  0                                    00000000 0000000000000000
  1 .strtab                            00000fee 0000000000000000
  2 .text                              00000000 0000000000000000 TEXT
  3 classifier/tc/prologue_v6          00000580 0000000000000000 TEXT
  4 .relclassifier/tc/prologue_v6      00000070 0000000000000000
  5 classifier/tc/accept_v6            00000028 0000000000000000 TEXT
  6 classifier/tc/icmp_v6              00000010 0000000000000000 TEXT
  7 classifier/tc/drop_v6              00000010 0000000000000000 TEXT
  8 classifier/tc/accept               000036f0 0000000000000000 TEXT
  9 .relclassifier/tc/accept           00000200 0000000000000000
 10 classifier/tc/icmp                 000008d0 0000000000000000 TEXT
 11 .relclassifier/tc/icmp             00000050 0000000000000000
 12 classifier/tc/host_ct_conflict     00001b40 0000000000000000 TEXT
 13 .relclassifier/tc/host_ct_conflict 000000f0 0000000000000000
 14 classifier/tc/drop                 00000340 0000000000000000 TEXT
 15 .relclassifier/tc/drop             00000080 0000000000000000
 16 classifier/calico_to_host_ep       00002f30 0000000000000000 TEXT
 17 .relclassifier/calico_to_host_ep   00000210 0000000000000000

felix/bpf-gpl/bin/from_hep_no_log_co-re.o:	file format elf64-bpf

Sections:
Idx Name                               Size     VMA              Type
  0                                    00000000 0000000000000000
  1 .strtab                            00000dfb 0000000000000000
  2 .text                              00000000 0000000000000000 TEXT
  3 classifier/tc/prologue_v6          00000498 0000000000000000 TEXT
  4 .relclassifier/tc/prologue_v6      00000050 0000000000000000
  5 classifier/tc/accept_v6            00000028 0000000000000000 TEXT
  6 classifier/tc/icmp_v6              00000010 0000000000000000 TEXT
  7 classifier/tc/drop_v6              00000010 0000000000000000 TEXT
  8 classifier/tc/accept               00003348 0000000000000000 TEXT
  9 .relclassifier/tc/accept           000001f0 0000000000000000
 10 classifier/tc/icmp                 00000950 0000000000000000 TEXT
 11 .relclassifier/tc/icmp             00000060 0000000000000000
 12 classifier/tc/drop                 00000340 0000000000000000 TEXT
 13 .relclassifier/tc/drop             00000080 0000000000000000
 14 classifier/calico_from_host_ep     00004570 0000000000000000 TEXT
 15 .relclassifier/calico_from_host_ep 00000290 0000000000000000

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: faster program loading for workload endpoint - unused programs not loaded.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
