### PR TITLE
Fix incorrect map cleanup in service policy index.

### DIFF
--- a/felix/calc/calc_graph_fv_test.go
+++ b/felix/calc/calc_graph_fv_test.go
@@ -421,6 +421,15 @@ var baseTests = []StateList{
 	{
 		endpointSliceActiveSpecNoPorts,
 	},
+	{
+		// This case repros an aliasing bug where having an ingress rule and an egress rule for the
+		// same selector resulted in collision at cleanup time.
+		endpointSliceActiveSpecNoPorts,
+		endpointSliceActiveSpecPortsAndNoPorts,
+		endpointSliceActiveSpecNoPorts,
+		endpointSliceActiveSpecPortsAndNoPorts,
+		endpointSliceActiveNewIPs,
+	},
 
 	// IPv6 VXLAN tests.
 

--- a/felix/calc/resources_for_test.go
+++ b/felix/calc/resources_for_test.go
@@ -879,6 +879,7 @@ var endpointSlice2NewIPs2 = discovery.EndpointSlice{
 	},
 }
 var servicePolicyKey = model.PolicyKey{Name: "svc-policy"}
+var servicePolicyKey2 = model.PolicyKey{Name: "svc-policy2"}
 var servicePolicy = model.Policy{
 	Namespace: "default",
 	OutboundRules: []model.Rule{

--- a/felix/calc/states_for_test.go
+++ b/felix/calc/states_for_test.go
@@ -2534,6 +2534,25 @@ var endpointSliceActiveSpecNoPorts = endpointSliceAndLocalWorkload.withKVUpdates
 	},
 )
 
+// Add the egress policy too...
+var endpointSliceActiveSpecPortsAndNoPorts = endpointSliceActiveSpecNoPorts.withKVUpdates(
+	KVPair{Key: servicePolicyKey2, Value: &servicePolicy},
+).withName(
+	"EndpointSliceActivePortsNoPorts",
+).withIPSet("svc:Jhwii46PCMT5NlhWsUqZmv7al8TeHFbNQMhoVg", []string{
+	"10.0.0.1,tcp:80",
+}).withActivePolicies(
+	proto.PolicyID{Tier: "default", Name: "svc-policy"},
+	proto.PolicyID{Tier: "default", Name: "svc-policy2"},
+).withEndpoint(
+	localWlEp1Id,
+	[]mock.TierInfo{
+		{Name: "default",
+			IngressPolicyNames: []string{"svc-policy"},
+			EgressPolicyNames:  []string{"svc-policy2"}},
+	},
+)
+
 var encapWithIPIPPool = empty.withKVUpdates(
 	KVPair{Key: ipPoolKey, Value: &ipPoolWithIPIP},
 ).withExpectedEncapsulation(

--- a/felix/serviceindex/serviceindex.go
+++ b/felix/serviceindex/serviceindex.go
@@ -317,7 +317,10 @@ func (idx *ServiceIndex) DeleteIPSet(id string) {
 	}
 
 	delete(idx.activeIPSetsByID, id)
-	delete(idx.activeIPSetsByService, as.ServiceName)
+	delete(idx.activeIPSetsByService[as.ServiceName], id)
+	if len(idx.activeIPSetsByService[as.ServiceName]) == 0 {
+		delete(idx.activeIPSetsByService, as.ServiceName)
+	}
 }
 
 func (idx *ServiceIndex) maybeReportLive() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
There was a bug in this scenario:

- Ingress and egress rules both become active, using the same service.
- Either rule becomes inactive.
- Service index would clean up the endpoints to IP set mapping for both IP sets.
- Updates to endpoint slices were then ignored for the remaining IP set.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix incorrect cleanup in the service policy index after having both ingress and egress rules that reference the same service, resulting in missed IP set updates after one rule was deactivated.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
