### PR TITLE
Remove remaining node update calls in calico-node startup

### DIFF
--- a/node/filesystem/etc/rc.local
+++ b/node/filesystem/etc/rc.local
@@ -36,8 +36,10 @@ if [ -z "$CALICO_DISABLE_FELIX" ]; then
   cp -a /etc/service/available/felix /etc/service/enabled/
 fi
 
-# Monitor change in node IP addresses and subnets.
-cp -a /etc/service/available/monitor-addresses  /etc/service/enabled/
+if [ "$CALICO_NETWORKING_BACKEND" != "none" ]; then
+  # Monitor change in node IP addresses and subnets.
+  cp -a /etc/service/available/monitor-addresses  /etc/service/enabled/
+fi
 
 # Enable the allocate tunnel IP service
 cp -a /etc/service/available/allocate-tunnel-addrs  /etc/service/enabled/


### PR DESCRIPTION
## Description

Remove node update on startup if CALICO_NETWORKING_BACKEND=none. Followup to https://github.com/projectcalico/calico/pull/7550


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
