### PR TITLE
bugfix:incomplete arp cause busy loop (high cpu util)

### DIFF
--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -1035,7 +1035,7 @@ func (r *RouteTable) syncL2RoutesForLink(ifaceName string) error {
 	var updatesFailed bool
 
 	for _, existing := range existingNeigh {
-		if _, ok := expected[existing.HardwareAddr.String()]; !ok {
+		if _, ok := expected[existing.HardwareAddr.String()]; !ok && existing.HardwareAddr != nil {
 			logCxt.WithField("neighbor", existing).Debug("Neighbor should no longer be programmed")
 
 			// Remove the FDB entry for this neighbor.


### PR DESCRIPTION
Hello. 
we have identified an issue with incomplete ARP entries that may cause a busy loop for calico-node in production.

We are unsure why every node is generating incomplete ARP entries, as shown in the attached image
![image](https://user-images.githubusercontent.com/3370345/222617328-402c9c09-84c3-414f-9a40-ec5bf6299eec.png)

These entries are causing the calico-node to experience high CPU utilization and become stuck in the syncL2RoutesForLink process. Specifically, the incomplete ARP entry, which holds a nil MAC address, is causing the kernel function rtnl_fdb_del to fail when attempting to remove the FDB entry

[https://elixir.bootlin.com/linux/v3.10.108/source/net/core/rtnetlink.c#L2223](https://elixir.bootlin.com/linux/v3.10.108/source/net/core/rtnetlink.c#L2223) 

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
