### PR TITLE
Create a symlink for libpcap.so.0.8

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -223,8 +223,6 @@ RUN chmod u+s /bin/mountns
 ADD clean-up-filesystem.sh /
 RUN /clean-up-filesystem.sh
 
-RUN ln -s /usr/lib64/libpcap.so.1 /usr/lib64/libpcap.so.0.8
-
 # Copy everything into a fresh scratch image so that naive CVE scanners don't pick up binaries and libraries
 # that have been removed in our later layers.
 FROM scratch
@@ -232,6 +230,10 @@ COPY --from=ubi / /
 
 # Add in top-level license file
 COPY LICENSE /licenses
+
+# Node is build on a debian image with pcap 1.8, but there is no 1.8 available so we copy 1.9 over. Ideally we should
+# should build node on a centos image so we can have correct pcap version alignment.
+RUN ln -s $(ls /usr/lib64/libpcap.so.1.9.* | tail -n 1) /usr/lib64/libpcap.so.0.8
 
 CMD ["start_runit"]
 

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -223,6 +223,8 @@ RUN chmod u+s /bin/mountns
 ADD clean-up-filesystem.sh /
 RUN /clean-up-filesystem.sh
 
+RUN ln -s /usr/lib64/libpcap.so.1 /usr/lib64/libpcap.so.0.8
+
 # Copy everything into a fresh scratch image so that naive CVE scanners don't pick up binaries and libraries
 # that have been removed in our later layers.
 FROM scratch

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -246,6 +246,8 @@ ADD clean-up-filesystem.sh /
 RUN sed -i 's#zmore#zmore\n\tqemu\n#m' clean-up-filesystem.sh
 RUN /clean-up-filesystem.sh
 
+RUN ln -s /usr/lib64/libpcap.so.1 /usr/lib64/libpcap.so.0.8
+
 # Copy everything into a fresh scratch image so that naive CVE scanners don't pick up binaries and libraries
 # that have been removed in our later layers.
 FROM scratch

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -246,8 +246,6 @@ ADD clean-up-filesystem.sh /
 RUN sed -i 's#zmore#zmore\n\tqemu\n#m' clean-up-filesystem.sh
 RUN /clean-up-filesystem.sh
 
-RUN ln -s /usr/lib64/libpcap.so.1 /usr/lib64/libpcap.so.0.8
-
 # Copy everything into a fresh scratch image so that naive CVE scanners don't pick up binaries and libraries
 # that have been removed in our later layers.
 FROM scratch


### PR DESCRIPTION
## Description

BPF log filters use gopacket/pcap which requires libpcap.so.0.8. Hence create a symlink for libpcap.so.0.8 pointing to libpcap.so.1

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
