### PR TITLE
felix/bpf: pod->svc->self does not need allow policy

### DIFF
--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -107,6 +107,11 @@ struct cali_tc_state {
 	/* Result of the NAT calculation.  Zeroed if there is no DNAT. */
 	struct calico_nat_dest nat_dest; /* 8 bytes */
 	__u64 prog_start_time;
+	/* Temporary store for the MASQ source when policing
+	 * pod->service->self. We use it to restore ip_src to create
+	 * appropriate conntrack entry.
+	 */
+	DECLARE_IP_ADDR(ip_src_masq);
 #ifndef IPVER6
 	__u8 __pad_ipv4[48];
 #endif

--- a/felix/bpf/state/map.go
+++ b/felix/bpf/state/map.go
@@ -114,10 +114,14 @@ type State struct {
 	_                   uint32
 	NATData             uint64
 	ProgStartTime       uint64
+	SrcAddrMasq         uint32
+	SrcAddrMasq1        uint32
+	SrcAddrMasq2        uint32
+	SrcAddrMasq3        uint32
 	_                   [48]byte // ipv6 padding
 }
 
-const expectedSize = 464
+const expectedSize = 480
 
 func (s *State) AsBytes() []byte {
 	bPtr := (*[expectedSize]byte)(unsafe.Pointer(s))


### PR DESCRIPTION
We allow this traffic to match iptables dp and not require to have a special policy that allows traffic based on its host IP which is hard to express when pods start and go.

The check is done after we parsed the packet and we do it before policy and before CT. So we only do it for the first packet of a connection with minimal overhead.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: When a pod connects via a service to self, ingress traffic is policed as if it's source is the pod and not the host after MASQ
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
