### PR TITLE
Felix FVs: fix SCTP tests.

### DIFF
--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -180,7 +180,7 @@ func (c *Checker) ResetExpectations() {
 // ActualConnectivity calculates the current connectivity for all the expected paths.  It returns a
 // slice containing one response for each attempted check (or nil if the check failed) along with
 // a same-length slice containing a pretty-printed description of the check and its result.
-func (c *Checker) ActualConnectivity() ([]*Result, []string) {
+func (c *Checker) ActualConnectivity(isARetry bool) ([]*Result, []string) {
 	UnactivatedCheckers.Discard(c)
 	var wg sync.WaitGroup
 	responses := make([]*Result, len(c.expectations))
@@ -208,18 +208,21 @@ func (c *Checker) ActualConnectivity() ([]*Result, []string) {
 		preCalcOpts[i] = opts
 	}
 
-	// Give all the checkers a chance to run some pre-test cleanup.  For example, removing conntrack entries that
-	// might have been leaked by an earlier run.  Important to do this first rather than in-line to avoid
-	// one checker running its cleanup in parallel with another actually doing its check.
-	for i, exp := range c.expectations {
-		wg.Add(1)
-		go func(i int, exp Expectation) {
-			defer ginkgo.GinkgoRecover()
-			defer wg.Done()
-			exp.From.PreConncheckCleanup(exp.To.IP, exp.To.Port, p, preCalcOpts[i]...)
-		}(i, exp)
+	if isARetry {
+		// Give all the checkers a chance to run some pre-test cleanup.  For example, removing conntrack entries that
+		// might have been leaked by an earlier run.  Important to do this first rather than in-line to avoid
+		// one checker running its cleanup in parallel with another actually doing its check.
+		log.Debug("Retry, calling pre-retry cleanup functions.")
+		for i, exp := range c.expectations {
+			wg.Add(1)
+			go func(i int, exp Expectation) {
+				defer ginkgo.GinkgoRecover()
+				defer wg.Done()
+				exp.From.PreRetryCleanup(exp.To.IP, exp.To.Port, p, preCalcOpts[i]...)
+			}(i, exp)
+		}
+		wg.Wait()
 	}
-	wg.Wait()
 
 	// Actually run the checks and format the results.
 	for i, exp := range c.expectations {
@@ -332,7 +335,8 @@ func (c *Checker) CheckConnectivityWithTimeoutOffset(callerSkip int, timeout tim
 
 	for {
 		checkStartTime := time.Now()
-		actualConn, actualConnPretty = c.ActualConnectivity()
+		isARetry := completedAttempts > 0
+		actualConn, actualConnPretty = c.ActualConnectivity(isARetry)
 		failed := false
 		finalErr = nil
 		expConnectivity = c.ExpectedConnectivityPretty()
@@ -473,14 +477,14 @@ type Matcher struct {
 }
 
 type ConnectionSource interface {
-	PreConncheckCleanup(ip, port, protocol string, opts ...CheckOption)
+	PreRetryCleanup(ip, port, protocol string, opts ...CheckOption)
 	CanConnectTo(ip, port, protocol string, opts ...CheckOption) *Result
 	SourceName() string
 	SourceIPs() []string
 }
 
 func (m *Matcher) Match(actual interface{}) (success bool, err error) {
-	actual.(ConnectionSource).PreConncheckCleanup(m.IP, m.Port, m.Protocol)
+	actual.(ConnectionSource).PreRetryCleanup(m.IP, m.Port, m.Protocol)
 	success = actual.(ConnectionSource).CanConnectTo(m.IP, m.Port, m.Protocol) != nil
 	return
 }

--- a/felix/fv/containers/containers.go
+++ b/felix/fv/containers/containers.go
@@ -702,6 +702,9 @@ func (c *Container) SourceIPs() []string {
 	return ips
 }
 
+func (c *Container) PreConncheckCleanup(ip, port, protocol string, opts ...connectivity.CheckOption) {
+}
+
 func (c *Container) CanConnectTo(ip, port, protocol string, opts ...connectivity.CheckOption) *connectivity.Result {
 	return connectivity.Check(c.Name, "Connection test", ip, port, protocol, opts...)
 }

--- a/felix/fv/containers/containers.go
+++ b/felix/fv/containers/containers.go
@@ -702,7 +702,7 @@ func (c *Container) SourceIPs() []string {
 	return ips
 }
 
-func (c *Container) PreConncheckCleanup(ip, port, protocol string, opts ...connectivity.CheckOption) {
+func (c *Container) PreRetryCleanup(ip, port, protocol string, opts ...connectivity.CheckOption) {
 }
 
 func (c *Container) CanConnectTo(ip, port, protocol string, opts ...connectivity.CheckOption) *connectivity.Result {

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -392,11 +392,21 @@ func (w *Workload) SourceIPs() []string {
 	return []string{w.IP}
 }
 
+func (w *Workload) PreConncheckCleanup(ip, port, protocol string, opts ...connectivity.CheckOption) {
+	anyPort := w.conncheckAnyPort()
+	anyPort.PreConncheckCleanup(ip, port, protocol, opts...)
+}
+
 func (w *Workload) CanConnectTo(ip, port, protocol string, opts ...connectivity.CheckOption) *connectivity.Result {
+	anyPort := w.conncheckAnyPort()
+	return anyPort.CanConnectTo(ip, port, protocol, opts...)
+}
+
+func (w *Workload) conncheckAnyPort() Port {
 	anyPort := Port{
 		Workload: w,
 	}
-	return anyPort.CanConnectTo(ip, port, protocol, opts...)
+	return anyPort
 }
 
 func (w *Workload) Port(port uint16) *Port {
@@ -677,9 +687,19 @@ type SpoofedWorkload struct {
 	SpoofedSourceIP string
 }
 
+func (s *SpoofedWorkload) PreConncheckCleanup(ip, port, protocol string, opts ...connectivity.CheckOption) {
+	opts = s.appendSourceIPOpt(opts)
+	s.Workload.preConncheckCleanupInner(ip, port, protocol, "(spoofed)", opts...)
+}
+
 func (s *SpoofedWorkload) CanConnectTo(ip, port, protocol string, opts ...connectivity.CheckOption) *connectivity.Result {
+	opts = s.appendSourceIPOpt(opts)
+	return s.Workload.canConnectToInner(ip, port, protocol, "(spoofed)", opts...)
+}
+
+func (s *SpoofedWorkload) appendSourceIPOpt(opts []connectivity.CheckOption) []connectivity.CheckOption {
 	opts = append(opts, connectivity.WithSourceIP(s.SpoofedSourceIP))
-	return canConnectTo(s.Workload, ip, port, protocol, "(spoofed)", opts...)
+	return opts
 }
 
 type Port struct {
@@ -698,17 +718,26 @@ func (p *Port) SourceIPs() []string {
 	return []string{p.IP}
 }
 
+func (p *Port) PreConncheckCleanup(ip, port, protocol string, opts ...connectivity.CheckOption) {
+	opts = p.maybeAppendPortOpt(opts)
+	p.Workload.preConncheckCleanupInner(ip, port, protocol, "(with source port)", opts...)
+}
+
 // Return if a connection is good and packet loss string "PacketLoss[xx]".
 // If it is not a packet loss test, packet loss string is "".
 func (p *Port) CanConnectTo(ip, port, protocol string, opts ...connectivity.CheckOption) *connectivity.Result {
+	opts = p.maybeAppendPortOpt(opts)
+	return p.Workload.canConnectToInner(ip, port, protocol, "(with source port)", opts...)
+}
+
+func (p *Port) maybeAppendPortOpt(opts []connectivity.CheckOption) []connectivity.CheckOption {
 	if p.Port != 0 {
 		opts = append(opts, connectivity.WithSourcePort(strconv.Itoa(int(p.Port))))
 	}
-	return canConnectTo(p.Workload, ip, port, protocol, "(with source port)", opts...)
+	return opts
 }
 
-func canConnectTo(w *Workload, ip, port, protocol, logSuffix string, opts ...connectivity.CheckOption) *connectivity.Result {
-
+func (w *Workload) preConncheckCleanupInner(ip, port, protocol, logSuffix string, opts ...connectivity.CheckOption) {
 	if protocol == "udp" || protocol == "sctp" {
 		// If this is a retry then we may have stale conntrack entries and we don't want those
 		// to influence the connectivity check.  UDP lacks a sequence number, so conntrack operates
@@ -720,7 +749,9 @@ func canConnectTo(w *Workload, ip, port, protocol, logSuffix string, opts ...con
 			_ = w.C.ExecMayFail("conntrack", "-D", "-p", protocol, "-s", w.IP, "-d", ip)
 		}
 	}
+}
 
+func (w *Workload) canConnectToInner(ip, port, protocol, logSuffix string, opts ...connectivity.CheckOption) *connectivity.Result {
 	logMsg := "Connection test"
 
 	// enforce the name space as we want to execute it in the workload


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Split pre-conncheck cleanup into a separate phase. Test was running one checker's cleanup in prallel with another's check.  If they used the same source/dest that could conflict by killing the check's conntrack entry.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
