### PR TITLE
cleanup: remove old apiversion for deployment

### DIFF
--- a/app-policy/config/demo/10-yaobank.yaml
+++ b/app-policy/config/demo/10-yaobank.yaml
@@ -32,11 +32,15 @@ metadata:
   labels:
     app: yaobank
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: database
 spec:
+  selector:
+    matchLabels:
+      app: database
+      version: v1
   replicas: 1
   template:
     metadata:
@@ -79,11 +83,15 @@ metadata:
     app: yaobank
     database: reader
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: summary
 spec:
+  selector:
+    matchLabels:
+      app: summary
+      version: v1
   replicas: 1
   template:
     metadata:
@@ -120,11 +128,15 @@ metadata:
     app: yaobank
     summary: reader
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: customer
 spec:
+  selector:
+    matchLabels:
+      app: customer
+      version: v1
   replicas: 1
   template:
     metadata:

--- a/app-policy/config/demo/20-attack-pod.yaml
+++ b/app-policy/config/demo/20-attack-pod.yaml
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: attack
 spec:
+  selector:
+    matchLabels:
+      app: attack
   replicas: 1
   template:
     metadata:

--- a/calico/getting-started/kubernetes/installation/calico-kube-controllers.yaml
+++ b/calico/getting-started/kubernetes/installation/calico-kube-controllers.yaml
@@ -8,7 +8,7 @@ layout: null
 
 # Create this manifest using kubectl to deploy
 # the {{site.prodname}} Kubernetes controllers.
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-kube-controllers
@@ -20,6 +20,9 @@ spec:
   # active at a time.  Since this pod is run as a Deployment,
   # Kubernetes will ensure the pod is recreated in case of failure,
   # removing the need for passive backups.
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
   replicas: 1
   strategy:
     type: Recreate

--- a/felix/k8sfv/monitoring.yaml
+++ b/felix/k8sfv/monitoring.yaml
@@ -1,11 +1,14 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-operator
   labels:
     operator: prometheus
 spec:
+  selector:
+    matchLabels:
+      operator: prometheus
   replicas: 1
   template:
     metadata:
@@ -845,13 +848,16 @@ data:
       "version": 0
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
   labels:
     app: grafana
 spec:
+  selector:
+    matchLabels:
+      app: grafana
   replicas: 1
   revisionHistoryLimit: 2
   template:

--- a/pod2daemon/flexvol/udsver-mount-dummy.yaml
+++ b/pod2daemon/flexvol/udsver-mount-dummy.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ubuntu
 spec:
+  selector:
+    matchLabels:
+      app: ubuntu
+      version: v1
   replicas: 1
   template:
     metadata:

--- a/pod2daemon/flexvol/udsver-mount.yaml
+++ b/pod2daemon/flexvol/udsver-mount.yaml
@@ -1,8 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: udsver-client
 spec:
+  selector:
+    matchLabels:
+      app: udsver-client
+      version: v1
   replicas: 2
   template:
     metadata:


### PR DESCRIPTION
## Description
The apiversion for `extensions/v1beta1` has been deprecated for a long time, mybe we should remove it.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



