### PR TITLE
[BPF] bpfEndpointManager.withIface explicit discard

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -412,34 +412,48 @@ func newBPFEndpointManager(
 	return m, nil
 }
 
+type wIfaceVerdict int
+
+const (
+	wIfaceClean   wIfaceVerdict = iota // unchanged
+	wIfaceOK                           // not clean, not dirty, do nothing
+	wIfaceDirty                        // add it to dirty devices
+	wIfaceDiscard                      // we are done, remove it
+)
+
 // withIface handles the bookkeeping for working with a particular bpfInterface value.  It
 // * creates the value if needed
 // * calls the giving callback with the value so it can be edited
 // * if the bpfInterface's info field changes, it marks it as dirty
 // * if the bpfInterface is now empty (no info or state), it cleans it up.
-func (m *bpfEndpointManager) withIface(ifaceName string, fn func(iface *bpfInterface) (forceDirty bool)) {
+func (m *bpfEndpointManager) withIface(ifaceName string, fn func(iface *bpfInterface) wIfaceVerdict) {
 	iface := m.nameToIface[ifaceName]
 	ifaceCopy := iface
-	dirty := fn(&iface)
+
+	verdict := fn(&iface)
+
 	logCtx := log.WithField("name", ifaceName)
 
-	var zeroIface bpfInterface
-	if reflect.DeepEqual(iface, zeroIface) {
-		logCtx.Debug("Interface info is now empty.")
+	if verdict == wIfaceDiscard {
+		logCtx.Debug("Discarding iface.")
 		delete(m.nameToIface, ifaceName)
-	} else {
-		// Always store the result (rather than checking the dirty flag) because dirty only covers the info..
-		m.nameToIface[ifaceName] = iface
-	}
-
-	dirty = dirty || iface.info != ifaceCopy.info
-
-	if !dirty {
 		return
 	}
 
-	logCtx.Debug("Marking iface dirty.")
-	m.dirtyIfaceNames.Add(ifaceName)
+	// Always store the result (rather than checking the dirty flag) because dirty only covers the info..
+	m.nameToIface[ifaceName] = iface
+
+	dirty := verdict == wIfaceDirty
+
+	if !dirty && iface.info != ifaceCopy.info {
+		logCtx.Debug("iface.info differs but not dirty - forcing dirty")
+		dirty = true
+	}
+
+	if dirty {
+		logCtx.Debug("Marking iface dirty.")
+		m.dirtyIfaceNames.Add(ifaceName)
+	}
 }
 
 func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
@@ -621,7 +635,7 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 		return
 	}
 
-	m.withIface(update.Name, func(iface *bpfInterface) (forceDirty bool) {
+	m.withIface(update.Name, func(iface *bpfInterface) wIfaceVerdict {
 		ifaceIsUp := update.State == ifacemonitor.StateUp
 		// Note, only need to handle the mapping and unmapping of the host-* endpoint here.
 		// For specific host endpoints OnHEPUpdate doesn't depend on iface state, and has
@@ -646,18 +660,20 @@ func (m *bpfEndpointManager) onInterfaceUpdate(update *ifaceUpdate) {
 			iface.info.ifIndex = update.Index
 			iface.info.isUP = true
 			m.updateIfaceStateMap(update.Name, iface)
-		} else {
-			if m.wildcardExists && reflect.DeepEqual(m.hostIfaceToEpMap[update.Name], m.wildcardHostEndpoint) {
-				log.Debugf("Unmap host-* endpoint for %v", update.Name)
-				m.removeHEPFromIndexes(update.Name, &m.wildcardHostEndpoint)
-				delete(m.hostIfaceToEpMap, update.Name)
-			}
-			iface.dpState.isReady = false
-			iface.info.isUP = false
-			m.updateIfaceStateMap(update.Name, iface)
-			iface.info.ifIndex = 0
+
+			return wIfaceDirty // Force interface to be marked dirty in case we missed a transition during a resync.
 		}
-		return true // Force interface to be marked dirty in case we missed a transition during a resync.
+
+		if m.wildcardExists && reflect.DeepEqual(m.hostIfaceToEpMap[update.Name], m.wildcardHostEndpoint) {
+			log.Debugf("Unmap host-* endpoint for %v", update.Name)
+			m.removeHEPFromIndexes(update.Name, &m.wildcardHostEndpoint)
+			delete(m.hostIfaceToEpMap, update.Name)
+		}
+		iface.dpState.isReady = false
+		iface.info.isUP = false
+		m.updateIfaceStateMap(update.Name, iface)
+
+		return wIfaceDiscard
 	})
 }
 
@@ -672,9 +688,9 @@ func (m *bpfEndpointManager) onWorkloadEndpointUpdate(msg *proto.WorkloadEndpoin
 	wl := msg.Endpoint
 	m.allWEPs[wlID] = wl
 	m.addWEPToIndexes(wlID, wl)
-	m.withIface(wl.Name, func(iface *bpfInterface) bool {
+	m.withIface(wl.Name, func(iface *bpfInterface) wIfaceVerdict {
 		iface.info.endpointID = &wlID
-		return true // Force interface to be marked dirty in case policies changed.
+		return wIfaceDirty // Force interface to be marked dirty in case policies changed.
 	})
 }
 
@@ -691,9 +707,9 @@ func (m *bpfEndpointManager) onWorkloadEnpdointRemove(msg *proto.WorkloadEndpoin
 		m.happyWEPsDirty = true
 	}
 
-	m.withIface(oldWEP.Name, func(iface *bpfInterface) bool {
+	m.withIface(oldWEP.Name, func(iface *bpfInterface) wIfaceVerdict {
 		iface.info.endpointID = nil
-		return false
+		return wIfaceDiscard
 	})
 	// Remove policy debug info if any
 	m.removeIfaceAllPolicyDebugInfo(oldWEP.Name)
@@ -947,10 +963,10 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 			}
 		}
 
-		m.withIface(iface, func(i *bpfInterface) bool {
+		m.withIface(iface, func(i *bpfInterface) wIfaceVerdict {
 			i.dpState.isReady = isReady
 			m.updateIfaceStateMap(iface, i)
-			return false // no need to enforce dirty
+			return wIfaceOK // no need to enforce dirty
 		})
 	}
 }
@@ -1051,19 +1067,21 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string, isReady *bool) erro
 	m.ifacesLock.Lock()
 	var endpointID *proto.WorkloadEndpointID
 	var ifaceUp bool
-	m.withIface(ifaceName, func(iface *bpfInterface) (forceDirty bool) {
+	m.withIface(ifaceName, func(iface *bpfInterface) wIfaceVerdict {
 		ifaceUp = iface.info.ifaceIsUp()
 		endpointID = iface.info.endpointID
-		if !ifaceUp {
-			log.WithField("iface", ifaceName).Debug("Interface is down/gone, closing jump maps.")
-			for _, fd := range iface.dpState.jumpMapFDs {
-				if err := fd.Close(); err != nil {
-					log.WithError(err).Error("Failed to close jump map.")
-				}
-			}
-			iface.dpState.jumpMapFDs = nil
+
+		if ifaceUp {
+			return wIfaceClean
 		}
-		return false
+
+		log.WithField("iface", ifaceName).Debug("Interface is down/gone, closing jump maps.")
+		for _, fd := range iface.dpState.jumpMapFDs {
+			if err := fd.Close(); err != nil {
+				log.WithError(err).Error("Failed to close jump map.")
+			}
+		}
+		return wIfaceDiscard
 	})
 	m.ifacesLock.Unlock()
 
@@ -1131,9 +1149,9 @@ func (m *bpfEndpointManager) applyPolicy(ifaceName string) error {
 	err := m.doApplyPolicy(ifaceName, &isReady)
 
 	m.ifacesLock.Lock()
-	m.withIface(ifaceName, func(iface *bpfInterface) (forceDirty bool) {
+	m.withIface(ifaceName, func(iface *bpfInterface) wIfaceVerdict {
 		iface.dpState.isReady = isReady
-		return false // already dirty
+		return wIfaceOK // already dirty
 	})
 	m.ifacesLock.Unlock()
 
@@ -1227,9 +1245,9 @@ func (m *bpfEndpointManager) addHostPolicy(rules *polprog.Rules, hostEndpoint *p
 func (m *bpfEndpointManager) ifaceIsUp(ifaceName string) (up bool) {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
-	m.withIface(ifaceName, func(iface *bpfInterface) bool {
+	m.withIface(ifaceName, func(iface *bpfInterface) wIfaceVerdict {
 		up = iface.info.ifaceIsUp()
-		return false
+		return wIfaceClean
 	})
 	return
 }
@@ -1552,11 +1570,6 @@ func (m *bpfEndpointManager) removeWEPFromIndexes(wlID proto.WorkloadEndpointID,
 	}
 
 	m.removeProfileToEPMappings(wep.ProfileIds, wlID)
-
-	m.withIface(wep.Name, func(iface *bpfInterface) bool {
-		iface.info.endpointID = nil
-		return false
-	})
 }
 
 func (m *bpfEndpointManager) removePolicyToEPMappings(polNames []string, id interface{}) {
@@ -1906,23 +1919,29 @@ func (m *bpfEndpointManager) ensureNoProgram(ap attachPoint) error {
 	return err
 }
 
-func (m *bpfEndpointManager) getJumpMapFD(ap attachPoint) (fd bpf.MapFD) {
+func (m *bpfEndpointManager) getJumpMapFD(ap attachPoint) bpf.MapFD {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
-	m.withIface(ap.IfaceName(), func(iface *bpfInterface) bool {
+
+	var fd bpf.MapFD
+
+	m.withIface(ap.IfaceName(), func(iface *bpfInterface) wIfaceVerdict {
 		if iface.dpState.jumpMapFDs != nil {
 			fd = iface.dpState.jumpMapFDs[ap.JumpMapFDMapKey()]
 		}
-		return false
+		return wIfaceClean
 	})
-	return
+
+	return fd
 }
 
 func (m *bpfEndpointManager) setJumpMapFD(ap attachPoint, fd bpf.MapFD) {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
 
-	m.withIface(ap.IfaceName(), func(iface *bpfInterface) bool {
+	m.withIface(ap.IfaceName(), func(iface *bpfInterface) wIfaceVerdict {
+		ret := wIfaceOK
+
 		if fd > 0 {
 			if iface.dpState.jumpMapFDs == nil {
 				iface.dpState.jumpMapFDs = make(map[string]bpf.MapFD)
@@ -1931,11 +1950,13 @@ func (m *bpfEndpointManager) setJumpMapFD(ap attachPoint, fd bpf.MapFD) {
 		} else if iface.dpState.jumpMapFDs != nil {
 			delete(iface.dpState.jumpMapFDs, ap.JumpMapFDMapKey())
 			if len(iface.dpState.jumpMapFDs) == 0 {
-				iface.dpState.jumpMapFDs = nil
+				ret = wIfaceDiscard
 			}
 		}
+
 		ap.Log().Debugf("Jump map now %v fd=%v", iface.dpState.jumpMapFDs, fd)
-		return false
+
+		return ret
 	})
 }
 


### PR DESCRIPTION
The call back return an explicit verdit whether device is clean/dirty or should be discarded. As the state grows we do not need to take care of zeroing all part properly.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
