### PR TITLE
Revert "Fix UID for v3 resources in KDD mode"

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/customresource.go
+++ b/libcalico-go/lib/backend/k8s/resources/customresource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019,2021-2022 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019,2021 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -220,10 +220,7 @@ func (c *customK8sResourceClient) Delete(ctx context.Context, k model.Key, revis
 
 	opts := &metav1.DeleteOptions{}
 	if uid != nil {
-		// The UID of the underlying CRD is reversed (see ReverseUID, ConvertK8sResourceToCalicoResource and
-		// ConvertCalicoResourceToK8sResource for details)
-		ruid := ReverseUID(*uid)
-		opts.Preconditions = &metav1.Preconditions{UID: &ruid}
+		opts.Preconditions = &metav1.Preconditions{UID: uid}
 	}
 
 	// Delete the resource using the name.

--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,9 @@
 package resources
 
 import (
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/calico/libcalico-go/lib/json"
@@ -141,7 +138,6 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	romCopy.ResourceVersion = ""
 	romCopy.Labels = nil
 	romCopy.Annotations = nil
-	romCopy.UID = ""
 
 	// Marshal the data and store the json representation in the annotations.
 	metadataBytes, err := json.Marshal(romCopy)
@@ -162,10 +158,7 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	meta.Namespace = rom.GetNamespace()
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
-
-	// Do not use the same UID as the underlying CRD as this breaks garbage collection. We reverse the underlying
-	// UID so that it can be reversed back again when applying to the CRD.
-	meta.UID = ReverseUID(rom.GetUID())
+	meta.UID = rom.GetUID()
 
 	resOut := resIn.DeepCopyObject().(Resource)
 	romOut := resOut.GetObjectMeta()
@@ -208,10 +201,7 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
 	meta.Annotations = annotations
-
-	// Do not use the same UID as the underlying CRD as this breaks garbage collection. We reverse the underlying
-	// UID so that it can be reversed back again when applying to the CRD.
-	meta.UID = ReverseUID(rom.GetUID())
+	meta.UID = rom.GetUID()
 
 	// If no creation timestamp was stored in the metadata annotation, use the one from the CR.
 	// The timestamp is normally set in the clientv3 code. However, for objects that bypass
@@ -225,27 +215,4 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.DeepCopyInto(rom.(*metav1.ObjectMeta))
 
 	return nil
-}
-
-// ReverseUID reverses the segments of a UID to create another UID.
-//
-// We use this to map between the CRD and v3 resource types. It is not possible to use the same UID as this breaks
-// garbage collection of the v3 resource types. We need to be able to deterministically map between the v3 and CRD
-// UID and this seems like a reasonable approach. We could potentially store in the annotation (so both CRD and v3
-// have this annotation and we switch annotation w/ the metadata UID) - however that doesn't work for deletes where
-// the metadata is unavailable, but a UID may have been supplied to handle atomicity.
-func ReverseUID(uid types.UID) types.UID {
-	parts := strings.Split(string(uid), "-")
-	for ii := range parts {
-		parts[ii] = ReverseString(parts[ii])
-	}
-	return types.UID(strings.Join(parts, "-"))
-}
-
-func ReverseString(s string) string {
-	r := []rune(s)
-	for ii, jj := 0, len(r)-1; ii < len(r)/2; ii, jj = ii+1, jj-1 {
-		r[ii], r[jj] = r[jj], r[ii]
-	}
-	return string(r)
 }


### PR DESCRIPTION
Reverts projectcalico/calico#7291

Fix was breaking the windows FV tests; let's back it out until we understand what's going on.  Looks like I was wrong about Enterprise having this fix, it only applies it to some resources and not others
```
2023-02-15 13:35:08.880 [ERROR][9] startup/customresource.go 179: Error updating resource Key=FelixConfiguration(default) Name="default" Resource="FelixConfigurations" Value=&v3.FelixConfiguration{TypeMeta:v1.TypeMeta{Kind:"FelixConfiguration", APIVersion:"projectcalico.org/v3"}, ObjectMeta:v1.ObjectMeta{Name:"default", GenerateName:"", Namespace:"", SelfLink:"", UID:"38e7c5c4-cb77-43e7-b32e-3e0df11a0fbc", ResourceVersion:"569", Generation:1, CreationTimestamp:time.Date(2023, time.February, 15, 10, 42, 27, 0, time.Local), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ZZZ_DeprecatedClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"operator", Operation:"Update", APIVersion:"crd.projectcalico.org/v1", Time:time.Date(2023, time.February, 15, 10, 42, 27, 0, time.Local), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc00037f110), Subresource:""}}}, Spec:v3.FelixConfigurationSpec{UseInternalDataplaneDriver:(*bool)(nil), DataplaneDriver:"", DataplaneWatchdogTimeout:(*v1.Duration)(nil), IPv6Support:(*bool)(nil), RouteRefreshInterval:(*v1.Duration)(nil), InterfaceRefreshInterval:(*v1.Duration)(nil), IptablesRefreshInterval:(*v1.Duration)(nil), IptablesPostWriteCheckInterval:(*v1.Duration)(nil), IptablesLockFilePath:"", IptablesLockTimeout:(*v1.Duration)(nil), IptablesLockProbeInterval:(*v1.Duration)(nil), FeatureDetectOverride:"", FeatureGates:"", IpsetsRefreshInterval:(*v1.Duration)(nil), MaxIpsetSize:(*int)(nil), IptablesBackend:(*v3.IptablesBackend)(nil), XDPRefreshInterval:(*v1.Duration)(nil), NetlinkTimeout:(*v1.Duration)(nil), MetadataAddr:"", MetadataPort:(*int)(nil), OpenstackRegion:"", InterfacePrefix:"", InterfaceExclude:"", ChainInsertMode:"", DefaultEndpointToHostAction:"", IptablesFilterAllowAction:"", IptablesMangleAllowAction:"", IptablesFilterDenyAction:"", LogPrefix:"", LogFilePath:"", LogSeverityFile:"", LogSeverityScreen:"Info", LogSeveritySys:"", LogDebugFilenameRegex:"", IPIPEnabled:(*bool)(nil), IPIPMTU:(*int)(nil), VXLANEnabled:(*bool)(nil), VXLANMTU:(*int)(nil), VXLANMTUV6:(*int)(nil), VXLANPort:(*int)(nil), VXLANVNI:(*int)(nil), AllowVXLANPacketsFromWorkloads:(*bool)(nil), AllowIPIPPacketsFromWorkloads:(*bool)(nil), ReportingInterval:(*v1.Duration)(0xc000518070), ReportingTTL:(*v1.Duration)(nil), EndpointReportingEnabled:(*bool)(nil), EndpointReportingDelay:(*v1.Duration)(nil), IptablesMarkMask:(*uint32)(nil), DisableConntrackInvalidCheck:(*bool)(nil), HealthEnabled:(*bool)(nil), HealthHost:(*string)(nil), HealthPort:(*int)(0xc000518060), HealthTimeoutOverrides:[]v3.HealthTimeoutOverride(nil), PrometheusMetricsEnabled:(*bool)(nil), PrometheusMetricsHost:"", PrometheusMetricsPort:(*int)(nil), PrometheusGoMetricsEnabled:(*bool)(nil), PrometheusProcessMetricsEnabled:(*bool)(nil), PrometheusWireGuardMetricsEnabled:(*bool)(nil), FailsafeInboundHostPorts:(*[]v3.ProtoPort)(nil), FailsafeOutboundHostPorts:(*[]v3.ProtoPort)(nil), KubeNodePortRanges:(*[]numorstring.Port)(nil), PolicySyncPathPrefix:"", UsageReportingEnabled:(*bool)(nil), UsageReportingInitialDelay:(*v1.Duration)(nil), UsageReportingInterval:(*v1.Duration)(nil), NATPortRange:(*numorstring.Port)(nil), NATOutgoingAddress:"", DeviceRouteSourceAddress:"", DeviceRouteSourceAddressIPv6:"", DeviceRouteProtocol:(*int)(nil), RemoveExternalRoutes:(*bool)(nil), ExternalNodesCIDRList:(*[]string)(nil), DebugMemoryProfilePath:"", DebugDisableLogDropping:(*bool)(nil), DebugSimulateCalcGraphHangAfter:(*v1.Duration)(nil), DebugSimulateDataplaneHangAfter:(*v1.Duration)(nil), IptablesNATOutgoingInterfaceFilter:"", SidecarAccelerationEnabled:(*bool)(nil), XDPEnabled:(*bool)(nil), GenericXDPEnabled:(*bool)(nil), BPFEnabled:(*bool)(nil), BPFDisableUnprivileged:(*bool)(nil), BPFLogLevel:"", BPFDataIfacePattern:"", BPFL3IfacePattern:"", BPFConnectTimeLoadBalancingEnabled:(*bool)(nil), BPFExternalServiceMode:"", BPFDSROptoutCIDRs:(*[]string)(nil), BPFExtToServiceConnmark:(*int)(nil), BPFKubeProxyIptablesCleanupEnabled:(*bool)(nil), BPFKubeProxyMinSyncPeriod:(*v1.Duration)(nil), BPFKubeProxyEndpointSlicesEnabled:(*bool)(nil), BPFPSNATPorts:(*numorstring.Port)(nil), BPFMapSizeNATFrontend:(*int)(nil), BPFMapSizeNATBackend:(*int)(nil), BPFMapSizeNATAffinity:(*int)(nil), BPFMapSizeRoute:(*int)(nil), BPFMapSizeConntrack:(*int)(nil), BPFMapSizeIPSets:(*int)(nil), BPFMapSizeIfState:(*int)(nil), BPFHostConntrackBypass:(*bool)(nil), BPFEnforceRPF:"", BPFPolicyDebugEnabled:(*bool)(nil), RouteSource:"", RouteTableRanges:(*v3.RouteTableRanges)(nil), RouteTableRange:(*v3.RouteTableRange)(nil), RouteSyncDisabled:(*bool)(nil), WireguardEnabled:(*bool)(nil), WireguardEnabledV6:(*bool)(nil), WireguardListeningPort:(*int)(nil), WireguardListeningPortV6:(*int)(nil), WireguardRoutingRulePriority:(*int)(nil), WireguardInterfaceName:"", WireguardInterfaceNameV6:"", WireguardMTU:(*int)(nil), WireguardMTUV6:(*int)(nil), WireguardHostEncryptionEnabled:(*bool)(nil), WireguardPersistentKeepAlive:(*v1.Duration)(nil), AWSSrcDstCheck:(*v3.AWSSrcDstCheckOption)(nil), ServiceLoopPrevention:"", WorkloadSourceSpoofing:"", MTUIfacePattern:"", FloatingIPs:(*v3.FloatingIPType)(0xc000181e40)}} error=Operation cannot be fulfilled on felixconfigurations.crd.projectcalico.org "default": StorageError: invalid object, Code: 4, Key: /registry/crd.projectcalico.org/felixconfigurations/default, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 4c5c7e83-77bc-7e34-e23b-cbf0a11fd0e3, UID in object meta: 38e7c5c4-cb77-43e7-b32e-3e0df11a0fbc
2023-02-15 13:35:08.880 [ERROR][9] startup/startup.go 1088: Error updating Felix global config FelixConfig=&v3.FelixConfiguration{TypeMeta:v1.TypeMeta{Kind:"FelixConfiguration", APIVersion:"projectcalico.org/v3"}, ObjectMeta:v1.ObjectMeta{Name:"default", GenerateName:"", Namespace:"", SelfLink:"", UID:"38e7c5c4-cb77-43e7-b32e-3e0df11a0fbc", ResourceVersion:"569", Generation:1, CreationTimestamp:time.Date(2023, time.February, 15, 10, 42, 27, 0, time.Local), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ZZZ_DeprecatedClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"operator", Operation:"Update", APIVersion:"crd.projectcalico.org/v1", Time:time.Date(2023, time.February, 15, 10, 42, 27, 0, time.Local), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc00037f110), Subresource:""}}}, Spec:v3.FelixConfigurationSpec{UseInternalDataplaneDriver:(*bool)(nil), DataplaneDriver:"", DataplaneWatchdogTimeout:(*v1.Duration)(nil), IPv6Support:(*bool)(nil), RouteRefreshInterval:(*v1.Duration)(nil), InterfaceRefreshInterval:(*v1.Duration)(nil), IptablesRefreshInterval:(*v1.Duration)(nil), IptablesPostWriteCheckInterval:(*v1.Duration)(nil), IptablesLockFilePath:"", IptablesLockTimeout:(*v1.Duration)(nil), IptablesLockProbeInterval:(*v1.Duration)(nil), FeatureDetectOverride:"", FeatureGates:"", IpsetsRefreshInterval:(*v1.Duration)(nil), MaxIpsetSize:(*int)(nil), IptablesBackend:(*v3.IptablesBackend)(nil), XDPRefreshInterval:(*v1.Duration)(nil), NetlinkTimeout:(*v1.Duration)(nil), MetadataAddr:"", MetadataPort:(*int)(nil), OpenstackRegion:"", InterfacePrefix:"", InterfaceExclude:"", ChainInsertMode:"", DefaultEndpointToHostAction:"", IptablesFilterAllowAction:"", IptablesMangleAllowAction:"", IptablesFilterDenyAction:"", LogPrefix:"", LogFilePath:"", LogSeverityFile:"", LogSeverityScreen:"Info", LogSeveritySys:"", LogDebugFilenameRegex:"", IPIPEnabled:(*bool)(nil), IPIPMTU:(*int)(nil), VXLANEnabled:(*bool)(nil), VXLANMTU:(*int)(nil), VXLANMTUV6:(*int)(nil), VXLANPort:(*int)(nil), VXLANVNI:(*int)(nil), AllowVXLANPacketsFromWorkloads:(*bool)(nil), AllowIPIPPacketsFromWorkloads:(*bool)(nil), ReportingInterval:(*v1.Duration)(0xc000518070), ReportingTTL:(*v1.Duration)(nil), EndpointReportingEnabled:(*bool)(nil), EndpointReportingDelay:(*v1.Duration)(nil), IptablesMarkMask:(*uint32)(nil), DisableConntrackInvalidCheck:(*bool)(nil), HealthEnabled:(*bool)(nil), HealthHost:(*string)(nil), HealthPort:(*int)(0xc000518060), HealthTimeoutOverrides:[]v3.HealthTimeoutOverride(nil), PrometheusMetricsEnabled:(*bool)(nil), PrometheusMetricsHost:"", PrometheusMetricsPort:(*int)(nil), PrometheusGoMetricsEnabled:(*bool)(nil), PrometheusProcessMetricsEnabled:(*bool)(nil), PrometheusWireGuardMetricsEnabled:(*bool)(nil), FailsafeInboundHostPorts:(*[]v3.ProtoPort)(nil), FailsafeOutboundHostPorts:(*[]v3.ProtoPort)(nil), KubeNodePortRanges:(*[]numorstring.Port)(nil), PolicySyncPathPrefix:"", UsageReportingEnabled:(*bool)(nil), UsageReportingInitialDelay:(*v1.Duration)(nil), UsageReportingInterval:(*v1.Duration)(nil), NATPortRange:(*numorstring.Port)(nil), NATOutgoingAddress:"", DeviceRouteSourceAddress:"", DeviceRouteSourceAddressIPv6:"", DeviceRouteProtocol:(*int)(nil), RemoveExternalRoutes:(*bool)(nil), ExternalNodesCIDRList:(*[]string)(nil), DebugMemoryProfilePath:"", DebugDisableLogDropping:(*bool)(nil), DebugSimulateCalcGraphHangAfter:(*v1.Duration)(nil), DebugSimulateDataplaneHangAfter:(*v1.Duration)(nil), IptablesNATOutgoingInterfaceFilter:"", SidecarAccelerationEnabled:(*bool)(nil), XDPEnabled:(*bool)(nil), GenericXDPEnabled:(*bool)(nil), BPFEnabled:(*bool)(nil), BPFDisableUnprivileged:(*bool)(nil), BPFLogLevel:"", BPFDataIfacePattern:"", BPFL3IfacePattern:"", BPFConnectTimeLoadBalancingEnabled:(*bool)(nil), BPFExternalServiceMode:"", BPFDSROptoutCIDRs:(*[]string)(nil), BPFExtToServiceConnmark:(*int)(nil), BPFKubeProxyIptablesCleanupEnabled:(*bool)(nil), BPFKubeProxyMinSyncPeriod:(*v1.Duration)(nil), BPFKubeProxyEndpointSlicesEnabled:(*bool)(nil), BPFPSNATPorts:(*numorstring.Port)(nil), BPFMapSizeNATFrontend:(*int)(nil), BPFMapSizeNATBackend:(*int)(nil), BPFMapSizeNATAffinity:(*int)(nil), BPFMapSizeRoute:(*int)(nil), BPFMapSizeConntrack:(*int)(nil), BPFMapSizeIPSets:(*int)(nil), BPFMapSizeIfState:(*int)(nil), BPFHostConntrackBypass:(*bool)(nil), BPFEnforceRPF:"", BPFPolicyDebugEnabled:(*bool)(nil), RouteSource:"", RouteTableRanges:(*v3.RouteTableRanges)(nil), RouteTableRange:(*v3.RouteTableRange)(nil), RouteSyncDisabled:(*bool)(nil), WireguardEnabled:(*bool)(nil), WireguardEnabledV6:(*bool)(nil), WireguardListeningPort:(*int)(nil), WireguardListeningPortV6:(*int)(nil), WireguardRoutingRulePriority:(*int)(nil), WireguardInterfaceName:"", WireguardInterfaceNameV6:"", WireguardMTU:(*int)(nil), WireguardMTUV6:(*int)(nil), WireguardHostEncryptionEnabled:(*bool)(nil), WireguardPersistentKeepAlive:(*v1.Duration)(nil), AWSSrcDstCheck:(*v3.AWSSrcDstCheckOption)(nil), ServiceLoopPrevention:"", WorkloadSourceSpoofing:"", MTUIfacePattern:"", FloatingIPs:(*v3.FloatingIPType)(0xc000181e40)}} error=resource does not exist: FelixConfiguration(default) with error: Operation cannot be fulfilled on felixconfigurations.crd.projectcalico.org "default": StorageError: invalid object, Code: 4, Key: /registry/crd.projectcalico.org/felixconfigurations/default, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 4c5c7e83-77bc-7e34-e23b-cbf0a11fd0e3, UID in object meta: 38e7c5c4-cb77-43e7-b32e-3e0df11a0fbc
2023-02-15 13:35:08.880 [ERROR][9] startup/startup.go 210: Unable to set global default configuration error=resource does not exist: FelixConfiguration(default) with error: Operation cannot be fulfilled on felixconfigurations.crd.projectcalico.org "default": StorageError: invalid object, Code: 4, Key: /registry/crd.projectcalico.org/felixconfigurations/default, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 4c5c7e83-77bc-7e34-e23b-cbf0a11fd0e3, UID in object meta: 38e7c5c4-cb77-43e7-b32e-3e0df11a0fbc
2023-02-15 13:35:08.880 [WARNING][9] startup/utils.go 48: Terminating
Calico node failed to start

```