### PR TITLE
Check active policy only for policy resolver

### DIFF
--- a/felix/calc/policy_resolver_test.go
+++ b/felix/calc/policy_resolver_test.go
@@ -1,0 +1,116 @@
+package calc_test
+
+import (
+	"github.com/projectcalico/calico/felix/calc"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"testing"
+)
+
+func TestPolicyResolver_OnUpdate(t *testing.T) {
+	pr := calc.NewPolicyResolver()
+
+	polKey := model.PolicyKey{
+		Name: "test-policy",
+	}
+
+	policy := model.Policy{}
+
+	kvp := model.KVPair{
+		Key:   polKey,
+		Value: &policy,
+	}
+	update := api.Update{}
+	update.Key = kvp.Key
+	update.Value = kvp.Value
+
+	pr.OnUpdate(update)
+
+	if _, found := pr.AllPolicies[polKey]; !found {
+		t.Error("Adding new inactive policy - expected policy to be in AllPolicies but it is not")
+	}
+
+	update.Value = nil
+
+	pr.OnUpdate(update)
+
+	if _, found := pr.AllPolicies[polKey]; found {
+		t.Error("Deleting inactive policy - expected AllPolicies not to contain policy but it does")
+	}
+}
+
+func TestPolicyResolver_OnPolicyMatch(t *testing.T) {
+	pr := calc.NewPolicyResolver()
+
+	polKey := model.PolicyKey{
+		Name: "test-policy",
+	}
+
+	pol := model.Policy{}
+
+	endpointKey := model.WorkloadEndpointKey{
+		Hostname: "test-workload-ep",
+	}
+
+	pr.AllPolicies[polKey] = &pol
+	pr.OnPolicyMatch(polKey, endpointKey)
+
+	if !pr.SortRequired {
+		t.Error("Adding new policy - expected SortRequired to be true but it was false")
+	}
+	if !pr.PolicyIDToEndpointIDs.ContainsKey(polKey) {
+		t.Error("Adding new policy - expected PolicyIDToEndpointIDs to contain new policy but it does not")
+	}
+	if !pr.EndpointIDToPolicyIDs.ContainsKey(endpointKey) {
+		t.Error("Adding new policy - expected EndpointIDToPolicyIDs to contain endpoint but it does not")
+	}
+	if !pr.DirtyEndpoints.Contains(endpointKey) {
+		t.Error("Adding new policy - expected DirtyEndpoints to contain endpoint for policy but it does not")
+	}
+
+	pr.SortRequired = false
+	pr.OnPolicyMatch(polKey, endpointKey)
+
+	if pr.SortRequired {
+		t.Error("Adding existing policy - expected SortRequired to be false but it was true")
+	}
+}
+
+func TestPolicyResolver_OnPolicyMatchStopped(t *testing.T) {
+	pr := calc.NewPolicyResolver()
+
+	polKey := model.PolicyKey{
+		Name: "test-policy",
+	}
+
+	pol := model.Policy{}
+
+	endpointKey := model.WorkloadEndpointKey{
+		Hostname: "test-workload-ep",
+	}
+
+	pr.PolicyIDToEndpointIDs.Put(polKey, endpointKey)
+	pr.EndpointIDToPolicyIDs.Put(endpointKey, polKey)
+	pr.PolicySorter.UpdatePolicy(polKey, &pol)
+	pr.OnPolicyMatchStopped(polKey, endpointKey)
+
+	if !pr.SortRequired {
+		t.Error("Deleting existing policy - expected SortRequired to be true but it was false")
+	}
+	if pr.PolicyIDToEndpointIDs.ContainsKey(polKey) {
+		t.Error("Deleting existing policy - expected PolicyIDToEndpointIDs not to contain policy but it does")
+	}
+	if pr.EndpointIDToPolicyIDs.ContainsKey(endpointKey) {
+		t.Error("Deleting existing policy - expected EndpointIDToPolicyIDs not to contain endpoint but it does")
+	}
+	if !pr.DirtyEndpoints.Contains(endpointKey) {
+		t.Error("Deleting existing policy - expected DirtyEndpoints to contain endpoint but it does not")
+	}
+
+	pr.SortRequired = false
+	pr.OnPolicyMatchStopped(polKey, endpointKey)
+
+	if pr.SortRequired {
+		t.Error("Deleting non-existent policy - expected SortRequired to be false but it was true")
+	}
+}

--- a/felix/calc/policy_sorter_test.go
+++ b/felix/calc/policy_sorter_test.go
@@ -16,9 +16,8 @@ package calc_test
 
 import (
 	. "github.com/projectcalico/calico/felix/calc"
-
-	. "github.com/onsi/ginkgo/extensions/table"
-	. "github.com/onsi/gomega"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"testing"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
@@ -27,15 +26,166 @@ var (
 	tenPointFive = 10.5
 )
 
-var _ = DescribeTable("PolKV should stringify correctly",
-	func(kv PolKV, expected string) {
-		Expect(kv.String()).To(Equal(expected))
-	},
-	Entry("zero", PolKV{}, "(nil policy)"),
-	Entry("nil policy", PolKV{Key: model.PolicyKey{Name: "name"}}, "name(nil policy)"),
-	Entry("nil order",
-		PolKV{Key: model.PolicyKey{Name: "name"}, Value: &model.Policy{}}, "name(default)"),
-	Entry("order set",
-		PolKV{Key: model.PolicyKey{Name: "name"}, Value: &model.Policy{Order: &tenPointFive}},
-		"name(10.5)"),
-)
+func TestPolKV_String(t *testing.T) {
+	type kvTestType struct {
+		name     string
+		kv       PolKV
+		expected string
+	}
+
+	tests := []kvTestType{
+		{
+			name:     "zero",
+			kv:       PolKV{},
+			expected: "(nil policy)",
+		},
+		{
+			name:     "nil policy",
+			kv:       PolKV{Key: model.PolicyKey{Name: "name"}},
+			expected: "name(nil policy)"},
+		{
+			name:     "nil order",
+			kv:       PolKV{Key: model.PolicyKey{Name: "name"}, Value: &model.Policy{}},
+			expected: "name(default)",
+		},
+		{
+			name:     "order set",
+			kv:       PolKV{Key: model.PolicyKey{Name: "name"}, Value: &model.Policy{Order: &tenPointFive}},
+			expected: "name(10.5)",
+		},
+	}
+
+	for _, tc := range tests {
+		got := tc.kv.String()
+		if got != tc.expected {
+			t.Errorf("%v - expected: %v, got: %v", tc.name, tc.expected, got)
+		}
+	}
+}
+
+func TestPolicySorter_OnUpdate(t *testing.T) {
+	poc := NewPolicySorter()
+
+	policy := model.Policy{}
+	kvp := model.KVPair{
+		Key: model.PolicyKey{
+			Name: "test-policy",
+		},
+		Value: &policy,
+	}
+	update := api.Update{}
+	update.Key = kvp.Key
+	update.Value = kvp.Value
+
+	dirty := poc.OnUpdate(update)
+	if !dirty {
+		t.Error("Update containing new policy - expected dirty to be true but it was false")
+	}
+
+	update.Value = nil
+
+	dirty = poc.OnUpdate(update)
+	if !dirty {
+		t.Error("Update containing empty value for existing policy - expected dirty to be true but it was false")
+	}
+
+	update.Value = kvp.Value
+	update.Key = model.HostEndpointKey{}
+
+	dirty = poc.OnUpdate(update)
+	if dirty {
+		t.Error("Update containing key type other than PolicyKey - expected dirty to be false but it was true")
+	}
+}
+
+func TestPolicySorter_UpdatePolicy(t *testing.T) {
+	poc := NewPolicySorter()
+
+	polKey := model.PolicyKey{
+		Name: "test-policy",
+	}
+
+	pol := model.Policy{}
+
+	dirty := poc.UpdatePolicy(polKey, &pol)
+	if !dirty {
+		t.Error("Adding new policy - expected dirty to be true but it was false")
+	}
+	if _, found := poc.Tier.Policies[polKey]; !found {
+		t.Error("Adding new policy - expected policy to be in Policies but it is not")
+	}
+
+	newOrder := float64(7)
+	newPol := model.Policy{}
+	newPol.Order = &newOrder
+
+	dirty = poc.UpdatePolicy(polKey, &newPol)
+	if !dirty {
+		t.Error("Updating existing policy Order field - expected dirty to be true but it was false")
+	}
+
+	pol.DoNotTrack = true
+
+	dirty = poc.UpdatePolicy(polKey, &pol)
+	if !dirty {
+		t.Error("Updating existing policy DoNotTrack field - expected dirty to be true but it was false")
+	}
+
+	newPol.PreDNAT = true
+
+	dirty = poc.UpdatePolicy(polKey, &newPol)
+	if !dirty {
+		t.Error("Updating existing policy PreDNAT field - expected dirty to be true but it was false")
+	}
+
+	pol.ApplyOnForward = true
+
+	dirty = poc.UpdatePolicy(polKey, &pol)
+	if !dirty {
+		t.Error("Updating existing policy ApplyOnForward field - expected dirty to be true but it was false")
+	}
+
+	newPol.Types = []string{"don't care"}
+
+	dirty = poc.UpdatePolicy(polKey, &newPol)
+	if !dirty {
+		t.Error("Updating existing policy Types field - expected dirty to be true but it was false")
+	}
+
+	dirty = poc.UpdatePolicy(polKey, &newPol)
+	if dirty {
+		t.Error("Updating existing policy with identical policy - expected dirty to be false but it was true")
+	}
+
+	dirty = poc.UpdatePolicy(polKey, nil)
+	if !dirty {
+		t.Error("Deleting existing policy - expected dirty to be true but it was false")
+	}
+	if _, found := poc.Tier.Policies[polKey]; found {
+		t.Error("Deleting existing policy - expected policy not to be in Policies but it is")
+	}
+
+	dirty = poc.UpdatePolicy(polKey, nil)
+	if dirty {
+		t.Error("Deleting non-existent policy - expected dirty to be false but it was true")
+	}
+}
+
+func TestPolicySorter_HasPolicy(t *testing.T) {
+	poc := NewPolicySorter()
+	polKey := model.PolicyKey{
+		Name: "test-policy",
+	}
+	found := poc.HasPolicy(polKey)
+	if found {
+		t.Error("Unexpectedly found policy when it should not be present")
+	}
+
+	pol := model.Policy{}
+	_ = poc.UpdatePolicy(polKey, &pol)
+
+	found = poc.HasPolicy(polKey)
+	if !found {
+		t.Error("Policy that should be present was not found")
+	}
+}


### PR DESCRIPTION
- Avoid sorting policies when unnecessary
- Introduce unit tests for PolicyResolver
- Extend unit tests for PolicySorter
- Convert existing unit tests for PolicySorter from gomega to standard golang UTs

## Description
This is based on an RFC from a community member who appears to be inactive. Original PR here:

https://github.com/projectcalico/calico/pull/5835
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- ~[ ] Documentation~
- ~[ ] Release note~

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
