### PR TITLE
fix:extension/v1beta1 to apps/v1 for DaemonSet

### DIFF
--- a/app-policy/config/install/05-calico-jenkins.yaml
+++ b/app-policy/config/install/05-calico-jenkins.yaml
@@ -51,7 +51,7 @@ metadata:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system

--- a/app-policy/config/install/05-calico.yaml
+++ b/app-policy/config/install/05-calico.yaml
@@ -166,7 +166,7 @@ data:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system

--- a/pod2daemon/nodeagent/nodeagent-dikastes.yaml
+++ b/pod2daemon/nodeagent/nodeagent-dikastes.yaml
@@ -3,7 +3,7 @@
 # the 'test-mgmt'/creds directory.
 # TBD: Change the nodeagent image to be one that reads from the cred's directory.
 ##
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nodeagent

--- a/pod2daemon/nodeagent/nodeagent.yaml
+++ b/pod2daemon/nodeagent/nodeagent.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nodeagent


### PR DESCRIPTION
Signed-off-by: yulng <wei.yang@daocloud.io>
Fix extension/v1beta1 to apps/v1 for DaemonSet
According to the following document:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
![image](https://user-images.githubusercontent.com/31728060/216942411-af9f7aea-450d-4893-b108-4a8007406e6c.png)
