### PR TITLE
fix: app-policy goboring build

### DIFF
--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -83,14 +83,31 @@ bin/dikastes-arm64: ARCH=arm64
 bin/dikastes-ppc64le: ARCH=ppc64le
 bin/dikastes-s390x: ARCH=s390x
 bin/dikastes-%: protobuf $(SRC_FILES)
+ifeq ($(ARCH),amd64)
 	$(call build_cgo_boring_binary, ./cmd/dikastes, $@)
+else
+	mkdir -p bin
+	$(DOCKER_RUN_RO) \
+	  -e CGO_ENABLED=$(CGO_ENABLED) \
+	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
+	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/dikastes-$(ARCH) ./cmd/dikastes
+endif
 
 bin/healthz-amd64: ARCH=amd64
 bin/healthz-arm64: ARCH=arm64
 bin/healthz-ppc64le: ARCH=ppc64le
 bin/healthz-s390x: ARCH=s390x
 bin/healthz-%: protobuf $(SRC_FILES)
+ifeq ($(ARCH),amd64)
 	$(call build_static_cgo_boring_binary, ./cmd/healthz, $@)
+else
+	mkdir -p bin || true
+	-mkdir -p .go-pkg-cache $(GOMOD_CACHE) || true
+	$(DOCKER_RUN_RO) \
+	  -e CGO_ENABLED=$(CGO_ENABLED) \
+	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
+	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/healthz-$(ARCH) ./cmd/healthz
+endif
 
 # We use gogofast for protobuf compilation.  Regular gogo is incompatible with
 # gRPC, since gRPC uses golang/protobuf for marshalling/unmarshalling in that

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -93,7 +93,7 @@ ifeq ($(ARCH),amd64)
 else
 	$(DOCKER_RUN_RO) \
 	  -e CGO_ENABLED=$(CGO_ENABLED) \
-	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/dikastes-$(ARCH) ./cmd/dikastes
+	  $(CALICO_BUILD) go build -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/dikastes-$(ARCH) ./cmd/dikastes
 endif
 
 bin/healthz-amd64: ARCH=amd64
@@ -106,7 +106,7 @@ ifeq ($(ARCH),amd64)
 else
 	$(DOCKER_RUN_RO) \
 	  -e CGO_ENABLED=$(CGO_ENABLED) \
-	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/healthz-$(ARCH) ./cmd/healthz
+	  $(CALICO_BUILD) go build -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/healthz-$(ARCH) ./cmd/healthz
 endif
 
 # We use gogofast for protobuf compilation.  Regular gogo is incompatible with

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -91,11 +91,9 @@ bin/dikastes-%: protobuf $(SRC_FILES)
 ifeq ($(ARCH),amd64)
 	$(call build_cgo_boring_binary, ./cmd/dikastes, $@)
 else
-	mkdir -p bin
 	$(DOCKER_RUN_RO) \
 	  -e CGO_ENABLED=$(CGO_ENABLED) \
-	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
-	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/dikastes-$(ARCH) ./cmd/dikastes
+	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/dikastes-$(ARCH) ./cmd/dikastes
 endif
 
 bin/healthz-amd64: ARCH=amd64
@@ -106,12 +104,9 @@ bin/healthz-%: protobuf $(SRC_FILES)
 ifeq ($(ARCH),amd64)
 	$(call build_static_cgo_boring_binary, ./cmd/healthz, $@)
 else
-	mkdir -p bin || true
-	-mkdir -p .go-pkg-cache $(GOMOD_CACHE) || true
 	$(DOCKER_RUN_RO) \
 	  -e CGO_ENABLED=$(CGO_ENABLED) \
-	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
-	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/healthz-$(ARCH) ./cmd/healthz
+	  $(CALICO_BUILD) go build $(BUILD_FLAGS) -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/healthz-$(ARCH) ./cmd/healthz
 endif
 
 # We use gogofast for protobuf compilation.  Regular gogo is incompatible with

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -72,11 +72,16 @@ clean-generated:
 
 .PHONY: build-all
 ## Build the binaries for all architectures and platforms
-build-all: $(addprefix bin/dikastes-,$(VALIDARCHES))
+$(VALIDARCHES):
+	$(MAKE) build ARCH=$@
+
+build-all: $(VALIDARCHES)
 
 .PHONY: build
 ## Build the binary for the current architecture and platform
-build: bin/dikastes-$(ARCH) bin/healthz-$(ARCH)
+build: 
+	$(MAKE) bin/dikastes-$(ARCH) ARCH=$(ARCH)
+	$(MAKE) bin/healthz-$(ARCH) ARCH=$(ARCH)
 
 bin/dikastes-amd64: ARCH=amd64
 bin/dikastes-arm64: ARCH=arm64

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -93,6 +93,7 @@ ifeq ($(ARCH),amd64)
 else
 	$(DOCKER_RUN_RO) \
 	  -e CGO_ENABLED=$(CGO_ENABLED) \
+	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
 	  $(CALICO_BUILD) go build -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/dikastes-$(ARCH) ./cmd/dikastes
 endif
 
@@ -106,6 +107,7 @@ ifeq ($(ARCH),amd64)
 else
 	$(DOCKER_RUN_RO) \
 	  -e CGO_ENABLED=$(CGO_ENABLED) \
+	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
 	  $(CALICO_BUILD) go build -buildvcs=false -ldflags "-X main.VERSION=$(GIT_VERSION)" -v -o bin/healthz-$(ARCH) ./cmd/healthz
 endif
 


### PR DESCRIPTION
## Description

Background: The `build_cgo_boring_binary` build macro doesn't seem to support s390x (only mentioning s390x because this is where it recently [failed](https://tigera.semaphoreci.com/jobs/419322b2-cd1e-4055-9e61-89770f2cf6d8)).

In this PR, we are simply copying how [node/Makefile](https://github.com/projectcalico/calico/blob/master/node/Makefile#L236) and other Makefile calls it:  we wrap it with an `ifeq ($(ARCH),amd64) ... else ... endif`.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
