### PR TITLE
Fix SCTP named ports flake

### DIFF
--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -681,7 +681,8 @@ type CheckCmd struct {
 	ipSource   string
 	portSource string
 
-	duration time.Duration
+	duration time.Duration // Duration for long running stream tests
+	timeout  time.Duration // Timeout for one-off pings.
 
 	sendLen int
 	recvLen int
@@ -702,6 +703,7 @@ func (cmd *CheckCmd) run(cName string, logMsg string) *Result {
 		fmt.Sprintf("--duration=%d", int(cmd.duration.Seconds())),
 		fmt.Sprintf("--sendlen=%d", cmd.sendLen),
 		fmt.Sprintf("--recvlen=%d", cmd.recvLen),
+		fmt.Sprintf("--timeout=%f", cmd.timeout.Seconds()),
 		cmd.nsPath, cmd.ip, cmd.port,
 	}
 
@@ -799,14 +801,22 @@ func WithRecvLen(l int) CheckOption {
 	}
 }
 
+func WithTimeout(t time.Duration) CheckOption {
+	return func(c *CheckCmd) {
+		c.timeout = t
+	}
+}
+
 // Check executes the connectivity check
 func Check(cName, logMsg, ip, port, protocol string, opts ...CheckOption) *Result {
 
+	const defaultPingTimeout = 2 * time.Second
 	cmd := CheckCmd{
 		nsPath:   "-",
 		ip:       ip,
 		port:     port,
 		protocol: protocol,
+		timeout:  defaultPingTimeout,
 	}
 
 	for _, opt := range opts {

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -352,10 +352,19 @@ func main() {
 					}
 				}
 
+				seenSrc := "<unknown>"
+				seenLocal := "<unknown>"
+				if conn.RemoteAddr() != nil {
+					seenSrc = conn.RemoteAddr().String()
+				}
+				if conn.LocalAddr() != nil {
+					seenLocal = conn.LocalAddr().String()
+				}
+
 				response := connectivity.Response{
 					Timestamp:  time.Now(),
-					SourceAddr: conn.RemoteAddr().String(),
-					ServerAddr: conn.LocalAddr().String(),
+					SourceAddr: seenSrc,
+					ServerAddr: seenLocal,
 					Request:    request,
 				}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This is a speculative fix.  I saw the test-workload panic when trying to read the remote address in a repro of this flake.  Handle that case.  Unfortunately, I'm not sure what that case actually means so hopefully just ignoring it is good enough.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
