### PR TITLE
update helm version to match k8s 1.24

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1234,7 +1234,7 @@ kubectl $(KUBECTL):
 bin/helm:
 	mkdir -p bin
 	$(eval TMP := $(shell mktemp -d))
-	wget -q https://get.helm.sh/helm-v3.3.1-linux-amd64.tar.gz -O $(TMP)/helm3.tar.gz
+	wget -q https://get.helm.sh/helm-v3.11.0-linux-amd64.tar.gz -O $(TMP)/helm3.tar.gz
 	tar -zxvf $(TMP)/helm3.tar.gz -C $(TMP)
 	mv $(TMP)/linux-amd64/helm bin/helm
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

## Description
update helm version to match k8s 1.24.
from [helm release](https://github.com/helm/helm/releases) , current 3.11.0 is the latest.
and from [3.9.0](https://github.com/helm/helm/releases/tag/v3.9.0) , helm updated to add Kubernetes 1.24 support 