### PR TITLE
Add information regarding CSI driver installation to relevant install…

### DIFF
--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.md
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.md
@@ -13,6 +13,13 @@ EKS has built-in support for {{site.prodname}}, providing a robust implementatio
 
 You can also use {{site.prodname}} for networking on EKS in place of the default AWS VPC networking without the need to use IP addresses from the underlying VPC. This allows you to take advantage of the full set of {{site.prodname}} networking features, including {{site.prodname}}'s flexible IP address management capabilities.
 
+### Before you begin...
+
+> **Note**: {{site.prodname}} makes use of the Kubernetes Container Storage Interface (CSI) to support various types of volumes. The necessary drivers required for CSI
+> to function correctly in EKS clusters will no longer be present by default in clusters running Kubernetes 1.23. Please see the following link to ensure your cluster
+> is configured correctly based on the version of Kubernetes being used in your cluster: {% include open-new-window.html text='AWS EBS CSI driver' url='https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html' %}
+{: .alert .alert-warning }
+
 ### How to
 
 #### Install EKS with Amazon VPC networking

--- a/calico/getting-started/kubernetes/self-managed-public-cloud/aws.md
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/aws.md
@@ -20,6 +20,12 @@ Kubernetes Operations (kops) is a cluster management tool that handles provision
 - Install {% include open-new-window.html text='kubectl' url='https://kubernetes.io/docs/tasks/tools/install-kubectl/' %}
 - Install {% include open-new-window.html text='AWS CLI tools' url='https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html' %}
 
+
+> **Note**: {{site.prodname}} makes use of the Kubernetes Container Storage Interface (CSI) to support various types of volumes. The necessary drivers required for CSI
+> to function correctly in EKS clusters will no longer be present by default in clusters running Kubernetes 1.23. Please see the following link to ensure your cluster
+> is configured correctly based on the version of Kubernetes being used in your cluster: {% include open-new-window.html text='AWS EBS CSI driver' url='https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html' %}
+{: .alert .alert-warning }
+
 ### How to
 
 There are many ways to install and manage Kubernetes in AWS. Using Kubernetes Operations (kops) is a good default choice for most people, as it gives you access to all of {{site.prodname}}’s [flexible and powerful networking features]({{site.baseurl}}/networking). However, there are other options that may work better for your environment.


### PR DESCRIPTION
…ation pages

## Description
AWS is transitioning to using CSI volume plugins instead of Kubernetes "in-tree" plugins. This means users will be required to manually install the necessary driver in their clusters if upgrading to or installing on clusters with Kubernetes version >=1.23

Modify our installation documentation to explicitly mention this new requirement, as well as provide a link to the relevant AWS documentation.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- ~~[ ] Tests~~
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update installation documentation for AWS to include information regarding and links for CSI driver installation
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
