### PR TITLE
[release-v3.26] Auto pick #7602: Fix: Dikastes required libraries

### DIFF
--- a/app-policy/Dockerfile.amd64
+++ b/app-policy/Dockerfile.amd64
@@ -42,6 +42,7 @@ ADD bin/healthz-amd64 /healthz
 COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
 COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
 COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=ubi /lib64/libresolv.so.2 /lib64/libresolv.so.2
 
 # Copy hostname configuration files from UBI so glibc hostname lookups work.
 COPY --from=ubi /etc/host.conf /etc/host.conf


### PR DESCRIPTION
Cherry pick of #7602 on release-v3.26.

#7602: Fix: Dikastes required libraries

# Original PR Body below

Dikastes requires libresolv.so.2, this PR adds the required library to the Dockerfile.

```
calico@dev-advocacy:~/calico/app-policy/bin$ ldd dikastes-amd64 
	linux-vdso.so.1 (0x00007ffe486e9000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007fb552338000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fb552333000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fb552000000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fb552367000)
```
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.