### PR TITLE
Add newline before heading to fix table rendering

### DIFF
--- a/calico/reference/resources/bgpconfig.md
+++ b/calico/reference/resources/bgpconfig.md
@@ -64,6 +64,7 @@ spec:
 | nodeMeshPassword   | BGP password for the all the peerings in a full mesh configuration. |  | [BGPPassword](bgppeer#bgppassword) | `nil` (no password) |
 | nodeMeshMaxRestartTime  | Restart time that is announced by BIRD in the BGP graceful restart capability and that specifies how long the neighbor would wait for the BGP session to re-establish after a restart before deleting stale routes in full mesh configurations. Note: extra care should be taken when changing this configuration, as it may break networking in your cluster. When not specified, BIRD uses the default value of 120 seconds. | `10s`, `120s`, `2m` etc.  | [Duration string][parse-duration] | `nil` (empty config, BIRD will use the default value of `120s`) |
 | ignoredInterfaces | List of network interfaces to be excluded when reading device routes. | A list of network interface names. The names can contain the wildcard character asterisk `*` to specify groups of interface names. | List of string | `nil` (no extra interfaces to be ignored) |
+
 #### communities
 
 | Field       | Description                 | Accepted Values   | Schema |


### PR DESCRIPTION
## Description

Fixes #7264 (broken table on the "BGP configuration definition" Page in the Reference Section)

Only Change is a blank line before a heading, that seems to have messed up the rendering.

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
