### PR TITLE
Add fossa scan to release branches and master

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -109,7 +109,7 @@ blocks:
   task:
     prologue:
       commands:
-      - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
+      - "curl -fsSLH 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
     jobs:
     - name: "FOSSA scan"
       commands:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -100,6 +100,23 @@ blocks:
       commands:
       - make ci-preflight-checks
 
+- name: "FOSSA scan"
+  run:
+    when: "branch =~ '^release-v' OR branch = 'master'"
+  execution_time_limit:
+    minutes: 30
+  dependencies: ["Prerequisites"]
+  task:
+    prologue:
+      commands:
+      - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
+    jobs:
+    - name: "FOSSA scan"
+      commands:
+      - "fossa analyze"
+    secrets:
+      - name: foss-api-key
+
 - name: "API"
   run:
     when: "true or change_in(['/*', '/api/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -100,6 +100,23 @@ blocks:
       commands:
       - make ci-preflight-checks
 
+- name: "FOSSA scan"
+  run:
+    when: "branch =~ '^release-v' OR branch = 'master'"
+  execution_time_limit:
+    minutes: 30
+  dependencies: ["Prerequisites"]
+  task:
+    prologue:
+      commands:
+      - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
+    jobs:
+    - name: "FOSSA scan"
+      commands:
+      - "fossa analyze"
+    secrets:
+      - name: foss-api-key
+
 - name: "API"
   run:
     when: "false or change_in(['/*', '/api/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -109,7 +109,7 @@ blocks:
   task:
     prologue:
       commands:
-      - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
+      - "curl -fsSLH 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
     jobs:
     - name: "FOSSA scan"
       commands:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -107,7 +107,7 @@ blocks:
   task:
     prologue:
       commands:
-      - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
+      - "curl-fsSLH 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
     jobs:
     - name: "FOSSA scan"
       commands:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -98,6 +98,23 @@ blocks:
       commands:
       - make ci-preflight-checks
 
+- name: "FOSSA scan"
+  run:
+    when: "branch =~ '^release-v' OR branch = 'master'"
+  execution_time_limit:
+    minutes: 30
+  dependencies: ["Prerequisites"]
+  task:
+    prologue:
+      commands:
+      - "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
+    jobs:
+    - name: "FOSSA scan"
+      commands:
+      - "fossa analyze"
+    secrets:
+      - name: foss-api-key
+
 - name: "API"
   run:
     when: "${FORCE_RUN} or change_in(['/*', '/api/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -107,7 +107,7 @@ blocks:
   task:
     prologue:
       commands:
-      - "curl-fsSLH 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
+      - "curl -fsSLH 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash"
     jobs:
     - name: "FOSSA scan"
       commands:


### PR DESCRIPTION
## Description
Adds FOSSA scanning to `release-v*` and `master` branches.

Run demonstrating correct operation of the new job (with hacked `when`):
https://tigera.semaphoreci.com/workflows/bd3f97a6-472b-4b4d-9617-244c80de5015?pipeline_id=287f6e24-ce7c-421c-bba3-03d0ed304e16

Run demonstrating skipping of new job for PRs (with correct `when`):
https://tigera.semaphoreci.com/workflows/d0a243ce-1367-4e4c-b5dd-6c4eba2fd8fb?pipeline_id=ecaf81ca-3e48-480f-99eb-69f01be902e4

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Not applicable
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
