### PR TITLE
Add logic to release to build a metadata yaml file

### DIFF
--- a/hack/release/cmd/main.go
+++ b/hack/release/cmd/main.go
@@ -11,12 +11,16 @@ import (
 	"github.com/projectcalico/calico/hack/release/pkg/builder"
 )
 
-var create, publish, newBranch bool
+var create, publish, newBranch, meta bool
+var dir string
 
 func init() {
 	flag.BoolVar(&create, "create", false, "Create a release from the current commit")
 	flag.BoolVar(&publish, "publish", false, "Publish the release built from the current tag")
 	flag.BoolVar(&newBranch, "new-branch", false, "Create a new release branch from master")
+	flag.BoolVar(&meta, "metadata", false, "Product release metadata")
+
+	flag.StringVar(&dir, "dir", "./", "Directory to place build metadata in")
 
 	flag.Parse()
 }
@@ -24,6 +28,16 @@ func init() {
 func main() {
 	// Create a releaseBuilder to use.
 	r := builder.NewReleaseBuilder(&builder.RealCommandRunner{})
+
+	if meta {
+		configureLogging("metadata.log")
+		err := r.BuildMetadata(dir)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to produce release metadata")
+			os.Exit(1)
+		}
+		return
+	}
 
 	if create {
 		configureLogging("release-build.log")


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds a helper metadata file to our release artifacts. This can be
helpful for tooling that might want to perform automation against our
releases, and can be augmented to include more information in the
future.

Example output for v3.25.0: 

```
version: v3.25.0
operatorVersion: v1.29.0
images:
- quay.io/tigera/operator:v1.29.0
- calico/typha:v3.25.0
- calico/ctl:v3.25.0
- calico/node:v3.25.0
- calico/cni:v3.25.0
- calico/apiserver:v3.25.0
- calico/kube-controllers:v3.25.0
- calico/windows:v3.25.0
- calico/dikastes:v3.25.0
- calico/pod2daemon-flexvol:v3.25.0
- calico/csi:v3.25.0
- calico/node-driver-registrar:v3.25.0
helmChartVersion: v3.25.0

```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.