### PR TITLE
Skip setting node IP annotation if CALICO_NETWORKING_BACKEND=none

### DIFF
--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -182,10 +182,9 @@ func Run() {
 		}
 	}
 
-	configureAndCheckIPAddressSubnets(ctx, cli, node, k8sNode)
-
 	// If Calico is running in policy only mode we don't need to write BGP related details to the Node.
 	if os.Getenv("CALICO_NETWORKING_BACKEND") != "none" {
+		configureAndCheckIPAddressSubnets(ctx, cli, node, k8sNode)
 		// Configure the node AS number.
 		configureASNumber(node)
 	}
@@ -310,6 +309,12 @@ func configureAndCheckIPAddressSubnets(ctx context.Context, cli client.Interface
 }
 
 func MonitorIPAddressSubnets() {
+	// If Calico is running in policy only mode we don't need to write BGP
+	// related details to the Node.
+	if os.Getenv("CALICO_NETWORKING_BACKEND") == "none" {
+		log.Info("Skipped monitoring node IP changes when CALICO_NETWORKING_BACKEND=none")
+		return
+	}
 	ctx := context.Background()
 	_, cli := calicoclient.CreateClient()
 	nodeName := utils.DetermineNodeName()


### PR DESCRIPTION
## Description

`projectcalico.org/IPv4Address` and `projectcalico.org/IPv4IPIPTunnelAddr` annotations are used for BGP so disabling these in `policy` only mode

If we remove this dependency, calico-node in policy only mode does not need k8s node update/ patch permissions which addresses a vulnerability associated with node agent's over provisioned permissions.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
When running Calico in policy-only mode, do not write the IP annotations to the node.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
