### PR TITLE
Update flannel to v0.21.2

### DIFF
--- a/charts/calico/values.yaml
+++ b/charts/calico/values.yaml
@@ -14,7 +14,7 @@ kubeControllers:
   image: docker.io/calico/kube-controllers
 flannel:
   image: docker.io/flannelcni/flannel
-  tag: v0.16.3
+  tag: v0.21.2
 flannelMigration:
   image: docker.io/calico/flannel-migration
 dikastes:

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -570,7 +570,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: docker.io/flannelcni/flannel:v0.16.3
+          image: docker.io/flannelcni/flannel:v0.21.2
           imagePullPolicy: IfNotPresent
           env:
             # The location of the etcd cluster.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4793,7 +4793,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: docker.io/flannelcni/flannel:v0.16.3
+          image: docker.io/flannelcni/flannel:v0.21.2
           imagePullPolicy: IfNotPresent
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:


### PR DESCRIPTION
## Description

The flannel version used in canal is more than one year old (`v0.16.3`). This PR updates flannel to the latest version `v0.21.2`.

## Related issues/PRs

fixes #7400 
