### PR TITLE
Wait for server shutdown in app-policy dikastes UT

### DIFF
--- a/app-policy/cmd/dikastes/dikastes_test.go
+++ b/app-policy/cmd/dikastes/dikastes_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -83,7 +84,7 @@ func TestHttpTerminationHandler_RunHTTPServer(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		gotSvr, _, gotErr := th.RunHTTPServer(tc.in.addr, tc.in.port)
+		gotSvr, wg, gotErr := th.RunHTTPServer(tc.in.addr, tc.in.port)
 		got := output{"", ""}
 		if gotSvr != nil {
 			got.addr = gotSvr.Addr
@@ -93,6 +94,13 @@ func TestHttpTerminationHandler_RunHTTPServer(t *testing.T) {
 		}
 		if !reflect.DeepEqual(tc.want, got) {
 			t.Fatalf("%s: expected: %v got: %v", tc.name, tc.want, got)
+		}
+
+		if gotSvr != nil {
+			if err := gotSvr.Shutdown(context.Background()); err != nil {
+				t.Fatalf("failed to shutdown: %v", err)
+			}
+			wg.Wait()
 		}
 	}
 }


### PR DESCRIPTION
## Description

We noticed app-policy dikastes UT fails intermittently on semaphore with the following error. This change adds the server shutdown step at the end of each iteration.

```bash
time="2023-03-01T16:57:48Z" level=info msg="starting HTTP server on :7777"
time="2023-03-01T16:57:48Z" level=info msg="starting HTTP server on 127.0.0.1:7777"
time="2023-03-01T16:57:48Z" level=fatal msg="HTTP server closed unexpectedly: listen tcp 127.0.0.1:7777: bind: address already in use"
FAIL    github.com/projectcalico/calico/app-policy/cmd/dikastes 0.029s
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
