### PR TITLE
[BPF] inc jump maps version after increasing size

### DIFF
--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -19,14 +19,14 @@ static CALI_BPF_INLINE struct cali_tc_state *state_get(void)
 	return cali_state_lookup_elem(&key);
 }
 
-struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump2 = {
+struct bpf_map_def_extended __attribute__((section("maps"))) cali_jump3 = {
 	.type = BPF_MAP_TYPE_PROG_ARRAY,
 	.key_size = 4,
 	.value_size = 4,
 	.max_entries = 32,
 };
 
-#define CALI_JUMP_TO(ctx, index) bpf_tail_call(ctx, &map_symbol(cali_jump, 2), index)
+#define CALI_JUMP_TO(ctx, index) bpf_tail_call(ctx, &map_symbol(cali_jump, 3), index)
 
 /* Add new values to the end as these are program indices */
 enum cali_jump_index {

--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -35,7 +35,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/utils"
 )
 
-const jumpMapVersion = 2
+const jumpMapVersion = 3
 
 func JumpMapName() string {
 	return fmt.Sprintf("cali_jump%d", jumpMapVersion)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Jumpmap versionincremented to prevent failures when upgrading from earlier calico versions
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
