### PR TITLE
[release-v3.24] Auto pick #7485: Use quay repo for metallb image

### DIFF
--- a/node/tests/k8st/infra/metallb.yaml
+++ b/node/tests/k8st/infra/metallb.yaml
@@ -133,7 +133,7 @@ spec:
       - args:
         - --port=7472
         - --config=config
-        image: metallb/controller:v0.9.5
+        image: quay.io/metallb/controller:v0.9.5
         imagePullPolicy: Always
         name: controller
         ports:


### PR DESCRIPTION
Cherry pick of #7485 on release-v3.24.

#7485: Use quay repo for metallb image