### PR TITLE
Add retry to git fetch commands for semaphore builds

### DIFF
--- a/.semaphore/push-images/alp.yml
+++ b/.semaphore/push-images/alp.yml
@@ -29,7 +29,7 @@ blocks:
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
         # Semaphore is doing shallow clone on a commit without tags.
         # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
         - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH

--- a/.semaphore/push-images/apiserver.yml
+++ b/.semaphore/push-images/apiserver.yml
@@ -29,7 +29,7 @@ blocks:
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
         # Semaphore is doing shallow clone on a commit without tags.
         # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
         - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH

--- a/.semaphore/push-images/calicoctl.yml
+++ b/.semaphore/push-images/calicoctl.yml
@@ -29,7 +29,7 @@ blocks:
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
         # Semaphore is doing shallow clone on a commit without tags.
         # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
         - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH

--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -29,7 +29,7 @@ blocks:
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
         # Semaphore is doing shallow clone on a commit without tags.
         # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
         - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH

--- a/.semaphore/push-images/kube-controllers.yml
+++ b/.semaphore/push-images/kube-controllers.yml
@@ -29,7 +29,7 @@ blocks:
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
         # Semaphore is doing shallow clone on a commit without tags.
         # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
         - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -29,7 +29,7 @@ blocks:
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
         # Semaphore is doing shallow clone on a commit without tags.
         # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
         - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH

--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -17,7 +17,7 @@ global_job_config:
     - checkout
     # Semaphore is doing shallow clone on a commit without tags.
     # unshallow it because we need a reliable git describe.
-    - git fetch --unshallow
+    - retry git fetch --unshallow
     - git config --global user.email marvin@tigera.io
     - git config --global user.name Marvin
     - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json

--- a/.semaphore/push-images/typha.yml
+++ b/.semaphore/push-images/typha.yml
@@ -29,7 +29,7 @@ blocks:
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
         # Semaphore is doing shallow clone on a commit without tags.
         # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
         - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
         - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -26,7 +26,7 @@ blocks:
         - ssh-add /home/semaphore/.keys/git_ssh_rsa
         # Checkout the code and unshallow it.
         - checkout
-        - git fetch --unshallow
+        - retry git fetch --unshallow
         # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
         # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
         # how much we churn docker containers during the build.  Disable it.

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -71,7 +71,7 @@ global_job_config:
     - mkdir artifacts
     # Semaphore is doing shallow clone on a commit without tags.
     # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-    - git fetch --unshallow
+    - retry git fetch --unshallow
     # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
     # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
     # how much we churn docker containers during the build.  Disable it.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -71,7 +71,7 @@ global_job_config:
     - mkdir artifacts
     # Semaphore is doing shallow clone on a commit without tags.
     # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-    - git fetch --unshallow
+    - retry git fetch --unshallow
     # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
     # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
     # how much we churn docker containers during the build.  Disable it.

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -69,7 +69,7 @@ global_job_config:
     - mkdir artifacts
     # Semaphore is doing shallow clone on a commit without tags.
     # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-    - git fetch --unshallow
+    - retry git fetch --unshallow
     # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
     # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
     # how much we churn docker containers during the build.  Disable it.

--- a/cni-plugin/.semaphore/semaphore.yml
+++ b/cni-plugin/.semaphore/semaphore.yml
@@ -54,7 +54,7 @@ blocks:
           - checkout
           # Semaphore is doing shallow clone on a commit without tags.
           # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always) @ Makefile.common
-          - git fetch --unshallow
+          - retry git fetch --unshallow
       jobs:
         - name: Test Version
           execution_time_limit:
@@ -75,7 +75,7 @@ blocks:
           - checkout
           # Semaphore is doing shallow clone on a commit without tags.
           # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always) @ Makefile.common
-          - git fetch --unshallow
+          - retry git fetch --unshallow
       jobs:
         - name: Static Checks
           execution_time_limit:
@@ -191,7 +191,7 @@ blocks:
           - checkout
           # Semaphore is doing shallow clone on a commit without tags.
           # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always) @ Makefile.common
-          - git fetch --unshallow
+          - retry git fetch --unshallow
           # Correct permissions since they are too open by default:
           - chmod 0600 ~/.keys/*
           # Add the key to the ssh agent:


### PR DESCRIPTION
## Description

This `retry` is recommended by sempahore to [workaround an ongoing issue](https://status.semaphoreci.com/) with github on Apr. 12, 2023.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
