### PR TITLE
Increase MTU tests timeout to remove flakes

### DIFF
--- a/felix/fv/mtu_test.go
+++ b/felix/fv/mtu_test.go
@@ -104,7 +104,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "30s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
+						}, "60s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
 					}
 
 					// Disable VXLAN. We should expect the MTU to change, but still based on the default 1460.
@@ -129,7 +129,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "30s", "100ms").Should(ContainSubstring(vxlanDisabledMtu))
+						}, "60s", "100ms").Should(ContainSubstring(vxlanDisabledMtu))
 					}
 				})
 
@@ -146,7 +146,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "30s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
+						}, "60s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
 					}
 
 					// Unset VXLAN on FelixConfiguration. We should expect the MTU not to change, since the VXLAN encap is set in the default IPPool.
@@ -161,7 +161,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "30s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
+						}, "60s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
 					}
 
 					// Set VXLANModeNever on the default IP pool(s)
@@ -183,7 +183,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "30s", "100ms").Should(ContainSubstring(vxlanDisabledMtu))
+						}, "60s", "100ms").Should(ContainSubstring(vxlanDisabledMtu))
 					}
 				})
 			})

--- a/felix/fv/mtu_test.go
+++ b/felix/fv/mtu_test.go
@@ -104,7 +104,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
+						}, "60s", "500ms").Should(ContainSubstring(vxlanEnabledMtu))
 					}
 
 					// Disable VXLAN. We should expect the MTU to change, but still based on the default 1460.
@@ -129,7 +129,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(vxlanDisabledMtu))
+						}, "60s", "500ms").Should(ContainSubstring(vxlanDisabledMtu))
 					}
 				})
 
@@ -146,7 +146,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
+						}, "60s", "500ms").Should(ContainSubstring(vxlanEnabledMtu))
 					}
 
 					// Unset VXLAN on FelixConfiguration. We should expect the MTU not to change, since the VXLAN encap is set in the default IPPool.
@@ -161,7 +161,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(vxlanEnabledMtu))
+						}, "60s", "500ms").Should(ContainSubstring(vxlanEnabledMtu))
 					}
 
 					// Set VXLANModeNever on the default IP pool(s)
@@ -183,7 +183,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(vxlanDisabledMtu))
+						}, "60s", "500ms").Should(ContainSubstring(vxlanDisabledMtu))
 					}
 				})
 			})

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -520,7 +520,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "60s", "100ms").Should(ContainSubstring(mtuStr))
+					}, "60s", "500ms").Should(ContainSubstring(mtuStr))
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
@@ -533,7 +533,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(mtuStrV6))
+						}, "60s", "500ms").Should(ContainSubstring(mtuStrV6))
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
@@ -565,14 +565,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "60s", "100ms").Should(ContainSubstring(mtuStr))
+					}, "60s", "500ms").Should(ContainSubstring(mtuStr))
 
 					if enableIPv6 {
 						// Felix checks host MTU every 30s
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(mtuStrV6))
+						}, "60s", "500ms").Should(ContainSubstring(mtuStrV6))
 					}
 
 					// And expect the MTU file on disk to be updated.
@@ -601,7 +601,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "60s", "100ms").Should(ContainSubstring("mtu 1300"))
+					}, "60s", "500ms").Should(ContainSubstring("mtu 1300"))
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
@@ -616,7 +616,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring("mtu 1300"))
+						}, "60s", "500ms").Should(ContainSubstring("mtu 1300"))
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
@@ -639,12 +639,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "60s", "100ms").Should(ContainSubstring(mtuStr))
+					}, "60s", "500ms").Should(ContainSubstring(mtuStr))
 					if enableIPv6 {
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(mtuStrV6))
+						}, "60s", "500ms").Should(ContainSubstring(mtuStrV6))
 					}
 				}
 
@@ -661,14 +661,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "60s", "100ms").ShouldNot(ContainSubstring(mtuStr))
+					}, "60s", "500ms").ShouldNot(ContainSubstring(mtuStr))
 					// IPv6 ignores the VXLAN enabled flag and must be disabled at the pool level. As such the ipv6
 					// interfaces should still exist at this point
 					if enableIPv6 {
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "60s", "100ms").Should(ContainSubstring(mtuStrV6))
+						}, "60s", "500ms").Should(ContainSubstring(mtuStrV6))
 					}
 				}
 
@@ -684,7 +684,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "60s", "100ms").ShouldNot(ContainSubstring(mtuStrV6))
+						}, "60s", "500ms").ShouldNot(ContainSubstring(mtuStrV6))
 					}
 				}
 			})

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -520,7 +520,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "10s", "100ms").Should(ContainSubstring(mtuStr))
+					}, "60s", "100ms").Should(ContainSubstring(mtuStr))
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
@@ -533,7 +533,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "10s", "100ms").Should(ContainSubstring(mtuStrV6))
+						}, "60s", "100ms").Should(ContainSubstring(mtuStrV6))
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
@@ -597,10 +597,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 
 				// Expect the settings to be changed on the device.
 				for _, felix := range felixes {
+					// Felix checks host MTU every 30s
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "30s", "100ms").Should(ContainSubstring("mtu 1300"))
+					}, "60s", "100ms").Should(ContainSubstring("mtu 1300"))
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
@@ -611,10 +612,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					}, "10s", "100ms").Should(ContainSubstring("dstport 4790"))
 
 					if enableIPv6 {
+						// Felix checks host MTU every 30s
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "30s", "100ms").Should(ContainSubstring("mtu 1300"))
+						}, "60s", "100ms").Should(ContainSubstring("mtu 1300"))
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
@@ -637,12 +639,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "10s", "100ms").Should(ContainSubstring(mtuStr))
+					}, "60s", "100ms").Should(ContainSubstring(mtuStr))
 					if enableIPv6 {
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "10s", "100ms").Should(ContainSubstring(mtuStrV6))
+						}, "60s", "100ms").Should(ContainSubstring(mtuStrV6))
 					}
 				}
 
@@ -659,14 +661,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 					Eventually(func() string {
 						out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan.calico")
 						return out
-					}, "10s", "100ms").ShouldNot(ContainSubstring(mtuStr))
+					}, "60s", "100ms").ShouldNot(ContainSubstring(mtuStr))
 					// IPv6 ignores the VXLAN enabled flag and must be disabled at the pool level. As such the ipv6
 					// interfaces should still exist at this point
 					if enableIPv6 {
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "10s", "100ms").Should(ContainSubstring(mtuStrV6))
+						}, "60s", "100ms").Should(ContainSubstring(mtuStrV6))
 					}
 				}
 
@@ -682,7 +684,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 						Eventually(func() string {
 							out, _ := felix.ExecOutput("ip", "-d", "link", "show", "vxlan-v6.calico")
 							return out
-						}, "10s", "100ms").ShouldNot(ContainSubstring(mtuStrV6))
+						}, "60s", "100ms").ShouldNot(ContainSubstring(mtuStrV6))
 					}
 				}
 			})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Increase timeouts on tests that verify MTU to 60s, due to the fact that Felix monitors host MTU every 30s. This should get rid of some flakiness in these tests.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
