### PR TITLE
[BPF] clasiffy correctly forwarded traffic

### DIFF
--- a/felix/bpf-gpl/skb.h
+++ b/felix/bpf-gpl/skb.h
@@ -172,4 +172,6 @@ static CALI_BPF_INLINE void skb_set_mark(struct __sk_buff *skb, __u32 mark)
 	);
 }
 
+#define skb_mark_equals(skb, mask, val) (((skb)->mark & (mask)) == (val))
+
 #endif /* __SKB_H__ */

--- a/felix/bpf/ut/failsafes_test.go
+++ b/felix/bpf/ut/failsafes_test.go
@@ -91,8 +91,9 @@ var failsafeTests = []failsafeTest{
 			DstIP:    fsafeDstIP,
 			Protocol: layers.IPProtocolUDP,
 		},
-		Outbound: true,
-		Allowed:  true,
+		Outbound:      true,
+		Allowed:       true,
+		FromLocalHost: true,
 	},
 	{
 		Description: "Packets from localhost to non-failsafe IP are denied",
@@ -106,8 +107,9 @@ var failsafeTests = []failsafeTest{
 			DstIP:    net.IPv4(4, 4, 4, 4),
 			Protocol: layers.IPProtocolUDP,
 		},
-		Outbound: false,
-		Allowed:  false,
+		Outbound:      false,
+		Allowed:       false,
+		FromLocalHost: true,
 	},
 	{
 		Description: "Packets from outbound failsafes to inbound failsafes are denied",
@@ -179,8 +181,9 @@ var failsafeTests = []failsafeTest{
 		IPHeaderUDP: &layers.UDP{
 			DstPort: 161,
 		},
-		Outbound: true,
-		Allowed:  false,
+		Outbound:      true,
+		Allowed:       false,
+		FromLocalHost: true,
 	},
 }
 
@@ -213,37 +216,47 @@ func TestFailsafes(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, test := range failsafeTests {
-		_, _, _, _, pktBytes, err := testPacket(nil, test.IPHeaderIPv4, test.IPHeaderUDP, nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		prog := "calico_from_host_ep"
-		skbMark = 0
-		if test.Outbound {
-			skbMark = tcdefs.MarkSeen
-			prog = "calico_to_host_ep"
-		}
-
-		result := "TC_ACT_SHOT"
-		if test.Allowed {
-			result = "TC_ACT_UNSPEC"
-		}
-
-		runBpfTest(t, prog, test.Rules, func(bpfrun bpfProgRunFn) {
-			res, err := bpfrun(pktBytes)
+		t.Run(test.Description, func(t *testing.T) {
+			_, _, _, _, pktBytes, err := testPacket(nil, test.IPHeaderIPv4, test.IPHeaderUDP, nil)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res.RetvalStr()).To(Equal(result), fmt.Sprintf("expected program to return %s", result))
+
+			prog := "calico_from_host_ep"
+			skbMark = 0
+
+			var opts []testOption
+
+			if test.Outbound {
+				if !test.FromLocalHost {
+					skbMark = tcdefs.MarkSeen
+				} else {
+					opts = append(opts, withHostNetworked())
+				}
+				prog = "calico_to_host_ep"
+			}
+
+			result := "TC_ACT_SHOT"
+			if test.Allowed {
+				result = "TC_ACT_UNSPEC"
+			}
+
+			runBpfTest(t, prog, test.Rules, func(bpfrun bpfProgRunFn) {
+				res, err := bpfrun(pktBytes)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.RetvalStr()).To(Equal(result), fmt.Sprintf("expected program to return %s", result))
+			}, opts...)
+			if !test.Outbound && test.Allowed {
+				expectMark(tcdefs.MarkSeen)
+			}
 		})
-		if !test.Outbound && test.Allowed {
-			expectMark(tcdefs.MarkSeen)
-		}
 	}
 }
 
 type failsafeTest struct {
-	Description  string
-	Rules        *polprog.Rules
-	IPHeaderIPv4 *layers.IPv4
-	IPHeaderUDP  gopacket.Layer
-	Outbound     bool
-	Allowed      bool
+	Description   string
+	Rules         *polprog.Rules
+	IPHeaderIPv4  *layers.IPv4
+	IPHeaderUDP   gopacket.Layer
+	Outbound      bool
+	Allowed       bool
+	FromLocalHost bool
 }


### PR DESCRIPTION
Previously, anything that had source the same as the host was considered as "from host" by the policy engine and global policies with applyOnForward=false would apply to such traffic. However, for instance SNATed traffic due to nat-outgoing would be also considered "from host" eventhough it originated in a workload.

This fixes it by first looking at a SEEN mark which indicates that the packet was seen by another endpoint and thus is forwarded with the exception of packets being routed via the bpf nat iface which is used by the host processes.

fixes https://github.com/projectcalico/calico/issues/7717

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix applyOnforward=false in global policies
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
