### PR TITLE
[BPF] Restart IPVS mode bug fix - no need to plumb in config

### DIFF
--- a/felix/dataplane/driver.go
+++ b/felix/dataplane/driver.go
@@ -365,7 +365,7 @@ func StartDataplaneDriver(configParams *config.Config,
 		}
 
 		intDP := intdataplane.NewIntDataplaneDriver(dpConfig)
-		intDP.Start(configParams)
+		intDP.Start()
 
 		// Set source-destination-check on AWS EC2 instance.
 		if configParams.AWSSrcDstCheck != string(apiv3.AWSSrcDstCheckOptionDoNothing) {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1230,12 +1230,12 @@ func (d *InternalDataplane) RegisterManager(mgr Manager) {
 	d.allManagers = append(d.allManagers, mgr)
 }
 
-func (d *InternalDataplane) Start(configParams *config.Config) {
+func (d *InternalDataplane) Start() {
 	// Do our start-of-day configuration.
 	d.doStaticDataplaneConfig()
 
 	// Then, start the worker threads.
-	go d.loopUpdatingDataplane(configParams)
+	go d.loopUpdatingDataplane()
 	go d.loopReportingStatus()
 	go d.ifaceMonitor.MonitorInterfaces()
 	go d.monitorHostMTU()
@@ -1639,7 +1639,7 @@ func (d *InternalDataplane) shutdownXDPCompletely() error {
 	return fmt.Errorf("Failed to wipe the XDP state after %v tries over %v seconds: Error %v", maxTries, waitInterval, err)
 }
 
-func (d *InternalDataplane) loopUpdatingDataplane(configParams *config.Config) {
+func (d *InternalDataplane) loopUpdatingDataplane() {
 	log.Info("Started internal iptables dataplane driver loop")
 	healthTicks := time.NewTicker(healthInterval).C
 	d.reportHealth()
@@ -1702,7 +1702,7 @@ func (d *InternalDataplane) loopUpdatingDataplane(configParams *config.Config) {
 
 	processIfaceUpdate := func(ifaceUpdate *ifaceUpdate) {
 		log.WithField("msg", ifaceUpdate).Info("Received interface update")
-		if ifaceUpdate.Name == KubeIPVSInterface && !configParams.BPFEnabled {
+		if ifaceUpdate.Name == KubeIPVSInterface && !d.config.BPFEnabled {
 			d.checkIPVSConfigOnStateUpdate(ifaceUpdate.State)
 			return
 		}


### PR DESCRIPTION
Fixes unnecessary plumbing of config in https://github.com/projectcalico/calico/pull/7174  because it is already available 


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
