### PR TITLE
doc: VXLAN in IPv6 is only supported for kernel versions >= 3.12

### DIFF
--- a/calico/networking/ipv6.md
+++ b/calico/networking/ipv6.md
@@ -46,6 +46,7 @@ This how-to guide uses the following {{site.prodname}} features:
   - The sysctl setting, `net.ipv6.conf.all.forwarding`, is set to `1`.
     This ensures both Kubernetes service traffic and {{site.prodname}} traffic is forwarded appropriately.
   - A default IPv6 route
+  - VXLAN in IPv6 is only supported for kernel versions >= 3.12
 
 **Kubernetes IPv4 host requirements**
   - An IPv4 address that is reachable from the other hosts


### PR DESCRIPTION
## Description

doc: VXLAN in IPv6 is only supported for kernel versions >= 3.12

## Related issues/PRs

https://github.com/projectcalico/calico/issues/6877
https://github.com/projectcalico/calico/issues/6273

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [√ ] Documentation
- [√ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
