### PR TITLE
add podsecurity to operator

### DIFF
--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -28,7 +28,7 @@ metadata:
   name: tigera-operator
   labels:
     name: tigera-operator
-	pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce: privileged
 EOF
 
 ${HELM} -n tigera-operator template \

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -28,6 +28,7 @@ metadata:
   name: tigera-operator
   labels:
     name: tigera-operator
+	pod-security.kubernetes.io/enforce: privileged
 EOF
 
 ${HELM} -n tigera-operator template \

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: tigera-operator
   labels:
     name: tigera-operator
+    pod-security.kubernetes.io/enforce: privileged
 ---
 # Source: crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -4,7 +4,6 @@ metadata:
   name: tigera-operator
   labels:
     name: tigera-operator
-    pod-security.kubernetes.io/enforce: privileged
 ---
 # Source: crds/calico/crd.projectcalico.org_bgpconfigurations.yaml
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
## Description
this allows the operator to work correctly with kubernetes clusters v1.25+ which have pod-security enabled by default (like TalOS)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add pod security standard annotation to the tigera-operator namespace for Kubernetes 1.25+
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
