### PR TITLE
Correct CSI driver installation documentation for self-managed Kubern…

### DIFF
--- a/calico/getting-started/kubernetes/self-managed-public-cloud/aws.md
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/aws.md
@@ -22,8 +22,10 @@ Kubernetes Operations (kops) is a cluster management tool that handles provision
 
 
 > **Note**: {{site.prodname}} makes use of the Kubernetes Container Storage Interface (CSI) to support various types of volumes. The necessary drivers required for CSI
-> to function correctly in EKS clusters will no longer be present by default in clusters running Kubernetes 1.23. Please see the following link to ensure your cluster
+> to function correctly in AWS clusters using EBS volumes will no longer be present by default in clusters running Kubernetes 1.23. Please see the following link to ensure your cluster
 > is configured correctly based on the version of Kubernetes being used in your cluster: {% include open-new-window.html text='AWS EBS CSI driver' url='https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html' %}
+> 
+> If using Kubernetes Operations (kops) as further down on this page please use the relevant linked kops documentation to ensure your cluster has the necessary configuration.
 {: .alert .alert-warning }
 
 ### How to
@@ -44,6 +46,7 @@ To use kops to create a cluster with {{site.prodname}} networking and network po
      ```
      export KOPS_STATE_STORE=s3://name-of-your-state-store-bucket
      ```
+1. {% include open-new-window.html text='Verify CSI driver installation configuration as per your particular cluster and volumes' url='https://kops.sigs.k8s.io/addons/#self-managed-aws-ebs-csi-driver' %}
 1. Configure kops to use {{site.prodname}} for networking.  
    The easiest way to do this is to pass `--networking calico` to kops when creating the cluster. For example:
 


### PR DESCRIPTION
…etes AWS installations

## Description
Correction for self-managed Kubernetes installation on AWS documentation as it pertains to CSI driver installation.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
Correction follow-on to [PR 6967](https://github.com/projectcalico/calico/pull/6967)
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- ~~[ ] Tests~~
- [x] Documentation
- ~~[ ] Release note~~

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
