### PR TITLE
ipam gc worker release IP resource of Evicted Failed status Pod

### DIFF
--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -911,6 +911,12 @@ func (c *ipamController) allocationIsValid(a *allocation, preferCache bool) bool
 		return true
 	}
 
+	// Pod evicted by agent like kubelet, failed forever, safe to release IP resource
+	if p.Status.Phase == v1.PodFailed && p.Status.Reason == "Evicted" {
+		logc.Debugf("Pod has failed with Evicted. Allocation no longer valid")
+		return false
+	}
+
 	// Convert the pod to a workload endpoint. This takes advantage of the IP
 	// gathering logic already implemented in the converter, and handles exceptional cases like
 	// additional WEPs attached to Multus networks.


### PR DESCRIPTION
Fix: https://github.com/projectcalico/calico/issues/7582

```release-note
Clean up IP addresses of pods with Evicted status.
```