### PR TITLE
Improve pod startup time

### DIFF
--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -67,9 +67,16 @@ func (d *linuxDataplane) DoNetworking(
 
 	d.logger.Infof("Setting the host side veth name to %s", hostVethName)
 
+	hostNlHandle, err := netlink.NewHandle()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create host netlink handle: %v", err)
+	}
+
+	defer hostNlHandle.Close()
+
 	// Clean up if hostVeth exists.
-	if oldHostVeth, err := netlink.LinkByName(hostVethName); err == nil {
-		if err = netlink.LinkDel(oldHostVeth); err != nil {
+	if oldHostVeth, err := hostNlHandle.LinkByName(hostVethName); err == nil {
+		if err = hostNlHandle.LinkDel(oldHostVeth); err != nil {
 			return "", "", fmt.Errorf("failed to delete old hostVeth %v: %v", hostVethName, err)
 		}
 		d.logger.Infof("Cleaning old hostVeth: %v", hostVethName)
@@ -82,8 +89,9 @@ func (d *linuxDataplane) DoNetworking(
 		la.NumTxQueues = d.queues
 		la.NumRxQueues = d.queues
 		veth := &netlink.Veth{
-			LinkAttrs: la,
-			PeerName:  hostVethName,
+			LinkAttrs:     la,
+			PeerName:      hostVethName,
+			PeerNamespace: netlink.NsFd(int(hostNS.Fd())),
 		}
 
 		if err := netlink.LinkAdd(veth); err != nil {
@@ -91,7 +99,7 @@ func (d *linuxDataplane) DoNetworking(
 			return err
 		}
 
-		hostVeth, err := netlink.LinkByName(hostVethName)
+		hostVeth, err := hostNlHandle.LinkByName(hostVethName)
 		if err != nil {
 			err = fmt.Errorf("failed to lookup %q: %v", hostVethName, err)
 			return err
@@ -102,7 +110,7 @@ func (d *linuxDataplane) DoNetworking(
 		} else {
 			// Set the MAC address on the host side interface so the kernel does not
 			// have to generate a persistent address which fails some times.
-			if err = netlink.LinkSetHardwareAddr(hostVeth, mac); err != nil {
+			if err = hostNlHandle.LinkSetHardwareAddr(hostVeth, mac); err != nil {
 				d.logger.Warnf("failed to Set MAC of %q: %v. Using kernel generated MAC.", hostVethName, err)
 			}
 		}
@@ -128,14 +136,23 @@ func (d *linuxDataplane) DoNetworking(
 			if err != nil {
 				return err
 			}
-			err = disableDAD(hostVethName)
+		}
+
+		err = hostNS.Do(func(_ ns.NetNS) error {
+			err := d.configureSysctls(hostVethName, hasIPv4, hasIPv6)
 			if err != nil {
-				return err
+				return fmt.Errorf("error configuring sysctls for interface: %s, error: %w", hostVethName, err)
 			}
+
+			return nil
+		})
+
+		if err != nil {
+			return err
 		}
 
 		// Explicitly set the veth to UP state; the veth won't get a link local address unless it's set to UP state.
-		if err = netlink.LinkSetUp(hostVeth); err != nil {
+		if err = hostNlHandle.LinkSetUp(hostVeth); err != nil {
 			return fmt.Errorf("failed to set %q up: %w", hostVethName, err)
 		}
 
@@ -230,7 +247,7 @@ func (d *linuxDataplane) DoNetworking(
 				// No need to add a dummy next hop route as the host veth device will already have an IPv6
 				// link local address that can be used as a next hop.
 				// Just fetch the address of the host end of the veth and use it as the next hop.
-				addresses, err = netlink.AddrList(hostVeth, netlink.FAMILY_V6)
+				addresses, err = hostNlHandle.AddrList(hostVeth, netlink.FAMILY_V6)
 				if err != nil {
 					d.logger.Errorf("Error listing IPv6 addresses for the host side of the veth pair: %s", err)
 				}
@@ -278,12 +295,6 @@ func (d *linuxDataplane) DoNetworking(
 			return fmt.Errorf("error configuring sysctls for the container netns, error: %s", err)
 		}
 
-		// Now that the everything has been successfully set up in the container, move the "host" end of the
-		// veth into the host namespace.
-		if err = netlink.LinkSetNsFd(hostVeth, int(hostNS.Fd())); err != nil {
-			return fmt.Errorf("failed to move veth to host netns: %v", err)
-		}
-
 		return nil
 	})
 
@@ -292,24 +303,13 @@ func (d *linuxDataplane) DoNetworking(
 		return "", "", err
 	}
 
-	err = d.configureSysctls(hostVethName, hasIPv4, hasIPv6)
-	if err != nil {
-		return "", "", fmt.Errorf("error configuring sysctls for interface: %s, error: %s", hostVethName, err)
-	}
-
-	// Moving a veth between namespaces always leaves it in the "DOWN" state. Set it back to "UP" now that we're
-	// back in the host namespace.
-	hostVeth, err := netlink.LinkByName(hostVethName)
+	hostVeth, err := hostNlHandle.LinkByName(hostVethName)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to lookup %q: %v", hostVethName, err)
 	}
 
-	if err = netlink.LinkSetUp(hostVeth); err != nil {
-		return "", "", fmt.Errorf("failed to set %q up: %v", hostVethName, err)
-	}
-
-	// Now that the host side of the veth is moved, state set to UP, and configured with sysctls, we can add the routes to it in the host namespace.
-	err = SetupRoutes(hostVeth, result)
+	// Add the routes to host veth in the host namespace.
+	err = SetupRoutes(hostNlHandle, hostVeth, result)
 	if err != nil {
 		return "", "", fmt.Errorf("error adding host side routes for interface: %s, error: %s", hostVeth.Attrs().Name, err)
 	}
@@ -327,7 +327,7 @@ func disableDAD(contVethName string) error {
 }
 
 // SetupRoutes sets up the routes for the host side of the veth pair.
-func SetupRoutes(hostVeth netlink.Link, result *cniv1.Result) error {
+func SetupRoutes(hostNlHandle *netlink.Handle, hostVeth netlink.Link, result *cniv1.Result) error {
 
 	// Go through all the IPs and add routes for each IP in the result.
 	for _, ipAddr := range result.IPs {
@@ -336,7 +336,7 @@ func SetupRoutes(hostVeth netlink.Link, result *cniv1.Result) error {
 			Scope:     netlink.SCOPE_LINK,
 			Dst:       &ipAddr.Address,
 		}
-		err := netlink.RouteAdd(&route)
+		err := hostNlHandle.RouteAdd(&route)
 
 		if err != nil {
 			switch err {
@@ -344,7 +344,7 @@ func SetupRoutes(hostVeth netlink.Link, result *cniv1.Result) error {
 			// Route already exists, but not necessarily pointing to the same interface.
 			case syscall.EEXIST:
 				// List all the routes for the interface.
-				routes, err := netlink.RouteList(hostVeth, netlink.FAMILY_ALL)
+				routes, err := hostNlHandle.RouteList(hostVeth, netlink.FAMILY_ALL)
 				if err != nil {
 					return fmt.Errorf("error listing routes")
 				}
@@ -364,7 +364,7 @@ func SetupRoutes(hostVeth netlink.Link, result *cniv1.Result) error {
 				}
 
 				// Search all routes and report the conflict, search the name of the iface
-				routes, err = netlink.RouteList(nil, netlink.FAMILY_ALL)
+				routes, err = hostNlHandle.RouteList(nil, netlink.FAMILY_ALL)
 				if err != nil {
 					return fmt.Errorf("error listing routes")
 				}
@@ -374,7 +374,7 @@ func SetupRoutes(hostVeth netlink.Link, result *cniv1.Result) error {
 				for _, r := range routes {
 					if r.Dst != nil && r.Dst.IP.Equal(route.Dst.IP) {
 						linkName := "unknown"
-						if link, err := netlink.LinkByIndex(r.LinkIndex); err == nil {
+						if link, err := hostNlHandle.LinkByIndex(r.LinkIndex); err == nil {
 							linkName = link.Attrs().Name
 						}
 
@@ -434,6 +434,12 @@ func (d *linuxDataplane) configureSysctls(hostVethName string, hasIPv4, hasIPv6 
 	}
 
 	if hasIPv6 {
+		// By default, the kernel does duplicate address detection for the IPv6 address. DAD delays use of the
+		// IP for up to a second and we don't need it because it's a point-to-point link.
+		if err := writeProcSys(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/accept_dad", hostVethName), "0"); err != nil {
+			return fmt.Errorf("failed to set net.ipv6.conf.%s.accept_dad=0: %s", hostVethName, err)
+		}
+
 		// Make sure ipv6 is enabled on the hostVeth interface in the host network namespace.
 		// Interfaces won't get a link local address without this sysctl set to 0.
 		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/disable_ipv6", hostVethName), "0"); err != nil {

--- a/cni-plugin/tests/calico_cni_test.go
+++ b/cni-plugin/tests/calico_cni_test.go
@@ -847,13 +847,17 @@ var _ = Describe("CalicoCni", func() {
 				containerID, result, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, "", testutils.TEST_DEFAULT_NS, "", "meep1337")
 				Expect(err).ShouldNot(HaveOccurred())
 
+				hostNlHandle, err := netlink.NewHandle()
+				Expect(err).ShouldNot(HaveOccurred())
+				defer hostNlHandle.Close()
+
 				// CNI plugin generates host side vEth name from containerID if used for "cni" orchestrator.
 				hostVethName := "cali" + containerID[:utils.Min(11, len(containerID))] //"cali" + containerID
 				hostVeth, err := netlink.LinkByName(hostVethName)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("setting up the same route CNI plugin installed in the initial run for the hostVeth")
-				err = linux.SetupRoutes(hostVeth, result)
+				err = linux.SetupRoutes(hostNlHandle, hostVeth, result)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), "", testutils.TEST_DEFAULT_NS, containerID)


### PR DESCRIPTION
## Description

Moving an interface from one namespace to another is time consuming (especially in CANAL when trying to create multiple pods) and requires the interface to be set back to UP again.  We can improve the current implementation by creating the host veth directly in the host namespace.

We measured the time it takes in calico cni plugin to set up the networking stack, more precisely the time it takes to execute DoNetworking. We ran benchmarks measuring the time spent when creating 16 pods simultaneously on a cluster with 1 control-plane node and 1 worker node. 

<details>
<summary>System specs</summary>
Red Hat Enterprise Linux 9.1
Kernel: 6.3.0-rc3
</details>

Below are the benchmarks for various Calico setups:
<details>
<summary>CALICO IPV4</summary>

```
before:
containerd[5219]: 2023-05-26 07:58:13.018 [INFO][46450] dataplane_linux.go 319: Finished DoNetworking. ContainerID="276c70d6b1f9aaa0b012399b5c99c97ec5abf6f47ef9b7655855ed04ad515e90" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-5" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--5-eth0" after=15.357635ms
containerd[5219]: 2023-05-26 07:58:13.043 [INFO][46448] dataplane_linux.go 319: Finished DoNetworking. ContainerID="6b3c632b3562577523a5acf4389f930be989aef01e1238a3ef0b29818f88a9fd" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-7" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--7-eth0" after=22.190691ms
containerd[5219]: 2023-05-26 07:58:13.071 [INFO][46442] dataplane_linux.go 319: Finished DoNetworking. ContainerID="718ea8a154349f0339c349f3e8ae6cded7bd8deaf171d864ffb8e50ce87434d9" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-2" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--2-eth0" after=28.392989ms
containerd[5219]: 2023-05-26 07:58:13.088 [INFO][46468] dataplane_linux.go 319: Finished DoNetworking. ContainerID="9abbe9758a181cc8f78cd9fe578e07506921fd1c8cbba7ee6f7b624ea3319726" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-4" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--4-eth0" after=28.349732ms
containerd[5219]: 2023-05-26 07:58:13.101 [INFO][46456] dataplane_linux.go 319: Finished DoNetworking. ContainerID="735bc443d42817f0dbb2cc09354913128f84ced50e5418464eae50187d01bd45" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-13" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--13-eth0" after=23.831761ms
containerd[5219]: 2023-05-26 07:58:13.152 [INFO][46547] dataplane_linux.go 319: Finished DoNetworking. ContainerID="23c690d255b131813d73eb7a5ddaa70f443a2a9b487610e3b878de8f3bce8d80" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-11" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--11-eth0" after=56.314785ms
containerd[5219]: 2023-05-26 07:58:13.165 [INFO][46542] dataplane_linux.go 319: Finished DoNetworking. ContainerID="6b77a64747716e78037105a116289993ce5d63451f9e052780726cb8682eb442" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-3" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--3-eth0" after=27.449413ms
containerd[5219]: 2023-05-26 07:58:13.165 [INFO][46555] dataplane_linux.go 319: Finished DoNetworking. ContainerID="f17776dda765527b52fa04d2710c3bd50ff7ec40aa26807d72b5720f1e761113" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-15" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--15-eth0" after=49.489791ms
containerd[5219]: 2023-05-26 07:58:13.178 [INFO][46544] dataplane_linux.go 319: Finished DoNetworking. ContainerID="7c6cb359601d07ab317015187f11eb41b716a031db0b423635a226d794e71fa8" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-14" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--14-eth0" after=14.242354ms
containerd[5219]: 2023-05-26 07:58:13.200 [INFO][46522] dataplane_linux.go 319: Finished DoNetworking. ContainerID="96a74315693e51f4e073daa889a89cc96143a45f3c9f88e239f515ab70b331ee" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-8" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--8-eth0" after=13.880612ms
containerd[5219]: 2023-05-26 07:58:13.225 [INFO][46609] dataplane_linux.go 319: Finished DoNetworking. ContainerID="7fb087f7320822694b9d5ad82650c50e82a6084ffe628c03a0f35dcac477d547" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-0" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--0-eth0" after=19.716989ms
containerd[5219]: 2023-05-26 07:58:13.246 [INFO][46585] dataplane_linux.go 319: Finished DoNetworking. ContainerID="9907596d244db3f61c92fdaad26fe8701ad7e73a4372abfdd8dc0dc33c890586" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-1" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--1-eth0" after=18.306579ms
containerd[5219]: 2023-05-26 07:58:13.261 [INFO][46684] dataplane_linux.go 319: Finished DoNetworking. ContainerID="2370e8ebcda79939e88e9a00046b962192139ed2f74636e49cde2e5df97e04f2" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-10" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--10-eth0" after=11.811679ms
containerd[5219]: 2023-05-26 07:58:13.288 [INFO][46641] dataplane_linux.go 319: Finished DoNetworking. ContainerID="de053a76856fd216e2d23e6f3953ffe587fc78689733afe8fcc603827f13b48a" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-12" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--12-eth0" after=16.934841ms
containerd[5219]: 2023-05-26 07:58:13.300 [INFO][46686] dataplane_linux.go 319: Finished DoNetworking. ContainerID="e4b6baf78b1531cc14d6f62184aaa5e21cf5364fc045412fe4a996d6d92789df" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-6" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--6-eth0" after=10.119797ms
containerd[5219]: 2023-05-26 07:58:13.332 [INFO][46679] dataplane_linux.go 319: Finished DoNetworking. ContainerID="251b511582a5392aeffe51e32027c6b0bb57241fec1674a0ba5bab24c8d805a6" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-9" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--9-eth0" after=19.631156ms

after:
containerd[5219]: 2023-05-26 08:00:34.329 [INFO][53745] dataplane_linux.go 329: Finished DoNetworking. ContainerID="5e2dd6e3715a5bad939e77c1483b8b6ac1dac3b4d9898e03357438992ecd017e" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-0" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--0-eth0" after=3.337002ms
containerd[5219]: 2023-05-26 08:00:34.349 [INFO][53780] dataplane_linux.go 329: Finished DoNetworking. ContainerID="bf9ec3565e7dbcff37127f15562538708672c49e22a80a4e6e56da78bc7c7ef2" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-13" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--13-eth0" after=1.477435ms
containerd[5219]: 2023-05-26 08:00:34.369 [INFO][53723] dataplane_linux.go 329: Finished DoNetworking. ContainerID="f3305dd83031e0d5b40996af603a9f946ba2a0a04ecbb505e378406b8d0fb2bc" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-1" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--1-eth0" after=2.212617ms
containerd[5219]: 2023-05-26 08:00:34.387 [INFO][53766] dataplane_linux.go 329: Finished DoNetworking. ContainerID="2da2353bb55767dbbe0988cbb40ff1362c68d1045c02d3152c1d1db6d1ddb7be" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-5" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--5-eth0" after=1.002398ms
containerd[5219]: 2023-05-26 08:00:34.406 [INFO][53792] dataplane_linux.go 329: Finished DoNetworking. ContainerID="0c6f2af44a40e47af4df235d65721df42a9c8cc868a6562e56e8b6f84d163660" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-2" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--2-eth0" after=1.103331ms
containerd[5219]: 2023-05-26 08:00:34.426 [INFO][53752] dataplane_linux.go 329: Finished DoNetworking. ContainerID="7dd4a90d2a8950781a635c5e1a65f3dd18724d82599b4ab80194bb513ea7bbd4" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-15" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--15-eth0" after=1.151782ms
containerd[5219]: 2023-05-26 08:00:34.447 [INFO][53788] dataplane_linux.go 329: Finished DoNetworking. ContainerID="2606d5f45d4c4ea406fc5e501e7f99c69e227b00066fc4685942964ff579126e" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-14" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--14-eth0" after=1.213658ms
containerd[5219]: 2023-05-26 08:00:34.466 [INFO][53720] dataplane_linux.go 329: Finished DoNetworking. ContainerID="f9215dfc55398852496bc93feca7496f6fa41686d1e9329d86ef535f5d4c70ce" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-10" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--10-eth0" after=1.04141ms
containerd[5219]: 2023-05-26 08:00:34.484 [INFO][53935] dataplane_linux.go 329: Finished DoNetworking. ContainerID="b408c5f2d1269dd75e6f561687ef1119d116396fb966b59c016b1f21a2c6d685" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-12" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--12-eth0" after=1.139266ms
containerd[5219]: 2023-05-26 08:00:34.507 [INFO][53956] dataplane_linux.go 329: Finished DoNetworking. ContainerID="d096353e7e40d4e7e6911d9f381188dba5428a3d1d0d32acfe1889a5f5ea8d93" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-4" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--4-eth0" after=1.285217ms
containerd[5219]: 2023-05-26 08:00:34.534 [INFO][53949] dataplane_linux.go 329: Finished DoNetworking. ContainerID="922ec29998f207b97a900f95bd30a0ad817ccd4f672eabe0c8d1a63e0aeed3a7" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-9" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--9-eth0" after=1.115956ms
containerd[5219]: 2023-05-26 08:00:34.559 [INFO][53918] dataplane_linux.go 329: Finished DoNetworking. ContainerID="cc5b67baee7e21dbf314e4360bef33eab90ba92dd34261845036ffe4d8156065" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-7" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--7-eth0" after=1.05643ms
containerd[5219]: 2023-05-26 08:00:34.582 [INFO][53957] dataplane_linux.go 329: Finished DoNetworking. ContainerID="c9e3bd434f7b42d0d065dbc8f50d13b3b70e5b2f322d5d8e625346c42fc1fe4e" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-6" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--6-eth0" after=1.110293ms
containerd[5219]: 2023-05-26 08:00:34.601 [INFO][53852] dataplane_linux.go 329: Finished DoNetworking. ContainerID="2da63e3965def05b1523d9f8d06452e828d122f88bfe4dab358ff377d0ac72c4" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-8" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--8-eth0" after=906.848µs
containerd[5219]: 2023-05-26 08:00:34.621 [INFO][53871] dataplane_linux.go 329: Finished DoNetworking. ContainerID="b5b891f46cdae179e6a042453f78eb22e67fddff0b940593a3bdc1913db00e56" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-3" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--3-eth0" after=980.648µs
containerd[5219]: 2023-05-26 08:00:34.642 [INFO][53965] dataplane_linux.go 329: Finished DoNetworking. ContainerID="eaf48bfb23e22a57bf12425f019e6de980b98d86c5d470670204f61969a907b6" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-11" WorkloadEndpoint="robot--all--0a65ff80--7adb--4852--9247--5272deaa4bb7--vmss000000-k8s-job--kbench--pod--oid--0--tid--11-eth0" after=1.207534ms
```
</details>

<details>
<summary>CALICO IPV4 + IPV6</summary>

```
before:
containerd[5248]: 2023-05-26 07:30:31.770 [INFO][711285] dataplane_linux.go 319: Finished DoNetworking. ContainerID="74aecf84c455d7934fc39363d15c3622431b5f105a91f8d0309a8cced83cc20e" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-5" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--5-eth0" after=12.629326ms
containerd[5248]: 2023-05-26 07:30:31.837 [INFO][711297] dataplane_linux.go 319: Finished DoNetworking. ContainerID="f028857e80dde0c2b68c894d7c8467309c45d7b3f0fa8f9d99bcdcd4ec818024" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-3" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--3-eth0" after=36.905691ms
containerd[5248]: 2023-05-26 07:30:31.854 [INFO][711312] dataplane_linux.go 319: Finished DoNetworking. ContainerID="a9bae3e7e4120f3b2e987437277728a2d7196790a9586f99312ca61ab1ef1d41" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-13" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--13-eth0" after=18.676218ms
containerd[5248]: 2023-05-26 07:30:31.895 [INFO][711329] dataplane_linux.go 319: Finished DoNetworking. ContainerID="fba246b731812d37576375cab06cfa242b63afc6909a76060bd134c3c6b60f38" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-12" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--12-eth0" after=17.84298ms
containerd[5248]: 2023-05-26 07:30:31.940 [INFO][711325] dataplane_linux.go 319: Finished DoNetworking. ContainerID="cd5f83f64b47047cbb005b4cd7aabeae3e448d37a422000906ab04b6156607ca" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-11" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--11-eth0" after=24.006812ms
containerd[5248]: 2023-05-26 07:30:31.974 [INFO][711338] dataplane_linux.go 319: Finished DoNetworking. ContainerID="0babe843b1d154e2c5a7439e9c0ce83bd3ac402eb554ff581987ea4bf0b21675" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-15" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--15-eth0" after=12.206808ms
containerd[5248]: 2023-05-26 07:30:32.013 [INFO][711373] dataplane_linux.go 319: Finished DoNetworking. ContainerID="2eb4bec12fb07f9d2acb9abb0b331386abcc8980058ba4230ffd1eea2fb9ee12" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-7" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--7-eth0" after=14.885459ms
containerd[5248]: 2023-05-26 07:30:32.057 [INFO][711368] dataplane_linux.go 319: Finished DoNetworking. ContainerID="061a7ab1f9278d797dde41db3504ba86758a102d4b3daaf4108f5e6667ce429b" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-6" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--6-eth0" after=18.818314ms
containerd[5248]: 2023-05-26 07:30:32.092 [INFO][711520] dataplane_linux.go 319: Finished DoNetworking. ContainerID="89622b323e99c78cae452f9cad551333e60099e424ff6d534d23fa68fe87d09c" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-1" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--1-eth0" after=13.376886ms
containerd[5248]: 2023-05-26 07:30:32.132 [INFO][711504] dataplane_linux.go 319: Finished DoNetworking. ContainerID="2e4f01b610b1d287cff45d33130a5e59290ebd7bbae218b017a67215a1675249" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-10" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--10-eth0" after=12.917016ms
containerd[5248]: 2023-05-26 07:30:32.172 [INFO][711540] dataplane_linux.go 319: Finished DoNetworking. ContainerID="5dd1c28e7d26cb05341f01ba66569e8d9a1c62e27f9c72a06a4f9f78e0e047c5" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-8" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--8-eth0" after=12.757143ms
containerd[5248]: 2023-05-26 07:30:32.217 [INFO][711576] dataplane_linux.go 319: Finished DoNetworking. ContainerID="a1ee58ac055345fe423b40fd35ff6e5964f49f46e4cc33f488eb6760b706e853" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-2" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--2-eth0" after=17.519774ms
containerd[5248]: 2023-05-26 07:30:32.278 [INFO][711562] dataplane_linux.go 319: Finished DoNetworking. ContainerID="204fd4455b4aeb14082fe5efb9b15e652f8b98a6e2195109dd692ce7a17541fc" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-9" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--9-eth0" after=20.268953ms
containerd[5248]: 2023-05-26 07:30:32.323 [INFO][711534] dataplane_linux.go 319: Finished DoNetworking. ContainerID="6281c43aef3e10d0b680d30910f89ea6c25a720526729df15dbd72db1d308c2e" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-0" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--0-eth0" after=17.864858ms
containerd[5248]: 2023-05-26 07:30:32.361 [INFO][711583] dataplane_linux.go 319: Finished DoNetworking. ContainerID="da0939b5d2e0c2caee73c5077ceef596c44692d1e7a0d48fbff2011ed03f7265" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-4" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--4-eth0" after=14.855653ms
containerd[5248]: 2023-05-26 07:30:32.400 [INFO][711589] dataplane_linux.go 319: Finished DoNetworking. ContainerID="359551220b23588136dd6eadc96e27e1c347812bff815ec4558b385312cd7c52" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-14" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--14-eth0" after=13.305052ms

after:

containerd[5248]: 2023-05-26 07:27:40.254 [INFO][703591] dataplane_linux.go 329: Finished DoNetworking. ContainerID="e65aa30aaa5254d7a79d363f44f63d4f9fd0c47a45287e4c91c6ae4ec96e7a28" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-13" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--13-eth0" after=1.9071ms
containerd[5248]: 2023-05-26 07:27:40.294 [INFO][703674] dataplane_linux.go 329: Finished DoNetworking. ContainerID="3fde8e63e8e9826d4a878f96b6ba13ab55cf28c91d30746d843b07e7258f6739" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-1" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--1-eth0" after=1.773576ms
containerd[5248]: 2023-05-26 07:27:40.332 [INFO][703637] dataplane_linux.go 329: Finished DoNetworking. ContainerID="701d43ce1d06dcbdb128a8d30104d693ec520e0bc9f569dd313c268db1948906" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-5" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--5-eth0" after=1.89356ms
containerd[5248]: 2023-05-26 07:27:40.374 [INFO][703690] dataplane_linux.go 329: Finished DoNetworking. ContainerID="52a1fb22eba9528a35e166c33b17d893282dc2d7263bfdd08a807c5eca881adf" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-0" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--0-eth0" after=2.03485ms
containerd[5248]: 2023-05-26 07:27:40.411 [INFO][703589] dataplane_linux.go 329: Finished DoNetworking. ContainerID="85f0babdc63b7eb9b87afb2ddb6aafa749a7e445de6eb03499dfabb17b25977a" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-2" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--2-eth0" after=2.028495ms
containerd[5248]: 2023-05-26 07:27:40.470 [INFO][703607] dataplane_linux.go 329: Finished DoNetworking. ContainerID="e3cf30ed2a5e4e6e4ab11cc7879b49ab7977d1e69dc3bf9c48f200f8fb02bd41" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-8" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--8-eth0" after=2.094088ms
containerd[5248]: 2023-05-26 07:27:40.508 [INFO][703596] dataplane_linux.go 329: Finished DoNetworking. ContainerID="6fe3b1f4ec903346e114de2270a8d874ddc851658dd6314e5899e9ed4f2ec15f" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-15" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--15-eth0" after=1.923648ms
containerd[5248]: 2023-05-26 07:27:40.549 [INFO][703651] dataplane_linux.go 329: Finished DoNetworking. ContainerID="5b768afab5e2d6c07d179ff6f43b765dedf761b5f7db154774ada16fa0dfdf60" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-7" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--7-eth0" after=2.084686ms
containerd[5248]: 2023-05-26 07:27:40.588 [INFO][703647] dataplane_linux.go 329: Finished DoNetworking. ContainerID="1decca1a9d04a9cf96a4c13ffe7fac16438ebd1919dd6927b6bfae86f568b533" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-12" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--12-eth0" after=2.083661ms
containerd[5248]: 2023-05-26 07:27:40.627 [INFO][703696] dataplane_linux.go 329: Finished DoNetworking. ContainerID="14dde2c17aefa634c7ea5666be35c89d432fe9d66775bec45538c3eb3fe92a1e" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-4" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--4-eth0" after=1.855242ms
containerd[5248]: 2023-05-26 07:27:40.669 [INFO][703736] dataplane_linux.go 329: Finished DoNetworking. ContainerID="2fb4f105c1da0f4071179b1efa281805364b42bc3c137058ba6e18b653162d39" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-11" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--11-eth0" after=2.056579ms
containerd[5248]: 2023-05-26 07:27:40.709 [INFO][703771] dataplane_linux.go 329: Finished DoNetworking. ContainerID="9de018c2051b47240204a9ed894e6a90c5bfae64987d02f68f170eb1646d0384" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-6" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--6-eth0" after=1.902558ms
containerd[5248]: 2023-05-26 07:27:40.749 [INFO][703731] dataplane_linux.go 329: Finished DoNetworking. ContainerID="e2f8a943c44bcc644b44a5cb333c24fff3ce66dc851d317302e32a40bff95fcb" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-3" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--3-eth0" after=2.006815ms
containerd[5248]: 2023-05-26 07:27:40.791 [INFO][703765] dataplane_linux.go 329: Finished DoNetworking. ContainerID="c47b09bd73aeff70889c0422f87b07002b98fb88cc8355722d1e54aee1756745" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-9" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--9-eth0" after=2.082091ms
containerd[5248]: 2023-05-26 07:27:40.832 [INFO][703769] dataplane_linux.go 329: Finished DoNetworking. ContainerID="29d7beaa7f47defef82e391da855f60f49a30060db2aa0dcd326190b5541d1a3" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-14" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--14-eth0" after=2.00943ms
containerd[5248]: 2023-05-26 07:27:40.874 [INFO][703777] dataplane_linux.go 329: Finished DoNetworking. ContainerID="0e48a237f649814a57e0bd3efdca0e3bebc63a4f3d3ff2ef5224b6a7e0608caf" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-10" WorkloadEndpoint="robot--all--b65806d0--d068--45f4--b8d8--c27894da3aea--vmss000000-k8s-job--kbench--pod--oid--0--tid--10-eth0" after=2.079218ms
```
</details>

<details>
<summary>CANAL IPV4</summary>

```
before:
containerd[96663]: 2023-05-26 08:17:21.301 [INFO][3561405] dataplane_linux.go 319: Finished DoNetworking. ContainerID="86156cfef9c1e2b54c1ad4d78535f1aa920e016700f2bcc68543f07a85540a8f" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-6" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--6-eth0" after=14.922946ms
containerd[96663]: 2023-05-26 08:17:21.328 [INFO][3561491] dataplane_linux.go 319: Finished DoNetworking. ContainerID="012baee0b6da7ba135522962fdd4c9d126515fb6517b6389337be92947b62776" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-14" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--14-eth0" after=37.699972ms
containerd[96663]: 2023-05-26 08:17:21.328 [INFO][3561426] dataplane_linux.go 319: Finished DoNetworking. ContainerID="b0dbffc9d9450937b443b2af4624de499b984dd61e8865999aa014758efa4fa3" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-0" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--0-eth0" after=36.681502ms
containerd[96663]: 2023-05-26 08:17:21.350 [INFO][3561391] dataplane_linux.go 319: Finished DoNetworking. ContainerID="088b09c9b1164437955ae99003d08779619e619c384789d79e598b4611a14419" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-15" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--15-eth0" after=62.104734ms
containerd[96663]: 2023-05-26 08:17:21.363 [INFO][3561503] dataplane_linux.go 319: Finished DoNetworking. ContainerID="fe0358b829a1b5df4890435c712dcaf85d42d19242125a03eb287a9631729738" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-8" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--8-eth0" after=66.698698ms
containerd[96663]: 2023-05-26 08:17:21.403 [INFO][3561407] dataplane_linux.go 319: Finished DoNetworking. ContainerID="a57c54a4864d56dc032f818e1a930d0edb2152803028a1e423fcaabdd0a75026" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-3" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--3-eth0" after=112.791289ms
containerd[96663]: 2023-05-26 08:17:21.466 [INFO][3561397] dataplane_linux.go 319: Finished DoNetworking. ContainerID="f282b479f27e34a267deb5000d426c1c5d3629793ee8c9fba166608bdb27ffbe" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-5" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--5-eth0" after=176.107701ms
containerd[96663]: 2023-05-26 08:17:21.466 [INFO][3561418] dataplane_linux.go 319: Finished DoNetworking. ContainerID="884c3063eebe4c6c65f9e72171d16bb9917cb6fb3bd8a4f83e397aafc7364808" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-1" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--1-eth0" after=161.569942ms
containerd[96663]: 2023-05-26 08:17:21.466 [INFO][3561423] dataplane_linux.go 319: Finished DoNetworking. ContainerID="0e2e3426dc7c86f3b1b877f649472083b658c3f6c6bf275b586f4ab2b0d3bfe3" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-10" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--10-eth0" after=175.34209ms
containerd[96663]: 2023-05-26 08:17:21.487 [INFO][3561475] dataplane_linux.go 319: Finished DoNetworking. ContainerID="412981db970b073943b512b54a0d9afa2e4bb5f3785c720ff4189f6ad6d2ae79" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-11" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--11-eth0" after=194.903993ms
containerd[96663]: 2023-05-26 08:17:21.487 [INFO][3561564] dataplane_linux.go 319: Finished DoNetworking. ContainerID="e9a44f866e02ff04e37111ff6a054dbf0152af17df9800371769c5196593e01a" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-12" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--12-eth0" after=176.565532ms
containerd[96663]: 2023-05-26 08:17:21.499 [INFO][3561482] dataplane_linux.go 319: Finished DoNetworking. ContainerID="7981d49fa2b13f59db3f620f03fd8ea5ad0be74ec2f061c749ff652b3a55ddab" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-9" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--9-eth0" after=205.255317ms
containerd[96663]: 2023-05-26 08:17:21.510 [INFO][3561584] dataplane_linux.go 319: Finished DoNetworking. ContainerID="ab2c1925bcc04668a2e0a9bada7502836dbd749a4d4ba7ed0b0358f3cb592931" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-4" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--4-eth0" after=195.993454ms
containerd[96663]: 2023-05-26 08:17:21.511 [INFO][3561599] dataplane_linux.go 319: Finished DoNetworking. ContainerID="c6b0f91324edae2ddf1eb2c0707dafd70af1610b6231824e9392db8ec042d304" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-13" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--13-eth0" after=196.194435ms
containerd[96663]: 2023-05-26 08:17:21.511 [INFO][3561582] dataplane_linux.go 319: Finished DoNetworking. ContainerID="44669a10e9fc0679199002c8238f1bdff8badb07ada8e382937f4593eddbc40f" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-7" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--7-eth0" after=195.539217ms
containerd[96663]: 2023-05-26 08:17:21.510 [INFO][3561488] dataplane_linux.go 319: Finished DoNetworking. ContainerID="0696f7abc3dfd8bc5bf49b9da79340c4f75583963aa9d969d3ca864c314e9bcd" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-2" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--2-eth0" after=215.619387ms

after:
containerd[96663]: 2023-05-26 08:19:46.892 [INFO][3567487] dataplane_linux.go 329: Finished DoNetworking. ContainerID="ad4b02bd5449aed2b7ef2deef6a650354256d2c64ba9607a5bd415fed985fa3f" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-1" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--1-eth0" after=3.364555ms
containerd[96663]: 2023-05-26 08:19:46.891 [INFO][3567455] dataplane_linux.go 329: Finished DoNetworking. ContainerID="fec6b4b97dd736756b65401bb867d5bb87d41e3d942adb1cc78cb4ec0e767d8f" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-12" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--12-eth0" after=2.828825ms
containerd[96663]: 2023-05-26 08:19:46.896 [INFO][3567453] dataplane_linux.go 329: Finished DoNetworking. ContainerID="c6a9128552baa9432662ec91659906acbbd1b953d7cbe5bc3cbd03174f3f11d8" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-10" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--10-eth0" after=2.901649ms
containerd[96663]: 2023-05-26 08:19:46.896 [INFO][3567481] dataplane_linux.go 329: Finished DoNetworking. ContainerID="f657fef429fe22236f43d47525fcbb7cea760eaee5f96c22082d797ec3e776b0" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-14" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--14-eth0" after=2.801595ms
containerd[96663]: 2023-05-26 08:19:46.898 [INFO][3567474] dataplane_linux.go 329: Finished DoNetworking. ContainerID="2861b0219730725c4dfaf3df46ae4cb150e9135f3e66b4a6c01a97af662c7432" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-7" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--7-eth0" after=3.546685ms
containerd[96663]: 2023-05-26 08:19:46.903 [INFO][3567466] dataplane_linux.go 329: Finished DoNetworking. ContainerID="9b26ea5aaa0d9ab1a217149080f17e49de08f8a257427ce8ce0c02272b14a5e2" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-5" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--5-eth0" after=3.632012ms
containerd[96663]: 2023-05-26 08:19:46.905 [INFO][3567551] dataplane_linux.go 329: Finished DoNetworking. ContainerID="b707c9fc5b54701b500fa63bd7952313ab5f9e5a094b3e14fbd1abf763d5b373" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-8" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--8-eth0" after=4.396384ms
containerd[96663]: 2023-05-26 08:19:46.909 [INFO][3567555] dataplane_linux.go 329: Finished DoNetworking. ContainerID="13f9c76ae0358930acc7a717182525424131169702fc351a4beac5b5031d849a" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-9" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--9-eth0" after=10.664247ms
containerd[96663]: 2023-05-26 08:19:46.910 [INFO][3567558] dataplane_linux.go 329: Finished DoNetworking. ContainerID="dacfbd06537c5d4d04a5d816ed898d370cb7a8ae261d858c1e329fde52d7e248" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-3" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--3-eth0" after=15.037687ms
containerd[96663]: 2023-05-26 08:19:46.909 [INFO][3567489] dataplane_linux.go 329: Finished DoNetworking. ContainerID="95ac44e1452f52360842a709b9f26e27d7f535dcf86504f174f8c3f23abbceb0" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-0" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--0-eth0" after=9.578695ms
containerd[96663]: 2023-05-26 08:19:46.925 [INFO][3567571] dataplane_linux.go 329: Finished DoNetworking. ContainerID="b298574c727571845f1328a041558e2770827f40657ec95dd41bf9112c26f3f7" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-2" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--2-eth0" after=3.430392ms
containerd[96663]: 2023-05-26 08:19:46.928 [INFO][3567616] dataplane_linux.go 329: Finished DoNetworking. ContainerID="5a9cc927e7c3147f694046885e8549092cdaf67bb554f26343c84b0836233a06" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-13" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--13-eth0" after=5.54113ms
containerd[96663]: 2023-05-26 08:19:46.926 [INFO][3567627] dataplane_linux.go 329: Finished DoNetworking. ContainerID="942a5cf639eb7c4c69a89cfadd5d676373887738eeb72b2274a90f67595e56e8" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-11" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--11-eth0" after=3.3913ms
containerd[96663]: 2023-05-26 08:19:46.925 [INFO][3567635] dataplane_linux.go 329: Finished DoNetworking. ContainerID="58ff79bf23c1660fe108d902b76104fbc393735ee50493bf432e7f0bc9a2b32e" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-4" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--4-eth0" after=3.121123ms
containerd[96663]: 2023-05-26 08:19:46.929 [INFO][3567641] dataplane_linux.go 329: Finished DoNetworking. ContainerID="160595f65afbed835cc987fe047b6bda663c23bb2233272fa399b6822d1e2134" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-15" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--15-eth0" after=6.527635ms
containerd[96663]: 2023-05-26 08:19:46.915 [INFO][3567538] dataplane_linux.go 329: Finished DoNetworking. ContainerID="1c42a584ad1b0db0227051e0c391a0c58dc07360353d66ca2afd9790dcf09f77" Namespace="kbench-pod-namespace" Pod="job-kbench-pod-oid-0-tid-6" WorkloadEndpoint="robot--all--c462ec59--139e--405b--a5ac--94e21cf95ec1--vmss000000-k8s-job--kbench--pod--oid--0--tid--6-eth0" after=17.189862ms
```
</details>


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
