### PR TITLE
[BPF] install rules to mark pre-established flows asap

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1367,6 +1367,7 @@ func (d *InternalDataplane) doStaticDataplaneConfig() {
 	d.configureKernel()
 
 	if d.config.BPFEnabled {
+		d.setUpIptablesBPFEarly()
 		d.setUpIptablesBPF()
 	} else {
 		d.setUpIptablesNormal()
@@ -1381,6 +1382,18 @@ func (d *InternalDataplane) doStaticDataplaneConfig() {
 	} else {
 		log.Info("IPIP disabled. Not starting tunnel update thread.")
 	}
+}
+
+func bpfMarkPreestablishedFlowsRules() []iptables.Rule {
+	return []iptables.Rule{{
+		Match: iptables.Match().
+			ConntrackState("ESTABLISHED,RELATED"),
+		Comment: []string{"Mark pre-established flows."},
+		Action: iptables.SetMaskedMarkAction{
+			Mark: tcdefs.MarkLinuxConntrackEstablished,
+			Mask: tcdefs.MarkLinuxConntrackEstablishedMask,
+		},
+	}}
 }
 
 func (d *InternalDataplane) setUpIptablesBPF() {
@@ -1416,17 +1429,7 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 		)
 
 		// Mark traffic leaving the host that already has an established linux conntrack entry.
-		outputRules = append(outputRules,
-			iptables.Rule{
-				Match: iptables.Match().
-					ConntrackState("ESTABLISHED,RELATED"),
-				Comment: []string{"Mark pre-established host flows."},
-				Action: iptables.SetMaskedMarkAction{
-					Mark: tcdefs.MarkLinuxConntrackEstablished,
-					Mask: tcdefs.MarkLinuxConntrackEstablishedMask,
-				},
-			},
-		)
+		outputRules = append(outputRules, bpfMarkPreestablishedFlowsRules()...)
 
 		for _, prefix := range rulesConfig.WorkloadIfacePrefixes {
 			fwdRules = append(fwdRules,
@@ -1475,17 +1478,7 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 			}
 		} else {
 			// Let the BPF programs know if Linux conntrack knows about the flow.
-			fwdRules = append(fwdRules,
-				iptables.Rule{
-					Match: iptables.Match().
-						ConntrackState("ESTABLISHED,RELATED"),
-					Comment: []string{"Mark pre-established flows."},
-					Action: iptables.SetMaskedMarkAction{
-						Mark: tcdefs.MarkLinuxConntrackEstablished,
-						Mask: tcdefs.MarkLinuxConntrackEstablishedMask,
-					},
-				},
-			)
+			fwdRules = append(fwdRules, bpfMarkPreestablishedFlowsRules()...)
 			// The packet may be about to go to a local workload.  However, the local workload may not have a BPF
 			// program attached (yet).  To catch that case, we send the packet through a dispatch chain.  We only
 			// add interfaces to the dispatch chain if the BPF program is in place.
@@ -1560,6 +1553,15 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 				Action:  iptables.SetConnMarkAction{Mark: mark, Mask: mark},
 			}})
 		}
+	}
+}
+
+// setUpIptablesBPFEarly that need to be written asap
+func (d *InternalDataplane) setUpIptablesBPFEarly() {
+	for _, t := range d.iptablesFilterTables {
+		t.InsertOrAppendRules("FORWARD", bpfMarkPreestablishedFlowsRules())
+		t.InsertOrAppendRules("OUTPUT", bpfMarkPreestablishedFlowsRules())
+		t.Apply()
 	}
 }
 


### PR DESCRIPTION
To avoid disruption to the flows, mark install the rules asap so that the tc programs get the information about existing conntrack immediately.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
