### PR TITLE
Use struct for passing data to libbpf

### DIFF
--- a/felix/bpf-gpl/routes.h
+++ b/felix/bpf-gpl/routes.h
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #ifndef __CALI_ROUTES_H__
@@ -68,10 +68,13 @@ static CALI_BPF_INLINE enum cali_rt_flags cali_rt_lookup_flags(__be32 addr)
 #define cali_rt_is_workload(rt)	((rt)->flags & CALI_RT_WORKLOAD)
 #define cali_rt_is_tunneled(rt)	((rt)->flags & CALI_RT_TUNNELED)
 
+#define cali_rt_flags_host(t) (((t) & CALI_RT_HOST) == CALI_RT_HOST)
 #define cali_rt_flags_local_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST)) == (CALI_RT_LOCAL | CALI_RT_HOST))
 #define cali_rt_flags_local_workload(t) (((t) & CALI_RT_LOCAL) && ((t) & CALI_RT_WORKLOAD))
 #define cali_rt_flags_remote_workload(t) (!((t) & CALI_RT_LOCAL) && ((t) & CALI_RT_WORKLOAD))
 #define cali_rt_flags_remote_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST)) == CALI_RT_HOST)
+#define cali_rt_flags_remote_tunneled_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST | CALI_RT_TUNNELED)) == (CALI_RT_HOST | CALI_RT_TUNNELED))
+#define cali_rt_flags_local_tunneled_host(t) (((t) & (CALI_RT_LOCAL | CALI_RT_HOST | CALI_RT_TUNNELED)) == (CALI_RT_LOCAL | CALI_RT_HOST | CALI_RT_TUNNELED))
 
 static CALI_BPF_INLINE bool rt_addr_is_local_host(__be32 addr)
 {
@@ -83,4 +86,13 @@ static CALI_BPF_INLINE bool rt_addr_is_remote_host(__be32 addr)
 	return  cali_rt_flags_remote_host(cali_rt_lookup_flags(addr));
 }
 
+static CALI_BPF_INLINE bool rt_addr_is_remote_tunneled_host(__be32 addr)
+{
+	return cali_rt_flags_remote_tunneled_host(cali_rt_lookup_flags(addr));
+}
+
+static CALI_BPF_INLINE bool rt_addr_is_local_tunneled_host(__be32 addr)
+{
+	return cali_rt_flags_local_tunneled_host(cali_rt_lookup_flags(addr));
+}
 #endif /* __CALI_ROUTES_H__ */

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -295,33 +295,38 @@ const (
 	GlobalsRPFStrictEnabled uint32 = C.CALI_GLOBALS_RPF_STRICT_ENABLED
 )
 
+type TcGlobalData struct {
+	HostIP       uint32
+	IntfIP       uint32
+	ExtToSvcMark uint32
+	Tmtu         uint16
+	VxlanPort    uint16
+	PSNatStart   uint16
+	PSNatLen     uint16
+	HostTunnelIP uint32
+	Flags        uint32
+	WgPort       uint16
+	NatIn        uint32
+	NatOut       uint32
+}
+
 func TcSetGlobals(
 	m *Map,
-	hostIP uint32,
-	intfIP uint32,
-	extToSvcMark uint32,
-	tmtu uint16,
-	vxlanPort uint16,
-	psNatStart uint16,
-	psNatLen uint16,
-	hostTunnelIP uint32,
-	flags uint32,
-	wgPort uint16,
-	natin, natout uint32,
+	globalData *TcGlobalData,
 ) error {
 	_, err := C.bpf_tc_set_globals(m.bpfMap,
-		C.uint(hostIP),
-		C.uint(intfIP),
-		C.uint(extToSvcMark),
-		C.ushort(tmtu),
-		C.ushort(vxlanPort),
-		C.ushort(psNatStart),
-		C.ushort(psNatLen),
-		C.uint(hostTunnelIP),
-		C.uint(flags),
-		C.ushort(wgPort),
-		C.uint(natin),
-		C.uint(natout),
+		C.uint(globalData.HostIP),
+		C.uint(globalData.IntfIP),
+		C.uint(globalData.ExtToSvcMark),
+		C.ushort(globalData.Tmtu),
+		C.ushort(globalData.VxlanPort),
+		C.ushort(globalData.PSNatStart),
+		C.ushort(globalData.PSNatLen),
+		C.uint(globalData.HostTunnelIP),
+		C.uint(globalData.Flags),
+		C.ushort(globalData.WgPort),
+		C.uint(globalData.NatIn),
+		C.uint(globalData.NatOut),
 	)
 
 	return err

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -103,7 +103,10 @@ const (
 	GlobalsRPFStrictEnabled uint32 = 16
 )
 
-func TcSetGlobals(_ *Map, _, _, _ uint32, _, _, _, _ uint16, _, _ uint32, _ uint16, _, _ uint32) error {
+type TcGlobalData struct {
+}
+
+func TcSetGlobals(_ *Map, globalData *TcGlobalData) error {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -104,6 +104,18 @@ const (
 )
 
 type TcGlobalData struct {
+	HostIP       uint32
+	IntfIP       uint32
+	ExtToSvcMark uint32
+	Tmtu         uint16
+	VxlanPort    uint16
+	PSNatStart   uint16
+	PSNatLen     uint16
+	HostTunnelIP uint32
+	Flags        uint32
+	WgPort       uint16
+	NatIn        uint32
+	NatOut       uint32
 }
 
 func TcSetGlobals(_ *Map, globalData *TcGlobalData) error {

--- a/felix/bpf/routes/map.go
+++ b/felix/bpf/routes/map.go
@@ -66,11 +66,13 @@ const (
 	FlagSameSubnet  Flags = 0x20
 	FlagTunneled    Flags = 0x40
 
-	FlagsUnknown        Flags = 0
-	FlagsRemoteWorkload       = FlagWorkload
-	FlagsRemoteHost           = FlagHost
-	FlagsLocalHost            = FlagLocal | FlagHost
-	FlagsLocalWorkload        = FlagLocal | FlagWorkload
+	FlagsUnknown            Flags = 0
+	FlagsRemoteWorkload           = FlagWorkload
+	FlagsRemoteHost               = FlagHost
+	FlagsLocalHost                = FlagLocal | FlagHost
+	FlagsLocalWorkload            = FlagLocal | FlagWorkload
+	FlagsRemoteTunneledHost       = FlagsRemoteHost | FlagTunneled
+	FlagsLocalTunneledHost        = FlagsLocalHost | FlagTunneled
 
 	_ = FlagsUnknown
 )

--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -305,6 +305,10 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.V4CIDR) *routes.Value {
 		nodeIP := net.ParseIP(cgRoute.DstNodeIp)
 		routeVal := routes.NewValueWithNextHop(flags, ip.FromNetIP(nodeIP).(ip.V4Addr))
 		route = &routeVal
+	case proto.RouteType_REMOTE_TUNNEL:
+		flags |= routes.FlagsRemoteTunneledHost
+		routeVal := routes.NewValueWithNextHop(flags, cidr.Addr().(ip.V4Addr))
+		route = &routeVal
 	case proto.RouteType_LOCAL_HOST:
 		// It may be a localhost IP that is not assigned to a device like an
 		// k8s ExternalIP. Route resolver knew that it was assigned to our
@@ -515,8 +519,8 @@ func (m *bpfRouteManager) onRouteUpdate(update *proto.RouteUpdate) {
 		return
 	}
 
-	// For now don't handle the tunnel addresses, which were previously not being included in the route updates.
-	if update.Type == proto.RouteType_REMOTE_TUNNEL || update.Type == proto.RouteType_LOCAL_TUNNEL {
+	// For now don't handle the local tunnel addresses, which were previously not being included in the route updates.
+	if update.Type == proto.RouteType_LOCAL_TUNNEL {
 		m.onRouteRemove(&proto.RouteRemove{Dst: update.Dst})
 		return
 	}

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -178,7 +178,9 @@ const expectedRouteDumpWithTunnelAddr = `10.65.0.0/16: remote in-pool nat-out
 FELIX_0/32: local host
 FELIX_0_TNL/32: local host
 FELIX_1/32: remote host
-FELIX_2/32: remote host`
+FELIX_1_TNL/32: remote host in-pool nat-out tunneled
+FELIX_2/32: remote host
+FELIX_2_TNL/32: remote host in-pool nat-out tunneled`
 
 const extIP = "10.1.2.3"
 
@@ -950,14 +952,22 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 			It("should have correct routes", func() {
 				tunnelAddr := ""
+				tunnelAddrFelix1 := ""
+				tunnelAddrFelix2 := ""
 				expectedRoutes := expectedRouteDump
 				switch {
 				case felixes[0].ExpectedIPIPTunnelAddr != "":
 					tunnelAddr = felixes[0].ExpectedIPIPTunnelAddr
+					tunnelAddrFelix1 = felixes[1].ExpectedIPIPTunnelAddr
+					tunnelAddrFelix2 = felixes[2].ExpectedIPIPTunnelAddr
 				case felixes[0].ExpectedVXLANTunnelAddr != "":
 					tunnelAddr = felixes[0].ExpectedVXLANTunnelAddr
+					tunnelAddrFelix1 = felixes[1].ExpectedVXLANTunnelAddr
+					tunnelAddrFelix2 = felixes[2].ExpectedVXLANTunnelAddr
 				case felixes[0].ExpectedWireguardTunnelAddr != "":
 					tunnelAddr = felixes[0].ExpectedWireguardTunnelAddr
+					tunnelAddrFelix1 = felixes[1].ExpectedWireguardTunnelAddr
+					tunnelAddrFelix2 = felixes[2].ExpectedWireguardTunnelAddr
 				}
 
 				if tunnelAddr != "" {
@@ -984,6 +994,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						l = idxRE.ReplaceAllLiteralString(l, "idx -")
 						if tunnelAddr != "" {
 							l = strings.ReplaceAll(l, tunnelAddr+"/32", "FELIX_0_TNL/32")
+						}
+						if tunnelAddrFelix1 != "" {
+							l = strings.ReplaceAll(l, tunnelAddrFelix1+"/32", "FELIX_1_TNL/32")
+						}
+						if tunnelAddrFelix2 != "" {
+							l = strings.ReplaceAll(l, tunnelAddrFelix2+"/32", "FELIX_2_TNL/32")
 						}
 						filteredLines = append(filteredLines, l)
 					}


### PR DESCRIPTION
## Description
1. Use a struct to pass data to libbpf APIs
2. Listen to remote tunnel route updates.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
