### PR TITLE
add post release tests for manifests archive contents

### DIFF
--- a/hack/postrelease/test_manifests_archives.py
+++ b/hack/postrelease/test_manifests_archives.py
@@ -1,0 +1,54 @@
+import requests
+import tarfile
+from nose.tools import with_setup
+
+from versions import RELEASE_VERSION
+
+url = "https://github.com/projectcalico/calico/releases/download/{v}/release-{v}.tgz".format(
+    v=RELEASE_VERSION
+)
+
+manifest_list = [
+    "calico.yaml",
+    "calico-etcd.yaml",
+    "calico-bpf.yaml",
+    "calico-typha.yaml",
+    "calico-vxlan.yaml",
+    "calico-windows-bgp.yaml",
+    "calico-windows-vxlan.yaml",
+    "calicoctl.yaml",
+    "calicoctl-etcd.yaml",
+    "canal.yaml",
+    "canal-etcd.yaml",
+    "tigera-operator.yaml",
+    "custom-resources.yaml",
+]
+
+
+def setup_archive():
+    response = requests.get(url, stream=True)
+    global file
+    file = tarfile.open(fileobj=response.raw, mode="r|gz")
+
+
+def teardown_archive():
+    file.close()
+
+
+@with_setup(setup=setup_archive, teardown=teardown_archive)
+def test_manifest_present():
+    for manifest in manifest_list:
+        yield check_manifest_present, manifest
+
+
+def check_manifest_present(manifest):
+    print("[INFO] checking {} is in archive".format(manifest))
+    try:
+        manifest_info = file.getmember(
+            "release-{v}/manifests/{m}".format(v=RELEASE_VERSION, m=manifest)
+        )
+        print(manifest_info.name, manifest_info.size)
+        assert manifest_info.isfile()
+        assert manifest_info.size > 100
+    except KeyError:
+        assert False, "{m} not found in archive: {url}".format(m=manifest, url=url)


### PR DESCRIPTION
## Description

This adds tests to verify the manifests of the archive included in a release.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
