### PR TITLE
[release-v3.24] Auto pick #7076: Fix panic while handling invalid spoofed IP ranges

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
@@ -45,7 +45,6 @@ func podToWorkloadEndpoint(c Converter, pod *kapiv1.Pod) (*model.KVPair, error) 
 }
 
 var _ = Describe("Test parsing strings", func() {
-
 	// Use a single instance of the Converter for these tests.
 	c := NewConverter()
 
@@ -171,7 +170,6 @@ var _ = Describe("Test selector conversion", func() {
 })
 
 var _ = Describe("Test Pod conversion", func() {
-
 	// Use a single instance of the Converter for these tests.
 	c := NewConverter()
 
@@ -520,7 +518,6 @@ var _ = Describe("Test Pod conversion", func() {
 
 		// Assert that the endpoint contains the appropriate DNAT
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).Spec.IPNATs).To(ConsistOf(libapiv3.IPNAT{InternalIP: "192.168.0.1", ExternalIP: "1.1.1.1"}))
-
 	})
 
 	It("should find the right address family target for dual stack floating IPs", func() {
@@ -556,10 +553,9 @@ var _ = Describe("Test Pod conversion", func() {
 			libapiv3.IPNAT{InternalIP: "192.168.0.1", ExternalIP: "1.1.1.1"},
 			libapiv3.IPNAT{InternalIP: "fd5f:8067::1", ExternalIP: "fd80:100:100::10"},
 		))
-
 	})
 
-	It("should look the source spoofing disabling annotation", func() {
+	It("should look at the source spoofing disabling annotation", func() {
 		pod := kapiv1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "podA",
@@ -580,6 +576,73 @@ var _ = Describe("Test Pod conversion", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(c.HasIPAddress(&pod)).To(BeTrue())
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).Spec.AllowSpoofedSourcePrefixes).To(ConsistOf([]string{"1.1.1.0/24", "8.8.8.8/32"}))
+	})
+
+	It("should error on empty string in the source spoofing disabling annotation", func() {
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "podA",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"cni.projectcalico.org/podIP":                 "192.168.0.1",
+					"cni.projectcalico.org/allowedSourcePrefixes": "[\"\"]",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+		}
+
+		wep, err := podToWorkloadEndpoint(c, &pod)
+		Expect(err).To(HaveOccurred())
+		Expect(wep).To(BeNil())
+	})
+
+	It("should error on invalid CIDR in the source spoofing disabling annotation", func() {
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "podA",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"cni.projectcalico.org/podIP":                 "192.168.0.1",
+					"cni.projectcalico.org/allowedSourcePrefixes": "[\"gumbo\"]",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+		}
+
+		wep, err := podToWorkloadEndpoint(c, &pod)
+		Expect(err).To(HaveOccurred())
+		Expect(wep).To(BeNil())
+	})
+
+	It("should normalize CIDRs in the source spoofing disabling annotation", func() {
+		pod := kapiv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "podA",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"cni.projectcalico.org/podIP":                 "192.168.0.1",
+					"cni.projectcalico.org/allowedSourcePrefixes": "[\"1.1.1.1/16\"]",
+				},
+				ResourceVersion: "1234",
+			},
+			Spec: kapiv1.PodSpec{
+				NodeName:   "nodeA",
+				Containers: []kapiv1.Container{},
+			},
+		}
+
+		wep, err := podToWorkloadEndpoint(c, &pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.HasIPAddress(&pod)).To(BeTrue())
+		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).Spec.AllowSpoofedSourcePrefixes).To(ConsistOf([]string{"1.1.0.0/16"}))
 	})
 
 	It("should return an error for a bad pod IP", func() {
@@ -1077,7 +1140,6 @@ var _ = Describe("Test Pod conversion", func() {
 })
 
 var _ = Describe("Test NetworkPolicy conversion", func() {
-
 	// Use a single instance of the Converter for these tests.
 	c := NewConverter()
 
@@ -2531,7 +2593,6 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		// As this is an IPBlock rule, podSel and nsSel should be empty (not nil!)
 		Expect(podSel).To(BeEmpty())
 		Expect(nsSel).To(BeEmpty())
-
 	})
 
 	It("should have empty and Nil NetworkPolicyPeerfields when an IPBlock is invalid", func() {
@@ -2551,7 +2612,6 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		// As this is an IPBlock rule, podSel and nsSel should be empty (not nil!)
 		Expect(podSel).To(BeEmpty())
 		Expect(nsSel).To(BeEmpty())
-
 	})
 
 	It("should parse a NetworkPolicyPeer with an CIDR and Except field", func() {
@@ -2574,7 +2634,6 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		// As this is an IPBlock rule, podSel and nsSel should be empty (not nil!)
 		Expect(podSel).To(BeEmpty())
 		Expect(nsSel).To(BeEmpty())
-
 	})
 
 	It("should parse a NetworkPolicy with both an Egress and an Ingress rule", func() {
@@ -2641,13 +2700,11 @@ var _ = Describe("Test NetworkPolicy conversion", func() {
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Types[0]).To(Equal(apiv3.PolicyTypeIngress))
 		Expect(pol.Value.(*apiv3.NetworkPolicy).Spec.Types[1]).To(Equal(apiv3.PolicyTypeEgress))
 	})
-
 })
 
 // This suite of tests is useful for ensuring we continue to support kubernetes apiserver
 // versions <= 1.7.x, and can be removed when that is no longer required.
 var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", func() {
-
 	// Use a single instance of the Converter for these tests.
 	c := NewConverter()
 
@@ -3025,7 +3082,6 @@ var _ = Describe("Test NetworkPolicy conversion (k8s <= 1.7, no policyTypes)", f
 })
 
 var _ = Describe("Test Namespace conversion", func() {
-
 	// Use a single instance of the Converter for these tests.
 	c := NewConverter()
 
@@ -3116,7 +3172,6 @@ var _ = Describe("Test Namespace conversion", func() {
 		// Ensure both inbound and outbound rules are set to allow.
 		Expect(Ingress[0]).To(Equal(apiv3.Rule{Action: apiv3.Allow}))
 		Expect(Egress[0]).To(Equal(apiv3.Rule{Action: apiv3.Allow}))
-
 	})
 
 	It("should not fail for malformed annotation", func() {
@@ -3169,7 +3224,6 @@ var _ = Describe("Test Namespace conversion", func() {
 })
 
 var _ = Describe("Test ServiceAccount conversion", func() {
-
 	// Use a single instance of the Converter for these tests.
 	c := NewConverter()
 

--- a/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -182,13 +182,24 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 	}
 
 	// Handle source IP spoofing annotation
-	var requestedSourcePrefixes []string
+	var sourcePrefixes []string
 	if annotation, ok := pod.Annotations["cni.projectcalico.org/allowedSourcePrefixes"]; ok && annotation != "" {
 		// Parse Annotation data
+		var requestedSourcePrefixes []string
 		err := json.Unmarshal([]byte(annotation), &requestedSourcePrefixes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse '%s' as JSON: %s", annotation, err)
 		}
+
+		// Filter out any invalid entries and normalize the CIDRs.
+		for _, prefix := range requestedSourcePrefixes {
+			if _, n, err := cnet.ParseCIDR(prefix); err != nil {
+				return nil, fmt.Errorf("failed to parse '%s' as a CIDR: %s", prefix, err)
+			} else {
+				sourcePrefixes = append(sourcePrefixes, n.String())
+			}
+		}
+
 	}
 
 	// Map any named ports through.
@@ -250,7 +261,7 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		Ports:                      endpointPorts,
 		IPNATs:                     floatingIPs,
 		ServiceAccountName:         pod.Spec.ServiceAccountName,
-		AllowSpoofedSourcePrefixes: requestedSourcePrefixes,
+		AllowSpoofedSourcePrefixes: sourcePrefixes,
 	}
 
 	// Embed the workload endpoint into a KVPair.

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/workloadendpointprocessor.go
@@ -16,6 +16,7 @@ package updateprocessors
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 
@@ -48,7 +49,6 @@ func convertWorkloadEndpointV2ToV1Key(v3key model.ResourceKey) (model.Key, error
 		WorkloadID:     v3key.Namespace + "/" + parts[2],
 		EndpointID:     parts[3],
 	}, nil
-
 }
 
 func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
@@ -162,8 +162,14 @@ func convertWorkloadEndpointV2ToV1Value(val interface{}) (interface{}, error) {
 			_, ipn, err := cnet.ParseCIDROrIP(prefix)
 			if err != nil {
 				return nil, err
+			} else if ipn == nil {
+				return nil, fmt.Errorf("failed to parse AllowSpoofedSourcePrefix (%s)", prefix)
 			}
-			allowedSources = append(allowedSources, *(ipn.Network()))
+			nw := ipn.Network()
+			if nw == nil {
+				return nil, fmt.Errorf("failed to parse AllowSpoofedSourcePrefix (%s) to network", prefix)
+			}
+			allowedSources = append(allowedSources, *nw)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #7076 on release-v3.24.

#7076: Fix panic while handling invalid spoofed IP ranges

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes the main issue in https://github.com/projectcalico/calico/issues/7068

We were not properly handling invalid CIDRs in the user input, resulting
in a nil pointer panic down the road.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix panic in calico-node when invalid spoofed IP range provided on a pod.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.