### PR TITLE
Fix some BPF FV flakes

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -401,7 +401,7 @@ blocks:
     jobs:
     - name: UT/FV tests on new kernel
       execution_time_limit:
-        minutes: 120
+        minutes: 180
       commands:
       - ./.semaphore/run-tests-on-vms ${VM_PREFIX}
     epilogue:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -401,7 +401,7 @@ blocks:
     jobs:
     - name: UT/FV tests on new kernel
       execution_time_limit:
-        minutes: 120
+        minutes: 180
       commands:
       - ./.semaphore/run-tests-on-vms ${VM_PREFIX}
     epilogue:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -399,7 +399,7 @@ blocks:
     jobs:
     - name: UT/FV tests on new kernel
       execution_time_limit:
-        minutes: 120
+        minutes: 180
       commands:
       - ./.semaphore/run-tests-on-vms ${VM_PREFIX}
     epilogue:

--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -360,7 +360,7 @@ func (b *PinnedMap) Iter(f IterCallback) error {
 		if action == IterDelete {
 			// The previous iteration asked us to delete its key; do that now before we check for the end of
 			// the iteration.
-			err := DeleteMapEntry(b.MapFD(), keyToDelete, b.ValueSize)
+			err := DeleteMapEntry(b.MapFD(), keyToDelete, valueSize)
 			if err != nil && !IsNotExists(err) {
 				return fmt.Errorf("failed to delete map entry: %w", err)
 			}

--- a/felix/fv/bpf_attach_test.go
+++ b/felix/fv/bpf_attach_test.go
@@ -72,12 +72,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 		// This should not happen at initial execution of felix, since there is no program attached
 		firstRunBase := felix.WatchStdoutFor(regexp.MustCompile("Program already attached, skip reattaching"))
 		// These should happen at first execution of felix, since there is no program attached
-		firstRunProg1 := felix.WatchStdoutFor(regexp.MustCompile(`Continue with attaching BPF program to_hep_fib_debug(|_co-re)\.o`))
-		firstRunProg2 := felix.WatchStdoutFor(regexp.MustCompile(`Continue with attaching BPF program from_hep_fib_debug(|_co-re)\.o`))
+		attachedHEPTo := felix.WatchStdoutFor(regexp.MustCompile(`Program attached to TC.*Type:"host", ToOrFrom:"to"`))
+		attachedHEPFrom := felix.WatchStdoutFor(regexp.MustCompile(`Program attached to TC.*Type:"host", ToOrFrom:"from"`))
 		By("Starting Felix")
 		felix.TriggerDelayedStart()
-		Eventually(firstRunProg1, "10s", "100ms").Should(BeClosed())
-		Eventually(firstRunProg2, "10s", "100ms").Should(BeClosed())
+		Eventually(attachedHEPTo, "10s", "100ms").Should(BeClosed())
+		Eventually(attachedHEPFrom, "10s", "100ms").Should(BeClosed())
 		Expect(firstRunBase).NotTo(BeClosed())
 
 		// This should not happen at initial execution of felix, since there is no program attached


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Increase run timeout.  We no longer had any headroom so a lot of runs were taking 1hr 55min and some were timing out.  Hoping the other fixes will bring the time down again anyway.
- Fix panic in logic for deleting map entries while iterating.
- Fix "should not reattach bpf programs" test; was flaking due to restarting felix too soon, before it had finished applying BPF programs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
