### PR TITLE
DevStack test: address flakes when cloning OpenStack repos

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -96,14 +96,8 @@ sudo sysctl -w net.ipv6.conf.all.forwarding=1
 
 # Clone the DevStack repository (if not already present).
 test -e devstack || \
-    git clone ${DEVSTACK_REPO:-https://opendev.org/openstack/devstack}
+    git clone -b ${DEVSTACK_BRANCH:-master} ${DEVSTACK_REPO:-https://opendev.org/openstack/devstack} --depth=1
 cd devstack
-
-# If DEVSTACK_BRANCH has been specified, check out that branch.  (Otherwise we
-# use DevStack's master branch.)
-if [ -n "$DEVSTACK_BRANCH" ]; then
-    git checkout ${DEVSTACK_BRANCH}
-fi
 
 # Prepare DevStack config.
 cat > local.conf <<EOF
@@ -122,6 +116,17 @@ LOGFILE=stack.log
 LOG_COLOR=False
 
 TEMPEST_BRANCH=29.0.0
+
+# We commonly hit GnuTLS errors when git cloning OpenStack repos, for example:
+# Cloning into 'devstack'...
+# remote: Enumerating objects: 28788, done.
+# remote: Counting objects: 100% (28788/28788), done.
+# remote: Compressing objects: 100% (9847/9847), done.
+# error: RPC failed; curl 56 GnuTLS recv error (-9): A TLS packet with unexpected length was received.
+#
+# https://stackoverflow.com/questions/38378914/how-to-fix-git-error-rpc-failed-curl-56-gnutls
+# suggests that this can be mitigated by reducing the depth of the git clone.
+GIT_DEPTH=1
 
 EOF
 

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -96,7 +96,7 @@ sudo sysctl -w net.ipv6.conf.all.forwarding=1
 
 # Clone the DevStack repository (if not already present).
 test -e devstack || \
-    git clone -b ${DEVSTACK_BRANCH:-master} ${DEVSTACK_REPO:-https://opendev.org/openstack/devstack} --depth=1
+    git clone -b ${DEVSTACK_BRANCH:-master} ${DEVSTACK_REPO:-https://github.com/openstack/devstack} --depth=1
 cd devstack
 
 # Prepare DevStack config.
@@ -127,6 +127,10 @@ TEMPEST_BRANCH=29.0.0
 # https://stackoverflow.com/questions/38378914/how-to-fix-git-error-rpc-failed-curl-56-gnutls
 # suggests that this can be mitigated by reducing the depth of the git clone.
 GIT_DEPTH=1
+
+# Unfortunately we still see GnuTLS errors with the above.  Let's try cloning from GitHub instead of
+# from opendev.org.
+GIT_BASE=https://github.com
 
 EOF
 


### PR DESCRIPTION
We commonly hit GnuTLS errors when git cloning OpenStack repos, for example:

    Cloning into 'devstack'...
    remote: Enumerating objects: 28788, done.
    remote: Counting objects: 100% (28788/28788), done.
    remote: Compressing objects: 100% (9847/9847), done.
    error: RPC failed; curl 56 GnuTLS recv error (-9): A TLS packet with unexpected length was received.

https://stackoverflow.com/questions/38378914/how-to-fix-git-error-rpc-failed-curl-56-gnutls suggests that this can be mitigated by reducing the depth of the git clone.

Unfortunately adding `--depth 1` wasn't enough; we still see the GnuTLS problem.  However it appears to be fixed if we configure GIT_BASE so as to clone from GitHub instead of from opendev.org.

Why though?  There doesn't seem to be clear info available about the GnuTLS issue, but
-  it might be related to the exact SSL/TLS exchanges between git (on Semaphore) and the Git server, including perhaps the details of the server certificate
-  some hits suggest it occurs more readily when the underlying network is less reliable.

I think I previously established that our Semaphore runs in Germany, while opendev.org is hosted in USA - so that's a transatlantic hop.  With GitHub, OTOH, I guess that github.com resolves to a server that is geographically closer to Semaphore.

Net, there's a bit of a reason why github could be better, so let's run with that for a while.  Let's also keep the `--depth 1` because we don't need any more than that.