### PR TITLE
DOCS-835: Doc-fix-network-design

### DIFF
--- a/calico/reference/architecture/design/l2-interconnect-fabric.md
+++ b/calico/reference/architecture/design/l2-interconnect-fabric.md
@@ -4,242 +4,114 @@ description: Understand the interconnect fabric options in a Calico network.
 canonical_url: '/reference/architecture/design/l2-interconnect-fabric'
 ---
 
-This is the first of a few *tech notes* that I will be authoring that
-will discuss some of the various interconnect fabric options in a {{site.prodname}}
-network.
+Any technology that is capable of transporting IP packets can be used as the interconnect fabric in a {{site.prodname}} network. This means that the standard tools used to transport IP, such as MPLS and Ethernet can be used in a {{site.prodname}} network.
 
-Any technology that is capable of transporting IP packets can be used as
-the interconnect fabric in a {{site.prodname}} network (the first person to test
-and publish the results of using [IP over Avian
-Carrier](https://datatracker.ietf.org/doc/html/rfc1149){:target="_blank"} as a transport for {{site.prodname}}
-will earn a very nice dinner on or with the core {{site.prodname}} team). This
-means that the standard tools used to transport IP, such as MPLS and
-Ethernet can be used in a {{site.prodname}} network.
+The focus of this article is on Ethernet as the interconnect network. Most at-scale cloud operators have converted to IP fabrics, and that infrastructure will work for {{site.prodname}} as well. However, the concerns that drove most of those operators to IP as the interconnection network in their pods are largely ameliorated by {{site.prodname}}, allowing Ethernet to be viably considered as a {{site.prodname}} interconnect, even in large-scale deployments.
 
-In this note, I'm going to focus on Ethernet as the interconnect
-network. Talking to most at-scale cloud operators, they have converted
-to IP fabrics, and as will cover in the next blog post that
-infrastructure will work for {{site.prodname}} as well. However, the concerns that
-drove most of those operators to IP as the interconnection network in
-their pods are largely ameliorated by Project Calico, allowing Ethernet
-to be viably considered as a {{site.prodname}} interconnect, even in large-scale
-deployments.
+### Concerns over Ethernet at scale
 
-## Concerns over Ethernet at scale
+It has been acknowledged by the industry for years that, beyond a certain size, classical Ethernet networks are unsuitable for production deployment. Although there have been {% include open-new-window.html text='multiple' url='https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering' %} {% include open-new-window.html text='attempts' url='https://web.archive.org/web/20150923231827/https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html' %} {% include open-new-window.html text='to address' url='https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service' %} these issues, the scale-out networking community has largely abandoned Ethernet for anything other than providing physical point-to-point links in the networking fabric. The principle reasons for Ethernet failures at large scale are:
 
-It has been acknowledged by the industry for years that, beyond a
-certain size, classical Ethernet networks are unsuitable for production
-deployment. Although there have been
-[multiple](https://en.wikipedia.org/wiki/Provider_Backbone_Bridge_Traffic_Engineering){:target="_blank"}
-[attempts](https://web.archive.org/web/20150923231827/https://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html){:target="_blank"} [to address](https://en.wikipedia.org/wiki/Virtual_Private_LAN_Service){:target="_blank"}
-these issues, the scale-out networking community has, largely abandoned
-Ethernet for anything other than providing physical point-to-point links
-in the networking fabric. The principal reasons for Ethernet failures at
-large scale are:
+- Large numbers of *endpoints* ([note 1](#note-1))
 
-1.  Large numbers of *end points* [^1]. Each switch in an Ethernet
-    network must learn the path to all Ethernet endpoints that are
-    connected to the Ethernet network. Learning this amount of state can
-    become a substantial task when we are talking about hundreds of
-    thousands of *end points*.
-2.  High rate of *churn* or change in the network. With that many end
-    points, most of them being ephemeral (such as virtual machines or
-    containers), there is a large amount of *churn* in the network. That
-    load of re-learning paths can be a substantial burden on the control
-    plane processor of most Ethernet switches.
-3.  High volumes of broadcast traffic. As each node on the Ethernet
-    network must use Broadcast packets to locate peers, and many use
-    broadcast for other purposes, the resultant packet replication to
-    each and every end point can lead to *broadcast storms* in large
-    Ethernet networks, effectively consuming most, if not all resources
-    in the network and the attached end points.
-4.  Spanning tree. Spanning tree is the protocol used to keep an
-    Ethernet network from forming loops. The protocol was designed in
-    the era of smaller, simpler networks, and it has not aged well. As
-    the number of links and interconnects in an Ethernet network goes
-    up, many implementations of spanning tree become more *fragile*.
-    Unfortunately, when spanning tree fails in an Ethernet network, the
-    effect is a catastrophic loop or partition (or both) in the network,
-    and, in most cases, difficult to troubleshoot or resolve.
+   Each switch in an Ethernet network must learn the path to all Ethernet endpoints that are connected to the Ethernet network. Learning this amount of state can become a substantial task when we are talking about hundreds of thousands of *endpoints*.
 
-While many of these issues are crippling at *VM scale* (tens of
-thousands of end points that live for hours, days, weeks), they will be
-absolutely lethal at *container scale* (hundreds of thousands of end
-points that live for seconds, minutes, days).
+- High rate of *churn* or change in the network
 
-If you weren't ready to turn off your Ethernet data center network
-before this, I bet you are now. Before you do, however, let's look at
-how Project Calico can mitigate these issues, even in very large
-deployments.
+   With that many endpoints, most of them being ephemeral (such as virtual machines orcontainers), there is a large amount of *churn* in the network. That load of re-learning paths can be a substantial burden on the control plane processor of most Ethernet switches.
 
-## How does {{site.prodname}} tame the Ethernet daemons?
+- High volumes of broadcast traffic
 
-First, let's look at how {{site.prodname}} uses an Ethernet interconnect fabric.
-It's important to remember that an Ethernet network *sees* nothing on
-the other side of an attached IP router, the Ethernet network just
-*sees* the router itself. This is why Ethernet switches can be used at
-Internet peering points, where large fractions of Internet traffic is
-exchanged. The switches only see the routers from the various ISPs, not
-those ISPs' customers' nodes. We leverage the same effect in {{site.prodname}}.
+   As each node on the Ethernet network must use Broadcast packets to locate peers, and many use broadcast for other purposes, the resultant packet replication to each and every endpoint can lead to *broadcast storms* in large Ethernet networks, effectively consuming most, if not all resources in the network and the attached endpoints.
+
+- Spanning tree
+
+   Spanning tree is the protocol used to keep an Ethernet network from forming loops. The protocol was designed in the era of smaller, simpler networks, and it has not aged well. As the number of links and interconnects in an Ethernet network goes up, many implementations of spanning tree become more *fragile*. Unfortunately, when spanning tree fails in an Ethernet network, the effect is a catastrophic loop or partition (or both) in the network, and, in most cases, difficult to troubleshoot or resolve.
+
+Although many of these issues are crippling at *VM scale* (tens of thousands of endpoints that live for hours, days, weeks), they will be absolutely lethal at *container scale* (hundreds of thousands of endpoints that live for seconds, minutes, days).
+
+If you weren't ready to turn off your Ethernet data center network before this, I bet you are now. Before you do, however, let's look at how {{site.prodname}} can mitigate these issues, even in very large deployments.
+
+### How does {{site.prodname}} tame the Ethernet daemons?
+
+First, let's look at how {{site.prodname}} uses an Ethernet interconnect fabric. It's important to remember that an Ethernet network *sees* nothing on the other side of an attached IP router, the Ethernet network just *sees* the router itself. This is why Ethernet switches can be used at Internet peering points, where large fractions of Internet traffic is exchanged. The switches only see the routers from the various ISPs, not those ISPs' customers' nodes. We leverage the same effect in {{site.prodname}}.
 
 To take the issues outlined above, let's revisit them in a {{site.prodname}}
 context.
 
-1.  Large numbers of end points. In a {{site.prodname}} network, the Ethernet
-    interconnect fabric only sees the routers/compute servers, not the
-    end point. In a standard cloud model, where there is tens of VMs per
-    server (or hundreds of containers), this reduces the number of nodes
-    that the Ethernet sees (and has to learn) by one to two orders
-    of magnitude. Even in very large pods (say twenty thousand servers),
-    the Ethernet network would still only see a few tens of thousands of
-    end points. Well within the scale of any competent data center
-    Ethernet top of rack (ToR) switch.
-2.  High rate of *churn*. In a classical Ethernet data center fabric,
-    there is a *churn* event each time an end point is created,
-    destroyed, or moved. In a large data center, with hundreds of
-    thousands of endpoints, this *churn* could run into tens of events
-    per second, every second of the day, with peaks easily in the
-    hundreds or thousands of events per second. In a {{site.prodname}} network,
-    however, the *churn* is very low. The only event that would lead to
-    *churn* in a {{site.prodname}} network's Ethernet fabric would be the addition
-    or loss of a compute server, switch, or physical connection. In a
-    twenty thousand server pod, even with a 5% daily failure rate (a few
-    orders of magnitude more than what is normally experienced), there
-    would only be two thousand events per **day**. Any switch that can
-    not handle that volume of change in the network should not be used
-    for any application.
-3.  High volume of broadcast traffic. Since the first (and last) hop for
-    any traffic in a {{site.prodname}} network is an IP hop, and IP hops terminate
-    broadcast traffic, there is no endpoint broadcast network in the
-    Ethernet fabric, period. In fact, the only broadcast traffic that
-    should be seen in the Ethernet fabric is the ARPs of the compute
-    servers locating each other. If the traffic pattern is fairly
-    consistent, the steady-state ARP rate should be almost zero. Even in
-    a pathological case, the ARP rate should be well within normal
-    accepted boundaries.
-4.  Spanning tree. Depending on the architecture chosen for the Ethernet
-    fabric, it may even be possible to turn off spanning tree. However,
-    even if it is left on, due to the reduction in node count, and
-    reduction in churn, most competent spanning tree implementations
-    should be able to handle the load without stress.
+- Large numbers of endpoints
 
-With these considerations in mind, it should be evident that an Ethernet
-connection fabric in {{site.prodname}} is not only possible, it is practical and
-should be seriously considered as the interconnect fabric for a {{site.prodname}}
+    In a {{site.prodname}} network, the Ethernet interconnect fabric only sees the routers/compute servers, not the
+    endpoint. In a standard cloud model, where there is tens of VMs per server (or hundreds of containers), this reduces the number of nodes that the Ethernet sees (and has to learn) by one to two orders
+    of magnitude. Even in very large pods (say twenty thousand servers), the Ethernet network would still only see a few tens of thousands of endpoints. Well within the scale of any competent data center
+    Ethernet top of rack (ToR) switch.
+
+- High rate of churn
+
+    In a classical Ethernet data center fabric, there is a *churn* event each time an endpoint is created,
+    destroyed, or moved. In a large data center, with hundreds of thousands of endpoints, this *churn* could run into tens of events per second, every second of the day, with peaks easily in the hundreds or thousands of events per second. In a {{site.prodname}} network, however, the *churn* is very low. The only event that would lead to *churn*
+    orders of magnitude more than what is normally experienced), there would only be two thousand events per **day**. Any switch that can not handle that volume of change in the network should not be used
+    for any application.
+
+- High volume of broadcast traffic
+
+    Because the first (and last) hop for any traffic in a {{site.prodname}} network is an IP hop, and IP hops terminate
+    broadcast traffic, there is no endpoint broadcast network in the Ethernet fabric, period. In fact, the only broadcast traffic that should be seen in the Ethernet fabric is the ARPs of the compute servers locating each other. If the traffic pattern is fairly consistent, the steady-state ARP rate should be almost zero. Even in a pathological case, the ARP rate should be well within normal accepted boundaries.
+
+- Spanning tree
+
+    Depending on the architecture chosen for the Ethernet fabric, it may even be possible to turn off spanning tree. However, even if it is left on, due to the reduction in node count, and reduction in churn, most competent spanning tree implementations should be able to handle the load without stress.
+
+With these considerations in mind, it should be evident that an Ethernet connection fabric in {{site.prodname}} is not only possible, it is practical and should be seriously considered as the interconnect fabric for a {{site.prodname}}
 network.
 
-As mentioned in the IP fabric post, an IP fabric is also quite feasible
-for {{site.prodname}}, but there are more considerations that must be taken into
-account. The Ethernet fabric option has fewer architectural
-considerations in its design.
+As mentioned in the IP fabric post, an IP fabric is also quite feasible for {{site.prodname}}, but there are more considerations that must be taken into account. The Ethernet fabric option has fewer architectural considerations in its design.
 
-## A brief note about Ethernet topology
+### A brief note about Ethernet topology
 
-As mentioned elsewhere in the {{site.prodname}} documentation, since {{site.prodname}} can use
-most of the standard IP tooling, some interesting options regarding
-fabric topology become possible.
+As mentioned elsewhere in the {{site.prodname}} documentation, because {{site.prodname}} can use most of the standard IP tooling, some interesting options regarding fabric topology become possible.
 
-We assume that an Ethernet fabric for {{site.prodname}} would most likely be
-constructed as a *leaf/spine* architecture. Other options are possible,
-but the *leaf/spine* is the predominant architectural model in use in
+We assume that an Ethernet fabric for {{site.prodname}} would most likely be constructed as a *leaf/spine* architecture. Other options are possible, but the *leaf/spine* is the predominant architectural model in use in
 scale-out infrastructure today.
 
-Since {{site.prodname}} is an IP routed fabric, a {{site.prodname}} network can use
-[ECMP](https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing){:target="_blank"} to
-distribute traffic across multiple links (instead of using Ethernet
-techniques such as MLAG). By leveraging ECMP load balancing on the
-{{site.prodname}} compute servers, it is possible to build the fabric out of
-multiple *independent* leaf/spine planes using no technologies other
-than IP routing in the {{site.prodname}} nodes, and basic Ethernet switching in the
-interconnect fabric. These planes would operate completely independently
-and could be designed such that they would not share a fault domain.
-This would allow for the catastrophic failure of one (or more) plane(s)
-of Ethernet interconnect fabric without the loss of the pod (the failure
-would just decrease the amount of interconnect bandwidth in the pod).
-This is a gentler failure mode than the pod-wide IP or Ethernet failure
-that is possible with today's designs.
+Because {{site.prodname}} is an IP routed fabric, a {{site.prodname}} network can use {% include open-new-window.html text='ECMP' url='https://en.wikipedia.org/wiki/Equal-cost_multi-path_routing' %} to distribute traffic across multiple links (instead of using Ethernet techniques such as MLAG). By leveraging ECMP load balancing on the {{site.prodname}} compute servers, it is possible to build the fabric out of multiple *independent* leaf/spine planes using no technologies other than IP routing in the {{site.prodname}} nodes, and basic Ethernet switching in the interconnect fabric. These planes would operate completely independently and could be designed such that they would not share a fault domain. This would allow for the catastrophic failure of one (or more) plane(s) of Ethernet interconnect fabric without the loss of the pod (the failure would just decrease the amount of interconnect bandwidth in the pod). This is a gentler failure mode than the pod-wide IP or Ethernet failure that is possible with today's designs.
 
-A more in-depth discussion is possible, so if you'd like, please make a
-request, and I will put up a post or white paper. In the meantime, it
-may be interesting to venture over to Facebook's [blog
-post](https://code.facebook.com/posts/360346274145943/introducing-data-center-fabric-the-next-generation-facebook-data-center-network/){:target="_blank"}
-on their fabric approach. A quick picture to visualize the idea is shown
-below.
+You might find this {% include open-new-window.html text='Facebook blog
+post' url='https://code.facebook.com/posts/360346274145943/introducing-data-center-fabric-the-next-generation-facebook-data-center-network/' %} on their fabric approach interesting. A graphic to visualize the idea is shown below.
 
-![A diagram showing the Ethernet spine planes. Each color represents a
-distinct Ethernet network, transporting a unique IP
-network.]({{site.baseurl}}/images/l2-spine-planes.png)
+![Ethernet spine planes]({{site.baseurl}}/images/l2-spine-planes.png)
 
-I am not showing the end points in this diagram, and the end points
-would be unaware of anything in the fabric (as noted above).
+The diagram does not show the endpoints in this diagram, and the endpoints would be unaware of anything in the fabric (as noted above).
 
-In the particular case of this diagram, each ToR is segmented into four
-logical switches (possibly by using 'port VLANs'), [^2] and each compute
-server has a connection to each of those logical switches. We will
-identify those logical switches by their color. Each ToR would then have
-a blue, green, orange, and red logical switch. Those 'colors' would be
-members of a given *plane*, so there would be a blue plane, a green
-plane, an orange plane, and a red plane. Each plane would have a
-dedicated spine switch. and each ToR in a given spine would be connected
-to its spine, and only its spine.
+In this diagram, each ToR is segmented into four logical switches (possibly by using 'port VLANs'), ([note 2](#note-2)) and each compute server has a connection to each of those logical switches. We will identify those logical switches by their color. Each ToR would then have a blue, green, orange, and red logical switch. Those 'colors' would be members of a given *plane*, so there would be a blue plane, a green plane, an orange plane, and a red plane. Each plane would have a dedicated spine switch. and each ToR in a given spine would be connected to its spine, and only its spine.
 
-Each plane would constitute an IP network, so the blue plane would be
-2001:db8:1000::/36, the green would be 2001:db8:2000::/36, and the
-orange and red planes would be 2001:db8:3000::/36 and 2001:db8:4000::/36
-respectively. [^3]
+Each plane would constitute an IP network, so the blue plane would be 2001:db8:1000::/36, the green would be 2001:db8:2000::/36, and the orange and red planes would be 2001:db8:3000::/36 and 2001:db8:4000::/36 respectively ([note 3](#note-3)).
 
-Each IP network (plane) requires it's own BGP route reflectors. Those
-route reflectors need to be peered with each other within the plane, but
-the route reflectors in each plane do not need to be peered with one
-another. Therefore, a fabric of four planes would have four route
-reflector meshes. Each compute server, border router, *etc.* would need
-to be a route reflector client of at least one route reflector in each
-plane, and very preferably two or more in each plane.
+Each IP network (plane) requires it's own BGP route reflectors. Those route reflectors need to be peered with each other within the plane, but the route reflectors in each plane do not need to be peered with one another. Therefore, a fabric of four planes would have four route reflector meshes. Each compute server, border router, *etc.* would need
+to be a route reflector client of at least one route reflector in each plane, and very preferably two or more in each plane.
 
-A diagram that visualizes the route reflector environment can be found
-below.
+The following diagram visualizes the route reflector environment.
 
-![A diagram showing the route reflector topology in the l2 spine plane
-architecture. The dashed diamonds are the route reflectors, with one or
-more per L2 spine plane. All compute servers are peered to all route
-reflectors, and all the route reflectors in a given plane are also
-meshed. However, the route reflectors in each spine plane are not meshed
-together (*e.g.* the *blue* route reflectors are not peered or meshed
-with the *red* route reflectors. The route reflectors themselves could
-be daemons running on the actual compute servers or on other dedicated
-or networking hardware.]({{site.baseurl}}/images/l2-rr-spine-planes.png)
+![route-reflector]({{site.baseurl}}/images/l2-rr-spine-planes.png)
 
-These route reflectors could be dedicated hardware connected to the
-spine switches (or the spine switches themselves), or physical or
-virtual route reflectors connected to the necessary logical leaf
-switches (blue, green, orange, and red). That may be a route reflector
-running on a compute server and connected directly to the correct plane
-link, and not routed through the vRouter, to avoid the chicken and egg
-problem that would occur if the route reflector were "behind" the {{site.prodname}}
-network.
+These route reflectors could be dedicated hardware connected to the spine switches (or the spine switches themselves), or physical or virtual route reflectors connected to the necessary logical leaf switches (blue, green, orange, and red). That may be a route reflector running on a compute server and connected directly to the correct plane link, and not routed through the vRouter, to avoid the chicken and egg problem that would occur if the route reflector were "behind" the {{site.prodname}} network.
 
-Other physical and logical configurations and counts are, of course,
-possible, this is just an example.
+Other physical and logical configurations and counts are, of course, possible, this is just an example.
 
-The logical configuration would then have each compute server would have
-an address on each plane's subnet, and announce its end points on each
-subnet. If ECMP is then turned on, the compute servers would distribute
-the load across all planes.
+The logical configuration would then have each compute server would have an address on each plane's subnet, and announce its endpoints on each subnet. If ECMP is then turned on, the compute servers would distribute the load across all planes.
 
-If a plane were to fail (say due to a spanning tree failure), then only
-that one plane would fail. The remaining planes would stay running.
+If a plane were to fail (say due to a spanning tree failure), then only that one plane would fail. The remaining planes would stay running.
 
-[^1]: In this document (and in all {{site.prodname}} documents) we tend to use the
-    terms *end point* to refer to a virtual machine, container,
-    appliance, bare metal server, or any other entity that is connected
-    to a {{site.prodname}} network. If we are referring to a specific type of end
-    point, we will call that out (such as referring to the behavior of
-    VMs as distinct from containers).
+#### Footnotes
 
-[^2]: We are using logical switches in this example. Physical ToRs could
-    also be used, or a mix of the two (say 2 logical switches hosted on
-    each physical switch).
+#### Note 1
 
-[^3]: We use IPv6 here purely as an example. IPv4 would be configured
-    similarly. I welcome your questions, either here on the blog, or via
-    the Project Calico mailing list.
+In this document (and in all {{site.prodname}} documents) we tend to use the term *endpoint* to refer to a virtual machine, container, appliance, bare metal server, or any other entity that is connected to a {{site.prodname}} network. If we are referring to a specific type of endpoint, we will call that out (such as referring to the behavior of VMs as distinct from containers).
+
+#### Note 2
+
+We are using logical switches in this example. Physical ToRs could also be used, or a mix of the two (say 2 logical switches hosted on each physical switch).
+
+#### Note 3 
+
+We use IPv6 here purely as an example. IPv4 would be configured similarly. 

--- a/calico/reference/architecture/design/l3-interconnect-fabric.md
+++ b/calico/reference/architecture/design/l3-interconnect-fabric.md
@@ -4,264 +4,129 @@ description: Understand considerations for implementing interconnect fabrics wit
 canonical_url: '/reference/architecture/design/l3-interconnect-fabric'
 ---
 
-{{site.prodname}} provides an end-to-end IP network that interconnects the
-endpoints [^1] in a scale-out or cloud environment. To do that, it needs
-an *interconnect fabric* to provide the physical networking layer on
-which {{site.prodname}} operates [^2].
+{{site.prodname}} provides an end-to-end IP network that interconnects the endpoints ([note 1](#note-1)) in a scale-out or cloud environment. To do that, it needs an *interconnect fabric* to provide the physical networking layer on which {{site.prodname}} operates ([note 2](#note-2)).
 
-While {{site.prodname}} is designed to work with any underlying interconnect fabric
-that can support IP traffic, the fabric that has the least
-considerations attached to its implementation is an Ethernet fabric as
-discussed in our earlier [technical note]({{ site.baseurl }}/reference/architecture/design/l2-interconnect-fabric).
+Although {{site.prodname}} is designed to work with any underlying interconnect fabric that can support IP traffic, the fabric that has the least considerations attached to its implementation is an Ethernet fabric as
+discussed in [Calico over Ethernet fabrics]({{site.baseurl}}/reference/architecture/design/l2-interconnect-fabric).
 
-In most cases, the Ethernet fabric is the appropriate choice, but there
-are infrastructures where L3 (an IP fabric) has already been deployed,
-or will be deployed, and it makes sense for {{site.prodname}} to operate in those
+In most cases, the Ethernet fabric is the appropriate choice, but there are infrastructures where L3 (an IP fabric) has already been deployed, or will be deployed, and it makes sense for {{site.prodname}} to operate in those
 environments.
 
-However, since {{site.prodname}} is, itself, a routed infrastructure, there are
-more engineering, architecture, and operations considerations that have
-to be weighed when running {{site.prodname}} with an IP routed interconnection
-fabric. We will briefly outline those in the rest of this post. That
-said, {{site.prodname}} operates equally well with Ethernet or IP interconnect
-fabrics.
+However, because {{site.prodname}} is, itself, a routed infrastructure, there are more engineering, architecture, and operations considerations that have to be weighed when running {{site.prodname}} with an IP routed interconnection
+fabric. We will briefly outline those in the rest of this post. That said, {{site.prodname}} operates equally well with Ethernet or IP interconnect fabrics.
 
-## Background
+### Background
 
-### Basic {{site.prodname}} architecture overview
+#### Basic {{site.prodname}} architecture overview
 
-A description of the {{site.prodname}} architecture can be found in our
-[architectural overview]({{ site.baseurl }}/reference/architecture/overview).
-However, a brief discussion of the routing and data paths is useful for
+A description of the {{site.prodname}} architecture can be found in our [architectural overview]({{site.baseurl}}/reference/architecture/overview). However, a brief discussion of the routing and data paths is useful for
 the discussion.
 
-In a {{site.prodname}} network, each compute server acts as a router for all of the
-endpoints that are hosted on that compute server. We call that function
-a vRouter. The data path is provided by the Linux kernel, the control
-plane by a BGP protocol server, and management plane by {{site.prodname}}'s
-on-server agent, *Felix*.
+In a {{site.prodname}} network, each compute server acts as a router for all of the endpoints that are hosted on that compute server. We call that function a vRouter. The data path is provided by the Linux kernel, the control
+plane by a BGP protocol server, and management plane by {{site.prodname}}'s on-server agent, *Felix*.
 
-Each endpoint can only communicate through its local vRouter, and the
-first and last *hop* in any {{site.prodname}} packet flow is an IP router hop
-through a vRouter. Each vRouter announces all of the endpoints it is
-attached to to all the other vRouters and other routers on the
-infrastructure fabric, using BGP, usually with BGP route reflectors to
-increase scale. A discussion of why we use BGP can be found in the [Why
-BGP?](https://www.projectcalico.org/why-bgp/){:target="_blank"} blog post.
+Each endpoint can only communicate through its local vRouter, and the first and last *hop* in any {{site.prodname}} packet flow is an IP router hop through a vRouter. Each vRouter announces all of the endpoints it is attached to to all the other vRouters and other routers on the infrastructure fabric, using BGP, usually with BGP route reflectors to
+increase scale. A discussion of why we use BGP can be found in {% include open-new-window.html text='Why BGP?' url='https://www.tigera.io/blog/why-bgp/' %}.
 
-Access control lists (ACLs) enforce security (and other) policy as
-directed by whatever cloud orchestrator is in use. There are other
-components in the {{site.prodname}} architecture, but they are irrelevant to the
-interconnect network fabric discussion.
+Access control lists (ACLs) enforce security (and other) policy as directed by whatever cloud orchestrator is in use. There are other components in the {{site.prodname}} architecture, but they are irrelevant to the interconnect network fabric discussion.
 
-### Overview of current common IP scale-out fabric architectures
+#### Overview of current common IP scale-out fabric architectures
 
-There are two approaches to building an IP fabric for a scale-out
-infrastructure. However, all of them, to date, have assumed that the
-edge router in the infrastructure is the top of rack (TOR) switch. In
-the {{site.prodname}} model, that function is pushed to the compute server itself.
+There are two approaches to building an IP fabric for a scale-out infrastructure. However, all of them, to date, have assumed that the edge router in the infrastructure is the top of rack (TOR) switch. In the {{site.prodname}} model, that function is pushed to the compute server itself.
 
-Furthermore, in most current virtualized environments, the actual
-endpoint is not addressed by the fabric. If it is a VM, it is usually
-encapsulated in an overlay, and if it is a container, it may be
-encapsulated in an overlay, or NATed by some form of proxy, such as is
-done in the [weave](http://www.weave.works/){:target="_blank"} project network model, or
-the router in standard [docker](http://www.docker.io/){:target="_blank"} networking.
+Furthermore, in most current virtualized environments, the actual endpoint is not addressed by the fabric. If it is a VM, it is usually encapsulated in an overlay, and if it is a container, it may be encapsulated in an overlay, or NATed by some form of proxy, such as is done in the {% include open-new-window.html text='Weave' url='http://www.weave.works/' %} project network model, or the router in standard {% include open-new-window.html text='Docker' url='http://www.docker.io/' %} networking.
 
-The two approaches are outlined below, in this technical note, we will
-cover the second option, as it is more common in the scale-out world. If
-there is interest in the first approach, please contact Project Calico,
-and we can discuss, and if there is enough interest, maybe we will do
-another technical note on that approach. If you know of other approaches
-in use, we would be happy to host a guest technical note.
+The two approaches are: 
 
-1.  The routing infrastructure is based on some form of IGP. Due to the
-    limitations in scale of IGP networks (see the [why BGP
-    post](https://www.projectcalico.org/why-bgp/){:target="_blank"} for discussion of this
-    topic), the Project Calico team does not believe that using an IGP
-    to distribute endpoint reachability information will adequately
-    scale in a {{site.prodname}} environment. However, it is possible to use a
-    combination of IGP and BGP in the interconnect fabric, where an IGP
-    communicates the path to the *next-hop* router (in {{site.prodname}}, this is
-    often the destination compute server) and BGP is used to distribute
-    the actual next-hop for a given endpoint. This is a valid model,
-    and, in fact is the most common approach in a widely distributed IP
-    network (say a carrier's backbone network). The design of these
-    networks is somewhat complex though, and will not be addressed
-    further in this technical note. [^3]
-2.  The other model, and the one that this note concerns itself with, is
-    one where the routing infrastructure is based entirely on BGP. In
-    this model, the IP network is "tight enough" or has a small enough
-    diameter that BGP can be used to distribute endpoint routes, and the
-    paths to the next-hops for those routes is known to all of the
-    routers in the network (in a {{site.prodname}} network this includes the
-    compute servers). This is the network model that this note
-    will address.
+**Routing infrastructure is based on some form of IGP** 
 
-### BGP-only interconnect fabrics
+Due to the limitations in scale of IGP networks, the {{site.prodname}} team does not believe that using an IGP to distribute endpoint reachability information will adequately scale in a {{site.prodname}} environment. However, it is possible to use a combination of IGP and BGP in the interconnect fabric, where an IGP communicates the path to the *next-hop* router (in {{site.prodname}}, this is often the destination compute server) and BGP is used to distribute the actual next-hop for a given endpoint. This is a valid model, and, in fact is the most common approach in a widely distributed IP network (say a carrier's backbone network). The design of these networks is somewhat complex though, and will not be addressed further in this article. ([note 3](#note-3)).
 
-There are multiple methods to build a BGP-only interconnect fabric. We
-will focus on three models, each with two widely viable variations.
-There are other options, and we will briefly touch on why we didn't
-include some of them in the [Other Options appendix](#other-options).
+**Routing infrastructure is based entirely on BGP**
+
+ In this model, the IP network is "tight enough" or has a small enough diameter that BGP can be used to distribute endpoint routes, and the paths to the next-hops for those routes is known to all of the routers in the network (in a {{site.prodname}} network this includes the compute servers). This is the network model that this note will address.
+
+In this article, we will cover the second option because it is more common in the scale-out world. 
+
+#### BGP-only interconnect fabrics
+
+There are multiple methods to build a BGP-only interconnect fabric. We will focus on three models, each with two widely viable variations. There are other options, and we will briefly touch on why we didn't include some of them in [Other Options](#other-options).
 
 The two methods are:
 
-1.  A BGP fabric where each of the TOR switches (and their subsidiary
-    compute servers) are a unique [Autonomous
-    System (AS)](https://en.wikipedia.org/wiki/Autonomous_System_(Internet)){:target="_blank"}
-    and they are interconnected via either an Ethernet switching plane
-    provided by the spine switches in a
-    [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/){:target="_blank"}
-    architecture, or via a set of spine switches, each of which is also
-    a unique AS. We'll refer to this as the *AS per rack* model. This
-    model is detailed in [IETF RFC 7938](https://datatracker.ietf.org/doc/html/rfc7938){:target="_blank"}.
-2.  A BGP fabric where each of the compute servers is a unique AS, and
-    the TOR switches make up a transit AS. We'll refer to this as the
-    *AS per server* model.
+- A BGP fabric where each of the TOR switches (and their subsidiary compute servers) are a unique {% include open-new-window.html text='Autonomous System (AS)' url='https://en.wikipedia.org/wiki/Autonomous_System_(Internet)' %}
+and they are interconnected via either an Ethernet switching plane provided by the spine switches in a {% include open-new-window.html text='leaf/spine' url='http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/' %} architecture, or via a set of spine switches, each of which is also a unique AS. We'll refer to this as the *AS per rack* model. This model is detailed in {% include open-new-window.html text='IETF RFC 7938' url='https://datatracker.ietf.org/doc/html/rfc7938' %}.
 
-Each of these models can either have an Ethernet or IP spine. In the
-case of an Ethernet spine, each spine switch provides an isolated
-Ethernet connection *plane* as in the {{site.prodname}} Ethernet interconnect
-fabric model and each TOR switch is connected to each spine switch.
+-  A BGP fabric where each of the compute servers is a unique AS, and the TOR switches make up a transit AS. We'll refer to this as the *AS per server* model.
 
-Another model is where each spine switch is a unique AS, and each TOR
-switch BGP peers with each spine switch. In both cases, the TOR switches
-use ECMP to load-balance traffic between all available spine switches.
+Each of these models can either have an Ethernet or IP spine. In the case of an Ethernet spine, each spine switch provides an isolated Ethernet connection *plane* as in the {{site.prodname}} Ethernet interconnect fabric model and each TOR switch is connected to each spine switch.
 
-### Some BGP network design considerations
+Another model is where each spine switch is a unique AS, and each TOR switch BGP peers with each spine switch. In both cases, the TOR switches use ECMP to load-balance traffic between all available spine switches.
 
-Contrary to popular opinion, BGP is actually a fairly simple protocol.
-For example, the BGP configuration on a {{site.prodname}} compute server is
-approximately sixty lines long, not counting comments. The perceived
-complexity is due to the things that you can *do* with BGP. Many uses of
-BGP involve complex policy rules, where the behavior of BGP can be
-modified to meet technical (or business, financial, political, *etc.*)
-requirements. A default {{site.prodname}} network does not venture into those
-areas, [^4] and therefore is fairly straight forward.
+#### BGP network design considerations
 
-That said, there are a few design rules for BGP that need to be kept in
-mind when designing an IP fabric that will interconnect nodes in a
-{{site.prodname}} network. These BGP design requirements *can* be worked around, if
-necessary, but doing so takes the designer out of the standard BGP
-*envelope* and should only be done by an implementer who is *very*
-comfortable with advanced BGP design.
+Contrary to popular opinion, BGP is actually a fairly simple protocol. For example, the BGP configuration on a {{site.prodname}} compute server is approximately sixty lines long, not counting comments. The perceived complexity is due to the things that you can *do* with BGP. Many uses of BGP involve complex policy rules, where the behavior of BGP can be modified to meet technical (or business, financial, political, etc.) requirements. A default {{site.prodname}} network does not venture into those areas, ([note 4](#note-4)) and therefore is fairly straight forward.
+
+That said, there are a few design rules for BGP that need to be kept in mind when designing an IP fabric that will interconnect nodes in a {{site.prodname}} network. These BGP design requirements *can* be worked around, if necessary, but doing so takes the designer out of the standard BGP *envelope* and should only be done by an implementer who is *very* comfortable with advanced BGP design.
 
 These considerations are:
 
-AS continuity
+- AS continuity or *AS puddling* 
 
-:   or *AS puddling* Any router in an AS *must* be able to communicate
-    with any other router in that same AS without transiting another AS.
+   Any router in an AS *must* be able to communicate with any other router in that same AS without transiting another AS.
 
-Next hop behavior
+- Next hop behavior
 
-:   By default BGP routers do not change the *next hop* of a route if it
-    is peering with another router in its same AS. The inverse is also
-    true, a BGP router will set itself as the *next hop* of a route if
-    it is peering with a router in another AS.
+   By default BGP routers do not change the *next hop* of a route if it is peering with another router in its same AS. The inverse is also true, a BGP router will set itself as the *next hop* of a route if it is peering with a router in another AS.
 
-Route reflection
+- Route reflection
 
-:   All BGP routers in a given AS must *peer* with all the other routers
-    in that AS. This is referred to a *complete BGP mesh*. This can
-    become problematic as the number of routers in the AS scales up. The
-    use of *route reflectors* reduce the need for the complete BGP mesh.
-    However, route reflectors also have scaling considerations.
+   All BGP routers in a given AS must *peer* with all the other routers in that AS. This is referred to a *complete BGP mesh*. This can become problematic as the number of routers in the AS scales up. The use of *route reflectors* reduce the need for the complete BGP mesh. However, route reflectors also have scaling considerations.
 
-Endpoints
+- Endpoints
 
-:   In a {{site.prodname}} network, each endpoint is a route. Hardware networking
-    platforms are constrained by the number of routes they can learn.
-    This is usually in range of 10,000's or 100,000's of routes. Route
-    aggregation can help, but that is usually dependent on the
-    capabilities of the scheduler used by the orchestration software
-    (*e.g.* OpenStack).
+   In a {{site.prodname}} network, each endpoint is a route. Hardware networking platforms are constrained by the number of routes they can learn. This is usually in range of 10,000's or 100,000's of routes. Route aggregation can help, but that is usually dependent on the capabilities of the scheduler used by the orchestration software (*e.g.* OpenStack).
 
-A deeper discussion of these considerations can be found in the IP
-Fabric Design Considerations\_ appendix.
+A deeper discussion of these considerations can be found in the [IP Fabric Design Considerations](#ip-fabric-design-considerations).
 
 The designs discussed below address these considerations.
 
-### The *AS Per Rack* model
+#### The AS Per Rack model
 
-This model is the closest to the model suggested by [IETF RFC 7938](https://datatracker.ietf.org/doc/html/rfc7938){:target="_blank"}.
+This model is the closest to the model suggested by {% include open-new-window.html text='IETF RFC 7938' url='https://datatracker.ietf.org/doc/html/rfc7938' %}.
 
-As mentioned earlier, there are two versions of this model, one with an
-set of Ethernet planes interconnecting the ToR switches, and the other
-where the core planes are also routers. The following diagrams may be
-useful for the discussion.
+As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion. 
 
 ![]({{site.baseurl}}/images/l3-fabric-diagrams-as-rack-l2-spine.png)
 
-The diagram above shows the *AS per rack model* where the ToR switches are
-physically meshed via a set of Ethernet switching planes.
+The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
 ![]({{site.baseurl}}/images/l3-fabric-diagrams-as-rack-l3-spine.png)
 
-The diagram above shows the *AS per rack model* where the ToR switches are
-physically meshed via a set of discrete BGP spine routers, each in
-their own AS.
+The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
-In this approach, every ToR-ToR or ToR-Spine (in the case of an AS per
-spine) link is an eBGP peering which means that there is no
-route-reflection possible (using standard BGP route reflectors) *north*
-of the ToR switches.
+In this approach, every ToR-ToR or ToR-Spine (in the case of an AS per spine) link is an eBGP peering which means that there is no route-reflection possible (using standard BGP route reflectors) *north* of the ToR switches.
 
-If the L2 spine option is used, the result of this is that each ToR must
-either peer with every other ToR switch in the cluster (which could be
-hundreds of peers).
+If the L2 spine option is used, the result of this is that each ToR must either peer with every other ToR switch in the cluster (which could be hundreds of peers).
 
-If the AS per spine option is used, then each ToR only has to peer with
-each spine (there are usually somewhere between two and sixteen spine
-switches in a pod). However, the spine switches must peer with all ToR
-switches (again, that would be hundreds, but most spine switches have
-more control plane capacity than the average ToR, so this might be more
-scalable in many circumstances).
+If the AS per spine option is used, then each ToR only has to peer with each spine (there are usually somewhere between two and sixteen spine switches in a pod). However, the spine switches must peer with all ToR
+switches (again, that would be hundreds, but most spine switches have more control plane capacity than the average ToR, so this might be more scalable in many circumstances).
 
-Within the rack, the configuration is the same for both variants, and is
-somewhat different than the configuration north of the ToR.
+Within the rack, the configuration is the same for both variants, and is somewhat different than the configuration north of the ToR.
 
-Every router within the rack, which, in the case of {{site.prodname}} is every
-compute server, shares the same AS as the ToR that they are connected
-to. That connection is in the form of an Ethernet switching layer. Each
-router in the rack must be directly connected to enable the AS to remain
-contiguous. The ToR's *router* function is then connected to that
-Ethernet switching layer as well. The actual configuration of this is
-dependent on the ToR in use, but usually it means that the ports that
-are connected to the compute servers are treated as *subnet* or
-*segment* ports, and then the ToR's *router* function has a single
-interface into that subnet.
+Every router within the rack, which, in the case of {{site.prodname}} is every compute server, shares the same AS as the ToR that they are connected to. That connection is in the form of an Ethernet switching layer. Each router in the rack must be directly connected to enable the AS to remain contiguous. The ToR's *router* function is then connected to that Ethernet switching layer as well. The actual configuration of this is dependent on the ToR in use, but usually it means that the ports that are connected to the compute servers are treated as *subnet* or *segment* ports, and then the ToR's *router* function has a single interface into that subnet.
 
-This configuration allows each compute server to connect to each other
-compute server in the rack without going through the ToR router, but it
-will, of course, go through the ToR switching function. The compute
-servers and the ToR router could all be directly meshed, or a route
-reflector could be used within the rack, either hosted on the ToR
-itself, or as a virtual function hosted on one or more compute servers
-within the rack.
+This configuration allows each compute server to connect to each other compute server in the rack without going through the ToR router, but it will, of course, go through the ToR switching function. The compute servers and the ToR router could all be directly meshed, or a route reflector could be used within the rack, either hosted on the ToR
+itself, or as a virtual function hosted on one or more compute servers within the rack.
 
-The ToR, as the eBGP router redistributes all of the routes from other
-ToRs as well as routes external to the data center to the compute
-servers that are in its AS, and announces all of the routes from within
-the AS (rack) to the other ToRs and the larger world. This means that
-each compute server will see the ToR as the next hop for all external
-routes, and the individual compute servers are the next hop for all
-routes internal to the rack.
+The ToR, as the eBGP router redistributes all of the routes from other ToRs as well as routes external to the data center to the compute servers that are in its AS, and announces all of the routes from within
+the AS (rack) to the other ToRs and the larger world. This means that each compute server will see the ToR as the next hop for all external routes, and the individual compute servers are the next hop for all routes internal to the rack.
 
-### The *AS per Compute Server* model
+#### The AS per Compute Server model
 
-This model takes the concept of an AS per rack to its logical
-conclusion. In the earlier referenced [IETF RFC 7938](https://datatracker.ietf.org/doc/html/rfc7938){:target="_blank"}
-the assumption in the overall model is that the ToR is first tier
-aggregating and routing element. In {{site.prodname}}, the ToR, if it is an L3
-router, is actually the second tier. Remember, in {{site.prodname}}, the compute
-server is always the first/last router for an endpoint, and is also the
-first/last point of aggregation.
+This model takes the concept of an AS per rack to its logical conclusion. In the earlier referenced {% include open-new-window.html text='IETF RFC 7938' url='https://datatracker.ietf.org/doc/html/rfc7938' %} the assumption in the overall model is that the ToR is first tier aggregating and routing element. In {{site.prodname}}, the ToR, if it is an L3 router, is actually the second tier. Remember, in {{site.prodname}}, the compute server is always the first/last router for an endpoint, and is also the first/last point of aggregation.
 
-Therefore, if we follow the architecture of the draft, the compute
-server, not the ToR should be the AS boundary. The differences can be
-seen in the following two diagrams.
+Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
 ![]({{site.baseurl}}/images/l3-fabric-diagrams-as-server-l2-spine.png)
 
@@ -270,294 +135,150 @@ switches are physically meshed via a set of Ethernet switching planes.
 
 ![]({{site.baseurl}}/images/l3-fabric-diagrams-as-server-l3-spine.png)
 
-The diagram above shows the *AS per compute server model* where the ToR
-switches are physically connected to a set of independent routing
-planes.
+The diagram above shows the *AS per compute server model* where the ToR switches are physically connected to a set of independent routing planes.
 
-As can be seen in these diagrams, there are still the same two variants
-as in the *AS per rack* model, one where the spine switches provide a
-set of independent Ethernet planes to interconnect the ToR switches, and
-the other where that is done by a set of independent routers.
+As can be seen in these diagrams, there are still the same two variants as in the *AS per rack* model, one where the spine switches provide a set of independent Ethernet planes to interconnect the ToR switches, and the other where that is done by a set of independent routers.
 
-The real difference in this model, is that the compute servers as well
-as the ToR switches are all independent autonomous systems. To make this
-work at scale, the use of four byte AS numbers as discussed in
-[RFC 4893](http://www.faqs.org/rfcs/rfc4893.html "RFC 4893"){:target="_blank"}. Without
-using four byte AS numbering, the total number of ToRs and compute
-servers in a {{site.prodname}} fabric would be limited to the approximately five
-thousand available private AS [^5] numbers. If four byte AS numbers are
-used, there are approximately ninety-two million private AS numbers
-available. This should be sufficient for any given {{site.prodname}} fabric.
+The real difference in this model, is that the compute servers as well as the ToR switches are all independent autonomous systems. To make this work at scale, the use of four byte AS numbers as discussed in {% include open-new-window.html text='RFC 4893' url='http://www.faqs.org/rfcs/rfc4893.html' %}. Without
+using four byte AS numbering, the total number of ToRs and compute servers in a {{site.prodname}} fabric would be limited to the approximately five thousand available private AS ([note 5](#note-5)) numbers. If four byte AS numbers are used, there are approximately ninety-two million private AS numbers available. This should be sufficient for any given {{site.prodname}} fabric.
 
-The other difference in this model *vs.* the AS per rack model, is that
-there are no route reflectors used, as all BGP peerings are eBGP. In
-this case, each compute server in a given rack peers with its ToR switch
-which is also acting as an eBGP router. For two servers within the same
-rack to communicate, they will be routed through the ToR. Therefore,
-each server will have one peering to each ToR it is connected to, and
-each ToR will have a peering with each compute server that it is
-connected to (normally, all the compute servers in the rack).
+The other difference in this model *vs.* the AS per rack model, is that there are no route reflectors used, as all BGP peerings are eBGP. In this case, each compute server in a given rack peers with its ToR switch which is also acting as an eBGP router. For two servers within the same rack to communicate, they will be routed through the ToR. Therefore, each server will have one peering to each ToR it is connected to, and each ToR will have a peering with each compute server that it is connected to (normally, all the compute servers in the rack).
 
-The inter-ToR connectivity considerations are the same in scale and
-scope as in the AS per rack model.
+The inter-ToR connectivity considerations are the same in scale and scope as in the AS per rack model.
 
-### The *Downward Default* model
+#### The Downward Default model
 
-The final model is a bit different. Whereas, in the previous models, all
-of the routers in the infrastructure carry full routing tables, and
-leave their AS paths intact, this model [^6] removes the AS numbers at
-each stage of the routing path. This is to prevent routes from other
-nodes in the network from not being installed due to it coming from the
-*local* AS (since they share the source and dest of the route share the
-same AS).
+The final model is a bit different. Whereas, in the previous models, all of the routers in the infrastructure carry full routing tables, and leave their AS paths intact, this model ([note 6](#note-6)) removes the AS numbers at
+each stage of the routing path. This is to prevent routes from other nodes in the network from not being installed due to it coming from the *local* AS (since they share the source and dest of the route share the same AS).
 
 The following diagram will show the AS relationships in this model.
 
 ![]({{site.baseurl}}/images/l3-fabric-downward-default.png)
 
-In the diagram above, we are showing that all {{site.prodname}} nodes share the same
-AS number, as do all ToR switches. However, those ASs are different
-(*A1* is not the same network as *A2*, even though the both share the
+In the diagram above, we are showing that all {{site.prodname}} nodes share the same AS number, as do all ToR switches. However, those ASs are different (*A1* is not the same network as *A2*, even though the both share the
 same AS number *A* ).
 
-While the use of a single AS for all ToR switches, and another for all
-compute servers simplifies deployment (standardized configuration), the
-real benefit comes in the offloading of the routing tables in the ToR
+Although the use of a single AS for all ToR switches, and another for all compute servers simplifies deployment (standardized configuration), the real benefit comes in the offloading of the routing tables in the ToR
 switches.
 
-In this model, each router announces all of its routes to its upstream
-peer (the {{site.prodname}} routers to their ToR, the ToRs to the spine switches).
-However, in return, the upstream router only announces a default route.
-In this case, a given {{site.prodname}} router only has routes for the endpoints
-that are locally hosted on it, as well as the default from the ToR.
-Since the ToR is the only route for the {{site.prodname}} network the rest of the
-network, this matches reality. The same happens between the ToR switches
-and the spine. This means that the ToR only has to install the routes
-that are for endpoints that are hosted on its downstream {{site.prodname}} nodes.
-Even if we were to host 200 endpoints per {{site.prodname}} node, and stuff 80
-{{site.prodname}} nodes in each rack, that would still limit the routing table on
-the ToR to a maximum of 16,000 entries (well within the capabilities of
+In this model, each router announces all of its routes to its upstream peer (the {{site.prodname}} routers to their ToR, the ToRs to the spine switches). However, in return, the upstream router only announces a default route.
+In this case, a given {{site.prodname}} router only has routes for the endpoints that are locally hosted on it, as well as the default from the ToR. Because the ToR is the only route for the {{site.prodname}} network the rest of the
+network, this matches reality. The same happens between the ToR switches and the spine. This means that the ToR only has to install the routes that are for endpoints that are hosted on its downstream {{site.prodname}} nodes.
+Even if we were to host 200 endpoints per {{site.prodname}} node, and stuff 80 {{site.prodname}} nodes in each rack, that would still limit the routing table on the ToR to a maximum of 16,000 entries (well within the capabilities of
 even the most modest of switches).
 
-Since the default is originated by the Spine (originally) there is no
-chance for a downward announced route to originate from the recipient's
-AS, preventing the *AS puddling* problem.
+Because the default is originated by the Spine (originally) there is no chance for a downward announced route to originate from the recipient's AS, preventing the **AS puddling** problem.
 
-There is one (minor) drawback to this model, in that all traffic that is
-destined for an invalid destination (the destination IP does not exist)
-will be forwarded to the spine switches before they are dropped.
+There is one (minor) drawback to this model, in that all traffic that is destined for an invalid destination (the destination IP does not exist) will be forwarded to the spine switches before they are dropped.
 
-It should also be noted that the spine switches do need to carry all of
-the {{site.prodname}} network routes, just as they do in the routed spines in the
-previous examples. In short, this model imposes no more load on the
-spines than they already would have, and substantially reduces the
-amount of routing table space used on the ToR switches. It also reduces
-the number of routes in the {{site.prodname}} nodes, but, as we have discussed
-before, that is not a concern in most deployments as the amount of
-memory consumed by a full routing table in {{site.prodname}} is a fraction of the
-total memory available on a modern compute server.
+It should also be noted that the spine switches do need to carry all of the {{site.prodname}} network routes, just as they do in the routed spines in the previous examples. In short, this model imposes no more load on the
+spines than they already would have, and substantially reduces the amount of routing table space used on the ToR switches. It also reduces the number of routes in the {{site.prodname}} nodes, but, as we have discussed
+before, that is not a concern in most deployments as the amount of memory consumed by a full routing table in {{site.prodname}} is a fraction of the total memory available on a modern compute server.
 
-## Recommendation
+### Recommendation
 
-The Project Calico team recommends the use of the [AS per rack](#the-as-per-rack-model) model if
-the resultant routing table size can be accommodated by the ToR and
-spine switches, remembering to account for projected growth.
+The {{site.prodname}} team recommends the use of the [AS per rack](#the-as-per-rack-model) model if the resultant routing table size can be accommodated by the ToR and spine switches, remembering to account for projected growth.
 
-If there is concern about the route table size in the ToR switches, the
-team recommends the [Downward Default](#the-downward-default-model) model.
+If there is concern about the route table size in the ToR switches, the {{site.prodname}}recommends the [Downward Default](#the-downward-default-model) model.
 
-If there are concerns about both the spine and ToR switch route table
-capacity, or there is a desire to run a very simple L2 fabric to connect
-the {{site.prodname}} nodes, then the user should consider the Ethernet fabric as
-detailed in [this post]({{ site.baseurl }}/reference/architecture/design/l2-interconnect-fabric).
+If there are concerns about both the spine and ToR switch route table capacity, or there is a desire to run a very simple L2 fabric to connect the {{site.prodname}} nodes, then the user should consider the Ethernet fabric as
+detailed in [Calico over Ethernet fabrics]({{site.baseurl}}/reference/architecture/design/l2-interconnect-fabric).
 
-If a {{site.prodname}} user is interested in the AS per compute server, the Project
-Calico team would be very interested in discussing the deployment of
-that model.
+If you are interested in the AS per compute server, the {{site.prodname}} team would be very interested in discussing the deployment of that model.
 
-## Appendix
+### Other options
 
-### Other Options
+The way the physical and logical connectivity is laid out in this article, and the [Ethernet fabric]({{site.baseurl}}/reference/architecture/design/l2-interconnect-fabric), the next hop router for a given route is always directly connected to the router receiving that route. This makes the need for another protocol to distribute the next hop routes unnecessary.
 
-The way the physical and logical connectivity is laid out in this note,
-and the [Ethernet fabric note]({{ site.baseurl }}/reference/architecture/design/l2-interconnect-fabric),
-The next hop router for a given route is always directly connected to
-the router receiving that route. This makes the need for another
-protocol to distribute the next hop routes unnecessary.
+However, in many (or most) WAN BGP networks, the routers within a given AS may not be directly adjacent. Therefore, a router may receive a route with a next hop address that it is not directly adjacent to. In those cases, an IGP, such as OSPF or IS-IS, is used by the routers within a given AS to determine the path to the BGP next hop route.
 
-However, in many (or most) WAN BGP networks, the routers within a given
-AS may not be directly adjacent. Therefore, a router may receive a route
-with a next hop address that it is not directly adjacent to. In those
-cases, an IGP, such as OSPF or IS-IS, is used by the routers within a
-given AS to determine the path to the BGP next hop route.
-
-There may be {{site.prodname}} architectures where there are similar models where
-the routers within a given AS are not directly adjacent. In those
-models, the use of an IGP in {{site.prodname}} may be warranted. The configuration
+There may be {{site.prodname}} architectures where there are similar models where the routers within a given AS are not directly adjacent. In those models, the use of an IGP in {{site.prodname}} may be warranted. The configuration
 of those protocols are, however, beyond the scope of this technical
 note.
 
-### IP Fabric Design Considerations
+#### IP fabric design considerations
 
-#### AS puddling
+**AS puddling**
 
-The first consideration is that an AS must be kept contiguous. This
-means that any two nodes in a given AS must be able to communicate
-without traversing any other AS. If this rule is not observed, the
-effect is often referred to as *AS puddling* and the network will *not*
-function correctly.
+The first consideration is that an AS must be kept contiguous. This means that any two nodes in a given AS must be able to communicate without traversing any other AS. If this rule is not observed, the effect is often referred to as *AS puddling* and the network will *not* function correctly.
 
-A corollary of that rule is that any two administrative regions that
-share the same AS number, are in the same AS, even if that was not the
-desire of the designer. BGP has no way of identifying if an AS is local
-or foreign other than the AS number. Therefore re-use of an AS number
-for two *networks* that are not directly connected, but only connected
-through another *network* or AS number will not work without a lot of
-policy changes to the BGP routers.
+A corollary of that rule is that any two administrative regions that share the same AS number, are in the same AS, even if that was not the desire of the designer. BGP has no way of identifying if an AS is local or foreign other than the AS number. Therefore re-use of an AS number for two *networks* that are not directly connected, but only connected
+through another *network* or AS number will not work without a lot of policy changes to the BGP routers.
 
-Another corollary of that rule is that a BGP router will not propagate a
-route to a peer if the route has an AS in its path that is the same AS
-as the peer. This prevents loops from forming in the network. The effect
-of this prevents two routers in the same AS from transiting another
-router (either in that AS or not).
+Another corollary of that rule is that a BGP router will not propagate a route to a peer if the route has an AS in its path that is the same AS as the peer. This prevents loops from forming in the network. The effect of this prevents two routers in the same AS from transiting another router (either in that AS or not).
 
-#### Next hop behavior
+**Next hop behavior**
 
-Another consideration is based on the differences between iBGP and eBGP.
-BGP operates in two modes, if two routers are BGP peers, but share the
-same AS number, then they are considered to be in an *internal* BGP (or
-iBGP) peering relationship. If they are members of different AS's, then
-they are in an *external* or eBGP relationship.
+Another consideration is based on the differences between iBGP and eBGP. BGP operates in two modes, if two routers are BGP peers, but share the same AS number, then they are considered to be in an *internal* BGP (or iBGP) peering relationship. If they are members of different AS's, then they are in an *external* or eBGP relationship.
 
-BGP's original design model was that all BGP routers within a given AS
-would know how to get to one another (via static routes, IGP [^7]
-routing protocols, or the like), and that routers in different ASs would
+BGP's original design model was that all BGP routers within a given AS would know how to get to one another (via static routes, IGP ([note 7](#note-7)) routing protocols, or the like), and that routers in different ASs would
 not know how to reach one another unless they were directly connected.
 
-Based on that design point, routers in an iBGP peering relationship
-assume that they do not transit traffic for other iBGP routers in a
-given AS (i.e. A can communicate with C, and therefore will not need to
-route through B), and therefore, do not change the *next hop* attribute
-in BGP [^8].
+Based on that design point, routers in an iBGP peering relationship assume that they do not transit traffic for other iBGP routers in a given AS (i.e. A can communicate with C, and therefore will not need to route through B), and therefore, do not change the *next hop* attribute in BGP ([note 8](#note-8)).
 
-A router with an eBGP peering, on the other hand, assumes that its eBGP
-peer will not know how to reach the next hop route, and then will
-substitute its own address in the next hop field. This is often referred
+A router with an eBGP peering, on the other hand, assumes that its eBGP peer will not know how to reach the next hop route, and then will substitute its own address in the next hop field. This is often referred
 to as *next hop self*.
 
-In the {{site.prodname}} [Ethernet fabric]({{ site.baseurl }}/reference/architecture/design/l2-interconnect-fabric)
-model, all of the compute servers (the routers in a {{site.prodname}} network) are
-directly connected over one or more Ethernet network(s) and therefore
-are directly reachable. In this case, a router in the {{site.prodname}} network
+In the {{site.prodname}} [Ethernet fabric]({{site.baseurl}}/reference/architecture/design/l2-interconnect-fabric)
+model, all of the compute servers (the routers in a {{site.prodname}} network) are directly connected over one or more Ethernet network(s) and therefore are directly reachable. In this case, a router in the {{site.prodname}} network
 does not need to set *next hop self* within the {{site.prodname}} fabric.
 
-The models we present in this technical note insure that all routes that
-may traverse a non-{{site.prodname}} router are eBGP routes, and therefore *next
-hop self* is automatically set correctly. If a deployment of {{site.prodname}} in
-an IP interconnect fabric does not satisfy that constraint, then *next
-hop self* must be appropriately configured.
+The models we present in this article ensure that all routes that may traverse a non-{{site.prodname}} router are eBGP routes, and therefore *next hop self* is automatically set correctly. If a deployment of {{site.prodname}} in
+an IP interconnect fabric does not satisfy that constraint, then *next hop self* must be appropriately configured.
 
-#### Route reflection
+**Route reflection**
 
-As mentioned above, BGP expects that all of the iBGP routers in a
-network can see (and speak) directly to one another, this is referred to
-as a *BGP full mesh*. In small networks this is not a problem, but it
-does become interesting as the number of routers increases. For example,
-if you have 99 BGP routers in an AS and wish to add one more, you would
-have to configure the peering to that new router on each of the 99
-existing routers. Not only is this a problem at configuration time, it
-means that each router is maintaining 100 protocol adjacencies, which
-can start being a drain on constrained resources in a router. While this
-might be *interesting* at 100 routers, it becomes an impossible task
-with 1000's or 10,000's of routers (the potential size of a {{site.prodname}}
-network).
+As mentioned above, BGP expects that all of the iBGP routers in a network can see (and speak) directly to one another, this is referred to as a *BGP full mesh*. In small networks this is not a problem, but it does become interesting as the number of routers increases. For example, if you have 99 BGP routers in an AS and wish to add one more, you would
+have to configure the peering to that new router on each of the 99 existing routers. Not only is this a problem at configuration time, it means that each router is maintaining 100 protocol adjacencies, which can start being a drain on constrained resources in a router. While this might be *interesting* at 100 routers, it becomes an impossible task
+with 1000's or 10,000's of routers (the potential size of a {{site.prodname}} network).
 
-Conveniently, large scale/Internet scale networks solved this problem
-almost 20 years ago by deploying BGP route reflection as described in
-[RFC 1966](http://www.faqs.org/rfcs/rfc1966.html "RFC 1966"){:target="_blank"}. This is a
-technique supported by almost all BGP routers today. In a large network,
-a number of route reflectors [^9] are evenly distributed and each iBGP
-router is *peered* with one or more route reflectors (usually 2 or 3).
-Each route reflector can handle 10's or 100's of route reflector clients
-(in {{site.prodname}}'s case, the compute server), depending on the route reflector
-being used. Those route reflectors are, in turn, peered with each other.
-This means that there are an order of magnitude less route reflectors
-that need to be completely meshed, and each route reflector client is
-only configured to peer to 2 or 3 route reflectors. This is much easier
-to manage.
+Conveniently, large scale/Internet scale networks solved this problem almost 20 years ago by deploying BGP route reflection as described in {% include open-new-window.html text='RFC 1966' url='http://www.faqs.org/rfcs/rfc1966.html' %}. This is a technique supported by almost all BGP routers today. In a large network, a number of route reflectors ([note 9](#note-9)) are evenly distributed and each iBGProuter is *peered* with one or more route reflectors (usually 2 or 3). Each route reflector can handle 10's or 100's of route reflector clients (in {{site.prodname}}'s case, the compute server), depending on the route reflector being used. Those route reflectors are, in turn, peered with each other. This means that there are an order of magnitude less route reflectors that need to be completely meshed, and each route reflector client is only configured to peer to 2 or 3 route reflectors. This is much easier to manage.
 
-Other route reflector architectures are possible, but those are beyond
-the scope of this document.
+Other route reflector architectures are possible, but those are beyond the scope of this document.
 
-#### Endpoints
+**Endpoints**
 
-The final consideration is the number of endpoints in a {{site.prodname}} network.
-In the [Ethernet fabric]({{ site.baseurl }}/reference/architecture/design/l2-interconnect-fabric)
-case the number of endpoints is not constrained by the interconnect
-fabric, as the interconnect fabric does not *see* the actual endpoints,
-it only *sees* the actual vRouters, or compute servers. This is not the
-case in an IP fabric, however. IP networks forward by using the
-destination IP address in the packet, which, in {{site.prodname}}'s case, is the
-destination endpoint. That means that the IP fabric nodes (ToR switches
-and/or spine switches, for example) must know the routes to each
-endpoint in the network. They learn this by participating as route
-reflector clients in the BGP mesh, just as the {{site.prodname}} vRouter/compute
-server does.
+The final consideration is the number of endpoints in a {{site.prodname}} network. In the [Ethernet fabric]({{site.baseurl}}/reference/architecture/design/l2-interconnect-fabric) case the number of endpoints is not constrained by the interconnect fabric, as the interconnect fabric does not *see* the actual endpoints, it only *sees* the actual vRouters, or compute servers. This is not the case in an IP fabric, however. IP networks forward by using the
+destination IP address in the packet, which, in {{site.prodname}}'s case, is the destination endpoint. That means that the IP fabric nodes (ToR switches and/or spine switches, for example) must know the routes to each endpoint in the network. They learn this by participating as route reflector clients in the BGP mesh, just as the {{site.prodname}} vRouter/compute server does.
 
-However, unlike a compute server which has a relatively unconstrained
-amount of memory, a physical switch is either memory constrained, or
-quite expensive. This means that the physical switch has a limit on how
-many *routes* it can handle. The current industry standard for modern
-commodity switches is in the range of 128,000 routes. This means that,
-without other routing *tricks*, such as aggregation, a {{site.prodname}}
-installation that uses an IP fabric will be limited to the routing table
-size of its constituent network hardware, with a reasonable upper limit
+However, unlike a compute server which has a relatively unconstrained amount of memory, a physical switch is either memory constrained, or quite expensive. This means that the physical switch has a limit on how many *routes* it can handle. The current industry standard for modern commodity switches is in the range of 128,000 routes. This means that,
+without other routing *tricks*, such as aggregation, a {{site.prodname}} installation that uses an IP fabric will be limited to the routing table size of its constituent network hardware, with a reasonable upper limit
 today of 128,000 endpoints.
 
-[^1]: In {{site.prodname}}'s terminology, an endpoint is an IP address and
-    interface. It could refer to a VM, a container, or even a process
-    bound to an IP address running on a bare metal server.
+#### Footnotes
 
-[^2]: This interconnect fabric provides the connectivity between the
-    {{site.prodname}} (v)Router (in almost all cases, the compute servers) nodes,
-    as well as any other elements in the fabric (*e.g.* bare metal
-    servers, border routers, and appliances).
+#### Note 1
 
-[^3]: If there is interest in a discussion of this approach, please let
-    us know. The Project Calico team could either arrange a discussion,
-    or if there was enough interest, publish a follow-up tech note.
+In {{site.prodname}}'s terminology, an endpoint is an IP address and interface. It could refer to a VM, a container, or even a process bound to an IP address running on a bare metal server.
 
-[^4]: However those tools are available if a given {{site.prodname}} instance needs
-    to utilize those policy constructs.
+#### Note 2
 
-[^5]: The two byte AS space reserves approximately the last five
-    thousand AS numbers for private use. There is no technical reason
-    why other AS numbers could not be used. However the re-use of global
-    scope AS numbers within a private infrastructure is strongly
-    discouraged. The chance for routing system failure or incorrect
-    routing is substantial, and not restricted to the entity that is
-    doing the reuse.
+This interconnect fabric provides the connectivity between the {{site.prodname}} (v)Router (in almost all cases, the compute servers) nodes, as well as any other elements in the fabric (*e.g.* bare metal servers, border routers, and appliances).
 
-[^6]: We first saw this design in a customer's lab, and thought it
-    innovative enough to share (we asked them first, of course). Similar
-    *AS Path Stripping* approaches are used in ISP networks, however.
+#### Note 3
 
-[^7]: An Interior Gateway Protocol is a local routing protocol that does
-    not cross an AS boundary. The primary IGPs in use today are OSPF and
-    IS-IS. While complex iBGP networks still use IGP routing protocols,
-    a data center is normally a fairly simple network, even if it has
-    many routers in it. Therefore, in the data center case, the use of
-    an IGP can often be disposed of.
+If there is interest in a discussion of this approach, please let us know. The {{site.prodname}} team could either arrange a discussion, or if there was enough interest, publish a follow-up tech note.
 
-[^8]: A Next hop is an attribute of a route announced by a routing
-    protocol. In simple terms a route is defined by a *target*, or the
-    destination that is to be reached, and a *next hop*, which is the
-    next router in the path to reach that target. There are many other
-    characteristics in a route, but those are well beyond the scope of
-    this post.
+#### Note 4
 
-[^9]: A route reflector may be a physical router, a software appliance,
-    or simply a BGP daemon. It only processes routing messages, and does
-    not pass actual data plane traffic. However, some route reflectors
-    are co-resident on regular routers that do pass data plane traffic.
-    While they may sit on one platform, the functions are distinct.
+However those tools are available if a given {{site.prodname}} instance needs to utilize those policy constructs.
+
+#### Note 5
+
+The two byte AS space reserves approximately the last five thousand AS numbers for private use. There is no technical reason why other AS numbers could not be used. However the re-use of global scope AS numbers within a private infrastructure is strongly discouraged. The chance for routing system failure or incorrect routing is substantial, and not restricted to the entity that is doing the reuse.
+
+#### Note 6 
+
+We first saw this design in a customer's lab, and thought it innovative enough to share (we asked them first, of course). Similar **AS Path Stripping** approaches are used in ISP networks, however.
+
+#### Note 7
+
+An Interior Gateway Protocol is a local routing protocol that does not cross an AS boundary. The primary IGPs in use today are OSPF and IS-IS. While complex iBGP networks still use IGP routing protocols, a data center is normally a fairly simple network, even if it has many routers in it. Therefore, in the data center case, the use of an IGP can often be disposed of.
+
+#### Note 8
+
+A Next hop is an attribute of a route announced by a routing protocol. In simple terms a route is defined by a *target*, or the destination that is to be reached, and a *next hop*, which is the next router in the path to reach that target. There are many other characteristics in a route, but those are well beyond the scope of this post.
+
+#### Note 9
+
+A route reflector may be a physical router, a software appliance, or simply a BGP daemon. It only processes routing messages, and does not pass actual data plane traffic. However, some route reflectors are co-resident on regular routers that do pass data plane traffic. Although they may sit on one platform, the functions are distinct.


### PR DESCRIPTION
### Fix formatting in L2 and L3 network design docs for migration

- Ticket: https://tigera.atlassian.net/browse/DOCS-835. 
- Included general cleanup 