### PR TITLE
Add more verbiage to imagePullSecrets comment

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -90,8 +90,6 @@ The default values.yaml should be suitable for most basic deployments.
 # Image pull secrets to provision for pulling images from private registries.
 # This field is a map of desired Secret name to .dockerconfigjson formatted data to use for the secret.
 # Populates the `imagePullSecrets` property for all Pods controlled by the `Installation` resource.
-# This will also populate a Secret in the `tigera-operator` namespace, but Secrets in other namespaces managed
-#  by the operator (e.g. `calico-system`) will require creation through other means.
 imagePullSecrets: {}
 
 # Configures general installation parameters for Calico. Schema is based

--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -89,6 +89,9 @@ The default values.yaml should be suitable for most basic deployments.
 ```
 # Image pull secrets to provision for pulling images from private registries.
 # This field is a map of desired Secret name to .dockerconfigjson formatted data to use for the secret.
+# Populates the `imagePullSecrets` property for all Pods controlled by the `Installation` resource.
+# This will also populate a Secret in the `tigera-operator` namespace, but Secrets in other namespaces managed
+#  by the operator (e.g. `calico-system`) will require creation through other means.
 imagePullSecrets: {}
 
 # Configures general installation parameters for Calico. Schema is based


### PR DESCRIPTION
## Description
Adding a bit more to the comments for `imagePullSecrets` to describe what is impacted by the value. This will resolve #6969

Type of fix: documentation
Details: I wanted to add an `imagePullSecret` for all pods that are controlled by the `tigera-operator`, so I looked at the chart README to understand how it will be inserted. The example values file lists an `imagePullSecret` at the root level, but the `installation` comments state that the schema is based on the `v1.InstallationSpec` API:
```
# Configures general installation parameters for Calico. Schema is based
# on the operator.tigera.io/Installation API documented
# here: https://projectcalico.docs.tigera.io/reference/installation/api#operator.tigera.io/v1.InstallationSpec
installation:
  enabled: true
  kubernetesProvider: ""
```
Since the API reference lists an `imagePullSecrets` property, I put it underneath `installation`. This did not work as expected and--only after looking at the chart--I discovered that the `imagePullSecret` value in the example not only fills the `Installation` resource, it creates a `Secret` in the operator's namespace.

I posted my experience about this in issue #6969 with more details.

## Related issues/PRs

#6969 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
