### PR TITLE
Explicitly set kubeletVolumePluginPath in tigera-operator Installatio…

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -146,4 +146,7 @@ tigeraOperator:
   registry: quay.io
 calicoctl:
   image: docker.io/calico/ctl
+
+# Configuration for the Calico CSI plugin - setting to None will disable the plugin, default: /var/lib/kubelet
+kubeletVolumePluginPath: None   
 ```

--- a/charts/tigera-operator/templates/crs/custom-resources.yaml
+++ b/charts/tigera-operator/templates/crs/custom-resources.yaml
@@ -6,6 +6,7 @@
 {{ $secrets = append $secrets $item }}
 {{ end }}
 {{ $_ := set $installSpec "imagePullSecrets" $secrets }}
+{{ $_ := set $installSpec "kubeletVolumePluginPath" .Values.kubeletVolumePluginPath }}
 
 apiVersion: operator.tigera.io/v1
 kind: Installation

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -46,3 +46,5 @@ tigeraOperator:
 calicoctl:
   image: docker.io/calico/ctl
   tag: master
+
+kubeletVolumePluginPath: /var/lib/kubelet


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Today, the Calico CSI plugin gets installed by default when trying to use the tigera-operator to install Calico.
I had to look at the [documentation](https://docs.tigera.io/calico/3.25/reference/installation/api#operator.tigera.io/v1.Installation) to figure out that setting `kubeletVolumePluginPath` to `None` will disable the CSI plugin. Since this was not very obvious at first glance, this small change calls this out in the Readme and makes a change to the `Installation` custom-resource Helm chart to explicitly set the `kubeletVolumePluginPath` value from the `values.yaml` file.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Expose the configuration for the CSI plugin in the operator helm chart
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
