### PR TITLE
Fix feature detection for netlink strict mode.

### DIFF
--- a/felix/ifacemonitor/netlink_real.go
+++ b/felix/ifacemonitor/netlink_real.go
@@ -23,16 +23,16 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/projectcalico/calico/felix/environment"
-	"github.com/projectcalico/calico/felix/netlinkshim"
+	"github.com/projectcalico/calico/felix/netlinkshim/handlemgr"
 )
 
 type netlinkReal struct {
-	handleMgr *netlinkshim.HandleManager
+	handleMgr *handlemgr.HandleManager
 }
 
 func newRealNetlink(featureDetector environment.FeatureDetectorIface, timeout time.Duration) *netlinkReal {
 	return &netlinkReal{
-		handleMgr: netlinkshim.NewHandleManager(netlink.FAMILY_ALL, featureDetector, netlinkshim.WithSocketTimeout(timeout)),
+		handleMgr: handlemgr.NewHandleManager(netlink.FAMILY_ALL, featureDetector, handlemgr.WithSocketTimeout(timeout)),
 	}
 }
 

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -58,6 +58,8 @@ func New() *MockNetlinkDataplane {
 				Table:    253,
 			},
 		},
+		SetStrictCheckErr: SimulatedError,
+
 		// Use a single global mutex.  This works around an issue in the wireguard tests, which use multiple
 		// mock dataplanes to hand to different parts of the code under test.  That led to concurrency bugs
 		// where one dataplane modified another dataplane's object without holding the right lock.
@@ -248,6 +250,7 @@ type MockNetlinkDataplane struct {
 
 	PersistFailures                bool
 	FailuresToSimulate             FailFlags
+	SetStrictCheckErr              error
 	DeleteInterfaceAfterLinkByName bool
 
 	addedArpEntries set.Set[string]
@@ -381,7 +384,7 @@ func (d *MockNetlinkDataplane) SetStrictCheck(b bool) error {
 
 	Expect(d.NetlinkOpen).To(BeTrue())
 	if d.shouldFail(FailNextSetStrict) {
-		return SimulatedError
+		return d.SetStrictCheckErr
 	}
 	d.StrictEnabled = b
 	return nil

--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -35,6 +35,7 @@ import (
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/logutils"
 	"github.com/projectcalico/calico/felix/netlinkshim"
+	"github.com/projectcalico/calico/felix/netlinkshim/handlemgr"
 	"github.com/projectcalico/calico/felix/timeshim"
 	cprometheus "github.com/projectcalico/calico/libcalico-go/lib/prometheus"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
@@ -204,7 +205,7 @@ type RouteTable struct {
 	deviceRouteProtocol  netlink.RouteProtocol
 	removeExternalRoutes bool
 
-	nl *netlinkshim.HandleManager
+	nl *handlemgr.HandleManager
 
 	// The route table index. A value of 0 defaults to the main table.
 	tableIndex int
@@ -354,11 +355,11 @@ func NewWithShims(
 		tableIndex:                     tableIndex,
 		opReporter:                     opReporter,
 		livenessCallback:               func() {},
-		nl: netlinkshim.NewHandleManager(
+		nl: handlemgr.NewHandleManager(
 			family,
 			featureDetector,
-			netlinkshim.WithNewHandleOverride(newNetlinkHandle),
-			netlinkshim.WithSocketTimeout(netlinkTimeout),
+			handlemgr.WithNewHandleOverride(newNetlinkHandle),
+			handlemgr.WithSocketTimeout(netlinkTimeout),
 		),
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Change netlink strict mode detection to "just try it" and disable if it fails.  The kernel version number was wrong: strict mode was actually added in v4.20.  However, current RH kernels are based on something older but with many backports so best to directly check.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
