### PR TITLE
Pin to the version of tox that was recently working for us

### DIFF
--- a/networking-calico/Dockerfile
+++ b/networking-calico/Dockerfile
@@ -4,4 +4,4 @@ FROM python:3.8
 
 COPY --from=etcd /usr/local/bin/etcd /usr/local/bin/etcd
 
-RUN pip3 install tox
+RUN pip3 install tox==3.25.1


### PR DESCRIPTION
tox 4 generally broke OpenStack usage - see
https://lists.openstack.org/pipermail/openstack-discuss/2023-January/031668.html

I discovered this while making an unrelated OpenStack change, when I saw that our unit tests were no longer running at all.  This is the fix for that general unit test problem, so now I've posting that first in its own PR.