### PR TITLE
Add envxx support to MTUIfacePattern for ppc arch

### DIFF
--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -385,7 +385,7 @@ type Config struct {
 	Variant string `config:"string;Calico"`
 
 	// Configures MTU auto-detection.
-	MTUIfacePattern *regexp.Regexp `config:"regexp;^((en|wl|ww|sl|ib)[Pcopsx].*|(eth|wlan|wwan).*)"`
+	MTUIfacePattern *regexp.Regexp `config:"regexp;^((en|wl|ww|sl|ib)[Pcopsvx].*|(eth|wlan|wwan).*)"`
 
 	// Encapsulation information calculated from IP Pools and FelixConfiguration (VXLANEnabled and IpInIpEnabled)
 	Encapsulation Encapsulation


### PR DESCRIPTION
Instead of https://github.com/projectcalico/calico/pull/7405

The below warning message appears in calico-node pod of k8s cluster on ppc64le architecture.

[WARNING][83] felix/int_dataplane.go 967: Failed to auto-detect host MTU - no interfaces matched the MTU interface pattern. To use auto-MTU, set mtuIfacePattern to match your host's interfaces

The mtuIfacePattern has default pattern ^((en|wl|ww|sl|ib)[Pcopsx].*|(eth|wlan|wwan).*), which does not match the network inteface in ppc64le.
The ppc64le architecture has the host interfaces starting with env. eg: env2, env3 etc..
Hence the default pattern has to include v in [Pcopsx].