### PR TITLE
Bump semaphore build os image to Ubuntu 20.04

### DIFF
--- a/.semaphore/cleanup.yml
+++ b/.semaphore/cleanup.yml
@@ -3,7 +3,7 @@ name: Felix
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 10

--- a/.semaphore/push-images/alp.yml
+++ b/.semaphore/push-images/alp.yml
@@ -3,7 +3,7 @@ name: Publish ALP images
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/push-images/apiserver.yml
+++ b/.semaphore/push-images/apiserver.yml
@@ -3,7 +3,7 @@ name: Publish apiserver images
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/push-images/calicoctl.yml
+++ b/.semaphore/push-images/calicoctl.yml
@@ -3,7 +3,7 @@ name: Publish calicoctl images
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -3,7 +3,7 @@ name: Publish cni-plugin images
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/push-images/kube-controllers.yml
+++ b/.semaphore/push-images/kube-controllers.yml
@@ -3,7 +3,7 @@ name: Publish kube-controllers images
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -3,7 +3,7 @@ name: Publish node images
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -3,7 +3,7 @@ name: Publish openstack packages
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/push-images/typha.yml
+++ b/.semaphore/push-images/typha.yml
@@ -3,7 +3,7 @@ name: Publish typha images
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -3,7 +3,7 @@ name: Publish official release
 agent:
   machine:
     type: e1-standard-4
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 180

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -9,7 +9,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 auto_cancel:
   running:
@@ -125,7 +125,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd apiserver
@@ -142,7 +142,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd apiserver
@@ -173,7 +173,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     jobs:
     - name: "Typha: UT and FV tests"
       commands:
@@ -204,7 +204,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd felix
@@ -241,7 +241,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd felix
@@ -436,7 +436,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-8
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd node
@@ -461,7 +461,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd node
@@ -484,7 +484,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-8
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     jobs:
     - name: "sig-network conformance"
       env_vars:
@@ -501,7 +501,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd kube-controllers
@@ -635,7 +635,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd networking-calico

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,7 +9,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 auto_cancel:
   running:
@@ -125,7 +125,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd apiserver
@@ -142,7 +142,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd apiserver
@@ -173,7 +173,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     jobs:
     - name: "Typha: UT and FV tests"
       commands:
@@ -204,7 +204,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd felix
@@ -241,7 +241,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd felix
@@ -436,7 +436,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-8
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd node
@@ -461,7 +461,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd node
@@ -484,7 +484,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-8
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     jobs:
     - name: "sig-network conformance"
       env_vars:
@@ -501,7 +501,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd kube-controllers
@@ -635,7 +635,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd networking-calico

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 auto_cancel:
   running:
@@ -123,7 +123,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd apiserver
@@ -140,7 +140,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd apiserver
@@ -171,7 +171,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     jobs:
     - name: "Typha: UT and FV tests"
       commands:
@@ -202,7 +202,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd felix
@@ -239,7 +239,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd felix
@@ -434,7 +434,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-8
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd node
@@ -459,7 +459,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd node
@@ -482,7 +482,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-8
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     jobs:
     - name: "sig-network conformance"
       env_vars:
@@ -499,7 +499,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd kube-controllers
@@ -633,7 +633,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - cd networking-calico

--- a/api/.semaphore/semaphore.yml
+++ b/api/.semaphore/semaphore.yml
@@ -6,7 +6,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 auto_cancel:
   running:

--- a/cni-plugin/.semaphore/cleanup.yml
+++ b/cni-plugin/.semaphore/cleanup.yml
@@ -3,7 +3,7 @@ name: CNIPlugin
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 10

--- a/cni-plugin/.semaphore/semaphore.yml
+++ b/cni-plugin/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 auto_cancel:
   running:

--- a/cni-plugin/.semaphore/update_pins.yml
+++ b/cni-plugin/.semaphore/update_pins.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 global_job_config:
   secrets:

--- a/felix/.semaphore/cleanup.yml
+++ b/felix/.semaphore/cleanup.yml
@@ -3,7 +3,7 @@ name: Felix
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 10

--- a/felix/.semaphore/semaphore.yml
+++ b/felix/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 auto_cancel:
   running:
@@ -45,7 +45,7 @@ blocks:
     agent:
       machine:
         type: e1-standard-4
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     jobs:
     - name: Build and run UT, k8sfv
       execution_time_limit:
@@ -207,7 +207,7 @@ blocks:
       machine:
         # Linters use a lot of RAM so use a bigger machine type.
         type: e1-standard-8
-        os_image: ubuntu1804
+        os_image: ubuntu2004
     prologue:
       commands:
       - checkout

--- a/felix/.semaphore/update_pins.yml
+++ b/felix/.semaphore/update_pins.yml
@@ -7,7 +7,7 @@ execution_time_limit:
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 global_job_config:
   secrets:


### PR DESCRIPTION
## Description

This change follows the Semaphore migration guidance in [1]. Ubuntu 18.04 is coming out of LTS in 2023 and Ubuntu 20.04 contains general improvements like a newer kernel, newer software stacks, and longer support until April 2025.

[1] https://docs.semaphoreci.com/ci-cd-environment/agent-migration-to-ubuntu2004/

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
