### PR TITLE
Reload Typha addresses between connection attempts.

### DIFF
--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -34,7 +34,6 @@ import (
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
-	"github.com/projectcalico/calico/typha/pkg/discovery"
 )
 
 var (
@@ -1032,13 +1031,6 @@ func (config *Config) SetLoadClientConfigFromEnvironmentFunction(fnc func() (*ap
 func (config *Config) OverrideParam(name, value string) (bool, error) {
 	config.internalOverrides[name] = value
 	return config.UpdateFrom(config.internalOverrides, InternalOverride)
-}
-
-func (config *Config) TyphaDiscoveryOpts() []discovery.Option {
-	return []discovery.Option{
-		discovery.WithAddrOverride(config.TyphaAddr),
-		discovery.WithKubeService(config.TyphaK8sNamespace, config.TyphaK8sServiceName),
-	}
 }
 
 // RouteTableIndices compares provided args for the deprecated RoutTableRange arg

--- a/felix/daemon/bootstrap_linux.go
+++ b/felix/daemon/bootstrap_linux.go
@@ -28,7 +28,7 @@ import (
 //
 // See wireguard.BootstrapAndFilterTyphaAddresses for details.
 func bootstrapWireguardAndFilterTyphaAddresses(
-	configParams *config.Config, v3Client clientv3.Interface, typhas []discovery.Typha,
+	configParams *config.Config, v3Client clientv3.NodesClient, typhas []discovery.Typha,
 ) ([]discovery.Typha, error) {
 	log.Debug("bootstrapping wireguard host connectivity")
 	return wireguard.BootstrapAndFilterTyphaAddresses(

--- a/felix/daemon/bootstrap_windows.go
+++ b/felix/daemon/bootstrap_windows.go
@@ -21,7 +21,7 @@ import (
 )
 
 func bootstrapWireguardAndFilterTyphaAddresses(
-	_ *config.Config, _ clientv3.Interface, typhas []discovery.Typha,
+	_ *config.Config, _ clientv3.NodesClient, typhas []discovery.Typha,
 ) ([]discovery.Typha, error) {
 	return typhas, nil
 } // no filtering

--- a/felix/daemon/daemon_test.go
+++ b/felix/daemon/daemon_test.go
@@ -134,3 +134,8 @@ var _ = Describe("Typha address discovery", func() {
 		)
 	})
 })
+
+func discoverTyphaAddrs(params *config.Config, sClient *fake.Clientset) ([]discovery.Typha, error) {
+	disc := createTyphaDiscoverer(params, sClient)
+	return disc.LoadTyphaAddrs()
+}

--- a/felix/fv/health_test.go
+++ b/felix/fv/health_test.go
@@ -422,6 +422,10 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 			startTypha(k8sInfra.GetDockerArgs)
 			startFelix(typhaContainer.IP+":5474", k8sInfra.GetDockerArgs, felixParams{dataplaneTimeout: "20", healthHost: "0.0.0.0"})
 		})
+		AfterEach(func() {
+			felix.Stop()
+			typhaContainer.Stop()
+		})
 		It("should become unready, then die", func() {
 			Eventually(felixReady, "5s", "1s").ShouldNot(BeGood())
 			Consistently(felix.Stopped, "20s").Should(BeFalse()) // Should stay up for 20+s

--- a/felix/wireguard/bootstrap.go
+++ b/felix/wireguard/bootstrap.go
@@ -130,7 +130,7 @@ func BootstrapAndFilterTyphaAddresses(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
 	getWireguardHandle func() (netlinkshim.Wireguard, error),
-	calicoClient clientv3.Interface,
+	calicoClient clientv3.NodesClient,
 	typhas []discovery.Typha,
 ) ([]discovery.Typha, error) {
 	var (
@@ -181,7 +181,7 @@ func bootstrapAndFilterTyphaAddressesForIPVersion(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
 	getWireguardHandle func() (netlinkshim.Wireguard, error),
-	calicoClient clientv3.Interface,
+	calicoClient clientv3.NodesClient,
 	typhas []discovery.Typha,
 	ipVersion uint8,
 ) ([]discovery.Typha, error) {
@@ -299,7 +299,7 @@ func RemoveWireguardConditionallyOnBootstrap(
 func removeWireguardConditionallyOnBootstrapForIPVersion(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
-	calicoClient clientv3.Interface,
+	calicoClient clientv3.NodesClient,
 	ipVersion uint8,
 ) error {
 	logCtx := log.WithField("ipVersion", ipVersion)
@@ -325,7 +325,7 @@ func removeWireguardConditionallyOnBootstrapForIPVersion(
 // to succeed. Any errors encountered are swallowed and the associated peer is just included.
 func filterTyphaEndpoints(
 	configParams *config.Config,
-	calicoClient clientv3.Interface,
+	calicoClient clientv3.NodesClient,
 	typhas []discovery.Typha,
 	peers set.Set[string],
 	ipVersion uint8,
@@ -393,7 +393,7 @@ func filterTyphaEndpoints(
 func removeWireguardForBootstrapping(
 	configParams *config.Config,
 	getNetlinkHandle func() (netlinkshim.Interface, error),
-	calicoClient clientv3.Interface,
+	calicoClient clientv3.NodesClient,
 	ipVersion uint8,
 ) error {
 	var errors []error
@@ -412,7 +412,7 @@ func removeWireguardForBootstrapping(
 }
 
 // getPublicKeyForNode returns the configured wireguard public key for a given node.
-func getPublicKeyForNode(logCtx *log.Entry, nodeName string, calicoClient clientv3.Interface, maxRetries int, ipVersion uint8) (string, error) {
+func getPublicKeyForNode(logCtx *log.Entry, nodeName string, calicoClient clientv3.NodesClient, maxRetries int, ipVersion uint8) (string, error) {
 	expBackoffMgr := wait.NewExponentialBackoffManager(
 		bootstrapBackoffDuration,
 		bootstrapBackoffMax,
@@ -556,7 +556,7 @@ func removeWireguardDevice(
 // removeWireguardPublicKey removes the public key from the node.
 func removeWireguardPublicKey(
 	nodeName string,
-	calicoClient clientv3.Interface,
+	calicoClient clientv3.NodesClient,
 	ipVersion uint8,
 ) error {
 	logCtx := log.WithFields(log.Fields{

--- a/libcalico-go/lib/clientv3/interface.go
+++ b/libcalico-go/lib/clientv3/interface.go
@@ -21,45 +21,25 @@ import (
 )
 
 type Interface interface {
-	// Nodes returns an interface for managing node resources.
-	Nodes() NodeInterface
-	// GlobalNetworkPolicies returns an interface for managing global network policy resources.
-	GlobalNetworkPolicies() GlobalNetworkPolicyInterface
-	// NetworkPolicies returns an interface for managing namespaced network policy resources.
-	NetworkPolicies() NetworkPolicyInterface
-	// IPPools returns an interface for managing IP pool resources.
-	IPPools() IPPoolInterface
-	// IPReservations returns an interface for managing IP reservation resources.
-	IPReservations() IPReservationInterface
-	// Profiles returns an interface for managing profile resources.
-	Profiles() ProfileInterface
-	// GlobalNetworkSets returns an interface for managing global network sets resources.
-	GlobalNetworkSets() GlobalNetworkSetInterface
-	// NetworkSets returns an interface for managing network sets resources.
-	NetworkSets() NetworkSetInterface
-	// HostEndpoints returns an interface for managing host endpoint resources.
-	HostEndpoints() HostEndpointInterface
-	// WorkloadEndpoints returns an interface for managing workload endpoint resources.
-	WorkloadEndpoints() WorkloadEndpointInterface
-	// BGPPeers returns an interface for managing BGP peer resources.
-	BGPPeers() BGPPeerInterface
-	// IPAM returns an interface for managing IP address assignment and releasing.
-	IPAM() ipam.Interface
-	// BGPConfigurations returns an interface for managing the BGP configuration resources.
-	BGPConfigurations() BGPConfigurationInterface
-	// FelixConfigurations returns an interface for managing the Felix configuration resources.
-	FelixConfigurations() FelixConfigurationInterface
-	// ClusterInformation returns an interface for managing the cluster information resource.
-	ClusterInformation() ClusterInformationInterface
-	// KubeControllersConfiguration returns an interface for managing the
-	// KubeControllersConfiguration resource.
-	KubeControllersConfiguration() KubeControllersConfigurationInterface
-	// CalicoNodeStatus returns an interface for managing CalicoNodeStatus resources.
-	CalicoNodeStatus() CalicoNodeStatusInterface
-	// IPAMConfig returns an interface for managing IPAMConfig resources.
-	IPAMConfig() IPAMConfigInterface
-	// BlockAffinities returns an interface for viewing IPAM block affinity resources.
-	BlockAffinities() BlockAffinityInterface
+	NodesClient
+	GlobalNetworkPoliciesClient
+	NetworkPoliciesClient
+	IPPoolsClient
+	IPReservationsClient
+	ProfilesClient
+	GlobalNetworkSetsClient
+	NetworkSetsClient
+	HostEndpointsClient
+	WorkloadEndpointsClient
+	BGPPeersClient
+	IPAMClient
+	BGPConfigurationsClient
+	FelixConfigurationsClient
+	ClusterInformationClient
+	KubeControllersConfigurationClient
+	CalicoNodeStatusClient
+	IPAMConfigClient
+	BlockAffinitiesClient
 
 	// EnsureInitialized is used to ensure the backend datastore is correctly
 	// initialized for use by Calico.  This method may be called multiple times, and
@@ -68,6 +48,101 @@ type Interface interface {
 	// method and so a general consumer of this API can assume that the datastore
 	// is already initialized.
 	EnsureInitialized(ctx context.Context, calicoVersion, clusterType string) error
+}
+
+type NodesClient interface {
+	// Nodes returns an interface for managing node resources.
+	Nodes() NodeInterface
+}
+
+type GlobalNetworkPoliciesClient interface {
+	// GlobalNetworkPolicies returns an interface for managing global network policy resources.
+	GlobalNetworkPolicies() GlobalNetworkPolicyInterface
+}
+
+type NetworkPoliciesClient interface {
+	// NetworkPolicies returns an interface for managing namespaced network policy resources.
+	NetworkPolicies() NetworkPolicyInterface
+}
+
+type IPPoolsClient interface {
+	// IPPools returns an interface for managing IP pool resources.
+	IPPools() IPPoolInterface
+}
+
+type IPReservationsClient interface {
+	// IPReservations returns an interface for managing IP reservation resources.
+	IPReservations() IPReservationInterface
+}
+
+type ProfilesClient interface {
+	// Profiles returns an interface for managing profile resources.
+	Profiles() ProfileInterface
+}
+
+type GlobalNetworkSetsClient interface {
+	// GlobalNetworkSets returns an interface for managing global network sets resources.
+	GlobalNetworkSets() GlobalNetworkSetInterface
+}
+
+type NetworkSetsClient interface {
+	// NetworkSets returns an interface for managing network sets resources.
+	NetworkSets() NetworkSetInterface
+}
+
+type HostEndpointsClient interface {
+	// HostEndpoints returns an interface for managing host endpoint resources.
+	HostEndpoints() HostEndpointInterface
+}
+
+type WorkloadEndpointsClient interface {
+	// WorkloadEndpoints returns an interface for managing workload endpoint resources.
+	WorkloadEndpoints() WorkloadEndpointInterface
+}
+
+type BGPPeersClient interface {
+	// BGPPeers returns an interface for managing BGP peer resources.
+	BGPPeers() BGPPeerInterface
+}
+
+type IPAMClient interface {
+	// IPAM returns an interface for managing IP address assignment and releasing.
+	IPAM() ipam.Interface
+}
+
+type BGPConfigurationsClient interface {
+	// BGPConfigurations returns an interface for managing the BGP configuration resources.
+	BGPConfigurations() BGPConfigurationInterface
+}
+
+type FelixConfigurationsClient interface {
+	// FelixConfigurations returns an interface for managing the Felix configuration resources.
+	FelixConfigurations() FelixConfigurationInterface
+}
+
+type ClusterInformationClient interface {
+	// ClusterInformation returns an interface for managing the cluster information resource.
+	ClusterInformation() ClusterInformationInterface
+}
+
+type KubeControllersConfigurationClient interface {
+	// KubeControllersConfiguration returns an interface for managing the KubeControllersConfiguration resource.
+	KubeControllersConfiguration() KubeControllersConfigurationInterface
+}
+
+type CalicoNodeStatusClient interface {
+	// CalicoNodeStatus returns an interface for managing CalicoNodeStatus resources.
+	CalicoNodeStatus() CalicoNodeStatusInterface
+}
+
+type IPAMConfigClient interface {
+	// IPAMConfig returns an interface for managing IPAMConfig resources.
+	IPAMConfig() IPAMConfigInterface
+}
+
+type BlockAffinitiesClient interface {
+	// BlockAffinities returns an interface for viewing IPAM block affinity resources.
+	BlockAffinities() BlockAffinityInterface
 }
 
 // Compile-time assertion that our client implements its interface.

--- a/typha/cmd/typha-client/typha-client.go
+++ b/typha/cmd/typha-client/typha-client.go
@@ -117,7 +117,8 @@ func main() {
 	}
 
 	hostname, _ := os.Hostname()
-	client := syncclient.New([]discovery.Typha{{Addr: addr}}, buildinfo.GitVersion, hostname, "typha command-line client", callbacks, options)
+	discoverer := discovery.New(discovery.WithAddrOverride(addr))
+	client := syncclient.New(discoverer, buildinfo.GitVersion, hostname, "typha command-line client", callbacks, options)
 	err = client.Start(context.Background())
 	if err != nil {
 		log.WithError(err).Panic("Client failed")

--- a/typha/fv-tests/server_harness_test.go
+++ b/typha/fv-tests/server_harness_test.go
@@ -194,7 +194,7 @@ func (h *ServerHarness) ExpectAllClientsToReachState(status api.SyncStatus, kvs 
 func (h *ServerHarness) createClient(id interface{}, options syncclient.Options, callbacks api.SyncerCallbacks) *ClientState {
 	serverAddr := fmt.Sprintf("127.0.0.1:%d", h.Server.Port())
 	client := syncclient.New(
-		[]discovery.Typha{{Addr: serverAddr}},
+		discovery.New(discovery.WithAddrOverride(serverAddr)),
 		"test-version",
 		fmt.Sprintf("test-host-%v", id),
 		"test-info",
@@ -305,6 +305,10 @@ func (h *ServerHarness) SendConfigUpdates(n int) map[string]api.Update {
 		h.Decoupler.OnUpdates([]api.Update{update})
 	}
 	return expectedEndState
+}
+
+func (h *ServerHarness) Discoverer() *discovery.Discoverer {
+	return discovery.New(discovery.WithAddrOverride(h.Addr()))
 }
 
 func generatePod(n int) *corev1.Pod {

--- a/typha/fv-tests/server_test.go
+++ b/typha/fv-tests/server_test.go
@@ -633,7 +633,7 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
 		client := syncclient.New(
-			[]discovery.Typha{{Addr: h.Addr()}},
+			h.Discoverer(),
 			"test-version",
 			"test-host",
 			"test-info",
@@ -670,7 +670,7 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 		recorder := NewRecorder()
 
 		client := syncclient.New(
-			[]discovery.Typha{{Addr: h.Addr()}},
+			h.Discoverer(),
 			"test-version",
 			"test-host",
 			"test-info",
@@ -894,7 +894,7 @@ var _ = Describe("With an in-process Server with long ping interval", func() {
 		clientCxt, clientCancel := context.WithCancel(context.Background())
 		recorder := NewRecorder()
 		client := syncclient.New(
-			[]discovery.Typha{{Addr: h.Addr()}},
+			h.Discoverer(),
 			"test-version",
 			"test-host",
 			"test-info",
@@ -1005,7 +1005,7 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			recorder.BlockAfterNUpdates(1, 2500*time.Millisecond)
 
 			client := syncclient.New(
-				[]discovery.Typha{{Addr: h.Addr()}},
+				h.Discoverer(),
 				"test-version",
 				"test-host",
 				"test-info",
@@ -1074,7 +1074,7 @@ var _ = Describe("With an in-process Server with short grace period", func() {
 			recorder.BlockAfterNUpdates(initialSnapshotSize+1, 2500*time.Millisecond)
 
 			client := syncclient.New(
-				[]discovery.Typha{{Addr: h.Addr()}},
+				h.Discoverer(),
 				"test-version",
 				"test-host",
 				"test-info",
@@ -1200,7 +1200,7 @@ var _ = Describe("With an in-process Server with short write timeout", func() {
 					recorder.BlockAfterNUpdates(1, 1*time.Second)
 
 					client := syncclient.New(
-						[]discovery.Typha{{Addr: h.Addr()}},
+						h.Discoverer(),
 						"test-version",
 						"test-host",
 						"test-info",
@@ -1426,7 +1426,7 @@ var _ = Describe("with server requiring TLS", func() {
 		recorder := NewRecorder()
 		serverAddr := fmt.Sprintf("127.0.0.1:%d", server.Port())
 		client := syncclient.New(
-			[]discovery.Typha{{Addr: serverAddr}},
+			discovery.New(discovery.WithAddrOverride(serverAddr)),
 			"test-version",
 			"test-host-1",
 			"test-info",

--- a/typha/pkg/daemon/daemon_test.go
+++ b/typha/pkg/daemon/daemon_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Daemon", func() {
 				addr := fmt.Sprintf("127.0.0.1:%d", port)
 				cbs := fvtests.NewRecorder()
 				client := syncclient.New(
-					[]discovery.Typha{{Addr: addr}},
+					discovery.New(discovery.WithAddrOverride(addr)),
 					"",
 					"",
 					"",

--- a/typha/pkg/discovery/discovery.go
+++ b/typha/pkg/discovery/discovery.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 )
 
@@ -43,7 +45,15 @@ type Typha struct {
 	NodeName *string
 }
 
-type options struct {
+func (t Typha) dedupeKey() string {
+	node := "<nil>"
+	if t.NodeName != nil {
+		node = *t.NodeName
+	}
+	return fmt.Sprintf("%s/%s/%s", t.Addr, t.IP, node)
+}
+
+type Discoverer struct {
 	addrOverride       string
 	nodeName           string
 	k8sClient          kubernetes.Interface
@@ -51,97 +61,140 @@ type options struct {
 	k8sNamespace       string
 	k8sServicePortName string
 	inCluster          bool
+	filters            []func(typhaAddresses []Typha) ([]Typha, error)
+
+	allKnownAddrs []Typha
 }
 
-type Option func(opts *options)
+type Option func(opts *Discoverer)
 
 func WithAddrOverride(addr string) Option {
-	return func(opts *options) {
-		opts.addrOverride = addr
+	return func(d *Discoverer) {
+		d.addrOverride = addr
 	}
 }
 
 func WithKubeClient(client kubernetes.Interface) Option {
-	return func(opts *options) {
-		opts.k8sClient = client
+	return func(d *Discoverer) {
+		d.k8sClient = client
 	}
 }
 
 // WithInClusterKubeClient enables auto-connection to Kubernetes using the in-cluster client config.
 // this is disabled by default to avoid creating an extra Kubernetes client that is then discarded.
 func WithInClusterKubeClient() Option {
-	return func(opts *options) {
-		opts.inCluster = true
+	return func(d *Discoverer) {
+		d.inCluster = true
 	}
 }
 
 func WithKubeService(namespaceName, serviceName string) Option {
-	return func(opts *options) {
-		opts.k8sNamespace = namespaceName
-		opts.k8sServiceName = serviceName
+	return func(d *Discoverer) {
+		d.k8sNamespace = namespaceName
+		d.k8sServiceName = serviceName
 	}
 }
 
 func WithKubeServicePortNameOverride(portName string) Option {
-	return func(opts *options) {
-		opts.k8sServicePortName = portName
+	return func(d *Discoverer) {
+		d.k8sServicePortName = portName
 	}
 }
 
 // WithNodeAffinity help discovery preference by supplying nodeName to determine which endpoints are local to node
 func WithNodeAffinity(nodeName string) Option {
-	return func(opts *options) {
-		opts.nodeName = nodeName
+	return func(d *Discoverer) {
+		d.nodeName = nodeName
 	}
 }
 
-// DiscoverTyphaAddrs tries to discover the best address(es) to use to connect to Typha.
+func WithPostDiscoveryFilter(f func(typhaAddresses []Typha) ([]Typha, error)) Option {
+	return func(d *Discoverer) {
+		d.AddPostDiscoveryFilter(f)
+	}
+}
+
+func New(opts ...Option) *Discoverer {
+	d := &Discoverer{
+		k8sServicePortName: "calico-typha",
+	}
+
+	for _, o := range opts {
+		o(d)
+	}
+
+	return d
+}
+
+func (d *Discoverer) AddPostDiscoveryFilter(f func(typhaAddresses []Typha) ([]Typha, error)) {
+	d.filters = append(d.filters, f)
+}
+
+// LoadTyphaAddrs tries to discover the best address(es) to use to connect to Typha.
 //
-// If an AddrOverride is supplied then that takes precedence, otherwise, DiscoverTyphaAddrs will
+// If an AddrOverride is supplied then that takes precedence, otherwise, LoadTyphaAddrs will
 // try to lookup one of the backend endpoints of the typha service (using the K8sServiceName and
 // K8sNamespace fields).
 //
 // Returns nil if typha is not enabled (i.e. fields are empty). If typha is enabled, this will return a non-empty slice
 // or an error.
-func DiscoverTyphaAddrs(opts ...Option) ([]Typha, error) {
-	options := options{
-		k8sServicePortName: "calico-typha",
+func (d *Discoverer) LoadTyphaAddrs() (ts []Typha, err error) {
+	defer func() {
+		d.allKnownAddrs = ts
+	}()
+	ts, err = d.discoverTyphaAddrs()
+	if err != nil {
+		return
 	}
-
-	for _, o := range opts {
-		o(&options)
+	for _, f := range d.filters {
+		ts, err = f(ts)
+		if err != nil {
+			return nil, fmt.Errorf("typha post-discovery filter failed: %w", err)
+		}
 	}
+	return
+}
 
-	if options.addrOverride != "" {
-		// Explicit address; trumps other sources of config.
-		return []Typha{{Addr: options.addrOverride}}, nil
-	}
+func (d *Discoverer) CachedTyphaAddrs() []Typha {
+	return d.allKnownAddrs
+}
 
-	if options.k8sServiceName == "" {
-		// No explicit address, and no service name, not using Typha.
+func (d *Discoverer) TyphaEnabled() bool {
+	return d.addrOverride != "" || d.k8sServiceName != ""
+}
+
+func (d *Discoverer) discoverTyphaAddrs() ([]Typha, error) {
+	if !d.TyphaEnabled() {
 		return nil, nil
 	}
 
+	if d.addrOverride != "" {
+		// Explicit address; trumps other sources of config.
+		return []Typha{{Addr: d.addrOverride}}, nil
+	}
+
 	// If we get here, we need to look up the Typha service using the k8s API.
-	if options.k8sClient == nil && options.inCluster {
+	if d.k8sClient == nil && d.inCluster {
 		// Client didn't provide a kube client but we're allowed to create one.
+		logrus.Info("Creating Kubernetes client for Typha discovery...")
 		k8sConf, err := rest.InClusterConfig()
 		if err != nil {
 			logrus.WithError(err).Error("Unable to create in-cluster Kubernetes config.")
 			return nil, err
 		}
-		options.k8sClient, err = kubernetes.NewForConfig(k8sConf)
+		d.k8sClient, err = kubernetes.NewForConfig(k8sConf)
 		if err != nil {
 			logrus.WithError(err).Error("Unable to create Kubernetes client set.")
 			return nil, err
 		}
-	} else if options.k8sClient == nil {
+	} else if d.k8sClient == nil {
 		return nil, errors.New("failed to look up Typha, no Kubernetes client available")
 	}
 
 	// If we get here, we need to look up the Typha service endpoints using the k8s API.
-	epClient := options.k8sClient.CoreV1().Endpoints(options.k8sNamespace)
-	eps, err := epClient.Get(context.Background(), options.k8sServiceName, v1.GetOptions{})
+	logrus.Info("(Re)discovering Typha endpoints using the Kubernetes API...")
+	epClient := d.k8sClient.CoreV1().Endpoints(d.k8sNamespace)
+	eps, err := epClient.Get(context.Background(), d.k8sServiceName, v1.GetOptions{})
 	if err != nil {
 		logrus.WithError(err).Error("Unable to get Typha service endpoints from Kubernetes.")
 		return nil, err
@@ -155,7 +208,7 @@ func DiscoverTyphaAddrs(opts ...Option) ([]Typha, error) {
 	for _, subset := range eps.Subsets {
 		var portForOurVersion int32
 		for _, port := range subset.Ports {
-			if port.Name == options.k8sServicePortName {
+			if port.Name == d.k8sServicePortName {
 				portForOurVersion = port.Port
 				break
 			}
@@ -168,7 +221,7 @@ func DiscoverTyphaAddrs(opts ...Option) ([]Typha, error) {
 		// If we get here, this endpoint supports the typha port we're looking for.
 		for _, h := range subset.Addresses {
 			typhaAddr := net.JoinHostPort(h.IP, fmt.Sprint(portForOurVersion))
-			if h.NodeName != nil && *h.NodeName == options.nodeName { // is local
+			if h.NodeName != nil && *h.NodeName == d.nodeName { // is local
 				local = append(local, Typha{Addr: typhaAddr, IP: h.IP, NodeName: h.NodeName})
 			} else {
 				remote = append(remote, Typha{Addr: typhaAddr, IP: h.IP, NodeName: h.NodeName})
@@ -189,7 +242,7 @@ func DiscoverTyphaAddrs(opts ...Option) ([]Typha, error) {
 	addresses = append(local, remote...)
 
 	fields := logrus.Fields{"addresses": addresses}
-	if options.nodeName != "" {
+	if d.nodeName != "" {
 		fields["local"] = local
 		fields["remote"] = remote
 	}
@@ -197,6 +250,84 @@ func DiscoverTyphaAddrs(opts ...Option) ([]Typha, error) {
 	logrus.WithFields(fields).Info("Found ready Typha addresses.")
 
 	return addresses, nil
+}
+
+type AddressLoader interface {
+	LoadTyphaAddrs() (ts []Typha, err error)
+	CachedTyphaAddrs() []Typha
+}
+
+func NewConnAttemptTracker(d AddressLoader) *ConnectionAttemptTracker {
+	return &ConnectionAttemptTracker{
+		discoverer:           d,
+		previouslyTriedAddrs: set.New[string](),
+	}
+}
+
+// ConnectionAttemptTracker deals with the fact that the list of available Typha instances may change during
+// a connection attempt.  Each call to NextAddr refreshes the list of available Typha addresses (if needed)
+// and then returns the first entry in the list that has not been returned before.  If the list is static,
+// NextAddr() will effectively just iterate through the static list.
+type ConnectionAttemptTracker struct {
+	discoverer           AddressLoader
+	previouslyTriedAddrs set.Set[string] // set contains output from dedupeKey()
+	allKnownAddrs        []Typha
+}
+
+var ErrTriedAllAddrs = fmt.Errorf("tried all available discovered addresses")
+
+func (d *ConnectionAttemptTracker) NextAddr() (Typha, error) {
+	if d.previouslyTriedAddrs.Len() > 0 || len(d.allKnownAddrs) == 0 {
+		// Either the addresses have never been loaded or this is a retry.  Refresh the list of addresses
+		// before we choose. This is important during upgrade to prevent an unlucky calico-node daemon from
+		// loading all the old Typha addresses just before the new ones come online.  In that case we'd
+		// try all the old addresses one by one with a 10s timeout for each address before giving up.
+		if err := d.refreshAddrs(); err != nil {
+			return Typha{}, err
+		}
+	}
+
+	return d.pickNextTypha()
+}
+
+func (d *ConnectionAttemptTracker) refreshAddrs() error {
+	if d.previouslyTriedAddrs.Len() == 0 {
+		// First time, use the cache if available.
+		d.allKnownAddrs = d.discoverer.CachedTyphaAddrs()
+		logrus.WithField("addrs", d.allKnownAddrs).Debug("Using cached typha addresses")
+		if len(d.allKnownAddrs) > 0 {
+			return nil
+		}
+	}
+
+	logrus.Debug("Reloading list of Typhas...")
+	addrs, err := d.discoverer.LoadTyphaAddrs()
+	if err != nil {
+		return fmt.Errorf("failed to reload list Typha addresses: %w", err)
+	}
+	logrus.WithField("addrs", addrs).Debug("New list of Typha instances")
+	if len(addrs) == 0 {
+		logrus.Panic("NextAddr() called but this cluster doesn't use Typha?")
+	}
+	d.allKnownAddrs = addrs
+	return nil
+}
+
+func (d *ConnectionAttemptTracker) pickNextTypha() (Typha, error) {
+	// Find the next addr that we haven't recorded as already tried.  Note: we don't want to randomise the
+	// choice _here_ because discoverTyphaAddrs and the filter functions already put the typha instances in
+	// preference order.
+	for _, a := range d.allKnownAddrs {
+		addrKey := a.dedupeKey()
+		if d.previouslyTriedAddrs.Contains(addrKey) {
+			logrus.WithField("key", addrKey).Debug("Already tried this Typha")
+			continue
+		}
+		d.previouslyTriedAddrs.Add(addrKey)
+		logrus.WithField("typha", a).Debug("Found next typha to try.")
+		return a, nil
+	}
+	return Typha{}, ErrTriedAllAddrs
 }
 
 func shuffleInPlace(s []Typha) {

--- a/typha/pkg/syncclient/sync_client.go
+++ b/typha/pkg/syncclient/sync_client.go
@@ -111,7 +111,7 @@ func (o *Options) validate() (err error) {
 }
 
 func New(
-	addrs []discovery.Typha,
+	discoverer *discovery.Discoverer,
 	myVersion, myHostname, myInfo string,
 	cbs api.SyncerCallbacks,
 	options *Options,
@@ -130,8 +130,8 @@ func New(
 			"myID": id,
 			"type": options.SyncerType,
 		}),
-		callbacks: cbs,
-		addrs:     addrs,
+		callbacks:  cbs,
+		discoverer: discoverer,
 
 		myVersion:  myVersion,
 		myHostname: myHostname,
@@ -147,7 +147,7 @@ func New(
 type SyncerClient struct {
 	ID                            uint64
 	logCxt                        *log.Entry
-	addrs                         []discovery.Typha
+	discoverer                    *discovery.Discoverer
 	connInfo                      *discovery.Typha
 	myHostname, myVersion, myInfo string
 	options                       *Options
@@ -169,22 +169,34 @@ type handshakeStatus struct {
 }
 
 func (s *SyncerClient) Start(cxt context.Context) error {
-	s.logCxt.WithField("addresses", s.addrs).Info("Syncer started")
-	// Connect synchronously.
-	var connectOk bool
-	for i, addr := range s.addrs {
-		s.logCxt.Infof("connecting to typha endpoint %s (%d of %d)", addr.Addr, i+1, len(s.addrs))
-		err := s.connect(cxt, addr)
+	// Connect synchronously so that we can return an error early if we can't connect at all.
+	s.logCxt.Info("Starting Typha client...")
+
+	// Defensive: set a sanity limit in case NextAddr() keeps finding new Typha addresses.
+	maxTries := len(s.discoverer.CachedTyphaAddrs()) * 2
+	if maxTries < 6 {
+		maxTries = 6
+	}
+	remainingTries := maxTries
+	cat := discovery.NewConnAttemptTracker(s.discoverer)
+	for {
+		remainingTries--
+		if remainingTries < 0 {
+			return fmt.Errorf("failed to connect to Typha after %d tries", maxTries)
+		}
+		addr, err := cat.NextAddr()
 		if err != nil {
-			s.logCxt.WithError(err).Warnf("error connecting to typha endpoint (%d of %d) %s", i+1, len(s.addrs), addr.Addr)
+			return fmt.Errorf("failed to load next Typha address to try: %w", err)
+		}
+		s.logCxt.Infof("Connecting to typha endpoint %s.", addr.Addr)
+		err = s.connect(cxt, addr)
+		if err != nil {
+			s.logCxt.WithError(err).Warnf("Failed to connect to typha endpoint %s.  Will try another if available...", addr.Addr)
+			time.Sleep(100 * time.Millisecond) // Avoid tight loop.
 		} else {
-			connectOk = true
+			s.logCxt.Infof("Successfully connected to Typha at %s.", addr.Addr)
 			break
 		}
-	}
-	// ran out of addresses with errors
-	if !connectOk {
-		return fmt.Errorf("connection to typhas (%v) failed", s.addrs)
 	}
 
 	// Then start our background goroutines.  We start the main loop and a second goroutine to

--- a/typha/pkg/syncclientutils/startsyncerclient.go
+++ b/typha/pkg/syncclientutils/startsyncerclient.go
@@ -39,23 +39,24 @@ func MustStartSyncerClientIfTyphaConfigured(
 	myVersion, myHostname, myInfo string,
 	cbs api.SyncerCallbacks,
 ) bool {
-	typhaAddr, err := discovery.DiscoverTyphaAddrs(
+	discoverer := discovery.New(
 		discovery.WithAddrOverride(typhaConfig.Addr),
 		discovery.WithInClusterKubeClient(), /* defer creation of a client until its needed. */
 		discovery.WithKubeService(typhaConfig.K8sNamespace, typhaConfig.K8sServiceName),
 	)
+	typhaAddrs, err := discoverer.LoadTyphaAddrs()
 	if err != nil {
 		log.WithError(err).Fatal("Typha discovery enabled but discovery failed.")
 	}
-	if len(typhaAddr) == 0 {
+	if !discoverer.TyphaEnabled() {
 		log.Debug("Typha is not configured")
 		return false
 	}
 
 	// Use a remote Syncer, via the Typha server.
-	log.WithField("addr", typhaAddr).Info("Connecting to Typha.")
+	log.WithField("addr", typhaAddrs).Info("Connecting to Typha.")
 	typhaConnection := syncclient.New(
-		typhaAddr,
+		discoverer,
 		myVersion, myHostname, myInfo,
 		cbs,
 		&syncclient.Options{


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Rework Typha discovery to avoid a long timeout if we happen to race with a Typha upgrade.  Previously we could:

- Load the list of typhas, just before...
- ...all the typhas start shutting down to be upgraded
- Attempt to connect to all the dead typhas one by one.
- Only once we'd timed out trying to connect to each gone Typha, give up and restart.  This could take 10s * number of Typhas; not the end of the world but also much longer than desired.

This change makes sure that we reload the list of Typhas between calls:

- Extract out a Discoverer object to keep track of the discovery parameters.
- Have the discoverer call back to initiate wireguard bootstrap handling.
- Replace loop over slice of Typhas with an object that handles refreshing the list of Typhas and avoiding connecting to the same one twice.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, if a Typha client loads the list of Typha instances just before they all get upgraded, it takes 30s+ to time out.  Reload the list of Typha instances between each connection attempt.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
