### PR TITLE
Fix UID for v3 resources in KDD mode

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/customresource.go
+++ b/libcalico-go/lib/backend/k8s/resources/customresource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019,2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019,2021-2022 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -220,7 +220,10 @@ func (c *customK8sResourceClient) Delete(ctx context.Context, k model.Key, revis
 
 	opts := &metav1.DeleteOptions{}
 	if uid != nil {
-		opts.Preconditions = &metav1.Preconditions{UID: uid}
+		// The UID of the underlying CRD is reversed (see ReverseUID, ConvertK8sResourceToCalicoResource and
+		// ConvertCalicoResourceToK8sResource for details)
+		ruid := ReverseUID(*uid)
+		opts.Preconditions = &metav1.Preconditions{UID: &ruid}
 	}
 
 	// Delete the resource using the name.


### PR DESCRIPTION
## Description

Picking up the fix for #5715.  Looks like we adopted this fix in Calico Enterprise already so let's be consistent.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->


fixes #5715

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Calico API server would reuse UUIDs from the underlying CRD objects that underpin the datamodel (thus confusing Kubernetes ownership tracking and ArgoCD).  This will result in the apparent UUIDs of calico "v3" resources changing over upgrade.  This was unavoidable in order to split them from the underlying CRD UUIDs.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
