### PR TITLE
kube-controllers/node: Use pod/node indexes

### DIFF
--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -450,7 +450,7 @@ type controllerControl struct {
 func (cc *controllerControl) InitControllers(ctx context.Context, cfg config.RunConfig, k8sClientset *kubernetes.Clientset, calicoClient client.Interface) {
 	// Create a shared informer factory to allow cache sharing between controllers monitoring the
 	// same resource.
-	factory := informers.NewSharedInformerFactory(k8sClientset, 0)
+	factory := informers.NewSharedInformerFactory(k8sClientset, 1*time.Minute)
 	podInformer := factory.Core().V1().Pods().Informer()
 	nodeInformer := factory.Core().V1().Nodes().Informer()
 

--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -82,7 +82,7 @@ func NewNodeController(ctx context.Context,
 	nodeDeletionFuncs := []func(){}
 
 	// Create the IPAM controller.
-	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset, nodeInformer.GetIndexer())
+	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, podInformer.GetIndexer(), nodeInformer.GetIndexer())
 	nc.ipamCtrl.RegisterWith(nc.dataFeed)
 	nodeDeletionFuncs = append(nodeDeletionFuncs, nc.ipamCtrl.OnKubernetesNodeDeleted)
 
@@ -133,7 +133,7 @@ func NewNodeController(ctx context.Context,
 		nc.ipamCtrl.OnKubernetesPodUpdated(key, pod)
 	}
 	podHandlers.DeleteFunc = func(obj interface{}) {
-		key, err := cache.MetaNamespaceKeyFunc(obj)
+		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 		if err != nil {
 			log.WithError(err).Error("Failed to generate key")
 			return

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -90,7 +90,7 @@ var _ = Describe("IPAM controller UTs", func() {
 	var c *ipamController
 	var cli client.Interface
 	var cs kubernetes.Interface
-	var ni cache.Indexer
+	var pi, ni cache.Indexer
 	var stopChan chan struct{}
 
 	BeforeEach(func() {
@@ -103,6 +103,7 @@ var _ = Describe("IPAM controller UTs", func() {
 		// Create a node indexer with the fake clientset
 		factory := informers.NewSharedInformerFactory(cs, 0)
 		ni = factory.Core().V1().Nodes().Informer().GetIndexer()
+		pi = factory.Core().V1().Pods().Informer().GetIndexer()
 
 		// Config for the test.
 		cfg := config.NodeControllerConfig{
@@ -114,7 +115,7 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Create a new controller. We don't register with a data feed,
 		// as the tests themselves will drive the controller.
-		c = NewIPAMController(cfg, cli, cs, ni)
+		c = NewIPAMController(cfg, cli, pi, ni)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
## Description

In large clusters (>20K pods) with a lot of pod churn we found that calico-kube-controllers Node controller will leak memory in its internal pod cache within IPAM controller loop https://github.com/projectcalico/calico/blob/54ade211b5b81f71fa265a50d85afd134bcd51c3/kube-controllers/pkg/controllers/node/ipam.go#L191

We were able to track it down to the combination of https://github.com/kubernetes/kubernetes/pull/115620 (will file separate issue to bump this dependency) and extremely inefficient cache refresh loop that is issuing separate GET requests on every pod in the cluster on startup which causes Informer's internal FIFO queue to fall far behind and start dropping deletes.

This change addresses the above with:

* Re-use Informer's index to query the Pod/Node state - this is more efficient than paying the roundtrip to APIServer as the state it already cached.
* Enable re-sync on the SharedIndexInformer to guard against index getting out of sync
* Use `cache.DeletionHandlingMetaNamespaceKeyFunc` in the Informer's delete callback

## Related issues/PRs

Possibly related to #5218 and #5037

## Todos

- [x] Tests
- [ ] Documentation (n/a)
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Prevents Node kube-controller's internal pod cache from getting out-of-sync thus leaking memory.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
