### PR TITLE
DOCS-991: syntax error in the ipam release command

### DIFF
--- a/calico/reference/calicoctl/ipam/release.md
+++ b/calico/reference/calicoctl/ipam/release.md
@@ -1,5 +1,5 @@
 ---
-title: calicoctl ipam
+title: calicoctl ipam release
 description: Command to release an IP address from Calico IP management.
 canonical_url: '/reference/calicoctl/ipam/release'
 ---


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix: documentation
- On the left nav title of [this topic](https://unified-docs.tigera.io/calico/reference/calicoctl/ipam/release), the command name is showing as "calicoctl ipam" instead of "calicoctl ipam release"
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
