### PR TITLE
Windows support hostprocess

### DIFF
--- a/cni-plugin/Dockerfile-windows
+++ b/cni-plugin/Dockerfile-windows
@@ -1,0 +1,36 @@
+# Copyright (c) 2015-2019 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+ARG GIT_VERSION=unknown
+
+LABEL name="Calico Networking for CNI" \
+      vendor="Project Calico" \
+      version=$GIT_VERSION \
+      release="1" \
+      summary="Calico Networking for CNI" \
+      description="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin" \
+      maintainer="maintainers@projectcalico.org"
+
+ADD licenses/ /licenses
+ADD LICENSE /licenses/
+
+ADD bin/windows/ /opt/cni/bin/
+
+ENV PATH=$PATH:/opt/cni/bin
+# Workdir is not support at this time
+# https://github.com/docker/buildx/issues/378
+# WORKDIR /opt/cni/bin
+CMD ["/opt/cni/bin/install.exe"]

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -38,6 +38,7 @@ CNI_SPEC_VERSION?=0.3.1
 # Markers for various images we produce.
 DEPLOY_CONTAINER_STATIC_MARKER=cni_deploy_container-$(ARCH).created
 DEPLOY_CONTAINER_FIPS_MARKER=cni_deploy_container-$(ARCH)-fips.created
+DEPLOY_CONTAINER_MARKER_WINDOWS=cni_deploy_container-windows.created
 
 # Set FIPS to true to enable a FIPS compliant build using BoringSSL and CGO.
 # Note that this produces binaries that are dynamically linked, and so have dependencies
@@ -60,9 +61,13 @@ clean:
 	# Clean .created files which indicate images / releases have been built.
 	find . -name '.*.created*' -type f -delete
 	find . -name '.*.published*' -type f -delete
-	rm -rf $(BIN) bin $(DEPLOY_CONTAINER_MARKER) .go-pkg-cache pkg/install/install.test 
+	rm -rf $(BIN) bin $(DEPLOY_CONTAINER_MARKER) $(DEPLOY_CONTAINER_MARKER_WINDOWS) .go-pkg-cache pkg/install/install.test
 	rm -f *.created
 	rm -rf config/
+		docker buildx rm img-builder 
+
+clean-windows:
+	docker buildx rm img-builder
 
 ###############################################################################
 # Building the binary
@@ -71,7 +76,7 @@ build: $(BIN)/install $(BIN)/calico $(BIN)/calico-ipam
 ifeq ($(ARCH),amd64)
 # Go only supports amd64 for Windows builds.
 BIN_WIN=bin/windows
-build: $(BIN_WIN)/calico.exe $(BIN_WIN)/calico-ipam.exe
+build: $(BIN_WIN)/install.exe $(BIN_WIN)/calico.exe $(BIN_WIN)/calico-ipam.exe
 endif
 # If ARCH is arm based, find the requested version/variant
 ifeq ($(word 1,$(subst v, ,$(ARCH))),arm)
@@ -97,19 +102,25 @@ else
 endif
 
 ## Build the Calico network plugin and ipam plugins for Windows
-$(BIN_WIN)/calico.exe $(BIN_WIN)/calico-ipam.exe: $(SRC_FILES)
+$(BIN_WIN)/install.exe $(BIN_WIN)/calico.exe $(BIN_WIN)/calico-ipam.exe: $(SRC_FILES)
 	$(DOCKER_RUN) \
 	-e GOOS=windows \
 	-e CGO_ENABLED=1 \
 	    $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 		go build -v -buildvcs=false -o $(BIN_WIN)/calico.exe -ldflags "$(LDFLAGS)" $(PACKAGE_NAME)/cmd/calico && \
-		go build -v -buildvcs=false -o $(BIN_WIN)/calico-ipam.exe -ldflags "$(LDFLAGS)" $(PACKAGE_NAME)/cmd/calico'
+		go build -v -buildvcs=false -o $(BIN_WIN)/calico-ipam.exe -ldflags "$(LDFLAGS)" $(PACKAGE_NAME)/cmd/calico\ 
+		go build -v -buildvcs=false -o $(BIN_WIN)/install.exe -ldflags "$(LDFLAGS)" $(PACKAGE_NAME)/cmd/calico'
 
 
 ###############################################################################
 # Building the image
 ###############################################################################
+BIN=bin/$(ARCH)
 image: $(DEPLOY_CONTAINER_MARKER)
+ifeq ($(ARCH),amd64)
+# Go only supports amd64 for Windows builds.
+image: $(DEPLOY_CONTAINER_MARKER_WINDOWS)
+endif
 image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
 	$(MAKE) image ARCH=$*
@@ -117,7 +128,7 @@ sub-image-fips-%:
 	$(MAKE) image FIPS=true ARCH=$*
 
 # Builds the statically compiled binaries into a container.
-$(DEPLOY_CONTAINER_STATIC_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
+$(DEPLOY_CONTAINER_STATIC_MARKER): Dockerfile.$(ARCH) build $(BIN)/fetch-cni-bins
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BIN) -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH) -f Dockerfile.$(ARCH) . --load
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
@@ -128,8 +139,13 @@ $(DEPLOY_CONTAINER_FIPS_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
 
-.PHONY: fetch-cni-bins
-fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
+$(DEPLOY_CONTAINER_MARKER_WINDOWS): Dockerfile-windows build 
+	docker buildx create --name img-builder --use --platform windows/amd64 
+	GO111MODULE=on docker buildx build --platform windows/amd64 --output=type=registry --pull -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH)-windows --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile-windows .
+	docker buildx rm img-builder 
+
+$(BIN)/fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
+$(WIN_BIN)/fetch-cni-bins: $(WIN_BIN)/flannel
 
 $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth:
 	mkdir -p $(BIN)

--- a/cni-plugin/cmd/calico/calico.go
+++ b/cni-plugin/cmd/calico/calico.go
@@ -36,7 +36,7 @@ func main() {
 		plugin.Main(VERSION)
 	case "calico-ipam", "calico-ipam.exe":
 		ipamplugin.Main(VERSION)
-	case "install":
+	case "install", "install.exe":
 		err := install.Install()
 		if err != nil {
 			logrus.WithError(err).Fatal("Error installing CNI plugin")

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -119,6 +121,20 @@ func loadConfig() config {
 	return c
 }
 
+// getServiceAccountFilePaths returns the mount paths for a container
+// In the case of Windows HostProcess containers this prepends the CONTAINER_SANDBOX_MOUNT_POINT env variable
+// for other operating systems or if the sandbox env variable is not set it returns the standard mount points
+// see https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/#volume-mounts
+func getHostPath(path string) string {
+	if runtime.GOOS == "windows" {
+		sandbox := os.Getenv("CONTAINER_SANDBOX_MOUNT_POINT")
+		// join them and return with forward slashes so it can be serialized properly in json later if required
+		path := filepath.Join(sandbox, path)
+		return filepath.ToSlash(path)
+	}
+	return path
+}
+
 func Install() error {
 	// Make sure the RNG is seeded.
 	seedrng.EnsureSeeded()
@@ -127,7 +143,7 @@ func Install() error {
 	logrus.SetFormatter(&logutils.Formatter{Component: "cni-installer"})
 
 	// Clean up any existing binaries / config / assets.
-	if err := os.RemoveAll("/host/etc/cni/net.d/calico-tls"); err != nil && !os.IsNotExist(err) {
+	if err := os.RemoveAll(getHostPath("/host/etc/cni/net.d/calico-tls")); err != nil && !os.IsNotExist(err) {
 		logrus.WithError(err).Warnf("Error removing old TLS directory")
 	}
 
@@ -137,7 +153,7 @@ func Install() error {
 	// Determine if we're running as a Kubernetes pod.
 	var kubecfg *rest.Config
 
-	serviceAccountTokenFile := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	serviceAccountTokenFile := getHostPath("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	c.ServiceAccountToken = make([]byte, 0)
 	var err error
 	if fileExists(serviceAccountTokenFile) {
@@ -162,34 +178,34 @@ func Install() error {
 	if directoryExists(c.TLSAssetsDir) {
 		logrus.Info("Installing any TLS assets")
 		mkdir("/host/etc/cni/net.d/calico-tls")
-		if err := copyFileAndPermissions(fmt.Sprintf("%s/%s", c.TLSAssetsDir, "etcd-ca"), "/host/etc/cni/net.d/calico-tls/etcd-ca"); err != nil {
+		if err := copyFileAndPermissions(fmt.Sprintf("%s/%s", c.TLSAssetsDir, "etcd-ca"), getHostPath("/host/etc/cni/net.d/calico-tls/etcd-ca")); err != nil {
 			logrus.Warnf("Missing etcd-ca")
 		}
-		if err := copyFileAndPermissions(fmt.Sprintf("%s/%s", c.TLSAssetsDir, "etcd-cert"), "/host/etc/cni/net.d/calico-tls/etcd-cert"); err != nil {
+		if err := copyFileAndPermissions(fmt.Sprintf("%s/%s", c.TLSAssetsDir, "etcd-cert"), getHostPath("/host/etc/cni/net.d/calico-tls/etcd-cert")); err != nil {
 			logrus.Warnf("Missing etcd-cert")
 		}
-		if err := copyFileAndPermissions(fmt.Sprintf("%s/%s", c.TLSAssetsDir, "etcd-key"), "/host/etc/cni/net.d/calico-tls/etcd-key"); err != nil {
+		if err := copyFileAndPermissions(fmt.Sprintf("%s/%s", c.TLSAssetsDir, "etcd-key"), getHostPath("/host/etc/cni/net.d/calico-tls/etcd-key")); err != nil {
 			logrus.Warnf("Missing etcd-key")
 		}
 	}
 
 	// Set the suid bit on the binaries to allow them to run as non-root users.
-	if err := setSuidBit("/opt/cni/bin/install"); err != nil {
+	if err := setSuidBit(getHostPath("/opt/cni/bin/install")); err != nil {
 		logrus.WithError(err).Fatalf("Failed to set the suid bit on the install binary")
 	}
 
 	// TODO: Remove the setSUID code here on calico and calico-ipam when they eventually
 	// get refactored to all use install as the source.
-	if err := setSuidBit("/opt/cni/bin/calico"); err != nil {
+	if err := setSuidBit(getHostPath("/opt/cni/bin/calico")); err != nil {
 		logrus.WithError(err).Fatalf("Failed to set the suid bit on the calico binary")
 	}
 
-	if err := setSuidBit("/opt/cni/bin/calico-ipam"); err != nil {
+	if err := setSuidBit(getHostPath("/opt/cni/bin/calico-ipam")); err != nil {
 		logrus.WithError(err).Fatalf("Failed to set the suid bit on the calico-ipam")
 	}
 
 	// Place the new binaries if the directory is writeable.
-	dirs := []string{"/host/opt/cni/bin", "/host/secondary-bin-dir"}
+	dirs := []string{getHostPath("/host/opt/cni/bin"), getHostPath("/host/secondary-bin-dir")}
 	binsWritten := false
 	for _, d := range dirs {
 		if err := fileutil.IsDirWriteable(d); err != nil {
@@ -198,13 +214,13 @@ func Install() error {
 		}
 
 		// Iterate through each binary we might want to install.
-		files, err := os.ReadDir("/opt/cni/bin/")
+		files, err := ioutil.ReadDir(getHostPath("/opt/cni/bin/"))
 		if err != nil {
 			log.Fatal(err)
 		}
 		for _, binary := range files {
 			target := fmt.Sprintf("%s/%s", d, binary.Name())
-			source := fmt.Sprintf("/opt/cni/bin/%s", binary.Name())
+			source := getHostPath(fmt.Sprintf("/opt/cni/bin/%s", binary.Name()))
 			if c.skipBinary(binary.Name()) {
 				continue
 			}
@@ -306,28 +322,7 @@ func isValidJSON(s string) error {
 }
 
 func writeCNIConfig(c config) {
-	netconf := `{
-  "name": "k8s-pod-network",
-  "cniVersion": "0.3.1",
-  "plugins": [
-    {
-      "type": "calico",
-      "log_level": "__LOG_LEVEL__",
-      "log_file_path": "__LOG_FILE_PATH__",
-      "datastore_type": "__DATASTORE_TYPE__",
-      "nodename": "__KUBERNETES_NODE_NAME__",
-      "mtu": __CNI_MTU__,
-      "ipam": {"type": "calico-ipam"},
-      "policy": {"type": "k8s"},
-      "kubernetes": {"kubeconfig": "__KUBECONFIG_FILEPATH__"}
-    },
-    {
-      "type": "portmap",
-      "snat": true,
-      "capabilities": {"portMappings": true}
-    }
-  ]
-}`
+	netconf := defaultNetConf()
 
 	// Pick the config template to use. This can either be through an env var,
 	// or a file mounted into the container.
@@ -367,23 +362,32 @@ func writeCNIConfig(c config) {
 
 	netconf = strings.Replace(netconf, "__SERVICEACCOUNT_TOKEN__", string(c.ServiceAccountToken), -1)
 
+	// Perform replacement of windows variables
+	if runtime.GOOS == "windows" {
+		netconf = strings.Replace(netconf, "__ROUTE_TYPE__", getEnv("ROUTE_TYPE", "OutBoundNAT"), -1)
+		netconf = strings.Replace(netconf, "__K8S_SERVICE_CIDR__", getEnv("K8S_SERVICE_CIDR", "10.96.0.0/12"), -1)
+		netconf = strings.Replace(netconf, "__VNI__", getEnv("VXLAN_VNI", "4096"), -1)
+		netconf = strings.Replace(netconf, "__MAC_PREFIX__", getEnv("MAC_PREFIX", "0E-2A"), -1)
+		netconf = strings.Replace(netconf, "__VNI__", getEnv("VXLAN_VNI", "4096"), -1)
+	}
+
 	// Replace etcd datastore variables.
 	hostSecretsDir := c.CNINetDir + "/calico-tls"
-	if fileExists("/host/etc/cni/net.d/calico-tls/etcd-cert") {
+	if fileExists(getHostPath("/host/etc/cni/net.d/calico-tls/etcd-cert")) {
 		etcdCertFile := fmt.Sprintf("%s/etcd-cert", hostSecretsDir)
 		netconf = strings.Replace(netconf, "__ETCD_CERT_FILE__", etcdCertFile, -1)
 	} else {
 		netconf = strings.Replace(netconf, "__ETCD_CERT_FILE__", "", -1)
 	}
 
-	if fileExists("/host/etc/cni/net.d/calico-tls/etcd-ca") {
+	if fileExists(getHostPath("/host/etc/cni/net.d/calico-tls/etcd-ca")) {
 		etcdCACertFile := fmt.Sprintf("%s/etcd-ca", hostSecretsDir)
 		netconf = strings.Replace(netconf, "__ETCD_CA_CERT_FILE__", etcdCACertFile, -1)
 	} else {
 		netconf = strings.Replace(netconf, "__ETCD_CA_CERT_FILE__", "", -1)
 	}
 
-	if fileExists("/host/etc/cni/net.d/calico-tls/etcd-key") {
+	if fileExists(getHostPath("/host/etc/cni/net.d/calico-tls/etcd-key")) {
 		etcdKeyFile := fmt.Sprintf("%s/etcd-key", hostSecretsDir)
 		netconf = strings.Replace(netconf, "__ETCD_KEY_FILE__", etcdKeyFile, -1)
 	} else {
@@ -399,8 +403,8 @@ func writeCNIConfig(c config) {
 
 	// Write out the file.
 	name := getEnv("CNI_CONF_NAME", "10-calico.conflist")
-	path := fmt.Sprintf("/host/etc/cni/net.d/%s", name)
-	err = os.WriteFile(path, []byte(netconf), 0644)
+	path := getHostPath(fmt.Sprintf("/host/etc/cni/net.d/%s", name))
+	err = ioutil.WriteFile(path, []byte(netconf), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -417,7 +421,7 @@ func writeCNIConfig(c config) {
 	oldName := getEnv("CNI_OLD_CONF_NAME", "10-calico.conflist")
 	if name != oldName {
 		logrus.Infof("Removing /host/etc/cni/net.d/%s", oldName)
-		if err := os.Remove(fmt.Sprintf("/host/etc/cni/net.d/%s", oldName)); err != nil {
+		if err := os.Remove(getHostPath(fmt.Sprintf("/host/etc/cni/net.d/%s", oldName))); err != nil {
 			logrus.WithError(err).Warnf("Failed to remove %s", oldName)
 		}
 	}
@@ -446,6 +450,11 @@ func copyFileAndPermissions(src, dst string) (err error) {
 	err = os.Rename(dstTmp, dst)
 	if err != nil {
 		return fmt.Errorf("failed to rename file: %s", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		// chmod doesn't work on windows
+		return
 	}
 
 	// chmod the dst file to match the original permissions.
@@ -503,7 +512,7 @@ current-context: calico-context`
 		data = strings.Replace(data, "__TLS_CFG__", ca, -1)
 	}
 
-	if err := os.WriteFile("/host/etc/cni/net.d/calico-kubeconfig", []byte(data), 0600); err != nil {
+	if err := ioutil.WriteFile(getHostPath("/host/etc/cni/net.d/calico-kubeconfig"), []byte(data), 0600); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cni-plugin/pkg/install/install_linux.go
+++ b/cni-plugin/pkg/install/install_linux.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+func defaultNetConf() string {
+	netconf := `{
+  "name": "k8s-pod-network",
+  "cniVersion": "0.3.1",
+  "plugins": [
+    {
+      "type": "calico",
+      "log_level": "__LOG_LEVEL__",
+      "log_file_path": "__LOG_FILE_PATH__",
+      "datastore_type": "__DATASTORE_TYPE__",
+      "nodename": "__KUBERNETES_NODE_NAME__",
+      "mtu": __CNI_MTU__,
+      "ipam": {"type": "calico-ipam"},
+      "policy": {"type": "k8s"},
+      "kubernetes": {"kubeconfig": "__KUBECONFIG_FILEPATH__"}
+    },
+    {
+      "type": "portmap",
+      "snat": true,
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}`
+	return netconf
+}

--- a/cni-plugin/pkg/install/install_windows.go
+++ b/cni-plugin/pkg/install/install_windows.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+func defaultNetConf() string {
+	netconf := `{
+  "name": "Calico",
+  "windows_use_single_network": true,
+  "cniVersion": "0.3.1",
+  "type": "calico",
+  "mode": "vxlan",
+  "vxlan_mac_prefix":  "__MAC_PREFIX__",
+  "vxlan_vni": __VNI__,
+  "policy": {
+    "type": "k8s"
+  },
+  "log_level": "info",
+  "capabilities": {"dns": true},
+  "DNS":  {
+    "Search":  [
+      "svc.cluster.local"
+    ]
+  },
+  "datastore_type": "__DATASTORE_TYPE__",
+  "kubernetes": {
+    "kubeconfig": "__KUBECONFIG_FILEPATH__"
+  },
+  "ipam": {
+    "type": "calico-ipam",
+    "subnet": "usePodCidr"
+  },
+  "policies":  [
+    {
+      "Name":  "EndpointPolicy",
+      "Value":  {
+        "Type":  "__ROUTE_TYPE__",
+        "ExceptionList":  [
+          "__K8S_SERVICE_CIDR__"
+        ]
+      }
+    },
+    {
+      "Name":  "EndpointPolicy",
+      "Value":  {
+        "Type":  "__ROUTE_TYPE__",
+        "DestinationPrefix":  "__K8S_SERVICE_CIDR__",
+        "NeedEncap":  true
+      }
+    }
+  ]
+}
+`
+	return netconf
+}

--- a/node/.dockerignore
+++ b/node/.dockerignore
@@ -8,3 +8,6 @@
 # - CentOS repository file and our license
 !centos.repo
 !LICENSE
+!windows-packaging/CalicoWindows/libs
+!windows-packaging/CalicoWindows/node
+!windows-packaging/CalicoWindows/felix

--- a/node/Dockerfile-windows
+++ b/node/Dockerfile-windows
@@ -1,0 +1,37 @@
+# Copyright (c) 2015-2019 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+ARG GIT_VERSION=unknown
+
+# Required labels for certification
+LABEL name="Calico node" \
+      vendor="Project Calico" \
+      version=$GIT_VERSION \
+      release="1" \
+      summary="Calico node handles networking and policy for Calico" \
+      description="Calico node handles networking and policy for Calico" \
+      maintainer="laurence@tigera.io"
+
+ADD LICENSE /licenses/
+
+ADD dist/bin/calico-node.exe /calico/calico-node.exe
+ADD windows-packaging/CalicoWindows/felix/felix-service.ps1 /calico/felix-service.ps1
+ADD windows-packaging/CalicoWindows/node/node-service.ps1 /calico/node-service.ps1
+Add windows-packaging/CalicoWindows/libs/calico/calico.psm1 /calico/libs/calico/calico.psm1
+Add windows-packaging/CalicoWindows/libs/hns/hns.psm1 /calico/libs/hns/hns.psm1
+
+ENV PATH=$PATH:/calico
+ENTRYPOINT ["powershell"]

--- a/node/Makefile
+++ b/node/Makefile
@@ -281,6 +281,14 @@ $(NODE_CONTAINER_CREATED): $(REMOTE_DEPS) ./Dockerfile.$(ARCH) $(NODE_CONTAINER_
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
+image-windows: clean-windows build 
+	docker buildx create --name img-builder --use --platform windows/amd64 
+	docker buildx build --platform windows/amd64 --output=type=registry --pull -t $(NODE_IMAGE):latest-$(ARCH)-windows --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile-windows .
+	docker buildx rm img-builder 
+
+clean-windows:
+	docker buildx rm img-builder || true
+
 # download BIRD source to include in image.
 $(BIRD_SOURCE): .bird-source.created
 .bird-source.created:

--- a/node/Makefile
+++ b/node/Makefile
@@ -281,7 +281,7 @@ $(NODE_CONTAINER_CREATED): $(REMOTE_DEPS) ./Dockerfile.$(ARCH) $(NODE_CONTAINER_
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
-image-windows: clean-windows build 
+image-windows: clean-windows build $(WINDOWS_BINARY) $(WINDOWS_ARCHIVE_ROOT)/libs/hns/hns.psm1
 	docker buildx create --name img-builder --use --platform windows/amd64 
 	docker buildx build --platform windows/amd64 --output=type=registry --pull -t $(NODE_IMAGE):latest-$(ARCH)-windows --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile-windows .
 	docker buildx rm img-builder 

--- a/node/windows-packaging/CalicoWindows/felix/felix-service.ps1
+++ b/node/windows-packaging/CalicoWindows/felix/felix-service.ps1
@@ -21,7 +21,7 @@ ipmo .\libs\calico\calico.psm1 -Force
 Wait-ForCalicoInit
 
 # Copy the nodename from the global setting.
-$env:FELIX_FELIXHOSTNAME = $env:NODENAME
+$env:FELIX_FELIXHOSTNAME = $(hostname).ToLower()
 
 # Disable OpenStack metadata server support, which is not available on Windows.
 $env:FELIX_METADATAADDR = "none"


### PR DESCRIPTION
## Description
This PR helps moving the Windows Calico hostprocess from [kubernetes-sigs/sig-windows-tools](https://github.com/kubernetes-sigs/sig-windows-tools) to this repository. This PR is based on the old PRs created in projectcalico/node and projectcalico/cni-plugin.

THIS PR IS STILL WORK IN PROGRESS!

## Related issues/PRs

- [#1201](https://github.com/projectcalico/node/pull/1201)
- [#1148](https://github.com/projectcalico/cni-plugin/pull/1148)
 
##Used for installing/building:
- containerd v1.7.0
- [calico-windows.yaml, kube-calico-rbac.yml](https://gist.github.com/fabi200123/45023ea57860721a013b329bb8c8c9ac)

