### PR TITLE
Using the netlink.NewLinkAttrs to bring default values from kernel

### DIFF
--- a/cni-plugin/internal/pkg/testutils/utils_linux.go
+++ b/cni-plugin/internal/pkg/testutils/utils_linux.go
@@ -345,13 +345,13 @@ func CreateHostVeth(containerId, k8sName, k8sNamespace, nodename string) error {
 		}
 	}
 
+	la := netlink.NewLinkAttrs()
+	la.Name = hostVethName
+	la.Flags = net.FlagUp
+	la.MTU = 1500
 	veth := &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:  hostVethName,
-			Flags: net.FlagUp,
-			MTU:   1500,
-		},
-		PeerName: peerVethName,
+		LinkAttrs: la,
+		PeerName:  peerVethName,
 	}
 
 	if err := netlink.LinkAdd(veth); err != nil {

--- a/cni-plugin/pkg/dataplane/grpc/test_server_linux.go
+++ b/cni-plugin/pkg/dataplane/grpc/test_server_linux.go
@@ -50,8 +50,10 @@ func (s *TestServer) Add(ctx context.Context, in *pb.AddRequest) (*pb.AddReply, 
 	// Create an unconfigured veth just to make the test code happy
 	if s.retval {
 		err := ns.WithNetNSPath(in.Netns, func(hostNS ns.NetNS) error {
+			la := netlink.NewLinkAttrs()
+			la.Name = in.InterfaceName
 			veth := &netlink.Veth{
-				LinkAttrs: netlink.LinkAttrs{Name: in.InterfaceName},
+				LinkAttrs: la,
 				PeerName:  "peer0",
 			}
 

--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -76,14 +76,14 @@ func (d *linuxDataplane) DoNetworking(
 	}
 
 	err = ns.WithNetNSPath(args.Netns, func(hostNS ns.NetNS) error {
+		la := netlink.NewLinkAttrs()
+		la.Name = contVethName
+		la.MTU = d.mtu
+		la.NumTxQueues = d.queues
+		la.NumRxQueues = d.queues
 		veth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{
-				Name:        contVethName,
-				MTU:         d.mtu,
-				NumTxQueues: d.queues,
-				NumRxQueues: d.queues,
-			},
-			PeerName: hostVethName,
+			LinkAttrs: la,
+			PeerName:  hostVethName,
 		}
 
 		if err := netlink.LinkAdd(veth); err != nil {

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -153,12 +153,12 @@ func TestPrecompiledBinariesAreLoadable(t *testing.T) {
 
 func createVeth() (string, netlink.Link) {
 	vethName := fmt.Sprintf("test%xa", rand.Uint32())
+	la := netlink.NewLinkAttrs()
+	la.Name = vethName
+	la.Flags = net.FlagUp
 	var veth netlink.Link = &netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:  vethName,
-			Flags: net.FlagUp,
-		},
-		PeerName: vethName + "b",
+		LinkAttrs: la,
+		PeerName:  vethName + "b",
 	}
 	err := netlink.LinkAdd(veth)
 	Expect(err).NotTo(HaveOccurred(), "failed to create test veth")

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1844,11 +1844,11 @@ func (m *bpfEndpointManager) ensureBPFDevices() error {
 
 	bpfin, err := netlink.LinkByName(bpfInDev)
 	if err != nil {
+		la := netlink.NewLinkAttrs()
+		la.Name = bpfInDev
 		nat := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: bpfInDev,
-			},
-			PeerName: bpfOutDev,
+			LinkAttrs: la,
+			PeerName:  bpfOutDev,
 		}
 		if err := netlink.LinkAdd(nat); err != nil {
 			return fmt.Errorf("failed to add %s: %w", bpfInDev, err)

--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -628,11 +628,11 @@ func (m *vxlanManager) configureVXLANDevice(mtu int, localVTEP *proto.VXLANTunne
 		addr = localVTEP.Ipv6Addr
 		parentDeviceIP = localVTEP.ParentDeviceIpv6
 	}
+	la := netlink.NewLinkAttrs()
+	la.Name = m.vxlanDevice
+	la.HardwareAddr = mac
 	vxlan := &netlink.Vxlan{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:         m.vxlanDevice,
-			HardwareAddr: mac,
-		},
+		LinkAttrs:    la,
 		VxlanId:      m.vxlanID,
 		Port:         m.vxlanPort,
 		VtepDevIndex: parent.Attrs().Index,

--- a/felix/dataplane/linux/vxlan_mgr_test.go
+++ b/felix/dataplane/linux/vxlan_mgr_test.go
@@ -35,21 +35,20 @@ type mockVXLANDataplane struct {
 }
 
 func (m *mockVXLANDataplane) LinkByName(name string) (netlink.Link, error) {
+	la := netlink.NewLinkAttrs()
+	la.Name = "vxlan"
 	link := &netlink.Vxlan{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: "vxlan",
-		},
+		LinkAttrs:    la,
 		VxlanId:      1,
 		Port:         20,
 		VtepDevIndex: 2,
 		SrcAddr:      ip.FromString("172.0.0.2").AsNetIP(),
 	}
 
+	la.Name = "vxlan-v6"
 	if m.ipVersion == 6 {
 		link = &netlink.Vxlan{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: "vxlan-v6",
-			},
+			LinkAttrs:    la,
 			VxlanId:      1,
 			Port:         20,
 			VtepDevIndex: 2,
@@ -124,6 +123,8 @@ var _ = Describe("VXLANManager", func() {
 			currentL2Routes: map[string][]routetable.L2Target{},
 		}
 
+		la := netlink.NewLinkAttrs()
+		la.Name = "eth0"
 		manager = newVXLANManagerWithShims(
 			common.NewMockIPSets(),
 			rt, brt,
@@ -138,7 +139,7 @@ var _ = Describe("VXLANManager", func() {
 				},
 			},
 			&mockVXLANDataplane{
-				links:     []netlink.Link{&mockLink{attrs: netlink.LinkAttrs{Name: "eth0"}}},
+				links:     []netlink.Link{&mockLink{attrs: la}},
 				ipVersion: 4,
 			},
 			4,
@@ -162,7 +163,7 @@ var _ = Describe("VXLANManager", func() {
 				},
 			},
 			&mockVXLANDataplane{
-				links:     []netlink.Link{&mockLink{attrs: netlink.LinkAttrs{Name: "eth0"}}},
+				links:     []netlink.Link{&mockLink{attrs: la}},
 				ipVersion: 6,
 			},
 			6,

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -109,12 +109,12 @@ func main() {
 			peerName = peerName[:11]
 		}
 		// Create a veth pair.
+		la := netlink.NewLinkAttrs()
+		la.Name = interfaceName
+		la.MTU = mtu
 		veth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: interfaceName,
-				MTU:  mtu,
-			},
-			PeerName: peerName,
+			LinkAttrs: la,
+			PeerName:  peerName,
 		}
 		err = netlink.LinkAdd(veth)
 		panicIfError(err)

--- a/felix/ifacemonitor/ifacemonitor_test.go
+++ b/felix/ifacemonitor/ifacemonitor_test.go
@@ -154,16 +154,16 @@ func (nl *netlinkTest) signalLink(name string, oldIndex int) {
 	nl.linksMutex.Unlock()
 
 	// Build the update.
+	la := netlink.NewLinkAttrs()
+	la.Name = name
+	la.Index = index
+	la.RawFlags = rawFlags
 	update := netlink.LinkUpdate{
 		Header: unix.NlMsghdr{
 			Type: msgType,
 		},
 		Link: &netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{
-				Name:     name,
-				Index:    index,
-				RawFlags: rawFlags,
-			},
+			LinkAttrs: la,
 		},
 	}
 
@@ -245,12 +245,12 @@ func (nl *netlinkTest) LinkList() ([]netlink.Link, error) {
 		if link.state == "up" {
 			rawFlags = syscall.IFF_RUNNING
 		}
+		la := netlink.NewLinkAttrs()
+		la.Name = name
+		la.Index = link.index
+		la.RawFlags = rawFlags
 		links = append(links, &netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{
-				Name:     name,
-				Index:    link.index,
-				RawFlags: rawFlags,
-			},
+			LinkAttrs: la,
 		})
 	}
 	nl.linksMutex.Unlock()

--- a/felix/ifacemonitor/update_filter_test.go
+++ b/felix/ifacemonitor/update_filter_test.go
@@ -286,11 +286,10 @@ func routeUpdate(cidrStr string, up bool, ifaceIdx int) netlink.RouteUpdate {
 }
 
 func linkUpdateWithIndex(idx int) netlink.LinkUpdate {
+	la := netlink.NewLinkAttrs()
+	la.Index = idx
 	return netlink.LinkUpdate{
-		Link: &netlink.Device{LinkAttrs: netlink.LinkAttrs{
-			Index: idx,
-		},
-		},
+		Link: &netlink.Device{LinkAttrs: la},
 		IfInfomsg: nl.IfInfomsg{
 			IfInfomsg: unix.IfInfomsg{
 				Index: int32(idx),

--- a/felix/k8sfv/pod.go
+++ b/felix/k8sfv/pod.go
@@ -125,8 +125,10 @@ func createPod(clientset *kubernetes.Clientset, d deployment, nsName string, spe
 		log.WithField("podNamespace", podNamespace).Debug("Created namespace")
 
 		// Create a veth pair.
+		la := netlink.NewLinkAttrs()
+		la.Name = interfaceName
 		veth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: interfaceName},
+			LinkAttrs: la,
 			PeerName:  "p" + interfaceName[1:],
 		}
 

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -280,12 +280,12 @@ func (d *MockNetlinkDataplane) AddIface(idx int, name string, up bool, running b
 	if strings.Contains(name, "wireguard") {
 		t = "wireguard"
 	}
+	la := netlink.NewLinkAttrs()
+	la.Name = name
+	la.Index = idx
 	link := &MockLink{
-		LinkAttrs: netlink.LinkAttrs{
-			Name:  name,
-			Index: idx,
-		},
-		LinkType: t,
+		LinkAttrs: la,
+		LinkType:  t,
 	}
 	d.NameToLink[name] = link
 	d.SetIface(name, up, running)

--- a/felix/wireguard/bootstrap_test.go
+++ b/felix/wireguard/bootstrap_test.go
@@ -282,11 +282,11 @@ var _ = Describe("Wireguard bootstrapping", func() {
 						FelixHostname:                  nodeName1,
 					}
 					if enableIPv4 {
+						la := netlink.NewLinkAttrs()
+						la.Name = "wireguard.cali"
+						la.Index = 10
 						link = &mocknetlink.MockLink{
-							LinkAttrs: netlink.LinkAttrs{
-								Name:  "wireguard.cali",
-								Index: 10,
-							},
+							LinkAttrs:           la,
 							LinkType:            "wireguard",
 							WireguardPrivateKey: node1PrivateKey,
 							WireguardPublicKey:  node1PrivateKey.PublicKey(),
@@ -299,11 +299,11 @@ var _ = Describe("Wireguard bootstrapping", func() {
 						netlinkDataplane.NameToLink["wireguard.cali"] = link
 					}
 					if enableIPv6 {
+						la := netlink.NewLinkAttrs()
+						la.Name = "wg-v6.cali"
+						la.Index = 10
 						linkV6 = &mocknetlink.MockLink{
-							LinkAttrs: netlink.LinkAttrs{
-								Name:  "wg-v6.cali",
-								Index: 10,
-							},
+							LinkAttrs:           la,
 							LinkType:            "wireguard",
 							WireguardPrivateKey: node1PrivateKeyV6,
 							WireguardPublicKey:  node1PrivateKeyV6.PublicKey(),


### PR DESCRIPTION
## Description

This PR solves a miscommunication between calico-cni and kernel, where a misconfiguration of the structure netlink.LinkAttrs was sending to kernel the information of the queue discipline for the veth pairs generated by calico-cni to be of value 0.
The problem was caused by creating the structure without the function netlink.NewLinkAttrs which initializes the TxQLen to -1, for not sending this info to kernel and getting the kernel default value instead.
For good practices I changed in everywhere the code.
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Ensure that veths are created with the proper default values from the kernel.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
