### PR TITLE
[CHERRY-PICK] [BPF] fix CTLB when ipv4 addr is masked as ipv6

### DIFF
--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -50,7 +50,7 @@ UT_C_FILES:=$(shell find ut -name '*.c')
 UT_OBJS:=$(UT_C_FILES:.c=.o) $(shell ./list-ut-objs)
 
 OBJS:=$(shell ./list-objs)
-C_FILES:=tc.c connect_balancer.c xdp.c
+C_FILES:=tc.c connect_balancer.c connect_balancer_v6.c xdp.c
 
 all: $(OBJS)
 ut-objs: $(UT_OBJS)

--- a/felix/bpf-gpl/connect.h
+++ b/felix/bpf-gpl/connect.h
@@ -1,0 +1,131 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+#ifndef __CONNECT_H__
+#define __CONNECT_H__
+
+#include <linux/bpf.h>
+
+#include "bpf.h"
+#include "nat_lookup.h"
+
+#if !defined(__BPFTOOL_LOADER__) && !defined (__IPTOOL_LOADER__)
+const volatile struct cali_ctlb_globals __globals;
+#define UDP_NOT_SEEN_TIMEO __globals.udp_not_seen_timeo
+#else
+#define UDP_NOT_SEEN_TIMEO 60 /* for tests */
+#endif
+
+static CALI_BPF_INLINE int do_nat_common(struct bpf_sock_addr *ctx, __u8 proto, __be32 *dst, bool connect)
+{
+	int err = 0;
+	/* We do not know what the source address is yet, we only know that it
+	 * is the localhost, so we might just use 0.0.0.0. That would not
+	 * conflict with traffic from elsewhere.
+	 *
+	 * XXX it means that all workloads that use the cgroup hook have the
+	 * XXX same affinity, which (a) is sub-optimal and (b) leaks info between
+	 * XXX workloads.
+	 */
+	nat_lookup_result res = NAT_LOOKUP_ALLOW;
+	__u16 dport_he = (__u16)(bpf_ntohl(ctx->user_port)>>16);
+	struct calico_nat_dest *nat_dest;
+	nat_dest = calico_v4_nat_lookup(0, *dst, proto, dport_he, false, &res,
+			proto == IPPROTO_UDP && !connect ? UDP_NOT_SEEN_TIMEO : 0, /* enforce affinity UDP */
+			proto == IPPROTO_UDP && !connect /* update affinity timer */);
+	if (!nat_dest) {
+		CALI_INFO("NAT miss.\n");
+		if (res == NAT_NO_BACKEND) {
+			err = -1;
+		}
+		goto out;
+	}
+
+	__be32 dport_be = host_to_ctx_port(nat_dest->port);
+
+	__u64 cookie = bpf_get_socket_cookie(ctx);
+	CALI_DEBUG("Store: ip=%x port=%d cookie=%x\n",
+			bpf_ntohl(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
+
+	/* For all protocols, record recent NAT operations in an LRU map; other BPF programs use this
+	 * cache to reverse our DNAT so they can do pre-DNAT policy. */
+	struct ct_nats_key natk = {
+		.cookie = cookie,
+		.ip = nat_dest->addr,
+		.port = dport_be,
+		.proto = proto,
+	};
+	struct sendrecv4_val val = {
+		.ip	= *dst,
+		.port	= ctx->user_port,
+	};
+	int rc = cali_v4_ct_nats_update_elem(&natk, &val, 0);
+	if (rc) {
+		/* if this happens things are really bad! report */
+		CALI_INFO("Failed to update ct_nats map rc=%d\n", rc);
+	}
+
+	if (proto != IPPROTO_TCP) {
+		/* For UDP, store a long-lived reverse mapping, which we use to reverse the DNAT for programs that
+		 * check the source on the return packets. */
+		__u64 cookie = bpf_get_socket_cookie(ctx);
+		CALI_DEBUG("Store: ip=%x port=%d cookie=%x\n",
+				bpf_ntohl(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
+		struct sendrecv4_key key = {
+			.ip	= nat_dest->addr,
+			.port	= dport_be,
+			.cookie	= cookie,
+		};
+
+		if (cali_v4_srmsg_update_elem(&key, &val, 0)) {
+			/* if this happens things are really bad! report */
+			CALI_INFO("Failed to update map\n");
+			goto out;
+		}
+	}
+
+	*dst = nat_dest->addr;
+	ctx->user_port = dport_be;
+
+out:
+	return err;
+}
+
+static CALI_BPF_INLINE int connect_v4(struct bpf_sock_addr *ctx, __be32 *dst)
+{
+	int ret = 1; /* OK value */
+
+	/* do not process anything non-TCP or non-UDP, but do not block it, will be
+	 * dealt with somewhere else.
+	 */
+	if (ctx->type != SOCK_STREAM && ctx->type != SOCK_DGRAM) {
+		CALI_INFO("unexpected sock type %d\n", ctx->type);
+		goto out;
+	}
+
+	__u8 ip_proto;
+	switch (ctx->type) {
+	case SOCK_STREAM:
+		CALI_DEBUG("SOCK_STREAM -> assuming TCP\n");
+		ip_proto = IPPROTO_TCP;
+		break;
+	case SOCK_DGRAM:
+		CALI_DEBUG("SOCK_DGRAM -> assuming UDP\n");
+		ip_proto = IPPROTO_UDP;
+		break;
+	default:
+		CALI_DEBUG("Unknown socket type: %d\n", (int)ctx->type);
+		goto out;
+	}
+
+	if (do_nat_common(ctx, ip_proto, dst, true) != 0) {
+		ret = 0; /* ret != 1 generates an error in pre-connect */
+		goto out;
+	}
+
+out:
+	return ret;
+}
+
+#endif /* __CONNECT_H__ */

--- a/felix/bpf-gpl/connect_balancer.c
+++ b/felix/bpf-gpl/connect_balancer.c
@@ -15,128 +15,16 @@
 #include "globals.h"
 #include "bpf.h"
 #include "log.h"
-#include "nat_lookup.h"
 
 #include "sendrecv.h"
-
-#if !defined(__BPFTOOL_LOADER__) && !defined (__IPTOOL_LOADER__)
-const volatile struct cali_ctlb_globals __globals;
-#define UDP_NOT_SEEN_TIMEO __globals.udp_not_seen_timeo
-#else
-#define UDP_NOT_SEEN_TIMEO 60 /* for tests */
-#endif
-
-static CALI_BPF_INLINE int do_nat_common(struct bpf_sock_addr *ctx, __u8 proto, bool connect)
-{
-	int err = 0;
-	/* We do not know what the source address is yet, we only know that it
-	 * is the localhost, so we might just use 0.0.0.0. That would not
-	 * conflict with traffic from elsewhere.
-	 *
-	 * XXX it means that all workloads that use the cgroup hook have the
-	 * XXX same affinity, which (a) is sub-optimal and (b) leaks info between
-	 * XXX workloads.
-	 */
-	nat_lookup_result res = NAT_LOOKUP_ALLOW;
-	__u16 dport_he = (__u16)(bpf_ntohl(ctx->user_port)>>16);
-	struct calico_nat_dest *nat_dest;
-	nat_dest = calico_v4_nat_lookup(0, ctx->user_ip4, proto, dport_he, false, &res,
-			proto == IPPROTO_UDP && !connect ? UDP_NOT_SEEN_TIMEO : 0, /* enforce affinity UDP */
-			proto == IPPROTO_UDP && !connect /* update affinity timer */);
-	if (!nat_dest) {
-		CALI_INFO("NAT miss.\n");
-		if (res == NAT_NO_BACKEND) {
-			err = -1;
-		}
-		goto out;
-	}
-
-	__u32 dport_be = host_to_ctx_port(nat_dest->port);
-
-	__u64 cookie = bpf_get_socket_cookie(ctx);
-	CALI_DEBUG("Store: ip=%x port=%d cookie=%x\n",
-			bpf_ntohl(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
-
-	/* For all protocols, record recent NAT operations in an LRU map; other BPF programs use this
-	 * cache to reverse our DNAT so they can do pre-DNAT policy. */
-	struct ct_nats_key natk = {
-		.cookie = cookie,
-		.ip = nat_dest->addr,
-		.port = dport_be,
-		.proto = proto,
-	};
-	struct sendrecv4_val val = {
-		.ip	= ctx->user_ip4,
-		.port	= ctx->user_port,
-	};
-	int rc = cali_v4_ct_nats_update_elem(&natk, &val, 0);
-	if (rc) {
-		/* if this happens things are really bad! report */
-		CALI_INFO("Failed to update ct_nats map rc=%d\n", rc);
-	}
-
-	if (proto != IPPROTO_TCP) {
-		/* For UDP, store a long-lived reverse mapping, which we use to reverse the DNAT for programs that
-		 * check the source on the return packets. */
-		__u64 cookie = bpf_get_socket_cookie(ctx);
-		CALI_DEBUG("Store: ip=%x port=%d cookie=%x\n",
-				bpf_ntohl(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
-		struct sendrecv4_key key = {
-			.ip	= nat_dest->addr,
-			.port	= dport_be,
-			.cookie	= cookie,
-		};
-
-		if (cali_v4_srmsg_update_elem(&key, &val, 0)) {
-			/* if this happens things are really bad! report */
-			CALI_INFO("Failed to update map\n");
-			goto out;
-		}
-	}
-
-	ctx->user_ip4 = nat_dest->addr;
-	ctx->user_port = dport_be;
-
-out:
-	return err;
-}
+#include "connect.h"
 
 SEC("cgroup/connect4")
 int calico_connect_v4(struct bpf_sock_addr *ctx)
 {
-	int ret = 1; /* OK value */
-
 	CALI_DEBUG("calico_connect_v4\n");
 
-	/* do not process anything non-TCP or non-UDP, but do not block it, will be
-	 * dealt with somewhere else.
-	 */
-	if (ctx->type != SOCK_STREAM && ctx->type != SOCK_DGRAM) {
-		CALI_INFO("unexpected sock type %d\n", ctx->type);
-		goto out;
-	}
-
-	__u8 ip_proto;
-	switch (ctx->type) {
-	case SOCK_STREAM:
-		CALI_DEBUG("SOCK_STREAM -> assuming TCP\n");
-		ip_proto = IPPROTO_TCP;
-		break;
-	case SOCK_DGRAM:
-		CALI_DEBUG("SOCK_DGRAM -> assuming UDP\n");
-		ip_proto = IPPROTO_UDP;
-		break;
-	default:
-		CALI_DEBUG("Unknown socket type: %d\n", (int)ctx->type);
-		goto out;
-	}
-
-	if (do_nat_common(ctx, ip_proto, true) != 0) {
-		ret = 0; /* ret != 1 generates an error in pre-connect */
-	}
-
-out:
-	return ret;
+	return connect_v4(ctx, &ctx->user_ip4);
 }
 
 SEC("cgroup/sendmsg4")
@@ -150,7 +38,7 @@ int calico_sendmsg_v4(struct bpf_sock_addr *ctx)
 		goto out;
 	}
 
-	do_nat_common(ctx, IPPROTO_UDP, false);
+	do_nat_common(ctx, IPPROTO_UDP, &ctx->user_ip4, false);
 
 out:
 	return 1;

--- a/felix/bpf-gpl/connect_balancer_v6.c
+++ b/felix/bpf-gpl/connect_balancer_v6.c
@@ -1,5 +1,5 @@
 // Project Calico BPF dataplane programs.
-// Copyright (c) 2020-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 #include <linux/bpf.h>
@@ -16,6 +16,42 @@
 #include "log.h"
 
 #include "sendrecv.h"
+#include "connect.h"
+
+SEC("cgroup/connect6")
+int calico_connect_v6(struct bpf_sock_addr *ctx)
+{
+	int ret = 1;
+	__be32 ipv4;
+
+	CALI_DEBUG("connect_v6 ip[0-1] %x%x\n",
+			ctx->user_ip6[0],
+			ctx->user_ip6[1]);
+	CALI_DEBUG("connect_v6 ip[2-3] %x%x\n",
+			ctx->user_ip6[2],
+			ctx->user_ip6[3]);
+
+	/* check if it is a IPv4 mapped as IPv6 and if so, use the v4 table */
+	if (ctx->user_ip6[0] == 0 && ctx->user_ip6[1] == 0 &&
+			ctx->user_ip6[2] == bpf_htonl(0x0000ffff)) {
+		goto v4;
+	}
+
+	CALI_DEBUG("connect_v6: not implemented for v6 yet\n");
+	goto out;
+
+v4:
+	ipv4 = ctx->user_ip6[3];
+
+ 	if ((ret = connect_v4(ctx, &ipv4)) != 1) {
+		goto out;
+	}
+
+	ctx->user_ip6[3] = ipv4;
+
+out:
+	return ret;
+}
 
 SEC("cgroup/sendmsg6")
 int calico_sendmsg_v6(struct bpf_sock_addr *ctx)

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -165,6 +165,11 @@ func InstallConnectTimeLoadBalancer(cgroupv2 string, logLevel string, udpNotSeen
 		return err
 	}
 
+	err = installProgram("connect", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes)
+	if err != nil {
+		return err
+	}
+
 	err = installProgram("sendmsg", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes)
 	if err != nil {
 		return err

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -2633,10 +2633,19 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								clusterIP := testSvc.Spec.ClusterIP
 								ports := ExpectWithPorts(uint16(testSvc.Spec.Ports[0].Port))
 
+								felixes[0].Exec("sysctl", "-w", "net.ipv6.conf.eth0.disable_ipv6=0")
+								felixes[1].Exec("sysctl", "-w", "net.ipv6.conf.eth0.disable_ipv6=0")
+
 								// Also try host networked pods, both on a local and remote node.
 								// N.B. it cannot work without the connect time balancer
 								cc.Expect(Some, hostW[0], TargetIP(clusterIP), ports, hostW0SrcIP)
 								cc.Expect(Some, hostW[1], TargetIP(clusterIP), ports, hostW1SrcIP)
+
+								if testOpts.protocol == "tcp" {
+									// Also excercise ipv4 as ipv6
+									cc.Expect(Some, hostW[0], TargetIPv4AsIPv6(clusterIP), ports, hostW0SrcIP)
+									cc.Expect(Some, hostW[1], TargetIPv4AsIPv6(clusterIP), ports, hostW1SrcIP)
+								}
 
 								cc.CheckConnectivity()
 							})

--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -427,6 +427,12 @@ func (s TargetIP) ToMatcher(explicitPort ...uint16) *Matcher {
 	}
 }
 
+type TargetIPv4AsIPv6 string
+
+func (s TargetIPv4AsIPv6) ToMatcher(explicitPort ...uint16) *Matcher {
+	return TargetIP("::ffff:" + s).ToMatcher(explicitPort...)
+}
+
 func HaveConnectivityTo(target ConnectionTarget, explicitPort ...uint16) types.GomegaMatcher {
 	return target.ToMatcher(explicitPort...)
 }
@@ -713,6 +719,7 @@ func (cmd *CheckCmd) run(cName string, logMsg string) *Result {
 
 	// Run 'test-connection' to the target.
 	connectionCmd := utils.Command("docker", args...)
+	connectionCmd.Env = []string{"GODEBUG=netdns=1"}
 
 	outPipe, err := connectionCmd.StdoutPipe()
 	Expect(err).NotTo(HaveOccurred())

--- a/felix/fv/test-connection/test-connection.go
+++ b/felix/fv/test-connection/test-connection.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -36,6 +37,7 @@ import (
 	"github.com/ishidawataru/sctp"
 	reuse "github.com/libp2p/go-reuseport"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/calico/felix/fv/cgroup"
 	"github.com/projectcalico/calico/felix/fv/connectivity"
@@ -988,6 +990,100 @@ func (d *connectedSCTP) MTU() (int, error) {
 	return 0, nil
 }
 
+func (d *connectedSCTP) SetReadDeadline(t time.Time) error {
+	return d.conn.SetReadDeadline(t)
+}
+
+type tcpConn6 struct {
+	s int
+}
+
+func (c *tcpConn6) Read(b []byte) (n int, err error) {
+	return unix.Read(c.s, b)
+}
+
+func (c *tcpConn6) Write(b []byte) (n int, err error) {
+	return unix.Write(c.s, b)
+}
+
+func (c *tcpConn6) Close() error {
+	return unix.Close(c.s)
+}
+
+func (c *tcpConn6) LocalAddr() net.Addr {
+	return nil
+}
+
+func (c *tcpConn6) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (c *tcpConn6) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *tcpConn6) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *tcpConn6) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *tcpConn6) SyscallConn() (syscall.RawConn, error) {
+	return &tcpConn6Raw{s: c.s}, nil
+}
+
+type tcpConn6Raw struct {
+	s int
+}
+
+func (c *tcpConn6Raw) Control(f func(fd uintptr)) error {
+	f(uintptr(c.s))
+	return nil
+}
+
+func (c *tcpConn6Raw) Read(f func(fd uintptr) (done bool)) error {
+	panic("not implemeneted")
+}
+
+func (c *tcpConn6Raw) Write(f func(fd uintptr) (done bool)) error {
+	panic("not implemeneted")
+}
+
+func tcpForceV6(ip net.IP, port int) (net.Conn, error) {
+	s, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM, unix.IPPROTO_TCP)
+	if err != nil {
+		return nil, err
+	}
+
+	err = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	err = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	saddr := unix.SockaddrInet6{
+		Port: port,
+	}
+
+	copy(saddr.Addr[:], ip.To16())
+
+	saddr.Addr[10] = 0xff
+	saddr.Addr[11] = 0xff
+
+	err = unix.Connect(s, &saddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tcpConn6{s: s}, nil
+}
+
 // connectedTCP abstracts an SCTP stream.
 type connectedTCP struct {
 	localAddr  string
@@ -1004,10 +1100,34 @@ func (d *connectedTCP) Connect() error {
 	// another call to this program, the original port is in post-close wait
 	// state and bind fails.  The reuse library implements a Dial() that sets
 	// these options.
-	conn, err := reuse.Dial("tcp", d.localAddr, d.remoteAddr)
-	if err != nil {
-		return err
+
+	var conn net.Conn
+
+	if strings.Contains(d.remoteAddr, "[") {
+		addr, port, _ := net.SplitHostPort(d.remoteAddr)
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			return fmt.Errorf("ip %s is invalid", addr)
+		}
+		if ip.To4() != nil {
+			// We want to force ipv6 on ipv4 address
+			var err error
+
+			p, _ := strconv.Atoi(port)
+			if conn, err = tcpForceV6(ip, p); err != nil {
+				return fmt.Errorf("failed creating v6 connection for ip %s", d.remoteAddr)
+			}
+		}
 	}
+
+	if conn == nil {
+		var err error
+		conn, err = reuse.Dial("tcp", d.localAddr, d.remoteAddr)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.conn = conn
 
 	d.r = bufio.NewReader(d.conn)


### PR DESCRIPTION
We need to attach to the v6 connect hook and do a v4 lookup.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

backport to 3.24.x of https://github.com/projectcalico/calico/issues/7092 fix.

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: CLTB resolves service when ipv4 is masked as ipv6. Commonly happens with grpc.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
