### PR TITLE
fix(docs): quickstart guide - separate out the taint commands

### DIFF
--- a/calico/getting-started/kubernetes/quickstart.md
+++ b/calico/getting-started/kubernetes/quickstart.md
@@ -108,7 +108,8 @@ The geeky details of what you get:
 1. Remove the taints on the master so that you can schedule pods on it.
 
    ```
-   kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
+   kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+   kubectl taint nodes --all node-role.kubernetes.io/master-
    ```
 
    It should return the following.


### PR DESCRIPTION
## Description

I propose to separate out the taints commands since when one fails, all fail:

```
a-vm:~$ kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
error: taint "node-role.kubernetes.io/master" not found
```

Turned out the only taint I had is "node-role.kubernetes.io/control-plane"
```
a-vm:~$ kubectl get nodes -o json | jq '.items[].spec'
{
  "podCIDR": "192.168.0.0/24",
  "podCIDRs": [
    "192.168.0.0/24"
  ],
  "taints": [
    {
      "effect": "NoSchedule",
      "key": "node-role.kubernetes.io/control-plane"
    }
  ]
}
```

So, this ran okay:
```
a-vm:~$ kubectl taint nodes --all node-role.kubernetes.io/control-plane-
node/nandaa-vm untainted
```

## Release Note

- `release-note-not-required`: This PR has no user-facing changes.
