### PR TITLE
Stop interfering with non-Calico VXLAN packets

### DIFF
--- a/felix/dataplane/linux/endpoint_mgr_test.go
+++ b/felix/dataplane/linux/endpoint_mgr_test.go
@@ -159,6 +159,7 @@ func chainsForIfaces(ifaceMetadata []string,
 		ProtoUDP  = 17
 		ProtoIPIP = 4
 		VXLANPort = 4789
+		VXLANVNI  = 4096
 	)
 
 	log.WithFields(log.Fields{
@@ -183,7 +184,8 @@ func chainsForIfaces(ifaceMetadata []string,
 	dropEncapRules := []iptables.Rule{
 		{
 			Match: iptables.Match().ProtocolNum(ProtoUDP).
-				DestPorts(uint16(VXLANPort)),
+				DestPorts(VXLANPort).
+				VXLANVNI(VXLANVNI),
 			Action:  iptables.DropAction{},
 			Comment: []string{"Drop VXLAN encapped packets originating in workloads"},
 		},

--- a/felix/rules/endpoints.go
+++ b/felix/rules/endpoints.go
@@ -362,7 +362,8 @@ func (r *DefaultRuleRenderer) endpointIptablesChain(
 	if !allowVXLANEncap {
 		rules = append(rules, Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
-				DestPorts(uint16(r.Config.VXLANPort)),
+				DestPorts(uint16(r.Config.VXLANPort)).
+				VXLANVNI(uint32(r.Config.VXLANVNI)),
 			Action:  r.IptablesFilterDenyAction(),
 			Comment: []string{fmt.Sprintf("%s VXLAN encapped packets originating in workloads", r.IptablesFilterDenyAction())},
 		})

--- a/felix/rules/endpoints_test.go
+++ b/felix/rules/endpoints_test.go
@@ -89,7 +89,8 @@ var _ = Describe("Endpoints", func() {
 
 		dropVXLANRule := Rule{
 			Match: Match().ProtocolNum(ProtoUDP).
-				DestPorts(uint16(VXLANPort)),
+				DestPorts(VXLANPort).
+				VXLANVNI(VXLANVNI),
 			Action:  denyAction,
 			Comment: []string{fmt.Sprintf("%s VXLAN encapped packets originating in workloads", denyActionString)},
 		}

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -229,21 +229,23 @@ func (r *DefaultRuleRenderer) filterInputChain(ipVersion uint8) *Chain {
 	}
 
 	if ipVersion == 4 && r.VXLANEnabled {
-		// IPv4 VXLAN is enabled, filter incoming VXLAN packets that match our VXLAN port to ensure they
+		// IPv4 VXLAN is enabled, filter incoming VXLAN packets that match our VXLAN port and VNI to ensure they
 		// come from a recognised host and are going to a local address on the host.
 		inputRules = append(inputRules,
 			Rule{
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
 					SourceIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
-					DestAddrType(AddrTypeLocal),
+					DestAddrType(AddrTypeLocal).
+					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
 				Action:  r.filterAllowAction,
 				Comment: []string{"Allow IPv4 VXLAN packets from allowed hosts"},
 			},
 			Rule{
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
-					DestAddrType(AddrTypeLocal),
+					DestAddrType(AddrTypeLocal).
+					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
 				Action:  DropAction{},
 				Comment: []string{"Drop IPv4 VXLAN packets from non-allowed hosts"},
 			},
@@ -251,21 +253,23 @@ func (r *DefaultRuleRenderer) filterInputChain(ipVersion uint8) *Chain {
 	}
 
 	if ipVersion == 6 && r.VXLANEnabledV6 {
-		// IPv6 VXLAN is enabled, filter incoming VXLAN packets that match our VXLAN port to ensure they
+		// IPv6 VXLAN is enabled, filter incoming VXLAN packets that match our VXLAN port and VNI to ensure they
 		// come from a recognised host and are going to a local address on the host.
 		inputRules = append(inputRules,
 			Rule{
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
 					SourceIPSet(r.IPSetConfigV6.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
-					DestAddrType(AddrTypeLocal),
+					DestAddrType(AddrTypeLocal).
+					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
 				Action:  r.filterAllowAction,
 				Comment: []string{"Allow IPv6 VXLAN packets from allowed hosts"},
 			},
 			Rule{
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
-					DestAddrType(AddrTypeLocal),
+					DestAddrType(AddrTypeLocal).
+					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
 				Action:  r.IptablesFilterDenyAction(),
 				Comment: []string{fmt.Sprintf("%s IPv6 VXLAN packets from non-allowed hosts", r.IptablesFilterDenyAction())},
 			},
@@ -744,7 +748,8 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
 					SrcAddrType(AddrTypeLocal, false).
-					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)),
+					DestIPSet(r.IPSetConfigV4.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
+					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
 				Action:  r.filterAllowAction,
 				Comment: []string{"Allow IPv4 VXLAN packets to other allowed hosts"},
 			},
@@ -760,7 +765,8 @@ func (r *DefaultRuleRenderer) filterOutputChain(ipVersion uint8) *Chain {
 				Match: Match().ProtocolNum(ProtoUDP).
 					DestPorts(uint16(r.Config.VXLANPort)).
 					SrcAddrType(AddrTypeLocal, false).
-					DestIPSet(r.IPSetConfigV6.NameForMainIPSet(IPSetIDAllVXLANSourceNets)),
+					DestIPSet(r.IPSetConfigV6.NameForMainIPSet(IPSetIDAllVXLANSourceNets)).
+					VXLANVNI(uint32(r.Config.VXLANVNI)), /* relies on protocol and port check */
 				Action:  r.filterAllowAction,
 				Comment: []string{"Allow IPv6 VXLAN packets to other allowed hosts"},
 			},


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Bug fix: reintroduce the iptables match clauses which restrict matches on VXLAN packets to those with a VNI related to Calico, reverting cce544613169bd84a8a06f5536abd65cdc3c7ab8. And add the same match clauses to the ip6tables versions of the rules for the first time. Calico will no longer interfere with other users of VXLAN on the same host.

Switch the implementation of the `VXLANVNI` match rule to use the `bpf` match which, unlike the `u32` match, is supported and installed by default on RHEL/CentOS 7, 8 and 9. And unlike the `u32` match expression which was only compatible with iptables, the cBPF socket filter program used with the `bpf` match rule is compatible with both iptables and ip6tables. The cBPF filter program is a straight port from https://github.com/moby/moby/pull/45308.

I have tested the filter program in isolation with both IPv4 and IPv6. I can port [the IPv4 unit test from moby/moby](https://github.com/moby/moby/blob/f117aef2ea63ee008c05a7506c8c9c50a1fa0c7f/libnetwork/drivers/overlay/bpf_linux_test.go) to Ginkgo if there is interest, with the caveat that it depends on `CAP_NET_RAW`. (Due to the use of cBPF extensions, the filter program cannot be tested with [user-space cBPF VMs.](https://pkg.go.dev/golang.org/x/net/bpf#VM))

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

- Fixes #6752

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
