### PR TITLE
typha: Fix missing nsswitch files causing localhost lookup fails

### DIFF
--- a/typha/docker-image/Dockerfile.amd64
+++ b/typha/docker-image/Dockerfile.amd64
@@ -46,20 +46,21 @@ COPY --from=ubi /usr/include /usr/include
 COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
 COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
 COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-COPY --from=ubi /lib64/libnss_dns.so.2 /lib64/libnss_dns.so.2
 COPY --from=ubi /lib64/libresolv.so.2 /lib64/libresolv.so.2
+# These two libnss_* files are referenced in our local nsswitch.conf
+# They depend on some of the previous libs
+COPY --from=ubi /lib64/libnss_dns.so.2 /lib64/libnss_dns.so.2
+COPY --from=ubi /lib64/libnss_files.so.2 /lib64/libnss_files.so.2
 
-# Copy hostname configuration files from the UBI image so glibc hostname lookups work.
+# Copy hostname configuration files so glibc hostname lookups work.
 COPY --from=ubi /etc/host.conf /etc/host.conf
-COPY --from=ubi /etc/nsswitch.conf /etc/nsswitch.conf
+# But we skip 'myhostname' because it depends on too many libraries.
+ADD nsswitch.conf /etc/nsswitch.conf
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.
 ADD bin/calico-typha-amd64 /code/calico-typha
 ADD typha.cfg /etc/calico/typha.cfg
-
-# Add nsswitch.conf so that we correctly resolve localhost based on /etc/hosts.
-ADD nsswitch.conf /etc/nsswitch.conf
 
 WORKDIR /code
 ENV PATH="$PATH:/code"

--- a/typha/docker-image/nsswitch.conf
+++ b/typha/docker-image/nsswitch.conf
@@ -1,1 +1,1 @@
-hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4
+hosts: files dns


### PR DESCRIPTION
## Description

Between the calico/typha:v3.23.5 and calico/typha:v3.24.0 Docker images, the included C libraries were reduced from many to only a handful. However, most prominently, it lacked libnss_files, which is needed to do proper lookups from /etc/hosts.

In some environments, things still worked. In others, the 'localhost' lookup would turn into a 'localhost.the-domain-the-pod-is-in' lookup, which could become something unexpected. For instance when '*' CNAMEs are used.

The result of the 'localhost' lookup is used to decide on which address the health check responder should bind. For 127.0.0.1, it would bind just fine. For an external IP, it would fail:

  health.go 296: Health endpoint failed, trying to restart it...
    error=listen tcp REMOTE_IP:9098: bind: cannot assign requested address

This in turn caused the pod to never become Ready.

Interestingly, the 'options' parameter in /etc/resolv.conf also affected the behaviour. Only when *any* 'options' was set AND the 'search' parameter was set, would this result in such a faulty lookup.

This changeset:

- removes the duplicate setting of nsswitch.conf
- sets only nsswitch libraries that are actually available

An alternative fix would be to run typha with GODEBUG=netdns=go forcing the use of the golang DNS subsystem. Using CGO_ENABLED=0 is not an option as typha relies on boringssl C libraries.

Fixes: #6710

Cheers,
Walter Doekes
OSSO B.V.

## Related issues/PRs

#6710 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Fix missing nsswitch files in Typha causing localhost lookup fails
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
