### PR TITLE
OpenStack: Support newer, more scalable version of etcd server

### DIFF
--- a/networking-calico/Dockerfile
+++ b/networking-calico/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/etcd:v3.3.11 as etcd
+FROM quay.io/coreos/etcd:v3.4.20 as etcd
 
 FROM python:3.8
 

--- a/networking-calico/networking_calico/common/config.py
+++ b/networking-calico/networking_calico/common/config.py
@@ -40,6 +40,9 @@ SHARED_OPTS = [
     cfg.StrOpt('etcd_password',
                help="Password for accessing an etcd cluster with "
                     "authentication enabled."),
+    cfg.StrOpt('etcd_api_path', default='/v3alpha/',
+               help="Can be set to '/v3beta/' or '/v3/' if the etcd server "
+                    "requires that instead of the default '/v3alpha/'."),
     # Large etcd subtree snapshot reads can take time, hence the
     # default of 60 seconds here as opposed to something much shorter.
     cfg.IntOpt('etcd_timeout', default=60,

--- a/networking-calico/networking_calico/common/config.py
+++ b/networking-calico/networking_calico/common/config.py
@@ -40,9 +40,6 @@ SHARED_OPTS = [
     cfg.StrOpt('etcd_password',
                help="Password for accessing an etcd cluster with "
                     "authentication enabled."),
-    cfg.StrOpt('etcd_api_path', default='/v3alpha/',
-               help="Can be set to '/v3beta/' or '/v3/' if the etcd server "
-                    "requires that instead of the default '/v3alpha/'."),
     # Large etcd subtree snapshot reads can take time, hence the
     # default of 60 seconds here as opposed to something much shorter.
     cfg.IntOpt('etcd_timeout', default=60,

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -406,14 +406,15 @@ _client = None
 class Etcd3AuthClient(Etcd3Client):
     def __init__(self, host='localhost', port=2379, protocol="http",
                  ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
-                 username=None, password=None):
+                 username=None, password=None, api_path=None):
         super(Etcd3AuthClient, self).__init__(host=host,
                                               port=port,
                                               protocol=protocol,
                                               ca_cert=ca_cert,
                                               cert_key=cert_key,
                                               cert_cert=cert_cert,
-                                              timeout=timeout)
+                                              timeout=timeout,
+                                              api_path=api_path)
         self.username = username
         self.password = password
 
@@ -491,12 +492,14 @@ def _get_client():
                                       cert_key=calico_cfg.etcd_key_file,
                                       cert_cert=calico_cfg.etcd_cert_file,
                                       username=calico_cfg.etcd_username,
-                                      password=calico_cfg.etcd_password)
+                                      password=calico_cfg.etcd_password,
+                                      api_path=calico_cfg.etcd_api_path)
         else:
             LOG.info("TLS disabled, using HTTP to connect to etcd.")
             _client = Etcd3AuthClient(host=calico_cfg.etcd_host,
                                       port=calico_cfg.etcd_port,
                                       protocol="http",
                                       username=calico_cfg.etcd_username,
-                                      password=calico_cfg.etcd_password)
+                                      password=calico_cfg.etcd_password,
+                                      api_path=calico_cfg.etcd_api_path)
     return _client

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import functools
-import socket
 
 from etcd3gw.client import Etcd3Client
 from etcd3gw.exceptions import Etcd3Exception
@@ -34,8 +33,8 @@ LOG = log.getLogger(__name__)
 # we leave plenty of headroom.
 CHUNK_SIZE_LIMIT = 200
 
-# Indicates that a put operation must update an existing resource and not create
-# a new resource.
+# Indicates that a put operation must update an existing resource and not
+# create a new resource.
 MUST_UPDATE = "MUST_UPDATE"
 
 
@@ -120,7 +119,8 @@ def put(key, value, mod_revision=None, lease=None, existing_value=None):
             'version': 0,
         }]
     elif mod_revision is not None:
-        # Write operation must _replace_ a KV entry with the specified revision.
+        # Write operation must _replace_ a KV entry with the specified
+        # revision.
         base64_key = _encode(key)
         txn['compare'] = [{
             'key': base64_key,

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -407,14 +407,26 @@ class Etcd3AuthClient(Etcd3Client):
     def __init__(self, host='localhost', port=2379, protocol="http",
                  ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
                  username=None, password=None, api_path=None):
-        super(Etcd3AuthClient, self).__init__(host=host,
-                                              port=port,
-                                              protocol=protocol,
-                                              ca_cert=ca_cert,
-                                              cert_key=cert_key,
-                                              cert_cert=cert_cert,
-                                              timeout=timeout,
-                                              api_path=api_path)
+        try:
+            super(Etcd3AuthClient, self).__init__(host=host,
+                                                  port=port,
+                                                  protocol=protocol,
+                                                  ca_cert=ca_cert,
+                                                  cert_key=cert_key,
+                                                  cert_cert=cert_cert,
+                                                  timeout=timeout,
+                                                  api_path=api_path)
+        except TypeError:
+            # Indicates an old version of etcd3gw that doesn't support the
+            # api_path keyword.
+            super(Etcd3AuthClient, self).__init__(host=host,
+                                                  port=port,
+                                                  protocol=protocol,
+                                                  ca_cert=ca_cert,
+                                                  cert_key=cert_key,
+                                                  cert_cert=cert_cert,
+                                                  timeout=timeout)
+
         self.username = username
         self.password = password
 

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -25,6 +25,11 @@ from etcd3gw.utils import _increment_last_byte
 from networking_calico.compat import cfg
 from networking_calico.compat import log
 
+# Incantations for enabling oslo_log debug logging, when desired:
+# log.register_options(cfg.CONF)
+# cfg.CONF.debug = True
+# cfg.CONF.use_stderr = True
+# log.setup(cfg.CONF, "demo")
 
 LOG = log.getLogger(__name__)
 

--- a/networking-calico/networking_calico/etcdv3.py
+++ b/networking-calico/networking_calico/etcdv3.py
@@ -390,6 +390,11 @@ def logging_exceptions(fn):
 _client = None
 
 
+# Possible API paths for connecting to an etcd server.  Defined as a variable
+# here so that test code can override it after importing this file.
+_possible_etcd_api_paths = ['/v3/', '/v3beta/', '/v3alpha/']
+
+
 # Wrap Etcd3Client to authenticate when needed and add an
 # Authorization header to the session headers.
 #
@@ -412,9 +417,8 @@ class Etcd3AuthClient(Etcd3Client):
     def __init__(self, host='localhost', port=2379, protocol="http",
                  ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
                  username=None, password=None):
-        # Begin with an invalid API path so as to keep testing the failure
-        # handling logic even when most installations support '/v3/'.
-        possible_api_paths = ['/invalid/', '/v3/', '/v3beta/', '/v3alpha/']
+        global _possible_etcd_api_paths
+        possible_api_paths = _possible_etcd_api_paths
         created_working_client = False
         while not created_working_client:
             try:

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -42,8 +42,18 @@ class TestFVEtcdutils(unittest.TestCase):
     def setUp(self):
         super(TestFVEtcdutils, self).setUp()
         self.etcd_server_running = False
+        self.normal_api_paths = etcdv3._possible_etcd_api_paths
+
+        # Add in an invalid API path so as to make sure to test the failure
+        # handling logic even when most installations support '/v3/'.
+        etcdv3._possible_etcd_api_paths = ['/invalid/'] + self.normal_api_paths
 
     def tearDown(self):
+        # Restore normal etcd API paths in case they are relevant to other test
+        # files.  (In practice I don't think they are; this is the only test
+        # file that connects to a real etcd server.)
+        etcdv3._possible_etcd_api_paths = self.normal_api_paths
+
         self.stop_etcd_server()
         etcdv3._client = None
         super(TestFVEtcdutils, self).tearDown()

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -84,7 +84,6 @@ class TestFVEtcdutils(unittest.TestCase):
 
         # Set up minimal config, so EtcdWatcher will use that etcd.
         calico_config.register_options(cfg.CONF)
-        cfg.CONF.set_override('etcd_api_path', '/v3/', group='calico')
 
         # Ensure etcd server is ready.
         self.wait_etcd_ready()
@@ -123,7 +122,6 @@ class TestFVEtcdutils(unittest.TestCase):
 
         # Set up minimal config, so EtcdWatcher will use that etcd.
         calico_config.register_options(cfg.CONF)
-        cfg.CONF.set_override('etcd_api_path', '/v3/', group='calico')
 
         # Ensure etcd server is ready.
         self.wait_etcd_ready()

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -84,6 +84,7 @@ class TestFVEtcdutils(unittest.TestCase):
 
         # Set up minimal config, so EtcdWatcher will use that etcd.
         calico_config.register_options(cfg.CONF)
+        cfg.CONF.set_override('etcd_api_path', '/v3/', group='calico')
 
         # Ensure etcd server is ready.
         self.wait_etcd_ready()
@@ -122,6 +123,7 @@ class TestFVEtcdutils(unittest.TestCase):
 
         # Set up minimal config, so EtcdWatcher will use that etcd.
         calico_config.register_options(cfg.CONF)
+        cfg.CONF.set_override('etcd_api_path', '/v3/', group='calico')
 
         # Ensure etcd server is ready.
         self.wait_etcd_ready()


### PR DESCRIPTION
## Description

etcd prior to v3.4.20 had a scalability bug that limited the number of possible simultaneous client watches, and hence the maximum number of cluster nodes in a Calico+OpenStack installation.  Hence we'd like to support etcd v3.4.20 and later.

However, etcd v3.4 only supports URL paths with '/v3beta/' or '/v3/', and not the '/v3alpha/' that is hardcoded in our documented version of the etcd3gw package (previously known as etcd3-gateway). Hence we also need to:

- document using a newer etcd3gw that supports the newer URL paths, namely version 1.0.1

- add a Calico config option to control that (bearing in mind that etcd3gw's default is still '/v3alpha/', and that some users might still be using older etcd servers, and so we can't just hardcode a newer setting).

## Release Note

```release-note
OpenStack: Support newer, more scalable version of etcd server
```
