### PR TITLE
Fix Felix packaging for Ubuntu

### DIFF
--- a/felix/debian/control
+++ b/felix/debian/control
@@ -2,7 +2,7 @@ Source: felix
 Section: net
 Priority: optional
 Maintainer: Project Calico Maintainers <maintainers@projectcalico.org>
-Build-Depends: debhelper (>= 8.0.0), base-files (>= 11.1~) | dh-systemd, libelf-dev
+Build-Depends: debhelper (>= 8.0.0), base-files (>= 11.1~) | dh-systemd, libelf-dev, libpcap-dev
 Standards-Version: 3.9.4
 
 Package: calico-common

--- a/felix/debian/control
+++ b/felix/debian/control
@@ -28,7 +28,8 @@ Depends:
  ipset,
  iproute2,
  net-tools,
- ${misc:Depends}
+ ${misc:Depends},
+ ${shlibs:Depends}
 Description: Project Calico virtual networking for cloud data centers.
  Project Calico is an open source solution for virtual networking in
  cloud data centers. Its IP-centric architecture offers numerous


### PR DESCRIPTION
## Description

Fix openstack packaging by adding `libpcap-dev` as a build dependency, and update the `debian/control` file to include the dpkg-calculated shared library dependencies.