### PR TITLE
[release-v3.25] Auto pick #7677: Fix statically building node-driver-registrar on amd64

### DIFF
--- a/manifests/alp/istio-inject-configmap-1.1.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.0.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.1.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.10.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.11.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.11.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.12.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.12.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.13.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.13.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.14.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.14.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.15.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.16.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.16.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.17.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.17.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.2.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.3.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.4.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.5.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.6.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.7.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.8.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.9.yaml
@@ -183,7 +183,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.10.yaml
@@ -433,7 +433,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:v3.25.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -720,7 +720,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:v3.25.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.15.yaml
@@ -434,7 +434,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:v3.25.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -719,7 +719,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:v3.25.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.0.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.1.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.2.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.3.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.4.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.5.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.6.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.7.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.8.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.9.yaml
@@ -303,7 +303,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.0.yaml
@@ -327,7 +327,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.1.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.2.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.3.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.4.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.5.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.0.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.1.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.2.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.6.yaml
@@ -363,7 +363,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.7.yaml
@@ -369,7 +369,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:master
+        image: calico/dikastes:v3.25.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.9.yaml
@@ -428,7 +428,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:v3.25.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -714,7 +714,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:master
+            image: calico/dikastes:v3.25.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -73,8 +73,14 @@ bin/csi-driver-amd64: $(SRC_FILES)
 UPSTREAM_REGISTRAR_PROJECT ?= kubernetes-csi/$(REGISTRAR_IMAGE)
 UPSTREAM_REGISTRAR_TAG     ?= v2.8.0
 
+ifeq ($(ARCH), $(filter $(ARCH),amd64))
+REGISTRAR_TIGERA_BUILD_CMD_LDFLAGS = -ldflags '-linkmode external -extldflags -static'
+else
+REGISTRAR_TIGERA_BUILD_CMD_LDFLAGS =
+endif
+
 REGISTRAR_TIGERA_BUILD_CMD="cd /go/src/github.com/$(UPSTREAM_REGISTRAR_PROJECT) && \
-                    			  go build -buildvcs=false -tags $(TAGS) -v -o bin/csi-node-driver-registrar cmd/csi-node-driver-registrar/*.go"
+                    			  go build -buildvcs=false $(REGISTRAR_TIGERA_BUILD_CMD_LDFLAGS) -tags $(TAGS) -v -o bin/csi-node-driver-registrar cmd/csi-node-driver-registrar/*.go"
 REGISTRAR_UPSTREAM_BUILD_CMD="cd /go/src/github.com/$(UPSTREAM_REGISTRAR_PROJECT) && \
 							      make build BUILD_PLATFORMS=$(BUILD_PLATFORMS)"
 


### PR DESCRIPTION
Cherry pick of #7677 on release-v3.25.

#7677: Fix statically building node-driver-registrar on amd64

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.