### PR TITLE
Revert GIT_DEPTH setting that now misses non-main branches

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -117,19 +117,14 @@ LOG_COLOR=False
 
 TEMPEST_BRANCH=29.1.0
 
-# We commonly hit GnuTLS errors when git cloning OpenStack repos, for example:
+# We clone from GitHub because we commonly used to hit GnuTLS errors when git cloning OpenStack
+# repos from opendev.org (which is the default server), for example:
+#
 # Cloning into 'devstack'...
 # remote: Enumerating objects: 28788, done.
 # remote: Counting objects: 100% (28788/28788), done.
 # remote: Compressing objects: 100% (9847/9847), done.
 # error: RPC failed; curl 56 GnuTLS recv error (-9): A TLS packet with unexpected length was received.
-#
-# https://stackoverflow.com/questions/38378914/how-to-fix-git-error-rpc-failed-curl-56-gnutls
-# suggests that this can be mitigated by reducing the depth of the git clone.
-GIT_DEPTH=1
-
-# Unfortunately we still see GnuTLS errors with the above.  Let's try cloning from GitHub instead of
-# from opendev.org.
 GIT_BASE=https://github.com
 
 EOF


### PR DESCRIPTION
(Following devstack commit b0bd5b92, which broke the git clone process when using GIT_DEPTH.)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
