### PR TITLE
Output the tail of CI logs. Extend log output.

### DIFF
--- a/.semaphore/run-and-monitor
+++ b/.semaphore/run-and-monitor
@@ -16,7 +16,7 @@
 
 set -e
 
-num_unfiltered_lines=1000
+num_unfiltered_lines=2000
 log_monitor_regexps=(
   "Failure"
   "FAIL"
@@ -71,7 +71,8 @@ tail --pid $pid -n 1000000 -F "$log_file" | {
 } &
 mon_pid=$!
 
-final_result=0
+final_result=1
+final_msg="==== Command ${cmd_escaped}INTERRUPTED (PID=$pid).  Full command output in artifacts/${log_file_name}."
 cmd_done=false
 function cleanup()
 {
@@ -79,21 +80,37 @@ function cleanup()
   if ! $cmd_done; then
     echo "==== Stopping command PID=${pid}..."
     kill $pid || true
-    final_result=1
   fi
-  echo "==== Done, exiting with RC=$final_result"
+
+  sleep 1 # So tail and grep can finish after stopping the main process.
+  output-tail
+  echo "$final_msg; exit with RC=$final_result"
   exit $final_result
 }
 trap cleanup EXIT
 
+function output-tail()
+{
+  # Output the last num_unfiltered_lines lines of the log, unless the log is short, in which case
+  # don't log lines that were already logged by head, above.
+  num_lines=$(wc "$log_file" | cut -d ' ' -f1)
+  if (( num_lines > num_unfiltered_lines )); then
+    num_lines_to_tail=$(( num_lines - num_unfiltered_lines ))
+    if (( num_lines_to_tail > num_unfiltered_lines )); then
+      num_lines_to_tail=$num_unfiltered_lines
+    fi
+    echo "---- Tail of output (may duplicate some lines that hit the log filter above) ----";
+    tail -n $num_lines_to_tail "$log_file"
+  fi
+}
+
 echo "==== Filtered output to screen, full output in artifacts/${log_file_name} (main PID=$pid, filter PID=$mon_pid)"
 if wait "$pid"; then
-  sleep 1 # so tail can finish
-  echo "==== Command ${cmd_escaped}SUCCEEDED (PID=$pid).  Full command output in artifacts/${log_file_name}."
+  final_msg="==== Command ${cmd_escaped}SUCCEEDED (PID=$pid).  Full command output in artifacts/${log_file_name}."
+  final_result=0
 else
-  sleep 1 # so tail can finish
-  echo "==== Command ${cmd_escaped}FAILED (PID=$pid).  Full command output in artifacts/${log_file_name}."
-  final_result=1
+  final_msg="==== Command ${cmd_escaped}FAILED (PID=$pid).  Full command output in artifacts/${log_file_name}."
 fi
+
 cmd_done=true
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adjust the run-and-monitor script so that it outputs both the first N lines of the log and the last N lines of the log.  Usually the last N lines of a failed log are useful since they tell you what went wrong.  Take care to avoid re-logging the first N lines.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
