### PR TITLE
DOCS-700: Changing 'else if' to 'elsif'

### DIFF
--- a/calico/_includes/content/reqs-sys.md
+++ b/calico/_includes/content/reqs-sys.md
@@ -64,7 +64,7 @@ Ensure that your hosts and firewalls allow the necessary traffic based on your c
 | {{site.prodname}} networking with VXLAN enabled              | All                  | Bidirectional   | UDP 4789 |
 | Typha access                                                 | Typha agent hosts    | Incoming        | TCP 5473 (default) |
 | All                                                          | kube-apiserver host  | Incoming        | Often TCP 443 or 8443\* |
-{%- else if include.orch == "Kubernetes" %}
+{%- elsif include.orch == "Kubernetes" %}
 | {{site.prodname}} networking with VXLAN enabled              | All                  | Bidirectional   | UDP 4789 |
 | {{site.prodname}} networking with Typha enabled              | Typha agent hosts    | Incoming        | TCP 5473 (default) |
 | {{site.prodname}} networking with IPv4 Wireguard enabled     | All                  | Bidirectional   | UDP 51820 (default) |


### PR DESCRIPTION
We found a bug while doing migration work for https://tigera.atlassian.net/browse/DOCS-700

Jekyll, and Liquid, use "elseif", not "else if"

See: https://shopify.github.io/liquid/tags/control-flow/

Because of this, this include isn't being rendered properly in the current Jekyll sites. Changing to elsif fixes this problem.

See current example: https://projectcalico.docs.tigera.io/master/getting-started/bare-metal/requirements
With 'elsif' working properly: https://deploy-preview-6965--calico-master.netlify.app/getting-started/bare-metal/requirements

CC: @alexeymagdich-tigera 