### PR TITLE
Merge pull request #7433 from dilyevsky/kube-controllers-node-out-of-…

### DIFF
--- a/kube-controllers/pkg/controllers/node/controller.go
+++ b/kube-controllers/pkg/controllers/node/controller.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/projectcalico/calico/kube-controllers/pkg/config"
 	"github.com/projectcalico/calico/kube-controllers/pkg/controllers/controller"
-	"github.com/projectcalico/calico/kube-controllers/pkg/converter"
 	api "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 )
@@ -82,7 +81,7 @@ func NewNodeController(ctx context.Context,
 	nodeDeletionFuncs := []func(){}
 
 	// Create the IPAM controller.
-	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset, nodeInformer.GetIndexer())
+	nc.ipamCtrl = NewIPAMController(cfg, calicoClient, k8sClientset, podInformer.GetIndexer(), nodeInformer.GetIndexer())
 	nc.ipamCtrl.RegisterWith(nc.dataFeed)
 	nodeDeletionFuncs = append(nodeDeletionFuncs, nc.ipamCtrl.OnKubernetesNodeDeleted)
 
@@ -104,42 +103,6 @@ func NewNodeController(ctx context.Context,
 				f()
 			}
 		}}
-
-	podHandlers := cache.ResourceEventHandlerFuncs{}
-	podHandlers.AddFunc = func(obj interface{}) {
-		key, err := cache.MetaNamespaceKeyFunc(obj)
-		if err != nil {
-			log.WithError(err).Error("Failed to generate key")
-			return
-		}
-		pod, err := converter.ExtractPodFromUpdate(obj)
-		if err != nil {
-			log.WithError(err).Error("Failed to extract pod")
-			return
-		}
-		nc.ipamCtrl.OnKubernetesPodUpdated(key, pod)
-	}
-	podHandlers.UpdateFunc = func(_, obj interface{}) {
-		key, err := cache.MetaNamespaceKeyFunc(obj)
-		if err != nil {
-			log.WithError(err).Error("Failed to generate key")
-			return
-		}
-		pod, err := converter.ExtractPodFromUpdate(obj)
-		if err != nil {
-			log.WithError(err).Error("Failed to extract pod")
-			return
-		}
-		nc.ipamCtrl.OnKubernetesPodUpdated(key, pod)
-	}
-	podHandlers.DeleteFunc = func(obj interface{}) {
-		key, err := cache.MetaNamespaceKeyFunc(obj)
-		if err != nil {
-			log.WithError(err).Error("Failed to generate key")
-			return
-		}
-		nc.ipamCtrl.OnKubernetesPodDeleted(key)
-	}
 
 	// Create the Auto HostEndpoint sub-controller and register it to receive data.
 	// We always launch this controller, even if auto-HEPs are disabled, since the controller
@@ -163,7 +126,6 @@ func NewNodeController(ctx context.Context,
 
 	// Set the handlers on the informers.
 	nc.nodeInformer.AddEventHandler(nodeHandlers)
-	nc.podInformer.AddEventHandler(podHandlers)
 
 	// Start the Calico data feed.
 	nc.dataFeed.Start()

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -90,8 +90,9 @@ var _ = Describe("IPAM controller UTs", func() {
 	var c *ipamController
 	var cli client.Interface
 	var cs kubernetes.Interface
-	var ni cache.Indexer
 	var stopChan chan struct{}
+	var pods chan *v1.Pod
+	var nodes chan *v1.Node
 
 	BeforeEach(func() {
 		// Create a fake clientset with nothing in it.
@@ -102,7 +103,8 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Create a node indexer with the fake clientset
 		factory := informers.NewSharedInformerFactory(cs, 0)
-		ni = factory.Core().V1().Nodes().Informer().GetIndexer()
+		podInformer := factory.Core().V1().Pods().Informer()
+		nodeInformer := factory.Core().V1().Nodes().Informer()
 
 		// Config for the test.
 		cfg := config.NodeControllerConfig{
@@ -112,9 +114,28 @@ var _ = Describe("IPAM controller UTs", func() {
 		// stopChan is used in AfterEach to stop the controller in each test.
 		stopChan = make(chan struct{})
 
+		pods = make(chan *v1.Pod, 1)
+		podInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				pod := obj.(*v1.Pod)
+				pods <- pod
+			},
+		})
+		nodes = make(chan *v1.Node, 1)
+		nodeInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				node := obj.(*v1.Node)
+				nodes <- node
+			},
+		})
+
+		factory.Start(stopChan)
+		cache.WaitForCacheSync(stopChan, podInformer.HasSynced)
+		cache.WaitForCacheSync(stopChan, nodeInformer.HasSynced)
+
 		// Create a new controller. We don't register with a data feed,
 		// as the tests themselves will drive the controller.
-		c = NewIPAMController(cfg, cli, cs, ni)
+		c = NewIPAMController(cfg, cli, cs, podInformer.GetIndexer(), nodeInformer.GetIndexer())
 	})
 
 	AfterEach(func() {
@@ -653,6 +674,8 @@ var _ = Describe("IPAM controller UTs", func() {
 
 		// Start the controller.
 		c.Start(stopChan)
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
 
 		idx := 0
 		handle := "test-handle"
@@ -718,6 +741,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		kn.Name = "kname"
 		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
 
 		// Create a pod for the allocation so that it doesn't get GC'd.
 		pod := v1.Pod{}
@@ -726,6 +751,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
 
 		// Start the controller.
 		c.Start(stopChan)
@@ -878,6 +905,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		kn.Name = "kname"
 		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
 
 		// Create a pod for the allocation - the pod will have a single IP in its status, but there will be
 		// two IPs allocated which belong to the pod's handle - one "leaked" and one valid. This simulates
@@ -891,6 +920,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod.Status.PodIPs = []v1.PodIP{{IP: "10.0.0.0"}}
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
 
 		// Add a new block with the IPv4 address.
 		idx := 0
@@ -1017,7 +1048,6 @@ var _ = Describe("IPAM controller UTs", func() {
 			// Deleting the pod should invalidate the IPv4 address, and result in both IPs being GC'd.
 			err = cs.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			c.OnKubernetesPodDeleted(fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
 		})
 
 		By("Verifying final state", func() {
@@ -1052,6 +1082,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		kn.Name = "kname"
 		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
 
 		// Start the controller.
 		c.Start(stopChan)
@@ -1120,6 +1152,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		kn.Name = "kname"
 		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
 
 		// Create a pod for the allocation so that it doesn't get GC'd.
 		pod := v1.Pod{}
@@ -1128,6 +1162,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
 
 		// Start the controller.
 		c.Start(stopChan)
@@ -1225,6 +1261,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		kn.Name = "kname"
 		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
 
 		// Create a pod for the allocation so that it doesn't get GC'd.
 		pod := v1.Pod{}
@@ -1233,6 +1271,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
 
 		// Start the controller.
 		c.Start(stopChan)
@@ -1330,6 +1370,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		kn.Name = "kname"
 		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
 
 		// Create a pod for the allocation so that it doesn't get GC'd.
 		pod := v1.Pod{}
@@ -1338,6 +1380,8 @@ var _ = Describe("IPAM controller UTs", func() {
 		pod.Spec.NodeName = "kname"
 		_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+		var gotPod *v1.Pod
+		Eventually(pods).WithTimeout(time.Second).Should(Receive(&gotPod))
 
 		// Start the controller.
 		c.Start(stopChan)


### PR DESCRIPTION
…sync

kube-controllers/node: Use pod/node indexes

## Description

Cherry-pick of https://github.com/projectcalico/calico/pull/7433 for v3.25 release.

## Related issues/PRs

https://github.com/projectcalico/calico/pull/7433

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Prevents Node kube-controller's internal pod cache from getting out-of-sync thus leaking memory.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
