### PR TITLE
[BPF] no need for CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP mark

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -175,12 +175,8 @@ enum calico_skb_mark {
 	/* "BYPASS_FWD" is a special case of "BYPASS" used when a packet returns from one of our
 	 * VXLAN tunnels.  It tells the downstream program to forward the packet. */
 	CALI_SKB_MARK_BYPASS_FWD             = CALI_SKB_MARK_BYPASS  | 0x00300000,
-	/* "BYPASS_FWD_SRC_FIXUP" is a special case of "BYPASS" used when a from-workload program
-	 * is returning a packet to our VXLAN tunnel.  The from-workload program does the encapsulation
-	 * but, due to RPF, it cannot set the source IP of the outer IP header.  The mark bit
-	 * tells the downstream HEP program to fix up the source IP to be the host IP as it leaves the
-	 * host namespace. */
-	CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP   = CALI_SKB_MARK_BYPASS  | 0x00500000,
+	/* Now unused mark */
+	CALI_SKB_MARK_free_to_use            = CALI_SKB_MARK_BYPASS  | 0x00500000,
 	CALI_SKB_MARK_BYPASS_MASK            = CALI_SKB_MARK_SEEN_MASK | 0x02700000,
 	/* The FALLTHROUGH bit is used by programs that are towards the host namespace to indicate
 	 * that the packet is not known in BPF conntrack. We have iptables rules to drop or allow

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -167,36 +167,6 @@ static CALI_BPF_INLINE int calico_tc(struct __sk_buff *skb)
 			CALI_DEBUG("Packet approved for forward.\n");
 			COUNTER_INC(&ctx, CALI_REASON_BYPASS);
 			goto allow;
-		case CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP:
-			CALI_DEBUG("Packet approved for forward - src ip fixup\n");
-			COUNTER_INC(&ctx, CALI_REASON_BYPASS);
-
-			/* we need to fix up the right src host IP */
-			if (skb_refresh_validate_ptrs(&ctx, UDP_SIZE)) {
-				DENY_REASON(&ctx, CALI_REASON_SHORT);
-				CALI_DEBUG("Too short\n");
-				goto deny;
-			}
-
-			__be32 ip_src = ip_hdr(&ctx)->saddr;
-			if (ip_src == HOST_IP) {
-				CALI_DEBUG("src ip fixup not needed %x\n", bpf_ntohl(ip_src));
-				goto allow;
-			} else {
-				CALI_DEBUG("src ip fixup %x\n", bpf_ntohl(HOST_IP));
-			}
-
-			/* XXX do a proper CT lookup to find this */
-			ip_hdr(&ctx)->saddr = HOST_IP;
-			int l3_csum_off = skb_iphdr_offset(&ctx) + offsetof(struct iphdr, check);
-
-			int res = bpf_l3_csum_replace(skb, l3_csum_off, ip_src, HOST_IP, 4);
-			if (res) {
-				DENY_REASON(&ctx, CALI_REASON_CSUM_FAIL);
-				goto deny;
-			}
-
-			goto allow;
 		}
 	}
 
@@ -1041,8 +1011,8 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				goto icmp_too_big;
 			}
 			state->ip_src = HOST_IP;
-			seen_mark = CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP; /* Do FIB if possible */
-			CALI_DEBUG("marking CALI_SKB_MARK_BYPASS_FWD_SRC_FIXUP\n");
+			seen_mark = CALI_SKB_MARK_BYPASS_FWD; /* Do FIB if possible */
+			CALI_DEBUG("marking CALI_SKB_MARK_BYPASS_FWD\n");
 
 			goto nat_encap;
 		}

--- a/felix/bpf/tc/defs/defs.go
+++ b/felix/bpf/tc/defs/defs.go
@@ -15,20 +15,19 @@
 package tcdefs
 
 const (
-	MarkSeen                         = 0x01000000
-	MarkSeenMask                     = MarkSeen
-	MarkSeenBypass                   = MarkSeen | 0x02000000
-	MarkSeenBypassMask               = MarkSeenMask | MarkSeenBypass
-	MarkSeenFallThrough              = MarkSeen | 0x04000000
-	MarkSeenFallThroughMask          = MarkSeenMask | MarkSeenFallThrough
-	MarkSeenBypassForward            = MarkSeenBypass | 0x00300000
-	MarkSeenBypassForwardMask        = MarkSeenBypassMask | 0x00f00000
-	MarkSeenBypassForwardSourceFixup = MarkSeenBypass | 0x00500000
-	MarkSeenNATOutgoing              = MarkSeenBypass | 0x00800000
-	MarkSeenNATOutgoingMask          = MarkSeenBypassMask | 0x00f00000
-	MarkSeenMASQ                     = MarkSeenBypass | 0x00600000
-	MarkSeenMASQMask                 = MarkSeenBypassMask | 0x00f00000
-	MarkSeenSkipFIB                  = MarkSeen | 0x00100000
+	MarkSeen                  = 0x01000000
+	MarkSeenMask              = MarkSeen
+	MarkSeenBypass            = MarkSeen | 0x02000000
+	MarkSeenBypassMask        = MarkSeenMask | MarkSeenBypass
+	MarkSeenFallThrough       = MarkSeen | 0x04000000
+	MarkSeenFallThroughMask   = MarkSeenMask | MarkSeenFallThrough
+	MarkSeenBypassForward     = MarkSeenBypass | 0x00300000
+	MarkSeenBypassForwardMask = MarkSeenBypassMask | 0x00f00000
+	MarkSeenNATOutgoing       = MarkSeenBypass | 0x00800000
+	MarkSeenNATOutgoingMask   = MarkSeenBypassMask | 0x00f00000
+	MarkSeenMASQ              = MarkSeenBypass | 0x00600000
+	MarkSeenMASQMask          = MarkSeenBypassMask | 0x00f00000
+	MarkSeenSkipFIB           = MarkSeen | 0x00100000
 
 	MarkLinuxConntrackEstablished     = 0x08000000
 	MarkLinuxConntrackEstablishedMask = 0x08000000

--- a/felix/bpf/ut/icmp_related_test.go
+++ b/felix/bpf/ut/icmp_related_test.go
@@ -253,7 +253,7 @@ func TestICMPRelatedFromHostBeforeNAT(t *testing.T) {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
 	})
-	expectMark(tcdefs.MarkSeenBypassForwardSourceFixup)
+	expectMark(tcdefs.MarkSeenBypassForward)
 
 	// we base the packet on the original packet before NAT as if we let the original packet through
 	// before we do the actual NAT as that is where we check for TTL as doing it for the tunneled

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -435,7 +435,7 @@ func TestNATNodePort(t *testing.T) {
 	Expect(v.Type()).To(Equal(conntrack.TypeNATReverse))
 	Expect(v.Flags()).To(Equal(conntrack3.FlagNATNPFwd))
 
-	expectMark(tcdefs.MarkSeenBypassForwardSourceFixup)
+	expectMark(tcdefs.MarkSeenBypassForward)
 	// Leaving node 1
 	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		res, err := bpfrun(encapedPkt)
@@ -783,7 +783,7 @@ func TestNATNodePort(t *testing.T) {
 		checkVxlanEncap(pktR, false, ipv4, udp, payload)
 	})
 
-	expectMark(tcdefs.MarkSeenBypassForwardSourceFixup)
+	expectMark(tcdefs.MarkSeenBypassForward)
 
 	/*
 	 * TEST that unknown VNI is passed through
@@ -1123,7 +1123,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 
 	var encapedPkt []byte
 
-	hostIP = node1ip2
+	hostIP = node1ip
 	skbMark = 0
 
 	// Setup routing
@@ -1185,7 +1185,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 
 	dumpCTMap(ctMap)
 
-	expectMark(tcdefs.MarkSeenBypassForwardSourceFixup)
+	expectMark(tcdefs.MarkSeenBypassForward)
 
 	hostIP = node1ip
 	var encapedGoPkt gopacket.Packet
@@ -1893,7 +1893,7 @@ func TestNATNodePortIngressDSR(t *testing.T) {
 
 		checkVxlanEncap(pktR, false, ipv4, udp, payload)
 	})
-	expectMark(tcdefs.MarkSeenBypassForwardSourceFixup)
+	expectMark(tcdefs.MarkSeenBypassForward)
 
 	dumpCTMap(ctMap)
 


### PR DESCRIPTION
We do not have a usecase for fixing up host IP when a packet is leaving the host. We always set the source when we do vxlan encap as expected. Therefore we do not need to ever set the mark and check for it, which makes the code simpler a slightly faster.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
