### PR TITLE
Fix concurrent access to the MockLink object.

### DIFF
--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -311,7 +311,7 @@ func (d *MockNetlinkDataplane) AddIface(idx int, name string, up bool, running b
 	}
 	d.NameToLink[name] = link
 	d.SetIface(name, up, running)
-	return link
+	return link.copy()
 }
 
 func (d *MockNetlinkDataplane) SetIface(name string, up bool, running bool) {
@@ -392,7 +392,7 @@ func (d *MockNetlinkDataplane) LinkList() ([]netlink.Link, error) {
 	}
 	var links []netlink.Link
 	for _, link := range d.NameToLink {
-		links = append(links, link)
+		links = append(links, link.copy())
 	}
 	return links, nil
 }
@@ -413,7 +413,7 @@ func (d *MockNetlinkDataplane) LinkByName(name string) (netlink.Link, error) {
 		defer delete(d.NameToLink, name)
 	}
 	if link, ok := d.NameToLink[name]; ok {
-		return link, nil
+		return link.copy(), nil
 	}
 	return nil, NotFoundError
 }
@@ -860,6 +860,34 @@ func (l *MockLink) Attrs() *netlink.LinkAttrs {
 
 func (l *MockLink) Type() string {
 	return l.LinkType
+}
+
+func (l *MockLink) copy() *MockLink {
+	var addrsCopy []netlink.Addr
+	if l.Addrs != nil {
+		addrsCopy = append(addrsCopy, l.Addrs...)
+	}
+
+	// Need to deep copy the map to avoid concurrent access.
+	var wgPeersCopy map[wgtypes.Key]wgtypes.Peer
+	if l.WireguardPeers != nil {
+		wgPeersCopy = map[wgtypes.Key]wgtypes.Peer{}
+		for k, v := range l.WireguardPeers {
+			wgPeersCopy[k] = v
+		}
+	}
+
+	return &MockLink{
+		LinkAttrs: l.LinkAttrs, // Shallow copy, but we don't use the nested pointers AFAICT.
+		Addrs:     addrsCopy,
+		LinkType:  l.LinkType,
+
+		WireguardPrivateKey:   l.WireguardPrivateKey,
+		WireguardPublicKey:    l.WireguardPublicKey,
+		WireguardListenPort:   l.WireguardListenPort,
+		WireguardFirewallMark: l.WireguardFirewallMark,
+		WireguardPeers:        wgPeersCopy,
+	}
 }
 
 func getArpKey(cidr ip.CIDR, destMAC net.HardwareAddr, ifaceName string) string {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Cherry-pick https://github.com/projectcalico/calico/pull/7373 to v3.25

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
