### PR TITLE
[BPF] no need for src fixup for packets from wl to tunnel

### DIFF
--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -568,8 +568,6 @@ func TestNATNodePort(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
 	})
 
-	hostIP = net.IPv4(0, 0, 0, 0) // workloads do not have it set
-
 	skbMark = tcdefs.MarkSeen
 
 	// Insert the reverse route for backend for RPF check.
@@ -641,7 +639,7 @@ func TestNATNodePort(t *testing.T) {
 		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
 		Expect(ipv4L).NotTo(BeNil())
 		ipv4R := ipv4L.(*layers.IPv4)
-		Expect(ipv4R.SrcIP.String()).To(Equal(natIP.String()))
+		Expect(ipv4R.SrcIP.String()).To(Equal(hostIP.String()))
 		Expect(ipv4R.DstIP.String()).To(Equal(node1ip.String()))
 
 		checkVxlan(pktR)
@@ -651,7 +649,7 @@ func TestNATNodePort(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	expectMark(tcdefs.MarkSeenBypassForwardSourceFixup)
+	expectMark(tcdefs.MarkSeen)
 
 	hostIP = node2ip
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1168,8 +1168,7 @@ var calicoRouterIP = net.IPv4(169, 254, 1, 1).To4()
 
 func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *proto.WorkloadEndpoint, polDirection PolDirection) error {
 	ap := m.calculateTCAttachPoint(polDirection, ifaceName)
-	// Host side of the veth is always configured as 169.254.1.1.
-	ap.HostIP = calicoRouterIP
+	ap.HostIP = m.hostIP
 	// * Since we don't pass packet length when doing fib lookup, MTU check is skipped.
 	// * Hence it is safe to set the tunnel mtu same as veth mtu
 	ap.TunnelMTU = uint16(m.vxlanMTU)

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1167,6 +1167,12 @@ func isLinkNotFoundError(err error) bool {
 var calicoRouterIP = net.IPv4(169, 254, 1, 1).To4()
 
 func (m *bpfEndpointManager) attachWorkloadProgram(ifaceName string, endpoint *proto.WorkloadEndpoint, polDirection PolDirection) error {
+
+	if m.hostIP == nil {
+		// Do not bother and wait
+		return fmt.Errorf("unknown host IP")
+	}
+
 	ap := m.calculateTCAttachPoint(polDirection, ifaceName)
 	ap.HostIP = m.hostIP
 	// * Since we don't pass packet length when doing fib lookup, MTU check is skipped.
@@ -1248,6 +1254,12 @@ func (m *bpfEndpointManager) ifaceIsUp(ifaceName string) (up bool) {
 }
 
 func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, ep *proto.HostEndpoint, polDirection PolDirection) error {
+
+	if m.hostIP == nil {
+		// Do not bother and wait
+		return fmt.Errorf("unknown host IP")
+	}
+
 	ap := m.calculateTCAttachPoint(polDirection, ifaceName)
 	ap.HostIP = m.hostIP
 	ap.TunnelMTU = uint16(m.vxlanMTU)

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
+	"net"
 	"regexp"
 	"strconv"
 	"sync"
@@ -256,6 +257,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			logutils.NewSummarizer("test"),
 		)
 		bpfEpMgr.Features = environment.NewFeatureDetector(nil).GetFeatures()
+		bpfEpMgr.hostIP = net.ParseIP("1.2.3.4")
 	}
 
 	genIfaceUpdate := func(name string, state ifacemonitor.State, index int) func() {

--- a/felix/fv/ipip_test.go
+++ b/felix/fv/ipip_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
-	libapi "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
@@ -378,34 +377,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 	})
 
 	Context("external nodes configured", func() {
+
+		var externalClient *containers.Container
+
 		BeforeEach(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-			defer cancel()
-			// Remove the node addresses
-			infra.RemoveNodeAddresses(felixes[0])
-			l, err := client.Nodes().List(ctx, options.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			// Now remove the BGP configuration for felixes[0]
-			var prevBGPSpec libapi.NodeBGPSpec
-			for _, node := range l.Items {
-				log.Infof("node: %v", node)
-				if node.Name == felixes[0].Name {
-					// save the old spec
-					prevBGPSpec = *node.Spec.BGP
-					node.Spec.BGP = nil
-					_, err = client.Nodes().Update(ctx, &node, options.SetOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				}
-			}
-			// Removing the BGP config triggers a Felix restart. Wait for the ipset to be updated as a signal that Felix
-			// has restarted.
-			if !bpfEnabled {
-				for _, f := range felixes {
-					Eventually(func() int {
-						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-					}, "5s", "200ms").Should(Equal(1))
-				}
-			}
+			externalClient = infrastructure.RunExtClient("ext-client")
 
 			updateConfig := func(addr string) {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -422,31 +398,52 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 						Expect(err).NotTo(HaveOccurred())
 					}
 				}
-				c.Spec.ExternalNodesCIDRList = &[]string{addr, "1.1.1.1"}
+				c.Spec.ExternalNodesCIDRList = &[]string{addr}
 				log.WithFields(log.Fields{"felixconfiguration": c, "adding Addr": addr}).Info("Updating FelixConfiguration ")
 				_, err = client.FelixConfigurations().Update(ctx, c, options.SetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}
-			updateConfig(prevBGPSpec.IPv4Address)
+
+			updateConfig(externalClient.IP)
 
 			// Wait for the config to take
 			for _, f := range felixes {
-				if bpfEnabled {
-					Eventually(f.BPFRoutes, "5s", "200ms").Should(ContainSubstring("1.1.1.1/32"))
-				} else {
-					Eventually(func() int {
-						return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-					}, "5s", "200ms").Should(Equal(3))
+				Eventually(func() int {
+					return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
+				}, "5s", "200ms").Should(Equal(3))
+			}
+
+			Eventually(func() error {
+				err := externalClient.ExecMayFail("ip", "tunnel", "add", "tunl0", "mode", "ipip")
+				if err != nil && strings.Contains(err.Error(), "SIOCADDTUNNEL: File exists") {
+					return nil
 				}
+				return err
+			}).Should(Succeed())
+
+			externalClient.Exec("ip", "link", "set", "tunl0", "up")
+			externalClient.Exec("ip", "addr", "add", "dev", "tunl0", "10.65.222.1")
+			externalClient.Exec("ip", "route", "add", "10.65.0.0/24", "via",
+				felixes[0].IP, "dev", "tunl0", "onlink")
+
+			felixes[0].Exec("ip", "route", "add", "10.65.222.1", "via",
+				externalClient.IP, "dev", "tunl0", "onlink")
+		})
+
+		JustAfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				externalClient.Exec("ip", "r")
+				externalClient.Exec("ip", "l")
+				externalClient.Exec("ip", "a")
 			}
 
 		})
+		AfterEach(func() {
+			externalClient.Stop()
+		})
 
 		It("should have all-hosts-net ipset configured with the external hosts and workloads connect", func() {
-			f := felixes[0]
-			// Add the ip route via tunnel back on the Felix for which we nuked when we removed its BGP spec.
-			f.Exec("ip", "route", "add", w[1].IP, "via", felixes[1].IP, "dev", "tunl0", "onlink")
-			cc.ExpectSome(w[0], w[1])
+			cc.ExpectSome(externalClient, w[0])
 			cc.CheckConnectivity()
 		})
 	})

--- a/felix/fv/ipip_test.go
+++ b/felix/fv/ipip_test.go
@@ -383,36 +383,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 		BeforeEach(func() {
 			externalClient = infrastructure.RunExtClient("ext-client")
 
-			updateConfig := func(addr string) {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				defer cancel()
-				c, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
-				if err != nil {
-					// Create the default config if it doesn't already exist.
-					if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
-						c = api.NewFelixConfiguration()
-						c.Name = "default"
-						c, err = client.FelixConfigurations().Create(ctx, c, options.SetOptions{})
-						Expect(err).NotTo(HaveOccurred())
-					} else {
-						Expect(err).NotTo(HaveOccurred())
-					}
-				}
-				c.Spec.ExternalNodesCIDRList = &[]string{addr}
-				log.WithFields(log.Fields{"felixconfiguration": c, "adding Addr": addr}).Info("Updating FelixConfiguration ")
-				_, err = client.FelixConfigurations().Update(ctx, c, options.SetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-			}
-
-			updateConfig(externalClient.IP)
-
-			// Wait for the config to take
-			for _, f := range felixes {
-				Eventually(func() int {
-					return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
-				}, "5s", "200ms").Should(Equal(3))
-			}
-
 			Eventually(func() error {
 				err := externalClient.ExecMayFail("ip", "tunnel", "add", "tunl0", "mode", "ipip")
 				if err != nil && strings.Contains(err.Error(), "SIOCADDTUNNEL: File exists") {
@@ -443,6 +413,54 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 		})
 
 		It("should have all-hosts-net ipset configured with the external hosts and workloads connect", func() {
+
+			By("testing that ext client ipip does not work if not part of ExternalNodesCIDRList")
+
+			// Make sure that only the internal nodes are present in the ipset
+			for _, f := range felixes {
+				Eventually(func() int {
+					return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
+				}, "5s", "200ms").Should(Equal(2))
+			}
+
+			cc.ExpectNone(externalClient, w[0])
+			cc.CheckConnectivity()
+
+			By("changing configuration to include the external client")
+
+			updateConfig := func(addr string) {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				c, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
+				if err != nil {
+					// Create the default config if it doesn't already exist.
+					if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+						c = api.NewFelixConfiguration()
+						c.Name = "default"
+						c, err = client.FelixConfigurations().Create(ctx, c, options.SetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+					} else {
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+				c.Spec.ExternalNodesCIDRList = &[]string{addr}
+				log.WithFields(log.Fields{"felixconfiguration": c, "adding Addr": addr}).Info("Updating FelixConfiguration ")
+				_, err = client.FelixConfigurations().Update(ctx, c, options.SetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			updateConfig(externalClient.IP)
+
+			// Wait for the config to take
+			for _, f := range felixes {
+				Eventually(func() int {
+					return getNumIPSetMembers(f.Container, "cali40all-hosts-net")
+				}, "5s", "200ms").Should(Equal(3))
+			}
+
+			By("testing that the ext client can connect via ipip")
+
+			cc.ResetExpectations()
 			cc.ExpectSome(externalClient, w[0])
 			cc.CheckConnectivity()
 		})


### PR DESCRIPTION
Previously, we had to preserve the pod's source on the already encapped vxlan packet when returning to the tunnel because when FIB failed, the packet was dropped to host namespace and strict RPF on the pod's iface would drop it.

We no longer need that because (1) RPF is now relaxed since BPF enforces strict on its own as there are other cases when a pod replies with service IP and (2) we forward 100% of the packets straight to the external interface (from where the traffic originally came) to avoid issues with source routing in EKS (which no longer is a problem with the non-pod's source)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
refs https://github.com/projectcalico/calico/issues/7040
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>


-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: no src fixup on host iface for traffic returning from pod to the nodeport tunnel
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
