### PR TITLE
Replaced io/ioutil with "os / io" package.

### DIFF
--- a/apiserver/test/integration/clientset_test.go
+++ b/apiserver/test/integration/clientset_test.go
@@ -19,7 +19,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"reflect"
@@ -99,7 +99,7 @@ func TestEtcdHealthCheckerSuccess(t *testing.T) {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal("couldn't read response body", err)
 	}

--- a/app-policy/syncher/syncserver_test.go
+++ b/app-policy/syncher/syncserver_test.go
@@ -15,7 +15,6 @@ package syncher
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -845,7 +844,7 @@ func (s *testSyncServer) listen() {
 const ListenerSocket = "policysync.sock"
 
 func makeTmpListenerDir() string {
-	dirPath, err := ioutil.TempDir("/tmp", "felixut")
+	dirPath, err := os.MkdirTemp("/tmp", "felixut")
 	Expect(err).ToNot(HaveOccurred())
 	return dirPath
 }

--- a/calicoctl/calicoctl/commands/common/printer.go
+++ b/calicoctl/calicoctl/commands/common/printer.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -154,7 +153,7 @@ type ResourcePrinterTemplateFile struct {
 }
 
 func (r ResourcePrinterTemplateFile) Print(client client.Interface, resources []runtime.Object) error {
-	template, err := ioutil.ReadFile(r.TemplateFile)
+	template, err := os.ReadFile(r.TemplateFile)
 	if err != nil {
 		return err
 	}

--- a/calicoctl/calicoctl/commands/datastore/migrate/import.go
+++ b/calicoctl/calicoctl/commands/datastore/migrate/import.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -188,7 +187,7 @@ func splitImportFile(filename string) ([]byte, []byte, []byte, error) {
 		fname = os.Stdin.Name()
 	}
 
-	b, err := ioutil.ReadFile(fname)
+	b, err := os.ReadFile(fname)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -305,7 +304,7 @@ func updateClusterInfo(ctx context.Context, c client.Interface, clusterInfoJson 
 
 func updateV3Resources(cfg *apiconfig.CalicoAPIConfig, data []byte) error {
 	// Create tempfile so the v3 resources can be created using Apply
-	tempfile, err := ioutil.TempFile("", "v3migration")
+	tempfile, err := os.CreateTemp("", "v3migration")
 	if err != nil {
 		return fmt.Errorf("Error while creating temporary v3 migration file: %s\n", err)
 	}
@@ -316,7 +315,7 @@ func updateV3Resources(cfg *apiconfig.CalicoAPIConfig, data []byte) error {
 	}
 
 	// Create a tempfile for the config so QPS will be overwritten
-	tempConfigFile, err := ioutil.TempFile("", "qpsconfig")
+	tempConfigFile, err := os.CreateTemp("", "qpsconfig")
 	if err != nil {
 		return fmt.Errorf("Error while creating temporary v3 migration config file: %s\n", err)
 	}

--- a/calicoctl/calicoctl/commands/file/iter_test.go
+++ b/calicoctl/calicoctl/commands/file/iter_test.go
@@ -16,7 +16,6 @@ package file_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -37,61 +36,61 @@ var _ = Describe("File and directory iteration", func() {
 
 	BeforeEach(func() {
 		// Create a temporary file and directory with a couple of files for performing our tests
-		f, err := ioutil.TempFile(".", "testfile*")
+		f, err := os.CreateTemp(".", "testfile*")
 		Expect(err).NotTo(HaveOccurred())
 		fname = f.Name()
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		dname, err = ioutil.TempDir(".", "testdir*")
+		dname, err = os.MkdirTemp(".", "testdir*")
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname, "testfile*.yaml")
+		f, err = os.CreateTemp(dname, "testfile*.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		dfname1 = f.Name()
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname, "testfile*.yml")
+		f, err = os.CreateTemp(dname, "testfile*.yml")
 		Expect(err).NotTo(HaveOccurred())
 		dfname2 = f.Name()
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname, "testfile*.json")
+		f, err = os.CreateTemp(dname, "testfile*.json")
 		Expect(err).NotTo(HaveOccurred())
 		dfname3 = f.Name()
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname, "testfile*.txt")
+		f, err = os.CreateTemp(dname, "testfile*.txt")
 		Expect(err).NotTo(HaveOccurred())
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create a sub-directory.
-		dname2, err := ioutil.TempDir(dname, "subdir*")
+		dname2, err := os.MkdirTemp(dname, "subdir*")
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname2, "testfile*.yaml")
+		f, err = os.CreateTemp(dname2, "testfile*.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		df2name1 = f.Name()
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname2, "testfile*.yml")
+		f, err = os.CreateTemp(dname2, "testfile*.yml")
 		Expect(err).NotTo(HaveOccurred())
 		df2name2 = f.Name()
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname2, "testfile*.json")
+		f, err = os.CreateTemp(dname2, "testfile*.json")
 		Expect(err).NotTo(HaveOccurred())
 		df2name3 = f.Name()
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile(dname2, "testfile*.txt")
+		f, err = os.CreateTemp(dname2, "testfile*.txt")
 		Expect(err).NotTo(HaveOccurred())
 		err = f.Close()
 		Expect(err).NotTo(HaveOccurred())

--- a/calicoctl/calicoctl/commands/ipam/check.go
+++ b/calicoctl/calicoctl/commands/ipam/check.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"sort"
 	"strings"
 
@@ -466,7 +466,7 @@ func (c *IPAMChecker) printReport() {
 		LeakedHandles:       c.leakedHandles,
 	}
 	bytes, _ := json.MarshalIndent(r, "", "  ")
-	_ = ioutil.WriteFile(c.outFile, bytes, 0777)
+	_ = os.WriteFile(c.outFile, bytes, 0777)
 }
 
 // recordAllocation takes a block and ordinal within that block and updates

--- a/calicoctl/calicoctl/commands/ipam/release.go
+++ b/calicoctl/calicoctl/commands/ipam/release.go
@@ -17,7 +17,7 @@ package ipam
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -160,7 +160,7 @@ func releaseFromReports(ctx context.Context, c client.Interface, force bool, rep
 	var reports []Report
 	for _, reportFile := range reportFiles {
 		r := Report{}
-		bytes, err := ioutil.ReadFile(reportFile)
+		bytes, err := os.ReadFile(reportFile)
 		if err != nil {
 			return err
 		}

--- a/calicoctl/calicoctl/commands/node/diags.go
+++ b/calicoctl/calicoctl/commands/node/diags.go
@@ -17,7 +17,6 @@ package node
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -103,7 +102,7 @@ func runDiags(logDir string) error {
 	fmt.Println("Collecting diagnostics")
 
 	// Create a temp directory in /tmp
-	tmpDir, err := ioutil.TempDir("", "calico")
+	tmpDir, err := os.MkdirTemp("", "calico")
 	if err != nil {
 		return fmt.Errorf("Error creating temp directory to dump logs: %v", err)
 	}
@@ -133,7 +132,7 @@ func runDiags(logDir string) error {
 			}
 
 			fp := filepath.Join(diagsTmpDir, parts[0])
-			if err := ioutil.WriteFile(fp, content, 0666); err != nil {
+			if err := os.WriteFile(fp, content, 0666); err != nil {
 				log.Errorf("Error writing diags to file: %s\n", err)
 			}
 		}
@@ -203,7 +202,7 @@ func getNodeContainerLogs(logDir string) {
 	containers := re.ReplaceAllString(string(result), "")
 
 	fmt.Println("Copying logs from Calico containers")
-	err = ioutil.WriteFile(logDir+"/"+"container_creation_time", []byte(containers), 0666)
+	err = os.WriteFile(logDir+"/"+"container_creation_time", []byte(containers), 0666)
 	if err != nil {
 		fmt.Printf("Could not save output of `docker ps` command to container_creation_time: %s\n", err)
 	}
@@ -218,7 +217,7 @@ func getNodeContainerLogs(logDir string) {
 			fmt.Printf("Could not pull log for container %s: %s\n", name, err)
 			continue
 		}
-		err = ioutil.WriteFile(logDir+"/"+name+".log", cLog, 0666)
+		err = os.WriteFile(logDir+"/"+name+".log", cLog, 0666)
 		if err != nil {
 			fmt.Printf("Failed to write log for container %s to file: %s\n", name, err)
 		}
@@ -248,7 +247,7 @@ func writeDiags(cmds diagCmd, dir string) error {
 	}
 
 	fp := filepath.Join(dir, cmds.filename)
-	if err := ioutil.WriteFile(fp, content, 0666); err != nil {
+	if err := os.WriteFile(fp, content, 0666); err != nil {
 		log.Errorf("Error writing diags to file: %s\n", err)
 	}
 	return nil

--- a/calicoctl/calicoctl/commands/node/run.go
+++ b/calicoctl/calicoctl/commands/node/run.go
@@ -17,7 +17,6 @@ package node
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	gonet "net"
 	"os"
 	"os/exec"
@@ -451,7 +450,7 @@ func loadModules() {
 
 func setupIPForwarding() error {
 	fmt.Println("Enabling IPv4 forwarding")
-	err := ioutil.WriteFile("/proc/sys/net/ipv4/ip_forward",
+	err := os.WriteFile("/proc/sys/net/ipv4/ip_forward",
 		[]byte("1"), 0)
 	if err != nil {
 		return fmt.Errorf("ERROR: Could not enable ipv4 forwarding")
@@ -459,7 +458,7 @@ func setupIPForwarding() error {
 
 	if _, err := os.Stat("/proc/sys/net/ipv6"); err == nil {
 		fmt.Println("Enabling IPv6 forwarding")
-		err := ioutil.WriteFile("/proc/sys/net/ipv6/conf/all/forwarding",
+		err := os.WriteFile("/proc/sys/net/ipv6/conf/all/forwarding",
 			[]byte("1"), 0)
 		if err != nil {
 			return fmt.Errorf("ERROR: Could not enable ipv6 forwarding")
@@ -478,7 +477,7 @@ func setNFConntrackMax() {
 	// To avoid this becoming a problem, we recommend increasing the conntrack
 	// table size. To do so, run the following commands:
 	fmt.Println("Increasing conntrack limit")
-	err := ioutil.WriteFile("/proc/sys/net/netfilter/nf_conntrack_max",
+	err := os.WriteFile("/proc/sys/net/netfilter/nf_conntrack_max",
 		[]byte("1000000"), 0)
 	if err != nil {
 		fmt.Println("WARNING: Could not set nf_contrack_max. This may have an impact at scale.")

--- a/calicoctl/calicoctl/resourcemgr/resourcemgr_test.go
+++ b/calicoctl/calicoctl/resourcemgr/resourcemgr_test.go
@@ -16,7 +16,6 @@ package resourcemgr_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -150,7 +149,7 @@ func createResources(specs ...string) ([]runtime.Object, error) {
 }
 
 func writeSpec(spec string) *os.File {
-	file, err := ioutil.TempFile("/tmp", "resource")
+	file, err := os.CreateTemp("/tmp", "resource")
 	Expect(err).NotTo(HaveOccurred())
 	_, err = file.WriteString(spec)
 	Expect(err).NotTo(HaveOccurred())

--- a/calicoctl/scripts/importcrds.go
+++ b/calicoctl/scripts/importcrds.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -33,7 +32,7 @@ const (
 func main() {
 	crdPath := "../../../../libcalico-go/config/crd/"
 
-	fs, _ := ioutil.ReadDir(crdPath)
+	fs, _ := os.ReadDir(crdPath)
 	out, _ := os.Create("../../commands/crds/crds.go")
 	_, _ = out.Write([]byte(fmt.Sprintf(`// Copyright (c) %s Tigera, Inc. All rights reserved.
 
@@ -56,7 +55,7 @@ func main() {
 			fname := strings.TrimPrefix(f.Name(), crdPrefix)
 			name := strings.TrimSuffix(fname, fileSuffix)
 			_, _ = out.Write([]byte("\t" + name + " = "))
-			b, _ := ioutil.ReadFile(crdPath + f.Name())
+			b, _ := os.ReadFile(crdPath + f.Name())
 			fstr := strconv.Quote(string(b))
 			_, _ = out.Write([]byte(fstr))
 			_, _ = out.Write([]byte("\n"))

--- a/calicoctl/tests/fv/ipam_test.go
+++ b/calicoctl/tests/fv/ipam_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -260,7 +259,7 @@ func TestIPAMCleanup(t *testing.T) {
 		// Run calicoctl ipam check and parse the resulting report.
 		out = Calicoctl(kdd, "ipam", "check", "--show-all-ips", "-o", "/tmp/ipam_report.json")
 		t.Log("IPAM check output:", out)
-		reportFile, err := ioutil.ReadFile("/tmp/ipam_report.json")
+		reportFile, err := os.ReadFile("/tmp/ipam_report.json")
 		Expect(err).NotTo(HaveOccurred())
 		t.Log("IPAM check report (raw JSON):", string(reportFile))
 		var report ipamcmd.Report

--- a/calicoctl/tests/fv/migrate_ipam_test.go
+++ b/calicoctl/tests/fv/migrate_ipam_test.go
@@ -16,7 +16,6 @@ package fv_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -154,7 +153,7 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 
 	// Export the data
 	// Create a temporary file
-	tempfile, err := ioutil.TempFile("", "ipam-migration-test")
+	tempfile, err := os.CreateTemp("", "ipam-migration-test")
 	defer os.Remove(tempfile.Name())
 	Expect(err).NotTo(HaveOccurred())
 	out = Calicoctl(false, "datastore", "migrate", "export")

--- a/cni-plugin/internal/pkg/azure/endpoint.go
+++ b/cni-plugin/internal/pkg/azure/endpoint.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/natefinch/atomic"
@@ -50,7 +49,7 @@ func (ae *AzureEndpoint) Write() error {
 }
 
 func (ae *AzureEndpoint) Load() error {
-	bytes, err := ioutil.ReadFile(ae.filename())
+	bytes, err := os.ReadFile(ae.filename())
 	if err != nil {
 		return nil
 	}

--- a/cni-plugin/internal/pkg/azure/network.go
+++ b/cni-plugin/internal/pkg/azure/network.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/natefinch/atomic"
@@ -55,7 +54,7 @@ func (an *AzureNetwork) Write() error {
 }
 
 func (an *AzureNetwork) Load() error {
-	bytes, err := ioutil.ReadFile(an.filename())
+	bytes, err := os.ReadFile(an.filename())
 	if err != nil {
 		return nil
 	}

--- a/cni-plugin/internal/pkg/utils/utils.go
+++ b/cni-plugin/internal/pkg/utils/utils.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -82,7 +81,7 @@ func nodenameFromFile(filename string) string {
 	if filename == "" {
 		filename = "/var/lib/calico/nodename"
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// File doesn't exist, return empty string.
@@ -101,7 +100,7 @@ func MTUFromFile(filename string) (int, error) {
 	if filename == "" {
 		filename = "/var/lib/calico/mtu"
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// File doesn't exist, return zero.

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -152,7 +151,7 @@ func Install() error {
 			return err
 		}
 
-		c.ServiceAccountToken, err = ioutil.ReadFile(serviceAccountTokenFile)
+		c.ServiceAccountToken, err = os.ReadFile(serviceAccountTokenFile)
 		if err != nil {
 			return err
 		}
@@ -199,7 +198,7 @@ func Install() error {
 		}
 
 		// Iterate through each binary we might want to install.
-		files, err := ioutil.ReadDir("/opt/cni/bin/")
+		files, err := os.ReadDir("/opt/cni/bin/")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -273,7 +272,7 @@ func Install() error {
 				select {
 				case <-watcher.Events:
 					logrus.Infoln("Updating installed secrets at:", time.Now().String())
-					files, err := ioutil.ReadDir(c.TLSAssetsDir)
+					files, err := os.ReadDir(c.TLSAssetsDir)
 					if err != nil {
 						logrus.Warn(err)
 					}
@@ -339,7 +338,7 @@ func writeCNIConfig(c config) {
 	if c.CNINetworkConfigFile != "" {
 		log.Info("Using CNI config template from CNI_NETWORK_CONFIG_FILE")
 		var err error
-		netconfBytes, err := ioutil.ReadFile(c.CNINetworkConfigFile)
+		netconfBytes, err := os.ReadFile(c.CNINetworkConfigFile)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -401,12 +400,12 @@ func writeCNIConfig(c config) {
 	// Write out the file.
 	name := getEnv("CNI_CONF_NAME", "10-calico.conflist")
 	path := fmt.Sprintf("/host/etc/cni/net.d/%s", name)
-	err = ioutil.WriteFile(path, []byte(netconf), 0644)
+	err = os.WriteFile(path, []byte(netconf), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -504,7 +503,7 @@ current-context: calico-context`
 		data = strings.Replace(data, "__TLS_CFG__", ca, -1)
 	}
 
-	if err := ioutil.WriteFile("/host/etc/cni/net.d/calico-kubeconfig", []byte(data), 0600); err != nil {
+	if err := os.WriteFile("/host/etc/cni/net.d/calico-kubeconfig", []byte(data), 0600); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cni-plugin/pkg/plugin/plugin.go
+++ b/cni-plugin/pkg/plugin/plugin.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -66,7 +66,7 @@ func init() {
 func testConnection() error {
 	// Unmarshal the network config
 	conf := types.NetConf{}
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return errors.New("failed to read from stdin")
 	}

--- a/cni-plugin/pkg/upgrade/migrate.go
+++ b/cni-plugin/pkg/upgrade/migrate.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -252,7 +251,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 
 	// Read in all the files in the host-local directory.
 	log.Info("reading files from host-local IPAM data dir...")
-	files, err := ioutil.ReadDir(ipAllocPath)
+	files, err := os.ReadDir(ipAllocPath)
 	if err != nil {
 		return fmt.Errorf("failed to read path %s: %s", ipAllocPath, err)
 	}
@@ -286,7 +285,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 		}
 
 		// The contents are the container ID.
-		b, err := ioutil.ReadFile(fname)
+		b, err := os.ReadFile(fname)
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %s", fname, err)
 		}

--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -545,7 +544,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 				err = os.MkdirAll("/var/lib/calico", os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
-				err = ioutil.WriteFile("/var/lib/calico/mtu", []byte("3000"), 0644)
+				err = os.WriteFile("/var/lib/calico/mtu", []byte("3000"), 0644)
 				Expect(err).NotTo(HaveOccurred())
 				defer os.Remove("/var/lib/calico/mtu")
 

--- a/confd/pkg/config/config.go
+++ b/confd/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 
 	"github.com/BurntSushi/toml"
@@ -82,7 +81,7 @@ func InitConfig(ignoreFlags bool) (*Config, error) {
 		log.Info("Skipping confd config file.")
 	} else {
 		log.Info("Loading " + configFile)
-		configBytes, err := ioutil.ReadFile(configFile)
+		configBytes, err := os.ReadFile(configFile)
 		if err != nil {
 			return nil, err
 		}

--- a/confd/pkg/resource/template/resource.go
+++ b/confd/pkg/resource/template/resource.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -161,7 +160,7 @@ func (t *TemplateResource) createStageFile() error {
 	}
 
 	// create TempFile in Dest directory to avoid cross-filesystem issues
-	temp, err := ioutil.TempFile(filepath.Dir(t.Dest), "."+filepath.Base(t.Dest))
+	temp, err := os.CreateTemp(filepath.Dir(t.Dest), "."+filepath.Base(t.Dest))
 	if err != nil {
 		return err
 	}
@@ -248,11 +247,11 @@ func (t *TemplateResource) sync(key string) error {
 				// try to open the file and write to it
 				var contents []byte
 				var rerr error
-				contents, rerr = ioutil.ReadFile(staged)
+				contents, rerr = os.ReadFile(staged)
 				if rerr != nil {
 					return rerr
 				}
-				if err := ioutil.WriteFile(t.Dest, contents, t.FileMode); err != nil {
+				if err := os.WriteFile(t.Dest, contents, t.FileMode); err != nil {
 					log.WithError(err).WithField("filename", t.Dest).Error("failed to write to file")
 					return err
 				}

--- a/felix/bpf/attach.go
+++ b/felix/bpf/attach.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -49,7 +48,7 @@ type AttachPointInfo interface {
 // AlreadyAttachedProg checks that the program we are going to attach has the
 // same parameters as what we remembered about the currently attached.
 func AlreadyAttachedProg(a AttachPointInfo, object string, id int) (bool, error) {
-	bytesToRead, err := ioutil.ReadFile(RuntimeJSONFilename(a.IfaceName(), a.HookName()))
+	bytesToRead, err := os.ReadFile(RuntimeJSONFilename(a.IfaceName(), a.HookName()))
 	if err != nil {
 		// If file does not exist, just ignore the err code, and return false
 		if os.IsNotExist(err) {
@@ -111,7 +110,7 @@ func RememberAttachedProg(a AttachPointInfo, object string, id int) error {
 		return err
 	}
 
-	if err = ioutil.WriteFile(RuntimeJSONFilename(a.IfaceName(), a.HookName()), bytesToWrite, 0600); err != nil {
+	if err = os.WriteFile(RuntimeJSONFilename(a.IfaceName(), a.HookName()), bytesToWrite, 0600); err != nil {
 		return err
 	}
 

--- a/felix/bpf/binary.go
+++ b/felix/bpf/binary.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/binary"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -33,7 +32,7 @@ type Binary struct {
 
 // BinaryFromFile reads a binary from a file
 func BinaryFromFile(ifile string) (*Binary, error) {
-	raw, err := ioutil.ReadFile(ifile)
+	raw, err := os.ReadFile(ifile)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +44,7 @@ func BinaryFromFile(ifile string) (*Binary, error) {
 
 // WriteToFile writes the binary to a file
 func (b *Binary) WriteToFile(ofile string) error {
-	err := ioutil.WriteFile(ofile, b.raw, 0600)
+	err := os.WriteFile(ofile, b.raw, 0600)
 	if err != nil {
 		return err
 	}

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -502,7 +501,7 @@ func (b *BPFLib) NewCIDRMap(ifName string, family IPFamily) (string, error) {
 
 func (b *BPFLib) ListCIDRMaps(family IPFamily) ([]string, error) {
 	var ifNames []string
-	maps, err := ioutil.ReadDir(b.xdpDir)
+	maps, err := os.ReadDir(b.xdpDir)
 	if err != nil {
 		return nil, err
 	}

--- a/felix/bpf/maps.go
+++ b/felix/bpf/maps.go
@@ -17,7 +17,6 @@ package bpf
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -785,7 +784,7 @@ func (b *PinnedMap) CopyDeltaFromOldMap() error {
 func (b *PinnedMap) getOldMapVersion() (int, error) {
 	oldVersion := 0
 	name := b.Name
-	files, err := ioutil.ReadDir(b.pinDir())
+	files, err := os.ReadDir(b.pinDir())
 	if err != nil {
 		return 0, fmt.Errorf("error reading pin path %w", err)
 	}

--- a/felix/bpf/mock_bpf_lib.go
+++ b/felix/bpf/mock_bpf_lib.go
@@ -18,7 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"path"
@@ -480,7 +480,7 @@ func (b *MockBPFLib) loadXDPRaw(objPath, ifName string, mode XDPMode, mapArgs []
 		return err
 	}
 
-	bytez, err := ioutil.ReadAll(f)
+	bytez, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -227,7 +226,7 @@ func setupAndRun(logger testLogger, loglevel, section string, rules *polprog.Rul
 		o(&topts)
 	}
 
-	tempDir, err := ioutil.TempDir("", "calico-bpf-")
+	tempDir, err := os.MkdirTemp("", "calico-bpf-")
 	Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(tempDir)
 
@@ -650,7 +649,7 @@ func bpftoolProgRun(progName string, dataIn, ctxIn []byte) (bpfRunResult, error)
 func bpftoolProgRunN(progName string, dataIn, ctxIn []byte, N int) (bpfRunResult, error) {
 	var res bpfRunResult
 
-	tempDir, err := ioutil.TempDir("", "bpftool-data-")
+	tempDir, err := os.MkdirTemp("", "bpftool-data-")
 	Expect(err).NotTo(HaveOccurred())
 
 	defer os.RemoveAll(tempDir)
@@ -661,12 +660,12 @@ func bpftoolProgRunN(progName string, dataIn, ctxIn []byte, N int) (bpfRunResult
 	ctxInFname := tempDir + "/ctx_in"
 	ctxOutFname := tempDir + "/ctx_out"
 
-	if err := ioutil.WriteFile(dataInFname, dataIn, 0644); err != nil {
+	if err := os.WriteFile(dataInFname, dataIn, 0644); err != nil {
 		return res, errors.Errorf("failed to write input data in file: %s", err)
 	}
 
 	if ctxIn != nil {
-		if err := ioutil.WriteFile(ctxInFname, ctxIn, 0644); err != nil {
+		if err := os.WriteFile(ctxInFname, ctxIn, 0644); err != nil {
 			return res, errors.Errorf("failed to write input ctx in file: %s", err)
 		}
 	}
@@ -688,13 +687,13 @@ func bpftoolProgRunN(progName string, dataIn, ctxIn []byte, N int) (bpfRunResult
 		return res, errors.Errorf("failed to unmarshall json: %s", err)
 	}
 
-	res.dataOut, err = ioutil.ReadFile(dataOutFname)
+	res.dataOut, err = os.ReadFile(dataOutFname)
 	if err != nil {
 		return res, errors.Errorf("failed to read output data from file: %s", err)
 	}
 
 	if ctxIn != nil {
-		ctxOut, err := ioutil.ReadFile(ctxOutFname)
+		ctxOut, err := os.ReadFile(ctxOutFname)
 		if err != nil {
 			return res, errors.Errorf("failed to read output ctx from file: %s", err)
 		}
@@ -726,7 +725,7 @@ func runBpfUnitTest(t *testing.T, source string, testFn func(bpfProgRunFn), opts
 		log.SetLevel(topts.logLevel)
 	}
 
-	tempDir, err := ioutil.TempDir("", "calico-bpf-")
+	tempDir, err := os.MkdirTemp("", "calico-bpf-")
 	Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(tempDir)
 

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -16,7 +16,6 @@ package xdp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -121,7 +120,7 @@ func ConfigureProgram(m *libbpf.Map, iface string) error {
 }
 
 func (ap *AttachPoint) AttachProgram() (int, error) {
-	tempDir, err := ioutil.TempDir("", "calico-xdp")
+	tempDir, err := os.MkdirTemp("", "calico-xdp")
 	if err != nil {
 		return -1, fmt.Errorf("failed to create temporary directory: %w", err)
 	}

--- a/felix/cmd/calico-bpf/commands/policy_debug.go
+++ b/felix/cmd/calico-bpf/commands/policy_debug.go
@@ -17,7 +17,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -126,7 +126,7 @@ func dumpPolicyInfo(cmd *cobra.Command, iface string, hook bpf.Hook, m counters.
 		return err
 	}
 
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	dec := json.NewDecoder(strings.NewReader(string(byteValue)))
 	err = dec.Decode(&policyDbg)
 	if err != nil {

--- a/felix/config/file_loader.go
+++ b/felix/config/file_loader.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/go-ini/ini"
@@ -27,7 +26,7 @@ func LoadConfigFile(filename string) (map[string]string, error) {
 		log.Infof("Ignoring absent config file: %v", filename)
 		return nil, nil
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -2085,7 +2084,7 @@ func (m *bpfEndpointManager) writePolicyDebugInfo(insns asm.Insns, ifaceName str
 		return err
 	}
 
-	if err := ioutil.WriteFile(filename, buffer.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(filename, buffer.Bytes(), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -16,7 +16,6 @@ package intdataplane
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -999,7 +998,7 @@ func writeMTUFile(mtu int) error {
 	// Write the smallest MTU to disk so other components can rely on this calculation consistently.
 	filename := "/var/lib/calico/mtu"
 	log.Debugf("Writing %d to "+filename, mtu)
-	if err := ioutil.WriteFile(filename, []byte(fmt.Sprintf("%d", mtu)), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(fmt.Sprintf("%d", mtu)), 0644); err != nil {
 		log.WithError(err).Error("Unable to write to " + filename)
 		return err
 	}

--- a/felix/dataplane/windows/policysets/static_rules.go
+++ b/felix/dataplane/windows/policysets/static_rules.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -114,7 +113,7 @@ func (f FileReader) ReadData() ([]byte, error) {
 	if _, err := os.Stat(ruleFile); os.IsNotExist(err) {
 		return []byte{}, ErrNoRuleSpecified
 	}
-	return ioutil.ReadFile(ruleFile)
+	return os.ReadFile(ruleFile)
 }
 
 // Read ACL policy rules from static rule file.

--- a/felix/environment/feature_detect.go
+++ b/felix/environment/feature_detect.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -209,7 +208,7 @@ func (d *FeatureDetector) getDistributionName() string {
 		return DefaultDistro
 	}
 
-	kernVersion, err := ioutil.ReadAll(versionReader)
+	kernVersion, err := io.ReadAll(versionReader)
 	if err != nil {
 		log.WithError(err).Warn("Failed to read kernel version from reader")
 		return DefaultDistro

--- a/felix/environment/versionparse.go
+++ b/felix/environment/versionparse.go
@@ -17,7 +17,6 @@ package environment
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -133,7 +132,7 @@ func GetDistFromString(s string) string {
 }
 
 func GetKernelVersion(reader io.Reader) (*Version, error) {
-	kernVersion, err := ioutil.ReadAll(reader)
+	kernVersion, err := io.ReadAll(reader)
 	if err != nil {
 		log.WithError(err).Warn("Failed to read kernel version from reader")
 		return nil, err
@@ -148,7 +147,7 @@ func GetDistributionName() string {
 		log.WithError(err).Warn("Failed to get kernel version reader")
 		return DefaultDistro
 	}
-	kernVersion, err := ioutil.ReadAll(reader)
+	kernVersion, err := io.ReadAll(reader)
 	if err != nil {
 		log.WithError(err).Warn("Failed to read kernel version from reader")
 		return DefaultDistro

--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -751,12 +751,12 @@ func (cmd *CheckCmd) run(cName string, logMsg string) *Result {
 
 	go func() {
 		defer wg.Done()
-		wOut, outErr = ioutil.ReadAll(outPipe)
+		wOut, outErr = io.ReadAll(outPipe)
 	}()
 
 	go func() {
 		defer wg.Done()
-		wErr, errErr = ioutil.ReadAll(errPipe)
+		wErr, errErr = io.ReadAll(errPipe)
 	}()
 
 	wg.Wait()

--- a/felix/fv/fv_infra_test.go
+++ b/felix/fv/fv_infra_test.go
@@ -18,7 +18,6 @@ package fv_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -186,7 +185,7 @@ var _ = infrastructure.DatastoreDescribe("Container self tests",
 
 			It("should panic and drop a core file", func() {
 				felixes[0].WaitNotRunning(5 * time.Second)
-				dir, err := ioutil.ReadDir("/tmp")
+				dir, err := os.ReadDir("/tmp")
 				Expect(err).NotTo(HaveOccurred())
 				name := ""
 				for _, f := range dir {

--- a/felix/fv/health_test.go
+++ b/felix/fv/health_test.go
@@ -37,7 +37,7 @@ package fv_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"time"
@@ -444,7 +444,7 @@ func getHealthStatus(ip, port, endpoint string) func() int {
 			return statusErr
 		}
 		defer resp.Body.Close()
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		log.WithField("resp", resp).Infof("Health response:\n%v\n", string(body))
 		return resp.StatusCode
 	}

--- a/felix/fv/infrastructure/typha.go
+++ b/felix/fv/infrastructure/typha.go
@@ -16,7 +16,6 @@ package infrastructure
 
 import (
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -94,7 +93,7 @@ func EnsureTLSCredentials() {
 
 	// Generate credentials needed for Felix-Typha TLS.
 	var err error
-	CertDir, err = ioutil.TempDir("", "felixfv")
+	CertDir, err = os.MkdirTemp("", "felixfv")
 	tlsutils.PanicIfErr(err)
 
 	// Trusted CA.

--- a/felix/fv/metrics/metrics.go
+++ b/felix/fv/metrics/metrics.go
@@ -20,9 +20,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -76,7 +76,7 @@ func GetMetric(ip string, port int, name, caFile, certFile, keyFile string) (met
 			// tlsConfig.ServerName, and we don't want that.  We will do certificate
 			// chain verification ourselves inside CertificateVerifier.
 			transport.TLSClientConfig.InsecureSkipVerify = true
-			caPEMBlock, err := ioutil.ReadFile(caFile)
+			caPEMBlock, err := os.ReadFile(caFile)
 			if err != nil {
 				log.WithError(err).Error("Failed to read CA data")
 				return "", err

--- a/felix/fv/policysync_test.go
+++ b/felix/fv/policysync_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -67,7 +66,7 @@ var _ = Context("_POL-SYNC_ _BPF-SAFE_ policy sync API tests", func() {
 		// Create a temporary directory to map into the container as /var/run/calico/policysync, which
 		// is where we tell Felix to put the policy sync mounts and credentials.
 		var err error
-		tempDir, err = ioutil.TempDir("", "felixfv")
+		tempDir, err = os.MkdirTemp("", "felixfv")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Configure felix to enable the policy sync API.
@@ -141,7 +140,7 @@ var _ = Context("_POL-SYNC_ _BPF-SAFE_ policy sync API tests", func() {
 			credentialFileName := credentials.Uid + binder.CredentialsExtension
 
 			credsFileTmp := filepath.Join(tempDir, credentialFileName)
-			err = ioutil.WriteFile(credsFileTmp, attrs, 0777)
+			err = os.WriteFile(credsFileTmp, attrs, 0777)
 			if err != nil {
 				return err
 			}

--- a/felix/iptables/lock_test.go
+++ b/felix/iptables/lock_test.go
@@ -16,7 +16,6 @@ package iptables_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -86,7 +85,7 @@ var _ = Describe("GrabIptablesLocks FV", func() {
 	var fileName string
 
 	BeforeEach(func() {
-		f, err := ioutil.TempFile("", "iptlocktest")
+		f, err := os.CreateTemp("", "iptlocktest")
 		Expect(err).NotTo(HaveOccurred())
 		fileName = f.Name()
 		f.Close()

--- a/felix/policysync/processor_test.go
+++ b/felix/policysync/processor_test.go
@@ -17,7 +17,6 @@ package policysync_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -1410,7 +1409,7 @@ func getDialer(proto string) func(context.Context, string) (net.Conn, error) {
 const ListenerSocket = "policysync.sock"
 
 func makeTmpListenerDir() string {
-	dirPath, err := ioutil.TempDir("/tmp", "felixut")
+	dirPath, err := os.MkdirTemp("/tmp", "felixut")
 	Expect(err).ToNot(HaveOccurred())
 	return dirPath
 }

--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -16,7 +16,6 @@ package builder
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -248,7 +247,7 @@ func (r *ReleaseBuilder) collectGithubArtifacts(ver string) error {
 	}
 
 	// We attach calicoctl binaries directly to the release as well.
-	files, err := ioutil.ReadDir("calicoctl/bin/")
+	files, err := os.ReadDir("calicoctl/bin/")
 	if err != nil {
 		return err
 	}
@@ -280,7 +279,7 @@ func (r *ReleaseBuilder) collectGithubArtifacts(ver string) error {
 	// Generate a SHA256SUMS file containing the checksums for each artifact
 	// that we attach to the release. These can be confirmed by end users via the following command:
 	// sha256sum -c --ignore-missing SHA256SUMS
-	files, err = ioutil.ReadDir(uploadDir)
+	files, err = os.ReadDir(uploadDir)
 	if err != nil {
 		return err
 	}

--- a/kube-controllers/cmd/kube-controllers/fv_test.go
+++ b/kube-controllers/cmd/kube-controllers/fv_test.go
@@ -17,7 +17,6 @@ package main_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -57,7 +56,7 @@ var _ = Describe("[etcd] kube-controllers health check FV tests", func() {
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)
@@ -188,7 +187,7 @@ var _ = Describe("[kdd] kube-controllers health check FV tests", func() {
 
 		// Write out a kubeconfig file
 		var err error
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/config/config_fv_test.go
+++ b/kube-controllers/pkg/config/config_fv_test.go
@@ -16,7 +16,6 @@ package config_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -57,7 +56,7 @@ var _ = Describe("KubeControllersConfiguration FV tests", func() {
 
 		// Write out a kubeconfig file
 		var err error
-		kconfigFile, err = ioutil.TempFile("", "ginkgo-nodecontroller")
+		kconfigFile, err = os.CreateTemp("", "ginkgo-nodecontroller")
 		Expect(err).NotTo(HaveOccurred())
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigFile.Write([]byte(data))

--- a/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
+++ b/kube-controllers/pkg/controllers/flannelmigration/flannel_migration_fv_test.go
@@ -17,7 +17,6 @@ package flannelmigration_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"regexp"
@@ -99,7 +98,7 @@ var _ = Describe("flannel-migration-controller FV test", func() {
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err = ioutil.TempFile("", "ginkgo-migrationcontroller")
+		kconfigfile, err = os.CreateTemp("", "ginkgo-migrationcontroller")
 		Expect(err).NotTo(HaveOccurred())
 
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/controllers/namespace/namespace_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/namespace/namespace_controller_fv_test.go
@@ -16,7 +16,6 @@ package namespace_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -55,7 +54,7 @@ var _ = Describe("Calico namespace controller FV tests (etcd mode)", func() {
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/controllers/networkpolicy/policy_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/networkpolicy/policy_controller_fv_test.go
@@ -16,7 +16,6 @@ package networkpolicy_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -55,7 +54,7 @@ var _ = Describe("Calico networkpolicy controller FV tests (etcd mode)", func() 
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/auto_hep_fv_test.go
@@ -16,7 +16,6 @@ package node_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -64,7 +63,7 @@ var _ = Describe("Auto Hostendpoint FV tests", func() {
 
 		// Write out a kubeconfig file
 		var err error
-		kconfigFile, err = ioutil.TempFile("", "ginkgo-nodecontroller")
+		kconfigFile, err = os.CreateTemp("", "ginkgo-nodecontroller")
 		Expect(err).NotTo(HaveOccurred())
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigFile.Write([]byte(data))

--- a/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/etcd_ipam_gc_fv_test.go
@@ -16,7 +16,6 @@ package node_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -62,7 +61,7 @@ var _ = Describe("kube-controllers IPAM FV tests (etcd mode)", func() {
 
 		// Write out a kubeconfig file we can mount into the container.
 		var err error
-		kconfigFile, err = ioutil.TempFile("", "ginkgo-nodecontroller")
+		kconfigFile, err = os.CreateTemp("", "ginkgo-nodecontroller")
 		Expect(err).NotTo(HaveOccurred())
 		data := testutils.BuildKubeconfig(apiserver.IP)
 		_, err = kconfigFile.Write([]byte(data))

--- a/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/kdd_ipam_gc_fv_test.go
@@ -17,7 +17,6 @@ package node_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -63,7 +62,7 @@ var _ = Describe("IPAM garbage collection FV tests with short leak grace period"
 
 		// Write out a kubeconfig file
 		var err error
-		kconfigfile, err = ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err = os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)
@@ -594,7 +593,7 @@ var _ = Describe("IPAM garbage collection FV tests with long leak grace period",
 
 		// Write out a kubeconfig file
 		var err error
-		kconfigfile, err = ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err = os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/controllers/node/metrics_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/metrics_fv_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -63,7 +63,7 @@ var _ = Describe("kube-controllers metrics FV tests", func() {
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)
@@ -623,7 +623,7 @@ func getMetrics(metricsURL string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/node/node_controller_fv_test.go
@@ -17,7 +17,6 @@ package node_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -68,7 +67,7 @@ var _ = Describe("Calico node controller FV tests (KDD mode)", func() {
 
 		// Write out a kubeconfig file
 		var err error
-		kconfigfile, err = ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err = os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)
@@ -436,7 +435,7 @@ var _ = Describe("Calico node controller FV tests (etcd mode)", func() {
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/controllers/pod/pod_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/pod/pod_controller_fv_test.go
@@ -17,7 +17,6 @@ package pod_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -60,7 +59,7 @@ var _ = Describe("Calico pod controller FV tests (etcd mode)", func() {
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/controllers/serviceaccount/serviceaccount_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/serviceaccount/serviceaccount_controller_fv_test.go
@@ -16,7 +16,6 @@ package serviceaccount_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -55,7 +54,7 @@ var _ = Describe("Calico serviceaccount controller FV tests (etcd mode)", func()
 		apiserver = testutils.RunK8sApiserver(etcd.IP)
 
 		// Write out a kubeconfig file
-		kconfigfile, err := ioutil.TempFile("", "ginkgo-policycontroller")
+		kconfigfile, err := os.CreateTemp("", "ginkgo-policycontroller")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(kconfigfile.Name())
 		data := testutils.BuildKubeconfig(apiserver.IP)

--- a/kube-controllers/pkg/status/status.go
+++ b/kube-controllers/pkg/status/status.go
@@ -16,7 +16,6 @@ package status
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,7 +132,7 @@ func (s *Status) writeStatus() error {
 	}
 
 	// Write the file.
-	err = ioutil.WriteFile(s.statusFile, b, 0644)
+	err = os.WriteFile(s.statusFile, b, 0644)
 	if err != nil {
 		logrus.Errorf("Failed to write readiness file: %s", err)
 		return err
@@ -145,7 +144,7 @@ func (s *Status) writeStatus() error {
 // ReadStatusFile reads in the status file as written by WriteStatus.
 func ReadStatusFile(file string) (*Status, error) {
 	st := &Status{}
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/kube-controllers/pkg/status/status_test.go
+++ b/kube-controllers/pkg/status/status_test.go
@@ -15,7 +15,6 @@
 package status
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"sync"
@@ -32,7 +31,7 @@ var _ = Describe("Status pkg UTs", func() {
 	})
 
 	It("should update the status file when changes happen", func() {
-		f, err := ioutil.TempFile("", "test")
+		f, err := os.CreateTemp("", "test")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.Remove(f.Name())
 		st := New(f.Name())

--- a/libcalico-go/lib/apiconfig/load.go
+++ b/libcalico-go/lib/apiconfig/load.go
@@ -17,7 +17,6 @@ package apiconfig
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -42,7 +41,7 @@ func LoadClientConfig(filename string) (*CalicoAPIConfig, error) {
 // LoadClientConfigFromFile loads the ClientConfig from the specified file, which must exist.
 // The datastore type is defaulted if not specified.
 func LoadClientConfigFromFile(filename string) (*CalicoAPIConfig, error) {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/libcalico-go/lib/backend/k8s/k8s_test.go
+++ b/libcalico-go/lib/backend/k8s/k8s_test.go
@@ -17,7 +17,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -3102,7 +3102,7 @@ var _ = testutils.E2eDatastoreDescribe("Test Inline kubeconfig support", testuti
 
 	BeforeEach(func() {
 		// Load kubeconfig file that was mounted in to the test.
-		conf, err := ioutil.ReadFile("/kubeconfig.yaml")
+		conf, err := os.ReadFile("/kubeconfig.yaml")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Override the provided config to use inline configuration.

--- a/libcalico-go/lib/client/client.go
+++ b/libcalico-go/lib/client/client.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 
 	"github.com/kelseyhightower/envconfig"
@@ -128,7 +128,7 @@ func LoadClientConfig(filename string) (*api.CalicoAPIConfig, error) {
 
 	// Override / merge with values loaded from the specified file.
 	if filename != "" {
-		b, err := ioutil.ReadFile(filename)
+		b, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, err
 		}

--- a/node/pkg/cni/token_watch.go
+++ b/node/pkg/cni/token_watch.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strings"
@@ -55,7 +54,7 @@ type TokenUpdate struct {
 }
 
 func NamespaceOfUsedServiceAccount() string {
-	namespace, err := ioutil.ReadFile(serviceAccountNamespace)
+	namespace, err := os.ReadFile(serviceAccountNamespace)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to read service account namespace file")
 	}
@@ -178,7 +177,7 @@ func (t *TokenRefresher) tokenRequestSupported(clientset *kubernetes.Clientset) 
 }
 
 func tokenUpdateFromFile() (TokenUpdate, error) {
-	tokenBytes, err := ioutil.ReadFile(tokenFile)
+	tokenBytes, err := os.ReadFile(tokenFile)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to read service account token file")
 		return TokenUpdate{}, err
@@ -272,7 +271,7 @@ current-context: calico-context`
 	data := fmt.Sprintf(template, cfg.Host, base64.StdEncoding.EncodeToString(cfg.CAData), token)
 
 	// Write the filled out config to disk.
-	if err := ioutil.WriteFile(kubeconfigPath, []byte(data), 0600); err != nil {
+	if err := os.WriteFile(kubeconfigPath, []byte(data), 0600); err != nil {
 		logrus.WithError(err).Error("Failed to write CNI plugin kubeconfig file")
 		return
 	}

--- a/node/pkg/lifecycle/utils/utils.go
+++ b/node/pkg/lifecycle/utils/utils.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -77,7 +76,7 @@ func shutdownTimestampFileName() string {
 func RemoveShutdownTimestampFile() error {
 	dataOK := true
 	filename := shutdownTimestampFileName()
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// File doesn't exist
@@ -104,7 +103,7 @@ func SaveShutdownTimestamp() error {
 	ts := time.Now().UTC().Format(time.RFC3339)
 	filename := shutdownTimestampFileName()
 	log.Infof("Writing shutdown timestamp %s to %s", ts, filename)
-	if err := ioutil.WriteFile(filename, []byte(ts), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(ts), 0644); err != nil {
 		log.WithError(err).Error("Unable to write to " + filename)
 		return err
 	}
@@ -157,7 +156,7 @@ func nodenameFileName() string {
 // returns the nodename within.
 func NodenameFromFile() string {
 	filename := nodenameFileName()
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// File doesn't exist, return empty string.
@@ -176,7 +175,7 @@ func NodenameFromFile() string {
 func WriteNodeConfig(nodeName string) {
 	filename := nodenameFileName()
 	log.Debugf("Writing %s to "+filename, nodeName)
-	if err := ioutil.WriteFile(filename, []byte(nodeName), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte(nodeName), 0644); err != nil {
 		log.WithError(err).Error("Unable to write to " + filename)
 		Terminate()
 	}

--- a/node/windows-packaging/tests/cni_conf_test.go
+++ b/node/windows-packaging/tests/cni_conf_test.go
@@ -17,7 +17,7 @@ package main_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -25,7 +25,7 @@ import (
 
 var _ = Describe("Windows CNI config template tests", func() {
 	It("should be valid JSON", func() {
-		f, err := ioutil.ReadFile("../../windows-packaging/CalicoWindows/cni.conf.template")
+		f, err := os.ReadFile("../../windows-packaging/CalicoWindows/cni.conf.template")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Swap out placeholders in the CNI config template for a valid JSON

--- a/pod2daemon/binder/binder.go
+++ b/pod2daemon/binder/binder.go
@@ -16,7 +16,6 @@ package binder
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -150,7 +149,7 @@ func (b *binder) addListener(uid string) {
 }
 
 func readCredentials(path string, c *Credentials) error {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/pod2daemon/binder/watcher.go
+++ b/pod2daemon/binder/watcher.go
@@ -15,7 +15,6 @@
 package binder
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -90,7 +89,7 @@ func (p *pollWatcher) poll(events chan<- workloadEvent, stop <-chan bool) {
 		}
 
 		// list the contents of the directory
-		files, err := ioutil.ReadDir(credPath)
+		files, err := os.ReadDir(credPath)
 		if err != nil {
 			log.Printf("error reading %s: %v", p.path, err)
 			close(events)

--- a/pod2daemon/csidriver/driver/driver.go
+++ b/pod2daemon/csidriver/driver/driver.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -108,7 +107,7 @@ func RetrieveConfig() (*ConfigurationOptions, error) {
 	config := ConfigurationOptions{}
 	if _, err := os.Stat(configFile); err == nil {
 		// Read the config from the file.
-		bytes, err := ioutil.ReadFile(configFile)
+		bytes, err := os.ReadFile(configFile)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to read configuration at %s: %v", configFile, err)
 		}

--- a/pod2daemon/csidriver/driver/node.go
+++ b/pod2daemon/csidriver/driver/node.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"syscall"
@@ -243,7 +243,7 @@ func (ns *nodeService) addCredentialFile(volumeID string, podInfo *creds.Credent
 	}
 
 	credsFileTmp := strings.Join([]string{ns.config.NodeAgentManagementHomeDir, volumeID + ".json"}, "/")
-	_ = ioutil.WriteFile(credsFileTmp, attrs, 0644)
+	_ = os.WriteFile(credsFileTmp, attrs, 0644)
 
 	// Move it to the right location now.
 	credsFile := strings.Join([]string{ns.config.NodeAgentCredentialsHomeDir, volumeID + ".json"}, "/")
@@ -266,7 +266,7 @@ func (ns *nodeService) retrievePodInfoFromFile(volumeID string) (*creds.Credenti
 
 	defer credsFile.Close()
 
-	credsFileBytes, err := ioutil.ReadAll(credsFile)
+	credsFileBytes, err := io.ReadAll(credsFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pod2daemon/flexvol/flexvoldriver.go
+++ b/pod2daemon/flexvol/flexvoldriver.go
@@ -24,7 +24,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log/syslog"
 	"os"
 	"os/exec"
@@ -411,7 +410,7 @@ func addCredentialFile(ninputs *creds.Credentials) error {
 	}
 
 	credsFileTmp := strings.Join([]string{configuration.NodeAgentManagementHomeDir, ninputs.UID + ".json"}, "/")
-	_ = ioutil.WriteFile(credsFileTmp, attrs, 0644)
+	_ = os.WriteFile(credsFileTmp, attrs, 0644)
 
 	// Move it to the right location now.
 	credsFile := strings.Join([]string{configuration.NodeAgentCredentialsHomeDir, ninputs.UID + ".json"}, "/")
@@ -434,7 +433,7 @@ func initConfiguration() {
 		return
 	}
 
-	bytes, err := ioutil.ReadFile(CONFIG_FILE)
+	bytes, err := os.ReadFile(CONFIG_FILE)
 	if err != nil {
 		logError("initConfiguration", "", fmt.Sprintf("Not able to read %s: %s\n", CONFIG_FILE, err.Error()), syslogOnlyTrue)
 		return

--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -1334,7 +1333,7 @@ var _ = Describe("with server requiring TLS", func() {
 
 		// Create a temporary directory for certificates.
 		var err error
-		certDir, err = ioutil.TempDir("", "typhafv")
+		certDir, err = os.MkdirTemp("", "typhafv")
 		tlsutils.PanicIfErr(err)
 
 		// Trusted CA.

--- a/typha/pkg/config/file_loader.go
+++ b/typha/pkg/config/file_loader.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/go-ini/ini"
@@ -27,7 +26,7 @@ func LoadConfigFile(filename string) (map[string]string, error) {
 		log.Infof("Ignoring absent config file: %v", filename)
 		return nil, nil
 	}
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"sync"
@@ -98,7 +97,7 @@ var _ = Describe("Daemon", func() {
 
 		BeforeEach(func() {
 			var err error
-			configFile, err = ioutil.TempFile("", "typha")
+			configFile, err = os.CreateTemp("", "typha")
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = configFile.Write(configContents)

--- a/typha/pkg/syncclient/sync_client.go
+++ b/typha/pkg/syncclient/sync_client.go
@@ -22,8 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -279,7 +279,7 @@ func (s *SyncerClient) connect(cxt context.Context, typhaAddr discovery.Typha) e
 		// we don't always want that.  We will do certificate chain verification ourselves
 		// inside CertificateVerifier.
 		tlsConfig.InsecureSkipVerify = true
-		caPEMBlock, err := ioutil.ReadFile(s.options.CAFile)
+		caPEMBlock, err := os.ReadFile(s.options.CAFile)
 		if err != nil {
 			log.WithError(err).Error("Failed to read CA data")
 			return err

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -352,7 +351,7 @@ func (s *Server) serve(cxt context.Context) {
 		// Arrange for server to verify the clients' certificates.
 		logCxt.Info("Will verify client certificates")
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-		caPEMBlock, tlsErr := ioutil.ReadFile(s.config.CAFile)
+		caPEMBlock, tlsErr := os.ReadFile(s.config.CAFile)
 		if tlsErr != nil {
 			logCxt.WithError(tlsErr).Panic("Failed to read CA data")
 		}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup
Hey , calico community..
We should clean all io/util package according the url: [ioutil deprecation](https://go.dev/doc/go1.16#ioutil)

