### PR TITLE
[Release 3.26] OpenStack packaging updates & Jammy support (cherry-pick #7622)

### DIFF
--- a/felix/debian/control
+++ b/felix/debian/control
@@ -2,7 +2,7 @@ Source: felix
 Section: net
 Priority: optional
 Maintainer: Project Calico Maintainers <maintainers@projectcalico.org>
-Build-Depends: debhelper (>= 8.0.0), dh-systemd, libelf-dev
+Build-Depends: debhelper (>= 8.0.0), base-files (>= 11.1~) | dh-systemd, libelf-dev
 Standards-Version: 3.9.4
 
 Package: calico-common

--- a/hack/release/packaging/docker-build-images/centos7-build.Dockerfile.amd64
+++ b/hack/release/packaging/docker-build-images/centos7-build.Dockerfile.amd64
@@ -1,5 +1,5 @@
 FROM centos:7
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM el7
 
 ARG UID
@@ -12,5 +12,6 @@ RUN ./install-centos-build-deps
 # some user/group entries calculated by the makefile.
 # use `--force` and `-o` since tests can run under root and command will fail with duplicate error
 RUN groupadd --force --gid=$GID user && useradd -o --home=/ --gid=$GID --uid=$UID user
+RUN /install-centos-build-deps
 
 WORKDIR /code

--- a/hack/release/packaging/docker-build-images/centos7-build.Dockerfile.ppc64le
+++ b/hack/release/packaging/docker-build-images/centos7-build.Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 FROM ppc64le/centos:7
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM el7
 
 ARG UID
@@ -15,8 +15,7 @@ ADD install-centos-build-deps install-centos-build-deps
 # some user/group entries calculated by the makefile.
 # use `--force` and `-o` since tests can run under root and command will fail with duplicate error
 
-RUN echo "#!/usr/bin/env bash" > /setup-user; \
-    echo "groupadd --force --gid=$GID user && useradd -o --home=/ --gid=$GID --uid=$UID user" >> /setup-user; \
-    chmod +x /setup-user
+RUN groupadd --force --gid=$GID user && useradd -o --home=/ --gid=$GID --uid=$UID user
+RUN /install-centos-build-deps
 
 WORKDIR /code

--- a/hack/release/packaging/docker-build-images/docker-bake.hcl
+++ b/hack/release/packaging/docker-build-images/docker-bake.hcl
@@ -1,0 +1,66 @@
+# docker-bake.hcl
+
+# To use a different arch, define it in an environment variable;
+# for example, `ARCH=ppc64le docker buildx bake`. 
+variable "ARCH" {
+    default = "amd64"
+}
+
+variable "UID" {
+    default = 1000
+}
+
+variable "GID" {
+    default = 1000
+}
+
+# Define groups for the builds we want to be able to do
+
+# This is the default rule if you don't specify one. It'll build
+# everything.
+
+group "default" {
+    targets = ["ubuntu", "centos"]
+}
+
+# All ubuntu images
+group "ubuntu" {
+  targets = ["trusty", "xenial", "bionic", "focal", "jammy"]
+}
+
+# All centos images
+group "centos" {
+    targets = ["centos7"]
+}
+
+# Ubuntu builds
+target "trusty" {
+  dockerfile = "ubuntu-trusty-build.Dockerfile.${ARCH}"
+  tags = ["calico-build/trusty"]
+}
+target "xenial" {
+  dockerfile = "ubuntu-xenial-build.Dockerfile.${ARCH}"
+  tags = ["calico-build/xenial"]
+}
+target "bionic" {
+  dockerfile = "ubuntu-bionic-build.Dockerfile.${ARCH}"
+  tags = ["calico-build/bionic"]
+}
+target "focal" {
+  dockerfile = "ubuntu-focal-build.Dockerfile.${ARCH}"
+  tags = ["calico-build/focal"]
+}
+target "jammy" {
+  dockerfile = "ubuntu-jammy-build.Dockerfile.${ARCH}"
+  tags = ["calico-build/jammy"]
+}
+
+# CentOS builds
+target "centos7" {
+  dockerfile = "centos7-build.Dockerfile.${ARCH}"
+  args = {
+    UID = UID
+    GID = GID
+  }
+  tags = ["calico-build/centos7"]
+}

--- a/hack/release/packaging/docker-build-images/install-ubuntu-build-deps
+++ b/hack/release/packaging/docker-build-images/install-ubuntu-build-deps
@@ -1,12 +1,35 @@
 #!/usr/bin/env bash
-set -x
-set -e
-apt-get update
+
+# shellcheck disable=SC1091
+
+set -x      # Print commands as they're run
+set -e      # Exit immediately if a command returns non-zero
+
+source /etc/os-release
+
+# Ubuntu 14.04 doesn't have UBUNTU_CODENAME in /etc/os-release
+if [[ $VERSION_ID == "14.04" ]]; then
+    UBUNTU_CODENAME=trusty
+fi
+
+# We need to detect which Ubuntu version we're on, because trusty/xenial/bionic
+# require dh-systemd, focal doesn't require it but has a transitional package,
+# and jammy and later no longer have the package.
+case $UBUNTU_CODENAME in
+    trusty|xenial|bionic)
+        echo "Detected release ${UBUNTU_CODENAME}, adding dh-systemd to depends"
+        dh_systemd_pkg=dh-systemd
+        ;;
+    *)
+        ;;
+esac
+
+apt-get -q update
 DEBIAN_FRONTEND=noninteractive \
-apt-get install -y build-essential  \
+apt-get install -y -q build-essential  \
                    devscripts \
                    debhelper \
-                   dh-systemd \
+                   "${dh_systemd_pkg}" \
                    dh-python \
                    python-all \
                    python-setuptools \

--- a/hack/release/packaging/docker-build-images/ubuntu-bionic-build.Dockerfile.amd64
+++ b/hack/release/packaging/docker-build-images/ubuntu-bionic-build.Dockerfile.amd64
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM bionic
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-focal-build.Dockerfile.amd64
+++ b/hack/release/packaging/docker-build-images/ubuntu-focal-build.Dockerfile.amd64
@@ -1,5 +1,5 @@
 FROM ubuntu:focal
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM focal
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-focal-build.Dockerfile.ppc64le
+++ b/hack/release/packaging/docker-build-images/ubuntu-focal-build.Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 FROM ppc64le/ubuntu:focal
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM focal
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-jammy-build.Dockerfile.amd64
+++ b/hack/release/packaging/docker-build-images/ubuntu-jammy-build.Dockerfile.amd64
@@ -1,6 +1,6 @@
-FROM ppc64le/ubuntu:bionic
+FROM ubuntu:jammy
 MAINTAINER Daniel Fox <dan.fox@tigera.io>
-ENV STREAM bionic
+ENV STREAM jammy
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps
 RUN ./install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-jammy-build.Dockerfile.ppc64le
+++ b/hack/release/packaging/docker-build-images/ubuntu-jammy-build.Dockerfile.ppc64le
@@ -1,6 +1,6 @@
-FROM ppc64le/ubuntu:bionic
+FROM ppc64le/ubuntu:jammy
 MAINTAINER Daniel Fox <dan.fox@tigera.io>
-ENV STREAM bionic
+ENV STREAM jammy
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps
 RUN ./install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-trusty-build.Dockerfile.amd64
+++ b/hack/release/packaging/docker-build-images/ubuntu-trusty-build.Dockerfile.amd64
@@ -1,5 +1,5 @@
 FROM ubuntu:trusty
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM trusty
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-trusty-build.Dockerfile.ppc64le
+++ b/hack/release/packaging/docker-build-images/ubuntu-trusty-build.Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 FROM ppc64le/ubuntu:trusty
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM trusty
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-xenial-build.Dockerfile.amd64
+++ b/hack/release/packaging/docker-build-images/ubuntu-xenial-build.Dockerfile.amd64
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM xenial
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps

--- a/hack/release/packaging/docker-build-images/ubuntu-xenial-build.Dockerfile.ppc64le
+++ b/hack/release/packaging/docker-build-images/ubuntu-xenial-build.Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 FROM ppc64le/ubuntu:xenial
-MAINTAINER Shaun Crampton <shaun@tigera.io>
+MAINTAINER Daniel Fox <dan.fox@tigera.io>
 ENV STREAM xenial
 
 ADD install-ubuntu-build-deps install-ubuntu-build-deps

--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 # Do everything that's needed to create or update the Calico PPA and
 # RPM repo named ${REPO_NAME}, so that those provide packages for the
@@ -26,7 +26,7 @@ rootdir=`git_repo_root`
 # Directory to copy package build output to. Ensure it exists
 # and is empty before each build.
 outputDir=${rootdir}/hack/release/packaging/output/
-rm -rf ${outputdir} && mkdir -p ${outputDir}
+rm -rf ${outputDir} && mkdir -p ${outputDir}
 
 pub_steps=
 if "${PUBLISH:-false}"; then
@@ -43,6 +43,19 @@ else
     # packages but do not publish them.
     : ${STEPS:=bld_images net_cal felix etcd3gw dnsmasq nettle}
 fi
+
+function check_bin {
+    which $1 > /dev/null
+}
+
+function error_exit {
+    echo "[error] $*"
+    exit 1
+}
+
+function require_commands {
+    check_bin ts || error_exit "This script requires the 'ts' command from the 'moreutils' package."
+}
 
 function require_version {
     # VERSION must be specified.  It should be either "master" or
@@ -82,22 +95,28 @@ function require_repo_name {
 function require_rpm_host_vars {
     # HOST and GCLOUD_ARGS must be set to indicate the RPM host, and a
     # gcloud identity that permits logging into that host.
-    test -n "$GCLOUD_ARGS"
-    echo GCLOUD_ARGS is "$GCLOUD_ARGS"
-    test -n "$HOST"
-    echo HOST is $HOST
+    if [[ -z  "$GCLOUD_ARGS" ]]; then
+        echo "GCLOUD_ARGS must be set!"
+        exit 1
+    fi
+
+    if [[ -z "$HOST" ]]; then
+        echo "HOST must be set!"
+        exit 1
+    fi
 }
 
 function require_deb_secret_key {
     # SECRET_KEY must be a file containing the GPG secret key for a member
     # of the Project Calico team on Launchpad.
-    test -n "$SECRET_KEY"
-    echo SECRET_KEY is $SECRET_KEY
+    if [[ ! (-r "$SECRET_KEY") || ! (-s "$SECRET_KEY") ]] ; then
+        echo "Variable SECRET_KEY needs to be set to a valid GPG key"
+    fi
 }
 
 # Decide target arch; by default the same as the native arch here.  We
 # conventionally say "amd64", where uname says "x86_64".
-ARCH=${ARCH:-`uname -m`}
+ARCH=${ARCH:-$(uname -m)}
 if [ $ARCH = x86_64 ]; then
     ARCH=amd64
 fi
@@ -131,8 +150,9 @@ function precheck_nettle {
 function precheck_pub_debs {
     # Check the PPA exists.
     require_repo_name
-    wget -O - https://launchpad.net/~project-calico/+archive/ubuntu/${REPO_NAME} | grep -F "PPA description" || {
-	cat <<EOF
+    curl -fsSL -I https://launchpad.net/~project-calico/+archive/ubuntu/${REPO_NAME} > /dev/null
+    if [[ $? != 0 ]]; then
+    	cat <<EOF
 
 ERROR: PPA for ${REPO_NAME} does not exist.  Create it, then rerun this job.
 
@@ -145,8 +165,8 @@ ERROR: PPA for ${REPO_NAME} does not exist.  Create it, then rerun this job.
   series.)
 
 EOF
-	exit 1
-    }
+	    exit 1
+    fi
 
     # We'll need a secret key to upload new source packages.
     require_deb_secret_key
@@ -160,26 +180,14 @@ function precheck_pub_rpms {
 # Execution of the requested steps.
 
 function docker_run_rm {
-    docker run --rm --user `id -u`:`id -g` -v $(dirname `pwd`):/code -w /code/$(basename `pwd`) "$@"
+    docker run --rm --user $(id -u):$(id -g) -v $(dirname $(pwd)):/code -w /code/$(basename $(pwd)) "$@"
 }
 
 function do_bld_images {
     # Build the docker images that we use for building for each target platform.
     pushd ${rootdir}/hack/release/packaging/docker-build-images
-    docker build -f ubuntu-trusty-build.Dockerfile.${ARCH} -t calico-build/trusty .
-    docker build -f ubuntu-xenial-build.Dockerfile.${ARCH} -t calico-build/xenial .
-    docker build -f ubuntu-bionic-build.Dockerfile.${ARCH} -t calico-build/bionic .
-    docker build -f ubuntu-focal-build.Dockerfile.${ARCH} -t calico-build/focal .
-    docker build --build-arg=UID=`id -u` --build-arg=GID=`id -g` -f centos7-build.Dockerfile.${ARCH} -t calico-build/centos7 .
+    UID=$(id -u) GID=$(id -g) docker buildx bake
     popd
-    if [ $ARCH = ppc64le ]; then
-	# Some commands that would typically be run at container build
-	# time must be run in a privileged container.
-	docker rm -f centos7Tmp
-	docker run --privileged --name=centos7Tmp calico-build/centos7 \
-	       /bin/bash -c "/setup-user; /install-centos-build-deps"
-	docker commit centos7Tmp calico-build/centos7:latest
-    fi
 }
 
 function do_net_cal {
@@ -324,12 +332,17 @@ function do_pub_rpms {
     popd
 }
 
+# Check script requirements
+require_commands
+
 # Do prechecks for requested steps.
 for step in ${STEPS}; do
+    echo "Processing precheck_${step}"
     eval precheck_${step}
 done
 
 # Execute requested steps.
 for step in ${STEPS}; do
+    echo "Processing do_${step}"
     eval do_${step}
 done

--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -186,7 +186,7 @@ function docker_run_rm {
 function do_bld_images {
     # Build the docker images that we use for building for each target platform.
     pushd ${rootdir}/hack/release/packaging/docker-build-images
-    UID=$(id -u) GID=$(id -g) docker buildx bake
+    docker buildx bake --set centos7.args.UID=$(id -u) --set centos7.args.GID=$(id -g)
     popd
 }
 

--- a/hack/release/packaging/utils/publish-debs.sh
+++ b/hack/release/packaging/utils/publish-debs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 REPO_NAME=${REPO_NAME:-master}
 test -n "$SECRET_KEY"
@@ -19,7 +19,7 @@ else
 fi
 docker run --rm ${interactive} -v ${rootdir}:/code -v ${keydir}:/keydir -w /code/hack/release/packaging/output calico-build/bionic /bin/sh -c "gpg --import --batch < /keydir/key && debsign -k'*@' --re-sign *_*_source.changes"
 
-for series in trusty xenial bionic focal; do
+for series in trusty xenial bionic focal jammy; do
     # Get the packages and versions that already exist in the PPA, so we can avoid
     # uploading the same package and version as already exist.  (As they would be rejected
     # anyway by Launchpad.)
@@ -38,6 +38,6 @@ for series in trusty xenial bionic focal; do
                 break
             fi
         done
-        ${already_exists} || docker run --rm -v ${rootdir}:/code -w /code/hack/release/packaging/output calico-build/${series} dput -u ppa:project-calico/${REPO_NAME} ${changes_file}
+        ${already_exists} || docker run --rm -v ${rootdir}:/code -w /code/hack/release/packaging/output calico-build/${series} dput -u ppa:project-calico/${REPO_NAME} ${changes_file} | ts "[upload $series]"
     done
 done

--- a/hack/release/packaging/utils/publish-rpms.sh
+++ b/hack/release/packaging/utils/publish-rpms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 # publish-rpms.sh
 #

--- a/networking-calico/debian/control
+++ b/networking-calico/debian/control
@@ -2,7 +2,7 @@ Source: networking-calico
 Section: net
 Priority: optional
 Maintainer: Neil Jerram <neil@projectcalico.org>
-Build-Depends: debhelper (>= 8.0.0), dh-systemd, dh-python, python3-all, python3-setuptools
+Build-Depends: debhelper (>= 8.0.0), base-files (>= 11.1~) | dh-systemd, dh-python, python3-all, python3-setuptools
 Standards-Version: 3.9.4
 
 Package: calico-compute


### PR DESCRIPTION
Update to our Openstack packaging system:

* Add support for Ubuntu Jammy amd64 and ppc64le
* Fix build-deps for Ubuntu Focal/Jammy
* Clean up CentOS 7 ppc64le builds
* Convert build image creation to use `docker buildx bake` (see https://docs.docker.com/build/bake/)
* Clean up build output

Cherry-pick from #7622

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
