### PR TITLE
[WIP] Build/push all architectures for node and apiserver during scheduled runs only

### DIFF
--- a/.semaphore/push-images/apiserver.yml
+++ b/.semaphore/push-images/apiserver.yml
@@ -38,10 +38,11 @@ blocks:
       - name: docker
       jobs:
       # The apiserver build takes a long time due to some architectures, so we split it up.
-      # TODO: Add support for other architectures
+      # Only build the other architectures for the daily scheduled runs.
       - name: "Linux amd64"
         env_vars:
         - name: DEV_REGISTRIES
           value: quay.io/calico docker.io/calico
         commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make VALIDARCHES=amd64 -C apiserver image-all cd-common CONFIRM=true; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ] && ["${SEMAPHORE_WORKFLOW_TRIGGERED_BY_SCHEDULE}" == "false"]; then make VALIDARCHES=amd64 -C apiserver image-all cd-common CONFIRM=true; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ] && ["${SEMAPHORE_WORKFLOW_TRIGGERED_BY_SCHEDULE}" == "true"]; then make -C apiserver image-all cd-common CONFIRM=true; fi

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -38,13 +38,14 @@ blocks:
       - name: docker
       jobs:
       # The node build takes a long time due to some architectures, so we split it up.
-      # TODO: Add support for other architectures
+      # Only build the other architectures for our daily scheduled runs.
       - name: "Linux amd64"
         env_vars:
         - name: DEV_REGISTRIES
           value: quay.io/calico docker.io/calico
         commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make VALIDARCHES=amd64 -C node image-all cd-common CONFIRM=true; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ] && [ "${SEMAPHORE_WORKFLOW_TRIGGERED_BY_SCHEDULE}" == "false" ]; then make VALIDARCHES=amd64 -C node image-all cd-common CONFIRM=true; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ] && [ "${SEMAPHORE_WORKFLOW_TRIGGERED_BY_SCHEDULE}" == "true" ]; then make -C node image-all cd-common CONFIRM=true; fi
 
       - name: "windows"
         env_vars:


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Build and push all of the node and apiserver images for all architectures only during the scheduled builds (which currently run daily). This should give us a balance between updated image builds while not taking up too much of our pipeline resources.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
