### PR TITLE
Let UID be stored and retrieved by annotation instead of cloning UIDs.

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -158,7 +158,6 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	meta.Namespace = rom.GetNamespace()
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
-	meta.UID = rom.GetUID()
 
 	resOut := resIn.DeepCopyObject().(Resource)
 	romOut := resOut.GetObjectMeta()
@@ -201,7 +200,6 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 	meta.ResourceVersion = rom.GetResourceVersion()
 	meta.Labels = rom.GetLabels()
 	meta.Annotations = annotations
-	meta.UID = rom.GetUID()
 
 	// If no creation timestamp was stored in the metadata annotation, use the one from the CR.
 	// The timestamp is normally set in the clientv3 code. However, for objects that bypass


### PR DESCRIPTION
## Description

When converting from calico to k8s objects and back, there is already logic storing the ObjectMeta in an annotation for the conversion. There should be no need to set the UUID of the converted object to match the source object, and it's a bad practice because kubernetes expectes UUIDs to be unique from one object to the next for operations like garbage collection.

If there are other parts of calico which rely on these UUIDs matching, I recommend treating those occurrences as bugs to be remediated.

## Related issues/PRs

fixes (https://github.com/projectcalico/calico/issues/5715)

Alternative approach to https://github.com/projectcalico/calico/pull/7291

My thought here is that kubernetes can manager UUIDs, there shouldn't be a need for the UUID of the calico object to be related to the UUID of the k8s object. The relationship between the two can be tracked via the storage of the k8s object in the calico metadata annotation.

@fasaxc stated there was a regression for the other PR, and I suspect this change might cause the same issues or similar issues. I'd love to help track down those regressions and get them fixed, I don't think calico should rely on matching UUIDs.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Fix that Calico API server would reuse UUIDs from the underlying CRD objects that underpin the datamodel (thus confusing Kubernetes ownership tracking and ArgoCD).  This will result in the apparent UUIDs of calico "v3" resources changing over upgrade.  This was unavoidable in order to split them from the underlying CRD UUIDs.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
