### PR TITLE
[BPF] fix flaking notrack checks in FVs

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -4026,6 +4026,15 @@ func checkNodeConntrack(felixes []*infrastructure.Felix) error {
 				if strings.Contains(line, felix.IP) {
 					continue lineLoop
 				}
+				if felix.ExpectedIPIPTunnelAddr != "" && strings.Contains(line, felix.ExpectedIPIPTunnelAddr) {
+					continue lineLoop
+				}
+				if felix.ExpectedVXLANTunnelAddr != "" && strings.Contains(line, felix.ExpectedVXLANTunnelAddr) {
+					continue lineLoop
+				}
+				if felix.ExpectedWireguardTunnelAddr != "" && strings.Contains(line, felix.ExpectedWireguardTunnelAddr) {
+					continue lineLoop
+				}
 				// Ignore DHCP
 				if strings.Contains(line, "sport=67 dport=68") {
 					continue lineLoop
@@ -4066,7 +4075,7 @@ func conntrackFlushWorkloadEntries(felixes []*infrastructure.Felix) func() {
 						// Expected "error" when there are no matching flows.
 						continue
 					}
-					ExpectWithOffset(1, err).NotTo(HaveOccurred(), "conntrack -F failed")
+					ExpectWithOffset(1, err).NotTo(HaveOccurred(), "conntrack -D failed")
 				}
 			}
 		}
@@ -4075,6 +4084,7 @@ func conntrackFlushWorkloadEntries(felixes []*infrastructure.Felix) func() {
 
 func conntrackChecks(felixes []*infrastructure.Felix) []interface{} {
 	return []interface{}{
+		CheckWithInit(conntrackFlushWorkloadEntries(felixes)),
 		CheckWithFinalTest(conntrackCheck(felixes)),
 		CheckWithBeforeRetry(conntrackFlushWorkloadEntries(felixes)),
 	}

--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -58,6 +58,7 @@ type Checker struct {
 	OnFail func(msg string)
 
 	description string
+	init        func()       // called before testing starts
 	beforeRetry func()       // called when a test fails and before it is retried
 	finalTest   func() error // called after connectivity test, if it is successful, may fail the test.
 }
@@ -69,6 +70,13 @@ type CheckerOpt func(*Checker)
 func CheckWithDescription(desc string) CheckerOpt {
 	return func(c *Checker) {
 		c.description = desc
+	}
+}
+
+func CheckWithInit(f func()) CheckerOpt {
+	return func(c *Checker) {
+		log.Debug("CheckWithInit set")
+		c.init = f
 	}
 }
 
@@ -300,6 +308,10 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 	var actualConn []*Result
 	var actualConnPretty []string
 	var finalErr error
+
+	if c.init != nil {
+		c.init()
+	}
 
 	for {
 		checkStartTime := time.Now()


### PR DESCRIPTION
Consider tunnel IPs as host IPs as they should be.

Clean up workload conntracks even before the test starts to be sure there are no leftovers - perhaps to paranoid.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
