### PR TITLE
Validate RouteReflector IP

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/node.go
+++ b/libcalico-go/lib/backend/k8s/resources/node.go
@@ -38,6 +38,7 @@ import (
 	cerrors "github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/json"
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
+	validatorv3 "github.com/projectcalico/calico/libcalico-go/lib/validator/v3"
 )
 
 const (
@@ -230,13 +231,10 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, erro
 	// Extract the BGP configuration stored in the annotations.
 	bgpSpec := &libapiv3.NodeBGPSpec{}
 	annotations := k8sNode.ObjectMeta.Annotations
-	bgpSpec.IPv4Address = annotations[nodeBgpIpv4AddrAnnotation]
-	bgpSpec.IPv6Address = annotations[nodeBgpIpv6AddrAnnotation]
-	// Validate the IP address specified for route reflector.
-	// When route reflector is configured using calicoctl, the address
-	// is already validated. When the node is annotated directly without
-	// using calicoctl, the IP address specified must be validated here.
-	bgpSpec.RouteReflectorClusterID = getAnnotation(k8sNode, nodeBgpCIDAnnotation, validateIPv4Address)
+	bgpSpec.IPv4Address = getAnnotation(k8sNode, nodeBgpIpv4AddrAnnotation, validatorv3.ValidateCIDRv4)
+	bgpSpec.IPv6Address = getAnnotation(k8sNode, nodeBgpIpv6AddrAnnotation, validatorv3.ValidateCIDRv6)
+	bgpSpec.RouteReflectorClusterID = getAnnotation(k8sNode, nodeBgpCIDAnnotation, validatorv3.ValidateIPv4Network)
+
 	asnString, ok := annotations[nodeBgpAsnAnnotation]
 	if ok {
 		asn, err := numorstring.ASNumberFromString(asnString)
@@ -269,9 +267,9 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, erro
 		}
 	} else {
 		// We are not using host local, so assign tunnel addresses from annotations.
-		bgpSpec.IPv4IPIPTunnelAddr = annotations[nodeBgpIpv4IPIPTunnelAddrAnnotation]
-		wireguardSpec.InterfaceIPv4Address = annotations[nodeWireguardIpv4IfaceAddrAnnotation]
-		wireguardSpec.InterfaceIPv6Address = annotations[nodeWireguardIpv6IfaceAddrAnnotation]
+		bgpSpec.IPv4IPIPTunnelAddr = getAnnotation(k8sNode, nodeBgpIpv4IPIPTunnelAddrAnnotation, validatorv3.ValidateIPv4Network)
+		wireguardSpec.InterfaceIPv4Address = getAnnotation(k8sNode, nodeWireguardIpv4IfaceAddrAnnotation, validatorv3.ValidateIPv4Network)
+		wireguardSpec.InterfaceIPv6Address = getAnnotation(k8sNode, nodeWireguardIpv6IfaceAddrAnnotation, validatorv3.ValidateIPv4Network)
 	}
 
 	// Only set the BGP spec if it is not empty.
@@ -285,10 +283,10 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, erro
 	}
 
 	// Set the VXLAN tunnel addresses based on annotation.
-	calicoNode.Spec.IPv4VXLANTunnelAddr = annotations[nodeBgpIpv4VXLANTunnelAddrAnnotation]
-	calicoNode.Spec.VXLANTunnelMACAddr = annotations[nodeBgpVXLANTunnelMACAddrAnnotation]
-	calicoNode.Spec.IPv6VXLANTunnelAddr = annotations[nodeBgpIpv6VXLANTunnelAddrAnnotation]
-	calicoNode.Spec.VXLANTunnelMACAddrV6 = annotations[nodeBgpVXLANTunnelMACAddrV6Annotation]
+	calicoNode.Spec.IPv4VXLANTunnelAddr = getAnnotation(k8sNode, nodeBgpIpv4VXLANTunnelAddrAnnotation, validatorv3.ValidateIPv4Network)
+	calicoNode.Spec.VXLANTunnelMACAddr = getAnnotation(k8sNode, nodeBgpVXLANTunnelMACAddrAnnotation, validatorv3.ValidateMAC)
+	calicoNode.Spec.IPv6VXLANTunnelAddr = getAnnotation(k8sNode, nodeBgpIpv6VXLANTunnelAddrAnnotation, validatorv3.ValidateIPv4Network)
+	calicoNode.Spec.VXLANTunnelMACAddrV6 = getAnnotation(k8sNode, nodeBgpVXLANTunnelMACAddrV6Annotation, validatorv3.ValidateMAC)
 
 	// Set the node status
 	nodeStatus := libapiv3.NodeStatus{}
@@ -571,16 +569,4 @@ func getAnnotation(n *kapiv1.Node, key string, validator validatorFunc) string {
 		return ""
 	}
 	return value
-}
-
-// validateIPv4Address validates if the given string is a valid IPv4 address.
-func validateIPv4Address(ipAddr string) error {
-	ip := net.ParseIP(ipAddr)
-	if ip == nil {
-		return fmt.Errorf("Error parsing IP %s", ipAddr)
-	}
-	if ip.To4() == nil {
-		return fmt.Errorf("%s is not a valid IPv4 address", ipAddr)
-	}
-	return nil
 }

--- a/libcalico-go/lib/backend/k8s/resources/node.go
+++ b/libcalico-go/lib/backend/k8s/resources/node.go
@@ -269,7 +269,7 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, erro
 		// We are not using host local, so assign tunnel addresses from annotations.
 		bgpSpec.IPv4IPIPTunnelAddr = getAnnotation(k8sNode, nodeBgpIpv4IPIPTunnelAddrAnnotation, validatorv3.ValidateIPv4Network)
 		wireguardSpec.InterfaceIPv4Address = getAnnotation(k8sNode, nodeWireguardIpv4IfaceAddrAnnotation, validatorv3.ValidateIPv4Network)
-		wireguardSpec.InterfaceIPv6Address = getAnnotation(k8sNode, nodeWireguardIpv6IfaceAddrAnnotation, validatorv3.ValidateIPv4Network)
+		wireguardSpec.InterfaceIPv6Address = getAnnotation(k8sNode, nodeWireguardIpv6IfaceAddrAnnotation, validatorv3.ValidateIPv6Network)
 	}
 
 	// Only set the BGP spec if it is not empty.
@@ -285,7 +285,7 @@ func K8sNodeToCalico(k8sNode *kapiv1.Node, usePodCIDR bool) (*model.KVPair, erro
 	// Set the VXLAN tunnel addresses based on annotation.
 	calicoNode.Spec.IPv4VXLANTunnelAddr = getAnnotation(k8sNode, nodeBgpIpv4VXLANTunnelAddrAnnotation, validatorv3.ValidateIPv4Network)
 	calicoNode.Spec.VXLANTunnelMACAddr = getAnnotation(k8sNode, nodeBgpVXLANTunnelMACAddrAnnotation, validatorv3.ValidateMAC)
-	calicoNode.Spec.IPv6VXLANTunnelAddr = getAnnotation(k8sNode, nodeBgpIpv6VXLANTunnelAddrAnnotation, validatorv3.ValidateIPv4Network)
+	calicoNode.Spec.IPv6VXLANTunnelAddr = getAnnotation(k8sNode, nodeBgpIpv6VXLANTunnelAddrAnnotation, validatorv3.ValidateIPv6Network)
 	calicoNode.Spec.VXLANTunnelMACAddrV6 = getAnnotation(k8sNode, nodeBgpVXLANTunnelMACAddrV6Annotation, validatorv3.ValidateMAC)
 
 	// Set the node status

--- a/libcalico-go/lib/backend/k8s/resources/node_test.go
+++ b/libcalico-go/lib/backend/k8s/resources/node_test.go
@@ -30,11 +30,9 @@ import (
 
 var _ = Describe("Test Node conversion", func() {
 	It("should parse a k8s Node to a Calico Node", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4AddrAnnotation: "172.17.17.10",
@@ -78,11 +76,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("should ignore RR cluster ID if its an invalid IPv4 address", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4AddrAnnotation: "172.17.17.10",
@@ -117,11 +113,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("should ignore RR cluster ID if it an IPv6 address", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4AddrAnnotation: "172.17.17.10",
@@ -156,11 +150,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("should parse a k8s Node to a Calico Node with RR cluster ID", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4AddrAnnotation: "172.17.17.10",
@@ -207,11 +199,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("should parse a k8s Node to a Calico Node with IPv6", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv6AddrAnnotation: "fd10::10",
@@ -253,11 +243,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("should parse a k8s Node to a Calico Node with podCIDR but no BGP config", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 			},
 			Status: k8sapi.NodeStatus{},
@@ -272,11 +260,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("Should parse and remove BGP info when given Calico Node with empty BGP spec", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		k8sNode := &k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4AddrAnnotation: "172.17.17.10",
@@ -295,7 +281,7 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("Should merge Calico Nodes into K8s Nodes", func() {
-		kl := map[string]string{"net.beta.kubernetes.io/role": "master"}
+		kl := map[string]string{"net.beta.kubernetes.io/role": "control-plane"}
 		cl := map[string]string{
 			"label1": "foo",
 			"label2": "bar",
@@ -354,8 +340,8 @@ var _ = Describe("Test Node conversion", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		calicoNodeWithMergedLabels := calicoNode.DeepCopy()
-		calicoNodeWithMergedLabels.Annotations[nodeK8sLabelAnnotation] = "{\"net.beta.kubernetes.io/role\":\"master\"}"
-		calicoNodeWithMergedLabels.Labels["net.beta.kubernetes.io/role"] = "master"
+		calicoNodeWithMergedLabels.Annotations[nodeK8sLabelAnnotation] = "{\"net.beta.kubernetes.io/role\":\"control-plane\"}"
+		calicoNodeWithMergedLabels.Labels["net.beta.kubernetes.io/role"] = "control-plane"
 		calicoNodeWithMergedLabels.Spec.Addresses = []libapiv3.NodeAddress{
 			libapiv3.NodeAddress{Address: "172.17.17.10/24", Type: libapiv3.CalicoNodeIP},
 			libapiv3.NodeAddress{Address: "aa:bb:cc::ffff/120", Type: libapiv3.CalicoNodeIP},
@@ -365,7 +351,7 @@ var _ = Describe("Test Node conversion", func() {
 
 	It("Should shadow labels correctly", func() {
 		kl := map[string]string{
-			"net.beta.kubernetes.io/role": "master",
+			"net.beta.kubernetes.io/role": "control-plane",
 			"shadowed":                    "k8s-value",
 		}
 		cl := map[string]string{
@@ -406,9 +392,9 @@ var _ = Describe("Test Node conversion", func() {
 		// When we merge k8s into Calico, the k8s labels get stashed in an annotation along with the shadowed labels:
 		calicoNodeWithMergedLabels := calicoNode.DeepCopy()
 		calicoNodeWithMergedLabels.Annotations = map[string]string{}
-		calicoNodeWithMergedLabels.Annotations[nodeK8sLabelAnnotation] = "{\"net.beta.kubernetes.io/role\":\"master\",\"shadowed\":\"k8s-value\"}"
+		calicoNodeWithMergedLabels.Annotations[nodeK8sLabelAnnotation] = "{\"net.beta.kubernetes.io/role\":\"control-plane\",\"shadowed\":\"k8s-value\"}"
 		// And, the k8s labels get merged in...
-		calicoNodeWithMergedLabels.Labels["net.beta.kubernetes.io/role"] = "master"
+		calicoNodeWithMergedLabels.Labels["net.beta.kubernetes.io/role"] = "control-plane"
 		calicoNodeWithMergedLabels.Labels["shadowed"] = "k8s-value"
 		Expect(newCalicoNode.Value).To(Equal(calicoNodeWithMergedLabels))
 
@@ -444,11 +430,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("should parse a k8s Node to a Calico Node with an IPv4IPIPTunnelAddr", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv4AddrAnnotation:           "172.17.17.10",
@@ -581,11 +565,9 @@ var _ = Describe("Test Node conversion", func() {
 	})
 
 	It("should parse addresses of all types into Calico Node", func() {
-		l := map[string]string{"net.beta.kubernetes.io/role": "master"}
 		node := k8sapi.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "TestNode",
-				Labels:          l,
 				ResourceVersion: "1234",
 				Annotations: map[string]string{
 					nodeBgpIpv6AddrAnnotation:             "fd10::10",


### PR DESCRIPTION
## Description

Route reflectors can be configured using calicoctl or my annotating the node resource directly.
While the calicoctl configuration goes through validations, the annotation value is not validated if the node resource is directly annotated. This PR adds validation to this IP.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
