### PR TITLE
Felix FVs: bail out early in IPv6 tests if docker IPv6 is disabled.

### DIFF
--- a/felix/fv/infrastructure/topology.go
+++ b/felix/fv/infrastructure/topology.go
@@ -287,6 +287,9 @@ func StartNNodeTopology(n int, opts TopologyOptions, infra DatastoreInfra) (feli
 		felix := felixes[i]
 		felix.TyphaIP = typhaIP
 
+		if opts.EnableIPv6 {
+			Expect(felix.IPv6).ToNot(BeEmpty(), "IPv6 enabled but Felix didn't get an IPv6 address, is docker configured for IPv6?")
+		}
 		expectedIPs := []string{felix.IP}
 
 		if kdd, ok := infra.(*K8sDatastoreInfra); ok && opts.ExternalIPs {

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -163,7 +163,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 
 						// Prepare route entry.
 						routeEntriesV6[i] = fmt.Sprintf("dead:beef::100:%d:0/122 dev %s metric 1024 pref medium", i, wireguardInterfaceNameV6Default)
-
 					}
 					// Swap route entry to match between workloads.
 					routeEntriesV6[0], routeEntriesV6[1] = routeEntriesV6[1], routeEntriesV6[0]


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Since we added wireguard IPv6 tests, we now need docker to have IPv6 enabled, not just the kernel.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
