### PR TITLE
DOCS-994: Adds redirect rules for docs.projectcalico.org

### DIFF
--- a/calico/netlify/_redirects_v3.21
+++ b/calico/netlify/_redirects_v3.21
@@ -258,26 +258,26 @@
 /archive/v1.5/getting-started/kubernetes/tutorials/*             https://calico-legacy.netlify.app/archive/v1.5/getting-started/kubernetes/tutorials/:splat         200
 
 # Some specific redirects that were linking to 404s
-/en/0.27/etcd-data-model.html                                    https://projectcalico.docs.tigera.io                                                               301!
-/en/1.3.0/opens-upgrade.html                                     https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/using.html                                            https://projectcalico.docs.tigera.io                                                               301!
-/en/0.27/faq.html                                                https://projectcalico.docs.tigera.io                                                               301!
-/en/0.27/addressing.html                                         https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/openstack.html                                        https://projectcalico.docs.tigera.io                                                               301!
-/getting-started/kubernetes/trying-ebpf                          https://projectcalico.docs.tigera.io                                                               301!
-/getting-started/clis/calicoctl/install                          https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/api-proposal.html                                     https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/architecture.html                                     https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/l2-interconnectFabric.html                            https://projectcalico.docs.tigera.io                                                               301!
-/getting-started/kubernetes/apiserver-preview                    https://projectcalico.docs.tigera.io                                                               301!
-/en/stable/openstack.html                                        https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/etcd-data-model.html                                  https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/l3-interconnectFabric.html                            https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/security-model.html                                   https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/ipv6.html                                             https://projectcalico.docs.tigera.io                                                               301!
-/en/1.3.0/openstack.html                                         https://projectcalico.docs.tigera.io                                                               301!
-/en/latest/arch-felix-and-acl.html                               https://projectcalico.docs.tigera.io                                                               301!
-/v3.18/reference/kube-controllers/prometheus                     https://projectcalico.docs.tigera.io                                                               301!
+/en/0.27/etcd-data-model.html                                    https://docs.tigera.io                                                             301!
+/en/1.3.0/opens-upgrade.html                                     https://docs.tigera.io                                                             301!
+/en/latest/using.html                                            https://docs.tigera.io                                                             301!
+/en/0.27/faq.html                                                https://docs.tigera.io                                                             301!
+/en/0.27/addressing.html                                         https://docs.tigera.io                                                             301!
+/en/latest/openstack.html                                        https://docs.tigera.io                                                             301!
+/getting-started/kubernetes/trying-ebpf                          https://docs.tigera.io                                                             301!
+/getting-started/clis/calicoctl/install                          https://docs.tigera.io                                                             301!
+/en/latest/api-proposal.html                                     https://docs.tigera.io                                                             301!
+/en/latest/architecture.html                                     https://docs.tigera.io                                                             301!
+/en/latest/l2-interconnectFabric.html                            https://docs.tigera.io                                                             301!
+/getting-started/kubernetes/apiserver-preview                    https://docs.tigera.io                                                             301!
+/en/stable/openstack.html                                        https://docs.tigera.io                                                             301!
+/en/latest/etcd-data-model.html                                  https://docs.tigera.io                                                             301!
+/en/latest/l3-interconnectFabric.html                            https://docs.tigera.io                                                             301!
+/en/latest/security-model.html                                   https://docs.tigera.io                                                             301!
+/en/latest/ipv6.html                                             https://docs.tigera.io                                                             301!
+/en/1.3.0/openstack.html                                         https://docs.tigera.io                                                             301!
+/en/latest/arch-felix-and-acl.html                               https://docs.tigera.io                                                             301!
+/v3.18/reference/kube-controllers/prometheus                     https://docs.tigera.io                                                             301!
 
 # blanket forced redirect for content
-/*                                                               https://projectcalico.docs.tigera.io/:splat                                                        301!
+/*                                                               https://docs.tigera.io/calico/latest/:splat                                                        301!

--- a/calico/robots.txt
+++ b/calico/robots.txt
@@ -1,9 +1,4 @@
-# Exclude from indexing
+# Exclude everything from indexing
 User-agent: *
-Allow: .js
-Allow: .css
-Disallow: /master/
-Disallow: /images/
-Disallow: /fonts/
-Disallow: /assets/
-Disallow: /archive/
+Disallow: /
+


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-994

Adds redirect rules for docs.projectcalico.org.

Most of the rules remain intact. Older versions continue to point at versioned Netlify sites.

A few rule  redirect traffic to projectcalico.docs.tigera.io. These are changed to docs.tigera.io.

Other redirect PRs:
* docs.projectcalico: https://github.com/projectcalico/calico/pull/7168
* projectcalico.docs.tigera.io: https://github.com/projectcalico/calico/pull/7169
* docs.calicocloud.io: https://github.com/tigera/calico-cloud/pull/201
* docs.tigera.io: https://github.com/tigera/docs/pull/184