### PR TITLE
Fix static-check with golanglint-ci v1.52.2

### DIFF
--- a/cni-plugin/internal/pkg/testutils/utils_linux.go
+++ b/cni-plugin/internal/pkg/testutils/utils_linux.go
@@ -265,7 +265,10 @@ func RunCNIPluginWithId(
 	if version.Compare(nc.CNIVersion, "0.3.0", "<") {
 		// Special case for older CNI versions.
 		var out []byte
-		out, err = json.Marshal(r)
+		if out, err = json.Marshal(r); err != nil {
+			log.WithError(err).Errorf("failed to marshal result: %v", r)
+			return
+		}
 		r020 := types020.Result{}
 		if err = json.Unmarshal(out, &r020); err != nil {
 			log.WithField("out", out).Errorf("Error unmarshaling output to Result: %v\n", err)

--- a/typha/pkg/promutils/registration.go
+++ b/typha/pkg/promutils/registration.go
@@ -29,9 +29,8 @@ func GetOrRegister[T prometheus.Collector](collector T) T {
 	if err != nil {
 		if err, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			return err.ExistingCollector.(T)
-		} else {
-			logrus.WithError(err).WithField("collector", collector).Panic("Failed to register prometheus collector.")
 		}
+		logrus.WithError(err).WithField("collector", collector).Panic("Failed to register prometheus collector.")
 	}
 	return collector
 }


### PR DESCRIPTION
## Description

This change fixes static-check with golanglint-ci v1.52.2.

## Related issues/PRs

This change is needed when we include the new golanglint-ci to our go-build.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
