### PR TITLE
[BPF] use libbpf to (re)pin maps

### DIFF
--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -408,3 +408,21 @@ func NumPossibleCPUs() (int, error) {
 	}
 	return ncpus, nil
 }
+
+func ObjPin(fd int, path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	_, err := C.bpf_obj_pin(C.int(fd), cPath)
+
+	return err
+}
+
+func ObjGet(path string) (int, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	fd, err := C.bpf_obj_get(cPath)
+
+	return int(fd), err
+}

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -124,3 +124,11 @@ func (m *Map) SetSize(size int) error {
 func NumPossibleCPUs() (int, error) {
 	return runtime.NumCPU(), nil
 }
+
+func ObjPin(_ int, _ string) error {
+	panic("LIBBPF syscall stub")
+}
+
+func ObjGet(_ string) (int, error) {
+	panic("LIBBPF syscall stub")
+}

--- a/felix/bpf/ut/map_upgrade_test.go
+++ b/felix/bpf/ut/map_upgrade_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/projectcalico/calico/felix/bpf/libbpf"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	mock "github.com/projectcalico/calico/felix/bpf/mock/multiversion"
 	v2 "github.com/projectcalico/calico/felix/bpf/mock/multiversion/v2"
@@ -343,12 +344,10 @@ func TestMapUpgradeWhileResizeInProgress(t *testing.T) {
 	}
 
 	// repin /sys/fs/bpf/tc/globals/cali_mock2 to /sys/fs/bpt/tc/globals/cali_mock2_old1
-	err = maps.RepinMap(mockMapv2_old.GetName(), mockMapv2_old.Path()+"_old1")
+	err = libbpf.ObjPin(int(mockMapv2_old.MapFD()), mockMapv2_old.Path()+"_old1")
 	Expect(err).NotTo(HaveOccurred())
 	// Delete /sys/fs/bpf/tc/globals/cali_mock2
 	os.Remove(mockMapv2_old.Path())
-	mapId, err := maps.GetMapIdFromPin(mockMapv2_old.Path() + "_old1")
-	Expect(err).NotTo(HaveOccurred())
 
 	// create another v2 map and add only the last 5 entries
 	mockMapv2 := mock.MapV2(30)
@@ -363,7 +362,7 @@ func TestMapUpgradeWhileResizeInProgress(t *testing.T) {
 	}
 
 	// Reping /sys/fs/bpt/tc/globals/cali_mock2_old1 to /sys/fs/bpt/tc/globals/cali_mock2_old
-	err = maps.RepinMapFromId(mapId, mockMapv2.Path()+"_old")
+	err = libbpf.ObjPin(int(mockMapv2_old.MapFD()), mockMapv2.Path()+"_old")
 	Expect(err).NotTo(HaveOccurred())
 	// Remove /sys/fs/bpt/tc/globals/cali_mock2_old1
 	os.Remove(mockMapv2_old.Path() + "_old1")


### PR DESCRIPTION
More efficient once we have the file descriptor as we do not need to list all the maps using bpftool and easy to get an fd when we know the old pin.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
