### PR TITLE
chore: add k8s node-role.kubernetes.io/control-plane taint

### DIFF
--- a/app-policy/config/install/05-calico.yaml
+++ b/app-policy/config/install/05-calico.yaml
@@ -194,6 +194,8 @@ spec:
         # the master to communicate with pods.
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
         # Mark the pod as a critical add-on for rescheduling.
         - key: "CriticalAddonsOnly"
           operator: "Exists"

--- a/confd/tests/mock_data/kdd/nodes.yaml
+++ b/confd/tests/mock_data/kdd/nodes.yaml
@@ -9,6 +9,7 @@ metadata:
     kubernetes.io/os: linux
     kubernetes.io/hostname: kube-master
     node-role.kubernetes.io/master: ""
+    node-role.kubernetes.io/control-plane: ""
   name: kube-master
   namespace: ""
 spec:

--- a/manifests/apiserver.yaml
+++ b/manifests/apiserver.yaml
@@ -108,6 +108,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: calico-apiserver-certs
         secret:


### PR DESCRIPTION
`node-role.kubernetes.io/master` has been deprecated from 1.20, and replaced by `node-role.kubernetes.io/control-plane`.

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/76980726/210051749-5a7ef27f-9edf-4ed9-8840-16be3dec7da7.png">
