### PR TITLE
Fix issues in networking-calico (OpenStack) UT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ hack/test/kind/kubectl
 hack/test/kind/*kubeconfig.yaml
 pod2daemon/node-driver-registrar/
 
+/networking-calico/upper-constraints.txt

--- a/networking-calico/.testr.conf
+++ b/networking-calico/.testr.conf
@@ -3,10 +3,8 @@ test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-0} \
              OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
 	     sh -c '\
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/tests && \
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_election && \
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_plugin_etcd && \
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_compaction'
+             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/tests $LISTOPT $IDOPTION && \
+             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/plugins/ml2/drivers/calico/test $LISTOPT $IDOPTION'
 
 test_id_option=--load-list $IDFILE
 test_list_option=--list

--- a/networking-calico/.testr.conf
+++ b/networking-calico/.testr.conf
@@ -2,10 +2,11 @@
 test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-0} \
              OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/tests
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_election
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_plugin_etcd
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_compaction
+	     sh -c '\
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/tests && \
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_election && \
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_plugin_etcd && \
+             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_compaction'
 
 test_id_option=--load-list $IDFILE
 test_list_option=--list

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -5,5 +5,7 @@ include ../metadata.mk
 ###############################################################################
 
 tox:
+	curl -L https://releases.openstack.org/constraints/upper/ussuri -o upper-constraints.txt
+	sed -i '/etcd3gw/d' upper-constraints.txt
 	docker build -t networking-calico-test .
 	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code --rm networking-calico-test tox

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1783,8 +1783,8 @@ class TestStatusWatcher(TestStatusWatcherBase):
             mock.call("hostname", "ep1", {"status": "up"}, priority="low"),
         ], any_order=True)
 
-        # Resync after deleting the Felix status.  We should see the other
-        # endpoint reported with status None.
+        # Resync after deleting the Felix status.  This does not affect the
+        # status of ep1.
         del self.etcd_data[felix_status_key]
         self.driver.on_felix_alive.reset_mock()
         self.driver.on_port_status_changed.reset_mock()
@@ -1792,7 +1792,7 @@ class TestStatusWatcher(TestStatusWatcherBase):
         self.watcher.start()
         self.driver.on_felix_alive.assert_not_called()
         self.driver.on_port_status_changed.assert_has_calls([
-            mock.call("hostname", "ep1", None, priority="low"),
+            mock.call("hostname", "ep1", {"status": "up"}, priority="low"),
         ], any_order=True)
 
         # Resync with some follow-on events; checks that the priority goes

--- a/networking-calico/networking_calico/tests/test_fv_etcdutils.py
+++ b/networking-calico/networking_calico/tests/test_fv_etcdutils.py
@@ -50,6 +50,7 @@ class TestFVEtcdutils(unittest.TestCase):
 
     def start_etcd_server(self):
         shutil.rmtree(".default.etcd", ignore_errors=True)
+        shutil.rmtree("default.etcd", ignore_errors=True)
         self.etcd = subprocess.Popen([
             "/usr/local/bin/etcd",
             "--advertise-client-urls", "http://127.0.0.1:2379",

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -20,5 +20,3 @@ neutron>=16,<17
 neutron-lib==2.3.0
 mock>=3.0.0 # BSD
 pyroute2<0.6.0 # Apache v2
-
-nose2

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -8,6 +8,7 @@ usedevelop = True
 setenv =
    VIRTUAL_ENV={envdir}
    PYTHONWARNINGS=default::DeprecationWarning,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:site,ignore:Using or importing the ABCs,ignore:dns.hash module,ignore:Please provide `is_available
+   PIP_CONSTRAINT={toxinidir}/upper-constraints.txt
 deps = -r{toxinidir}/test-requirements.txt
 commands =
     pip install -q -e "git+https://opendev.org/openstack/etcd3gw.git@1.0.1#egg=etcd3gw"


### PR DESCRIPTION
#### Use Python package constraints for Ussuri, except for etcd3gw

etcd3gw is an exception because in that case we want to use a later version.

Adding these constraints was specifically prompted by noticing that the latest dnspython (2.3,
released end December) breaks us; but then I realized that we really ought to be using the full set
of constraints that OpenStack curate for each release.

#### Given that we currently have failing UTs, make sure to fail overall!

#### etcd data dir is now default.etcd; clean it when starting etcd

I'm not sure if it was previously .default.etcd with another version, but I see no harm from keeping
the rmtree for that name as well.

#### Revert to using subunit.run instead of nose2

There seems to be a conflict between nose2's and neutron.test.base's handling of failed tests.  They
both have non-trivial code for intercepting assertion failures, and when test_dhcp_agent.py fails on
this line:

            # Check DHCP driver was asked to restart.
            call_driver.assert_called_with('restart', mock.ANY)

the result is that we get an exception from nose2's own code about not being able to use `join` with
an argument that is not an iterable.  Modifying the nose2 code at that point shows this:

    MODIFIED OUTPUT:
    test=<networking_calico.tests.test_dhcp_agent.TestDhcpAgent.test_mainline id=0x7fc780dd9a60>
    exctype=<class 'testtools.testresult.real._StringException'>
    value=_StringException('
    Empty attachments:
      stdout

    Traceback (most recent call last):
      File "/code/.tox/py38/lib/python3.8/site-packages/neutron/tests/base.py", line 182, in func
        return f(self, *args, **kwargs)
      File "/code/networking_calico/tests/test_dhcp_agent.py", line 137, in test_mainline
        call_driver.assert_called_with(\'restart\', mock.ANY)
      File "/code/.tox/py38/lib/python3.8/site-packages/mock/mock.py", line 932, in assert_called_with
        raise AssertionError(error_message)
    AssertionError: expected call not found.
    Expected: call_driver(\'restart\', <ANY>)
    Actual: not called.
    ')
    tb=None

It looks like nose2 expects direct access to the traceback, but neutron.test.base has already
reformatted into a string form that nose2 can't handle.

When we revert to using subunit.run, we get this useful failure output:

    FAIL: networking_calico.tests.test_dhcp_agent.TestDhcpAgent.test_mainline
    tags: worker-0
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/code/.tox/py38/lib/python3.8/site-packages/neutron/tests/base.py", line 182, in func
        return f(self, *args, **kwargs)
      File "/code/networking_calico/tests/test_dhcp_agent.py", line 137, in test_mainline
        call_driver.assert_called_with('restart', mock.ANY)
      File "/code/.tox/py38/lib/python3.8/site-packages/mock/mock.py", line 932, in assert_called_with
        raise AssertionError(error_message)
    AssertionError: expected call not found.
    Expected: call_driver('restart', <ANY>)
    Actual: not called.

Obvious question: so why did I recently switch from subunit.run to nose2?  I can't remember
precisely, but I suspect it was a situation that has now been fixed in the more correct way by
imposing all of the Ussuri release's constraints on Python packages.

#### Adapt test_dhcp_agent for recent move of dnsmasq update to own thread

That happened in commit 9a8a6c9bc2.  The failing test was missed at the time because of how
test_command was defined in .testr.conf.

#### Fix bug with port status checking in test_snapshot

We had a bug in product code that was recently fixed by
https://github.com/projectcalico/calico/pull/6979.  That bug caused some port statuses to be
signalled as "None" when they should not be.

Unfortunately we also had this test (test_snapshot) that had been coded to match the bug, i.e. to
expect a port status update of "None".  The correct behaviour is that the port status should not be
changed by this passage of test code.

This was missed at the time of the 6979 PR because our UT running had a bug that allowed some tests
to fail but still reported success overall.
