### PR TITLE
[BPF] Extend syncer to include endpoint slices at Terminating status

### DIFF
--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -552,7 +552,7 @@ func (s *Syncer) apply(state DPSyncerState) error {
 		eps := make([]k8sp.Endpoint, 0, len(state.EpsMap[sname]))
 		for _, ep := range state.EpsMap[sname] {
 			zoneHints := ep.GetZoneHints()
-			if ep.IsReady() {
+			if ep.IsReady() || ep.IsTerminating() {
 				if ShouldAppendTopologyAwareEndpoint(nodeZone, hintsAnnotation, zoneHints) {
 					eps = append(eps, ep)
 				} else {
@@ -707,8 +707,12 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 		if !ep.GetIsLocal() {
 			continue
 		}
-		if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
-			return 0, 0, err
+
+		// eps could contain Ready and Terminating pods but only write Ready pods to backend.
+		if ep.IsReady() {
+			if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
+				return 0, 0, err
+			}
 		}
 
 		cpEps = append(cpEps, ep)
@@ -720,8 +724,12 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 		if ep.GetIsLocal() {
 			continue
 		}
-		if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
-			return 0, 0, err
+
+		// eps could contain Ready and Terminating pods but only write Ready pods to backend.
+		if ep.IsReady() {
+			if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
+				return 0, 0, err
+			}
 		}
 
 		cpEps = append(cpEps, ep)


### PR DESCRIPTION
Extend syncer to include endpoint slices at Terminating status. The endpoint are excluded from the NAT backend table, but are not removed from conntrack as long as they are terminating to to honor the shut down grace period and to allow pod to shut down gracefully.

fixes https://github.com/projectcalico/calico/issues/7110

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Connections to terminating endpoints of services not removed from conntrack in order to honor their grace shutdown period.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
