### PR TITLE
Pin to Docker version that was the latest until this morning

### DIFF
--- a/felix/.semaphore/create-test-vm
+++ b/felix/.semaphore/create-test-vm
@@ -41,7 +41,7 @@ function create-vm() {
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg" && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable' | sudo tee /etc/apt/sources.list.d/docker.list" && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt update -y && \
-  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt install -y --no-install-recommends git docker-ce docker-ce-cli containerd.io make iproute2 wireguard && \
+  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt install -y --no-install-recommends git docker-ce=5:20.10.9~3-0~ubuntu-focal docker-ce-cli=5:20.10.9~3-0~ubuntu-focal containerd.io make iproute2 wireguard && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo usermod -a -G docker ubuntu && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo modprobe ipip && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- 'if [ -s /etc/docker/daemon.json ] ; then cat /etc/docker/daemon.json | sed "\$d" | sed "\$s/\$/,/" > /tmp/daemon.json ; else echo -en {\\n > /tmp/daemon.json ; fi' && \


### PR DESCRIPTION
## Description

There has just (earlier today) been a new Ubuntu package for docker-ce released on download.docker.com:

    docker-ce_20.10.9~3-0~ubuntu-focal_amd64.deb                                          2021-10-25 08:19:44 20.2 MiB
    docker-ce_23.0.0-1~ubuntu.20.04~focal_amd64.deb                                       2023-02-02 10:31:57 20.9 MiB

(specifically that's from https://download.docker.com/linux/ubuntu/dists/focal/pool/stable/amd64/)

I think that's what's causing our core CI now to fail in the "UT/FV tests on new kernel" job.  The
specific problem is

    + gcloud --quiet compute ssh --zone=europe-west3-c ubuntu@sem-calico-87839f4e-ut -- sudo mv /tmp/daemon.json /etc/docker/daemon.json
    Pseudo-terminal will not be allocated because stdin is not a terminal.
    mv: cannot move '/tmp/daemon.json' to '/etc/docker/daemon.json': No such file or directory

i.e. it looks like the new Docker package doesn't create the /etc/docker directory.

To avoid that, this PR pins back to the previous Docker package versions.
