### PR TITLE
[release-v3.24] Auto pick #6942: Add 'nodelocaldns' to IP auto-detection skipping

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,4 +20,5 @@ var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
 	"^virbr.*", "^lxcbr.*", "^veth.*", "^lo",
 	"^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*",
 	"^vxlan\\.calico.*", "^vxlan-v6\\.calico.*", "^wireguard\\.cali.*", "^wg-v6\\.cali.*",
+	"^nodelocaldns.*",
 }

--- a/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
+++ b/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
@@ -79,4 +79,10 @@ var _ = DescribeTable("GetInterfaces",
 		},
 		expectFound: false,
 	}),
+	Entry("should skip nodelocaldns", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "nodelocaldns"}}, nil
+		},
+		expectFound: false,
+	}),
 )


### PR DESCRIPTION
Cherry pick of #6942 on release-v3.24.

#6942: Add 'nodelocaldns' to IP auto-detection skipping

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
https://github.com/projectcalico/calico/issues/6910

## Todos

- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
By default, skip 'nodelocaldns' interface in IP auto-detection
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.