### PR TITLE
Move UID/GID assignment to command-line

### DIFF
--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -186,7 +186,7 @@ function docker_run_rm {
 function do_bld_images {
     # Build the docker images that we use for building for each target platform.
     pushd ${rootdir}/hack/release/packaging/docker-build-images
-    UID=$(id -u) GID=$(id -g) docker buildx bake
+    docker buildx bake --set centos7.args.UID=$(id -u) --set centos7.args.GID=$(id -g)
     popd
 }
 


### PR DESCRIPTION
Specifying a read-only variable in front of a command works in some shells' interactive sessions, but not in bash. Move the variable assignment to command-line parameters for docker buildx build instead.