### PR TITLE
Fix that Felix FVs failed to wait for Felix restart as expected.

### DIFF
--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -39,26 +39,25 @@ type Felix struct {
 	*containers.Container
 
 	// ExpectedIPIPTunnelAddr contains the IP that the infrastructure expects to
-	// get assigned to the IPIP tunnel.  Filled in by AddNode().
+	// get assigned to the IPIP tunnel.  Filled in by SetExpectedIPIPTunnelAddr().
 	ExpectedIPIPTunnelAddr string
 	// ExpectedVXLANTunnelAddr contains the IP that the infrastructure expects to
-	// get assigned to the IPv4 VXLAN tunnel.  Filled in by AddNode().
+	// get assigned to the IPv4 VXLAN tunnel.  Filled in by SetExpectedVXLANTunnelAddr().
 	ExpectedVXLANTunnelAddr string
 	// ExpectedVXLANV6TunnelAddr contains the IP that the infrastructure expects to
-	// get assigned to the IPv6 VXLAN tunnel.  Filled in by AddNode().
+	// get assigned to the IPv6 VXLAN tunnel.  Filled in by SetExpectedVXLANV6TunnelAddr().
 	ExpectedVXLANV6TunnelAddr string
 	// ExpectedWireguardTunnelAddr contains the IPv4 address that the infrastructure expects to
-	// get assigned to the IPv4 Wireguard tunnel.  Filled in by AddNode().
+	// get assigned to the IPv4 Wireguard tunnel.  Filled in by SetExpectedWireguardTunnelAddr().
 	ExpectedWireguardTunnelAddr string
 	// ExpectedWireguardV6TunnelAddr contains the IPv6 address that the infrastructure expects to
-	// get assigned to the IPv6 Wireguard tunnel.  Filled in by AddNode().
+	// get assigned to the IPv6 Wireguard tunnel.  Filled in by SetExpectedWireguardV6TunnelAddr().
 	ExpectedWireguardV6TunnelAddr string
 
 	// IP of the Typha that this Felix is using (if any).
 	TyphaIP string
 
-	// If sets, acts like an external IP of a node. Filled in by AddNode().
-	// XXX setup routes
+	// If set, acts like an external IP of a node. Filled in by SetExternalIP().
 	ExternalIP string
 
 	startupDelayed bool

--- a/felix/fv/infrastructure/topology.go
+++ b/felix/fv/infrastructure/topology.go
@@ -173,7 +173,7 @@ func StartSingleNodeTopology(options TopologyOptions, infra DatastoreInfra) (fel
 //   index in the returned array.  When creating workloads, use IPs from the relevant block.
 // - Configures the Tunnel IP for each host as 10.65.x.1.
 func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (felixes []*Felix, client client.Interface) {
-	log.Infof("Starting a %d-node topology.", n)
+	log.WithField("options", opts).Infof("Starting a %d-node topology", n)
 	success := false
 	var err error
 	startTime := time.Now()
@@ -192,6 +192,7 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 	if opts.VXLANMode == "" {
 		opts.VXLANMode = api.VXLANModeNever
 	}
+
 	// Get client.
 	client = infra.GetCalicoClient()
 	mustInitDatastore(client)
@@ -292,25 +293,26 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 			kdd.SetExternalIP(felix, i)
 			expectedIPs = append(expectedIPs, felix.ExternalIP)
 		}
+		setUpBGPNodeIPAndIPIPTunnelIP := n > 1 || opts.NeedNodeIP
 		if opts.IPIPEnabled {
-			infra.SetExpectedIPIPTunnelAddr(felix, i, bool(n > 1))
+			infra.SetExpectedIPIPTunnelAddr(felix, i, setUpBGPNodeIPAndIPIPTunnelIP)
 			expectedIPs = append(expectedIPs, felix.ExpectedIPIPTunnelAddr)
 		}
 		if opts.VXLANMode != api.VXLANModeNever {
-			infra.SetExpectedVXLANTunnelAddr(felix, i, bool(n > 1))
+			infra.SetExpectedVXLANTunnelAddr(felix, i, n > 1)
 			expectedIPs = append(expectedIPs, felix.ExpectedVXLANTunnelAddr)
 			if opts.EnableIPv6 {
 				expectedIPs = append(expectedIPs, felix.IPv6)
-				infra.SetExpectedVXLANV6TunnelAddr(felix, i, bool(n > 1))
+				infra.SetExpectedVXLANV6TunnelAddr(felix, i, n > 1)
 				expectedIPs = append(expectedIPs, felix.ExpectedVXLANV6TunnelAddr)
 			}
 		}
 		if opts.WireguardEnabled {
-			infra.SetExpectedWireguardTunnelAddr(felix, i, bool(n > 1))
+			infra.SetExpectedWireguardTunnelAddr(felix, i, n > 1)
 			expectedIPs = append(expectedIPs, felix.ExpectedWireguardTunnelAddr)
 		}
 		if opts.WireguardEnabledV6 {
-			infra.SetExpectedWireguardV6TunnelAddr(felix, i, bool(n > 1))
+			infra.SetExpectedWireguardV6TunnelAddr(felix, i, n > 1)
 			expectedIPs = append(expectedIPs, felix.ExpectedWireguardV6TunnelAddr)
 		}
 
@@ -319,15 +321,18 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 			// If felix has an IPIP tunnel address defined, Felix may restart after loading its config.
 			// Handle that here by monitoring the log and waiting for the correct tunnel IP to show up
 			// before we return.
+			log.Info("Waiting for felix to restart after setting tunnel IP.")
 			w = felix.WatchStdoutFor(regexp.MustCompile(
-				`"IpInIpTunnelAddr":"` + regexp.QuoteMeta(felix.ExpectedIPIPTunnelAddr) + `"`))
+				`Successfully loaded configuration.*"IpInIpTunnelAddr":"` + regexp.QuoteMeta(felix.ExpectedIPIPTunnelAddr) + `"`))
 		} else if opts.NeedNodeIP {
-			w = felix.WatchStdoutFor(regexp.MustCompile(
-				`Host config update for this host|Host IP changed`))
+			// opts.NeedNodeIP is implicitly handled by the previous branch.  We rely on the infra to
+			// set the (formerly BGP) node IP and tunnel IP together so if we hit this branch then the
+			// infra isn't doing what we expect.
+			log.Panic("NeedNodeIP set but infra didn't set ExpectedIPIPTunnelAddr.")
 		}
-		infra.AddNode(felix, i, bool(n > 1 || opts.NeedNodeIP))
+		infra.AddNode(felix, i, setUpBGPNodeIPAndIPIPTunnelIP)
 		if w != nil {
-			// Wait for any Felix restart...
+			// Wait for any expected Felix restart...
 			log.Info("Wait for Felix to restart")
 			Eventually(w, "10s").Should(BeClosed(),
 				fmt.Sprintf("Timed out waiting for %s to restart", felix.Name))


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Set the expected tunnel address _before_ checking it.
- Improve regex to only match the post-restart logs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
