### PR TITLE
Fix panic while handling invalid spoofed IP ranges

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -182,13 +182,24 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 	}
 
 	// Handle source IP spoofing annotation
-	var requestedSourcePrefixes []string
+	var sourcePrefixes []string
 	if annotation, ok := pod.Annotations["cni.projectcalico.org/allowedSourcePrefixes"]; ok && annotation != "" {
 		// Parse Annotation data
+		var requestedSourcePrefixes []string
 		err := json.Unmarshal([]byte(annotation), &requestedSourcePrefixes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse '%s' as JSON: %s", annotation, err)
 		}
+
+		// Filter out any invalid entries and normalize the CIDRs.
+		for _, prefix := range requestedSourcePrefixes {
+			if _, n, err := cnet.ParseCIDR(prefix); err != nil {
+				return nil, fmt.Errorf("failed to parse '%s' as a CIDR: %s", prefix, err)
+			} else {
+				sourcePrefixes = append(sourcePrefixes, n.String())
+			}
+		}
+
 	}
 
 	// Map any named ports through.
@@ -250,7 +261,7 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		Ports:                      endpointPorts,
 		IPNATs:                     floatingIPs,
 		ServiceAccountName:         pod.Spec.ServiceAccountName,
-		AllowSpoofedSourcePrefixes: requestedSourcePrefixes,
+		AllowSpoofedSourcePrefixes: sourcePrefixes,
 	}
 
 	if v, ok := pod.Annotations["k8s.v1.cni.cncf.io/network-status"]; ok {

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -16,6 +16,7 @@ package updateprocessors
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 
@@ -48,7 +49,6 @@ func convertWorkloadEndpointV2ToV1Key(v3key model.ResourceKey) (model.Key, error
 		WorkloadID:     v3key.Namespace + "/" + parts[2],
 		EndpointID:     parts[3],
 	}, nil
-
 }
 
 func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
@@ -162,8 +162,14 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 			_, ipn, err := cnet.ParseCIDROrIP(prefix)
 			if err != nil {
 				return nil, err
+			} else if ipn == nil {
+				return nil, fmt.Errorf("failed to parse AllowSpoofedSourcePrefix (%s)", prefix)
 			}
-			allowedSources = append(allowedSources, *(ipn.Network()))
+			nw := ipn.Network()
+			if nw == nil {
+				return nil, fmt.Errorf("failed to parse AllowSpoofedSourcePrefix (%s) to network", prefix)
+			}
+			allowedSources = append(allowedSources, *nw)
 		}
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes the main issue in https://github.com/projectcalico/calico/issues/7068

We were not properly handling invalid CIDRs in the user input, resulting
in a nil pointer panic down the road.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix panic in calico-node when invalid spoofed IP range provided on a pod.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.