### PR TITLE
Docs-update-k8s-version

### DIFF
--- a/calico/getting-started/kubernetes/requirements.md
+++ b/calico/getting-started/kubernetes/requirements.md
@@ -15,6 +15,7 @@ We test {{site.prodname}} {{page.version}} against the following Kubernetes vers
 - v1.22
 - v1.23
 - v1.24
+- v1.25
 
 Due to changes in the Kubernetes API, {{site.prodname}} {{page.version}} will not work
 on Kubernetes v1.15 or below.  v1.16-v1.18 may work, but they are no longer tested. 


### PR DESCRIPTION
### Update docs to support k8s 1.25

- Added supported in Enterprise in 3.15
- Merge to /nightly only for 3.25
