### PR TITLE
Add imageRegistry and imagePath support in Helm Chart

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -92,6 +92,12 @@ The default values.yaml should be suitable for most basic deployments.
 # Populates the `imagePullSecrets` property for all Pods controlled by the `Installation` resource.
 imagePullSecrets: {}
 
+# Install from a third-party (private) container repository
+imageRegistry: ""
+
+# Directory in the third-party (private) registry that contains images required
+imagePath: ""
+
 # Configures general installation parameters for Calico. Schema is based
 # on the operator.tigera.io/Installation API documented
 # here: https://projectcalico.docs.tigera.io/reference/installation/api#operator.tigera.io/v1.InstallationSpec

--- a/charts/tigera-operator/templates/crs/custom-resources.yaml
+++ b/charts/tigera-operator/templates/crs/custom-resources.yaml
@@ -16,6 +16,13 @@ spec:
 
 {{ end }}
 
+{{- if .Values.imageRegistry }}
+  registry: {{.Values.imageRegistry}}
+{{- end }}
+{{- if .Values.imagePath }}
+  imagePath: {{.Values.imagePath}}
+{{- end }}
+
 {{ if .Values.apiServer.enabled }}
 {{ $apiServerSpec := omit .Values.apiServer "enabled" }}
 ---

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -1,5 +1,8 @@
 imagePullSecrets: {}
 
+imageRegistry: ""
+imagePath: ""
+
 installation:
   enabled: true
   kubernetesProvider: ""


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add in support for third-party (private) image registry and image path in the helm chart.

Testing has been done manually on a private k8s cluster with a private ECR.

Docs probably want to be updated for Helm installation so that users are aware of the feature flags.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
