### PR TITLE
Add note to help debug apiserver error

### DIFF
--- a/calico/maintenance/install-apiserver.md
+++ b/calico/maintenance/install-apiserver.md
@@ -132,6 +132,8 @@ After following the above steps, you should see the API server pod become ready,
    profiles                                                                          projectcalico.org              false        Profile
    ```
 
+If the above command returns `error: unable to retrieve the complete list of server APIs: projectcalico.org/v3: the server is currently unable to handle the request` you should check that the `kube-apiserver` is able to communicate with the `calico-apiserver` on TCP 5443.
+ 
 > **Note:** kubectl may continue to prefer the crd.projectcalico.org API group due to the way it caches APIs locally. You can force kubectl to update
 >           by removing its cache directory for your cluster. By default, the cache is located in `$(HOME)/.kube/cache`.
 {: .alert .alert-info}


### PR DESCRIPTION
## Description
This PR adds a note to the documentation which explains an error that occurs when using kubectl with the calico api-resources.  If the API server cannot talk to calico on port 5443 a user will receive a kubectl error, it is worth pointing out where the error is likely to be as it isn't clear in any logs what is going on, especially when using a managed cluster and the Kube-apiserver logs are not available.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
N/A
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

N/A

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
