### PR TITLE
Felix FV: fix flakes caused by unexpected felix restarts

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1413,6 +1413,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								Ports:         "57005", // 0xdead
 								Protocol:      testOpts.protocol,
 								InterfaceName: "eth20",
+								MTU:           1500, // Need to match host MTU or felix will restart.
 							}
 							err := eth20.Start()
 							Expect(err).NotTo(HaveOccurred())
@@ -1434,6 +1435,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								Ports:         "57005", // 0xdead
 								Protocol:      testOpts.protocol,
 								InterfaceName: "eth30",
+								MTU:           1500, // Need to match host MTU or felix will restart.
 							}
 							err = eth30.Start()
 							Expect(err).NotTo(HaveOccurred())
@@ -3215,6 +3217,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 											Ports:         "57005", // 0xdead
 											Protocol:      testOpts.protocol,
 											InterfaceName: "eth20",
+											MTU:           1500, // Need to match host MTU or felix will restart.
 										}
 										err := eth20.Start()
 										Expect(err).NotTo(HaveOccurred())

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -308,15 +308,17 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			case "vxlan":
 				options.VXLANMode = api.VXLANModeAlways
 			case "wireguard":
-				// Delay running Felix until Node resource has been created.
-				options.DelayFelixStart = true
-				options.TriggerDelayedFelixStart = true
 				// Allocate tunnel address for Wireguard.
 				options.WireguardEnabled = true
 				// Enable Wireguard.
 				options.ExtraEnvVars["FELIX_WIREGUARDENABLED"] = "true"
 			default:
 				Fail("bad tunnel option")
+			}
+			if testOpts.tunnel != "none" {
+				// Avoid felix restart mid-test, wait for the node resource to be created before starting Felix.
+				options.DelayFelixStart = true
+				options.TriggerDelayedFelixStart = true
 			}
 			options.ExtraEnvVars["FELIX_BPFConnectTimeLoadBalancingEnabled"] = fmt.Sprint(testOpts.connTimeEnabled)
 			options.ExtraEnvVars["FELIX_BPFLogLevel"] = fmt.Sprint(testOpts.bpfLogLevel)

--- a/felix/fv/rpf_test.go
+++ b/felix/fv/rpf_test.go
@@ -105,6 +105,7 @@ var _ = infrastructure.DatastoreDescribe(
 					Ports:         "57005", // 0xdead
 					Protocol:      "udp",
 					InterfaceName: "eth20",
+					MTU:           1500, // Need to match host MTU or felix will restart.
 				}
 				err := external.Start()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Felix will restart if it sees a new host interface with a smaller MTU.  This caused a flake due to Felix being unexpectedly down for a few seconds.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
