### PR TITLE
[BPF] UTs loaded with libbpf

### DIFF
--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -84,6 +84,8 @@ from%_v6.ll: tc6.c tc.d calculate-flags
 	$(COMPILE)
 test%.ll: tc.c tc.d calculate-flags
 	$(COMPILE)
+test%_v6.ll: tc6.c tc.d calculate-flags
+	$(COMPILE)
 xdp%.ll: xdp.c xdp.d calculate-flags
 	$(COMPILE)
 test_xdp%.ll: xdp.c xdp.d calculate-flags

--- a/felix/bpf-gpl/arp.h
+++ b/felix/bpf-gpl/arp.h
@@ -15,6 +15,6 @@ struct arp_value {
 	char mac_dst[6];
 };
 
-CALI_MAP(cali_v4_arp, 2, BPF_MAP_TYPE_LRU_HASH, struct arp_key, struct arp_value, 10000, 0, MAP_PIN_GLOBAL)
+CALI_MAP(cali_v4_arp, 2, BPF_MAP_TYPE_LRU_HASH, struct arp_key, struct arp_value, 10000, 0)
 
 #endif /* __CALI_ARP_H__ */

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -284,14 +284,6 @@ CALI_PATCH_DEFINE(__skb_mark, 0x4d424b53) /* be 0x4d424b53 = ASCII(SKBM) */
 #define SKB_MARK	CALI_PATCH(__skb_mark)
 #endif
 
-#define MAP_PIN_GLOBAL	2
-
-#ifndef __BPFTOOL_LOADER__
-#define CALI_MAP_TC_EXT_PIN(pin)	.pinning_strategy = pin,
-#else
-#define CALI_MAP_TC_EXT_PIN(pin)
-#endif
-
 #define map_symbol(name, ver) name##ver
 
 #define MAP_LOOKUP_FN(name, ver) \
@@ -312,21 +304,7 @@ static CALI_BPF_INLINE int name##_delete_elem(const void* key)	\
 	return bpf_map_delete_elem(&map_symbol(name, ver), key);	\
 }
 
-#if defined(__BPFTOOL_LOADER__)
-#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags, pin)		\
-struct bpf_map_def_extended __attribute__((section("maps"))) map_symbol(name, ver) = {	\
-	.type = map_type,								\
-	.key_size = sizeof(key_type),							\
-	.value_size = sizeof(val_type),							\
-	.map_flags = flags,								\
-	.max_entries = size,								\
-	CALI_MAP_TC_EXT_PIN(pin)							\
-};											\
-	MAP_LOOKUP_FN(name, ver)							\
-	MAP_UPDATE_FN(name, ver)							\
-	MAP_DELETE_FN(name, ver)
-#else
-#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags, pin)		\
+#define CALI_MAP(name, ver,  map_type, key_type, val_type, size, flags)			\
 struct {										\
 	__uint(type, map_type);								\
 	__type(key, key_type);								\
@@ -338,9 +316,8 @@ struct {										\
 	MAP_UPDATE_FN(name, ver)							\
 	MAP_DELETE_FN(name, ver)
 
-#endif
-#define CALI_MAP_V1(name, map_type, key_type, val_type, size, flags, pin)		\
-		CALI_MAP(name,, map_type, key_type, val_type, size, flags, pin)
+#define CALI_MAP_V1(name, map_type, key_type, val_type, size, flags)			\
+		CALI_MAP(name,, map_type, key_type, val_type, size, flags)
 
 char ____license[] __attribute__((section("license"), used)) = "GPL";
 

--- a/felix/bpf-gpl/calculate-flags
+++ b/felix/bpf-gpl/calculate-flags
@@ -34,10 +34,6 @@ else
 fi
 
 if [[ "${filename}" =~ test_.* ]]; then
-  args+=("-D__BPFTOOL_LOADER__")
-fi
-
-if [[ "${filename}" =~ test_.* ]]; then
   args+=("-DUNITTEST")
 fi
 

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -146,7 +146,7 @@ struct ct_create_ctx {
 CALI_MAP(cali_v4_ct, 3,
 		BPF_MAP_TYPE_HASH,
 		struct calico_ct_key, struct calico_ct_value,
-		512000, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		512000, BPF_F_NO_PREALLOC)
 
 enum calico_ct_result_type {
 	/* CALI_CT_NEW means that the packet is not part of a known conntrack flow.

--- a/felix/bpf-gpl/counters.h
+++ b/felix/bpf-gpl/counters.h
@@ -12,7 +12,7 @@ typedef __u64 counters_t[MAX_COUNTERS_SIZE];
 CALI_MAP(cali_counters, 1,
 		BPF_MAP_TYPE_PERCPU_ARRAY,
 		__u32, counters_t, 1,
-		0, MAP_PIN_GLOBAL)
+		0)
 
 static CALI_BPF_INLINE counters_t *counters_get(void)
 {

--- a/felix/bpf-gpl/ctlb.h
+++ b/felix/bpf-gpl/ctlb.h
@@ -1,13 +1,8 @@
 #ifndef _CTLB_H_
 #define _CTLB_H_
 
-#if !defined(__BPFTOOL_LOADER__) && (!CALI_F_XDP)
 const volatile struct cali_ctlb_globals __globals;
 #define CTLB_UDP_NOT_SEEN_TIMEO __globals.udp_not_seen_timeo
 #define CTLB_EXCLUDE_UDP __globals.exclude_udp
-#else
-#define CTLB_UDP_NOT_SEEN_TIMEO 60 /* for tests */
-#define CTLB_EXCLUDE_UDP false
-#endif
 
 #endif /* _CTLB_H_ */

--- a/felix/bpf-gpl/failsafe.h
+++ b/felix/bpf-gpl/failsafe.h
@@ -24,8 +24,7 @@ CALI_MAP(cali_v4_fsafes, 2,
 		BPF_MAP_TYPE_LPM_TRIE,
 		struct failsafe_key, struct failsafe_val,
 		65536,
-		BPF_F_NO_PREALLOC,
-		MAP_PIN_GLOBAL)
+		BPF_F_NO_PREALLOC)
 
 #define CALI_FSAFE_OUT 1
 

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -35,4 +35,8 @@ struct cali_ctlb_globals {
 	bool exclude_udp;
 };
 
+struct cali_xdp_globals {
+	__u8 iface_name[16];
+};
+
 #endif /* __CALI_GLOBALS_H__ */

--- a/felix/bpf-gpl/ifstate.h
+++ b/felix/bpf-gpl/ifstate.h
@@ -13,7 +13,7 @@ struct ifstate_val {
 CALI_MAP(cali_iface, 2,
 		BPF_MAP_TYPE_HASH,
 		__u32, struct ifstate_val,
-		1000, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		1000, BPF_F_NO_PREALLOC)
 
 #define IFACE_STATE_WEP		0x1
 #define IFACE_STATE_READY	0x2

--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -11,7 +11,7 @@
 CALI_MAP(cali_state, 2,
 		BPF_MAP_TYPE_PERCPU_ARRAY,
 		__u32, struct cali_tc_state,
-		1, 0, MAP_PIN_GLOBAL)
+		1, 0)
 
 static CALI_BPF_INLINE struct cali_tc_state *state_get(void)
 {

--- a/felix/bpf-gpl/list-ut-objs
+++ b/felix/bpf-gpl/list-ut-objs
@@ -11,6 +11,7 @@
 
 emit_filename() {
   echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}.o"
+  echo "bin/test_${from_or_to}_${ep_type}_fib_${log_level}${dsr}_v6.o"
 }
 
 log_level=debug

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -27,11 +27,13 @@
 		bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
 } while (0)
 
-#if !defined(UNITTEST) && !defined(__BPFTOOL_LOADER__) && ! (CALI_F_XDP) && !CALI_F_CGROUP
-extern const volatile struct cali_tc_globals __globals;
-#define CALI_TC_LOG(fmt, ...) CALI_LOG("%s" fmt, __globals.iface_name, ## __VA_ARGS__)
+#if ! (CALI_F_XDP) && !CALI_F_CGROUP
+#define CALI_IFACE_LOG(fmt, ...) CALI_LOG("%s" fmt, __globals.iface_name, ## __VA_ARGS__)
+#elif CALI_F_XDP
+extern const volatile struct cali_xdp_globals __globals;
+#define CALI_IFACE_LOG(fmt, ...) CALI_LOG("%s" fmt, __globals.iface_name, ## __VA_ARGS__)
 #else
-#define CALI_TC_LOG(fmt, ...) CALI_LOG("CALICOLO" fmt, ## __VA_ARGS__)
+#define CALI_IFACE_LOG(fmt, ...) CALI_LOG("CALICOLO" fmt, ## __VA_ARGS__)
 #endif
 
 #define CALI_INFO_NO_FLAG(fmt, ...)  CALI_LOG_IF(CALI_LOG_LEVEL_INFO, fmt, ## __VA_ARGS__)
@@ -58,15 +60,15 @@ extern const volatile struct cali_tc_globals __globals;
 	if ((flags) & CALI_CGROUP) { \
 		CALI_LOG("CTLB------------: " fmt, ## __VA_ARGS__); \
 	} else if ((flags) & CALI_XDP_PROG) { \
-		CALI_LOG("CALICOLO---------X: " fmt, ## __VA_ARGS__); \
+		CALI_IFACE_LOG("-X: " fmt, ## __VA_ARGS__); \
 	} else if (((flags) & CALI_TC_HOST_EP) && ((flags) & CALI_TC_INGRESS)) { \
-		CALI_TC_LOG("-I: " fmt, ## __VA_ARGS__); \
+		CALI_IFACE_LOG("-I: " fmt, ## __VA_ARGS__); \
 	} else if ((flags) & CALI_TC_HOST_EP) { \
-		CALI_TC_LOG("-E: " fmt, ## __VA_ARGS__); \
+		CALI_IFACE_LOG("-E: " fmt, ## __VA_ARGS__); \
 	} else if ((flags) & CALI_TC_INGRESS) { \
-		CALI_TC_LOG("-I: " fmt, ## __VA_ARGS__); \
+		CALI_IFACE_LOG("-I: " fmt, ## __VA_ARGS__); \
 	} else { \
-		CALI_TC_LOG("-E: " fmt, ## __VA_ARGS__); \
+		CALI_IFACE_LOG("-E: " fmt, ## __VA_ARGS__); \
 	} \
 } while (0)
 

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -27,13 +27,13 @@
 		bpf_trace_printk(fmt, sizeof(fmt), ## __VA_ARGS__); \
 } while (0)
 
-#if ! (CALI_F_XDP) && !CALI_F_CGROUP
+#if !(CALI_F_XDP) && !(CALI_F_CGROUP)
 #define CALI_IFACE_LOG(fmt, ...) CALI_LOG("%s" fmt, __globals.iface_name, ## __VA_ARGS__)
 #elif CALI_F_XDP
 extern const volatile struct cali_xdp_globals __globals;
 #define CALI_IFACE_LOG(fmt, ...) CALI_LOG("%s" fmt, __globals.iface_name, ## __VA_ARGS__)
 #else
-#define CALI_IFACE_LOG(fmt, ...) CALI_LOG("CALICOLO" fmt, ## __VA_ARGS__)
+#define CALI_IFACE_LOG(fmt, ...) /* just for cases like ctlb whenit is not used */
 #endif
 
 #define CALI_INFO_NO_FLAG(fmt, ...)  CALI_LOG_IF(CALI_LOG_LEVEL_INFO, fmt, ## __VA_ARGS__)

--- a/felix/bpf-gpl/nat_types.h
+++ b/felix/bpf-gpl/nat_types.h
@@ -62,7 +62,7 @@ struct calico_nat_v4_value {
 CALI_MAP(cali_v4_nat_fe, 3,
 		BPF_MAP_TYPE_LPM_TRIE,
 		union calico_nat_v4_lpm_key, struct calico_nat_v4_value,
-		64*1024, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		64*1024, BPF_F_NO_PREALLOC)
 
 
 // Map: NAT level two.  ID and ordinal -> new dest and port.
@@ -81,7 +81,7 @@ struct calico_nat_dest {
 CALI_MAP_V1(cali_v4_nat_be,
 		BPF_MAP_TYPE_HASH,
 		struct calico_nat_secondary_v4_key, struct calico_nat_dest,
-		256*1024, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		256*1024, BPF_F_NO_PREALLOC)
 
 struct calico_nat_v4_affinity_key {
 	struct calico_nat_v4 nat_key;
@@ -98,7 +98,7 @@ struct calico_nat_v4_affinity_val {
 CALI_MAP_V1(cali_v4_nat_aff,
 		BPF_MAP_TYPE_LRU_HASH,
 		struct calico_nat_v4_affinity_key, struct calico_nat_v4_affinity_val,
-		64*1024, 0, MAP_PIN_GLOBAL)
+		64*1024, 0)
 
 struct vxlanhdr {
 	__be32 flags;

--- a/felix/bpf-gpl/policy_program.h
+++ b/felix/bpf-gpl/policy_program.h
@@ -83,6 +83,6 @@ deny:
 	return TC_ACT_SHOT;
 }
 
-#endif /* CALI_DEBUG_NO_PROG */
+#endif /* CALI_NO_DEFAULT_POLICY_PROG */
 
 #endif /*  __CALI_POL_PROG_H__ */

--- a/felix/bpf-gpl/policy_program.h
+++ b/felix/bpf-gpl/policy_program.h
@@ -72,6 +72,7 @@ int calico_tc_norm_pol_tail(struct __sk_buff *skb)
 	state->pol_rc = execute_policy_norm(skb, state->ip_proto, state->ip_src,
 					    state->ip_dst, state->sport, state->dport);
 
+	CALI_DEBUG("jumping to allowed\n");
 	CALI_JUMP_TO(skb, PROG_INDEX_ALLOWED);
 #else
 	CALI_JUMP_TO(skb, PROG_INDEX_V6_ALLOWED);

--- a/felix/bpf-gpl/routes.h
+++ b/felix/bpf-gpl/routes.h
@@ -44,7 +44,7 @@ struct cali_rt {
 CALI_MAP_V1(cali_v4_routes,
 		BPF_MAP_TYPE_LPM_TRIE,
 		union cali_rt_lpm_key, struct cali_rt,
-		256*1024, BPF_F_NO_PREALLOC, MAP_PIN_GLOBAL)
+		256*1024, BPF_F_NO_PREALLOC)
 
 static CALI_BPF_INLINE struct cali_rt *cali_rt_lookup(__be32 addr)
 {

--- a/felix/bpf-gpl/rule_counters.h
+++ b/felix/bpf-gpl/rule_counters.h
@@ -9,7 +9,7 @@
 
 CALI_MAP(cali_rule_ctrs, 2,
 		BPF_MAP_TYPE_PERCPU_HASH,
-		__u64, __u64, 10000, 0, MAP_PIN_GLOBAL)
+		__u64, __u64, 10000, 0)
 
 static CALI_BPF_INLINE void update_rule_counters(struct cali_tc_state *state) {
 	int ret = 0;

--- a/felix/bpf-gpl/sendrecv.h
+++ b/felix/bpf-gpl/sendrecv.h
@@ -19,7 +19,7 @@ struct sendrecv4_val {
 CALI_MAP_V1(cali_v4_srmsg,
 		BPF_MAP_TYPE_LRU_HASH,
 		struct sendrecv4_key, struct sendrecv4_val,
-		510000, 0, MAP_PIN_GLOBAL)
+		510000, 0)
 
 struct ct_nats_key {
 	__u64 cookie;
@@ -32,7 +32,7 @@ struct ct_nats_key {
 CALI_MAP_V1(cali_v4_ct_nats,
 		BPF_MAP_TYPE_LRU_HASH,
 		struct ct_nats_key, struct sendrecv4_val,
-		10000, 0, MAP_PIN_GLOBAL)
+		10000, 0)
 
 static CALI_BPF_INLINE __u16 ctx_port_to_host(__u32 port)
 {

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -46,9 +46,7 @@
 
 #define HAS_HOST_CONFLICT_PROG CALI_F_TO_HEP
 
-#if !defined(__BPFTOOL_LOADER__)
 const volatile struct cali_tc_globals __globals;
-#endif
 
 /* calico_tc is the main function used in all of the tc programs.  It is specialised
  * for particular hook at build time based on the CALI_F build flags.

--- a/felix/bpf-gpl/tc6.c
+++ b/felix/bpf-gpl/tc6.c
@@ -20,9 +20,7 @@
 #include "jump.h"
 #include "policy_program.h"
 
-#if !defined(__BPFTOOL_LOADER__)
 const volatile struct cali_tc_globals __globals;
-#endif
 
 
 SEC("classifier/tc/prologue")

--- a/felix/bpf-gpl/tc6.c
+++ b/felix/bpf-gpl/tc6.c
@@ -87,13 +87,19 @@ int calico_tc(struct __sk_buff *skb)
 	CALI_DEBUG("IPv6 on host interface: allow\n");
 	CALI_DEBUG("About to jump to normal policy program\n");
 	CALI_JUMP_TO(skb, PROG_INDEX_V6_POLICY);
+	if (CALI_F_HEP) {
+		CALI_DEBUG("HEP with no policy, allow.\n");
+		goto allow;
+	}
 	CALI_DEBUG("Tail call to normal policy program failed: DROP\n");
+	
+deny:
+	skb->mark = CALI_SKB_MARK_SEEN;
+	return TC_ACT_SHOT;
 
 allow:
+	skb->mark = CALI_SKB_MARK_SEEN;
 	return TC_ACT_UNSPEC;
-
-deny:
-	return TC_ACT_SHOT;
 }
 
 SEC("classifier/tc/accept")

--- a/felix/bpf-gpl/ut/ut.h
+++ b/felix/bpf-gpl/ut/ut.h
@@ -6,7 +6,7 @@
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb);
 
-__attribute__((section("calico_unittest"))) int unittest(struct __sk_buff *skb)
+__attribute__((section("classifier/calico_unittest"))) int unittest(struct __sk_buff *skb)
 {
 	return calico_unittest_entry(skb);
 }

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -24,6 +24,9 @@
 #include "failsafe.h"
 #include "jump.h"
 #include "metadata.h"
+#include "globals.h"
+
+const volatile struct cali_xdp_globals __globals;
 
 /* calico_xdp is the main function used in all of the xdp programs */
 static CALI_BPF_INLINE int calico_xdp(struct xdp_md *xdp)

--- a/felix/bpf/binary.go
+++ b/felix/bpf/binary.go
@@ -21,10 +21,8 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"io/ioutil"
-	"net"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -92,81 +90,10 @@ func (b *Binary) replaceAllLoadImm32(orig, replacement []byte) {
 	b.ReplaceAll(ldimm[:], rep[:])
 }
 
-// PatchIPv4 replaces a place holder with the actual IPv4
-func (b *Binary) PatchIPv4(ip net.IP) error {
-	ipv4 := ip.To4()
-	if ipv4 == nil {
-		return errors.Errorf("%s is not IPv4", ip)
-	}
-	b.replaceAllLoadImm32([]byte("HOST"), []byte(ipv4))
-
-	return nil
-}
-
-// PatchIntfIPv4 replaces a place holder Intf IP with the actual IPv4
-func (b *Binary) PatchIntfAddr(ip net.IP) error {
-	ipv4 := ip.To4()
-	if ipv4 == nil {
-		return errors.Errorf("%s is not IPv4", ip)
-	}
-	b.replaceAllLoadImm32([]byte("INTF"), []byte(ipv4))
-	return nil
-}
-
-// PatchLogPrefix patches in the log prefix. Is is trimmed to 8 bytes and padded
-// with '-' on the right
-func (b *Binary) PatchLogPrefix(prefix string) {
-	pfx := []byte(prefix + "--------") // Pad on the right to make sure its long enough.
-
-	b.replaceAllLoadImm32([]byte("CALI"), pfx[:4])
-	b.replaceAllLoadImm32([]byte("COLO"), pfx[4:8])
-}
-
-// PatchTunnelMTU replaces a placeholder with the actual mtu
-func (b *Binary) PatchTunnelMTU(mtu uint16) {
-	b.patchU32Placeholder("TMTU", uint32(mtu))
-}
-
-// PatchVXLANPort replaces the VXPR placeholder with the actual port.
-func (b *Binary) PatchVXLANPort(port uint16) {
-	logrus.WithField("port", port).Debug("Patching VXLAN port")
-	b.patchU32Placeholder("VXPR", uint32(port))
-}
-
-// PatchFlags replaces the FLGS placeholder with the actual flags
-func (b *Binary) PatchFlags(flags uint32) {
-	logrus.WithField("flags", flags).Debug("Patching Flags")
-	b.patchU32Placeholder("FLGS", flags)
-}
-
-// PatchExtToServiceConnmark replaces the MARK placeholder with the actual mark.
-func (b *Binary) PatchExtToServiceConnmark(mark uint32) {
-	logrus.WithField("mark", mark).Debug("Patching to-host mark")
-	b.patchU32Placeholder("MARK", uint32(mark))
-}
-
-// PatchPSNATPorts replaces PSNAT_START and PSNAT_LEN with the provided port range.
-func (b *Binary) PatchPSNATPorts(start, end uint32) {
-	logrus.WithFields(logrus.Fields{"start": start, "end": end}).Debug("Patching pSNAT ports")
-	b.patchU32Placeholder("PRTS", start)
-	b.patchU32Placeholder("PRTL", end-start+1)
-}
-
 // PatchSkbMark replaces SKBM with the expected mark - for tests.
 func (b *Binary) PatchSkbMark(mark uint32) {
 	logrus.WithField("mark", mark).Debug("Patching skb mark")
 	b.patchU32Placeholder("SKBM", uint32(mark))
-}
-
-// PatchHostTunnelIPv4 replaces TUNL with the tunnel interface IP.
-func (b *Binary) PatchHostTunnelIPv4(ip net.IP) error {
-	ipv4 := ip.To4()
-	if ipv4 == nil {
-		return errors.Errorf("%s is not IPv4", ip)
-	}
-	b.replaceAllLoadImm32([]byte("TUNL"), []byte(ipv4))
-
-	return nil
 }
 
 // patchU32Placeholder replaces a placeholder with the given value.

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -2358,6 +2358,9 @@ func ListPerEPMaps() (map[int]string, error) {
 		if err != nil {
 			return err
 		}
+		if strings.Contains(p, "globals") {
+			return nil
+		}
 		if strings.HasPrefix(info.Name(), JumpMapName()) ||
 			strings.HasPrefix(info.Name(), CountersMapName()) {
 			log.WithField("path", p).Debug("Examining map")

--- a/felix/bpf/jump/map.go
+++ b/felix/bpf/jump/map.go
@@ -20,7 +20,7 @@ import (
 
 func MapForTest(mc *bpf.MapContext) bpf.Map {
 	return mc.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_v4_jump",
+		Filename:   "/sys/fs/bpf/tc/globals/cali_jump2",
 		Type:       "prog_array",
 		KeySize:    4,
 		ValueSize:  4,

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -21,8 +21,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/projectcalico/calico/felix/bpf/bpfutils"
 	"golang.org/x/sys/unix"
+
+	"github.com/projectcalico/calico/felix/bpf/bpfutils"
 )
 
 // #include "libbpf_api.h"

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -386,6 +386,19 @@ func CTLBSetGlobals(m *Map, udpNotSeen time.Duration, excludeUDP bool) error {
 	return err
 }
 
+func XDPSetGlobals(
+	m *Map,
+	globalData *XDPGlobalData,
+) error {
+
+	cName := C.CString(globalData.IfaceName)
+	defer C.free(unsafe.Pointer(cName))
+
+	_, err := C.bpf_xdp_set_globals(m.bpfMap, cName)
+
+	return err
+}
+
 func NumPossibleCPUs() (int, error) {
 	ncpus := int(C.num_possible_cpu())
 	if ncpus < 0 {

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/projectcalico/calico/felix/bpf/bpfutils"
+	"golang.org/x/sys/unix"
 )
 
 // #include "libbpf_api.h"
@@ -71,6 +72,10 @@ func (m *Map) SetPinPath(path string) error {
 	return nil
 }
 
+func (m *Map) MaxEntries() int {
+	return int(C.bpf_map__max_entries(m.bpfMap))
+}
+
 func (m *Map) SetMapSize(size uint32) error {
 	_, err := C.bpf_map_set_max_entries(m.bpfMap, C.uint(size))
 	if err != nil {
@@ -81,6 +86,10 @@ func (m *Map) SetMapSize(size uint32) error {
 
 func (m *Map) IsMapInternal() bool {
 	return bool(C.bpf_map__is_internal(m.bpfMap))
+}
+
+func (m *Map) IsJumpMap() bool {
+	return m.Type() == int(C.BPF_MAP_TYPE_PROG_ARRAY)
 }
 
 func OpenObject(filename string) (*Obj, error) {
@@ -168,6 +177,54 @@ func (o *Obj) AttachXDP(ifName, progName string, oldID int, mode uint) (int, err
 		return -1, fmt.Errorf("error querying xdp information. interface %s: %w", ifName, err)
 	}
 	return int(progId), nil
+}
+
+func (o *Obj) Pin(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	errno := C.bpf_object__pin(o.obj, cPath)
+	if errno != 0 {
+		err := syscall.Errno(errno)
+		return fmt.Errorf("pinning programs failed %w", err)
+	}
+	return nil
+}
+
+func (o *Obj) Unpin(path string) error {
+	return unix.Unlink(path)
+}
+
+func (o *Obj) PinPrograms(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	errno := C.bpf_object__pin_programs(o.obj, cPath)
+	if errno != 0 {
+		err := syscall.Errno(errno)
+		return fmt.Errorf("pinning programs failed %w", err)
+	}
+	return nil
+}
+
+func (o *Obj) UnpinPrograms(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	errno := C.bpf_object__unpin_programs(o.obj, cPath)
+	if errno != 0 {
+		err := syscall.Errno(errno)
+		return fmt.Errorf("pinning programs failed %w", err)
+	}
+	return nil
+}
+
+func (o *Obj) PinMaps(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	errno := C.bpf_object__pin_maps(o.obj, cPath)
+	if errno != 0 {
+		err := syscall.Errno(errno)
+		return fmt.Errorf("pinning maps failed %w", err)
+	}
+	return nil
 }
 
 func DetachXDP(ifName string, mode uint) error {

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -237,6 +237,17 @@ void bpf_ctlb_set_globals(struct bpf_map *map, uint udp_not_seen_timeo, bool exc
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
 }
 
+void bpf_xdp_set_globals(struct bpf_map *map, char *iface_name)
+{
+	struct cali_xdp_globals data = {
+	};
+
+	strncpy(data.iface_name, iface_name, sizeof(data.iface_name));
+	data.iface_name[sizeof(data.iface_name)-1] = '\0';
+
+	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
+}
+
 void bpf_map_set_max_entries(struct bpf_map *map, uint max_entries) {
 	set_errno(bpf_map__resize(map, max_entries));
 }

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -29,3 +29,7 @@ type TcGlobalData struct {
 	NatIn        uint32
 	NatOut       uint32
 }
+
+type XDPGlobalData struct {
+	IfaceName string
+}

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -111,6 +111,10 @@ func CTLBSetGlobals(_ *Map, _ time.Duration, _ bool) error {
 	panic("LIBBPF syscall stub")
 }
 
+func XDPSetGlobals(_ *Map, _ *XDPGlobalData) error {
+	panic("LIBBPF syscall stub")
+}
+
 func (m *Map) SetMapSize(size uint32) error {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -465,11 +465,15 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 		}
 	}
 
+	return ConfigureProgram(m, ap.Iface, &globalData)
+}
+
+func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalData) error {
 	in := []byte("---------------")
-	copy(in, ap.Iface)
+	copy(in, iface)
 	globalData.IfaceName = string(in)
 
-	return libbpf.TcSetGlobals(m, &globalData)
+	return libbpf.TcSetGlobals(m, globalData)
 }
 
 func (ap *AttachPoint) setMapSize(m *libbpf.Map) error {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -615,7 +615,7 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 
 out:
 	if err != nil {
-		obj.UnpinPrograms(bpfFsDir)
+		_ = obj.UnpinPrograms(bpfFsDir)
 		obj.Close()
 		return nil, fmt.Errorf("%s: %w", ipFamily, err)
 	}
@@ -743,7 +743,7 @@ func runBpfUnitTest(t *testing.T, source string, testFn func(bpfProgRunFn), opts
 
 	obj, err := objLoad(objFname, bpfFsDir, "IPv4", topts, true, false)
 	Expect(err).NotTo(HaveOccurred())
-	defer obj.UnpinPrograms(bpfFsDir)
+	defer func() { _ = obj.UnpinPrograms(bpfFsDir) }()
 	defer obj.Close()
 
 	ctxIn := make([]byte, 18*4)

--- a/felix/bpf/ut/icmp_related_test.go
+++ b/felix/bpf/ut/icmp_related_test.go
@@ -48,6 +48,9 @@ var rulesAllowUDP = &polprog.Rules{
 func TestICMPRelatedPlain(t *testing.T) {
 	RegisterTestingT(t)
 
+	bpfIfaceName = "PLAN"
+	defer func() { bpfIfaceName = "" }()
+
 	defer resetBPFMaps()
 
 	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefault()

--- a/felix/bpf/ut/icmp_related_test.go
+++ b/felix/bpf/ut/icmp_related_test.go
@@ -48,7 +48,7 @@ var rulesAllowUDP = &polprog.Rules{
 func TestICMPRelatedPlain(t *testing.T) {
 	RegisterTestingT(t)
 
-	bpfIfaceName = "PLAN"
+	bpfIfaceName = "ICMPPlain"
 	defer func() { bpfIfaceName = "" }()
 
 	defer resetBPFMaps()

--- a/felix/bpf/ut/ipv6_test.go
+++ b/felix/bpf/ut/ipv6_test.go
@@ -64,7 +64,6 @@ var ipTestCases = []ipv6Test{
 }
 
 func TestIPv6Parsing(t *testing.T) {
-	t.Skip("DISABLED")
 	RegisterTestingT(t)
 
 	defer resetBPFMaps()
@@ -85,6 +84,6 @@ func TestIPv6Parsing(t *testing.T) {
 			Expect(res.RetvalStr()).To(Equal(result), fmt.Sprintf("expected the program to return %s", result))
 			Expect(res.dataOut).To(HaveLen(len(tc.pkt.bytes)))
 			Expect(res.dataOut).To(Equal(tc.pkt.bytes))
-		})
+		}, withIPv6(), withDescription(tc.Description))
 	}
 }

--- a/felix/bpf/ut/pol_prog_test.go
+++ b/felix/bpf/ut/pol_prog_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/asm"
 	"github.com/projectcalico/calico/felix/bpf/ipsets"
+	"github.com/projectcalico/calico/felix/bpf/jump"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/state"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
@@ -121,7 +122,7 @@ func TestLoadKitchenSinkPolicy(t *testing.T) {
 
 	cleanIPSetMap()
 
-	pg := polprog.NewBuilder(alloc, ipsMap.MapFD(), stateMap.MapFD(), tcJumpMap.MapFD(), false)
+	pg := polprog.NewBuilder(alloc, ipsMap.MapFD(), stateMap.MapFD(), jumpMap.MapFD(), false)
 	insns, err := pg.Instructions(polprog.Rules{
 		Tiers: []polprog.Tier{{
 			Name: "base tier",
@@ -2403,8 +2404,13 @@ func runTest(t *testing.T, tp testPolicy) {
 
 	setUpIPSets(tp.IPSets(), realAlloc, ipsMap)
 
+	jumpMap = jump.MapForTest(&bpf.MapContext{})
+	_ = unix.Unlink(jumpMap.Path())
+	err := jumpMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
 	// Build the program.
-	pg := polprog.NewBuilder(forceAlloc, ipsMap.MapFD(), testStateMap.MapFD(), tcJumpMap.MapFD(), false)
+	pg := polprog.NewBuilder(forceAlloc, ipsMap.MapFD(), testStateMap.MapFD(), jumpMap.MapFD(), false)
 	if tp.ForIPv6() {
 		pg.EnableIPv6Mode()
 	}
@@ -2426,7 +2432,7 @@ func runTest(t *testing.T, tp testPolicy) {
 	if tp.ForIPv6() {
 		jumpMapIndex = tcdefs.ProgIndexV6Allowed
 	}
-	epiFD := installAllowedProgram(tcJumpMap, jumpMapIndex)
+	epiFD := installAllowedProgram(jumpMap, jumpMapIndex)
 	defer func() {
 		err := epiFD.Close()
 		Expect(err).NotTo(HaveOccurred())
@@ -2436,7 +2442,7 @@ func runTest(t *testing.T, tp testPolicy) {
 	if tp.ForIPv6() {
 		jumpMapIndex = tcdefs.ProgIndexV6Drop
 	}
-	dropFD := installDropProgram(tcJumpMap, jumpMapIndex)
+	dropFD := installDropProgram(jumpMap, jumpMapIndex)
 	defer func() {
 		err := dropFD.Close()
 		Expect(err).NotTo(HaveOccurred())

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -48,6 +48,8 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 		bpfutils.BTFEnabled = bpfutils.SupportsBTF()
 	}()
 
+	defer bpf.CleanUpMaps()
+
 	for _, logLevel := range []string{"OFF", "INFO", "DEBUG"} {
 		logLevel := logLevel
 		// Compile the TC endpoint programs.

--- a/felix/bpf/ut/xdp_test.go
+++ b/felix/bpf/ut/xdp_test.go
@@ -236,7 +236,10 @@ func TestXDPPrograms(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	for _, tc := range xdpTestCases {
+	defer func() { bpfIfaceName = "" }()
+
+	for i, tc := range xdpTestCases {
+		bpfIfaceName = fmt.Sprintf("XDP-%d", i)
 		runBpfTest(t, "xdp_calico_entrypoint", tc.Rules, func(bpfrun bpfProgRunFn) {
 			_, _, _, _, pktBytes, err := testPacket(nil, tc.IPv4Header, tc.NextHeader, nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/felix/bpf/ut/xdp_test.go
+++ b/felix/bpf/ut/xdp_test.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/failsafes"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/proto"
@@ -28,17 +27,6 @@ import (
 	"github.com/google/gopacket/layers"
 	. "github.com/onsi/gomega"
 )
-
-func MapForTest(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/cali_jump_xdp",
-		Type:       "prog_array",
-		KeySize:    4,
-		ValueSize:  4,
-		MaxEntries: 16,
-		Name:       bpf.JumpMapName(),
-	})
-}
 
 const (
 	TOS_BYTE   = 15

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -106,6 +106,20 @@ func (ap *AttachPoint) AlreadyAttached(object string) (int, bool) {
 	return -1, false
 }
 
+func ConfigureProgram(m *libbpf.Map, iface string) error {
+	var globalData libbpf.XDPGlobalData
+
+	in := []byte("---------------")
+	copy(in, iface)
+	globalData.IfaceName = string(in)
+
+	if err := libbpf.XDPSetGlobals(m, &globalData); err != nil {
+		return fmt.Errorf("failed to configure xdp: %w", err)
+	}
+
+	return nil
+}
+
 func (ap *AttachPoint) AttachProgram() (int, error) {
 	tempDir, err := ioutil.TempDir("", "calico-xdp")
 	if err != nil {
@@ -117,22 +131,20 @@ func (ap *AttachPoint) AttachProgram() (int, error) {
 
 	filename := ap.FileName()
 	preCompiledBinary := path.Join(bpf.ObjectDir, filename)
-	tempBinary := path.Join(tempDir, filename)
 
-	// Patch the binary so that its log prefix is like "eth0------X".
-	err = ap.patchBinary(preCompiledBinary, tempBinary)
-	if err != nil {
-		ap.Log().WithError(err).Error("Failed to patch binary")
-		return -1, err
-	}
-
-	obj, err := libbpf.OpenObject(tempBinary)
+	obj, err := libbpf.OpenObject(preCompiledBinary)
 	if err != nil {
 		return -1, err
 	}
 	defer obj.Close()
 
 	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
+		if m.IsMapInternal() {
+			if err := ConfigureProgram(m, ap.Iface); err != nil {
+				return -1, err
+			}
+			continue
+		}
 		// TODO: We need to set map size here like tc.
 		pinPath := bpf.MapPinPath(m.Type(), m.Name(), ap.Iface, bpf.HookXDP)
 		if err := m.SetPinPath(pinPath); err != nil {
@@ -239,22 +251,6 @@ func (ap *AttachPoint) DetachProgram() error {
 	if err = bpf.ForgetAttachedProg(ap.IfaceName(), "xdp"); err != nil {
 		return fmt.Errorf("failed to delete hash of BPF program from disk: %w", err)
 	}
-	return nil
-}
-
-func (ap *AttachPoint) patchBinary(ifile, ofile string) error {
-	b, err := bpf.BinaryFromFile(ifile)
-	if err != nil {
-		return fmt.Errorf("failed to read pre-compiled BPF binary: %w", err)
-	}
-
-	b.PatchLogPrefix(ap.Iface)
-
-	err = b.WriteToFile(ofile)
-	if err != nil {
-		return fmt.Errorf("failed to write pre-compiled BPF binary: %w", err)
-	}
-
 	return nil
 }
 

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -272,7 +272,7 @@ func updateJumpMap(obj *libbpf.Obj) error {
 
 	for _, ipFamily := range ipVersions {
 		if err := UpdateJumpMap(obj, JumpMapIndexes[ipFamily]); err != nil {
-			return fmt.Errorf("proto %s: %w", ipFamily)
+			return fmt.Errorf("proto %s: %w", ipFamily, err)
 		}
 	}
 

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -275,14 +275,21 @@ func updateJumpMap(obj *libbpf.Obj) error {
 	ipVersions := []string{"IPv4"}
 
 	for _, ipFamily := range ipVersions {
-		progs := JumpMapIndexes[ipFamily]
-		mapName := bpf.JumpMapName()
+		if err := UpdateJumpMap(obj, JumpMapIndexes[ipFamily]); err != nil {
+			return fmt.Errorf("proto %s: %w", ipFamily)
+		}
+	}
 
-		for idx, name := range progs {
-			err := obj.UpdateJumpMap(mapName, name, idx)
-			if err != nil {
-				return fmt.Errorf("failed to update %s program '%s' at index %d: %w", ipFamily, name, idx, err)
-			}
+	return nil
+}
+
+func UpdateJumpMap(obj *libbpf.Obj, progs map[int]string) error {
+	mapName := bpf.JumpMapName()
+
+	for idx, name := range progs {
+		err := obj.UpdateJumpMap(mapName, name, idx)
+		if err != nil {
+			return fmt.Errorf("failed to update program '%s' at index %d: %w", name, idx, err)
 		}
 	}
 


### PR DESCRIPTION
## Description

    [BPF] reenable v6 UTs

    [BPF] remove __BPFTOOL_LOADER__ related code

    [BPF] nopatching except skb marks in UTs

    [BPF/UT] use libbpf to load the programs


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
