### PR TITLE
update pod2daemon nodeagent's DaemonSet apiVersion.

### DIFF
--- a/pod2daemon/README.md
+++ b/pod2daemon/README.md
@@ -2,7 +2,7 @@
 pod2daemon enables secure communication between a Kubernetes pod and a daemon (e.g. created with a DaemonSet) running on the host. It creates a Kubernetes [FlexVolume Driver](https://github.com/kubernetes/community/blob/release-1.6/contributors/devel/flexvolume.md) type `nodeagent/uds` to enable [Nodeagent](https://docs.google.com/document/d/1J67aol2phtZdBwbfuyk36fqLzRHn8c7k_2rAxwGslCk/edit#heading=h.x9snb54sjlu9) to verify the identity of a workload.
 A Flexvolume driver type `nodeagent/uds` is added to each workload and when such a workload is created, with the volume type mounted, the Nodeagent is notified by the Flexvolume driver. The `workloadhandler` creates a Unix Domain Socket (UDS) per workload and then initializes the workloadAPI Grpc Server (see below). The workloadAPI Grpc server can get the credentials of the workload from the workload handler.
 
-The code here was tested with Kubernetes version v1.8.
+The code here was tested with Kubernetes version v1.22.
 
 # What is in this repo
  ## Flexvolume driver:

--- a/pod2daemon/nodeagent/nodeagent-dikastes.yaml
+++ b/pod2daemon/nodeagent/nodeagent-dikastes.yaml
@@ -3,7 +3,7 @@
 # the 'test-mgmt'/creds directory.
 # TBD: Change the nodeagent image to be one that reads from the cred's directory.
 ##
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nodeagent

--- a/pod2daemon/nodeagent/nodeagent.yaml
+++ b/pod2daemon/nodeagent/nodeagent.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nodeagent


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup

The pod2daemon/README.md says
```
The code here was tested with Kubernetes version v1.8.
```
But i found the pod2daemon/flexvol's Deployment is the 'apps/v1'.
So we can update the pod2daemon/nodeagent's DaemonSet to the match version 'apps/v1'.

Is that ok?