### PR TITLE
[FIX] defaultRuleRenderer is used incorrectly in linux.InternalDataplane

### DIFF
--- a/felix/iptables/actions.go
+++ b/felix/iptables/actions.go
@@ -22,6 +22,7 @@ import (
 
 type Action interface {
 	ToFragment(features *environment.Features) string
+	String() string
 }
 
 type Referrer interface {

--- a/felix/rules/dispatch.go
+++ b/felix/rules/dispatch.go
@@ -39,7 +39,7 @@ func (r *DefaultRuleRenderer) WorkloadDispatchChains(
 	endRules := []Rule{
 		Rule{
 			Match:   Match(),
-			Action:  r.IptablesFilterDenyAction,
+			Action:  r.IptablesFilterDenyAction(),
 			Comment: []string{"Unknown interface"},
 		},
 	}
@@ -68,7 +68,7 @@ func (r *DefaultRuleRenderer) WorkloadInterfaceAllowChains(
 	endRules := []Rule{
 		{
 			Match:   Match(),
-			Action:  r.IptablesFilterDenyAction,
+			Action:  r.IptablesFilterDenyAction(),
 			Comment: []string{"Unknown interface"},
 		},
 	}
@@ -383,7 +383,7 @@ func (r *DefaultRuleRenderer) endpointMarkDispatchChains(
 		ifaceMatch := prefix + "+"
 		rootSetMarkRules = append(rootSetMarkRules, Rule{
 			Match:   Match().InInterface(ifaceMatch),
-			Action:  r.IptablesFilterDenyAction,
+			Action:  r.IptablesFilterDenyAction(),
 			Comment: []string{"Unknown endpoint"},
 		})
 	}
@@ -427,10 +427,10 @@ func (r *DefaultRuleRenderer) endpointMarkDispatchChains(
 	}
 
 	// Finalizing with a drop/reject rule.
-	log.Debugf("Adding %s rules at end of root from mark chains.", r.IptablesFilterDenyAction)
+	log.Debugf("Adding %s rules at end of root from mark chains.", r.IptablesFilterDenyAction())
 	rootFromMarkRules = append(rootFromMarkRules, Rule{
 		Match:   Match(),
-		Action:  r.IptablesFilterDenyAction,
+		Action:  r.IptablesFilterDenyAction(),
 		Comment: []string{"Unknown interface"},
 	})
 

--- a/felix/rules/endpoints.go
+++ b/felix/rules/endpoints.go
@@ -329,7 +329,7 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		// Endpoint is admin-down, drop all traffic to/from it.
 		rules = append(rules, Rule{
 			Match:   Match(),
-			Action:  r.IptablesFilterDenyAction,
+			Action:  r.IptablesFilterDenyAction(),
 			Comment: []string{"Endpoint admin disabled"},
 		})
 		return &Chain{
@@ -363,15 +363,15 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		rules = append(rules, Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
 				DestPorts(uint16(r.Config.VXLANPort)),
-			Action:  r.IptablesFilterDenyAction,
-			Comment: []string{fmt.Sprintf("%s VXLAN encapped packets originating in workloads", r.IptablesFilterDenyAction)},
+			Action:  r.IptablesFilterDenyAction(),
+			Comment: []string{fmt.Sprintf("%s VXLAN encapped packets originating in workloads", r.IptablesFilterDenyAction())},
 		})
 	}
 	if !allowIPIPEncap {
 		rules = append(rules, Rule{
 			Match:   Match().ProtocolNum(ProtoIPIP),
-			Action:  r.IptablesFilterDenyAction,
-			Comment: []string{fmt.Sprintf("%s IPinIP encapped packets originating in workloads", r.IptablesFilterDenyAction)},
+			Action:  r.IptablesFilterDenyAction(),
+			Comment: []string{fmt.Sprintf("%s IPinIP encapped packets originating in workloads", r.IptablesFilterDenyAction())},
 		})
 	}
 
@@ -423,8 +423,8 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 			// normal rules still to be applied to the packet in the filter table.
 			rules = append(rules, Rule{
 				Match:   Match().MarkClear(r.IptablesMarkPass),
-				Action:  r.IptablesFilterDenyAction,
-				Comment: []string{fmt.Sprintf("%s if no policies passed packet", r.IptablesFilterDenyAction)},
+				Action:  r.IptablesFilterDenyAction(),
+				Comment: []string{fmt.Sprintf("%s if no policies passed packet", r.IptablesFilterDenyAction())},
 			})
 		}
 
@@ -464,8 +464,8 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 		//if dropIfNoProfilesMatched {
 		rules = append(rules, Rule{
 			Match:   Match(),
-			Action:  r.IptablesFilterDenyAction,
-			Comment: []string{fmt.Sprintf("%s if no profiles matched", r.IptablesFilterDenyAction)},
+			Action:  r.IptablesFilterDenyAction(),
+			Comment: []string{fmt.Sprintf("%s if no profiles matched", r.IptablesFilterDenyAction())},
 		})
 		//}
 	}
@@ -499,7 +499,7 @@ func (r *DefaultRuleRenderer) appendConntrackRules(rules []Rule, allowAction Act
 		// connection.
 		rules = append(rules, Rule{
 			Match:  Match().ConntrackState("INVALID"),
-			Action: r.IptablesFilterDenyAction,
+			Action: r.IptablesFilterDenyAction(),
 		})
 	}
 	return rules

--- a/felix/rules/policy.go
+++ b/felix/rules/policy.go
@@ -524,7 +524,7 @@ func (r *DefaultRuleRenderer) CalculateActions(pRule *proto.Rule, ipVersion uint
 		actions = append(actions, iptables.ReturnAction{})
 	case "deny":
 		// Deny maps to DROP/REJECT.
-		actions = append(actions, r.IptablesFilterDenyAction)
+		actions = append(actions, r.IptablesFilterDenyAction())
 	case "log":
 		// This rule should log.
 		actions = append(actions, iptables.LogAction{

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -222,8 +222,8 @@ func (r *DefaultRuleRenderer) filterInputChain(ipVersion uint8) *Chain {
 			},
 			Rule{
 				Match:   Match().ProtocolNum(ProtoIPIP),
-				Action:  r.IptablesFilterDenyAction,
-				Comment: []string{fmt.Sprintf("%s IPIP packets from non-Calico hosts", r.IptablesFilterDenyAction)},
+				Action:  r.IptablesFilterDenyAction(),
+				Comment: []string{fmt.Sprintf("%s IPIP packets from non-Calico hosts", r.IptablesFilterDenyAction())},
 			},
 		)
 	}
@@ -266,8 +266,8 @@ func (r *DefaultRuleRenderer) filterInputChain(ipVersion uint8) *Chain {
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
 					DestAddrType(AddrTypeLocal),
-				Action:  r.IptablesFilterDenyAction,
-				Comment: []string{fmt.Sprintf("%s IPv6 VXLAN packets from non-allowed hosts", r.IptablesFilterDenyAction)},
+				Action:  r.IptablesFilterDenyAction(),
+				Comment: []string{fmt.Sprintf("%s IPv6 VXLAN packets from non-allowed hosts", r.IptablesFilterDenyAction())},
 			},
 		)
 	}
@@ -1258,7 +1258,7 @@ func (r *DefaultRuleRenderer) StaticRawPreroutingChain(ipVersion uint8) *Chain {
 	// usually spoof but privileged containers and VMs can.
 	//
 	rules = append(rules,
-		RPFilter(ipVersion, markFromWorkload, markFromWorkload, r.OpenStackSpecialCasesEnabled, false, r.IptablesFilterDenyAction)...)
+		RPFilter(ipVersion, markFromWorkload, markFromWorkload, r.OpenStackSpecialCasesEnabled, false, r.IptablesFilterDenyAction())...)
 
 	rules = append(rules,
 		// Send non-workload traffic to the untracked policy chains.


### PR DESCRIPTION
IptablesFilterDenyAction is not initialized to any default value. We want to use the actual ruleRenderer to render the rules.

refs https://github.com/projectcalico/calico/pull/5735

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
