### PR TITLE
DOCS-1022: Remove extra columns from a table

### DIFF
--- a/calico/reference/resources/felixconfig.md
+++ b/calico/reference/resources/felixconfig.md
@@ -132,7 +132,7 @@ spec:
 | bpfMapSizeRoute | In eBPF dataplane mode, controls the size of the route map. | int | int | 262144 |
 | bpfPolicyDebugEnabled              | In eBPF dataplane mode, controls whether felix will collect policy dump for each interface. | true, false | boolean | true |
 | routeSource                        | Where Felix gets is routing information from for VXLAN and the BPF dataplane. The CalicoIPAM setting is more efficient because it supports route aggregation, but it only works when Calico's IPAM or host-local IPAM is in use. Use the WorkloadIPs setting if you are using Calico's VXLAN or BPF dataplane and not using Calico IPAM or host-local IPAM. | CalicoIPAM,WorkloadIPs | string | `CalicoIPAM` |
-| mtuIfacePattern                    | Pattern used to discover the host's interface for MTU auto-detection. | regex | string | `^((en|wl|ww|sl|ib)[copsx].*|(eth|wlan|wwan).*)` |
+| mtuIfacePattern                    | Pattern used to discover the host's interface for MTU auto-detection. | regex | string | ^((en&#124;wl&#124;ww&#124;sl&#124;ib)[copsx].* &#124;(eth&#124;wlan&#124;wwan).*) |
 
 <br>
 


### PR DESCRIPTION
## Description
Fixed extraneous columns in a table in this topic: https://unified-docs.tigera.io/calico/reference/resources/felixconfig

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - documentation
- This is the issue that is fixed:
(https://unified-docs.tigera.io/calico/reference/resources/felixconfig)
- the fix is working on a local Jekyll build

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
