### PR TITLE
[release-v3.24] Auto pick #7189: Host the ocp.tgz bundle on our GitHub releases instead of in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ helm-index:
 			     SEMAPHORE_WORKFLOW_FILE=../releases/calico/helmindex/update_helm.yml \
 			     $(MAKE) semaphore-run-workflow
 
+# Creates the tar file used for installing Calico on OpenShift.
+bin/ocp.tgz: manifests/ocp/
+	mkdir -p bin
+	tar czvf $@ -C manifests/ ocp
+
 ## Generates release notes for the given version.
 .PHONY: release-notes
 release-notes:

--- a/calico/_includes/content/install-openshift-manifests.md
+++ b/calico/_includes/content/install-openshift-manifests.md
@@ -2,6 +2,6 @@ Download the {{site.prodname}} manifests for OpenShift and add them to the gener
 
 ```bash
 mkdir calico
-wget -qO- {{ "/manifests/ocp.tgz" | absolute_url }} | tar xvz --strip-components=1 -C calico
+wget -qO- https://github.com/projectcalico/calico/releases/download/{{page.version}}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/
 ```

--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -111,6 +111,9 @@ func (r *ReleaseBuilder) BuildRelease() error {
 	// Build the helm charts
 	r.runner.Run("make", []string{"chart"}, []string{})
 
+	// Build OpenShift bundle.
+	r.runner.Run("make", []string{"bin/ocp.tgz"}, []string{})
+
 	// TODO: Assert the produced images are OK. e.g., have correct
 	// commit and version information compiled in.
 
@@ -253,7 +256,7 @@ func (r *ReleaseBuilder) collectGithubArtifacts(ver string) error {
 		return err
 	}
 
-	// Add in the already-built windows zip archive, the Windows install script, and the helm chart.
+	// Add in the already-built windows zip archive, the Windows install script, ocp bundle, and the helm chart.
 	if _, err := r.runner.Run("cp", []string{fmt.Sprintf("node/dist/calico-windows-%s.zip", ver), uploadDir}, nil); err != nil {
 		return err
 	}
@@ -261,6 +264,9 @@ func (r *ReleaseBuilder) collectGithubArtifacts(ver string) error {
 		return err
 	}
 	if _, err := r.runner.Run("cp", []string{fmt.Sprintf("bin/tigera-operator-%s.tgz", ver), uploadDir}, nil); err != nil {
+		return err
+	}
+	if _, err := r.runner.Run("cp", []string{"manifests/ocp.tgz", ver, uploadDir}, nil); err != nil {
 		return err
 	}
 
@@ -397,6 +403,7 @@ Attached to this release are the following artifacts:
 - {release_tar}: container images, binaries, and kubernetes manifests.
 - {calico_windows_zip}: Calico for Windows.
 - {helm_chart}: Calico Helm v3 chart.
+- ocp.tgz: Manifest bundle for OpenShift.
 `
 	sv, err := semver.NewVersion(strings.TrimPrefix(ver, "v"))
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #7189 on release-v3.24.

#7189: Host the ocp.tgz bundle on our GitHub releases instead of in

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Currently, this is handled as part of the docs build. However, when we switch to the new docs infrastructure, the docs will no longer be in this repository and we want to decouple product artifacts from documentation.

So instead, this PR has us build ocp.tgz at release time and host it on our GitHub release.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ocp.tgz now hosted on GitHub
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.