### PR TITLE
DOCS-1040/3.24: Add K8 v1.25 support to docs

### DIFF
--- a/calico/getting-started/kubernetes/requirements.md
+++ b/calico/getting-started/kubernetes/requirements.md
@@ -15,6 +15,7 @@ We test {{site.prodname}} {{page.version}} against the following Kubernetes vers
 - v1.22
 - v1.23
 - v1.24
+- v1.25
 
 Due to changes in the Kubernetes API, {{site.prodname}} {{page.version}} will not work
 on Kubernetes v1.15 or below.  v1.16-v1.18 may work, but they are no longer tested. 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - documentation
- Support for K8 v 1.25 is not included in Calico OS 3.24 docs, which is what this PR addresses.
- Built a local site and tested the output
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
