### PR TITLE
[release-v3.25] Auto pick #7216: Add operator-crds.yaml to manifest generation

### DIFF
--- a/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_apiservers_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/tigera-operator/crds/operator.tigera.io_imagesets_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_imagesets_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_installations_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/tigera-operator/crds/operator.tigera.io_tigerastatuses_crd.yaml
+++ b/charts/tigera-operator/crds/operator.tigera.io_tigerastatuses_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -53,6 +53,26 @@ for FILE in $(ls ../charts/calico/crds); do
 done
 
 ##########################################################################
+# Build manifest which includes both Calico and Operator CRDs.
+##########################################################################
+echo "# CustomResourceDefinitions for Calico and Tigera operator" > operator-crds.yaml
+for FILE in $(ls ../charts/tigera-operator/crds/*.yaml | xargs -n1 basename); do
+	${HELM} -n tigera-operator template \
+		--include-crds \
+		--show-only $FILE \
+	        --set version=$CALICO_VERSION \
+	       ../charts/tigera-operator >> operator-crds.yaml
+done
+for FILE in $(ls ../charts/calico/crds); do
+	${HELM} template ../charts/calico \
+		--include-crds \
+		--show-only $FILE \
+	        --set version=$CALICO_VERSION \
+		-f ../charts/values/calico.yaml >> operator-crds.yaml
+done
+
+
+##########################################################################
 # Build Calico manifests.
 #
 # To add a new manifest to this directory, define

--- a/manifests/ocp/operator.tigera.io_apiservers_crd.yaml
+++ b/manifests/ocp/operator.tigera.io_apiservers_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/ocp/operator.tigera.io_imagesets_crd.yaml
+++ b/manifests/ocp/operator.tigera.io_imagesets_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/ocp/operator.tigera.io_installations_crd.yaml
+++ b/manifests/ocp/operator.tigera.io_installations_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/ocp/operator.tigera.io_tigerastatuses_crd.yaml
+++ b/manifests/ocp/operator.tigera.io_tigerastatuses_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/operator-crds.yaml
+++ b/manifests/operator-crds.yaml
@@ -1,3 +1,4 @@
+# CustomResourceDefinitions for Calico and Tigera operator
 ---
 # Source: crds/operator.tigera.io_apiservers_crd.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -35,6 +36,1308 @@ spec:
             type: object
           spec:
             description: Specification of the desired state for the Tigera API server.
+            properties:
+              apiServerDeployment:
+                description: APIServerDeployment configures the calico-apiserver (or
+                  tigera-apiserver in Enterprise) Deployment. If used in conjunction
+                  with ControlPlaneNodeSelector or ControlPlaneTolerations, then these
+                  overrides take precedence.
+                properties:
+                  metadata:
+                    description: Metadata is a subset of a Kubernetes object's metadata
+                      that is added to the Deployment.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of arbitrary non-identifying
+                          metadata. Each of these key/value pairs are added to the
+                          object's annotations provided the key does not already exist
+                          in the object's annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values that
+                          may match replicaset and service selectors. Each of these
+                          key/value pairs are added to the object's labels provided
+                          the key does not already exist in the object's labels.
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the API server Deployment.
+                    properties:
+                      minReadySeconds:
+                        description: MinReadySeconds is the minimum number of seconds
+                          for which a newly created Deployment pod should be ready
+                          without any of its container crashing, for it to be considered
+                          available. If specified, this overrides any minReadySeconds
+                          value that may be set on the API server Deployment. If omitted,
+                          the API server Deployment will use its default value for
+                          minReadySeconds.
+                        format: int32
+                        maximum: 2147483647
+                        minimum: 0
+                        type: integer
+                      template:
+                        description: Template describes the API server Deployment
+                          pod that will be created.
+                        properties:
+                          metadata:
+                            description: Metadata is a subset of a Kubernetes object's
+                              metadata that is added to the pod's metadata.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a map of arbitrary non-identifying
+                                  metadata. Each of these key/value pairs are added
+                                  to the object's annotations provided the key does
+                                  not already exist in the object's annotations.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a map of string keys and values
+                                  that may match replicaset and service selectors.
+                                  Each of these key/value pairs are added to the object's
+                                  labels provided the key does not already exist in
+                                  the object's labels.
+                                type: object
+                            type: object
+                          spec:
+                            description: Spec is the API server Deployment's PodSpec.
+                            properties:
+                              affinity:
+                                description: 'Affinity is a group of affinity scheduling
+                                  rules for the API server pods. If specified, this
+                                  overrides any affinity that may be set on the API
+                                  server Deployment. If omitted, the API server Deployment
+                                  will use its default value for affinity. WARNING:
+                                  Please note that this field will override the default
+                                  API server Deployment affinity.'
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              containers:
+                                description: Containers is a list of API server containers.
+                                  If specified, this overrides the specified API server
+                                  Deployment containers. If omitted, the API server
+                                  Deployment will use its default values for its containers.
+                                items:
+                                  description: APIServerDeploymentContainer is an
+                                    API server Deployment container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the API server Deployment container by name.
+                                      enum:
+                                      - calico-apiserver
+                                      - tigera-queryserver
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named API server Deployment
+                                        container's resources. If omitted, the API
+                                        server Deployment will use its default value
+                                        for this container's resources. If used in
+                                        conjunction with the deprecated ComponentResources,
+                                        then this value takes precedence.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              initContainers:
+                                description: InitContainers is a list of API server
+                                  init containers. If specified, this overrides the
+                                  specified API server Deployment init containers.
+                                  If omitted, the API server Deployment will use its
+                                  default values for its init containers.
+                                items:
+                                  description: APIServerDeploymentInitContainer is
+                                    an API server Deployment init container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the API server Deployment init container by
+                                        name.
+                                      enum:
+                                      - calico-apiserver-certs-key-cert-provisioner
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named API server Deployment
+                                        init container's resources. If omitted, the
+                                        API server Deployment will use its default
+                                        value for this init container's resources.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is the API server pod''s
+                                  scheduling constraints. If specified, each of the
+                                  key/value pairs are added to the API server Deployment
+                                  nodeSelector provided the key does not already exist
+                                  in the object''s nodeSelector. If used in conjunction
+                                  with ControlPlaneNodeSelector, that nodeSelector
+                                  is set on the API server Deployment and each of
+                                  this field''s key/value pairs are added to the API
+                                  server Deployment nodeSelector provided the key
+                                  does not already exist in the object''s nodeSelector.
+                                  If omitted, the API server Deployment will use its
+                                  default value for nodeSelector. WARNING: Please
+                                  note that this field will modify the default API
+                                  server Deployment nodeSelector.'
+                                type: object
+                              tolerations:
+                                description: 'Tolerations is the API server pod''s
+                                  tolerations. If specified, this overrides any tolerations
+                                  that may be set on the API server Deployment. If
+                                  omitted, the API server Deployment will use its
+                                  default value for tolerations. WARNING: Please note
+                                  that this field will override the default API server
+                                  Deployment tolerations.'
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
             type: object
           status:
             description: Most recently observed status for the Tigera API server.
@@ -48,6 +1351,12 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 # Source: crds/operator.tigera.io_imagesets_crd.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -166,6 +1475,1255 @@ spec:
             description: Specification of the desired state for the Calico or Calico
               Enterprise installation.
             properties:
+              calicoKubeControllersDeployment:
+                description: CalicoKubeControllersDeployment configures the calico-kube-controllers
+                  Deployment. If used in conjunction with the deprecated ComponentResources,
+                  then these overrides take precedence.
+                properties:
+                  metadata:
+                    description: Metadata is a subset of a Kubernetes object's metadata
+                      that is added to the Deployment.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of arbitrary non-identifying
+                          metadata. Each of these key/value pairs are added to the
+                          object's annotations provided the key does not already exist
+                          in the object's annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values that
+                          may match replicaset and service selectors. Each of these
+                          key/value pairs are added to the object's labels provided
+                          the key does not already exist in the object's labels.
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the calico-kube-controllers
+                      Deployment.
+                    properties:
+                      minReadySeconds:
+                        description: MinReadySeconds is the minimum number of seconds
+                          for which a newly created Deployment pod should be ready
+                          without any of its container crashing, for it to be considered
+                          available. If specified, this overrides any minReadySeconds
+                          value that may be set on the calico-kube-controllers Deployment.
+                          If omitted, the calico-kube-controllers Deployment will
+                          use its default value for minReadySeconds.
+                        format: int32
+                        maximum: 2147483647
+                        minimum: 0
+                        type: integer
+                      template:
+                        description: Template describes the calico-kube-controllers
+                          Deployment pod that will be created.
+                        properties:
+                          metadata:
+                            description: Metadata is a subset of a Kubernetes object's
+                              metadata that is added to the pod's metadata.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a map of arbitrary non-identifying
+                                  metadata. Each of these key/value pairs are added
+                                  to the object's annotations provided the key does
+                                  not already exist in the object's annotations.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a map of string keys and values
+                                  that may match replicaset and service selectors.
+                                  Each of these key/value pairs are added to the object's
+                                  labels provided the key does not already exist in
+                                  the object's labels.
+                                type: object
+                            type: object
+                          spec:
+                            description: Spec is the calico-kube-controllers Deployment's
+                              PodSpec.
+                            properties:
+                              affinity:
+                                description: 'Affinity is a group of affinity scheduling
+                                  rules for the calico-kube-controllers pods. If specified,
+                                  this overrides any affinity that may be set on the
+                                  calico-kube-controllers Deployment. If omitted,
+                                  the calico-kube-controllers Deployment will use
+                                  its default value for affinity. WARNING: Please
+                                  note that this field will override the default calico-kube-controllers
+                                  Deployment affinity.'
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              containers:
+                                description: Containers is a list of calico-kube-controllers
+                                  containers. If specified, this overrides the specified
+                                  calico-kube-controllers Deployment containers. If
+                                  omitted, the calico-kube-controllers Deployment
+                                  will use its default values for its containers.
+                                items:
+                                  description: CalicoKubeControllersDeploymentContainer
+                                    is a calico-kube-controllers Deployment container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the calico-kube-controllers Deployment container
+                                        by name.
+                                      enum:
+                                      - calico-kube-controllers
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named calico-kube-controllers
+                                        Deployment container's resources. If omitted,
+                                        the calico-kube-controllers Deployment will
+                                        use its default value for this container's
+                                        resources. If used in conjunction with the
+                                        deprecated ComponentResources, then this value
+                                        takes precedence.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is the calico-kube-controllers
+                                  pod''s scheduling constraints. If specified, each
+                                  of the key/value pairs are added to the calico-kube-controllers
+                                  Deployment nodeSelector provided the key does not
+                                  already exist in the object''s nodeSelector. If
+                                  used in conjunction with ControlPlaneNodeSelector,
+                                  that nodeSelector is set on the calico-kube-controllers
+                                  Deployment and each of this field''s key/value pairs
+                                  are added to the calico-kube-controllers Deployment
+                                  nodeSelector provided the key does not already exist
+                                  in the object''s nodeSelector. If omitted, the calico-kube-controllers
+                                  Deployment will use its default value for nodeSelector.
+                                  WARNING: Please note that this field will modify
+                                  the default calico-kube-controllers Deployment nodeSelector.'
+                                type: object
+                              tolerations:
+                                description: 'Tolerations is the calico-kube-controllers
+                                  pod''s tolerations. If specified, this overrides
+                                  any tolerations that may be set on the calico-kube-controllers
+                                  Deployment. If omitted, the calico-kube-controllers
+                                  Deployment will use its default value for tolerations.
+                                  WARNING: Please note that this field will override
+                                  the default calico-kube-controllers Deployment tolerations.'
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
               calicoNetwork:
                 description: CalicoNetwork specifies networking configuration options
                   for Calico.
@@ -209,6 +2767,12 @@ spec:
                           description: CIDR contains the address range for the IP
                             Pool in classless inter-domain routing format.
                           type: string
+                        disableBGPExport:
+                          default: false
+                          description: 'DisableBGPExport specifies whether routes
+                            from this IP pool''s CIDR are exported over BGP. Default:
+                            false'
+                          type: boolean
                         encapsulation:
                           description: 'Encapsulation specifies the encapsulation
                             type that will be used with the IP Pool. Default: IPIP'
@@ -333,6 +2897,2547 @@ spec:
                         type: string
                     type: object
                 type: object
+              calicoNodeDaemonSet:
+                description: CalicoNodeDaemonSet configures the calico-node DaemonSet.
+                  If used in conjunction with the deprecated ComponentResources, then
+                  these overrides take precedence.
+                properties:
+                  metadata:
+                    description: Metadata is a subset of a Kubernetes object's metadata
+                      that is added to the DaemonSet.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of arbitrary non-identifying
+                          metadata. Each of these key/value pairs are added to the
+                          object's annotations provided the key does not already exist
+                          in the object's annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values that
+                          may match replicaset and service selectors. Each of these
+                          key/value pairs are added to the object's labels provided
+                          the key does not already exist in the object's labels.
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the calico-node DaemonSet.
+                    properties:
+                      minReadySeconds:
+                        description: MinReadySeconds is the minimum number of seconds
+                          for which a newly created DaemonSet pod should be ready
+                          without any of its container crashing, for it to be considered
+                          available. If specified, this overrides any minReadySeconds
+                          value that may be set on the calico-node DaemonSet. If omitted,
+                          the calico-node DaemonSet will use its default value for
+                          minReadySeconds.
+                        format: int32
+                        maximum: 2147483647
+                        minimum: 0
+                        type: integer
+                      template:
+                        description: Template describes the calico-node DaemonSet
+                          pod that will be created.
+                        properties:
+                          metadata:
+                            description: Metadata is a subset of a Kubernetes object's
+                              metadata that is added to the pod's metadata.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a map of arbitrary non-identifying
+                                  metadata. Each of these key/value pairs are added
+                                  to the object's annotations provided the key does
+                                  not already exist in the object's annotations.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a map of string keys and values
+                                  that may match replicaset and service selectors.
+                                  Each of these key/value pairs are added to the object's
+                                  labels provided the key does not already exist in
+                                  the object's labels.
+                                type: object
+                            type: object
+                          spec:
+                            description: Spec is the calico-node DaemonSet's PodSpec.
+                            properties:
+                              affinity:
+                                description: 'Affinity is a group of affinity scheduling
+                                  rules for the calico-node pods. If specified, this
+                                  overrides any affinity that may be set on the calico-node
+                                  DaemonSet. If omitted, the calico-node DaemonSet
+                                  will use its default value for affinity. WARNING:
+                                  Please note that this field will override the default
+                                  calico-node DaemonSet affinity.'
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              containers:
+                                description: Containers is a list of calico-node containers.
+                                  If specified, this overrides the specified calico-node
+                                  DaemonSet containers. If omitted, the calico-node
+                                  DaemonSet will use its default values for its containers.
+                                items:
+                                  description: CalicoNodeDaemonSetContainer is a calico-node
+                                    DaemonSet container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the calico-node DaemonSet container by name.
+                                      enum:
+                                      - calico-node
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named calico-node DaemonSet
+                                        container's resources. If omitted, the calico-node
+                                        DaemonSet will use its default value for this
+                                        container's resources. If used in conjunction
+                                        with the deprecated ComponentResources, then
+                                        this value takes precedence.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              initContainers:
+                                description: InitContainers is a list of calico-node
+                                  init containers. If specified, this overrides the
+                                  specified calico-node DaemonSet init containers.
+                                  If omitted, the calico-node DaemonSet will use its
+                                  default values for its init containers.
+                                items:
+                                  description: CalicoNodeDaemonSetInitContainer is
+                                    a calico-node DaemonSet init container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the calico-node DaemonSet init container by
+                                        name.
+                                      enum:
+                                      - install-cni
+                                      - hostpath-init
+                                      - flexvol-driver
+                                      - mount-bpffs
+                                      - node-certs-key-cert-provisioner
+                                      - calico-node-prometheus-server-tls-key-cert-provisioner
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named calico-node DaemonSet
+                                        init container's resources. If omitted, the
+                                        calico-node DaemonSet will use its default
+                                        value for this container's resources. If used
+                                        in conjunction with the deprecated ComponentResources,
+                                        then this value takes precedence.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is the calico-node pod''s
+                                  scheduling constraints. If specified, each of the
+                                  key/value pairs are added to the calico-node DaemonSet
+                                  nodeSelector provided the key does not already exist
+                                  in the object''s nodeSelector. If omitted, the calico-node
+                                  DaemonSet will use its default value for nodeSelector.
+                                  WARNING: Please note that this field will modify
+                                  the default calico-node DaemonSet nodeSelector.'
+                                type: object
+                              tolerations:
+                                description: 'Tolerations is the calico-node pod''s
+                                  tolerations. If specified, this overrides any tolerations
+                                  that may be set on the calico-node DaemonSet. If
+                                  omitted, the calico-node DaemonSet will use its
+                                  default value for tolerations. WARNING: Please note
+                                  that this field will override the default calico-node
+                                  DaemonSet tolerations.'
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              calicoWindowsUpgradeDaemonSet:
+                description: CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade
+                  DaemonSet.
+                properties:
+                  metadata:
+                    description: Metadata is a subset of a Kubernetes object's metadata
+                      that is added to the Deployment.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of arbitrary non-identifying
+                          metadata. Each of these key/value pairs are added to the
+                          object's annotations provided the key does not already exist
+                          in the object's annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values that
+                          may match replicaset and service selectors. Each of these
+                          key/value pairs are added to the object's labels provided
+                          the key does not already exist in the object's labels.
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the calico-windows-upgrade
+                      DaemonSet.
+                    properties:
+                      minReadySeconds:
+                        description: MinReadySeconds is the minimum number of seconds
+                          for which a newly created Deployment pod should be ready
+                          without any of its container crashing, for it to be considered
+                          available. If specified, this overrides any minReadySeconds
+                          value that may be set on the calico-windows-upgrade DaemonSet.
+                          If omitted, the calico-windows-upgrade DaemonSet will use
+                          its default value for minReadySeconds.
+                        format: int32
+                        maximum: 2147483647
+                        minimum: 0
+                        type: integer
+                      template:
+                        description: Template describes the calico-windows-upgrade
+                          DaemonSet pod that will be created.
+                        properties:
+                          metadata:
+                            description: Metadata is a subset of a Kubernetes object's
+                              metadata that is added to the pod's metadata.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a map of arbitrary non-identifying
+                                  metadata. Each of these key/value pairs are added
+                                  to the object's annotations provided the key does
+                                  not already exist in the object's annotations.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a map of string keys and values
+                                  that may match replicaset and service selectors.
+                                  Each of these key/value pairs are added to the object's
+                                  labels provided the key does not already exist in
+                                  the object's labels.
+                                type: object
+                            type: object
+                          spec:
+                            description: Spec is the calico-windows-upgrade DaemonSet's
+                              PodSpec.
+                            properties:
+                              affinity:
+                                description: 'Affinity is a group of affinity scheduling
+                                  rules for the calico-windows-upgrade pods. If specified,
+                                  this overrides any affinity that may be set on the
+                                  calico-windows-upgrade DaemonSet. If omitted, the
+                                  calico-windows-upgrade DaemonSet will use its default
+                                  value for affinity. WARNING: Please note that this
+                                  field will override the default calico-windows-upgrade
+                                  DaemonSet affinity.'
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              containers:
+                                description: Containers is a list of calico-windows-upgrade
+                                  containers. If specified, this overrides the specified
+                                  calico-windows-upgrade DaemonSet containers. If
+                                  omitted, the calico-windows-upgrade DaemonSet will
+                                  use its default values for its containers.
+                                items:
+                                  description: CalicoWindowsUpgradeDaemonSetContainer
+                                    is a calico-windows-upgrade DaemonSet container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the calico-windows-upgrade DaemonSet container
+                                        by name.
+                                      enum:
+                                      - calico-windows-upgrade
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named calico-windows-upgrade
+                                        DaemonSet container's resources. If omitted,
+                                        the calico-windows-upgrade DaemonSet will
+                                        use its default value for this container's
+                                        resources.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is the calico-windows-upgrade
+                                  pod''s scheduling constraints. If specified, each
+                                  of the key/value pairs are added to the calico-windows-upgrade
+                                  DaemonSet nodeSelector provided the key does not
+                                  already exist in the object''s nodeSelector. If
+                                  omitted, the calico-windows-upgrade DaemonSet will
+                                  use its default value for nodeSelector. WARNING:
+                                  Please note that this field will modify the default
+                                  calico-windows-upgrade DaemonSet nodeSelector.'
+                                type: object
+                              tolerations:
+                                description: 'Tolerations is the calico-windows-upgrade
+                                  pod''s tolerations. If specified, this overrides
+                                  any tolerations that may be set on the calico-windows-upgrade
+                                  DaemonSet. If omitted, the calico-windows-upgrade
+                                  DaemonSet will use its default value for tolerations.
+                                  WARNING: Please note that this field will override
+                                  the default calico-windows-upgrade DaemonSet tolerations.'
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
               certificateManagement:
                 description: CertificateManagement configures pods to submit a CertificateSigningRequest
                   to the certificates.k8s.io/v1beta1 API in order to obtain TLS certificates.
@@ -429,12 +5534,14 @@ spec:
                 - type
                 type: object
               componentResources:
-                description: ComponentResources can be used to customize the resource
-                  requirements for each component. Node, Typha, and KubeControllers
-                  are supported for installations.
+                description: Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment,
+                  and KubeControllersDeployment. ComponentResources can be used to
+                  customize the resource requirements for each component. Node, Typha,
+                  and KubeControllers are supported for installations.
                 items:
-                  description: The ComponentResource struct associates a ResourceRequirements
-                    with a component by name
+                  description: Deprecated. Please use component resource config fields
+                    in Installation.Spec instead. The ComponentResource struct associates
+                    a ResourceRequirements with a component by name
                   properties:
                     componentName:
                       description: ComponentName is an enum which identifies the component
@@ -531,6 +5638,14 @@ spec:
                       type: string
                   type: object
                 type: array
+              fipsMode:
+                description: 'FIPSMode uses images and features only that are using
+                  FIPS 140-2 validated cryptographic modules and standards. Default:
+                  Disabled'
+                enum:
+                - Enabled
+                - Disabled
+                type: string
               flexVolumePath:
                 description: FlexVolumePath optionally specifies a custom path for
                   FlexVolume. If not specified, FlexVolume will be enabled by default.
@@ -571,6 +5686,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              kubeletVolumePluginPath:
+                description: 'KubeletVolumePluginPath optionally specifies enablement
+                  of Calico CSI plugin. If not specified, CSI will be enabled by default.
+                  If set to ''None'', CSI will be disabled. Default: /var/lib/kubelet'
+                type: string
               kubernetesProvider:
                 description: KubernetesProvider specifies a particular provider of
                   the Kubernetes platform and enables provider-specific configuration.
@@ -586,6 +5706,7 @@ spec:
                 - AKS
                 - OpenShift
                 - DockerEnterprise
+                - RKE2
                 type: string
               nodeMetricsPort:
                 description: NodeMetricsPort specifies which port calico/node serves
@@ -630,7 +5751,7 @@ spec:
                           on any given node can double if the readiness check fails,
                           and so resource intensive daemonsets should take into account
                           that they may cause evictions during disruption. This is
-                          an alpha field and requires enabling DaemonSetUpdateSurge
+                          beta field and enabled/disabled by DaemonSetUpdateSurge
                           feature gate.'
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
@@ -641,18 +5762,17 @@ spec:
                           be unavailable during the update. Value can be an absolute
                           number (ex: 5) or a percentage of total number of DaemonSet
                           pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding down to a minimum
-                          of one. This cannot be 0 if MaxSurge is 0 Default value
-                          is 1. Example: when this is set to 30%, at most 30% of the
-                          total number of nodes that should be running the daemon
-                          pod (i.e. status.desiredNumberScheduled) can have their
-                          pods stopped for an update at any given time. The update
-                          starts by stopping at most 30% of those DaemonSet pods and
-                          then brings up new DaemonSet pods in their place. Once the
-                          new pods are available, it then proceeds onto other DaemonSet
-                          pods, thus ensuring that at least 70% of original number
-                          of DaemonSet pods are available at all times during the
-                          update.'
+                          is calculated from percentage by rounding up. This cannot
+                          be 0 if MaxSurge is 0 Default value is 1. Example: when
+                          this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time.
+                          The update starts by stopping at most 30% of those DaemonSet
+                          pods and then brings up new DaemonSet pods in their place.
+                          Once the new pods are available, it then proceeds onto other
+                          DaemonSet pods, thus ensuring that at least 70% of original
+                          number of DaemonSet pods are available at all times during
+                          the update.'
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
@@ -675,7 +5795,8 @@ spec:
                   above format."
                 type: string
               typhaAffinity:
-                description: TyphaAffinity allows configuration of node affinity characteristics
+                description: Deprecated. Please use Installation.Spec.TyphaDeployment
+                  instead. TyphaAffinity allows configuration of node affinity characteristics
                   for Typha pods.
                 properties:
                   nodeAffinity:
@@ -886,6 +6007,1301 @@ spec:
                         type: object
                     type: object
                 type: object
+              typhaDeployment:
+                description: TyphaDeployment configures the typha Deployment. If used
+                  in conjunction with the deprecated ComponentResources or TyphaAffinity,
+                  then these overrides take precedence.
+                properties:
+                  metadata:
+                    description: Metadata is a subset of a Kubernetes object's metadata
+                      that is added to the Deployment.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is a map of arbitrary non-identifying
+                          metadata. Each of these key/value pairs are added to the
+                          object's annotations provided the key does not already exist
+                          in the object's annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of string keys and values that
+                          may match replicaset and service selectors. Each of these
+                          key/value pairs are added to the object's labels provided
+                          the key does not already exist in the object's labels.
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the typha Deployment.
+                    properties:
+                      minReadySeconds:
+                        description: MinReadySeconds is the minimum number of seconds
+                          for which a newly created Deployment pod should be ready
+                          without any of its container crashing, for it to be considered
+                          available. If specified, this overrides any minReadySeconds
+                          value that may be set on the typha Deployment. If omitted,
+                          the typha Deployment will use its default value for minReadySeconds.
+                        format: int32
+                        maximum: 2147483647
+                        minimum: 0
+                        type: integer
+                      template:
+                        description: Template describes the typha Deployment pod that
+                          will be created.
+                        properties:
+                          metadata:
+                            description: Metadata is a subset of a Kubernetes object's
+                              metadata that is added to the pod's metadata.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations is a map of arbitrary non-identifying
+                                  metadata. Each of these key/value pairs are added
+                                  to the object's annotations provided the key does
+                                  not already exist in the object's annotations.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels is a map of string keys and values
+                                  that may match replicaset and service selectors.
+                                  Each of these key/value pairs are added to the object's
+                                  labels provided the key does not already exist in
+                                  the object's labels.
+                                type: object
+                            type: object
+                          spec:
+                            description: Spec is the typha Deployment's PodSpec.
+                            properties:
+                              affinity:
+                                description: 'Affinity is a group of affinity scheduling
+                                  rules for the typha pods. If specified, this overrides
+                                  any affinity that may be set on the typha Deployment.
+                                  If omitted, the typha Deployment will use its default
+                                  value for affinity. If used in conjunction with
+                                  the deprecated TyphaAffinity, then this value takes
+                                  precedence. WARNING: Please note that this field
+                                  will override the default calico-typha Deployment
+                                  affinity.'
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: Represents a
+                                                          key's relationship to a
+                                                          set of values. Valid operators
+                                                          are In, NotIn, Exists, DoesNotExist.
+                                                          Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces. This field
+                                                is beta-level and is only honored
+                                                when PodAffinityNamespaceSelector
+                                                feature is enabled.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace"
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              containers:
+                                description: Containers is a list of typha containers.
+                                  If specified, this overrides the specified typha
+                                  Deployment containers. If omitted, the typha Deployment
+                                  will use its default values for its containers.
+                                items:
+                                  description: TyphaDeploymentContainer is a typha
+                                    Deployment container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the typha Deployment container by name.
+                                      enum:
+                                      - calico-typha
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named typha Deployment container's
+                                        resources. If omitted, the typha Deployment
+                                        will use its default value for this container's
+                                        resources. If used in conjunction with the
+                                        deprecated ComponentResources, then this value
+                                        takes precedence.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              initContainers:
+                                description: InitContainers is a list of typha init
+                                  containers. If specified, this overrides the specified
+                                  typha Deployment init containers. If omitted, the
+                                  typha Deployment will use its default values for
+                                  its init containers.
+                                items:
+                                  description: TyphaDeploymentInitContainer is a typha
+                                    Deployment init container.
+                                  properties:
+                                    name:
+                                      description: Name is an enum which identifies
+                                        the typha Deployment init container by name.
+                                      enum:
+                                      - typha-certs-key-cert-provisioner
+                                      type: string
+                                    resources:
+                                      description: Resources allows customization
+                                        of limits and requests for compute resources
+                                        such as cpu and memory. If specified, this
+                                        overrides the named typha Deployment init
+                                        container's resources. If omitted, the typha
+                                        Deployment will use its default value for
+                                        this init container's resources. If used in
+                                        conjunction with the deprecated ComponentResources,
+                                        then this value takes precedence.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is the calico-typha pod''s
+                                  scheduling constraints. If specified, each of the
+                                  key/value pairs are added to the calico-typha Deployment
+                                  nodeSelector provided the key does not already exist
+                                  in the object''s nodeSelector. If omitted, the calico-typha
+                                  Deployment will use its default value for nodeSelector.
+                                  WARNING: Please note that this field will modify
+                                  the default calico-typha Deployment nodeSelector.'
+                                type: object
+                              tolerations:
+                                description: 'Tolerations is the typha pod''s tolerations.
+                                  If specified, this overrides any tolerations that
+                                  may be set on the typha Deployment. If omitted,
+                                  the typha Deployment will use its default value
+                                  for tolerations. WARNING: Please note that this
+                                  field will override the default calico-typha Deployment
+                                  tolerations.'
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: Effect indicates the taint effect
+                                        to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule,
+                                        PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: Operator represents a key's relationship
+                                        to the value. Valid operators are Exists and
+                                        Equal. Defaults to Equal. Exists is equivalent
+                                        to wildcard for value, so that a pod can tolerate
+                                        all taints of a particular category.
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
               typhaMetricsPort:
                 description: TyphaMetricsPort specifies which port calico/typha serves
                   prometheus metrics on. By default, metrics are not enabled.
@@ -907,6 +7323,1355 @@ spec:
                 description: Computed is the final installation including overlaid
                   resources.
                 properties:
+                  calicoKubeControllersDeployment:
+                    description: CalicoKubeControllersDeployment configures the calico-kube-controllers
+                      Deployment. If used in conjunction with the deprecated ComponentResources,
+                      then these overrides take precedence.
+                    properties:
+                      metadata:
+                        description: Metadata is a subset of a Kubernetes object's
+                          metadata that is added to the Deployment.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a map of arbitrary non-identifying
+                              metadata. Each of these key/value pairs are added to
+                              the object's annotations provided the key does not already
+                              exist in the object's annotations.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a map of string keys and values
+                              that may match replicaset and service selectors. Each
+                              of these key/value pairs are added to the object's labels
+                              provided the key does not already exist in the object's
+                              labels.
+                            type: object
+                        type: object
+                      spec:
+                        description: Spec is the specification of the calico-kube-controllers
+                          Deployment.
+                        properties:
+                          minReadySeconds:
+                            description: MinReadySeconds is the minimum number of
+                              seconds for which a newly created Deployment pod should
+                              be ready without any of its container crashing, for
+                              it to be considered available. If specified, this overrides
+                              any minReadySeconds value that may be set on the calico-kube-controllers
+                              Deployment. If omitted, the calico-kube-controllers
+                              Deployment will use its default value for minReadySeconds.
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                            type: integer
+                          template:
+                            description: Template describes the calico-kube-controllers
+                              Deployment pod that will be created.
+                            properties:
+                              metadata:
+                                description: Metadata is a subset of a Kubernetes
+                                  object's metadata that is added to the pod's metadata.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a map of arbitrary
+                                      non-identifying metadata. Each of these key/value
+                                      pairs are added to the object's annotations
+                                      provided the key does not already exist in the
+                                      object's annotations.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels is a map of string keys and
+                                      values that may match replicaset and service
+                                      selectors. Each of these key/value pairs are
+                                      added to the object's labels provided the key
+                                      does not already exist in the object's labels.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Spec is the calico-kube-controllers Deployment's
+                                  PodSpec.
+                                properties:
+                                  affinity:
+                                    description: 'Affinity is a group of affinity
+                                      scheduling rules for the calico-kube-controllers
+                                      pods. If specified, this overrides any affinity
+                                      that may be set on the calico-kube-controllers
+                                      Deployment. If omitted, the calico-kube-controllers
+                                      Deployment will use its default value for affinity.
+                                      WARNING: Please note that this field will override
+                                      the default calico-kube-controllers Deployment
+                                      affinity.'
+                                    properties:
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                        type: object
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  containers:
+                                    description: Containers is a list of calico-kube-controllers
+                                      containers. If specified, this overrides the
+                                      specified calico-kube-controllers Deployment
+                                      containers. If omitted, the calico-kube-controllers
+                                      Deployment will use its default values for its
+                                      containers.
+                                    items:
+                                      description: CalicoKubeControllersDeploymentContainer
+                                        is a calico-kube-controllers Deployment container.
+                                      properties:
+                                        name:
+                                          description: Name is an enum which identifies
+                                            the calico-kube-controllers Deployment
+                                            container by name.
+                                          enum:
+                                          - calico-kube-controllers
+                                          type: string
+                                        resources:
+                                          description: Resources allows customization
+                                            of limits and requests for compute resources
+                                            such as cpu and memory. If specified,
+                                            this overrides the named calico-kube-controllers
+                                            Deployment container's resources. If omitted,
+                                            the calico-kube-controllers Deployment
+                                            will use its default value for this container's
+                                            resources. If used in conjunction with
+                                            the deprecated ComponentResources, then
+                                            this value takes precedence.
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is the calico-kube-controllers
+                                      pod''s scheduling constraints. If specified,
+                                      each of the key/value pairs are added to the
+                                      calico-kube-controllers Deployment nodeSelector
+                                      provided the key does not already exist in the
+                                      object''s nodeSelector. If used in conjunction
+                                      with ControlPlaneNodeSelector, that nodeSelector
+                                      is set on the calico-kube-controllers Deployment
+                                      and each of this field''s key/value pairs are
+                                      added to the calico-kube-controllers Deployment
+                                      nodeSelector provided the key does not already
+                                      exist in the object''s nodeSelector. If omitted,
+                                      the calico-kube-controllers Deployment will
+                                      use its default value for nodeSelector. WARNING:
+                                      Please note that this field will modify the
+                                      default calico-kube-controllers Deployment nodeSelector.'
+                                    type: object
+                                  tolerations:
+                                    description: 'Tolerations is the calico-kube-controllers
+                                      pod''s tolerations. If specified, this overrides
+                                      any tolerations that may be set on the calico-kube-controllers
+                                      Deployment. If omitted, the calico-kube-controllers
+                                      Deployment will use its default value for tolerations.
+                                      WARNING: Please note that this field will override
+                                      the default calico-kube-controllers Deployment
+                                      tolerations.'
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                    type: object
                   calicoNetwork:
                     description: CalicoNetwork specifies networking configuration
                       options for Calico.
@@ -951,6 +8716,12 @@ spec:
                               description: CIDR contains the address range for the
                                 IP Pool in classless inter-domain routing format.
                               type: string
+                            disableBGPExport:
+                              default: false
+                              description: 'DisableBGPExport specifies whether routes
+                                from this IP pool''s CIDR are exported over BGP. Default:
+                                false'
+                              type: boolean
                             encapsulation:
                               description: 'Encapsulation specifies the encapsulation
                                 type that will be used with the IP Pool. Default:
@@ -1078,6 +8849,2748 @@ spec:
                             type: string
                         type: object
                     type: object
+                  calicoNodeDaemonSet:
+                    description: CalicoNodeDaemonSet configures the calico-node DaemonSet.
+                      If used in conjunction with the deprecated ComponentResources,
+                      then these overrides take precedence.
+                    properties:
+                      metadata:
+                        description: Metadata is a subset of a Kubernetes object's
+                          metadata that is added to the DaemonSet.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a map of arbitrary non-identifying
+                              metadata. Each of these key/value pairs are added to
+                              the object's annotations provided the key does not already
+                              exist in the object's annotations.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a map of string keys and values
+                              that may match replicaset and service selectors. Each
+                              of these key/value pairs are added to the object's labels
+                              provided the key does not already exist in the object's
+                              labels.
+                            type: object
+                        type: object
+                      spec:
+                        description: Spec is the specification of the calico-node
+                          DaemonSet.
+                        properties:
+                          minReadySeconds:
+                            description: MinReadySeconds is the minimum number of
+                              seconds for which a newly created DaemonSet pod should
+                              be ready without any of its container crashing, for
+                              it to be considered available. If specified, this overrides
+                              any minReadySeconds value that may be set on the calico-node
+                              DaemonSet. If omitted, the calico-node DaemonSet will
+                              use its default value for minReadySeconds.
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                            type: integer
+                          template:
+                            description: Template describes the calico-node DaemonSet
+                              pod that will be created.
+                            properties:
+                              metadata:
+                                description: Metadata is a subset of a Kubernetes
+                                  object's metadata that is added to the pod's metadata.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a map of arbitrary
+                                      non-identifying metadata. Each of these key/value
+                                      pairs are added to the object's annotations
+                                      provided the key does not already exist in the
+                                      object's annotations.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels is a map of string keys and
+                                      values that may match replicaset and service
+                                      selectors. Each of these key/value pairs are
+                                      added to the object's labels provided the key
+                                      does not already exist in the object's labels.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Spec is the calico-node DaemonSet's PodSpec.
+                                properties:
+                                  affinity:
+                                    description: 'Affinity is a group of affinity
+                                      scheduling rules for the calico-node pods. If
+                                      specified, this overrides any affinity that
+                                      may be set on the calico-node DaemonSet. If
+                                      omitted, the calico-node DaemonSet will use
+                                      its default value for affinity. WARNING: Please
+                                      note that this field will override the default
+                                      calico-node DaemonSet affinity.'
+                                    properties:
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                        type: object
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  containers:
+                                    description: Containers is a list of calico-node
+                                      containers. If specified, this overrides the
+                                      specified calico-node DaemonSet containers.
+                                      If omitted, the calico-node DaemonSet will use
+                                      its default values for its containers.
+                                    items:
+                                      description: CalicoNodeDaemonSetContainer is
+                                        a calico-node DaemonSet container.
+                                      properties:
+                                        name:
+                                          description: Name is an enum which identifies
+                                            the calico-node DaemonSet container by
+                                            name.
+                                          enum:
+                                          - calico-node
+                                          type: string
+                                        resources:
+                                          description: Resources allows customization
+                                            of limits and requests for compute resources
+                                            such as cpu and memory. If specified,
+                                            this overrides the named calico-node DaemonSet
+                                            container's resources. If omitted, the
+                                            calico-node DaemonSet will use its default
+                                            value for this container's resources.
+                                            If used in conjunction with the deprecated
+                                            ComponentResources, then this value takes
+                                            precedence.
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  initContainers:
+                                    description: InitContainers is a list of calico-node
+                                      init containers. If specified, this overrides
+                                      the specified calico-node DaemonSet init containers.
+                                      If omitted, the calico-node DaemonSet will use
+                                      its default values for its init containers.
+                                    items:
+                                      description: CalicoNodeDaemonSetInitContainer
+                                        is a calico-node DaemonSet init container.
+                                      properties:
+                                        name:
+                                          description: Name is an enum which identifies
+                                            the calico-node DaemonSet init container
+                                            by name.
+                                          enum:
+                                          - install-cni
+                                          - hostpath-init
+                                          - flexvol-driver
+                                          - mount-bpffs
+                                          - node-certs-key-cert-provisioner
+                                          - calico-node-prometheus-server-tls-key-cert-provisioner
+                                          type: string
+                                        resources:
+                                          description: Resources allows customization
+                                            of limits and requests for compute resources
+                                            such as cpu and memory. If specified,
+                                            this overrides the named calico-node DaemonSet
+                                            init container's resources. If omitted,
+                                            the calico-node DaemonSet will use its
+                                            default value for this container's resources.
+                                            If used in conjunction with the deprecated
+                                            ComponentResources, then this value takes
+                                            precedence.
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is the calico-node
+                                      pod''s scheduling constraints. If specified,
+                                      each of the key/value pairs are added to the
+                                      calico-node DaemonSet nodeSelector provided
+                                      the key does not already exist in the object''s
+                                      nodeSelector. If omitted, the calico-node DaemonSet
+                                      will use its default value for nodeSelector.
+                                      WARNING: Please note that this field will modify
+                                      the default calico-node DaemonSet nodeSelector.'
+                                    type: object
+                                  tolerations:
+                                    description: 'Tolerations is the calico-node pod''s
+                                      tolerations. If specified, this overrides any
+                                      tolerations that may be set on the calico-node
+                                      DaemonSet. If omitted, the calico-node DaemonSet
+                                      will use its default value for tolerations.
+                                      WARNING: Please note that this field will override
+                                      the default calico-node DaemonSet tolerations.'
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  calicoWindowsUpgradeDaemonSet:
+                    description: CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade
+                      DaemonSet.
+                    properties:
+                      metadata:
+                        description: Metadata is a subset of a Kubernetes object's
+                          metadata that is added to the Deployment.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a map of arbitrary non-identifying
+                              metadata. Each of these key/value pairs are added to
+                              the object's annotations provided the key does not already
+                              exist in the object's annotations.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a map of string keys and values
+                              that may match replicaset and service selectors. Each
+                              of these key/value pairs are added to the object's labels
+                              provided the key does not already exist in the object's
+                              labels.
+                            type: object
+                        type: object
+                      spec:
+                        description: Spec is the specification of the calico-windows-upgrade
+                          DaemonSet.
+                        properties:
+                          minReadySeconds:
+                            description: MinReadySeconds is the minimum number of
+                              seconds for which a newly created Deployment pod should
+                              be ready without any of its container crashing, for
+                              it to be considered available. If specified, this overrides
+                              any minReadySeconds value that may be set on the calico-windows-upgrade
+                              DaemonSet. If omitted, the calico-windows-upgrade DaemonSet
+                              will use its default value for minReadySeconds.
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                            type: integer
+                          template:
+                            description: Template describes the calico-windows-upgrade
+                              DaemonSet pod that will be created.
+                            properties:
+                              metadata:
+                                description: Metadata is a subset of a Kubernetes
+                                  object's metadata that is added to the pod's metadata.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a map of arbitrary
+                                      non-identifying metadata. Each of these key/value
+                                      pairs are added to the object's annotations
+                                      provided the key does not already exist in the
+                                      object's annotations.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels is a map of string keys and
+                                      values that may match replicaset and service
+                                      selectors. Each of these key/value pairs are
+                                      added to the object's labels provided the key
+                                      does not already exist in the object's labels.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Spec is the calico-windows-upgrade DaemonSet's
+                                  PodSpec.
+                                properties:
+                                  affinity:
+                                    description: 'Affinity is a group of affinity
+                                      scheduling rules for the calico-windows-upgrade
+                                      pods. If specified, this overrides any affinity
+                                      that may be set on the calico-windows-upgrade
+                                      DaemonSet. If omitted, the calico-windows-upgrade
+                                      DaemonSet will use its default value for affinity.
+                                      WARNING: Please note that this field will override
+                                      the default calico-windows-upgrade DaemonSet
+                                      affinity.'
+                                    properties:
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                        type: object
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  containers:
+                                    description: Containers is a list of calico-windows-upgrade
+                                      containers. If specified, this overrides the
+                                      specified calico-windows-upgrade DaemonSet containers.
+                                      If omitted, the calico-windows-upgrade DaemonSet
+                                      will use its default values for its containers.
+                                    items:
+                                      description: CalicoWindowsUpgradeDaemonSetContainer
+                                        is a calico-windows-upgrade DaemonSet container.
+                                      properties:
+                                        name:
+                                          description: Name is an enum which identifies
+                                            the calico-windows-upgrade DaemonSet container
+                                            by name.
+                                          enum:
+                                          - calico-windows-upgrade
+                                          type: string
+                                        resources:
+                                          description: Resources allows customization
+                                            of limits and requests for compute resources
+                                            such as cpu and memory. If specified,
+                                            this overrides the named calico-windows-upgrade
+                                            DaemonSet container's resources. If omitted,
+                                            the calico-windows-upgrade DaemonSet will
+                                            use its default value for this container's
+                                            resources.
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is the calico-windows-upgrade
+                                      pod''s scheduling constraints. If specified,
+                                      each of the key/value pairs are added to the
+                                      calico-windows-upgrade DaemonSet nodeSelector
+                                      provided the key does not already exist in the
+                                      object''s nodeSelector. If omitted, the calico-windows-upgrade
+                                      DaemonSet will use its default value for nodeSelector.
+                                      WARNING: Please note that this field will modify
+                                      the default calico-windows-upgrade DaemonSet
+                                      nodeSelector.'
+                                    type: object
+                                  tolerations:
+                                    description: 'Tolerations is the calico-windows-upgrade
+                                      pod''s tolerations. If specified, this overrides
+                                      any tolerations that may be set on the calico-windows-upgrade
+                                      DaemonSet. If omitted, the calico-windows-upgrade
+                                      DaemonSet will use its default value for tolerations.
+                                      WARNING: Please note that this field will override
+                                      the default calico-windows-upgrade DaemonSet
+                                      tolerations.'
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                    type: object
                   certificateManagement:
                     description: CertificateManagement configures pods to submit a
                       CertificateSigningRequest to the certificates.k8s.io/v1beta1
@@ -1176,12 +11689,15 @@ spec:
                     - type
                     type: object
                   componentResources:
-                    description: ComponentResources can be used to customize the resource
-                      requirements for each component. Node, Typha, and KubeControllers
-                      are supported for installations.
+                    description: Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment,
+                      and KubeControllersDeployment. ComponentResources can be used
+                      to customize the resource requirements for each component. Node,
+                      Typha, and KubeControllers are supported for installations.
                     items:
-                      description: The ComponentResource struct associates a ResourceRequirements
-                        with a component by name
+                      description: Deprecated. Please use component resource config
+                        fields in Installation.Spec instead. The ComponentResource
+                        struct associates a ResourceRequirements with a component
+                        by name
                       properties:
                         componentName:
                           description: ComponentName is an enum which identifies the
@@ -1281,6 +11797,14 @@ spec:
                           type: string
                       type: object
                     type: array
+                  fipsMode:
+                    description: 'FIPSMode uses images and features only that are
+                      using FIPS 140-2 validated cryptographic modules and standards.
+                      Default: Disabled'
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   flexVolumePath:
                     description: FlexVolumePath optionally specifies a custom path
                       for FlexVolume. If not specified, FlexVolume will be enabled
@@ -1321,6 +11845,12 @@ spec:
                           type: string
                       type: object
                     type: array
+                  kubeletVolumePluginPath:
+                    description: 'KubeletVolumePluginPath optionally specifies enablement
+                      of Calico CSI plugin. If not specified, CSI will be enabled
+                      by default. If set to ''None'', CSI will be disabled. Default:
+                      /var/lib/kubelet'
+                    type: string
                   kubernetesProvider:
                     description: KubernetesProvider specifies a particular provider
                       of the Kubernetes platform and enables provider-specific configuration.
@@ -1336,6 +11866,7 @@ spec:
                     - AKS
                     - OpenShift
                     - DockerEnterprise
+                    - RKE2
                     type: string
                   nodeMetricsPort:
                     description: NodeMetricsPort specifies which port calico/node
@@ -1381,8 +11912,8 @@ spec:
                               by the daemonset on any given node can double if the
                               readiness check fails, and so resource intensive daemonsets
                               should take into account that they may cause evictions
-                              during disruption. This is an alpha field and requires
-                              enabling DaemonSetUpdateSurge feature gate.'
+                              during disruption. This is beta field and enabled/disabled
+                              by DaemonSetUpdateSurge feature gate.'
                             x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
@@ -1393,10 +11924,10 @@ spec:
                               absolute number (ex: 5) or a percentage of total number
                               of DaemonSet pods at the start of the update (ex: 10%).
                               Absolute number is calculated from percentage by rounding
-                              down to a minimum of one. This cannot be 0 if MaxSurge
-                              is 0 Default value is 1. Example: when this is set to
-                              30%, at most 30% of the total number of nodes that should
-                              be running the daemon pod (i.e. status.desiredNumberScheduled)
+                              up. This cannot be 0 if MaxSurge is 0 Default value
+                              is 1. Example: when this is set to 30%, at most 30%
+                              of the total number of nodes that should be running
+                              the daemon pod (i.e. status.desiredNumberScheduled)
                               can have their pods stopped for an update at any given
                               time. The update starts by stopping at most 30% of those
                               DaemonSet pods and then brings up new DaemonSet pods
@@ -1427,7 +11958,8 @@ spec:
                       the above format."
                     type: string
                   typhaAffinity:
-                    description: TyphaAffinity allows configuration of node affinity
+                    description: Deprecated. Please use Installation.Spec.TyphaDeployment
+                      instead. TyphaAffinity allows configuration of node affinity
                       characteristics for Typha pods.
                     properties:
                       nodeAffinity:
@@ -1647,6 +12179,1403 @@ spec:
                             type: object
                         type: object
                     type: object
+                  typhaDeployment:
+                    description: TyphaDeployment configures the typha Deployment.
+                      If used in conjunction with the deprecated ComponentResources
+                      or TyphaAffinity, then these overrides take precedence.
+                    properties:
+                      metadata:
+                        description: Metadata is a subset of a Kubernetes object's
+                          metadata that is added to the Deployment.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a map of arbitrary non-identifying
+                              metadata. Each of these key/value pairs are added to
+                              the object's annotations provided the key does not already
+                              exist in the object's annotations.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a map of string keys and values
+                              that may match replicaset and service selectors. Each
+                              of these key/value pairs are added to the object's labels
+                              provided the key does not already exist in the object's
+                              labels.
+                            type: object
+                        type: object
+                      spec:
+                        description: Spec is the specification of the typha Deployment.
+                        properties:
+                          minReadySeconds:
+                            description: MinReadySeconds is the minimum number of
+                              seconds for which a newly created Deployment pod should
+                              be ready without any of its container crashing, for
+                              it to be considered available. If specified, this overrides
+                              any minReadySeconds value that may be set on the typha
+                              Deployment. If omitted, the typha Deployment will use
+                              its default value for minReadySeconds.
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                            type: integer
+                          template:
+                            description: Template describes the typha Deployment pod
+                              that will be created.
+                            properties:
+                              metadata:
+                                description: Metadata is a subset of a Kubernetes
+                                  object's metadata that is added to the pod's metadata.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: Annotations is a map of arbitrary
+                                      non-identifying metadata. Each of these key/value
+                                      pairs are added to the object's annotations
+                                      provided the key does not already exist in the
+                                      object's annotations.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: Labels is a map of string keys and
+                                      values that may match replicaset and service
+                                      selectors. Each of these key/value pairs are
+                                      added to the object's labels provided the key
+                                      does not already exist in the object's labels.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Spec is the typha Deployment's PodSpec.
+                                properties:
+                                  affinity:
+                                    description: 'Affinity is a group of affinity
+                                      scheduling rules for the typha pods. If specified,
+                                      this overrides any affinity that may be set
+                                      on the typha Deployment. If omitted, the typha
+                                      Deployment will use its default value for affinity.
+                                      If used in conjunction with the deprecated TyphaAffinity,
+                                      then this value takes precedence. WARNING: Please
+                                      note that this field will override the default
+                                      calico-typha Deployment affinity.'
+                                    properties:
+                                      nodeAffinity:
+                                        description: Describes node affinity scheduling
+                                          rules for the pod.
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node matches the corresponding
+                                              matchExpressions; the node(s) with the
+                                              highest sum are the most preferred.
+                                            items:
+                                              description: An empty preferred scheduling
+                                                term matches all objects with implicit
+                                                weight 0 (i.e. it's a no-op). A null
+                                                preferred scheduling term matches
+                                                no objects (i.e. is also a no-op).
+                                              properties:
+                                                preference:
+                                                  description: A node selector term,
+                                                    associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding nodeSelectorTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to an update),
+                                              the system may or may not try to eventually
+                                              evict the pod from its node.
+                                            properties:
+                                              nodeSelectorTerms:
+                                                description: Required. A list of node
+                                                  selector terms. The terms are ORed.
+                                                items:
+                                                  description: A null or empty node
+                                                    selector term matches no objects.
+                                                    The requirements of them are ANDed.
+                                                    The TopologySelectorTerm type
+                                                    implements a subset of the NodeSelectorTerm.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        labels.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      description: A list of node
+                                                        selector requirements by node's
+                                                        fields.
+                                                      items:
+                                                        description: A node selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: The label
+                                                              key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: Represents
+                                                              a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists, DoesNotExist.
+                                                              Gt, and Lt.
+                                                            type: string
+                                                          values:
+                                                            description: An array
+                                                              of string values. If
+                                                              the operator is In or
+                                                              NotIn, the values array
+                                                              must be non-empty. If
+                                                              the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. If the operator
+                                                              is Gt or Lt, the values
+                                                              array must have a single
+                                                              element, which will
+                                                              be interpreted as an
+                                                              integer. This array
+                                                              is replaced during a
+                                                              strategic merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                type: array
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                        type: object
+                                      podAffinity:
+                                        description: Describes pod affinity scheduling
+                                          rules (e.g. co-locate this pod in the same
+                                          node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the affinity expressions specified by
+                                              this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                      podAntiAffinity:
+                                        description: Describes pod anti-affinity scheduling
+                                          rules (e.g. avoid putting this pod in the
+                                          same node, zone, etc. as some other pod(s)).
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            description: The scheduler will prefer
+                                              to schedule pods to nodes that satisfy
+                                              the anti-affinity expressions specified
+                                              by this field, but it may choose a node
+                                              that violates one or more of the expressions.
+                                              The node that is most preferred is the
+                                              one with the greatest sum of weights,
+                                              i.e. for each node that meets all of
+                                              the scheduling requirements (resource
+                                              request, requiredDuringScheduling anti-affinity
+                                              expressions, etc.), compute a sum by
+                                              iterating through the elements of this
+                                              field and adding "weight" to the sum
+                                              if the node has pods which matches the
+                                              corresponding podAffinityTerm; the node(s)
+                                              with the highest sum are the most preferred.
+                                            items:
+                                              description: The weights of all of the
+                                                matched WeightedPodAffinityTerm fields
+                                                are added per-node to find the most
+                                                preferred node(s)
+                                              properties:
+                                                podAffinityTerm:
+                                                  description: Required. A pod affinity
+                                                    term, associated with the corresponding
+                                                    weight.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: A label query over
+                                                        the set of namespaces that
+                                                        the term applies to. The term
+                                                        is applied to the union of
+                                                        the namespaces selected by
+                                                        this field and the ones listed
+                                                        in the namespaces field. null
+                                                        selector and null or empty
+                                                        namespaces list means "this
+                                                        pod's namespace". An empty
+                                                        selector ({}) matches all
+                                                        namespaces. This field is
+                                                        beta-level and is only honored
+                                                        when PodAffinityNamespaceSelector
+                                                        feature is enabled.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        a static list of namespace
+                                                        names that the term applies
+                                                        to. The term is applied to
+                                                        the union of the namespaces
+                                                        listed in this field and the
+                                                        ones selected by namespaceSelector.
+                                                        null or empty namespaces list
+                                                        and null namespaceSelector
+                                                        means "this pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  description: weight associated with
+                                                    matching the corresponding podAffinityTerm,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            description: If the anti-affinity requirements
+                                              specified by this field are not met
+                                              at scheduling time, the pod will not
+                                              be scheduled onto the node. If the anti-affinity
+                                              requirements specified by this field
+                                              cease to be met at some point during
+                                              pod execution (e.g. due to a pod label
+                                              update), the system may or may not try
+                                              to eventually evict the pod from its
+                                              node. When there are multiple elements,
+                                              the lists of nodes corresponding to
+                                              each podAffinityTerm are intersected,
+                                              i.e. all terms must be satisfied.
+                                            items:
+                                              description: Defines a set of pods (namely
+                                                those matching the labelSelector relative
+                                                to the given namespace(s)) that this
+                                                pod should be co-located (affinity)
+                                                or not co-located (anti-affinity)
+                                                with, where co-located is defined
+                                                as running on a node whose value of
+                                                the label with key <topologyKey> matches
+                                                that of any node on which a pod of
+                                                the set of pods is running
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                    This field is beta-level and is
+                                                    only honored when PodAffinityNamespaceSelector
+                                                    feature is enabled.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace"
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  containers:
+                                    description: Containers is a list of typha containers.
+                                      If specified, this overrides the specified typha
+                                      Deployment containers. If omitted, the typha
+                                      Deployment will use its default values for its
+                                      containers.
+                                    items:
+                                      description: TyphaDeploymentContainer is a typha
+                                        Deployment container.
+                                      properties:
+                                        name:
+                                          description: Name is an enum which identifies
+                                            the typha Deployment container by name.
+                                          enum:
+                                          - calico-typha
+                                          type: string
+                                        resources:
+                                          description: Resources allows customization
+                                            of limits and requests for compute resources
+                                            such as cpu and memory. If specified,
+                                            this overrides the named typha Deployment
+                                            container's resources. If omitted, the
+                                            typha Deployment will use its default
+                                            value for this container's resources.
+                                            If used in conjunction with the deprecated
+                                            ComponentResources, then this value takes
+                                            precedence.
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  initContainers:
+                                    description: InitContainers is a list of typha
+                                      init containers. If specified, this overrides
+                                      the specified typha Deployment init containers.
+                                      If omitted, the typha Deployment will use its
+                                      default values for its init containers.
+                                    items:
+                                      description: TyphaDeploymentInitContainer is
+                                        a typha Deployment init container.
+                                      properties:
+                                        name:
+                                          description: Name is an enum which identifies
+                                            the typha Deployment init container by
+                                            name.
+                                          enum:
+                                          - typha-certs-key-cert-provisioner
+                                          type: string
+                                        resources:
+                                          description: Resources allows customization
+                                            of limits and requests for compute resources
+                                            such as cpu and memory. If specified,
+                                            this overrides the named typha Deployment
+                                            init container's resources. If omitted,
+                                            the typha Deployment will use its default
+                                            value for this init container's resources.
+                                            If used in conjunction with the deprecated
+                                            ComponentResources, then this value takes
+                                            precedence.
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'NodeSelector is the calico-typha
+                                      pod''s scheduling constraints. If specified,
+                                      each of the key/value pairs are added to the
+                                      calico-typha Deployment nodeSelector provided
+                                      the key does not already exist in the object''s
+                                      nodeSelector. If omitted, the calico-typha Deployment
+                                      will use its default value for nodeSelector.
+                                      WARNING: Please note that this field will modify
+                                      the default calico-typha Deployment nodeSelector.'
+                                    type: object
+                                  tolerations:
+                                    description: 'Tolerations is the typha pod''s
+                                      tolerations. If specified, this overrides any
+                                      tolerations that may be set on the typha Deployment.
+                                      If omitted, the typha Deployment will use its
+                                      default value for tolerations. WARNING: Please
+                                      note that this field will override the default
+                                      calico-typha Deployment tolerations.'
+                                    items:
+                                      description: The pod this Toleration is attached
+                                        to tolerates any taint that matches the triple
+                                        <key,value,effect> using the matching operator
+                                        <operator>.
+                                      properties:
+                                        effect:
+                                          description: Effect indicates the taint
+                                            effect to match. Empty means match all
+                                            taint effects. When specified, allowed
+                                            values are NoSchedule, PreferNoSchedule
+                                            and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Key is the taint key that the
+                                            toleration applies to. Empty means match
+                                            all taint keys. If the key is empty, operator
+                                            must be Exists; this combination means
+                                            to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: Operator represents a key's
+                                            relationship to the value. Valid operators
+                                            are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value,
+                                            so that a pod can tolerate all taints
+                                            of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: TolerationSeconds represents
+                                            the period of time the toleration (which
+                                            must be of effect NoExecute, otherwise
+                                            this field is ignored) tolerates the taint.
+                                            By default, it is not set, which means
+                                            tolerate the taint forever (do not evict).
+                                            Zero and negative values will be treated
+                                            as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: Value is the taint value the
+                                            toleration matches to. If the operator
+                                            is Exists, the value should be empty,
+                                            otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                    type: object
                   typhaMetricsPort:
                     description: TyphaMetricsPort specifies which port calico/typha
                       serves prometheus metrics on. By default, metrics are not enabled.
@@ -1660,6 +13589,78 @@ spec:
                     - TigeraSecureEnterprise
                     type: string
                 type: object
+              conditions:
+                description: Conditions represents the latest observed set of conditions
+                  for the component. A component may be one or more of Ready, Progressing,
+                  Degraded or other customer types.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               imageSet:
                 description: ImageSet is the name of the ImageSet being used, if there
                   is an ImageSet that is being used. If an ImageSet is not being used
@@ -1765,6 +13766,14 @@ spec:
                       description: Optionally, a detailed message providing additional
                         context.
                       type: string
+                    observedGeneration:
+                      description: observedGeneration represents the generation that
+                        the condition was set based upon. For instance, if generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
                     reason:
                       description: A brief reason explaining the condition.
                       type: string
@@ -1797,7 +13806,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
+# Source: crds/crd.projectcalico.org_bgpconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1809,6 +13818,7 @@ spec:
     listKind: BGPConfigurationList
     plural: bgpconfigurations
     singular: bgpconfiguration
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -1861,6 +13871,12 @@ spec:
                       pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
                       type: string
                   type: object
+                type: array
+              ignoredInterfaces:
+                description: IgnoredInterfaces indicates the network interfaces that
+                  needs to be excluded when reading device routes.
+                items:
+                  type: string
                 type: array
               listenPort:
                 description: ListenPort is the port where BGP protocol should listen.
@@ -1977,7 +13993,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_bgppeers.yaml
+# Source: crds/crd.projectcalico.org_bgppeers.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1989,6 +14005,7 @@ spec:
     listKind: BGPPeerList
     plural: bgppeers
     singular: bgppeer
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -2079,12 +14096,23 @@ spec:
                   remote AS number comes from the remote node's NodeBGPSpec.ASNumber,
                   or the global default if that is not set.
                 type: string
+              reachableBy:
+                description: Add an exact, i.e. /32, static route toward peer IP in
+                  order to prevent route flapping. ReachableBy contains the address
+                  of the gateway which peer can be reached by.
+                type: string
               sourceAddress:
                 description: Specifies whether and how to configure a source address
                   for the peerings generated by this BGPPeer resource.  Default value
                   "UseNodeIP" means to configure the node IP as the source address.  "None"
                   means not to configure a source address.
                 type: string
+              ttlSecurity:
+                description: TTLSecurity enables the generalized TTL security mechanism
+                  (GTSM) which protects against spoofed packets by ignoring received
+                  packets with a smaller than expected TTL value. The provided value
+                  is the number of hops (edges) between the peers.
+                type: integer
             type: object
         type: object
     served: true
@@ -2096,7 +14124,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_blockaffinities.yaml
+# Source: crds/crd.projectcalico.org_blockaffinities.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2108,6 +14136,7 @@ spec:
     listKind: BlockAffinityList
     plural: blockaffinities
     singular: blockaffinity
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -2157,7 +14186,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_caliconodestatuses.yaml
+# Source: crds/crd.projectcalico.org_caliconodestatuses.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2172,6 +14201,7 @@ spec:
     listKind: CalicoNodeStatusList
     plural: caliconodestatuses
     singular: caliconodestatus
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -2420,7 +14450,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_clusterinformations.yaml
+# Source: crds/crd.projectcalico.org_clusterinformations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2432,6 +14462,7 @@ spec:
     listKind: ClusterInformationList
     plural: clusterinformations
     singular: clusterinformation
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -2484,7 +14515,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_felixconfigurations.yaml
+# Source: crds/crd.projectcalico.org_felixconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2496,6 +14527,7 @@ spec:
     listKind: FelixConfigurationList
     plural: felixconfigurations
     singular: felixconfiguration
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -2565,9 +14597,10 @@ spec:
                   [Default: false]'
                 type: boolean
               bpfEnforceRPF:
-                description: 'BPFEnforceRPF enforce strict RPF on all interfaces with
-                  BPF programs regardless of what is the per-interfaces or global
-                  setting. Possible values are Disabled or Strict. [Default: Strict]'
+                description: 'BPFEnforceRPF enforce strict RPF on all host interfaces
+                  with BPF programs regardless of what is the per-interfaces or global
+                  setting. Possible values are Disabled, Strict or Loose. [Default:
+                  Strict]'
                 type: string
               bpfExtToServiceConnmark:
                 description: 'BPFExtToServiceConnmark in BPF mode, control a 32bit
@@ -2586,6 +14619,11 @@ spec:
                   node appears to use the IP of the ingress node; this requires a
                   permissive L2 network.  [Default: Tunnel]'
                 type: string
+              bpfHostConntrackBypass:
+                description: 'BPFHostConntrackBypass Controls whether to bypass Linux
+                  conntrack in BPF mode for workloads and services. [Default: true
+                  - bypass Linux conntrack]'
+                type: boolean
               bpfKubeProxyEndpointSlicesEnabled:
                 description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
                   whether Felix's embedded kube-proxy accepts EndpointSlices or not.
@@ -2601,6 +14639,14 @@ spec:
                   minimum time between updates to the dataplane for Felix''s embedded
                   kube-proxy.  Lower values give reduced set-up latency.  Higher values
                   reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                type: string
+              bpfL3IfacePattern:
+                description: BPFL3IfacePattern is a regular expression that allows
+                  to list tunnel devices like wireguard or vxlan (i.e., L3 devices)
+                  in addition to BPFDataIfacePattern. That is, tunnel interfaces not
+                  created by Calico, that Calico workload traffic flows over as well
+                  as any interfaces that handle incoming traffic to nodeports and
+                  services from outside the cluster.
                 type: string
               bpfLogLevel:
                 description: 'BPFLogLevel controls the log level of the BPF programs
@@ -2620,6 +14666,11 @@ spec:
                   matched by every selector in the source/destination matches in network
                   policy.  Selectors such as "all()" can result in large numbers of
                   entries (one entry per endpoint in that case).
+                type: integer
+              bpfMapSizeIfState:
+                description: BPFMapSizeIfState sets the size for ifstate map.  The
+                  ifstate map must be large enough to hold an entry for each device
+                  (host + workloads) on a host.
                 type: integer
               bpfMapSizeNATAffinity:
                 type: integer
@@ -2653,6 +14704,11 @@ spec:
                   are inclusive. [Default: 20000:29999]'
                 pattern: ^.*
                 x-kubernetes-int-or-string: true
+              bpfPolicyDebugEnabled:
+                description: BPFPolicyDebugEnabled when true, Felix records detailed
+                  information about the BPF policy programs, which can be examined
+                  with the calico-bpf command-line tool.
+                type: boolean
               chainInsertMode:
                 description: 'ChainInsertMode controls whether Felix hooks the kernel''s
                   top-level iptables chains by inserting a rule at the top of the
@@ -2667,11 +14723,12 @@ spec:
                   to use.  Only used if UseInternalDataplaneDriver is set to false.
                 type: string
               dataplaneWatchdogTimeout:
-                description: 'DataplaneWatchdogTimeout is the readiness/liveness timeout
-                  used for Felix''s (internal) dataplane driver. Increase this value
+                description: "DataplaneWatchdogTimeout is the readiness/liveness timeout
+                  used for Felix's (internal) dataplane driver. Increase this value
                   if you experience spurious non-ready or non-live events when Felix
                   is under heavy load. Decrease the value to get felix to report non-live
-                  or non-ready more quickly. [Default: 90s]'
+                  or non-ready more quickly. [Default: 90s] \n Deprecated: replaced
+                  by the generic HealthTimeoutOverrides."
                 type: string
               debugDisableLogDropping:
                 type: boolean
@@ -2775,16 +14832,21 @@ spec:
                   type: object
                 type: array
               featureDetectOverride:
-                description: FeatureDetectOverride is used to override the feature
-                  detection. Values are specified in a comma separated list with no
-                  spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
-                  "true" or "false" will force the feature, empty or omitted values
-                  are auto-detected.
+                description: FeatureDetectOverride is used to override feature detection
+                  based on auto-detected platform capabilities.  Values are specified
+                  in a comma separated list with no spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".  "true"
+                  or "false" will force the feature, empty or omitted values are auto-detected.
+                type: string
+              featureGates:
+                description: FeatureGates is used to enable or disable tech-preview
+                  Calico features. Values are specified in a comma separated list
+                  with no spaces, example; "BPFConnectTimeLoadBalancingWorkaround=enabled,XyZ=false".
+                  This is used to enable features that are not fully production ready.
                 type: string
               floatingIPs:
-                default: Disabled
                 description: FloatingIPs configures whether or not Felix will program
-                  floating IP addresses.
+                  non-OpenStack floating IP addresses.  (OpenStack-derived floating
+                  IPs are always programmed, regardless of this setting.)
                 enum:
                 - Enabled
                 - Disabled
@@ -2801,6 +14863,23 @@ spec:
                 type: string
               healthPort:
                 type: integer
+              healthTimeoutOverrides:
+                description: HealthTimeoutOverrides allows the internal watchdog timeouts
+                  of individual subcomponents to be overriden.  This is useful for
+                  working around "false positive" liveness timeouts that can occur
+                  in particularly stressful workloads or if CPU is constrained.  For
+                  a list of active subcomponents, see Felix's logs.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    timeout:
+                      type: string
+                  required:
+                  - name
+                  - timeout
+                  type: object
+                type: array
               interfaceExclude:
                 description: 'InterfaceExclude is a comma-separated list of interfaces
                   that Felix should exclude when monitoring for host endpoints. The
@@ -2842,7 +14921,7 @@ spec:
                 type: string
               iptablesBackend:
                 description: IptablesBackend specifies which backend of iptables will
-                  be used. The default is legacy.
+                  be used. The default is Auto.
                 type: string
               iptablesFilterAllowAction:
                 type: string
@@ -3044,6 +15123,10 @@ spec:
                   information. - WorkloadIPs: use workload endpoints to construct
                   routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
                 type: string
+              routeSyncDisabled:
+                description: RouteSyncDisabled will disable all operations performed
+                  on the route table. Set to true to run in network-policy mode only.
+                type: boolean
               routeTableRange:
                 description: Deprecated in favor of RouteTableRanges. Calico programs
                   additional Linux route tables for various purposes. RouteTableRange
@@ -3105,8 +15188,8 @@ spec:
                 type: boolean
               vxlanEnabled:
                 description: 'VXLANEnabled overrides whether Felix should create the
-                  VXLAN tunnel device for VXLAN networking. Optional as Felix determines
-                  this based on the existing IP pools. [Default: nil (unset)]'
+                  VXLAN tunnel device for IPv4 VXLAN networking. Optional as Felix
+                  determines this based on the existing IP pools. [Default: nil (unset)]'
                 type: boolean
               vxlanMTU:
                 description: 'VXLANMTU is the MTU to set on the IPv4 VXLAN tunnel
@@ -3122,11 +15205,13 @@ spec:
                 type: integer
               wireguardEnabled:
                 description: 'WireguardEnabled controls whether Wireguard is enabled
-                  for IPv4. [Default: false]'
+                  for IPv4 (encapsulating IPv4 traffic over an IPv4 underlay network).
+                  [Default: false]'
                 type: boolean
               wireguardEnabledV6:
                 description: 'WireguardEnabledV6 controls whether Wireguard is enabled
-                  for IPv6. [Default: false]'
+                  for IPv6 (encapsulating IPv6 traffic over an IPv6 underlay network).
+                  [Default: false]'
                 type: boolean
               wireguardHostEncryptionEnabled:
                 description: 'WireguardHostEncryptionEnabled controls whether Wireguard
@@ -3146,7 +15231,11 @@ spec:
                 type: string
               wireguardListeningPort:
                 description: 'WireguardListeningPort controls the listening port used
-                  by Wireguard. [Default: 51820]'
+                  by IPv4 Wireguard. [Default: 51820]'
+                type: integer
+              wireguardListeningPortV6:
+                description: 'WireguardListeningPortV6 controls the listening port
+                  used by IPv6 Wireguard. [Default: 51821]'
                 type: integer
               wireguardMTU:
                 description: 'WireguardMTU controls the MTU on the IPv4 Wireguard
@@ -3187,7 +15276,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_globalnetworkpolicies.yaml
+# Source: crds/crd.projectcalico.org_globalnetworkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3199,6 +15288,7 @@ spec:
     listKind: GlobalNetworkPolicyList
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4042,7 +16132,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_globalnetworksets.yaml
+# Source: crds/crd.projectcalico.org_globalnetworksets.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4054,6 +16144,7 @@ spec:
     listKind: GlobalNetworkSetList
     plural: globalnetworksets
     singular: globalnetworkset
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4095,7 +16186,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_hostendpoints.yaml
+# Source: crds/crd.projectcalico.org_hostendpoints.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4107,6 +16198,7 @@ spec:
     listKind: HostEndpointList
     plural: hostendpoints
     singular: hostendpoint
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4203,7 +16295,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_ipamblocks.yaml
+# Source: crds/crd.projectcalico.org_ipamblocks.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4215,6 +16307,7 @@ spec:
     listKind: IPAMBlockList
     plural: ipamblocks
     singular: ipamblock
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4322,7 +16415,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_ipamconfigs.yaml
+# Source: crds/crd.projectcalico.org_ipamconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4334,6 +16427,7 @@ spec:
     listKind: IPAMConfigList
     plural: ipamconfigs
     singular: ipamconfig
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4361,6 +16455,8 @@ spec:
               maxBlocksPerHost:
                 description: MaxBlocksPerHost, if non-zero, is the max number of blocks
                   that can be affine to each host.
+                maximum: 2147483647
+                minimum: 0
                 type: integer
               strictAffinity:
                 type: boolean
@@ -4378,7 +16474,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_ipamhandles.yaml
+# Source: crds/crd.projectcalico.org_ipamhandles.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4390,6 +16486,7 @@ spec:
     listKind: IPAMHandleList
     plural: ipamhandles
     singular: ipamhandle
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4434,7 +16531,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_ippools.yaml
+# Source: crds/crd.projectcalico.org_ippools.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4446,6 +16543,7 @@ spec:
     listKind: IPPoolList
     plural: ippools
     singular: ippool
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4517,7 +16615,7 @@ spec:
                   for internal use only.'
                 type: boolean
               natOutgoing:
-                description: When nat-outgoing is true, packets sent from Calico networked
+                description: When natOutgoing is true, packets sent from Calico networked
                   containers in this pool to destinations outside of this pool will
                   be masqueraded.
                 type: boolean
@@ -4543,7 +16641,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_ipreservations.yaml
+# Source: crds/crd.projectcalico.org_ipreservations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4558,6 +16656,7 @@ spec:
     listKind: IPReservationList
     plural: ipreservations
     singular: ipreservation
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4597,7 +16696,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+# Source: crds/crd.projectcalico.org_kubecontrollersconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4609,6 +16708,7 @@ spec:
     listKind: KubeControllersConfigurationList
     plural: kubecontrollersconfigurations
     singular: kubecontrollersconfiguration
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4850,7 +16950,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_networkpolicies.yaml
+# Source: crds/crd.projectcalico.org_networkpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4862,6 +16962,7 @@ spec:
     listKind: NetworkPolicyList
     plural: networkpolicies
     singular: networkpolicy
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1
@@ -5686,7 +17787,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-# Source: crds/calico/crd.projectcalico.org_networksets.yaml
+# Source: crds/crd.projectcalico.org_networksets.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5698,6 +17799,7 @@ spec:
     listKind: NetworkSetList
     plural: networksets
     singular: networkset
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1
@@ -5736,4 +17838,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -4056,8 +4056,6 @@ status:
 
 ---
 # Source: crds/operator.tigera.io_apiservers_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5417,8 +5415,6 @@ status:
 
 ---
 # Source: crds/operator.tigera.io_imagesets_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -5497,8 +5493,6 @@ status:
 
 ---
 # Source: crds/operator.tigera.io_installations_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -17757,8 +17751,6 @@ status:
 
 ---
 # Source: crds/operator.tigera.io_tigerastatuses_crd.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Cherry pick of #7216 on release-v3.25.

#7216: Add operator-crds.yaml to manifest generation

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Looks like we never added the logic to update `operator-crds.yaml` when we switch how we generate manifest files.

`crds.yaml` was being properly updated, though.

This PR adds a new block that updates `operator-crds.yaml`, putting both Calico and Operator CRDs inside.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix generation of `operator-crds.yaml` manifest.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.