### PR TITLE
DOCS-1114: Adds warning to docs readme and contributors guide

### DIFF
--- a/CONTRIBUTING_DOCS.md
+++ b/CONTRIBUTING_DOCS.md
@@ -1,5 +1,10 @@
 # Contributing to Calico documentation
 
+> **WARNING** On 16 January 2023 we migrated the source files for Calico documentation to the [tigera/docs repository](https://github.com/tigera/docs).
+> Do not submit docs PRs to the projectcalico/calico repo.
+> If you do, your changes will not be migrated to the new repoository and they will never be published.
+> Submit your changes directly to [tigera/docs repo](https://github.com/tigera/docs).
+
 ## Overview
 
 We welcome contributions to the Calico documentation.

--- a/calico/README.md
+++ b/calico/README.md
@@ -1,3 +1,8 @@
 # The Calico Documentation
 
+> **WARNING** On 16 January 2023 we migrated the source files for Calico documentation to the [tigera/docs repository](https://github.com/tigera/docs).
+> Do not submit docs PRs to the projectcalico/calico repo.
+> If you do, your changes will not be migrated to the new repoository and they will never be published.
+> Submit your changes directly to [tigera/docs repo](https://github.com/tigera/docs).
+
 Run `make serve` to run a documentation site served on localhost to preview changes.


### PR DESCRIPTION
Adds a warning to the docs readme and the contributors' guide. We don't want folks sending docs changes here. 

Interim solution until we remove docs files from these branches entirely. 

