### PR TITLE
Bump kubectl version to 1.24.8

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -155,7 +155,7 @@ run-kubernetes-server: run-k8s-controller-manager
 		--rm \
 		-v  $(CURDIR):/manifests \
 		-v $(CERTS_PATH):/home/user/certs \
-		lachlanevenson/k8s-kubectl:${KUBECTL_VERSION} \
+		bitnami/kubectl:$(subst v,,$(KUBECTL_VERSION)) \
 		--kubeconfig=/home/user/certs/kubeconfig \
 		apply -f /manifests/test/mock-node.yaml
 
@@ -166,7 +166,7 @@ run-kubernetes-server: run-k8s-controller-manager
 		--rm \
 		-v  $(CURDIR):/manifests \
 		-v $(CERTS_PATH):/home/user/certs \
-		lachlanevenson/k8s-kubectl:${KUBECTL_VERSION} \
+		bitnami/kubectl:$(subst v,,$(KUBECTL_VERSION)) \
 		--kubeconfig=/home/user/certs/kubeconfig \
 		apply -f /manifests/test/namespaces.yaml
 

--- a/metadata.mk
+++ b/metadata.mk
@@ -6,9 +6,9 @@
 GO_BUILD_VER = v0.76
 
 # Version of Kubernetes to use for tests.
-K8S_VERSION     = v1.24.3
-# This is used for lachlanevenson/k8s-kubectl and kubectl binary release.
-KUBECTL_VERSION = v1.24.3
+K8S_VERSION     = v1.24.7
+# This is used for bitnami/kubectl and kubectl binary release.
+KUBECTL_VERSION = v1.24.8
 
 # Version of various tools used in the build and tests.
 COREDNS_VERSION=1.5.2


### PR DESCRIPTION
## Description

This changeset updates `kubectl` version from 1.24.3 to 1.24.8. This
reduces CVEs detected in some enterprise container images as `kubectl`
1.24.3 is built by golang 1.18.3. This change affects UT/FVs in Calico
open source.

`kubectl` container image is changed from `lachlanevenson/k8s-kubectl`
to `bitnami/kubectl` as the former one doesn't have the latest tags.

`K8S_VERSION` stays at 1.24.7 as this is the latest tag from
`kindest/node` container image for k8s 1.24.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
