### PR TITLE
BPF-2122 Additional check for IPVS mode

### DIFF
--- a/felix/dataplane/driver.go
+++ b/felix/dataplane/driver.go
@@ -365,7 +365,7 @@ func StartDataplaneDriver(configParams *config.Config,
 		}
 
 		intDP := intdataplane.NewIntDataplaneDriver(dpConfig)
-		intDP.Start()
+		intDP.Start(configParams)
 
 		// Set source-destination-check on AWS EC2 instance.
 		if configParams.AWSSrcDstCheck != string(apiv3.AWSSrcDstCheckOptionDoNothing) {


### PR DESCRIPTION
Since we ignore kube-proxy mode in ebpf we must not restart when we see that the mode has changed otherwise we stay in an infinite loop of restarts.
NB: I'm not sure how `int_dataplane.go` L240 and L257 seem to magically insert the "#" - I did not do anything here - thanks
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: prevents infinite restarts when we switch to ebpf after kube-proxy was in ipvs mode.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
