### PR TITLE
Fix race in typha FV tests during shutdown of client.

### DIFF
--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -642,7 +642,9 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 		)
 		err := client.Start(clientCxt)
 		Expect(err).NotTo(HaveOccurred())
-		go recorder.Loop(clientCxt)
+		recorderCtx, recorderCancel := context.WithCancel(context.Background())
+		defer recorderCancel()
+		go recorder.Loop(recorderCtx)
 		defer func() {
 			clientCancel()
 			client.Finished.Wait()
@@ -676,7 +678,9 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 			nil,
 		)
 		err := client.Start(clientCxt)
-		go recorder.Loop(clientCxt)
+		recorderCtx, recorderCancel := context.WithCancel(context.Background())
+		defer recorderCancel()
+		go recorder.Loop(recorderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() {
 			clientCancel()
@@ -901,7 +905,9 @@ var _ = Describe("With an in-process Server with long ping interval", func() {
 			},
 		)
 		err := client.Start(clientCxt)
-		go recorder.Loop(clientCxt)
+		recorderCtx, recorderCancel := context.WithCancel(context.Background())
+		defer recorderCancel()
+		go recorder.Loop(recorderCtx)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() {
 			clientCancel()
@@ -1014,7 +1020,9 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			)
 
 			err = client.Start(clientCxt)
-			go recorder.Loop(clientCxt)
+			recorderCtx, recorderCancel := context.WithCancel(context.Background())
+			defer recorderCancel()
+			go recorder.Loop(recorderCtx)
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				clientCancel()
@@ -1074,7 +1082,9 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 				nil,
 			)
 			err = client.Start(clientCxt)
-			go recorder.Loop(clientCxt)
+			recorderCtx, recorderCancel := context.WithCancel(context.Background())
+			defer recorderCancel()
+			go recorder.Loop(recorderCtx)
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				clientCancel()
@@ -1206,7 +1216,9 @@ var _ = Describe("With an in-process Server with short write timeout", func() {
 					)
 
 					err := client.Start(clientCxt)
-					go recorder.Loop(clientCxt)
+					recorderCtx, recorderCancel := context.WithCancel(context.Background())
+					defer recorderCancel()
+					go recorder.Loop(recorderCtx)
 					Expect(err).NotTo(HaveOccurred())
 					defer func() {
 						clientCancel()
@@ -1400,15 +1412,17 @@ var _ = Describe("with server requiring TLS", func() {
 
 	// Each client we create gets recorded here for cleanup.
 	type clientState struct {
-		clientCxt    context.Context
-		clientCancel context.CancelFunc
-		client       *syncclient.SyncerClient
-		recorder     *StateRecorder
-		startErr     error
+		clientCxt      context.Context
+		clientCancel   context.CancelFunc
+		recorderCancel context.CancelFunc
+		client         *syncclient.SyncerClient
+		recorder       *StateRecorder
+		startErr       error
 	}
 
 	createClient := func(options *syncclient.Options) clientState {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
+		recorderCxt, recorderCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
 		serverAddr := fmt.Sprintf("127.0.0.1:%d", server.Port())
 		client := syncclient.New(
@@ -1421,14 +1435,15 @@ var _ = Describe("with server requiring TLS", func() {
 		)
 
 		err := client.Start(clientCxt)
-		go recorder.Loop(clientCxt)
+		go recorder.Loop(recorderCxt)
 
 		cs := clientState{
-			clientCxt:    clientCxt,
-			client:       client,
-			clientCancel: clientCancel,
-			recorder:     recorder,
-			startErr:     err,
+			clientCxt:      clientCxt,
+			client:         client,
+			clientCancel:   clientCancel,
+			recorderCancel: recorderCancel,
+			recorder:       recorder,
+			startErr:       err,
 		}
 		return cs
 	}
@@ -1494,6 +1509,7 @@ var _ = Describe("with server requiring TLS", func() {
 		}
 		// Connect with specified TLS options.
 		clientState := createClient(options)
+		defer clientState.recorderCancel()
 		if clientCertName == "" || expectConnection {
 			// Expecting this connection to succeed so there should be no error from Start().
 			Expect(clientState.startErr).NotTo(HaveOccurred())

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -175,12 +175,14 @@ var _ = Describe("Daemon", func() {
 					nil,
 				)
 				clientCxt, clientCancelFn := context.WithCancel(context.Background())
+				recorderCtx, recorderCancelFn := context.WithCancel(context.Background())
 				defer func() {
 					clientCancelFn()
 					client.Finished.Wait()
+					recorderCancelFn()
 				}()
 				err := client.Start(clientCxt)
-				go cbs.Loop(clientCxt)
+				go cbs.Loop(recorderCtx)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Send in an update at the top of the processing pipeline.


### PR DESCRIPTION
Was using the same context for client and the state recorder. If the state recorder stopped while the client was calling its OnUpdates method then it could block forever.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Was using the same context for client and the state recorder. If the state recorder stopped while the client was calling its OnUpdates method then it could block forever.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
