### PR TITLE
Add compression to the Typha protocol.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golang/protobuf v1.5.2
+	github.com/golang/snappy v0.0.4
 	github.com/google/btree v1.1.2
 	github.com/google/gopacket v1.1.19
 	github.com/google/netstack v0.0.0-20191123085552-55fcc16cd0eb

--- a/go.sum
+++ b/go.sum
@@ -401,7 +401,10 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/libcalico-go/lib/readlogger/readlogger.go
+++ b/libcalico-go/lib/readlogger/readlogger.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package readlogger
+
+import (
+	"io"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type ReadLogger struct {
+	r io.Reader
+}
+
+func (wl *ReadLogger) Read(p []byte) (n int, err error) {
+	logrus.WithField("len", len(p)).Debug("Reading...")
+	start := time.Now()
+	n, err = wl.r.Read(p)
+	logrus.WithFields(logrus.Fields{
+		"len":  len(p),
+		"n":    n,
+		"err":  err,
+		"time": time.Since(start),
+	}).Info("...read completed.")
+	return
+}
+
+func New(r io.Reader) *ReadLogger {
+	return &ReadLogger{r: r}
+}
+
+var _ io.Reader = (*ReadLogger)(nil)

--- a/libcalico-go/lib/writelogger/writelogger.go
+++ b/libcalico-go/lib/writelogger/writelogger.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writelogger
+
+import (
+	"io"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type WriteLogger struct {
+	w io.Writer
+}
+
+func (wl *WriteLogger) Write(p []byte) (n int, err error) {
+	logrus.WithField("len", len(p)).Debug("Writing...")
+	start := time.Now()
+	n, err = wl.w.Write(p)
+	logrus.WithFields(logrus.Fields{
+		"len":  len(p),
+		"n":    n,
+		"err":  err,
+		"time": time.Since(start),
+	}).Info("...write completed.")
+	return
+}
+
+func New(w io.Writer) *WriteLogger {
+	return &WriteLogger{w: w}
+}
+
+var _ io.Writer = (*WriteLogger)(nil)

--- a/typha/fv-tests/server_harness_test.go
+++ b/typha/fv-tests/server_harness_test.go
@@ -1,0 +1,360 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fvtests_test
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	. "github.com/projectcalico/calico/typha/fv-tests"
+	"github.com/projectcalico/calico/typha/pkg/calc"
+	"github.com/projectcalico/calico/typha/pkg/discovery"
+	"github.com/projectcalico/calico/typha/pkg/snapcache"
+	"github.com/projectcalico/calico/typha/pkg/syncclient"
+	"github.com/projectcalico/calico/typha/pkg/syncproto"
+	"github.com/projectcalico/calico/typha/pkg/syncserver"
+)
+
+// ServerHarness runs a syncserver.Server with a couple of cache syncer cache types and allows for creating test
+// clients.  The server configuration can be adjusted after creation but before calling Start(). Stop() should be
+// called in an AfterEach.  The server runs on a random high numbered port.
+type ServerHarness struct {
+	Decoupler, BGPDecoupler *calc.SyncerCallbacksDecoupler
+	ValFilter               *calc.ValidationFilter
+	cacheCxt                context.Context
+	cacheCancel             context.CancelFunc
+	FelixCache, BGPCache    *snapcache.Cache
+	Server                  *syncserver.Server
+	serverCxt               context.Context
+	ServerCancel            context.CancelFunc
+	Config                  syncserver.Config
+
+	ClientStates     []*ClientState
+	NoOpClientStates []*ClientState
+
+	updIdx int
+}
+
+func NewHarness() *ServerHarness {
+	// Set up a pipeline:
+	//
+	//    This goroutine -> callback -chan-> validation -> snapshot -> server
+	//                      decoupler        filter        cache
+	//
+	h := &ServerHarness{}
+	h.Decoupler = calc.NewSyncerCallbacksDecoupler()
+	h.FelixCache = snapcache.New(snapcache.Config{
+		// Set the batch size small, so we can force new Breadcrumbs easily.
+		MaxBatchSize: 10,
+		// Reduce the wake-up interval from the default to give us faster tear down.
+		WakeUpInterval: 50 * time.Millisecond,
+	})
+	h.BGPDecoupler = calc.NewSyncerCallbacksDecoupler()
+	h.BGPCache = snapcache.New(snapcache.Config{
+		// Set the batch size small, so we can force new Breadcrumbs easily.
+		MaxBatchSize: 10,
+		// Reduce the wake-up interval from the default to give us faster tear down.
+		WakeUpInterval: 50 * time.Millisecond,
+	})
+	h.cacheCxt, h.cacheCancel = context.WithCancel(context.Background())
+	h.ValFilter = calc.NewValidationFilter(h.FelixCache)
+	h.Config = syncserver.Config{
+		PingInterval: 10 * time.Second,
+		Port:         syncserver.PortRandom,
+		DropInterval: 50 * time.Millisecond,
+	}
+	return h
+}
+
+type ClientState struct {
+	clientCxt    context.Context
+	clientCancel context.CancelFunc
+	client       *syncclient.SyncerClient
+	recorder     *StateRecorder
+	syncerType   syncproto.SyncerType
+}
+
+func (h *ServerHarness) Start() {
+	h.Server = syncserver.New(
+		map[syncproto.SyncerType]syncserver.BreadcrumbProvider{
+			syncproto.SyncerTypeFelix: h.FelixCache,
+			syncproto.SyncerTypeBGP:   h.BGPCache,
+		},
+		h.Config)
+
+	go h.Decoupler.SendToContext(h.cacheCxt, h.ValFilter)
+	go h.BGPDecoupler.SendToContext(h.cacheCxt, h.BGPCache)
+	h.FelixCache.Start(h.cacheCxt)
+	h.BGPCache.Start(h.cacheCxt)
+	h.serverCxt, h.ServerCancel = context.WithCancel(context.Background())
+	h.Server.Start(h.serverCxt)
+}
+
+func (h *ServerHarness) Addr() string {
+	return fmt.Sprintf("127.0.0.1:%d", h.Server.Port())
+}
+
+func (h *ServerHarness) Stop() {
+	allClients := append(h.ClientStates, h.NoOpClientStates...)
+
+	for _, c := range allClients {
+		c.clientCancel()
+	}
+	for _, c := range allClients {
+		if c.client != nil {
+			log.Info("Waiting for client to shut down.")
+			c.client.Finished.Wait()
+			log.Info("Done waiting for client to shut down.")
+		}
+	}
+
+	h.ServerCancel()
+	log.Info("Waiting for server to shut down")
+	h.Server.Finished.Wait()
+	log.Info("Done waiting for server to shut down")
+	h.cacheCancel()
+}
+
+func (h *ServerHarness) CreateNoOpClient(id interface{}, syncType syncproto.SyncerType) *ClientState {
+	c := h.createClient(id, syncclient.Options{SyncerType: syncType, DebugDiscardKVUpdates: true}, NoOpCallbacks{})
+	h.NoOpClientStates = append(h.ClientStates, c)
+	return c
+}
+
+func (h *ServerHarness) CreateClient(id interface{}, syncType syncproto.SyncerType) *ClientState {
+	recorder := NewRecorder()
+	c := h.createClient(id, syncclient.Options{SyncerType: syncType}, recorder)
+	c.recorder = recorder
+	go recorder.Loop(c.clientCxt)
+	h.ClientStates = append(h.ClientStates, c)
+	return c
+}
+
+func (h *ServerHarness) CreateClientNoDecodeRestart(id interface{}, syncType syncproto.SyncerType) *ClientState {
+	recorder := NewRecorder()
+	c := h.createClient(id, syncclient.Options{SyncerType: syncType, DisableDecoderRestart: true}, recorder)
+	c.recorder = recorder
+	go recorder.Loop(c.clientCxt)
+	h.ClientStates = append(h.ClientStates, c)
+	return c
+}
+
+func (h *ServerHarness) CreateNoOpClientNoDecodeRestart(id interface{}, syncType syncproto.SyncerType) *ClientState {
+	c := h.createClient(id, syncclient.Options{SyncerType: syncType, DisableDecoderRestart: true, DebugDiscardKVUpdates: true}, NoOpCallbacks{})
+	h.NoOpClientStates = append(h.ClientStates, c)
+	return c
+}
+
+func (h *ServerHarness) ExpectAllClientsToReachState(status api.SyncStatus, kvs map[string]api.Update) {
+	var wg sync.WaitGroup
+	for _, s := range h.ClientStates {
+		wg.Add(1)
+		go func(s *ClientState) {
+			defer wg.Done()
+			defer GinkgoRecover()
+			// Wait until we reach that state.
+			Eventually(s.recorder.Status, 60*time.Second, 50*time.Millisecond).Should(Equal(status))
+			Eventually(s.recorder.KVCompareFn(kvs), 20*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred())
+		}(s)
+	}
+	wg.Wait()
+}
+
+func (h *ServerHarness) createClient(id interface{}, options syncclient.Options, callbacks api.SyncerCallbacks) *ClientState {
+	clientCxt, clientCancel := context.WithCancel(context.Background())
+	serverAddr := fmt.Sprintf("127.0.0.1:%d", h.Server.Port())
+	client := syncclient.New(
+		[]discovery.Typha{{Addr: serverAddr}},
+		"test-version",
+		fmt.Sprintf("test-host-%v", id),
+		"test-info",
+		callbacks,
+		&options,
+	)
+
+	err := client.Start(clientCxt)
+	Expect(err).NotTo(HaveOccurred())
+
+	cs := &ClientState{
+		clientCxt:    clientCxt,
+		client:       client,
+		clientCancel: clientCancel,
+		syncerType:   options.SyncerType,
+	}
+	return cs
+}
+
+func (h *ServerHarness) CreateNoOpClients(n int) {
+	for i := 0; i < n; i++ {
+		h.CreateNoOpClient(i, syncproto.SyncerTypeFelix)
+	}
+}
+
+func (h *ServerHarness) CreateNoOpClientsNoDecodeRestart(n int) {
+	for i := 0; i < n; i++ {
+		h.CreateNoOpClientNoDecodeRestart(i, syncproto.SyncerTypeFelix)
+	}
+}
+
+func (h *ServerHarness) CreateClients(n int) {
+	for i := 0; i < n; i++ {
+		h.CreateClient(i, syncproto.SyncerTypeFelix)
+	}
+}
+
+func (h *ServerHarness) SendStatus(s api.SyncStatus) {
+	h.Decoupler.OnStatusUpdated(s)
+}
+
+func (h *ServerHarness) SendInitialSnapshotPods(numPods int) map[string]api.Update {
+	expState := h.SendInitialSnapshotPodsNoInSync(numPods)
+	h.SendStatus(api.InSync)
+	return expState
+}
+
+func (h *ServerHarness) SendInitialSnapshotPodsNoInSync(numPods int) map[string]api.Update {
+	h.SendStatus(api.ResyncInProgress)
+	expState := h.SendPodUpdates(numPods)
+	return expState
+}
+
+func (h *ServerHarness) SendPodUpdates(numPods int) map[string]api.Update {
+	expectedEndState := map[string]api.Update{}
+	conv := conversion.NewConverter()
+	for i := 0; i < numPods; i++ {
+		pod := generatePod(h.updIdx)
+		h.updIdx++
+		weps, err := conv.PodToWorkloadEndpoints(pod)
+		Expect(err).NotTo(HaveOccurred())
+		update := api.Update{
+			KVPair:     *weps[0],
+			UpdateType: api.UpdateTypeKVNew,
+		}
+		path, err := model.KeyToDefaultPath(update.Key)
+		Expect(err).NotTo(HaveOccurred())
+		expectedEndState[path] = update
+		h.Decoupler.OnUpdates([]api.Update{update})
+	}
+	return expectedEndState
+}
+
+func (h *ServerHarness) SendInitialSnapshotConfigs(numConfigs int) map[string]api.Update {
+	expState := h.SendInitialSnapshotConfigsNoInSync(numConfigs)
+	h.SendStatus(api.InSync)
+	return expState
+}
+
+func (h *ServerHarness) SendInitialSnapshotConfigsNoInSync(numConfigs int) map[string]api.Update {
+	h.SendStatus(api.ResyncInProgress)
+	expState := h.SendConfigUpdates(numConfigs)
+	return expState
+}
+
+func (h *ServerHarness) SendConfigUpdates(n int) map[string]api.Update {
+	expectedEndState := map[string]api.Update{}
+	for i := 0; i < n; i++ {
+		update := api.Update{
+			KVPair: model.KVPair{
+				Key: model.GlobalConfigKey{
+					Name: fmt.Sprintf("foo%v", h.updIdx),
+				},
+				// Nice big value so that we can fill up the send queue.
+				Value:    fmt.Sprint(h.updIdx, "=", randomHex(1000)),
+				Revision: fmt.Sprintf("%v", h.updIdx),
+			},
+			UpdateType: api.UpdateTypeKVNew,
+		}
+		h.updIdx++
+		path, err := model.KeyToDefaultPath(update.Key)
+		Expect(err).NotTo(HaveOccurred())
+		expectedEndState[path] = update
+		h.Decoupler.OnUpdates([]api.Update{update})
+	}
+	return expectedEndState
+}
+
+func generatePod(n int) *corev1.Pod {
+	namespace := fmt.Sprintf("a-namespace-name-%x", n/100)
+	var buf [8]byte
+	rand.Read(buf[:])
+	name := fmt.Sprintf("some-app-name-%d-%x", n, buf[:])
+	hostname := fmt.Sprintf("hostname%d", n/20)
+	ip := net.IP{0, 0, 0, 0}
+	binary.BigEndian.PutUint32(ip, uint32(n))
+	ip[0] = 10
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Annotations: map[string]string{
+				"cni.projectcalico.org/containerID": randomHex(64),
+				"cni.projectcalico.org/podIP":       fmt.Sprintf("%s,/32", ip.String()),
+				"cni.projectcalico.org/podIPs":      fmt.Sprintf("%s,/32", ip.String()),
+			},
+			Labels: map[string]string{
+				"kubernetes-topology-label": "zone-A",
+				"kubernetes-region-label":   "zone-A",
+				"owner":                     "someone-" + randomHex(4),
+				"oneof10":                   fmt.Sprintf("value-%d", n/10),
+				"oneof100":                  fmt.Sprintf("value-%d", n/100),
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:  fmt.Sprintf("container-%s", name),
+			Image: "ignore",
+		}},
+			NodeName: hostname,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionTrue,
+			}},
+			PodIP:  ip.String(),
+			PodIPs: []corev1.PodIP{{IP: ip.String()}},
+		},
+	}
+	return p
+}
+
+func randomHex(length int) string {
+	buf := make([]byte, length/2)
+	rand.Read(buf)
+	return fmt.Sprintf("%x", buf)
+}
+
+type NoOpCallbacks struct {
+}
+
+func (n NoOpCallbacks) OnStatusUpdated(_ api.SyncStatus) {
+}
+
+func (n NoOpCallbacks) OnUpdates(_ []api.Update) {
+}

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -180,6 +180,7 @@ var _ = Describe("Daemon", func() {
 					client.Finished.Wait()
 				}()
 				err := client.Start(clientCxt)
+				go cbs.Loop(clientCxt)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Send in an update at the top of the processing pipeline.

--- a/typha/pkg/jitter/jittered_ticker.go
+++ b/typha/pkg/jitter/jittered_ticker.go
@@ -54,7 +54,7 @@ tickLoop:
 	for {
 		select {
 		case <-t.stop:
-			log.Info("Stopping jittered ticker")
+			log.Debug("Stopping jittered ticker")
 			close(c)
 			timer.Stop()
 			break tickLoop

--- a/typha/pkg/syncclient/sync_client.go
+++ b/typha/pkg/syncclient/sync_client.go
@@ -21,12 +21,16 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"sync"
 	"time"
 
+	"github.com/golang/snappy"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/readlogger"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/typha/pkg/discovery"
@@ -34,7 +38,7 @@ import (
 	"github.com/projectcalico/calico/typha/pkg/tlsutils"
 )
 
-var nextID uint64
+var nextID uint64 = 1 // Non-zero so we can tell whether it's set at all.
 
 const (
 	defaultReadtimeout  = 30 * time.Second
@@ -42,14 +46,26 @@ const (
 )
 
 type Options struct {
-	ReadTimeout  time.Duration
-	WriteTimeout time.Duration
-	KeyFile      string
-	CertFile     string
-	CAFile       string
-	ServerCN     string
-	ServerURISAN string
-	SyncerType   syncproto.SyncerType
+	ReadTimeout    time.Duration
+	ReadBufferSize int
+	WriteTimeout   time.Duration
+	KeyFile        string
+	CertFile       string
+	CAFile         string
+	ServerCN       string
+	ServerURISAN   string
+	SyncerType     syncproto.SyncerType
+
+	// DisableDecoderRestart disables decoder restart and the features that depend on
+	// it (such as compression).  Useful for simulating an older client in UT.
+	DisableDecoderRestart bool
+
+	// DebugLogReads tells the client to wrap each connection with a Reader that
+	// logs every read.  Intended only for use in tests!
+	DebugLogReads bool
+	// DebugDiscardKVUpdates discards all KV updates from typha without decoding them.
+	// Useful for load testing Typha without having to run a "full" client.
+	DebugDiscardKVUpdates bool
 }
 
 func (o *Options) readTimeout() time.Duration {
@@ -107,8 +123,8 @@ func New(
 	return &SyncerClient{
 		ID: id,
 		logCxt: log.WithFields(log.Fields{
-			"connID": id,
-			"type":   options.SyncerType,
+			"myID": id,
+			"type": options.SyncerType,
 		}),
 		callbacks: cbs,
 		addrs:     addrs,
@@ -133,6 +149,7 @@ type SyncerClient struct {
 	options                       *Options
 
 	connection                  net.Conn
+	connR                       io.Reader
 	encoder                     *gob.Encoder
 	decoder                     *gob.Decoder
 	handshakeStatus             *handshakeStatus
@@ -174,18 +191,19 @@ func (s *SyncerClient) Start(cxt context.Context) error {
 
 	s.Finished.Add(1)
 	go func() {
+		// Broadcast that we're finished.
+		defer s.Finished.Done()
+
 		// Wait for the context to finish, either due to external cancel or our own loop
 		// exiting.
 		<-cxt.Done()
-		s.logCxt.Info("Typha client Context asked us to exit")
+		s.logCxt.Info("Typha client Context asked us to exit, closing connection...")
 		// Close the connection.  This will trigger the main loop to exit if it hasn't
 		// already.
 		err := s.connection.Close()
 		if err != nil {
 			log.WithError(err).Warn("Ignoring error from Close during shut-down of client.")
 		}
-		// Broadcast that we're finished.
-		s.Finished.Done()
 	}()
 	return nil
 }
@@ -268,6 +286,10 @@ func (s *SyncerClient) connect(cxt context.Context, typhaAddr discovery.Typha) e
 		if err != nil {
 			return err
 		}
+		s.connR = s.connection
+		if s.options.DebugLogReads {
+			s.connR = readlogger.New(s.connection)
+		}
 	}
 	if cxt.Err() != nil {
 		if s.connection != nil {
@@ -278,8 +300,23 @@ func (s *SyncerClient) connect(cxt context.Context, typhaAddr discovery.Typha) e
 		}
 		return cxt.Err()
 	}
+
+	if s.options.ReadBufferSize != 0 {
+		tcpConn := extractTCPConn(s.connection)
+		if tcpConn == nil {
+			log.Warn("Cannot set read buffer size, not a TCP connection?")
+		} else {
+			err := tcpConn.SetReadBuffer(s.options.ReadBufferSize)
+			if err != nil {
+				log.WithError(err).Warn("Failed to set read buffer size, ignoring")
+			} else {
+				log.WithField("size", s.options.ReadBufferSize).Warn("Set read buffer size")
+			}
+		}
+	}
+
 	logCxt.Info("Connected to Typha.")
-	s.connInfo = &discovery.Typha{}
+	s.connInfo = &typhaAddr
 
 	// Log TLS connection details.
 	tlsConn, ok := s.connection.(*tls.Conn)
@@ -300,6 +337,19 @@ func (s *SyncerClient) connect(cxt context.Context, typhaAddr discovery.Typha) e
 	return nil
 }
 
+func extractTCPConn(c net.Conn) *net.TCPConn {
+	if wrapper, ok := c.(interface{ NetConn() net.Conn }); ok {
+		// TLS conn provides an interface to get the underlying net.Conn
+		c = wrapper.NetConn()
+	}
+	switch c := c.(type) {
+	case *net.TCPConn:
+		return c
+	default:
+		return nil
+	}
+}
+
 func (s *SyncerClient) logConnectionFailure(cxt context.Context, logCxt *log.Entry, err error, operation string) {
 	if cxt.Err() != nil {
 		logCxt.WithError(err).Warn("Connection failed while being shut down by context.")
@@ -315,30 +365,77 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 	logCxt := s.logCxt.WithField("connection", s.connInfo)
 	logCxt.Info("Started Typha client main loop")
 
+	// Always start with basic gob encoding for the handshake.  We may upgrade to a compressed version below.
 	s.encoder = gob.NewEncoder(s.connection)
-	s.decoder = gob.NewDecoder(s.connection)
+	s.decoder = gob.NewDecoder(s.connR)
 
 	ourSyncerType := s.options.SyncerType
 	if ourSyncerType == "" {
 		ourSyncerType = syncproto.SyncerTypeFelix
 	}
+	compAlgs := []syncproto.CompressionAlgorithm{syncproto.CompressionSnappy}
+	if s.options.DisableDecoderRestart {
+		// Compression requires decoder restart.
+		compAlgs = nil
+	}
 	err := s.sendMessageToServer(cxt, logCxt, "send hello to server",
 		syncproto.MsgClientHello{
-			Hostname:   s.myHostname,
-			Version:    s.myVersion,
-			Info:       s.myInfo,
-			SyncerType: ourSyncerType,
+			Hostname:                       s.myHostname,
+			Version:                        s.myVersion,
+			Info:                           s.myInfo,
+			SyncerType:                     ourSyncerType,
+			SupportsDecoderRestart:         !s.options.DisableDecoderRestart,
+			SupportedCompressionAlgorithms: compAlgs,
+			ClientConnID:                   s.ID,
 		},
 	)
 	if err != nil {
 		return // (Failure already logged.)
 	}
 
+	// Read the handshake response.  It must be the first message.
+	msg, err := s.readMessageFromServer(cxt, logCxt)
+	if err != nil {
+		return
+	}
+	serverHello, ok := msg.(syncproto.MsgServerHello)
+	if !ok {
+		logCxt.WithField("msg", msg).Error("Unexpected first message from server.")
+		return
+	}
+	if serverHello.ServerConnID != 0 {
+		logCxt = logCxt.WithField("serverConnID", serverHello.ServerConnID)
+	}
+	logCxt.WithField("serverMsg", serverHello).Info("ServerHello message received")
+
+	// Check whether Typha supports node resource updates.
+	if !serverHello.SupportsNodeResourceUpdates {
+		logCxt.Info("Server responded without support for node resource updates, assuming older Typha")
+	}
+	s.supportsNodeResourceUpdates = serverHello.SupportsNodeResourceUpdates
+	s.handshakeStatus.helloReceivedChan <- struct{}{}
+
+	// Check the SyncerType reported by the server.  If the server is too old to support SyncerType then
+	// the message will have an empty string in place of the SyncerType.  In that case we only proceed if
+	// the client wants the felix syncer.
+	serverSyncerType := serverHello.SyncerType
+	if serverSyncerType == "" {
+		logCxt.Info("Server responded without SyncerType, assuming an old Typha version that only " +
+			"supports SyncerTypeFelix.")
+		serverSyncerType = syncproto.SyncerTypeFelix
+	}
+	if ourSyncerType != serverSyncerType {
+		logCxt.Errorf("We require SyncerType %s but Typha server doesn't support it.", ourSyncerType)
+		return
+	}
+
+	// Handshake done, start processing messages from the server.
 	for cxt.Err() == nil {
 		msg, err := s.readMessageFromServer(cxt, logCxt)
 		if err != nil {
 			return
 		}
+		debug := log.GetLevel() >= log.DebugLevel
 		switch msg := msg.(type) {
 		case syncproto.MsgSyncStatus:
 			logCxt.WithField("newStatus", msg.SyncStatus).Info("Status update from Typha.")
@@ -356,44 +453,59 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 			logCxt.Debug("Pong sent to Typha")
 		case syncproto.MsgKVs:
 			updates := make([]api.Update, 0, len(msg.KVs))
+			if s.options.DebugDiscardKVUpdates {
+				// For simulating lots of clients in tests, just throw away the data.
+				continue
+			}
 			for _, kv := range msg.KVs {
 				update, err := kv.ToUpdate()
 				if err != nil {
 					logCxt.WithError(err).Error("Failed to deserialize update, skipping.")
 					continue
 				}
-				logCxt.WithFields(log.Fields{
-					"serialized":   kv,
-					"deserialized": update,
-				}).Debug("Decoded update from Typha")
+				if debug {
+					logCxt.WithFields(log.Fields{
+						"serialized":   kv,
+						"deserialized": update,
+					}).Debug("Decoded update from Typha")
+				}
 				updates = append(updates, update)
 			}
 			s.callbacks.OnUpdates(updates)
-		case syncproto.MsgServerHello:
-			logCxt.WithField("serverVersion", msg.Version).Info("Server hello message received")
-
-			// Check whether Typha supports node resource updates.
-			if !msg.SupportsNodeResourceUpdates {
-				logCxt.Info("Server responded without support for node resource updates, assuming older Typha")
-			}
-			s.supportsNodeResourceUpdates = msg.SupportsNodeResourceUpdates
-			s.handshakeStatus.helloReceivedChan <- struct{}{}
-
-			// Check the SyncerType reported by the server.  If the server is too old to support SyncerType then
-			// the message will have an empty string in place of the SyncerType.  In that case we only proceed if
-			// the client wants the felix syncer.
-			serverSyncerType := msg.SyncerType
-			if serverSyncerType == "" {
-				logCxt.Info("Server responded without SyncerType, assuming an old Typha version that only " +
-					"supports SyncerTypeFelix.")
-				serverSyncerType = syncproto.SyncerTypeFelix
-			}
-			if ourSyncerType != serverSyncerType {
-				logCxt.Errorf("We require SyncerType %s but Typha server doesn't support it.", ourSyncerType)
+		case syncproto.MsgDecoderRestart:
+			if s.options.DisableDecoderRestart {
+				log.Error("Server sent MsgDecoderRestart but we signalled no support.")
 				return
 			}
+			err = s.restartDecoder(cxt, logCxt, msg)
+			if err != nil {
+				log.WithError(err).Error("Failed to restart decoder")
+				return
+			}
+		case syncproto.MsgServerHello:
+			logCxt.WithField("serverVersion", msg.Version).Error("Unexpected extra server hello message received")
+			return
 		}
 	}
+}
+
+func (s *SyncerClient) restartDecoder(cxt context.Context, logCxt *log.Entry, msg syncproto.MsgDecoderRestart) error {
+	logCxt.WithField("msg", msg).Info("Server asked us to restart our decoder")
+	// Check if we should enable compression.
+	switch msg.CompressionAlgorithm {
+	case syncproto.CompressionSnappy:
+		logCxt.Info("Server selected snappy compression.")
+		r := snappy.NewReader(s.connR)
+		s.decoder = gob.NewDecoder(r)
+	case "":
+		logCxt.Info("Server selected no compression.")
+		s.decoder = gob.NewDecoder(s.connR)
+	}
+	// Server requires an ack of the MsgDecoderRestart before it can send data in the new format.
+	err := s.sendMessageToServer(cxt, logCxt, "send ACK to server",
+		syncproto.MsgACK{},
+	)
+	return err
 }
 
 // sendMessageToServer sends a single value-type MsgXYZ object to the server.  It updates the connection's

--- a/typha/pkg/syncserver/syncserver_test.go
+++ b/typha/pkg/syncserver/syncserver_test.go
@@ -33,6 +33,7 @@ var _ = Describe("With zero config", func() {
 	It("it should apply correct defaults", func() {
 		config.ApplyDefaults()
 		Expect(config).To(Equal(Config{
+			WriteTimeout:                   120 * time.Second,
 			MaxMessageSize:                 100,
 			MaxFallBehind:                  300 * time.Second,
 			NewClientFallBehindGracePeriod: 300 * time.Second,


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Allow the decoder to be restarted by the server.  (This is a key building block for #7035.)
- When restarting decoder, allow a snappy compression reader to be included.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The Typha protocol now supports compression.  This is enabled automatically if client and server both support it.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
