### PR TITLE
[release-v3.24] Auto pick #7267: Add logic to release to build a metadata yaml file

### DIFF
--- a/hack/release/cmd/main.go
+++ b/hack/release/cmd/main.go
@@ -11,12 +11,16 @@ import (
 	"github.com/projectcalico/calico/hack/release/pkg/builder"
 )
 
-var create, publish, newBranch bool
+var create, publish, newBranch, meta bool
+var dir string
 
 func init() {
 	flag.BoolVar(&create, "create", false, "Create a release from the current commit")
 	flag.BoolVar(&publish, "publish", false, "Publish the release built from the current tag")
 	flag.BoolVar(&newBranch, "new-branch", false, "Create a new release branch from master")
+	flag.BoolVar(&meta, "metadata", false, "Product release metadata")
+
+	flag.StringVar(&dir, "dir", "./", "Directory to place build metadata in")
 
 	flag.Parse()
 }
@@ -24,6 +28,16 @@ func init() {
 func main() {
 	// Create a releaseBuilder to use.
 	r := builder.NewReleaseBuilder(&builder.RealCommandRunner{})
+
+	if meta {
+		configureLogging("metadata.log")
+		err := r.BuildMetadata(dir)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to produce release metadata")
+			os.Exit(1)
+		}
+		return
+	}
 
 	if create {
 		configureLogging("release-build.log")

--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 // Global configuration for releases.
@@ -51,6 +52,59 @@ func NewReleaseBuilder(runner CommandRunner) *ReleaseBuilder {
 type ReleaseBuilder struct {
 	// Allow specification of command runner so it can be overridden in tests.
 	runner CommandRunner
+}
+
+// releaseImages returns the set of images that should be expected for a release.
+// This function needs to be kept up-to-date with the actual release artifacts produced for a
+// release if images are added or removed.
+func releaseImages(version, operatorVersion string) []string {
+	return []string{
+		fmt.Sprintf("quay.io/tigera/operator:%s", operatorVersion),
+		fmt.Sprintf("calico/typha:%s", version),
+		fmt.Sprintf("calico/ctl:%s", version),
+		fmt.Sprintf("calico/node:%s", version),
+		fmt.Sprintf("calico/cni:%s", version),
+		fmt.Sprintf("calico/apiserver:%s", version),
+		fmt.Sprintf("calico/kube-controllers:%s", version),
+		fmt.Sprintf("calico/windows:%s", version),
+		fmt.Sprintf("calico/dikastes:%s", version),
+		fmt.Sprintf("calico/pod2daemon-flexvol:%s", version),
+		fmt.Sprintf("calico/csi:%s", version),
+		fmt.Sprintf("calico/node-driver-registrar:%s", version),
+	}
+}
+
+func (r *ReleaseBuilder) BuildMetadata(dir string) error {
+	type metadata struct {
+		Version          string   `json:"version"`
+		OperatorVersion  string   `json:"operator_version" yaml:"operatorVersion"`
+		Images           []string `json:"images"`
+		HelmChartVersion string   `json:"helm_chart_version" yaml:"helmChartVersion"`
+	}
+
+	// Determine the versions to use based on the manifests, which should
+	// have already been updated with the correct tags.
+	calicoVersion, operatorVersion := r.getVersionsFromManifests()
+
+	m := metadata{
+		Version:          calicoVersion,
+		OperatorVersion:  operatorVersion,
+		Images:           releaseImages(calicoVersion, operatorVersion),
+		HelmChartVersion: calicoVersion,
+	}
+
+	// Render it as yaml and write it to a file.
+	bs, err := yaml.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(fmt.Sprintf("%s/metadata.yaml", dir), []byte(bs), 0o644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // BuildRelease creates a Calico release.
@@ -237,7 +291,13 @@ func (r *ReleaseBuilder) collectGithubArtifacts(ver string) error {
 	// TODO: Delete if already exists.
 	err := os.MkdirAll(uploadDir, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("Failed to create dir: %s", err)
+		return fmt.Errorf("failed to create dir: %s", err)
+	}
+
+	// Add in a release metadata file.
+	err = r.BuildMetadata(uploadDir)
+	if err != nil {
+		return fmt.Errorf("failed to build release metadata file: %s", err)
 	}
 
 	// We attach calicoctl binaries directly to the release as well.
@@ -477,6 +537,47 @@ func (r *ReleaseBuilder) publishContainerImages(ver string) error {
 		}
 	}
 	return nil
+}
+
+// getVersionsFromManifests returns the Calico and Operator versions in-use by this
+// release based on the generated manifests to be used for this release.
+func (r *ReleaseBuilder) getVersionsFromManifests() (string, string) {
+	manifests := []string{"calico.yaml", "tigera-operator.yaml"}
+
+	var operatorVersion, version string
+	for _, m := range manifests {
+		args := []string{"-Po", `image:\K(.*)`, m}
+		out, err := r.runner.RunInDir("manifests", "grep", args, nil)
+		if err != nil {
+			panic(err)
+		}
+
+		imgs := strings.Split(out, "\n")
+
+		for _, i := range imgs {
+			if strings.Contains(i, "operator") && operatorVersion == "" {
+				splits := strings.SplitAfter(i, ":")
+				operatorVersion = splits[len(splits)-1]
+				logrus.Infof("Using version %s from image %s", version, i)
+			} else if strings.Contains(i, "calico/") && version == "" {
+				splits := strings.SplitAfter(i, ":")
+				version = splits[len(splits)-1]
+				logrus.Infof("Using version %s from image %s", version, i)
+			}
+			if operatorVersion != "" && version != "" {
+				break
+			}
+		}
+		if operatorVersion != "" && version != "" {
+			break
+		}
+	}
+
+	if version == "" || operatorVersion == "" {
+		panic("Missing version!")
+	}
+
+	return version, operatorVersion
 }
 
 // determineReleaseVersion uses historical clues to figure out the next semver


### PR DESCRIPTION
Cherry pick of #7267 on release-v3.24.

#7267: Add logic to release to build a metadata yaml file

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds a helper metadata file to our release artifacts. This can be
helpful for tooling that might want to perform automation against our
releases, and can be augmented to include more information in the
future.

Example output for v3.25.0: 

```
version: v3.25.0
operatorVersion: v1.29.0
images:
- quay.io/tigera/operator:v1.29.0
- calico/typha:v3.25.0
- calico/ctl:v3.25.0
- calico/node:v3.25.0
- calico/cni:v3.25.0
- calico/apiserver:v3.25.0
- calico/kube-controllers:v3.25.0
- calico/windows:v3.25.0
- calico/dikastes:v3.25.0
- calico/pod2daemon-flexvol:v3.25.0
- calico/csi:v3.25.0
- calico/node-driver-registrar:v3.25.0
helmChartVersion: v3.25.0

```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.