### PR TITLE
Fix flake in UDP spoof tests; wait for BPF programs to be ready.

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1452,6 +1452,12 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							_, err = eth30.RunCmd("ip", "route", "add", w[1][1].IP+"/32", "via", "10.0.0.30")
 							Expect(err).NotTo(HaveOccurred())
 
+							// Make sure Felix adds a BPF program before we run the test, otherwise the conntrack
+							// may be crated in the reverse direction.  Since we're pretending to be a host interface
+							// Felix doesn't block traffic by default.
+							Eventually(felixes[1].NumTCBPFProgsFn("eth20"), "30s", "200ms").Should(Equal(2))
+							Eventually(felixes[1].NumTCBPFProgsFn("eth30"), "30s", "200ms").Should(Equal(2))
+
 							// Make sure that networking with the .20 and .30 networks works
 							cc.ResetExpectations()
 							cc.ExpectSome(w[1][1], TargetIP(eth20.IP), 0xdead)
@@ -1509,8 +1515,10 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 							// Ifindex must have changed
 							// B2A because of IPA > IPB - deterministic
-							Expect(ctBefore[k].Data().B2A.Ifindex).NotTo(BeNumerically("==", 0))
-							Expect(ctAfter[k].Data().B2A.Ifindex).NotTo(BeNumerically("==", 0))
+							Expect(ctBefore[k].Data().B2A.Ifindex).NotTo(BeNumerically("==", 0),
+								"Expected 'before' conntrack B2A ifindex to be set")
+							Expect(ctAfter[k].Data().B2A.Ifindex).NotTo(BeNumerically("==", 0),
+								"Expected 'after' conntrack B2A ifindex to be set")
 							Expect(ctBefore[k].Data().B2A.Ifindex).
 								NotTo(BeNumerically("==", ctAfter[k].Data().B2A.Ifindex))
 						})

--- a/felix/fv/containers/containers.go
+++ b/felix/fv/containers/containers.go
@@ -728,6 +728,12 @@ func (c *Container) NumTCBPFProgs(ifaceName string) int {
 	return total
 }
 
+func (c *Container) NumTCBPFProgsFn(ifaceName string) func() int {
+	return func() int {
+		return c.NumTCBPFProgs(ifaceName)
+	}
+}
+
 // NumTCBPFProgs Returns the number of TC BPF programs attached to eth0.  Only direct-action programs are
 // listed (i.e. the type that we use).
 func (c *Container) NumTCBPFProgsEth0() int {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
