### PR TITLE
[release-v3.24] Auto pick #7294: Clean up deprecated+removed cmd line flags

### DIFF
--- a/app-policy/config/cluster/master-config.yaml
+++ b/app-policy/config/cluster/master-config.yaml
@@ -57,7 +57,6 @@ coreos:
         --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota \
         --advertise-address=$private_ipv4 \
         --service-cluster-ip-range=10.100.0.0/24 \
-        --logtostderr=true \
         --basic-auth-file=/etc/kubernetes/k8s-passwd.csv \
         --authorization-mode=RBAC \
         --tls-cert-file=/etc/kubernetes/apiserver.crt \
@@ -84,7 +83,6 @@ coreos:
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
         --service-account-private-key-file=/etc/kubernetes/apiserver.key \
-        --logtostderr=true \
         --allocate-node-cidrs=true \
         --cluster-cidr="192.168.128.0/18" \
         --root-ca-file=/etc/kubernetes/apiserver.crt \
@@ -130,7 +128,6 @@ coreos:
         --cluster-dns=10.100.0.10 \
         --cluster-domain=cluster.local \
         --hostname-override=$private_ipv4 \
-        --logtostderr=true \
         --register-node=true \
         --register-schedulable=false \
         --volume-plugin-dir=/opt/bin/volume-plugins
@@ -157,7 +154,6 @@ coreos:
         --master=http://$private_ipv4:8080 \
         --cluster-cidr="192.168.128.0/18" \
         --proxy-mode=iptables \
-        --logtostderr=true
         Restart=always
         RestartSec=10
 

--- a/app-policy/config/cluster/node-config.yaml
+++ b/app-policy/config/cluster/node-config.yaml
@@ -57,8 +57,6 @@ coreos:
         --cluster-dns=10.100.0.10 \
         --cluster-domain=cluster.local \
         --hostname-override=$private_ipv4 \
-        --logtostderr=true \
-        --network-plugin=cni \
         --volume-plugin-dir=/opt/bin/volume-plugins
         Restart=always
         RestartSec=10
@@ -83,6 +81,5 @@ coreos:
         --master=http://172.18.18.101:8080 \
         --cluster-cidr="192.168.128.0/18" \
         --proxy-mode=iptables \
-        --logtostderr=true
         Restart=always
         RestartSec=10

--- a/calico/scripts/PrepareNode.ps1
+++ b/calico/scripts/PrepareNode.ps1
@@ -103,7 +103,7 @@ if ($global:containerRuntime -eq "Docker") {
     }
 }
 
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --resolv-conf=`"`""
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -45,7 +45,6 @@ $argList = @(`
     "--kubeconfig=c:\k\config",`
     "--hairpin-mode=promiscuous-bridge",`
     "--cgroups-per-qos=false",`
-    "--logtostderr=true",`
     "--enforce-node-allocatable=""""",`
     "--kubeconfig=""c:\k\config"""`
 )


### PR DESCRIPTION
Cherry pick of #7294 on release-v3.24.

#7294: Clean up deprecated+removed cmd line flags

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

[https://kubernetes.io/docs/concepts/cluster-administration/system-logs/ ](https://kubernetes.io/docs/concepts/cluster-administration/system-logs/,) says these flags were deprecated in v1.23, and seem to have been removed in v1.26, and it also says "Output will always be written to stderr, regardless of the output format."

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Remove usage of deprecated '--logtostderr' command line flag.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.