### PR TITLE
Add flag to calico windows uninstall script and pass it from hostprocess install

### DIFF
--- a/node/windows-packaging/CalicoWindows/uninstall-calico.ps1
+++ b/node/windows-packaging/CalicoWindows/uninstall-calico.ps1
@@ -13,7 +13,8 @@
 # limitations under the License.
 param
 (
-    [bool][parameter(Mandatory=$false)]$ExceptUpgradeService = $false
+    [bool][parameter(Mandatory=$false)]$ExceptUpgradeService = $false,
+    [bool][parameter(Mandatory=$false)]$CleanupForHostProcessInstall = $false
 )
 
 ipmo "$PSScriptRoot\libs\calico\calico.psm1" -Force
@@ -25,8 +26,10 @@ Test-CalicoConfiguration
 $ErrorActionPreference = 'SilentlyContinue'
 
 # If running in a hostprocess container, remove Calico CNI if installed.
-# Skip the rest of the logic that applies to manual installations only.
-if (($env:CONTAINER_SANDBOX_MOUNT_POINT) -and ($env:CALICO_NETWORKING_BACKEND -NE "none"))
+# Skip the rest of the logic that applies to manual installations only,
+# unless this is being run by the hostprocess installation itself (which
+# will pass the -CleanupForHostProcessInstall param).
+if (($env:CONTAINER_SANDBOX_MOUNT_POINT) -and ($env:CALICO_NETWORKING_BACKEND -NE "none") -and (-Not $CleanupForHostProcessInstall))
 {
     if ($env:CALICO_NETWORKING_BACKEND -NE "none") {
         Remove-CNIPlugin

--- a/node/windows-packaging/host-process-install.ps1
+++ b/node/windows-packaging/host-process-install.ps1
@@ -19,7 +19,7 @@ $rootDir = "c:\CalicoWindows"
 Write-Host "Uninstalling any existing Calico install before proceeding with installation..."
 if ((Get-Service | where Name -Like 'Calico*') -NE $null) {
     Write-Host "Calico services running. Executing $rootDir\uninstall-calico.ps1..."
-    & "$rootDir\uninstall-calico.ps1"
+    & "$rootDir\uninstall-calico.ps1" -CleanupForHostProcessInstall $true
 }
 # If this is a hostprocess install, and the root install dir exists, try
 # removing any Calico CNI config install


### PR DESCRIPTION
## Description

The calico windows uninstall script would not run fully when it detects it is running in a hostprocess container, but it is called by the hostprocess installation to clean up a previous manual install, so it needs to run fully in this special case. Fixing it by adding a flag to indicate this situation.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed issue when Calico Windows hostprocess installation would fail to clean up a previous manual install of Calico Windows.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
