### PR TITLE
felix/bpf: tc.AttachPoint is always a pointer

### DIFF
--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -45,23 +45,23 @@ type AttachPoint struct {
 	Modes    []bpf.XDPMode
 }
 
-func (ap AttachPoint) IfaceName() string {
+func (ap *AttachPoint) IfaceName() string {
 	return ap.Iface
 }
 
-func (ap AttachPoint) HookName() bpf.Hook {
+func (ap *AttachPoint) HookName() bpf.Hook {
 	return bpf.HookXDP
 }
 
-func (ap AttachPoint) Config() string {
+func (ap *AttachPoint) Config() string {
 	return fmt.Sprintf("%+v", ap)
 }
 
-func (ap AttachPoint) JumpMapFDMapKey() string {
+func (ap *AttachPoint) JumpMapFDMapKey() string {
 	return string(bpf.HookXDP)
 }
 
-func (ap AttachPoint) FileName() string {
+func (ap *AttachPoint) FileName() string {
 	logLevel := strings.ToLower(ap.LogLevel)
 	if logLevel == "off" {
 		logLevel = "no_log"
@@ -69,11 +69,11 @@ func (ap AttachPoint) FileName() string {
 	return "xdp_" + logLevel + ".o"
 }
 
-func (ap AttachPoint) ProgramName() string {
+func (ap *AttachPoint) ProgramName() string {
 	return "xdp_calico_entry"
 }
 
-func (ap AttachPoint) Log() *log.Entry {
+func (ap *AttachPoint) Log() *log.Entry {
 	return log.WithFields(log.Fields{
 		"iface":    ap.Iface,
 		"modes":    ap.Modes,
@@ -106,7 +106,7 @@ func (ap *AttachPoint) AlreadyAttached(object string) (int, bool) {
 	return -1, false
 }
 
-func (ap AttachPoint) AttachProgram() (int, error) {
+func (ap *AttachPoint) AttachProgram() (int, error) {
 	tempDir, err := ioutil.TempDir("", "calico-xdp")
 	if err != nil {
 		return -1, fmt.Errorf("failed to create temporary directory: %w", err)
@@ -193,7 +193,7 @@ func (ap AttachPoint) AttachProgram() (int, error) {
 	return progID, nil
 }
 
-func (ap AttachPoint) DetachProgram() error {
+func (ap *AttachPoint) DetachProgram() error {
 	// Get the current XDP program ID, if any.
 	progID, err := ap.ProgramID()
 	if err != nil {
@@ -258,7 +258,7 @@ func (ap *AttachPoint) patchBinary(ifile, ofile string) error {
 	return nil
 }
 
-func (ap AttachPoint) IsAttached() (bool, error) {
+func (ap *AttachPoint) IsAttached() (bool, error) {
 	_, err := ap.ProgramID()
 	return err == nil, err
 }

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1100,7 +1100,7 @@ func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *p
 	ap.IntfIP = calicoRouterIP
 	ap.ExtToServiceConnmark = uint32(m.bpfExtToServiceConnmark)
 
-	jumpMapFD, err := m.dp.ensureProgramAttached(&ap)
+	jumpMapFD, err := m.dp.ensureProgramAttached(ap)
 	if err != nil {
 		return err
 	}
@@ -1137,7 +1137,7 @@ func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *p
 		rules.SuppressNormalHostPolicy = true
 	}
 
-	return m.dp.updatePolicyProgram(jumpMapFD, rules, polDirection.RuleDir(), &ap)
+	return m.dp.updatePolicyProgram(jumpMapFD, rules, polDirection.RuleDir(), ap)
 }
 
 func (m *bpfEndpointManager) addHostPolicy(rules *polprog.Rules, hostEndpoint *proto.HostEndpoint, polDirection PolDirection) {
@@ -1187,7 +1187,7 @@ func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, ep *proto.
 	ap.NATin = uint32(m.natInIdx)
 	ap.NATout = uint32(m.natOutIdx)
 
-	jumpMapFD, err := m.dp.ensureProgramAttached(&ap)
+	jumpMapFD, err := m.dp.ensureProgramAttached(ap)
 	if err != nil {
 		return err
 	}
@@ -1208,14 +1208,14 @@ func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, ep *proto.
 }
 
 func (m *bpfEndpointManager) attachXDPProgram(ifaceName string, ep *proto.HostEndpoint) error {
-	ap := xdp.AttachPoint{
+	ap := &xdp.AttachPoint{
 		Iface:    ifaceName,
 		LogLevel: m.bpfLogLevel,
 		Modes:    m.xdpModes,
 	}
 
 	if ep != nil && len(ep.UntrackedTiers) == 1 {
-		jumpMapFD, err := m.dp.ensureProgramAttached(&ap)
+		jumpMapFD, err := m.dp.ensureProgramAttached(ap)
 		if err != nil {
 			return err
 		}
@@ -1229,7 +1229,7 @@ func (m *bpfEndpointManager) attachXDPProgram(ifaceName string, ep *proto.HostEn
 		ap.Log().Debugf("Rules: %v", rules)
 		return m.dp.updatePolicyProgram(jumpMapFD, rules, string(bpf.HookXDP), ap)
 	} else {
-		return m.dp.ensureNoProgram(&ap)
+		return m.dp.ensureNoProgram(ap)
 	}
 }
 
@@ -1256,8 +1256,11 @@ func (polDirection PolDirection) Inverse() PolDirection {
 	return PolDirnIngress
 }
 
-func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection, ifaceName string) tc.AttachPoint {
-	var ap tc.AttachPoint
+func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection, ifaceName string) *tc.AttachPoint {
+	ap := &tc.AttachPoint{
+		Iface: ifaceName,
+	}
+
 	var endpointType tc.EndpointType
 
 	// Determine endpoint type.
@@ -1311,7 +1314,6 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection
 		toOrFrom = tc.ToEp
 	}
 
-	ap.Iface = ifaceName
 	ap.Type = endpointType
 	ap.ToOrFrom = toOrFrom
 	ap.ToHostDrop = (m.epToHostAction == "DROP")

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -2473,7 +2473,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							// then CTLB succeeds.
 							natFtKey := nat.NewNATKey(net.ParseIP(ip), port, numericProto)
 							Eventually(func() bool {
-								m := dumpNATMap(felixes[0])
+								m := dumpNATMap(felixes[1])
 								v, ok := m[natFtKey]
 								if !ok || v.Count() == 0 {
 									return false
@@ -2481,7 +2481,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 								beKey := nat.NewNATBackendKey(v.ID(), 0)
 
-								be := dumpEPMap(felixes[0])
+								be := dumpEPMap(felixes[1])
 								_, ok = be[beKey]
 								return ok
 							}, 5*time.Second).Should(BeTrue())


### PR DESCRIPTION
Some methods have pointer and some value receivers. It is unified now.

Given that it is passed in places as an interface, we do not really save the allocations and the size of the object keeps growing so no need to copy it for simple method calls.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
