### PR TITLE
PodSecurityPolicy was deprecated in Kubernetes v1.21, and removed fro…

### DIFF
--- a/calico/_includes/content/reqs-sys.md
+++ b/calico/_includes/content/reqs-sys.md
@@ -96,5 +96,5 @@ privileged container. This requires that the kubelet be allowed to run privilege
 containers. There are two ways this can be achieved.
 
 - Specify `--allow-privileged` on the kubelet (deprecated).
-- Use a {% include open-new-window.html text='pod security policy' url='https://kubernetes.io/docs/concepts/policy/pod-security-policy/' %}.
+- Use a {% include open-new-window.html text='pod security policy' url='https://kubernetes.io/docs/concepts/policy/pod-security-policy/' %}(deprecated).
 {% endif -%}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>
/kind cleanup

PodSecurityPolicy was [deprecated](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/#podsecuritypolicy-deprecation) in Kubernetes v1.21, and removed from Kubernetes in v1.25.