### PR TITLE
Update release version for dikastes in manifests

### DIFF
--- a/manifests/alp/istio-inject-configmap-1.1.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.0.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.1.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.10.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.11.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.11.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.12.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.12.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.13.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.13.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.14.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.14.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.15.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.16.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.16.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.17.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.17.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.2.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.3.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.4.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.5.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.6.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.7.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.8.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.9.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.10.yaml
@@ -433,7 +433,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:release-v3.26
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -720,7 +720,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:release-v3.26
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.15.yaml
@@ -434,7 +434,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:release-v3.26
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -719,7 +719,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:release-v3.26
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.0.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.1.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.2.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.3.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.4.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.5.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.6.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.7.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.8.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.9.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.0.yaml
@@ -327,7 +327,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.1.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.2.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.3.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.4.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.5.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.0.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.1.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.2.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.6.yaml
@@ -363,7 +363,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.7.yaml
@@ -369,7 +369,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:release-v3.26
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.9.yaml
@@ -428,7 +428,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:release-v3.26
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -714,7 +714,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:release-v3.26
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Description

`make ci-preflight-checks` is failing because the files implicated in this PR are returned by `check-dirty`. This is likely a result of 
commit 06d1c0b3493bdf390a5b4073e9f7ad20f6a89afc that added dikastes to the list of manifests.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

~- [ ] Tests~
~- [ ] Documentation~
~- [ ] Release note~

## ~Release Note~

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
