### PR TITLE
docs: Add env CALICO_IPV6POOL_NAT_OUTGOING to calico-node for IPv6

### DIFF
--- a/calico/networking/ipv6.md
+++ b/calico/networking/ipv6.md
@@ -109,6 +109,9 @@ spec:
    | `IP6`         | `autodetect` |
    | `FELIX_IPV6SUPPORT` | `true` |
 
+   **Note**: For IPv6 IP Pools with private IPs, the environment `CALICO_IPV6POOL_NAT_OUTGOING: true` should be set to perform outbound NAT for connections from pods to outside of the cluster.
+   {: .alert .alert-info}
+
 1. For clusters **not** provisioned with kubeadm (see note below), configure the default IPv6 IP pool by adding the following variable setting to the environment for the `calico-node` container:
 
    | Variable name | Value |
@@ -190,6 +193,9 @@ spec:
    | ------------- | ----- |
    | `IP6`         | `autodetect` |
    | `FELIX_IPV6SUPPORT` | `true` |
+
+   **Note**: For IPv6 IP Pools with private IPs, the environment `CALICO_IPV6POOL_NAT_OUTGOING: true` should be set to perform outbound NAT for connections from pods to outside of the cluster.
+   {: .alert .alert-info}
 
 1. For clusters **not** provisioned with kubeadm (see note below), configure the default IPv6 IP pool by adding the following variable setting to the environment for the `calico-node` container:
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fix #7183
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
