### PR TITLE
Enable/Add support for Feliv FV test for arm64

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -254,7 +254,7 @@ $(FELIX_CONTAINER_CREATED): docker-image/calico-felix-wrapper \
                             docker-image/Dockerfile* \
                             $(shell test "$(FELIX_IMAGE_ID)" || echo force-rebuild)
 	$(MAKE) register
-	$(DOCKER_BUILD) -t $(FELIX_IMAGE_WITH_TAG) --file ./docker-image/Dockerfile.$(ARCH) docker-image --load;
+	$(DOCKER_BUILD) -t $(FELIX_IMAGE_WITH_TAG) --file ./docker-image/Dockerfile docker-image --load;
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $(FELIX_CONTAINER_CREATED)
 
@@ -328,6 +328,7 @@ fv-no-prereqs:
 	  PRIVATE_KEY=`pwd`/private.key \
 	  GINKGO_ARGS='$(GINKGO_ARGS)' \
 	  GINKGO_FOCUS="$(GINKGO_FOCUS)" \
+	  ARCH=$(ARCH) \
 	  FELIX_FV_ENABLE_BPF="$(FELIX_FV_ENABLE_BPF)" \
 	  FV_RACE_DETECTOR_ENABLED=$(FV_RACE_DETECTOR_ENABLED) \
 	  FV_BINARY=$(FV_BINARY) \

--- a/felix/docker-image/Dockerfile.amd64
+++ b/felix/docker-image/Dockerfile.amd64
@@ -22,7 +22,8 @@ FROM ubuntu:focal as wgtool
 RUN apt-get update && \
     apt-get install --no-install-recommends wireguard-tools -y
 
-FROM calico/bpftool:v5.3-amd64 as bpftool
+ARG TARGETARCH
+FROM calico/bpftool:v5.3-${TARGETARCH} as bpftool
 
 FROM debian:10-slim
 LABEL maintainer="Shaun Crampton <shaun@tigera.io>"

--- a/felix/fv/infrastructure/etcd.go
+++ b/felix/fv/infrastructure/etcd.go
@@ -15,6 +15,9 @@
 package infrastructure
 
 import (
+	"fmt"
+	"os"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/fv/containers"
@@ -22,17 +25,29 @@ import (
 )
 
 func RunEtcd() *containers.Container {
-	log.Info("Starting etcd")
-	return containers.Run("etcd",
-		containers.RunOpts{
-			AutoRemove: true,
-			StopSignal: "SIGKILL",
-		},
+	args := []string{
 		"--privileged", // So that we can add routes inside the etcd container,
 		// when using the etcd container to model an external client connecting
 		// into the cluster.
 		utils.Config.EtcdImage,
 		"etcd",
 		"--advertise-client-urls", "http://127.0.0.1:2379",
-		"--listen-client-urls", "http://0.0.0.0:2379")
+		"--listen-client-urls", "http://0.0.0.0:2379"}
+	arch := os.Getenv("ARCH")
+	if len(arch) == 0 {
+		log.Info("ARCH env is not defined, set it to amd64")
+		arch = "amd64"
+	}
+	if arch != "amd64" {
+		args = append([]string{"-e", fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=%s", arch)},
+			args...)
+	}
+
+	log.Info("Starting etcd")
+	return containers.Run("etcd",
+		containers.RunOpts{
+			AutoRemove: true,
+			StopSignal: "SIGKILL",
+		},
+		args...)
 }

--- a/felix/fv/infrastructure/etcd.go
+++ b/felix/fv/infrastructure/etcd.go
@@ -16,7 +16,6 @@ package infrastructure
 
 import (
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -33,11 +32,7 @@ func RunEtcd() *containers.Container {
 		"etcd",
 		"--advertise-client-urls", "http://127.0.0.1:2379",
 		"--listen-client-urls", "http://0.0.0.0:2379"}
-	arch := os.Getenv("ARCH")
-	if len(arch) == 0 {
-		log.Info("ARCH env is not defined, set it to amd64")
-		arch = "amd64"
-	}
+	arch := utils.GetSysArch()
 	if arch != "amd64" {
 		args = append([]string{"-e", fmt.Sprintf("ETCD_UNSUPPORTED_ARCH=%s", arch)},
 			args...)

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -124,11 +124,7 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	wd, err := os.Getwd()
 	Expect(err).NotTo(HaveOccurred(), "failed to get working directory")
 
-	arch := os.Getenv("ARCH")
-	if len(arch) == 0 {
-		log.Info("ARCH env not defined, set it to amd64")
-                arch = "amd64"
-        }
+	arch := utils.GetSysArch()
 
 	fvBin := os.Getenv("FV_BINARY")
 	if fvBin == "" {

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -123,9 +123,16 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	// Collect the volumes for this container.
 	wd, err := os.Getwd()
 	Expect(err).NotTo(HaveOccurred(), "failed to get working directory")
+
+	arch := os.Getenv("ARCH")
+	if len(arch) == 0 {
+		log.Info("ARCH env not defined, set it to amd64")
+                arch = "amd64"
+        }
+
 	fvBin := os.Getenv("FV_BINARY")
 	if fvBin == "" {
-		fvBin = "bin/calico-felix-amd64"
+		fvBin = fmt.Sprintf("bin/calico-felix-%s", arch)
 	}
 	volumes := map[string]string{
 		path.Join(wd, "..", "bin"):        "/usr/local/bin",

--- a/felix/fv/infrastructure/infra_etcd.go
+++ b/felix/fv/infrastructure/infra_etcd.go
@@ -56,6 +56,12 @@ func GetEtcdDatastoreInfra() (*EtcdDatastoreInfra, error) {
 		return nil, errors.New("failed to create etcd container")
 	}
 
+	arch := os.Getenv("ARCH")
+        if len(arch) == 0 {
+		log.Info("ARCH env is not defined, set to amd64")
+		arch = "amd64"
+	}
+
 	// In BPF mode, start BPF logging.
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
 		eds.bpfLog = containers.Run("bpf-log",
@@ -64,7 +70,7 @@ func GetEtcdDatastoreInfra() (*EtcdDatastoreInfra, error) {
 				IgnoreEmptyLines: true,
 			},
 			"--privileged",
-			"calico/bpftool:v5.3-amd64", "/bpftool", "prog", "tracelog")
+			"calico/bpftool:v5.3-" + arch, "/bpftool", "prog", "tracelog")
 	}
 
 	eds.Endpoint = fmt.Sprintf("https://%s:6443", eds.etcdContainer.IP)

--- a/felix/fv/infrastructure/infra_etcd.go
+++ b/felix/fv/infrastructure/infra_etcd.go
@@ -56,11 +56,7 @@ func GetEtcdDatastoreInfra() (*EtcdDatastoreInfra, error) {
 		return nil, errors.New("failed to create etcd container")
 	}
 
-	arch := os.Getenv("ARCH")
-        if len(arch) == 0 {
-		log.Info("ARCH env is not defined, set to amd64")
-		arch = "amd64"
-	}
+	arch := utils.GetSysArch()
 
 	// In BPF mode, start BPF logging.
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
@@ -70,7 +66,7 @@ func GetEtcdDatastoreInfra() (*EtcdDatastoreInfra, error) {
 				IgnoreEmptyLines: true,
 			},
 			"--privileged",
-			"calico/bpftool:v5.3-" + arch, "/bpftool", "prog", "tracelog")
+			"calico/bpftool:v5.3-"+arch, "/bpftool", "prog", "tracelog")
 	}
 
 	eds.Endpoint = fmt.Sprintf("https://%s:6443", eds.etcdContainer.IP)

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -163,13 +163,19 @@ func GetK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 
 func (kds *K8sDatastoreInfra) PerTestSetup() {
 	// In BPF mode, start BPF logging.
+        arch := os.Getenv("ARCH")
+	if len(arch) == 0 {
+		log.Info("ARCH env is not defined, set to amd64");
+                arch = "amd64"
+        }
+
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
 		kds.bpfLog = containers.Run("bpf-log",
 			containers.RunOpts{
 				AutoRemove:       true,
 				IgnoreEmptyLines: true,
 			}, "--privileged",
-			"calico/bpftool:v5.3-amd64", "/bpftool", "prog", "tracelog")
+			"calico/bpftool:v5.3-" + arch, "/bpftool", "prog", "tracelog")
 	}
 	K8sInfra.runningTest = ginkgo.CurrentGinkgoTestDescription().FullTestText
 }

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -163,11 +163,7 @@ func GetK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 
 func (kds *K8sDatastoreInfra) PerTestSetup() {
 	// In BPF mode, start BPF logging.
-        arch := os.Getenv("ARCH")
-	if len(arch) == 0 {
-		log.Info("ARCH env is not defined, set to amd64");
-                arch = "amd64"
-        }
+	arch := utils.GetSysArch()
 
 	if os.Getenv("FELIX_FV_ENABLE_BPF") == "true" {
 		kds.bpfLog = containers.Run("bpf-log",
@@ -175,7 +171,7 @@ func (kds *K8sDatastoreInfra) PerTestSetup() {
 				AutoRemove:       true,
 				IgnoreEmptyLines: true,
 			}, "--privileged",
-			"calico/bpftool:v5.3-" + arch, "/bpftool", "prog", "tracelog")
+			"calico/bpftool:v5.3-"+arch, "/bpftool", "prog", "tracelog")
 	}
 	K8sInfra.runningTest = ginkgo.CurrentGinkgoTestDescription().FullTestText
 }

--- a/felix/fv/utils/utils.go
+++ b/felix/fv/utils/utils.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -274,4 +275,13 @@ func UpdateFelixConfig(client client.Interface, deltaFn func(*api.FelixConfigura
 		_, err = client.FelixConfigurations().Update(ctx, cfg, options.SetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	}
+}
+
+func GetSysArch() string {
+	arch := os.Getenv("ARCH")
+	if len(arch) == 0 {
+		log.Info("ARCH env is not defined, set it to amd64")
+		arch = "amd64"
+	}
+	return arch
 }


### PR DESCRIPTION
## Description

Add support for Feliv FV test on arm64:

Add ARCH env support in Makefile
Add Multi-arch support in Dockerfile.amd64(for which Dockerfile sw links to),
now the building in Makefile uses a single Dockerfile, instead of
Dockerfile.$(arch).
Use arch realated image for various images(felix, bpftool)
used in test.
Add multi-arch support(ETCD_UNSUPPORTED_ARCH) to Etcd container running environment.
Those changes have been tested on both arm64 and amd64 platforms.
The test results showed it works for both arm64 and amd64 platforms.

Those changes should also work for other architectures(ppcle64, ...), but not tested here.

Related issues:


## Related issues/PRs
https://github.com/projectcalico/calico/issues/6199


<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
