### PR TITLE
Link to more detailed calicoctl install instructions e.g. for K8s

### DIFF
--- a/calicoctl/README.md
+++ b/calicoctl/README.md
@@ -25,8 +25,12 @@ If you want to use a package manager:
 
 - [Homebrew] users can use `brew install calicoctl`.
 
+More detailed installation instructions, including how to install `calicoctl` as a
+Kubernetes pod, are available in the [online documentation][detailed install instructions].
+
 [Releases page]: https://github.com/projectcalico/calicoctl/releases
 [Homebrew]: https://brew.sh/
+[detailed install instructions]: https://projectcalico.docs.tigera.io/master/maintenance/clis/calicoctl/install
 
 ### Developing
 

--- a/calicoctl/README.md
+++ b/calicoctl/README.md
@@ -25,12 +25,12 @@ If you want to use a package manager:
 
 - [Homebrew] users can use `brew install calicoctl`.
 
-More detailed installation instructions, including how to install `calicoctl` as a
-Kubernetes pod, are available in the [online documentation][detailed install instructions].
+More detailed installation instructions, including are available in the
+[online documentation][detailed install instructions].
 
 [Releases page]: https://github.com/projectcalico/calicoctl/releases
 [Homebrew]: https://brew.sh/
-[detailed install instructions]: https://projectcalico.docs.tigera.io/master/maintenance/clis/calicoctl/install
+[detailed install instructions]: https://docs.tigera.io/calico/latest/operations/calicoctl/install
 
 ### Developing
 


### PR DESCRIPTION
## Description

I was trying to find this documentation and it took me a while; I ended up finding the proper link through the Calico Users Slack server, of all things. I figure providing a link to the docs in this README will help others save some time.

It could be argued that the reference page should link to the install page, but that would be its own PR. More breadcrumb trails don't hurt, IMO.

Since this only changes the README, I'm not sure how much the PR template's questions apply here. Like, there aren't any tests for this, nor components affected besides the README itself, right? So I'm just going to check off all the to-dos and apologize for being brazen.

## Related issues/PRs

N/A

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

N/A

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
