### PR TITLE
Support configuring pods with the same mac address prefix

### DIFF
--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -15,11 +15,16 @@
 package linux
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
+	"net/netip"
 	"os"
+	"regexp"
 	"syscall"
 	"time"
 
@@ -170,21 +175,12 @@ func (d *linuxDataplane) DoNetworking(
 		// Check if there is an annotation requesting a specific fixed MAC address for the container Veth, otherwise
 		// use kernel-assigned MAC.
 		if requestedContVethMac, found := annotations["cni.projectcalico.org/hwAddr"]; found {
-			tmpContVethMAC, err := net.ParseMAC(requestedContVethMac)
+			contVethMAC, err = resetHardwareAddr(contVeth, requestedContVethMac, result.IPs[0].Address.IP.String())
 			if err != nil {
-				return fmt.Errorf("failed to parse MAC address %v provided via cni.projectcalico.org/hwAddr: %v",
-					requestedContVethMac, err)
+				return err
 			}
-
-			err = netlink.LinkSetHardwareAddr(contVeth, tmpContVethMAC)
-			if err != nil {
-				return fmt.Errorf("failed to set container veth MAC to %v as requested via cni.projectcalico.org/hwAddr: %v",
-					requestedContVethMac, err)
-			}
-
-			contVethMAC = tmpContVethMAC.String()
-			d.logger.Infof("successfully configured container veth MAC to %v as requested via cni.projectcalico.org/hwAddr",
-				contVethMAC)
+			d.logger.Infof("successfully reset container veth's mac to %v with cni.projectcalico.org/hwAddr: %v",
+				contVethMAC, requestedContVethMac)
 		} else {
 			contVethMAC = contVeth.Attrs().HardwareAddr.String()
 		}
@@ -514,6 +510,78 @@ func writeProcSys(path, value string) error {
 		err = err1
 	}
 	return err
+}
+
+// resetHardwareAddr set specific fixed MAC address for the container Veth via the requested mac address
+// if requested mac address is valid, do set directly and return. if requested mac address is valid
+// prefix, convert the ip address to a mac address suffix, then splice a new mac address with the prefix
+func resetHardwareAddr(contVeth netlink.Link, requestedContVethMac, conVethIP string) (string, error) {
+	contVethMac, err := net.ParseMAC(requestedContVethMac)
+	if err == nil {
+		// if requestedContVethMac is a valid mac address, do set directly
+		if err = netlink.LinkSetHardwareAddr(contVeth, contVethMac); err != nil {
+			return "", fmt.Errorf("failed to reset container veth's mac to %v with cni.projectcalico.org/hwAddr: %v",
+				contVethMac, err)
+		}
+		return contVethMac.String(), nil
+	}
+
+	// if requestedContVethMac is a valid mac address prefix (format like: 0a:1b)
+	// the new mac address is stitched together by prefix and decode(ip)
+	matchRegexp := regexp.MustCompile("^" + "(" + "[a-fA-F0-9][a-fA-F,0,2-9][:-][a-fA-F0-9]{2}" + ")" + "$")
+	if matchRegexp != nil && !matchRegexp.MatchString(requestedContVethMac) {
+		return "", fmt.Errorf("invalid mac prefix: %s, the format is like: 0a:1b", requestedContVethMac)
+	}
+
+	var macSuffix string
+	macSuffix, err = inetAton(netip.MustParseAddr(conVethIP))
+	if err != nil {
+		return "", fmt.Errorf("failed to converts pod's ip: %s to mac suffiex: %v", conVethIP, err)
+	}
+
+	contVethMacStr := spliceHardwareAddr(requestedContVethMac, macSuffix)
+	contVethMac, err = net.ParseMAC(contVethMacStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse mac address %s: %v", contVethMacStr, err)
+	}
+
+	if err = netlink.LinkSetHardwareAddr(contVeth, contVethMac); err != nil {
+		return "", fmt.Errorf("failed to set container veth's mac to %v with cni.projectcalico.org/hwAddr: %v",
+			contVethMacStr, err)
+	}
+	return contVethMacStr, nil
+}
+
+// inetAton converts an IP Address (IPv4 or IPv6) netip.addr object to a hexadecimal representation.
+func inetAton(ip netip.Addr) (string, error) {
+	if ip.AsSlice() == nil {
+		return "", fmt.Errorf("invalid ip address")
+	}
+
+	ipInt := big.NewInt(0)
+	macBytes := make([]byte, hex.EncodedLen(ip.BitLen()))
+	ipInt.SetBytes(ip.AsSlice()[:])
+	hex.Encode(macBytes, ipInt.Bytes())
+
+	return convertHex2Mac(macBytes, ip.Is6()), nil
+}
+
+// convertHex2Mac convert hexcode to 8 Byte hardware address
+// convert ip(hex) to "xx:xx:xx:xx"
+func convertHex2Mac(macBytes []byte, isV6 bool) string {
+	if isV6 {
+		// for ipv6: 128 bit = 32 hex
+		// take the last 8 hexcode(4 Byte) as the mac suffix
+		macBytes = macBytes[24:]
+	}
+
+	// spilt by length: 2
+	regexSpilt := regexp.MustCompile(".{2}")
+	return string(bytes.Join(regexSpilt.FindAll(macBytes, 4), []byte(":")))
+}
+
+func spliceHardwareAddr(prefix, suffix string) string {
+	return fmt.Sprintf("%s:%s", prefix, suffix)
 }
 
 func (d *linuxDataplane) CleanUpNamespace(args *skel.CmdArgs) error {


### PR DESCRIPTION
## Description

Support configuring pods with the same mac address prefix via annotations: `cni.projectcalico.org/hwAddr`. and added unit-tests for it

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

https://github.com/projectcalico/calico/issues/7396

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
