### PR TITLE
Add CRD upgrade to helm upgrade instructions

### DIFF
--- a/calico/maintenance/kubernetes-upgrade.md
+++ b/calico/maintenance/kubernetes-upgrade.md
@@ -71,7 +71,7 @@ ownership of the helm resources to the new chart location.
 1. Apply the {{page.version}} CRDs:
 
    ```bash
-   kubectl apply -f {{site.data.versions.first.manifests_url}}/manifests/operator-crds.yaml
+   kubectl replace -f {{site.data.versions.first.manifests_url}}/manifests/operator-crds.yaml
    ```
 
 1. Run the helm upgrade:

--- a/calico/maintenance/kubernetes-upgrade.md
+++ b/calico/maintenance/kubernetes-upgrade.md
@@ -68,6 +68,12 @@ ownership of the helm resources to the new chart location.
 
 ### All other upgrades
 
+1. Apply the {{page.version}} CRDs:
+
+   ```bash
+   kubectl apply -f {{site.data.versions.first.manifests_url}}/manifests/operator-crds.yaml
+   ```
+
 1. Run the helm upgrade:
 
    ```bash


### PR DESCRIPTION
## Description
Helm doesn't upgrade CRDs.  

We've had a few users follow the helm upgrade instructions here and find that the uplevel Calico doesn't work because the uplevel CRDs are not present.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Upgrade instructions for Helm now include a step to upgrade the CRDs.  
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
