### PR TITLE
DOCS-1347: Fixing dead links in manifests

### DIFF
--- a/calico/reference/kube-controllers/configuration.md
+++ b/calico/reference/kube-controllers/configuration.md
@@ -53,7 +53,7 @@ The `*_FILE` variables are _paths_ to the corresponding certificates/keys. As su
 must ensure that the files exist within the pod. This is usually done in one of two ways:
 
 * Mount the certificates from the host. This requires that the certificates be present on the host running the controller.
-* Use Kubernetes [Secrets](http://kubernetes.io/docs/user-guide/secrets/){:target="_blank"} to mount the certificates into the pod as files.
+* Use Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/){:target="_blank"} to mount the certificates into the pod as files.
 
 #### kubernetes
 

--- a/charts/calico/templates/calico-etcd-secrets.yaml
+++ b/charts/calico/templates/calico-etcd-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.datastore "etcd" -}}
 # The following contains k8s Secrets for use with a TLS enabled etcd cluster.
-# For information on populating Secrets, see http://kubernetes.io/docs/user-guide/secrets/
+# For information on populating Secrets, see https://kubernetes.io/docs/concepts/configuration/secret/
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/charts/calico/templates/calico-node-rbac.yaml
+++ b/charts/calico/templates/calico-node-rbac.yaml
@@ -178,7 +178,7 @@ rules:
 
 {{- if eq .Values.network "flannel" }}
 # Flannel ClusterRole
-# Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
+# Pulled from https://github.com/flannel-io/flannel/blob/master/Documentation/k8s-old-manifests/kube-flannel-rbac.yml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -31,7 +31,7 @@ metadata:
 ---
 # Source: calico/templates/calico-etcd-secrets.yaml
 # The following contains k8s Secrets for use with a TLS enabled etcd cluster.
-# For information on populating Secrets, see http://kubernetes.io/docs/user-guide/secrets/
+# For information on populating Secrets, see https://kubernetes.io/docs/concepts/configuration/secret/
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -31,7 +31,7 @@ metadata:
 ---
 # Source: calico/templates/calico-etcd-secrets.yaml
 # The following contains k8s Secrets for use with a TLS enabled etcd cluster.
-# For information on populating Secrets, see http://kubernetes.io/docs/user-guide/secrets/
+# For information on populating Secrets, see https://kubernetes.io/docs/concepts/configuration/secret/
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -200,7 +200,7 @@ rules:
 ---
 # Source: calico/templates/calico-node-rbac.yaml
 # Flannel ClusterRole
-# Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
+# Pulled from https://github.com/flannel-io/flannel/blob/master/Documentation/k8s-old-manifests/kube-flannel-rbac.yml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4302,7 +4302,7 @@ rules:
 ---
 # Source: calico/templates/calico-node-rbac.yaml
 # Flannel ClusterRole
-# Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
+# Pulled from https://github.com/flannel-io/flannel/blob/master/Documentation/k8s-old-manifests/kube-flannel-rbac.yml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
## Description

Our tests turned up some broken links in code comments of manifest files. This PR fixes those links everywhere. Hopefully some of these are the right ones that are used at build time to populate the manifest files.

Specifically:
http://kubernetes.io/docs/user-guide/secrets/ is dead (404)
==>Origin: https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico-etcd.yaml
https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml is dead (404)
==>Origin: https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/canal.yaml
http://kubernetes.io/docs/user-guide/secrets/ is dead (404)
==>Origin: https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico-etcd.yaml

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
