### PR TITLE
bpf/ut: TestNATAffinity flakes because of a too short timeout

### DIFF
--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -1711,7 +1711,7 @@ func TestNATAffinity(t *testing.T) {
 	natKey := nat.NewNATKey(ipv4.DstIP, uint16(udp.DstPort), uint8(ipv4.Protocol))
 	err = natMap.Update(
 		natKey.AsBytes(),
-		nat.NewNATValue(0, 1, 0, 1 /* second */).AsBytes(),
+		nat.NewNATValue(0, 1, 0, 60 /* seconds */).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1747,7 +1747,7 @@ func TestNATAffinity(t *testing.T) {
 
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
-		nat.NewNATValue(0, 2, 0, 1 /* second */).AsBytes(),
+		nat.NewNATValue(0, 2, 0, 60 /* seconds */).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1779,7 +1779,7 @@ func TestNATAffinity(t *testing.T) {
 	// sure that a new selection in made
 	err = natMap.Update(
 		nat.NewNATKey(ipv4.DstIP, uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
-		nat.NewNATValue(0, 1, 0, 1 /* second */).AsBytes(),
+		nat.NewNATValue(0, 1, 0, 60 /* seconds */).AsBytes(),
 	)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
The test may take longer than the timeout,mainly because of loading the test bpf programs.

The length of the timeout is not important for the test because the test expires the NAT selections artificially to make the test deterministic and without a need for the timeout to trully expire.

Co-Authored-By: Sridhar Mahadevan <sridhar@tigera.io>

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
