### PR TITLE
bpf map context and explicit pin path removed

### DIFF
--- a/felix/bpf/arp/map.go
+++ b/felix/bpf/arp/map.go
@@ -29,7 +29,6 @@ func init() {
 }
 
 var MapParams = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_arp",
 	Type:       "lru_hash",
 	KeySize:    KeySize,
 	ValueSize:  ValueSize,

--- a/felix/bpf/arp/map.go
+++ b/felix/bpf/arp/map.go
@@ -24,6 +24,10 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 )
 
+func init() {
+	bpf.SetMapSize(MapParams.VersionedName(), MapParams.MaxEntries)
+}
+
 var MapParams = bpf.MapParameters{
 	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_arp",
 	Type:       "lru_hash",
@@ -34,8 +38,8 @@ var MapParams = bpf.MapParameters{
 	Version:    2,
 }
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParams)
+func Map() bpf.Map {
+	return bpf.NewPinnedMap(MapParams)
 }
 
 const KeySize = 8

--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -96,6 +96,8 @@ const (
 
 	DefaultBPFfsPath = "/sys/fs/bpf"
 	CgroupV2Path     = "/run/calico/cgroup"
+
+	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 )
 
 var (
@@ -2296,7 +2298,7 @@ func CountersMapName() string {
 	return fmt.Sprintf("cali_counters%d", countersMapVersion)
 }
 
-func MapPinPath(typ int, name, iface string, hook Hook) string {
+func MapPinDir(typ int, name, iface string, hook Hook) string {
 	PinBaseDir := path.Join(DefaultBPFfsPath, "tc")
 	subDir := "globals"
 	// We need one jump map and one counter map for each program, thus we need to pin those
@@ -2309,14 +2311,14 @@ func MapPinPath(typ int, name, iface string, hook Hook) string {
 		case HookXDP:
 			subDir = ifName + "_xdp"
 		case HookIngress:
-			subDir = ifName + "_igr/"
+			subDir = ifName + "_igr"
 		case HookEgress:
 			subDir = ifName + "_egr"
 		default:
 			panic("Invalid hook")
 		}
 	}
-	return path.Join(PinBaseDir, subDir, name)
+	return path.Join(PinBaseDir, subDir)
 }
 
 type TcList []struct {

--- a/felix/bpf/bpf_syscall.go
+++ b/felix/bpf/bpf_syscall.go
@@ -260,7 +260,7 @@ func checkMapIfDebug(mapFD MapFD, keySize, valueSize int) error {
 		log.WithError(err).Error("Failed to read map information")
 		return err
 	}
-	log.WithField("mapInfo", mapInfo).Debug("Map metadata")
+	log.WithField("fd", mapFD).WithField("mapInfo", mapInfo).Debug("Map metadata")
 	if keySize != mapInfo.KeySize {
 		log.WithField("mapInfo", mapInfo).WithField("keyLen", keySize).Panic("Incorrect key length")
 	}

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -42,11 +42,9 @@ func CreateBPFMapContext(
 	routeMapSize,
 	ctMapSize,
 	ifstateSize int,
-	repinEnabled bool,
 ) *bpf.MapContext {
 	bpfMapContext := &bpf.MapContext{
-		RepinningEnabled: repinEnabled,
-		MapSizes:         map[string]uint32{},
+		MapSizes: map[string]uint32{},
 	}
 	bpfMapContext.MapSizes[ipsets.MapParameters.VersionedName()] = uint32(ipsetsMapSize)
 	bpfMapContext.MapSizes[nat.FrontendMapParameters.VersionedName()] = uint32(natFEMapSize)

--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
@@ -34,99 +32,99 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/state"
 )
 
-func CreateBPFMapContext(
-	ipsetsMapSize,
-	natFEMapSize,
-	natBEMapSize,
-	natAffMapSize,
-	routeMapSize,
-	ctMapSize,
-	ifstateSize int,
-) *bpf.MapContext {
-	bpfMapContext := &bpf.MapContext{
-		MapSizes: map[string]uint32{},
-	}
-	bpfMapContext.MapSizes[ipsets.MapParameters.VersionedName()] = uint32(ipsetsMapSize)
-	bpfMapContext.MapSizes[nat.FrontendMapParameters.VersionedName()] = uint32(natFEMapSize)
-	bpfMapContext.MapSizes[nat.BackendMapParameters.VersionedName()] = uint32(natBEMapSize)
-	bpfMapContext.MapSizes[nat.AffinityMapParameters.VersionedName()] = uint32(natAffMapSize)
-	bpfMapContext.MapSizes[routes.MapParameters.VersionedName()] = uint32(routeMapSize)
-	bpfMapContext.MapSizes[conntrack.MapParams.VersionedName()] = uint32(ctMapSize)
-
-	bpfMapContext.MapSizes[state.MapParameters.VersionedName()] = uint32(state.MapParameters.MaxEntries)
-	bpfMapContext.MapSizes[arp.MapParams.VersionedName()] = uint32(arp.MapParams.MaxEntries)
-	bpfMapContext.MapSizes[failsafes.MapParams.VersionedName()] = uint32(failsafes.MapParams.MaxEntries)
-	bpfMapContext.MapSizes[nat.SendRecvMsgMapParameters.VersionedName()] = uint32(nat.SendRecvMsgMapParameters.MaxEntries)
-	bpfMapContext.MapSizes[nat.CTNATsMapParameters.VersionedName()] = uint32(nat.CTNATsMapParameters.MaxEntries)
-	bpfMapContext.MapSizes[ifstate.MapParams.VersionedName()] = uint32(ifstateSize)
-
-	return bpfMapContext
+type Maps struct {
+	IpsetsMap       bpf.Map
+	StateMap        bpf.Map
+	ArpMap          bpf.Map
+	FailsafesMap    bpf.Map
+	FrontendMap     bpf.Map
+	BackendMap      bpf.Map
+	AffinityMap     bpf.Map
+	RouteMap        bpf.Map
+	CtMap           bpf.Map
+	SrMsgMap        bpf.Map
+	CtNatsMap       bpf.Map
+	IfStateMap      bpf.Map
+	RuleCountersMap bpf.Map
 }
 
-func MigrateDataFromOldMap(mc *bpf.MapContext) {
-	ctMap := mc.CtMap
-	err := ctMap.CopyDeltaFromOldMap()
-	if err != nil {
-		log.WithError(err).Debugf("Failed to copy data from old conntrack map %s", err)
+func (m *Maps) Destroy() {
+	maps := []bpf.Map{
+		m.IpsetsMap,
+		m.StateMap,
+		m.ArpMap,
+		m.FailsafesMap,
+		m.FrontendMap,
+		m.BackendMap,
+		m.AffinityMap,
+		m.RouteMap,
+		m.CtMap,
+		m.SrMsgMap,
+		m.CtNatsMap,
 	}
-}
 
-func DestroyBPFMaps(mc *bpf.MapContext) {
-	maps := []bpf.Map{mc.IpsetsMap, mc.StateMap, mc.ArpMap, mc.FailsafesMap, mc.FrontendMap,
-		mc.BackendMap, mc.AffinityMap, mc.RouteMap, mc.CtMap, mc.SrMsgMap, mc.CtNatsMap}
 	for _, m := range maps {
 		os.Remove(m.(*bpf.PinnedMap).Path())
 		m.(*bpf.PinnedMap).Close()
 	}
 }
 
-func CreateBPFMaps(mc *bpf.MapContext) error {
+func CreateBPFMaps() (*Maps, error) {
 	maps := []bpf.Map{}
+	ret := new(Maps)
 
-	mc.IpsetsMap = ipsets.Map(mc)
-	maps = append(maps, mc.IpsetsMap)
+	ret.IpsetsMap = ipsets.Map()
+	maps = append(maps, ret.IpsetsMap)
 
-	mc.StateMap = state.Map(mc)
-	maps = append(maps, mc.StateMap)
+	ret.StateMap = state.Map()
+	maps = append(maps, ret.StateMap)
 
-	mc.ArpMap = arp.Map(mc)
-	maps = append(maps, mc.ArpMap)
+	ret.ArpMap = arp.Map()
+	maps = append(maps, ret.ArpMap)
 
-	mc.FailsafesMap = failsafes.Map(mc)
-	maps = append(maps, mc.FailsafesMap)
+	ret.FailsafesMap = failsafes.Map()
+	maps = append(maps, ret.FailsafesMap)
 
-	mc.FrontendMap = nat.FrontendMap(mc)
-	maps = append(maps, mc.FrontendMap)
+	ret.FrontendMap = nat.FrontendMap()
+	maps = append(maps, ret.FrontendMap)
 
-	mc.BackendMap = nat.BackendMap(mc)
-	maps = append(maps, mc.BackendMap)
+	ret.BackendMap = nat.BackendMap()
+	maps = append(maps, ret.BackendMap)
 
-	mc.AffinityMap = nat.AffinityMap(mc)
-	maps = append(maps, mc.AffinityMap)
+	ret.AffinityMap = nat.AffinityMap()
+	maps = append(maps, ret.AffinityMap)
 
-	mc.RouteMap = routes.Map(mc)
-	maps = append(maps, mc.RouteMap)
+	ret.RouteMap = routes.Map()
+	maps = append(maps, ret.RouteMap)
 
-	mc.CtMap = conntrack.Map(mc)
-	maps = append(maps, mc.CtMap)
+	ret.CtMap = conntrack.Map()
+	maps = append(maps, ret.CtMap)
 
-	mc.SrMsgMap = nat.SendRecvMsgMap(mc)
-	maps = append(maps, mc.SrMsgMap)
+	ret.SrMsgMap = nat.SendRecvMsgMap()
+	maps = append(maps, ret.SrMsgMap)
 
-	mc.CtNatsMap = nat.AllNATsMsgMap(mc)
-	maps = append(maps, mc.CtNatsMap)
+	ret.CtNatsMap = nat.AllNATsMsgMap()
+	maps = append(maps, ret.CtNatsMap)
 
-	mc.IfStateMap = ifstate.Map(mc)
-	maps = append(maps, mc.IfStateMap)
+	ret.IfStateMap = ifstate.Map()
+	maps = append(maps, ret.IfStateMap)
 
-	mc.RuleCountersMap = counters.PolicyMap(mc)
-	maps = append(maps, mc.RuleCountersMap)
+	ret.RuleCountersMap = counters.PolicyMap()
+	maps = append(maps, ret.RuleCountersMap)
 
-	for _, bpfMap := range maps {
+	for i, bpfMap := range maps {
 		err := bpfMap.EnsureExists()
 		if err != nil {
-			return fmt.Errorf("Failed to create %s map, err=%w", bpfMap.GetName(), err)
+
+			for j := 0; j < i; j++ {
+				m := maps[j]
+				os.Remove(m.(*bpf.PinnedMap).Path())
+				m.(*bpf.PinnedMap).Close()
+			}
+
+			return nil, fmt.Errorf("failed to create %s map, err=%w", bpfMap.GetName(), err)
 		}
 	}
-	return nil
+
+	return ret, nil
 }

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -28,6 +28,14 @@ import (
 	curVer "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
 )
 
+func init() {
+	SetMapSize(MapParams.MaxEntries)
+}
+
+func SetMapSize(size int) {
+	bpf.SetMapSize(MapParams.VersionedName(), size)
+}
+
 const KeySize = curVer.KeySize
 const ValueSize = curVer.ValueSize
 const MaxEntries = curVer.MaxEntries
@@ -74,16 +82,16 @@ type Leg = curVer.Leg
 
 var MapParams = curVer.MapParams
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	b := mc.NewPinnedMap(MapParams)
+func Map() bpf.Map {
+	b := bpf.NewPinnedMap(MapParams)
 	b.(*bpf.PinnedMap).UpgradeFn = upgrade.UpgradeBPFMap
 	b.(*bpf.PinnedMap).GetMapParams = GetMapParams
 	b.(*bpf.PinnedMap).KVasUpgradable = GetKeyValueTypeFromVersion
 	return b
 }
 
-func MapV2(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(v2.MapParams)
+func MapV2() bpf.Map {
+	return bpf.NewPinnedMap(v2.MapParams)
 }
 
 const (

--- a/felix/bpf/conntrack/v2/map.go
+++ b/felix/bpf/conntrack/v2/map.go
@@ -485,7 +485,6 @@ func (e Value) Upgrade() bpf.Upgradable {
 }
 
 var MapParams = bpf.MapParameters{
-	Filename:     "/sys/fs/bpf/tc/globals/cali_v4_ct",
 	Type:         "hash",
 	KeySize:      KeySize,
 	ValueSize:    ValueSize,

--- a/felix/bpf/conntrack/v3/map.go
+++ b/felix/bpf/conntrack/v3/map.go
@@ -502,10 +502,6 @@ var MapParams = bpf.MapParameters{
 	UpdatedByBPF: true,
 }
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParams)
-}
-
 const (
 	ProtoICMP = 1
 	ProtoTCP  = 6

--- a/felix/bpf/conntrack/v3/map.go
+++ b/felix/bpf/conntrack/v3/map.go
@@ -491,7 +491,6 @@ func (e Value) Upgrade() bpf.Upgradable {
 }
 
 var MapParams = bpf.MapParameters{
-	Filename:     "/sys/fs/bpf/tc/globals/cali_v4_ct",
 	Type:         "hash",
 	KeySize:      KeySize,
 	ValueSize:    ValueSize,

--- a/felix/bpf/counters/counters.go
+++ b/felix/bpf/counters/counters.go
@@ -152,10 +152,10 @@ func NewCounters(iface string) *Counters {
 	}
 
 	for index, hook := range bpf.Hooks {
-		pinPath := bpf.MapPinPath(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
+		pinDir := bpf.MapPinDir(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
 			bpf.CountersMapName(), iface, hook)
-		cntr.maps[index] = Map(pinPath)
-		logrus.Debugf("%s counter map pin path: %v", hook, pinPath)
+		cntr.maps[index] = Map(pinDir)
+		logrus.Debugf("%s counter map pin dir: %v", hook, pinDir)
 	}
 	return &cntr
 }

--- a/felix/bpf/counters/counters.go
+++ b/felix/bpf/counters/counters.go
@@ -154,7 +154,7 @@ func NewCounters(iface string) *Counters {
 	for index, hook := range bpf.Hooks {
 		pinPath := bpf.MapPinPath(unix.BPF_MAP_TYPE_PERCPU_ARRAY,
 			bpf.CountersMapName(), iface, hook)
-		cntr.maps[index] = Map(&bpf.MapContext{}, pinPath)
+		cntr.maps[index] = Map(pinPath)
 		logrus.Debugf("%s counter map pin path: %v", hook, pinPath)
 	}
 	return &cntr

--- a/felix/bpf/counters/map.go
+++ b/felix/bpf/counters/map.go
@@ -17,8 +17,6 @@ package counters
 import (
 	"encoding/binary"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/projectcalico/calico/felix/bpf"
 )
 
@@ -34,13 +32,13 @@ var MapParameters = bpf.MapParameters{
 	Name:       bpf.CountersMapName(),
 }
 
-func Map(mc *bpf.MapContext, pinPath string) bpf.Map {
+func Map(pinPath string) bpf.Map {
 	MapParameters.Filename = pinPath
-	return mc.NewPinnedMap(MapParameters)
+	return bpf.NewPinnedMap(MapParameters)
 }
 
-func MapForTest(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParameters)
+func MapForTest() bpf.Map {
+	return bpf.NewPinnedMap(MapParameters)
 }
 
 var PolicyMapParameters = bpf.MapParameters{
@@ -53,8 +51,8 @@ var PolicyMapParameters = bpf.MapParameters{
 	Version:    2,
 }
 
-func PolicyMap(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(PolicyMapParameters)
+func PolicyMap() bpf.Map {
+	return bpf.NewPinnedMap(PolicyMapParameters)
 }
 
 type PolicyMapMem map[uint64]uint64
@@ -86,14 +84,5 @@ func PolicyMapMemIter(m PolicyMapMem) bpf.IterCallback {
 		}
 		m[key] = value
 		return bpf.IterNone
-	}
-}
-
-func DeleteAllPolicyCounters(mc *bpf.MapContext) {
-	err := mc.RuleCountersMap.Iter(func(k, v []byte) bpf.IteratorAction {
-		return bpf.IterDelete
-	})
-	if err != nil {
-		logrus.WithError(err).Warn("Failed to iterate over policy counters map")
 	}
 }

--- a/felix/bpf/counters/map.go
+++ b/felix/bpf/counters/map.go
@@ -24,7 +24,6 @@ const PolicyMapKeySize = 8
 const PolicyMapValueSize = 8
 
 var MapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_counters",
 	Type:       "percpu_array",
 	KeySize:    counterMapKeySize, // __u32
 	ValueSize:  counterMapValueSize * MaxCounterNumber,
@@ -32,8 +31,8 @@ var MapParameters = bpf.MapParameters{
 	Name:       bpf.CountersMapName(),
 }
 
-func Map(pinPath string) bpf.Map {
-	MapParameters.Filename = pinPath
+func Map(pinDir string) bpf.Map {
+	MapParameters.PinDir = pinDir
 	return bpf.NewPinnedMap(MapParameters)
 }
 
@@ -42,7 +41,6 @@ func MapForTest() bpf.Map {
 }
 
 var PolicyMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_rule_ctrs",
 	Type:       "percpu_hash",
 	KeySize:    PolicyMapKeySize,
 	ValueSize:  PolicyMapValueSize,

--- a/felix/bpf/failsafes/failsafes_map.go
+++ b/felix/bpf/failsafes/failsafes_map.go
@@ -26,6 +26,10 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 )
 
+func init() {
+	bpf.SetMapSize(MapParams.VersionedName(), MapParams.MaxEntries)
+}
+
 const (
 	// PrefixLen (4) + Port (2) + Proto (1) + Flags (1) + IP (4)
 	KeySize   = 12
@@ -66,8 +70,8 @@ var MapParams = bpf.MapParameters{
 	Version:    2,
 }
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParams)
+func Map() bpf.Map {
+	return bpf.NewPinnedMap(MapParams)
 }
 
 func MakeKey(ipProto uint8, port uint16, outbound bool, ip string, mask int) Key {

--- a/felix/bpf/failsafes/failsafes_map.go
+++ b/felix/bpf/failsafes/failsafes_map.go
@@ -60,7 +60,6 @@ func (k Key) String() string {
 }
 
 var MapParams = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_fsafes",
 	Type:       "lpm_trie",
 	KeySize:    KeySize,
 	ValueSize:  ValueSize,

--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -49,7 +49,6 @@ var flagsToStr = map[uint32]string{
 }
 
 var MapParams = bpf.MapParameters{
-	Filename:     "/sys/fs/bpf/tc/globals/cali_iface",
 	Type:         "hash",
 	KeySize:      KeySize,
 	ValueSize:    ValueSize,

--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -24,6 +24,14 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 )
 
+func init() {
+	SetMapSize(MapParams.MaxEntries)
+}
+
+func SetMapSize(size int) {
+	bpf.SetMapSize(MapParams.VersionedName(), size)
+}
+
 const (
 	KeySize    = 4
 	ValueSize  = 4 + 16
@@ -52,8 +60,8 @@ var MapParams = bpf.MapParameters{
 	UpdatedByBPF: false,
 }
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParams)
+func Map() bpf.Map {
+	return bpf.NewPinnedMap(MapParams)
 }
 
 type Key [4]byte

--- a/felix/bpf/ipsets/map.go
+++ b/felix/bpf/ipsets/map.go
@@ -50,8 +50,16 @@ var MapParameters = bpf.MapParameters{
 	Flags:      unix.BPF_F_NO_PREALLOC,
 }
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParameters)
+func init() {
+	SetMapSize(MapParameters.MaxEntries)
+}
+
+func SetMapSize(size int) {
+	bpf.SetMapSize(MapParameters.VersionedName(), size)
+}
+
+func Map() bpf.Map {
+	return bpf.NewPinnedMap(MapParameters)
 }
 
 func (e IPSetEntry) SetID() uint64 {

--- a/felix/bpf/ipsets/map.go
+++ b/felix/bpf/ipsets/map.go
@@ -41,7 +41,6 @@ const IPSetEntrySize = 20
 type IPSetEntry [IPSetEntrySize]byte
 
 var MapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_ip_sets",
 	Type:       "lpm_trie",
 	KeySize:    IPSetEntrySize,
 	ValueSize:  4,

--- a/felix/bpf/jump/map.go
+++ b/felix/bpf/jump/map.go
@@ -18,8 +18,8 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 )
 
-func MapForTest(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(bpf.MapParameters{
+func MapForTest() bpf.Map {
+	return bpf.NewPinnedMap(bpf.MapParameters{
 		Filename:   "/sys/fs/bpf/tc/globals/cali_jump2",
 		Type:       "prog_array",
 		KeySize:    4,

--- a/felix/bpf/jump/map.go
+++ b/felix/bpf/jump/map.go
@@ -20,7 +20,6 @@ import (
 
 func MapForTest() bpf.Map {
 	return bpf.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_jump2",
 		Type:       "prog_array",
 		KeySize:    4,
 		ValueSize:  4,

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -77,7 +77,7 @@ func (m *Map) MaxEntries() int {
 	return int(C.bpf_map__max_entries(m.bpfMap))
 }
 
-func (m *Map) SetMapSize(size uint32) error {
+func (m *Map) SetMapSize(size int) error {
 	_, err := C.bpf_map_set_max_entries(m.bpfMap, C.uint(size))
 	if err != nil {
 		return fmt.Errorf("setting %s map size failed %w", m.Name(), err)

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -116,7 +116,7 @@ func XDPSetGlobals(_ *Map, _ *XDPGlobalData) error {
 	panic("LIBBPF syscall stub")
 }
 
-func (m *Map) SetMapSize(size uint32) error {
+func (m *Map) SetMapSize(size int) error {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/maps.go
+++ b/felix/bpf/maps.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"golang.org/x/sys/unix"
 
@@ -52,10 +53,30 @@ type Value interface {
 	AsBytes
 }
 
-var repinningEnabled bool
+var (
+	repinningEnabled     bool
+	repinningEnabledLock sync.RWMutex
+)
 
-func EnabledRepin() {
+func EnableRepin() {
+	repinningEnabledLock.Lock()
+	defer repinningEnabledLock.Unlock()
+
 	repinningEnabled = true
+}
+
+func DisableRepin() {
+	repinningEnabledLock.Lock()
+	defer repinningEnabledLock.Unlock()
+
+	repinningEnabled = false
+}
+
+func repinningIsEnabled() bool {
+	repinningEnabledLock.RLock()
+	defer repinningEnabledLock.RUnlock()
+
+	return repinningEnabled
 }
 
 type IterCallback func(k, v []byte) IteratorAction
@@ -115,33 +136,49 @@ func (mp *MapParameters) versionedFilename() string {
 	return versionedStr(mp.Version, mp.Filename)
 }
 
-type MapContext struct {
-	IpsetsMap       Map
-	StateMap        Map
-	ArpMap          Map
-	FailsafesMap    Map
-	FrontendMap     Map
-	BackendMap      Map
-	AffinityMap     Map
-	RouteMap        Map
-	CtMap           Map
-	SrMsgMap        Map
-	CtNatsMap       Map
-	IfStateMap      Map
-	RuleCountersMap Map
-	MapSizes        map[string]uint32
+var (
+	defaultMapsSizes = make(map[string]int)
+	mapSizes         = make(map[string]int)
+	mapSizesLock     sync.RWMutex
+)
+
+func SetMapSize(name string, size int) {
+	mapSizesLock.Lock()
+	defer mapSizesLock.Unlock()
+
+	if _, ok := defaultMapsSizes[name]; !ok {
+		defaultMapsSizes[name] = size
+	}
+	mapSizes[name] = size
 }
 
-func (c *MapContext) NewPinnedMap(params MapParameters) MapWithExistsCheck {
+func MapSize(name string) int {
+	mapSizesLock.RLock()
+	defer mapSizesLock.RUnlock()
+
+	if sz, ok := mapSizes[name]; ok {
+		return sz
+	}
+
+	return defaultMapsSizes[name]
+}
+
+func ResetMapSizes() {
+	mapSizesLock.Lock()
+	defer mapSizesLock.Unlock()
+
+	mapSizes = make(map[string]int)
+}
+
+func NewPinnedMap(params MapParameters) MapWithExistsCheck {
 	if len(params.VersionedName()) >= unix.BPF_OBJ_NAME_LEN {
 		logrus.WithField("name", params.Name).Panic("Bug: BPF map name too long")
 	}
-	if val, ok := c.MapSizes[params.VersionedName()]; ok {
-		params.MaxEntries = int(val)
+	if val := MapSize(params.VersionedName()); val != 0 {
+		params.MaxEntries = val
 	}
 
 	m := &PinnedMap{
-		context:       c,
 		MapParameters: params,
 		perCPU:        strings.Contains(params.Type, "percpu"),
 	}
@@ -149,7 +186,6 @@ func (c *MapContext) NewPinnedMap(params MapParameters) MapWithExistsCheck {
 }
 
 type PinnedMap struct {
-	context *MapContext
 	MapParameters
 
 	fdLoaded bool
@@ -378,12 +414,21 @@ func (b *PinnedMap) Delete(k []byte) error {
 }
 
 func (b *PinnedMap) updateDeltaEntries() error {
+	logrus.WithField("name", b.Name).Debug("updateDeltaEntries")
+
+	if b.oldfd == b.fd {
+		return fmt.Errorf("old and new maps are the same")
+	}
+
+	logrus.WithField("name", b.Name).Debugf("updateDeltaEntries from fd %d -> %d", b.oldfd, b.fd)
+
 	numEntriesCopied := 0
 	mapMem := make(map[string]struct{})
 	it, err := NewMapIterator(b.oldfd, b.KeySize, b.ValueSize, b.oldSize)
 	if err != nil {
 		return fmt.Errorf("failed to create BPF map iterator: %w", err)
 	}
+	logrus.WithField("name", b.Name).Debugf("updateDeltaEntries iterator over fd %d", b.oldfd)
 	defer func() {
 		err := it.Close()
 		if err != nil {
@@ -395,7 +440,7 @@ func (b *PinnedMap) updateDeltaEntries() error {
 
 		if err != nil {
 			if err == ErrIterationFinished {
-				return nil
+				break
 			}
 			return errors.Errorf("iterating the old map failed: %s", err)
 		}
@@ -419,6 +464,10 @@ func (b *PinnedMap) updateDeltaEntries() error {
 		mapMem[string(k)] = struct{}{}
 		numEntriesCopied++
 	}
+
+	logrus.WithField("name", b.Name).Debugf("updateDeltaEntries copied %d", numEntriesCopied)
+
+	return nil
 }
 
 func (b *PinnedMap) copyFromOldMap() error {
@@ -456,7 +505,7 @@ func (b *PinnedMap) copyFromOldMap() error {
 		if err != nil {
 			return fmt.Errorf("error copying data from the old map")
 		}
-		logrus.Debugf("copied data from old map to new map key=%v, value=%v", k, v)
+		logrus.WithField("name", b.Name).Debugf("copied data from old map to new map key=%v, value=%v", k, v)
 		mapMem[string(k)] = struct{}{}
 		numEntriesCopied++
 	}
@@ -464,6 +513,7 @@ func (b *PinnedMap) copyFromOldMap() error {
 
 func (b *PinnedMap) Open() error {
 	if b.fdLoaded {
+		logrus.WithField("name", b.Name).Debug("Open - fd loaded")
 		return nil
 	}
 
@@ -484,8 +534,8 @@ func (b *PinnedMap) Open() error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		logrus.Debug("Map file didn't exist")
-		if repinningEnabled {
+		logrus.WithField("name", b.Name).Debug("Map file didn't exist")
+		if repinningIsEnabled() {
 			logrus.WithField("name", b.Name).Info("Looking for map by name (to repin it)")
 			err = RepinMap(b.VersionedName(), b.versionedFilename())
 			if err != nil && !os.IsNotExist(err) {
@@ -495,12 +545,11 @@ func (b *PinnedMap) Open() error {
 	}
 
 	if err == nil {
-		logrus.Debug("Map file already exists, trying to open it")
+		logrus.WithField("name", b.Name).Debug("Map file already exists, trying to open it")
 		b.fd, err = GetMapFDByPin(b.versionedFilename())
 		if err == nil {
 			b.fdLoaded = true
-			logrus.WithField("fd", b.fd).WithField("name", b.versionedFilename()).
-				Info("Loaded map file descriptor.")
+			logrus.WithField("fd", b.fd).WithField("name", b.Name).Info("Loaded map file descriptor.")
 			return nil
 		}
 		return err
@@ -541,6 +590,7 @@ func (b *PinnedMap) EnsureExists() error {
 	// In case felix restarts in the middle of migration, we might end up with
 	// old map. Repin the old map and let the map creation continue.
 	if b.oldMapExists() {
+		logrus.WithField("name", b.Name).Debug("Old map exists")
 		if _, err := os.Stat(b.Path()); err == nil {
 			os.Remove(b.Path())
 		}
@@ -560,6 +610,7 @@ func (b *PinnedMap) EnsureExists() error {
 		if b.MaxEntries == mapInfo.MaxEntries {
 			return nil
 		}
+		logrus.WithField("name", b.Name).Debugf("Size changed %d -> %d", mapInfo.MaxEntries, b.MaxEntries)
 
 		// store the old fd
 		b.oldfd = b.MapFD()
@@ -579,7 +630,7 @@ func (b *PinnedMap) EnsureExists() error {
 		}
 	}
 
-	logrus.Debug("Map didn't exist, creating it")
+	logrus.WithField("name", b.Name).Debug("Map didn't exist, creating it")
 	cmd := exec.Command("bpftool", "map", "create", b.versionedFilename(),
 		"type", b.Type,
 		"key", fmt.Sprint(b.KeySize),
@@ -660,7 +711,6 @@ func RepinMap(name string, filename string) error {
 	if err != nil {
 		return errors.Wrap(err, "bpftool map list failed")
 	}
-	logrus.WithField("maps", string(out)).Debug("Got map metadata.")
 
 	var maps []bpftoolMapMeta
 	err = json.Unmarshal(out, &maps)
@@ -683,11 +733,15 @@ func (b *PinnedMap) CopyDeltaFromOldMap() error {
 	// check if there is any old version of the map.
 	// If so upgrade delta entries from the old map
 	// to the new map.
+
+	logrus.WithField("name", b.Name).Debug("CopyDeltaFromOldMap")
+
 	err := b.upgrade()
 	if err != nil {
 		return fmt.Errorf("error upgrading data from old map %s, err=%w", b.GetName(), err)
 	}
 	if b.oldfd == 0 {
+		logrus.WithField("name", b.Name).Debug("CopyDeltaFromOldMap - no old map, done.")
 		return nil
 	}
 
@@ -737,6 +791,7 @@ func (b *PinnedMap) getOldMapVersion() (int, error) {
 // If there is a resized version of v2, which is v2_old, data is upgraded from
 // v2_old as well to v3.
 func (b *PinnedMap) upgrade() error {
+	logrus.WithField("name", b.Name).Debug("upgrade")
 	if b.UpgradeFn == nil {
 		return nil
 	}
@@ -753,10 +808,9 @@ func (b *PinnedMap) upgrade() error {
 	}
 
 	// Get a pinnedMap handle for the old map
-	ctx := b.context
 	oldMapParams := b.GetMapParams(oldVersion)
 	oldMapParams.MaxEntries = b.MaxEntries
-	oldBpfMap := ctx.NewPinnedMap(oldMapParams)
+	oldBpfMap := NewPinnedMap(oldMapParams)
 	defer func() {
 		oldBpfMap.(*PinnedMap).Close()
 		oldBpfMap.(*PinnedMap).fd = 0

--- a/felix/bpf/mock/map.go
+++ b/felix/bpf/mock/map.go
@@ -61,7 +61,7 @@ func (m *Map) GetName() string {
 }
 
 func (m *Map) Path() string {
-	return m.Filename
+	return m.VersionedFilename()
 }
 
 func (m *Map) Iter(f bpf.IterCallback) error {

--- a/felix/bpf/mock/multiversion/map.go
+++ b/felix/bpf/mock/multiversion/map.go
@@ -73,48 +73,48 @@ func GetKeyValueTypeFromVersion(version int, k, v []byte) (bpf.Upgradable, bpf.U
 	}
 }
 
-func MapV2(mc *bpf.MapContext, maxEntries int) bpf.Map {
+func MapV2(maxEntries int) bpf.Map {
 	mockParams := v2.MockMapParams
 	if maxEntries > 0 {
 		mockParams.MaxEntries = maxEntries
 	}
-	b := mc.NewPinnedMap(mockParams)
+	b := bpf.NewPinnedMap(mockParams)
 	b.(*bpf.PinnedMap).UpgradeFn = upgrade.UpgradeBPFMap
 	b.(*bpf.PinnedMap).GetMapParams = GetMapParams
 	b.(*bpf.PinnedMap).KVasUpgradable = GetKeyValueTypeFromVersion
 	return b
 }
 
-func MapV3(mc *bpf.MapContext, maxEntries int) bpf.Map {
+func MapV3(maxEntries int) bpf.Map {
 	mockParams := v3.MockMapParams
 	if maxEntries > 0 {
 		mockParams.MaxEntries = maxEntries
 	}
-	b := mc.NewPinnedMap(mockParams)
+	b := bpf.NewPinnedMap(mockParams)
 	b.(*bpf.PinnedMap).UpgradeFn = upgrade.UpgradeBPFMap
 	b.(*bpf.PinnedMap).GetMapParams = GetMapParams
 	b.(*bpf.PinnedMap).KVasUpgradable = GetKeyValueTypeFromVersion
 	return b
 }
 
-func MapV4(mc *bpf.MapContext, maxEntries int) bpf.Map {
+func MapV4(maxEntries int) bpf.Map {
 	mockParams := v4.MockMapParams
 	if maxEntries > 0 {
 		mockParams.MaxEntries = maxEntries
 	}
-	b := mc.NewPinnedMap(mockParams)
+	b := bpf.NewPinnedMap(mockParams)
 	b.(*bpf.PinnedMap).UpgradeFn = upgrade.UpgradeBPFMap
 	b.(*bpf.PinnedMap).GetMapParams = GetMapParams
 	b.(*bpf.PinnedMap).KVasUpgradable = GetKeyValueTypeFromVersion
 	return b
 }
 
-func MapV5(mc *bpf.MapContext, maxEntries int) bpf.Map {
+func MapV5(maxEntries int) bpf.Map {
 	mockParams := v5.MockMapParams
 	if maxEntries > 0 {
 		mockParams.MaxEntries = maxEntries
 	}
-	b := mc.NewPinnedMap(mockParams)
+	b := bpf.NewPinnedMap(mockParams)
 	b.(*bpf.PinnedMap).UpgradeFn = upgrade.UpgradeBPFMap
 	b.(*bpf.PinnedMap).GetMapParams = GetMapParams
 	b.(*bpf.PinnedMap).KVasUpgradable = GetKeyValueTypeFromVersion

--- a/felix/bpf/mock/multiversion/v2/map.go
+++ b/felix/bpf/mock/multiversion/v2/map.go
@@ -24,7 +24,6 @@ import (
 )
 
 var MockMapParams = bpf.MapParameters{
-	Filename:     "/sys/fs/bpf/tc/globals/cali_mock",
 	Type:         "hash",
 	KeySize:      16,
 	ValueSize:    64,

--- a/felix/bpf/mock/multiversion/v3/map.go
+++ b/felix/bpf/mock/multiversion/v3/map.go
@@ -24,7 +24,6 @@ import (
 )
 
 var MockMapParams = bpf.MapParameters{
-	Filename:     "/sys/fs/bpf/tc/globals/cali_mock",
 	Type:         "hash",
 	KeySize:      24,
 	ValueSize:    72,

--- a/felix/bpf/mock/multiversion/v4/map.go
+++ b/felix/bpf/mock/multiversion/v4/map.go
@@ -24,7 +24,6 @@ import (
 )
 
 var MockMapParams = bpf.MapParameters{
-	Filename:     "/sys/fs/bpf/tc/globals/cali_mock",
 	Type:         "hash",
 	KeySize:      32,
 	ValueSize:    80,

--- a/felix/bpf/mock/multiversion/v5/map.go
+++ b/felix/bpf/mock/multiversion/v5/map.go
@@ -23,7 +23,6 @@ import (
 )
 
 var MockMapParams = bpf.MapParameters{
-	Filename:     "/sys/fs/bpf/tc/globals/cali_mock",
 	Type:         "hash",
 	KeySize:      40,
 	ValueSize:    88,

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -108,7 +108,6 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSe
 	}
 	defer obj.Close()
 
-	baseDir := "/sys/fs/bpf/tc/globals/"
 	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
 		// In case of global variables, libbpf creates an internal map <prog_name>.rodata
 		// The values are read only for the BPF programs, but can be set to a value from
@@ -126,8 +125,7 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSe
 				return fmt.Errorf("error set map size %s: %w", m.Name(), err)
 			}
 		}
-		pinPath := baseDir + m.Name()
-		if err := m.SetPinPath(pinPath); err != nil {
+		if err := m.SetPinPath(path.Join(bpf.GlobalPinDir, m.Name())); err != nil {
 			return fmt.Errorf("error pinning map %s: %w", m.Name(), err)
 		}
 		log.WithFields(log.Fields{"program": progName, "map": m.Name()}).Debug("Pinned map")

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -87,8 +87,7 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 	return nil
 }
 
-func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSeen time.Duration,
-	maxEntries map[string]uint32, excludeUDP bool) error {
+func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
 
 	progPinDir := path.Join(bpfMount, "calico_connect4")
 	_ = os.RemoveAll(progPinDir)
@@ -121,7 +120,7 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSe
 			continue
 		}
 
-		if size, ok := maxEntries[m.Name()]; ok {
+		if size := bpf.MapSize(m.Name()); size != 0 {
 			err := m.SetMapSize(size)
 			if err != nil {
 				return fmt.Errorf("error set map size %s: %w", m.Name(), err)
@@ -149,8 +148,7 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSe
 	return nil
 }
 
-func InstallConnectTimeLoadBalancer(cgroupv2 string, logLevel string, udpNotSeen time.Duration, bpfMc *bpf.MapContext,
-	excludeUDP bool) error {
+func InstallConnectTimeLoadBalancer(cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
 
 	bpfMount, err := bpf.MaybeMountBPFfs()
 	if err != nil {
@@ -163,33 +161,33 @@ func InstallConnectTimeLoadBalancer(cgroupv2 string, logLevel string, udpNotSeen
 		return errors.Wrap(err, "failed to set-up cgroupv2")
 	}
 
-	err = installProgram("connect", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes, excludeUDP)
+	err = installProgram("connect", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, excludeUDP)
 	if err != nil {
 		return err
 	}
 
-	err = installProgram("connect", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes, excludeUDP)
+	err = installProgram("connect", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, excludeUDP)
 	if err != nil {
 		return err
 	}
 
 	if !excludeUDP {
-		err = installProgram("sendmsg", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes, false)
+		err = installProgram("sendmsg", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
 		if err != nil {
 			return err
 		}
 
-		err = installProgram("recvmsg", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes, false)
+		err = installProgram("recvmsg", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
 		if err != nil {
 			return err
 		}
 
-		err = installProgram("sendmsg", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes, false)
+		err = installProgram("sendmsg", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
 		if err != nil {
 			return err
 		}
 
-		err = installProgram("recvmsg", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, bpfMc.MapSizes, false)
+		err = installProgram("recvmsg", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
 		if err != nil {
 			return err
 		}

--- a/felix/bpf/nat/maps.go
+++ b/felix/bpf/nat/maps.go
@@ -28,6 +28,20 @@ import (
 	"github.com/projectcalico/calico/felix/ip"
 )
 
+func init() {
+	bpf.SetMapSize(FrontendMapParameters.VersionedName(), FrontendMapParameters.MaxEntries)
+	bpf.SetMapSize(BackendMapParameters.VersionedName(), BackendMapParameters.MaxEntries)
+	bpf.SetMapSize(AffinityMapParameters.VersionedName(), AffinityMapParameters.MaxEntries)
+	bpf.SetMapSize(SendRecvMsgMapParameters.VersionedName(), SendRecvMsgMapParameters.MaxEntries)
+	bpf.SetMapSize(CTNATsMapParameters.VersionedName(), CTNATsMapParameters.MaxEntries)
+}
+
+func SetMapSizes(fsize, bsize, asize int) {
+	bpf.SetMapSize(FrontendMapParameters.VersionedName(), fsize)
+	bpf.SetMapSize(BackendMapParameters.VersionedName(), bsize)
+	bpf.SetMapSize(AffinityMapParameters.VersionedName(), asize)
+}
+
 // struct calico_nat_v4_key {
 //    uint32_t prefixLen;
 //    uint32_t addr; // NBO
@@ -304,8 +318,8 @@ var FrontendMapParameters = bpf.MapParameters{
 	Version:    3,
 }
 
-func FrontendMap(mc *bpf.MapContext) bpf.MapWithExistsCheck {
-	return mc.NewPinnedMap(FrontendMapParameters)
+func FrontendMap() bpf.MapWithExistsCheck {
+	return bpf.NewPinnedMap(FrontendMapParameters)
 }
 
 var BackendMapParameters = bpf.MapParameters{
@@ -318,8 +332,8 @@ var BackendMapParameters = bpf.MapParameters{
 	Flags:      unix.BPF_F_NO_PREALLOC,
 }
 
-func BackendMap(mc *bpf.MapContext) bpf.MapWithExistsCheck {
-	return mc.NewPinnedMap(BackendMapParameters)
+func BackendMap() bpf.MapWithExistsCheck {
+	return bpf.NewPinnedMap(BackendMapParameters)
 }
 
 // NATMapMem represents FrontendMap loaded into memory
@@ -555,8 +569,8 @@ var AffinityMapParameters = bpf.MapParameters{
 }
 
 // AffinityMap returns an instance of an affinity map
-func AffinityMap(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(AffinityMapParameters)
+func AffinityMap() bpf.Map {
+	return bpf.NewPinnedMap(AffinityMapParameters)
 }
 
 // AffinityMapMem represents affinity map in memory
@@ -674,12 +688,12 @@ var CTNATsMapParameters = bpf.MapParameters{
 
 // SendRecvMsgMap tracks reverse translations for sendmsg/recvmsg of
 // unconnected UDP
-func SendRecvMsgMap(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(SendRecvMsgMapParameters)
+func SendRecvMsgMap() bpf.Map {
+	return bpf.NewPinnedMap(SendRecvMsgMapParameters)
 }
 
-func AllNATsMsgMap(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(CTNATsMapParameters)
+func AllNATsMsgMap() bpf.Map {
+	return bpf.NewPinnedMap(CTNATsMapParameters)
 }
 
 // SendRecvMsgMapMem represents affinity map in memory

--- a/felix/bpf/nat/maps.go
+++ b/felix/bpf/nat/maps.go
@@ -308,7 +308,6 @@ func BackendValueFromBytes(b []byte) BackendValue {
 }
 
 var FrontendMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_nat_fe",
 	Type:       "lpm_trie",
 	KeySize:    frontendKeySize,
 	ValueSize:  frontendValueSize,
@@ -323,7 +322,6 @@ func FrontendMap() bpf.MapWithExistsCheck {
 }
 
 var BackendMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_nat_be",
 	Type:       "hash",
 	KeySize:    backendKeySize,
 	ValueSize:  backendValueSize,
@@ -560,7 +558,6 @@ func (v AffinityValue) AsBytes() []byte {
 
 // AffinityMapParameters describe the AffinityMap
 var AffinityMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_nat_aff",
 	Type:       "lru_hash",
 	KeySize:    affinityKeySize,
 	ValueSize:  affinityValueSize,
@@ -669,7 +666,6 @@ func (v SendRecvMsgValue) String() string {
 
 // SendRecvMsgMapParameters define SendRecvMsgMap
 var SendRecvMsgMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_srmsg",
 	Type:       "lru_hash",
 	KeySize:    sendRecvMsgKeySize,
 	ValueSize:  sendRecvMsgValueSize,
@@ -678,7 +674,6 @@ var SendRecvMsgMapParameters = bpf.MapParameters{
 }
 
 var CTNATsMapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_ct_nats",
 	Type:       "lru_hash",
 	KeySize:    ctNATsMsgKeySize,
 	ValueSize:  sendRecvMsgValueSize,

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	"github.com/projectcalico/calico/felix/cachingmap"
@@ -60,15 +61,15 @@ type KubeProxy struct {
 
 // StartKubeProxy start a new kube-proxy if there was no error
 func StartKubeProxy(k8s kubernetes.Interface, hostname string,
-	bpfMapContext *bpf.MapContext, opts ...Option) (*KubeProxy, error) {
+	bpfMaps *bpfmap.Maps, opts ...Option) (*KubeProxy, error) {
 
 	kp := &KubeProxy{
 		k8s:         k8s,
 		hostname:    hostname,
-		frontendMap: bpfMapContext.FrontendMap.(bpf.MapWithExistsCheck),
-		backendMap:  bpfMapContext.BackendMap.(bpf.MapWithExistsCheck),
-		affinityMap: bpfMapContext.AffinityMap,
-		ctMap:       bpfMapContext.CtMap,
+		frontendMap: bpfMaps.FrontendMap.(bpf.MapWithExistsCheck),
+		backendMap:  bpfMaps.BackendMap.(bpf.MapWithExistsCheck),
+		affinityMap: bpfMaps.AffinityMap,
+		ctMap:       bpfMaps.CtMap,
 		opts:        opts,
 		rt:          NewRTCache(),
 

--- a/felix/bpf/proxy/kube-proxy_test.go
+++ b/felix/bpf/proxy/kube-proxy_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/mock"
 	proxy "github.com/projectcalico/calico/felix/bpf/proxy"
@@ -32,12 +32,12 @@ import (
 var _ = Describe("BPF kube-proxy", func() {
 	initIP := net.IPv4(1, 1, 1, 1)
 
-	bpfMc := &bpf.MapContext{}
-	bpfMc.FrontendMap = newMockNATMap()
-	bpfMc.BackendMap = newMockNATBackendMap()
-	bpfMc.AffinityMap = newMockAffinityMap()
-	bpfMc.CtMap = mock.NewMockMap(conntrack.MapParams)
-	front := bpfMc.FrontendMap.(*mockNATMap)
+	maps := new(bpfmap.Maps)
+	maps.FrontendMap = newMockNATMap()
+	maps.BackendMap = newMockNATBackendMap()
+	maps.AffinityMap = newMockAffinityMap()
+	maps.CtMap = mock.NewMockMap(conntrack.MapParams)
+	front := maps.FrontendMap.(*mockNATMap)
 
 	var p *proxy.KubeProxy
 
@@ -81,7 +81,7 @@ var _ = Describe("BPF kube-proxy", func() {
 		}
 
 		k8s := fake.NewSimpleClientset(testSvc, testSvcEps)
-		p, _ = proxy.StartKubeProxy(k8s, "test-node", bpfMc, proxy.WithImmediateSync())
+		p, _ = proxy.StartKubeProxy(k8s, "test-node", maps, proxy.WithImmediateSync())
 	})
 
 	AfterEach(func() {

--- a/felix/bpf/proxy/service_type_change_test.go
+++ b/felix/bpf/proxy/service_type_change_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/mock"
 	"github.com/projectcalico/calico/felix/bpf/nat"
@@ -85,12 +85,12 @@ var _ = Describe("BPF service type change", func() {
 
 	initIP := net.IPv4(1, 1, 1, 1)
 
-	bpfMc := &bpf.MapContext{}
-	bpfMc.FrontendMap = newMockNATMap()
-	bpfMc.BackendMap = newMockNATBackendMap()
-	bpfMc.AffinityMap = newMockAffinityMap()
-	bpfMc.CtMap = mock.NewMockMap(conntrack.MapParams)
-	front := bpfMc.FrontendMap.(*mockNATMap)
+	bpfMaps := &bpfmap.Maps{}
+	bpfMaps.FrontendMap = newMockNATMap()
+	bpfMaps.BackendMap = newMockNATBackendMap()
+	bpfMaps.AffinityMap = newMockAffinityMap()
+	bpfMaps.CtMap = mock.NewMockMap(conntrack.MapParams)
+	front := bpfMaps.FrontendMap.(*mockNATMap)
 
 	keyClusterIP := nat.NewNATKey(clusterIP, port, proxy.ProtoV1ToIntPanic(proto))
 	keyExtIP := nat.NewNATKey(extIP, port, proxy.ProtoV1ToIntPanic(proto))
@@ -100,7 +100,7 @@ var _ = Describe("BPF service type change", func() {
 	var p *proxy.KubeProxy
 
 	BeforeEach(func() {
-		p, _ = proxy.StartKubeProxy(k8s, "test-node", bpfMc, proxy.WithImmediateSync())
+		p, _ = proxy.StartKubeProxy(k8s, "test-node", bpfMaps, proxy.WithImmediateSync())
 		p.OnHostIPsUpdate([]net.IP{initIP})
 	})
 

--- a/felix/bpf/proxy/syncer_bench_test.go
+++ b/felix/bpf/proxy/syncer_bench_test.go
@@ -180,10 +180,10 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 	} else {
-		feMap := nat.FrontendMap(new(bpf.MapContext))
+		feMap := nat.FrontendMap()
 		err = feMap.EnsureExists()
 		Expect(err).ShouldNot(HaveOccurred())
-		beMap := nat.BackendMap(new(bpf.MapContext))
+		beMap := nat.BackendMap()
 		err = beMap.EnsureExists()
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/felix/bpf/routes/map.go
+++ b/felix/bpf/routes/map.go
@@ -193,7 +193,6 @@ func NewValueWithIfIndex(flags Flags, ifIndex int) Value {
 }
 
 var MapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_v4_routes",
 	Type:       "lpm_trie",
 	KeySize:    KeySize,
 	ValueSize:  ValueSize,

--- a/felix/bpf/routes/map.go
+++ b/felix/bpf/routes/map.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,14 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/ip"
 )
+
+func init() {
+	SetMapSize(MapParameters.MaxEntries)
+}
+
+func SetMapSize(size int) {
+	bpf.SetMapSize(MapParameters.VersionedName(), size)
+}
 
 //
 // struct cali_rt_key {
@@ -194,8 +202,8 @@ var MapParameters = bpf.MapParameters{
 	Flags:      unix.BPF_F_NO_PREALLOC,
 }
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParameters)
+func Map() bpf.Map {
+	return bpf.NewPinnedMap(MapParameters)
 }
 
 type MapMem map[Key]Value

--- a/felix/bpf/state/map.go
+++ b/felix/bpf/state/map.go
@@ -138,7 +138,6 @@ func StateFromBytes(bytes []byte) State {
 }
 
 var MapParameters = bpf.MapParameters{
-	Filename:   "/sys/fs/bpf/tc/globals/cali_state",
 	Type:       "percpu_array",
 	KeySize:    4,
 	ValueSize:  expectedSize,
@@ -153,7 +152,6 @@ func Map() bpf.Map {
 
 func MapForTest() bpf.Map {
 	return bpf.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/test_state",
 		Type:       "array",
 		KeySize:    4,
 		ValueSize:  expectedSize,

--- a/felix/bpf/state/map.go
+++ b/felix/bpf/state/map.go
@@ -22,6 +22,10 @@ import (
 	"github.com/projectcalico/calico/felix/bpf"
 )
 
+func init() {
+	bpf.SetMapSize(MapParameters.VersionedName(), MapParameters.MaxEntries)
+}
+
 type PolicyResult int32
 
 const (
@@ -143,12 +147,12 @@ var MapParameters = bpf.MapParameters{
 	Version:    2,
 }
 
-func Map(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(MapParameters)
+func Map() bpf.Map {
+	return bpf.NewPinnedMap(MapParameters)
 }
 
-func MapForTest(mc *bpf.MapContext) bpf.Map {
-	return mc.NewPinnedMap(bpf.MapParameters{
+func MapForTest() bpf.Map {
+	return bpf.NewPinnedMap(bpf.MapParameters{
 		Filename:   "/sys/fs/bpf/tc/globals/test_state",
 		Type:       "array",
 		KeySize:    4,

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -115,8 +115,8 @@ func (ap *AttachPoint) loadObject(ipVer int, file string) (*libbpf.Obj, error) {
 		if err := ap.setMapSize(m); err != nil {
 			return nil, fmt.Errorf("error setting map size %s : %w", m.Name(), err)
 		}
-		pinPath := bpf.MapPinPath(m.Type(), m.Name(), ap.Iface, ap.Hook)
-		if err := m.SetPinPath(pinPath); err != nil {
+		pinDir := bpf.MapPinDir(m.Type(), m.Name(), ap.Iface, ap.Hook)
+		if err := m.SetPinPath(path.Join(pinDir, m.Name())); err != nil {
 			return nil, fmt.Errorf("error pinning map %s: %w", m.Name(), err)
 		}
 	}

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -52,7 +52,6 @@ type AttachPoint struct {
 	PSNATStart           uint16
 	PSNATEnd             uint16
 	IPv6Enabled          bool
-	MapSizes             map[string]uint32
 	RPFEnforceOption     uint8
 	NATin                uint32
 	NATout               uint32
@@ -482,7 +481,7 @@ func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalDa
 }
 
 func (ap *AttachPoint) setMapSize(m *libbpf.Map) error {
-	if size, ok := ap.MapSizes[m.Name()]; ok {
+	if size := bpf.MapSize(m.Name()); size != 0 {
 		return m.SetMapSize(size)
 	}
 	return nil

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -430,20 +430,18 @@ var (
 
 func initMapsOnce() {
 	mapInitOnce.Do(func() {
-		mc := &bpf.MapContext{}
-
-		natMap = nat.FrontendMap(mc)
-		natBEMap = nat.BackendMap(mc)
-		ctMap = conntrack.Map(mc)
-		rtMap = routes.Map(mc)
-		ipsMap = ipsets.Map(mc)
-		stateMap = state.Map(mc)
-		testStateMap = state.MapForTest(mc)
-		affinityMap = nat.AffinityMap(mc)
-		arpMap = arp.Map(mc)
-		fsafeMap = failsafes.Map(mc)
-		countersMap = counters.MapForTest(mc)
-		ifstateMap = ifstate.Map(mc)
+		natMap = nat.FrontendMap()
+		natBEMap = nat.BackendMap()
+		ctMap = conntrack.Map()
+		rtMap = routes.Map()
+		ipsMap = ipsets.Map()
+		stateMap = state.Map()
+		testStateMap = state.MapForTest()
+		affinityMap = nat.AffinityMap()
+		arpMap = arp.Map()
+		fsafeMap = failsafes.Map()
+		countersMap = counters.MapForTest()
+		ifstateMap = ifstate.Map()
 
 		allMaps = []bpf.Map{natMap, natBEMap, ctMap, rtMap, ipsMap, stateMap, testStateMap,
 			affinityMap, arpMap, fsafeMap, countersMap, ifstateMap}
@@ -516,7 +514,7 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 
 	forXDP := topts.xdp
 
-	jumpMap = jump.MapForTest(&bpf.MapContext{})
+	jumpMap = jump.MapForTest()
 	if ipFamily == "IPv4" {
 		// don't do for v6 as that requires v4 atm
 		_ = unix.Unlink(jumpMap.Path())
@@ -1215,7 +1213,7 @@ func resetBPFMaps() {
 func TestMapIterWithDelete(t *testing.T) {
 	RegisterTestingT(t)
 
-	m := (&bpf.MapContext{}).NewPinnedMap(bpf.MapParameters{
+	m := bpf.NewPinnedMap(bpf.MapParameters{
 		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
 		Type:       "hash",
 		KeySize:    8,
@@ -1263,7 +1261,7 @@ func TestMapIterWithDelete(t *testing.T) {
 func TestMapIterWithDeleteLastOfBatch(t *testing.T) {
 	RegisterTestingT(t)
 
-	m := (&bpf.MapContext{}).NewPinnedMap(bpf.MapParameters{
+	m := bpf.NewPinnedMap(bpf.MapParameters{
 		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
 		Type:       "hash",
 		KeySize:    8,

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1214,7 +1214,6 @@ func TestMapIterWithDelete(t *testing.T) {
 	RegisterTestingT(t)
 
 	m := bpf.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
 		Type:       "hash",
 		KeySize:    8,
 		ValueSize:  8,
@@ -1262,7 +1261,6 @@ func TestMapIterWithDeleteLastOfBatch(t *testing.T) {
 	RegisterTestingT(t)
 
 	m := bpf.NewPinnedMap(bpf.MapParameters{
-		Filename:   "/sys/fs/bpf/tc/globals/cali_tmap",
 		Type:       "hash",
 		KeySize:    8,
 		ValueSize:  8,

--- a/felix/bpf/ut/map_upgrade_test.go
+++ b/felix/bpf/ut/map_upgrade_test.go
@@ -46,8 +46,7 @@ func deleteMap(bpfMap bpf.Map) {
 
 func TestMapUpgradeV2ToV3(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv2 := mock.MapV2(mc, 0)
+	mockMapv2 := mock.MapV2(0)
 	err := mockMapv2.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -57,7 +56,7 @@ func TestMapUpgradeV2ToV3(t *testing.T) {
 	err = mockMapv2.Update(k.AsBytes(), v.AsBytes())
 	Expect(err).NotTo(HaveOccurred())
 
-	mockMapv3 := mock.MapV3(mc, 0)
+	mockMapv3 := mock.MapV3(0)
 	err = mockMapv3.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -74,8 +73,7 @@ func TestMapUpgradeV2ToV3(t *testing.T) {
 
 func TestMapUpgradeV2ToV4(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv2 := mock.MapV2(mc, 0)
+	mockMapv2 := mock.MapV2(0)
 	err := mockMapv2.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -85,7 +83,7 @@ func TestMapUpgradeV2ToV4(t *testing.T) {
 	err = mockMapv2.Update(k.AsBytes(), v.AsBytes())
 	Expect(err).NotTo(HaveOccurred())
 
-	mockMapv4 := mock.MapV4(mc, 0)
+	mockMapv4 := mock.MapV4(0)
 	err = mockMapv4.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -102,8 +100,7 @@ func TestMapUpgradeV2ToV4(t *testing.T) {
 
 func TestMapUpgradeV2ToV5(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv2 := mock.MapV2(mc, 0)
+	mockMapv2 := mock.MapV2(0)
 	err := mockMapv2.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -113,7 +110,7 @@ func TestMapUpgradeV2ToV5(t *testing.T) {
 	err = mockMapv2.Update(k.AsBytes(), v.AsBytes())
 	Expect(err).NotTo(HaveOccurred())
 
-	mockMapv5 := mock.MapV5(mc, 0)
+	mockMapv5 := mock.MapV5(0)
 	err = mockMapv5.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -130,8 +127,7 @@ func TestMapUpgradeV2ToV5(t *testing.T) {
 
 func TestMapUpgradeV3ToV5(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv3 := mock.MapV3(mc, 0)
+	mockMapv3 := mock.MapV3(0)
 	err := mockMapv3.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -141,7 +137,7 @@ func TestMapUpgradeV3ToV5(t *testing.T) {
 	err = mockMapv3.Update(k.AsBytes(), v.AsBytes())
 	Expect(err).NotTo(HaveOccurred())
 
-	mockMapv5 := mock.MapV5(mc, 0)
+	mockMapv5 := mock.MapV5(0)
 	err = mockMapv5.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -158,8 +154,7 @@ func TestMapUpgradeV3ToV5(t *testing.T) {
 
 func TestMapUpgradeV3ToV5WithDifferentSize(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv3 := mock.MapV3(mc, 10)
+	mockMapv3 := mock.MapV3(10)
 	err := mockMapv3.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -169,7 +164,7 @@ func TestMapUpgradeV3ToV5WithDifferentSize(t *testing.T) {
 	err = mockMapv3.Update(k.AsBytes(), v.AsBytes())
 	Expect(err).NotTo(HaveOccurred())
 
-	mockMapv5 := mock.MapV5(mc, 20)
+	mockMapv5 := mock.MapV5(20)
 	err = mockMapv5.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -186,8 +181,7 @@ func TestMapUpgradeV3ToV5WithDifferentSize(t *testing.T) {
 
 func TestMapUpgradeV3ToV5WithLowerSize(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv3 := mock.MapV3(mc, 10)
+	mockMapv3 := mock.MapV3(10)
 	err := mockMapv3.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -199,7 +193,7 @@ func TestMapUpgradeV3ToV5WithLowerSize(t *testing.T) {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	mockMapv5 := mock.MapV5(mc, 7)
+	mockMapv5 := mock.MapV5(7)
 	err = mockMapv5.EnsureExists()
 	Expect(err).To(HaveOccurred())
 	deleteMap(mockMapv3)
@@ -210,12 +204,11 @@ func TestMapUpgradeV3ToV5WithLowerSize(t *testing.T) {
 
 func TestMapUpgradeV5ToV3(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv5 := mock.MapV5(mc, 0)
+	mockMapv5 := mock.MapV5(0)
 	err := mockMapv5.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	mockMapv3 := mock.MapV3(mc, 0)
+	mockMapv3 := mock.MapV3(0)
 	err = mockMapv3.EnsureExists()
 	Expect(err).To(HaveOccurred())
 	deleteMap(mockMapv5)
@@ -226,8 +219,7 @@ func TestMapUpgradeV5ToV3(t *testing.T) {
 
 func TestMapUpgradeWithDeltaEntries(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
-	mockMapv2 := mock.MapV2(mc, 0)
+	mockMapv2 := mock.MapV2(0)
 	err := mockMapv2.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -237,7 +229,7 @@ func TestMapUpgradeWithDeltaEntries(t *testing.T) {
 	err = mockMapv2.Update(k.AsBytes(), v.AsBytes())
 	Expect(err).NotTo(HaveOccurred())
 
-	mockMapv5 := mock.MapV5(mc, 0)
+	mockMapv5 := mock.MapV5(0)
 	err = mockMapv5.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -285,10 +277,9 @@ func TestMapUpgradeWithDeltaEntries(t *testing.T) {
 
 func TestMapResizeWhileUpgradeInProgress(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
 
 	// create v2 map and add 10 entries to it
-	mockMapv2 := mock.MapV2(mc, 20)
+	mockMapv2 := mock.MapV2(20)
 	err := mockMapv2.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -300,7 +291,7 @@ func TestMapResizeWhileUpgradeInProgress(t *testing.T) {
 	}
 
 	// create v5 map
-	mockMapv5 := mock.MapV5(mc, 20)
+	mockMapv5 := mock.MapV5(20)
 	err = mockMapv5.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -318,7 +309,7 @@ func TestMapResizeWhileUpgradeInProgress(t *testing.T) {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	mockMapv5_new := mock.MapV5(mc, 30)
+	mockMapv5_new := mock.MapV5(30)
 	err = mockMapv5_new.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -338,10 +329,9 @@ func TestMapResizeWhileUpgradeInProgress(t *testing.T) {
 
 func TestMapUpgradeWhileResizeInProgress(t *testing.T) {
 	RegisterTestingT(t)
-	mc := &bpf.MapContext{}
 
 	// create v2 map and add 10 entries to it
-	mockMapv2_old := mock.MapV2(mc, 20)
+	mockMapv2_old := mock.MapV2(20)
 	err := mockMapv2_old.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -361,7 +351,7 @@ func TestMapUpgradeWhileResizeInProgress(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// create another v2 map and add only the last 5 entries
-	mockMapv2 := mock.MapV2(mc, 30)
+	mockMapv2 := mock.MapV2(30)
 	err = mockMapv2.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -388,7 +378,7 @@ func TestMapUpgradeWhileResizeInProgress(t *testing.T) {
 	// 5. Removes /sys/fs/bpt/tc/globals/cali_mock2
 	// 6. Repins /sys/fs/bpt/tc/globals/cali_mock2_old as /sys/fs/bpt/tc/globals/cali_mock2
 	// 7. Upgrades k,v from version 2 to version 5
-	mockMapv5 := mock.MapV5(mc, 40)
+	mockMapv5 := mock.MapV5(40)
 	err = mockMapv5.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 

--- a/felix/bpf/ut/maps_test.go
+++ b/felix/bpf/ut/maps_test.go
@@ -31,8 +31,11 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 )
 
-func restoreMaps(mc *bpf.MapContext) {
-	bpfmap.DestroyBPFMaps(mc)
+func restoreMaps(maps *bpfmap.Maps) {
+	if maps != nil {
+		maps.Destroy()
+	}
+	bpf.ResetMapSizes()
 	// close the already created map and recreate them
 	for _, m := range allMaps {
 		os.Remove(m.Path())
@@ -43,33 +46,29 @@ func restoreMaps(mc *bpf.MapContext) {
 			logrus.WithError(err).Panic("Failed to initialise maps")
 		}
 	}
+	logrus.Info("maps restored")
 }
 
 func TestMapResize(t *testing.T) {
 	// Resize the maps.
 	RegisterTestingT(t)
-	ipsetsMapSize := 100
-	natFeMapSize := 200
-	natBeMapSize := 300
-	natAffMapSize := 400
-	rtMapSize := 500
-	ctMapSize := 600
-	ifStateMapSize := 100
+	conntrack.SetMapSize(600)
+	defer bpf.ResetMapSizes()
 
-	bpf.EnabledRepin()
+	bpf.EnableRepin()
+	defer bpf.DisableRepin()
 
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
-	err := bpfmap.CreateBPFMaps(mc)
+	maps, err := bpfmap.CreateBPFMaps()
 	Expect(err).NotTo(HaveOccurred())
-	defer restoreMaps(mc)
+	defer restoreMaps(maps)
 	// New CT map should have max_entries as 600
-	ctMapInfo, err := bpf.GetMapInfo(mc.CtMap.MapFD())
+	ctMapInfo, err := bpf.GetMapInfo(maps.CtMap.MapFD())
 	Expect(err).NotTo(HaveOccurred(), "Failed to get ct map info")
-	Expect(ctMapInfo.MaxEntries).To(Equal(ctMapSize))
+	Expect(ctMapInfo.MaxEntries).To(Equal(600))
 	// Except CT map, other map's old pins should be deleted.
-	_, err = os.Stat(mc.RouteMap.Path() + "_old")
+	_, err = os.Stat(maps.RouteMap.Path() + "_old")
 	Expect(err).To(HaveOccurred(), "old route map present")
-	_, err = os.Stat(mc.CtMap.Path() + "_old")
+	_, err = os.Stat(maps.CtMap.Path() + "_old")
 	Expect(err).NotTo(HaveOccurred(), "old ct map not present")
 }
 
@@ -77,27 +76,21 @@ func TestMapResizeWithCopy(t *testing.T) {
 	// Add a k,v pair to the old ctmap
 	k, err := setUpMapTestWithSingleKV(t)
 	Expect(err).NotTo(HaveOccurred(), "Failed to create ct entry")
-	ipsetsMapSize := 100
-	natFeMapSize := 200
-	natBeMapSize := 300
-	natAffMapSize := 400
-	rtMapSize := 500
-	ctMapSize := 600
-	ifStateMapSize := 100
 
 	// Resize the CT map to 600. New map should have the entry in the old map
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
-	err = bpfmap.CreateBPFMaps(mc)
+	conntrack.SetMapSize(600)
+	maps, err := bpfmap.CreateBPFMaps()
 	Expect(err).NotTo(HaveOccurred())
-	defer restoreMaps(mc)
-	val, err := mc.CtMap.Get(k.AsBytes())
+	defer restoreMaps(maps)
+	val, err := maps.CtMap.Get(k.AsBytes())
 	Expect(err).NotTo(HaveOccurred(), "ct entry not present in the new map")
 	v := conntrack.Value{}
 	for i := range v {
 		v[i] = uint8(i)
 	}
 	Expect(v.AsBytes()).To(Equal(val))
-	bpfmap.MigrateDataFromOldMap(mc)
+	err = maps.CtMap.CopyDeltaFromOldMap()
+	Expect(err).NotTo(HaveOccurred(), "migration failed")
 }
 
 func TestMapDownSize(t *testing.T) {
@@ -110,20 +103,13 @@ func TestMapDownSize(t *testing.T) {
 	}
 
 	// Resize the ct map to 6, which is less than the total number of entries
-	ipsetsMapSize := 100
-	natFeMapSize := 200
-	natBeMapSize := 300
-	natAffMapSize := 400
-	rtMapSize := 500
-	ctMapSize := 6
-	ifStateMapSize := 100
+	conntrack.SetMapSize(6)
 
 	// New map creation should panic as the number of entries in old map is more than what the new map can
 	// accommodate
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
-	defer restoreMaps(mc)
-	err := bpfmap.CreateBPFMaps(mc)
-	expectedError := fmt.Sprintf("Failed to create %s map, err=new map cannot hold all the data from the old map %s", ctMap.GetName(), ctMap.GetName())
+	maps, err := bpfmap.CreateBPFMaps()
+	defer restoreMaps(maps)
+	expectedError := fmt.Sprintf("failed to create %s map, err=new map cannot hold all the data from the old map %s", ctMap.GetName(), ctMap.GetName())
 	Expect(err.Error()).To(Equal(expectedError))
 }
 
@@ -132,29 +118,24 @@ func TestCTDeltaMigration(t *testing.T) {
 	k, err := setUpMapTestWithSingleKV(t)
 	Expect(err).NotTo(HaveOccurred(), "Failed to create ct entry")
 
-	// Resize the ctmap to size 600 entries
-	ipsetsMapSize := 100
-	natFeMapSize := 200
-	natBeMapSize := 300
-	natAffMapSize := 400
-	rtMapSize := 500
-	ctMapSize := 600
-	ifStateMapSize := 100
+	// Resize the ctmap
+	conntrack.SetMapSize(666)
 
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
-	err = bpfmap.CreateBPFMaps(mc)
+	maps, err := bpfmap.CreateBPFMaps()
 	Expect(err).NotTo(HaveOccurred())
 
-	defer restoreMaps(mc)
+	defer restoreMaps(maps)
 	v := conntrack.Value{}
 	for i := range v {
 		v[i] = uint8(i)
 	}
 
 	// Total number of k,v in old map should be 1
-	ctSaved := saveCTMap(mc.CtMap)
+	ctSaved := saveCTMap(maps.CtMap)
 	Expect(ctSaved).To(HaveLen(1))
 	Expect(ctSaved).Should(HaveKeyWithValue(k, v))
+
+	t.Log("STEP: update existing key in the old map")
 
 	// update the value for the old key in the old map
 	newVal := conntrack.Value{}
@@ -164,6 +145,8 @@ func TestCTDeltaMigration(t *testing.T) {
 
 	err = ctMap.Update(k.AsBytes(), newVal[:])
 	Expect(err).NotTo(HaveOccurred())
+
+	t.Log("STEP: add 10 entries to the old map")
 
 	// Add 10 more entries to the old map
 	numEntries := 10
@@ -185,16 +168,19 @@ func TestCTDeltaMigration(t *testing.T) {
 		}
 	}
 
-	_, err = os.Stat(mc.CtMap.Path() + "_old")
-	Expect(err).NotTo(HaveOccurred(), "old route map present")
+	t.Log("STEP: copy delta")
+
+	_, err = os.Stat(maps.CtMap.Path() + "_old")
+	Expect(err).NotTo(HaveOccurred(), "old conntrack map present")
 	// Migrate the delta (10 k,v pairs) to the new map
-	bpfmap.MigrateDataFromOldMap(mc)
-	ctSaved = saveCTMap(mc.CtMap)
+	err = maps.CtMap.CopyDeltaFromOldMap()
+	Expect(err).NotTo(HaveOccurred(), "migration failed")
+	ctSaved = saveCTMap(maps.CtMap)
 	Expect(ctSaved).To(HaveLen(numEntries + 1))
 	matchKeyVals(ctSaved)
 
 	Expect(err).NotTo(HaveOccurred())
-	_, err = os.Stat(mc.CtMap.Path() + "_old")
+	_, err = os.Stat(maps.CtMap.Path() + "_old")
 	Expect(err).To(HaveOccurred(), "old conntrack map present")
 }
 

--- a/felix/bpf/ut/maps_test.go
+++ b/felix/bpf/ut/maps_test.go
@@ -55,7 +55,10 @@ func TestMapResize(t *testing.T) {
 	rtMapSize := 500
 	ctMapSize := 600
 	ifStateMapSize := 100
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize, true)
+
+	bpf.EnabledRepin()
+
+	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
 	err := bpfmap.CreateBPFMaps(mc)
 	Expect(err).NotTo(HaveOccurred())
 	defer restoreMaps(mc)
@@ -83,7 +86,7 @@ func TestMapResizeWithCopy(t *testing.T) {
 	ifStateMapSize := 100
 
 	// Resize the CT map to 600. New map should have the entry in the old map
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize, true)
+	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
 	err = bpfmap.CreateBPFMaps(mc)
 	Expect(err).NotTo(HaveOccurred())
 	defer restoreMaps(mc)
@@ -117,7 +120,7 @@ func TestMapDownSize(t *testing.T) {
 
 	// New map creation should panic as the number of entries in old map is more than what the new map can
 	// accommodate
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize, true)
+	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
 	defer restoreMaps(mc)
 	err := bpfmap.CreateBPFMaps(mc)
 	expectedError := fmt.Sprintf("Failed to create %s map, err=new map cannot hold all the data from the old map %s", ctMap.GetName(), ctMap.GetName())
@@ -138,7 +141,7 @@ func TestCTDeltaMigration(t *testing.T) {
 	ctMapSize := 600
 	ifStateMapSize := 100
 
-	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize, true)
+	mc := bpfmap.CreateBPFMapContext(ipsetsMapSize, natFeMapSize, natBeMapSize, natAffMapSize, rtMapSize, ctMapSize, ifStateMapSize)
 	err = bpfmap.CreateBPFMaps(mc)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/gopacket/layers"
 	. "github.com/onsi/gomega"
 
-	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	conntrack3 "github.com/projectcalico/calico/felix/bpf/conntrack/v3"
@@ -46,12 +45,11 @@ func TestNATPodPodXNode(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
 
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -70,7 +68,7 @@ func TestNATPodPodXNode(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -313,12 +311,11 @@ func TestNATNodePort(t *testing.T) {
 	_, ipv4, l4, payload, pktBytes, err := testPacketUDPDefaultNP(node1ip)
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -342,7 +339,7 @@ func TestNATNodePort(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -362,7 +359,7 @@ func TestNATNodePort(t *testing.T) {
 	})
 
 	// Setup routing
-	rtMap := routes.Map(mc)
+	rtMap := routes.Map()
 	err = rtMap.EnsureExists()
 	defer resetRTMap(rtMap)
 	Expect(err).NotTo(HaveOccurred())
@@ -925,12 +922,11 @@ func TestNATNodePortNoFWD(t *testing.T) {
 	_, ipv4, l4, payload, pktBytes, err := testPacketUDPDefaultNP(node1ip)
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -950,7 +946,7 @@ func TestNATNodePortNoFWD(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -961,7 +957,7 @@ func TestNATNodePortNoFWD(t *testing.T) {
 	skbMark = 0
 
 	// Setup routing
-	rtMap := routes.Map(mc)
+	rtMap := routes.Map()
 	err = rtMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	defer resetRTMap(rtMap)
@@ -1079,12 +1075,11 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 	_, ipv4, l4, payload, pktBytes, err := testPacketUDPDefaultNP(node1ip2)
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1116,7 +1111,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -1127,7 +1122,7 @@ func TestNATNodePortMultiNIC(t *testing.T) {
 	skbMark = 0
 
 	// Setup routing
-	rtMap := routes.Map(mc)
+	rtMap := routes.Map()
 	err = rtMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	defer resetRTMap(rtMap)
@@ -1354,12 +1349,11 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
 
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1384,7 +1378,7 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
 
-	rtMap := routes.Map(mc)
+	rtMap := routes.Map()
 	err = rtMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	defer resetRTMap(rtMap)
@@ -1395,7 +1389,7 @@ func TestNATNodePortICMPTooBig(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -1521,16 +1515,15 @@ func TestNATSYNRetryGoesToSameBackend(t *testing.T) {
 	cleanUpMaps()
 	defer cleanUpMaps()
 
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err := natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1649,20 +1642,19 @@ func TestNATAffinity(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
 
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natAffMap := nat.AffinityMap(mc)
+	natAffMap := nat.AffinityMap()
 	err = natAffMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1825,12 +1817,11 @@ func TestNATNodePortIngressDSR(t *testing.T) {
 	_, ipv4, l4, payload, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -1854,7 +1845,7 @@ func TestNATNodePortIngressDSR(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -1864,7 +1855,7 @@ func TestNATNodePortIngressDSR(t *testing.T) {
 	skbMark = 0
 
 	// Setup routing
-	rtMap := routes.Map(mc)
+	rtMap := routes.Map()
 	err = rtMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	defer resetRTMap(rtMap)
@@ -2220,12 +2211,11 @@ func TestNATHostRemoteNPLocalPod(t *testing.T) {
 	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefaultNP(node2ip)
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -2250,7 +2240,7 @@ func TestNATHostRemoteNPLocalPod(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -2261,7 +2251,7 @@ func TestNATHostRemoteNPLocalPod(t *testing.T) {
 	skbMark = 0
 
 	// Setup routing
-	rtMap := routes.Map(mc)
+	rtMap := routes.Map()
 	err = rtMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	defer resetRTMap(rtMap)

--- a/felix/bpf/ut/pol_prog_test.go
+++ b/felix/bpf/ut/pol_prog_test.go
@@ -62,7 +62,7 @@ func TestLoadAllowAllProgram(t *testing.T) {
 func TestLoadProgramWithMapAccess(t *testing.T) {
 	RegisterTestingT(t)
 
-	ipsMap := ipsets.Map(&bpf.MapContext{})
+	ipsMap := ipsets.Map()
 	Expect(ipsMap.EnsureExists()).NotTo(HaveOccurred())
 	Expect(ipsMap.MapFD()).NotTo(BeZero())
 
@@ -2404,7 +2404,7 @@ func runTest(t *testing.T, tp testPolicy) {
 
 	setUpIPSets(tp.IPSets(), realAlloc, ipsMap)
 
-	jumpMap = jump.MapForTest(&bpf.MapContext{})
+	jumpMap = jump.MapForTest()
 	_ = unix.Unlink(jumpMap.Path())
 	err := jumpMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())

--- a/felix/bpf/ut/snat_test.go
+++ b/felix/bpf/ut/snat_test.go
@@ -19,8 +19,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/projectcalico/calico/felix/bpf"
-
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	. "github.com/onsi/gomega"
@@ -44,12 +42,11 @@ func TestSNATHostServiceRemotePod(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
 
-	mc := &bpf.MapContext{}
-	natMap := nat.FrontendMap(mc)
+	natMap := nat.FrontendMap()
 	err = natMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
-	natBEMap := nat.BackendMap(mc)
+	natBEMap := nat.BackendMap()
 	err = natBEMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 
@@ -68,7 +65,7 @@ func TestSNATHostServiceRemotePod(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean

--- a/felix/bpf/ut/whitelist_test.go
+++ b/felix/bpf/ut/whitelist_test.go
@@ -22,7 +22,6 @@ import (
 
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 
-	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	"github.com/projectcalico/calico/felix/ip"
@@ -104,9 +103,7 @@ func TestAllowEnterHostToWorkload(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
 
-	mc := &bpf.MapContext{}
-
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean
@@ -174,9 +171,7 @@ func TestAllowWorkloadToWorkload(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	udp := l4.(*layers.UDP)
 
-	mc := &bpf.MapContext{}
-
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	err = ctMap.EnsureExists()
 	Expect(err).NotTo(HaveOccurred())
 	resetCTMap(ctMap) // ensure it is clean

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -146,8 +146,8 @@ func (ap *AttachPoint) AttachProgram() (int, error) {
 			continue
 		}
 		// TODO: We need to set map size here like tc.
-		pinPath := bpf.MapPinPath(m.Type(), m.Name(), ap.Iface, bpf.HookXDP)
-		if err := m.SetPinPath(pinPath); err != nil {
+		pinDir := bpf.MapPinDir(m.Type(), m.Name(), ap.Iface, bpf.HookXDP)
+		if err := m.SetPinPath(path.Join(pinDir, m.Name())); err != nil {
 			return -1, fmt.Errorf("error pinning map %s: %w", m.Name(), err)
 		}
 	}

--- a/felix/cmd/calico-bpf/commands/arp.go
+++ b/felix/cmd/calico-bpf/commands/arp.go
@@ -58,7 +58,7 @@ var arpCmd = &cobra.Command{
 }
 
 func dumpARP() error {
-	arpMap := arp.Map(&bpf.MapContext{})
+	arpMap := arp.Map()
 
 	if err := arpMap.Open(); err != nil {
 		return errors.WithMessage(err, "failed to open map")
@@ -82,7 +82,7 @@ func dumpARP() error {
 }
 
 func cleanARP() error {
-	arpMap := arp.Map(&bpf.MapContext{})
+	arpMap := arp.Map()
 
 	if err := arpMap.Open(); err != nil {
 		return errors.WithMessage(err, "failed to open map")

--- a/felix/cmd/calico-bpf/commands/conntrack.go
+++ b/felix/cmd/calico-bpf/commands/conntrack.go
@@ -109,12 +109,11 @@ func dumpCtMapV2(ctMap bpf.Map) error {
 
 func (cmd *conntrackDumpCmd) Run(c *cobra.Command, _ []string) {
 	var ctMap bpf.Map
-	mc := &bpf.MapContext{}
 	switch cmd.version {
 	case "2":
-		ctMap = conntrack.MapV2(mc)
+		ctMap = conntrack.MapV2()
 	default:
-		ctMap = conntrack.Map(mc)
+		ctMap = conntrack.Map()
 	}
 	if err := ctMap.Open(); err != nil {
 		log.WithError(err).Fatal("Failed to access ConntrackMap")
@@ -267,8 +266,7 @@ func (cmd *conntrackRemoveCmd) Args(c *cobra.Command, args []string) error {
 }
 
 func (cmd *conntrackRemoveCmd) Run(c *cobra.Command, _ []string) {
-	mc := &bpf.MapContext{}
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	if err := ctMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access ConntrackMap")
 	}
@@ -300,8 +298,7 @@ func (cmd *conntrackRemoveCmd) Run(c *cobra.Command, _ []string) {
 }
 
 func runClean(c *cobra.Command, _ []string) {
-	mc := &bpf.MapContext{}
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 	if err := ctMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access ConntrackMap")
 	}
@@ -355,12 +352,11 @@ func (cmd *conntrackCreateCmd) Args(c *cobra.Command, args []string) error {
 
 func (cmd *conntrackCreateCmd) Run(c *cobra.Command, _ []string) {
 	var ctMap bpf.Map
-	mc := &bpf.MapContext{}
 	switch cmd.version {
 	case "2":
-		ctMap = conntrack.MapV2(mc)
+		ctMap = conntrack.MapV2()
 	default:
-		ctMap = conntrack.Map(mc)
+		ctMap = conntrack.Map()
 	}
 	if err := ctMap.EnsureExists(); err != nil {
 		log.WithError(err).Errorf("Failed to create conntrackMap version %s", cmd.version)
@@ -436,12 +432,11 @@ func (cmd *conntrackWriteCmd) Args(c *cobra.Command, args []string) error {
 }
 
 func (cmd *conntrackWriteCmd) Run(c *cobra.Command, _ []string) {
-	mc := &bpf.MapContext{}
 	var ctMap bpf.Map
 	if cmd.version == "2" {
-		ctMap = conntrack.MapV2(mc)
+		ctMap = conntrack.MapV2()
 	} else {
-		ctMap = conntrack.Map(mc)
+		ctMap = conntrack.Map()
 	}
 
 	if err := ctMap.Open(); err != nil {
@@ -475,8 +470,7 @@ func newConntrackFillCmd() *cobra.Command {
 }
 
 func (cmd *conntrackFillCmd) Run(c *cobra.Command, _ []string) {
-	mc := &bpf.MapContext{}
-	ctMap := conntrack.Map(mc)
+	ctMap := conntrack.Map()
 
 	var key conntrack.Key
 	copy(key[:], cmd.key)

--- a/felix/cmd/calico-bpf/commands/ifstate.go
+++ b/felix/cmd/calico-bpf/commands/ifstate.go
@@ -45,7 +45,7 @@ var ifstateCmd = &cobra.Command{
 }
 
 func dumpIfState(cmd *cobra.Command) error {
-	ifstateMap := ifstate.Map(&bpf.MapContext{})
+	ifstateMap := ifstate.Map()
 
 	if err := ifstateMap.Open(); err != nil {
 		return errors.WithMessage(err, "failed to open map")

--- a/felix/cmd/calico-bpf/commands/ipsets.go
+++ b/felix/cmd/calico-bpf/commands/ipsets.go
@@ -48,7 +48,7 @@ var ipsetsCmd = &cobra.Command{
 }
 
 func dumpIPSets() error {
-	ipsetMap := ipsets.Map(&bpf.MapContext{})
+	ipsetMap := ipsets.Map()
 
 	if err := ipsetMap.Open(); err != nil {
 		return errors.WithMessage(err, "failed to open map")

--- a/felix/cmd/calico-bpf/commands/nat.go
+++ b/felix/cmd/calico-bpf/commands/nat.go
@@ -19,8 +19,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/projectcalico/calico/felix/bpf"
-
 	"github.com/docopt/docopt-go"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -83,8 +81,7 @@ var natDelCmd = &cobra.Command{
 }
 
 func dumpAff(cmd *cobra.Command) (err error) {
-	mc := &bpf.MapContext{}
-	affMap, err := nat.LoadAffinityMap(nat.AffinityMap(mc))
+	affMap, err := nat.LoadAffinityMap(nat.AffinityMap())
 	if err != nil {
 		return err
 	}
@@ -99,13 +96,12 @@ func dumpAff(cmd *cobra.Command) (err error) {
 }
 
 func dump(cmd *cobra.Command) error {
-	mc := &bpf.MapContext{}
-	natMap, err := nat.LoadFrontendMap(nat.FrontendMap(mc))
+	natMap, err := nat.LoadFrontendMap(nat.FrontendMap())
 	if err != nil {
 		return err
 	}
 
-	back, err := nat.LoadBackendMap(nat.BackendMap(mc))
+	back, err := nat.LoadBackendMap(nat.BackendMap())
 	if err != nil {
 		return err
 	}
@@ -227,7 +223,7 @@ func (cmd *natFrontend) ArgsSet(c *cobra.Command, args []string) error {
 }
 
 func (cmd *natFrontend) RunSet(c *cobra.Command, _ []string) {
-	natMap := nat.FrontendMap(&bpf.MapContext{})
+	natMap := nat.FrontendMap()
 	if err := natMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}
@@ -273,7 +269,7 @@ func (cmd *natFrontend) ArgsDel(c *cobra.Command, args []string) error {
 }
 
 func (cmd *natFrontend) RunDel(c *cobra.Command, _ []string) {
-	natMap := nat.FrontendMap(&bpf.MapContext{})
+	natMap := nat.FrontendMap()
 	if err := natMap.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}
@@ -358,8 +354,7 @@ func (cmd *natBackend) ArgsSet(c *cobra.Command, args []string) error {
 }
 
 func (cmd *natBackend) RunSet(c *cobra.Command, _ []string) {
-	mc := &bpf.MapContext{}
-	m := nat.BackendMap(mc)
+	m := nat.BackendMap()
 	if err := m.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}
@@ -405,8 +400,7 @@ func (cmd *natBackend) ArgsDel(c *cobra.Command, args []string) error {
 }
 
 func (cmd *natBackend) RunDel(c *cobra.Command, _ []string) {
-	mc := &bpf.MapContext{}
-	m := nat.BackendMap(mc)
+	m := nat.BackendMap()
 	if err := m.Open(); err != nil {
 		log.WithError(err).Error("Failed to access NATMap")
 	}

--- a/felix/cmd/calico-bpf/commands/policy_debug.go
+++ b/felix/cmd/calico-bpf/commands/policy_debug.go
@@ -65,7 +65,7 @@ var policyDumpCmd = &cobra.Command{
 			hooks = []bpf.Hook{bpf.HookXDP}
 		}
 
-		rmap := counters.PolicyMap(&bpf.MapContext{})
+		rmap := counters.PolicyMap()
 		m, err := counters.LoadPolicyMap(rmap)
 		if err != nil {
 			log.WithError(err).Error("error loading rule counters map.")

--- a/felix/cmd/calico-bpf/commands/routes.go
+++ b/felix/cmd/calico-bpf/commands/routes.go
@@ -50,8 +50,7 @@ var routesCmd = &cobra.Command{
 }
 
 func dumpRoutes() error {
-	mc := &bpf.MapContext{}
-	routesMap := routes.Map(mc)
+	routesMap := routes.Map()
 
 	if err := routesMap.Open(); err != nil {
 		return errors.WithMessage(err, "failed to open map")

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -55,7 +55,6 @@ import (
 	bpfarp "github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/asm"
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
-	"github.com/projectcalico/calico/felix/bpf/counters"
 	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/bpf/polprog"
 	"github.com/projectcalico/calico/felix/bpf/tc"
@@ -204,7 +203,7 @@ type bpfEndpointManager struct {
 	dsrEnabled              bool
 	bpfExtToServiceConnmark int
 	psnatPorts              numorstring.Port
-	bpfMapContext           *bpf.MapContext
+	maps                    *bpfmap.Maps
 	ifStateMap              *cachingmap.CachingMap[ifstate.Key, ifstate.Value]
 
 	ruleRenderer        bpfAllowChainRenderer
@@ -274,7 +273,7 @@ type bpfAllowChainRenderer interface {
 func newBPFEndpointManager(
 	dp bpfDataplane,
 	config *Config,
-	bpfMapContext *bpf.MapContext,
+	maps *bpfmap.Maps,
 	fibLookupEnabled bool,
 	workloadIfaceRegex *regexp.Regexp,
 	ipSetIDAlloc *idalloc.IDAllocator,
@@ -312,10 +311,10 @@ func newBPFEndpointManager(
 		dsrEnabled:              config.BPFNodePortDSREnabled,
 		bpfExtToServiceConnmark: config.BPFExtToServiceConnmark,
 		psnatPorts:              config.BPFPSNATPorts,
-		bpfMapContext:           bpfMapContext,
+		maps:                    maps,
 		ifStateMap: cachingmap.New[ifstate.Key, ifstate.Value](ifstate.MapParams.Name,
 			bpf.NewTypedMap[ifstate.Key, ifstate.Value](
-				bpfMapContext.IfStateMap.(bpf.MapWithExistsCheck), ifstate.KeyFromBytes, ifstate.ValueFromBytes,
+				maps.IfStateMap.(bpf.MapWithExistsCheck), ifstate.KeyFromBytes, ifstate.ValueFromBytes,
 			)),
 		ruleRenderer:        iptablesRuleRenderer,
 		iptablesFilterTable: iptablesFilterTable,
@@ -331,7 +330,7 @@ func newBPFEndpointManager(
 		bpfPolicyDebugEnabled: config.BPFPolicyDebugEnabled,
 		polNameToMatchIDs:     map[string]set.Set[polprog.RuleMatchID]{},
 		dirtyRules:            set.New[polprog.RuleMatchID](),
-		arpMap:                bpfMapContext.ArpMap,
+		arpMap:                maps.ArpMap,
 	}
 
 	// Calculate allowed XDP attachment modes.  Note, in BPF mode untracked ingress policy is
@@ -406,7 +405,12 @@ func newBPFEndpointManager(
 	}
 
 	if m.bpfPolicyDebugEnabled {
-		counters.DeleteAllPolicyCounters(m.bpfMapContext)
+		err := m.maps.RuleCountersMap.Iter(func(k, v []byte) bpf.IteratorAction {
+			return bpf.IterDelete
+		})
+		if err != nil {
+			log.WithError(err).Warn("Failed to iterate over policy counters map")
+		}
 	}
 
 	return m, nil
@@ -755,7 +759,7 @@ func (m *bpfEndpointManager) removeDirtyPolicies() {
 	m.dirtyRules.Iter(func(item polprog.RuleMatchID) error {
 		binary.LittleEndian.PutUint64(b, item)
 		log.WithField("ruleId", item).Debug("deleting entry")
-		err := m.bpfMapContext.RuleCountersMap.Delete(b)
+		err := m.maps.RuleCountersMap.Delete(b)
 		if err != nil && !bpf.IsNotExists(err) {
 			log.WithField("ruleId", item).Info("error deleting entry")
 		}
@@ -853,7 +857,10 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 	// Copy data from old map to the new map
 	m.copyDeltaOnce.Do(func() {
 		log.Info("Copy delta entries from old map to the new map")
-		bpfmap.MigrateDataFromOldMap(m.bpfMapContext)
+		err := m.maps.CtMap.CopyDeltaFromOldMap()
+		if err != nil {
+			log.WithError(err).Debugf("Failed to copy data from old conntrack map %s", err)
+		}
 	})
 	return nil
 }
@@ -1398,7 +1405,6 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(policyDirection PolDirection
 	ap.PSNATStart = m.psnatPorts.MinPort
 	ap.PSNATEnd = m.psnatPorts.MaxPort
 	ap.IPv6Enabled = m.ipv6Enabled
-	ap.MapSizes = m.bpfMapContext.MapSizes
 
 	switch m.rpfEnforceOption {
 	case "Strict":
@@ -2062,8 +2068,8 @@ func policyProgramName(iface, polDir string, ipFamily proto.IPVersion) string {
 func (m *bpfEndpointManager) doUpdatePolicyProgram(progName string, jumpMapFD bpf.MapFD, rules polprog.Rules,
 	ipFamily proto.IPVersion) (asm.Insns, error) {
 
-	pg := polprog.NewBuilder(m.ipSetIDAlloc, m.bpfMapContext.IpsetsMap.MapFD(),
-		m.bpfMapContext.StateMap.MapFD(), jumpMapFD, m.bpfPolicyDebugEnabled)
+	pg := polprog.NewBuilder(m.ipSetIDAlloc, m.maps.IpsetsMap.MapFD(),
+		m.maps.StateMap.MapFD(), jumpMapFD, m.bpfPolicyDebugEnabled)
 	if ipFamily == proto.IPVersion_IPV6 {
 		pg.EnableIPv6Mode()
 	}

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -199,9 +199,9 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		ipSetIDAllocator = idalloc.New()
 		vxlanMTU = 0
 		nodePortDSR = true
-		bpfMapContext = &bpf.MapContext{
-			RepinningEnabled: true,
-		}
+
+		bpf.EnabledRepin()
+
 		bpfMapContext.IpsetsMap = bpfipsets.Map(bpfMapContext)
 		bpfMapContext.StateMap = state.Map(bpfMapContext)
 		bpfMapContext.CtMap = conntrack.Map(bpfMapContext)

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/projectcalico/calico/felix/logutils"
 
 	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/counters"
 	"github.com/projectcalico/calico/felix/bpf/ifstate"
@@ -184,7 +185,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		ipSetIDAllocator     *idalloc.IDAllocator
 		vxlanMTU             int
 		nodePortDSR          bool
-		bpfMapContext        *bpf.MapContext
+		maps                 *bpfmap.Maps
 		rrConfigNormal       rules.Config
 		ruleRenderer         rules.RuleRenderer
 		filterTableV4        iptablesTable
@@ -200,14 +201,16 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		vxlanMTU = 0
 		nodePortDSR = true
 
-		bpf.EnabledRepin()
+		bpf.EnableRepin()
 
-		bpfMapContext.IpsetsMap = bpfipsets.Map(bpfMapContext)
-		bpfMapContext.StateMap = state.Map(bpfMapContext)
-		bpfMapContext.CtMap = conntrack.Map(bpfMapContext)
+		maps = new(bpfmap.Maps)
+
+		maps.IpsetsMap = bpfipsets.Map()
+		maps.StateMap = state.Map()
+		maps.CtMap = conntrack.Map()
 		ifStateMap = mock.NewMockMap(ifstate.MapParams)
-		bpfMapContext.IfStateMap = ifStateMap
-		bpfMapContext.RuleCountersMap = mock.NewMockMap(counters.PolicyMapParameters)
+		maps.IfStateMap = ifStateMap
+		maps.RuleCountersMap = mock.NewMockMap(counters.PolicyMapParameters)
 		rrConfigNormal = rules.Config{
 			IPIPEnabled:                 true,
 			IPIPTunnelAddress:           nil,
@@ -226,6 +229,10 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		}
 		ruleRenderer = rules.NewRenderer(rrConfigNormal)
 		filterTableV4 = newMockTable("filter")
+	})
+
+	AfterEach(func() {
+		bpf.DisableRepin()
 	})
 
 	newBpfEpMgr := func() {
@@ -247,7 +254,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				},
 				BPFPolicyDebugEnabled: true,
 			},
-			bpfMapContext,
+			maps,
 			fibLookupEnabled,
 			regexp.MustCompile(workloadIfaceRegex),
 			ipSetIDAllocator,
@@ -626,7 +633,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			egrRuleMatchId := bpfEpMgr.dp.ruleMatchID("Egress", "Allow", "Policy", "allowPol", 0)
 			k := make([]byte, 8)
 			v := make([]byte, 8)
-			rcMap := bpfEpMgr.bpfMapContext.RuleCountersMap
+			rcMap := bpfEpMgr.maps.RuleCountersMap
 
 			// create a new policy
 			bpfEpMgr.OnUpdate(&proto.ActivePolicyUpdate{
@@ -692,7 +699,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			egrRuleMatchId := bpfEpMgr.dp.ruleMatchID("Egress", "Allow", "Policy", "allowPol", 0)
 			k := make([]byte, 8)
 			v := make([]byte, 8)
-			rcMap := bpfEpMgr.bpfMapContext.RuleCountersMap
+			rcMap := bpfEpMgr.maps.RuleCountersMap
 
 			binary.LittleEndian.PutUint64(k, ingRuleMatchId)
 			binary.LittleEndian.PutUint64(v, uint64(10))

--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf"
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/routes"
 	"github.com/projectcalico/calico/felix/ifacemonitor"
 	"github.com/projectcalico/calico/felix/ip"
@@ -85,7 +86,7 @@ type bpfRouteManager struct {
 	wgEnabled bool
 }
 
-func newBPFRouteManager(config *Config, mc *bpf.MapContext,
+func newBPFRouteManager(config *Config, maps *bpfmap.Maps,
 	opReporter logutils.OpRecorder) *bpfRouteManager {
 
 	// Record the external node CIDRs and pre-mark them as dirty.  These can only change with a config update,
@@ -119,7 +120,7 @@ func newBPFRouteManager(config *Config, mc *bpf.MapContext,
 		dirtyCIDRs:        dirtyCIDRs,
 
 		desiredRoutes: map[routes.Key]routes.Value{},
-		routeMap:      mc.RouteMap,
+		routeMap:      maps.RouteMap,
 
 		dirtyRoutes:     set.New[routes.Key](),
 		resyncScheduled: true,

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -601,6 +601,10 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		defaultRPFilter = []byte{'1'}
 	}
 
+	if config.BPFMapRepin {
+		bpf.EnabledRepin()
+	}
+
 	bpfMapContext := bpfmap.CreateBPFMapContext(
 		config.BPFMapSizeIPSets,
 		config.BPFMapSizeNATFrontend,
@@ -609,7 +613,6 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		config.BPFMapSizeRoute,
 		config.BPFMapSizeConntrack,
 		config.BPFMapSizeIfState,
-		config.BPFMapRepin,
 	)
 
 	var bpfEndpointManager *bpfEndpointManager

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -33,6 +33,9 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/projectcalico/calico/felix/bpf/bpfmap"
+	"github.com/projectcalico/calico/felix/bpf/failsafes"
+	"github.com/projectcalico/calico/felix/bpf/nat"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 	"github.com/projectcalico/calico/felix/environment"
 	"github.com/projectcalico/calico/felix/iptables/cmdshim"
@@ -40,12 +43,12 @@ import (
 	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/felix/bpf"
-	"github.com/projectcalico/calico/felix/bpf/bpfmap"
-	"github.com/projectcalico/calico/felix/bpf/conntrack"
-	"github.com/projectcalico/calico/felix/bpf/failsafes"
+	bpfconntrack "github.com/projectcalico/calico/felix/bpf/conntrack"
+	bpfifstate "github.com/projectcalico/calico/felix/bpf/ifstate"
 	bpfipsets "github.com/projectcalico/calico/felix/bpf/ipsets"
-	"github.com/projectcalico/calico/felix/bpf/nat"
+	bpfnat "github.com/projectcalico/calico/felix/bpf/nat"
 	bpfproxy "github.com/projectcalico/calico/felix/bpf/proxy"
+	bpfroutes "github.com/projectcalico/calico/felix/bpf/routes"
 
 	"github.com/projectcalico/calico/felix/bpf/tc"
 	"github.com/projectcalico/calico/felix/config"
@@ -189,7 +192,7 @@ type Config struct {
 	BPFL3IfacePattern                  *regexp.Regexp
 	XDPEnabled                         bool
 	XDPAllowGeneric                    bool
-	BPFConntrackTimeouts               conntrack.Timeouts
+	BPFConntrackTimeouts               bpfconntrack.Timeouts
 	BPFCgroupV2                        string
 	BPFConnTimeLBEnabled               bool
 	BPFMapRepin                        bool
@@ -577,7 +580,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		dp.RegisterManager(newPolicyManager(rawTableV4, mangleTableV4, filterTableV4, ruleRenderer, 4))
 
 		// Clean up any leftover BPF state.
-		err := nat.RemoveConnectTimeLoadBalancer("")
+		err := bpfnat.RemoveConnectTimeLoadBalancer("")
 		if err != nil {
 			log.WithError(err).Info("Failed to remove BPF connect-time load balancer, ignoring.")
 		}
@@ -602,24 +605,26 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	}
 
 	if config.BPFMapRepin {
-		bpf.EnabledRepin()
+		bpf.EnableRepin()
+	} else {
+		bpf.DisableRepin()
 	}
 
-	bpfMapContext := bpfmap.CreateBPFMapContext(
-		config.BPFMapSizeIPSets,
-		config.BPFMapSizeNATFrontend,
-		config.BPFMapSizeNATBackend,
-		config.BPFMapSizeNATAffinity,
-		config.BPFMapSizeRoute,
-		config.BPFMapSizeConntrack,
-		config.BPFMapSizeIfState,
-	)
+	bpfipsets.SetMapSize(config.BPFMapSizeIPSets)
+	bpfnat.SetMapSizes(config.BPFMapSizeNATFrontend, config.BPFMapSizeNATBackend, config.BPFMapSizeNATAffinity)
+	bpfroutes.SetMapSize(config.BPFMapSizeRoute)
+	bpfconntrack.SetMapSize(config.BPFMapSizeConntrack)
+	bpfifstate.SetMapSize(config.BPFMapSizeIfState)
 
-	var bpfEndpointManager *bpfEndpointManager
+	var (
+		bpfEndpointManager *bpfEndpointManager
+		bpfMaps            *bpfmap.Maps
+	)
 
 	if config.BPFEnabled {
 		log.Info("BPF enabled, starting BPF endpoint manager and map manager.")
-		err := bpfmap.CreateBPFMaps(bpfMapContext)
+		var err error
+		bpfMaps, err = bpfmap.CreateBPFMaps()
 		if err != nil {
 			log.WithError(err).Panic("error creating bpf maps")
 		}
@@ -630,19 +635,19 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		ipSetsV4 := bpfipsets.NewBPFIPSets(
 			ipSetsConfigV4,
 			ipSetIDAllocator,
-			bpfMapContext.IpsetsMap,
+			bpfMaps.IpsetsMap,
 			dp.loopSummarizer,
 		)
 		dp.ipSets = append(dp.ipSets, ipSetsV4)
 		ipsetsManager.AddDataplane(ipSetsV4)
-		bpfRTMgr := newBPFRouteManager(&config, bpfMapContext, dp.loopSummarizer)
+		bpfRTMgr := newBPFRouteManager(&config, bpfMaps, dp.loopSummarizer)
 		dp.RegisterManager(bpfRTMgr)
 
 		// Forwarding into an IPIP tunnel fails silently because IPIP tunnels are L3 devices and support for
 		// L3 devices in BPF is not available yet.  Disable the FIB lookup in that case.
 		fibLookupEnabled := !config.RulesConfig.IPIPEnabled
 		failsafeMgr := failsafes.NewManager(
-			bpfMapContext.FailsafesMap,
+			bpfMaps.FailsafesMap,
 			config.RulesConfig.FailsafeInboundHostPorts,
 			config.RulesConfig.FailsafeOutboundHostPorts,
 			dp.loopSummarizer,
@@ -653,7 +658,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		bpfEndpointManager, err = newBPFEndpointManager(
 			nil,
 			&config,
-			bpfMapContext,
+			bpfMaps,
 			fibLookupEnabled,
 			workloadIfaceRegex,
 			ipSetIDAllocator,
@@ -671,8 +676,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 
 		bpfEndpointManager.Features = dataplaneFeatures
 
-		conntrackScanner := conntrack.NewScanner(bpfMapContext.CtMap,
-			conntrack.NewLivenessScanner(config.BPFConntrackTimeouts, config.BPFNodePortDSREnabled))
+		conntrackScanner := bpfconntrack.NewScanner(bpfMaps.CtMap,
+			bpfconntrack.NewLivenessScanner(config.BPFConntrackTimeouts, config.BPFNodePortDSREnabled))
 
 		// Before we start, scan for all finished / timed out connections to
 		// free up the conntrack table asap as it may take time to sync up the
@@ -692,7 +697,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			kp, err := bpfproxy.StartKubeProxy(
 				config.KubeClientSet,
 				config.Hostname,
-				bpfMapContext,
+				bpfMaps,
 				bpfproxyOpts...,
 			)
 			if err != nil {
@@ -700,7 +705,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			}
 			bpfRTMgr.setHostIPUpdatesCallBack(kp.OnHostIPsUpdate)
 			bpfRTMgr.setRoutesCallBacks(kp.OnRouteUpdate, kp.OnRouteDelete)
-			conntrackScanner.AddUnlocked(conntrack.NewStaleNATScanner(kp))
+			conntrackScanner.AddUnlocked(bpfconntrack.NewStaleNATScanner(kp))
 			conntrackScanner.Start()
 		} else {
 			log.Info("BPF enabled but no Kubernetes client available, unable to run kube-proxy module.")
@@ -715,8 +720,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				}
 			}
 			// Activate the connect-time load balancer.
-			err = nat.InstallConnectTimeLoadBalancer(
-				config.BPFCgroupV2, config.BPFLogLevel, config.BPFConntrackTimeouts.UDPLastSeen, bpfMapContext, excludeUDP)
+			err = bpfnat.InstallConnectTimeLoadBalancer(
+				config.BPFCgroupV2, config.BPFLogLevel, config.BPFConntrackTimeouts.UDPLastSeen, excludeUDP)
 			if err != nil {
 				log.WithError(err).Panic("BPFConnTimeLBEnabled but failed to attach connect-time load balancer, bailing out.")
 			}

--- a/felix/fv/bpf_counters_test.go
+++ b/felix/fv/bpf_counters_test.go
@@ -27,7 +27,6 @@ import (
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/counters"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/utils"
@@ -228,7 +227,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test counters", [
 })
 
 func dumpRuleCounterMap(felix *infrastructure.Felix) counters.PolicyMapMem {
-	rcMap := counters.PolicyMap(&bpf.MapContext{})
+	rcMap := counters.PolicyMap()
 	m := make(counters.PolicyMapMem)
 	dumpBPFMap(felix, rcMap, counters.PolicyMapMemIter(m))
 	return m

--- a/felix/fv/bpf_map_resize_test.go
+++ b/felix/fv/bpf_map_resize_test.go
@@ -111,7 +111,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 			cfg.Spec.BPFMapSizeConntrack = &newCtMapSize
 		})
 
-		ctMap := conntrack.Map(&bpf.MapContext{})
+		ctMap := conntrack.Map()
 		Eventually(func() int { return getMapSize(felixes[0], ctMap) }, "10s", "200ms").Should(Equal(newCtMapSize))
 		out, err = felixes[0].ExecOutput("calico-bpf", "conntrack", "dump")
 		Expect(err).NotTo(HaveOccurred())
@@ -120,12 +120,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 	})
 
 	It("should program new map sizes", func() {
-		affMap := nat.AffinityMap(&bpf.MapContext{})
-		feMap := nat.FrontendMap(&bpf.MapContext{})
-		beMap := nat.BackendMap(&bpf.MapContext{})
-		rtMap := routes.Map(&bpf.MapContext{})
-		ipsMap := ipsets.Map(&bpf.MapContext{})
-		ctMap := conntrack.Map(&bpf.MapContext{})
+		affMap := nat.AffinityMap()
+		feMap := nat.FrontendMap()
+		beMap := nat.BackendMap()
+		rtMap := routes.Map()
+		ipsMap := ipsets.Map()
+		ctMap := conntrack.Map()
 
 		felix := felixes[0]
 		Eventually(func() int { return getMapSize(felix, rtMap) }, "10s", "200ms").Should(Equal((rtMap.(*bpf.PinnedMap)).MaxEntries))

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -608,7 +608,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 			if testOpts.protocol != "udp" { // No need to run these tests per-protocol.
 
-				mapPath := conntrack.Map(&bpf.MapContext{}).Path()
+				mapPath := conntrack.Map().Path()
 
 				Describe("with map repinning enabled", func() {
 					BeforeEach(func() {
@@ -2345,7 +2345,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							Eventually(func() nat.BackendValue {
 								// Remove the affinity entry to emulate timer
 								// expiring / no prior affinity.
-								m := nat.AffinityMap(&bpf.MapContext{})
+								m := nat.AffinityMap()
 								cmd, err := bpf.MapDeleteKeyCmd(m, mkey.AsBytes())
 								Expect(err).NotTo(HaveOccurred())
 								err = felixes[0].ExecMayFail(cmd...)
@@ -3799,42 +3799,42 @@ func dumpBPFMap(felix *infrastructure.Felix, m bpf.Map, iter bpf.IterCallback) {
 }
 
 func dumpNATMap(felix *infrastructure.Felix) nat.MapMem {
-	bm := nat.FrontendMap(&bpf.MapContext{})
+	bm := nat.FrontendMap()
 	m := make(nat.MapMem)
 	dumpBPFMap(felix, bm, nat.MapMemIter(m))
 	return m
 }
 
 func dumpEPMap(felix *infrastructure.Felix) nat.BackendMapMem {
-	bm := nat.BackendMap(&bpf.MapContext{})
+	bm := nat.BackendMap()
 	m := make(nat.BackendMapMem)
 	dumpBPFMap(felix, bm, nat.BackendMapMemIter(m))
 	return m
 }
 
 func dumpAffMap(felix *infrastructure.Felix) nat.AffinityMapMem {
-	bm := nat.AffinityMap(&bpf.MapContext{})
+	bm := nat.AffinityMap()
 	m := make(nat.AffinityMapMem)
 	dumpBPFMap(felix, bm, nat.AffinityMapMemIter(m))
 	return m
 }
 
 func dumpCTMap(felix *infrastructure.Felix) conntrack.MapMem {
-	bm := conntrack.Map(&bpf.MapContext{})
+	bm := conntrack.Map()
 	m := make(conntrack.MapMem)
 	dumpBPFMap(felix, bm, conntrack.MapMemIter(m))
 	return m
 }
 
 func dumpSendRecvMap(felix *infrastructure.Felix) nat.SendRecvMsgMapMem {
-	bm := nat.SendRecvMsgMap(&bpf.MapContext{})
+	bm := nat.SendRecvMsgMap()
 	m := make(nat.SendRecvMsgMapMem)
 	dumpBPFMap(felix, bm, nat.SendRecvMsgMapMemIter(m))
 	return m
 }
 
 func dumpIfStateMap(felix *infrastructure.Felix) ifstate.MapMem {
-	im := ifstate.Map(&bpf.MapContext{})
+	im := ifstate.Map()
 	m := make(ifstate.MapMem)
 	dumpBPFMap(felix, im, ifstate.MapMemIter(m))
 	return m


### PR DESCRIPTION
## Description

    [BPF] no explicit pin file name in maps
    
    Makes easier to change the location of the pins and easier to maintain
    maps and add new ones.
    
    Allow multiple char version.

    [BPF] remove MapContext

    [BPF] remove RepinningEnabled from MapContext
    
    It is pretty much a global setting, mostly turned on.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
