### PR TITLE
Release documentation update

### DIFF
--- a/hack/release/RELEASING.md
+++ b/hack/release/RELEASING.md
@@ -43,8 +43,6 @@ To publish Calico, you need **the following permissions**:
 
 - You must be able to access binaries.projectcalico.org.
 
-- You must have admin access to projectcalico.docs.tigera.io site on netlify.
-
 - To publish the helm release to the repo, you’ll need an AWS helm profile:
   Add this to your ~/.aws/config
       ```

--- a/hack/release/RELEASING.md
+++ b/hack/release/RELEASING.md
@@ -69,7 +69,7 @@ for the main Calico repo.
 
 To verify that the code and GitHub are in the right state for releasing the chosen version.
 
-1. [Make sure the Milestone is empty](https://github.com/projectcalico/calico/pulls?q=is%3Aopen+is%3Apr+milestone%3A%22Calico+v3.21.3%22) either by merging PRs, or kicking them out of the Milestone.
+1. [Make sure the Milestone is empty](https://github.com/projectcalico/calico/milestones) either by merging PRs, or kicking them out of the Milestone.
 1. [Make sure that there are no pending cherry-pick PRs](https://github.com/projectcalico/calico/pulls?q=is%3Aopen+is%3Apr+label%3Acherry-pick-candidate+) relevant to the release.
 1. [Make sure there are no pending PRs which need docs](https://github.com/projectcalico/calico/pulls?q=is%3Apr+label%3Adocs-pr-required+is%3Aclosed+milestone%3A%22Calico+v3.21.3%22) for this release.
 1. [Make sure each PR with a release note is within a Milestone](https://github.com/projectcalico/calico/pulls?q=is%3Apr+label%3Arelease-note-required+is%3Aclosed+milestone%3A%22Calico+v3.21.3%22+).

--- a/hack/release/RELEASING.md
+++ b/hack/release/RELEASING.md
@@ -79,7 +79,7 @@ Check the status of each of these items daily in the week leading up to the rele
 
 When starting development on a new minor release, the first step is to create a release branch.
 
-**For patch releases, this section can be skipped and you can go directly to [Performing a release](#performing-a-release)**
+**For patch releases, this section can be skipped and you can go directly to [Performing a release](#4-performing-a-release)**
 
 ### Setting up the branch
 


### PR DESCRIPTION
## Description

### Update release documentation:

1. Fix milestone link (currently points to 3.21.3)
2. Remove netlify admin access requirement (handled by docs team now)
3. Fix "go directly to Performing a release" link

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
