### PR TITLE
Fix data race in Typha sync server.

### DIFF
--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -676,12 +676,15 @@ type connection struct {
 	conn            net.Conn
 	// connW is the writer to use to send things to the client.  It may be the net.Conn itself or a wrapper
 	// around it.
-	connW                io.Writer
-	currentWriteDeadline time.Time
+	connW io.Writer
 
-	encoder     *gob.Encoder
-	flushWriter func() error
-	readC       chan interface{}
+	// writeLock is used to protect calls that write to the connection after the initial synchronous handshake.
+	// The delta-sending goroutine and the pinger both write to the connection.
+	writeLock            sync.Mutex
+	currentWriteDeadline time.Time
+	encoder              *gob.Encoder
+	flushWriter          func() error
+	readC                chan interface{}
 
 	logCxt                       *log.Entry
 	chosenCompression            syncproto.CompressionAlgorithm
@@ -1001,7 +1004,7 @@ func (h *connection) waitForAckAndRestartEncoder() error {
 	return nil
 }
 
-// sendMsg sends a message to the client.  It may be called from multiple goroutines because the Encoder is thread-safe.
+// sendMsg sends a message to the client.  It may be called from multiple goroutines.
 func (h *connection) sendMsg(msg interface{}) error {
 	if h.cxt.Err() != nil {
 		// Optimisation, don't bother to send if we're being torn down.
@@ -1012,6 +1015,10 @@ func (h *connection) sendMsg(msg interface{}) error {
 		Message: msg,
 	}
 	startTime := time.Now()
+
+	// The gob Encoder has its own mutex, but we need to synchronise around the flush operation as well.
+	h.writeLock.Lock()
+	defer h.writeLock.Unlock()
 
 	// Make sure we have a timeout on the connection so that we can't block forever in the synchronous
 	// part of the protocol.  After we send the snapshot we rely more on the layer 7 ping/pong.


### PR DESCRIPTION
Previously we relied on the embedded mutex in the gob Encoder but that is no longer sufficient now that we have buffering under the gob encoder.  We need a mutex that locks around the call to flush the underlying buffer too.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Previously we relied on the embedded mutex in the gob Encoder but that is no longer sufficient now that we have buffering under the gob encoder.  We need a mutex that locks around the call to flush the underlying buffer too.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
