### PR TITLE
Update versions and manifests for v3.26.1

### DIFF
--- a/charts/calico/values.yaml
+++ b/charts/calico/values.yaml
@@ -1,5 +1,5 @@
 # The Calico version to use when generating manifests.
-version: v3.26.0
+version: v3.26.1
 
 # Configure the images to use when generating manifests.
 node:
@@ -25,11 +25,11 @@ csi-driver:
 # Some defaults used in the templates.
 includeCRDs: true
 imagePullPolicy: IfNotPresent
-mtu: "1440"
-ipam: "calico-ipam"
+mtu: '1440'
+ipam: calico-ipam
 etcd:
-  endpoints: "http://<ETCD_IP>:<ETCD_PORT>"
+  endpoints: http://<ETCD_IP>:<ETCD_PORT>
   tls:
-    crt: null
-    ca: null
-    key: null
+    crt:
+    ca:
+    key:

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -2,7 +2,7 @@ imagePullSecrets: {}
 
 installation:
   enabled: true
-  kubernetesProvider: ""
+  kubernetesProvider: ''
 
 apiServer:
   enabled: true
@@ -45,4 +45,4 @@ tigeraOperator:
   registry: quay.io
 calicoctl:
   image: docker.io/calico/ctl
-  tag: v3.26.0
+  tag: v3.26.1

--- a/hack/release/update_versions.py
+++ b/hack/release/update_versions.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+from types import SimpleNamespace
+
+from ruamel.yaml import YAML
+
+yaml = YAML()
+
+from rich import print
+
+# ====
+
+CHARTS = [
+    "charts/calico/values.yaml",
+    "charts/tigera-operator/values.yaml"
+]
+
+def get_git_root():
+    return subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).strip().decode()
+
+def get_git_describe():
+    result = subprocess.check_output(['git', 'describe', '--tags', '--long']).strip().decode()
+    describe = result.split("-")
+    version, commits, abbr = describe
+
+    d = SimpleNamespace(version=version, commits=int(commits), abbr=abbr, commit=abbr.strip("g"))
+    return d
+
+def parse_version(version):
+    return [int(ver) for ver in version.strip("v").split(".")]
+
+def unparse_version(version):
+    return f"v{version[0]}.{version[1]}.{version[2]}"
+
+def bump_version_string(version_string):
+    version = parse_version(version_string)
+    version[2] += 1
+    new_version_string = unparse_version(version)
+    return new_version_string
+
+def get_should_version(describe):
+    if describe.commits == 0:
+        return describe.version
+    else:
+        return bump_version_string(describe.version)
+
+os.chdir(get_git_root())
+
+def update_calico_chart(chart_file_path):
+    with open(chart_file_path) as values_file:
+        input_values = yaml.load(values_file)
+
+    describe = get_git_describe()
+    old_version = input_values['version']
+    tag_version = describe.version
+
+    should_version = get_should_version(describe)
+
+    print(f"{should_version=} {old_version=} {tag_version=}")
+
+    if should_version != old_version:
+        print(input_values)
+        input_values['version'] = should_version
+        print(input_values)
+    
+    with open(chart_file_path, "w") as output_yaml:
+        yaml.dump(input_values, output_yaml)
+
+def update_operator_chart(chart_file_path):
+    with open(chart_file_path) as values_file:
+        input_values = yaml.load(values_file)
+
+    describe = get_git_describe()
+    old_version = input_values['calicoctl']['tag']
+    tag_version = describe.version
+
+    should_version = get_should_version(describe)
+
+    print(f"{should_version=} {old_version=} {tag_version=}")
+
+    if should_version != old_version:
+        print(input_values)
+        input_values['calicoctl']['tag'] = should_version
+        print(input_values)
+    
+    with open(chart_file_path, "w") as output_yaml:
+        yaml.dump(input_values, output_yaml)
+
+update_calico_chart("charts/calico/values.yaml")
+update_operator_chart("charts/tigera-operator/values.yaml")

--- a/manifests/alp/istio-inject-configmap-1.1.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.0.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.1.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.10.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.11.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.11.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.12.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.12.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.13.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.13.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.14.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.14.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.15.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.16.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.16.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.17.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.17.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.2.yaml
@@ -178,7 +178,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.3.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.4.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.5.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.6.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.7.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.8.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.1.9.yaml
@@ -180,7 +180,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.10.yaml
+++ b/manifests/alp/istio-inject-configmap-1.10.yaml
@@ -433,7 +433,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:v3.26.0
+            image: calico/dikastes:v3.26.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -720,7 +720,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:v3.26.0
+            image: calico/dikastes:v3.26.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.15.yaml
+++ b/manifests/alp/istio-inject-configmap-1.15.yaml
@@ -434,7 +434,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:v3.26.0
+            image: calico/dikastes:v3.26.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -719,7 +719,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:v3.26.0
+            image: calico/dikastes:v3.26.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.0.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.1.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.2.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.3.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.4.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.5.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.6.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.7.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.8.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.8.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.2.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.2.9.yaml
@@ -301,7 +301,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.0.yaml
@@ -327,7 +327,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.1.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.2.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.3.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.3.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.4.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.4.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.3.5.yaml
+++ b/manifests/alp/istio-inject-configmap-1.3.5.yaml
@@ -333,7 +333,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.0.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.0.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.1.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.1.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.4.2.yaml
+++ b/manifests/alp/istio-inject-configmap-1.4.2.yaml
@@ -351,7 +351,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.6.yaml
+++ b/manifests/alp/istio-inject-configmap-1.6.yaml
@@ -363,7 +363,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.7.yaml
+++ b/manifests/alp/istio-inject-configmap-1.7.yaml
@@ -369,7 +369,7 @@ data:
         - mountPath: /var/run/dikastes
           name: dikastes-sock
       - name: dikastes
-        image: calico/dikastes:v3.26.0
+        image: calico/dikastes:v3.26.1
         args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/alp/istio-inject-configmap-1.9.yaml
+++ b/manifests/alp/istio-inject-configmap-1.9.yaml
@@ -428,7 +428,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:v3.26.0
+            image: calico/dikastes:v3.26.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false
@@ -714,7 +714,7 @@ data:
               name: dikastes-sock
 
           - name: dikastes
-            image: calico/dikastes:v3.26.0
+            image: calico/dikastes:v3.26.1
             args: ["server", "-l", "/var/run/dikastes/dikastes.sock", "-d", "/var/run/felix/nodeagent/socket"]
             securityContext:
               allowPrivilegeEscalation: false

--- a/manifests/apiserver.yaml
+++ b/manifests/apiserver.yaml
@@ -77,7 +77,7 @@ spec:
         env:
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: calico/apiserver:v3.26.0
+        image: calico/apiserver:v3.26.1
         livenessProbe:
           httpGet:
             path: /version

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -4644,7 +4644,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4683,7 +4683,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4737,7 +4737,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4763,7 +4763,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4994,7 +4994,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -302,7 +302,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -348,7 +348,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -374,7 +374,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -614,7 +614,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # The location of the etcd cluster.

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -4625,7 +4625,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4662,7 +4662,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4688,7 +4688,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4876,7 +4876,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -4960,7 +4960,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: docker.io/calico/typha:v3.26.0
+      - image: docker.io/calico/typha:v3.26.1
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -4675,7 +4675,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4703,7 +4703,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4746,7 +4746,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4772,7 +4772,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4995,7 +4995,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.
@@ -5079,7 +5079,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: docker.io/calico/typha:v3.26.0
+      - image: docker.io/calico/typha:v3.26.1
         imagePullPolicy: IfNotPresent
         name: calico-typha
         ports:

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -4639,7 +4639,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4667,7 +4667,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4710,7 +4710,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4736,7 +4736,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4951,7 +4951,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/manifests/calico-windows-bgp.yaml
+++ b/manifests/calico-windows-bgp.yaml
@@ -60,7 +60,7 @@ spec:
           operator: Exists
       initContainers:
       - name: install
-        image: calico/windows:v3.26.0
+        image: calico/windows:v3.26.1
         args:
           - ".\\host-process-install.ps1"
         imagePullPolicy: Always
@@ -76,7 +76,7 @@ spec:
               fieldPath: spec.nodeName
       containers:
       - name: node
-        image: calico/windows:v3.26.0
+        image: calico/windows:v3.26.1
         imagePullPolicy: Always
         args:
           - ".\\node\\node-service.ps1"
@@ -94,7 +94,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: felix
-        image: calico/windows:v3.26.0
+        image: calico/windows:v3.26.1
         imagePullPolicy: Always
         args:
         - ".\\felix\\felix-service.ps1"
@@ -128,7 +128,7 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 10
       - name: confd
-        image: calico/windows:v3.26.0
+        image: calico/windows:v3.26.1
         imagePullPolicy: Always
         args:
           - ".\\confd\\confd-service.ps1"

--- a/manifests/calico-windows-vxlan.yaml
+++ b/manifests/calico-windows-vxlan.yaml
@@ -60,7 +60,7 @@ spec:
           operator: Exists
       initContainers:
       - name: install
-        image: calico/windows:v3.26.0
+        image: calico/windows:v3.26.1
         args:
           - ".\\host-process-install.ps1"
         imagePullPolicy: Always
@@ -76,7 +76,7 @@ spec:
               fieldPath: spec.nodeName
       containers:
       - name: node
-        image: calico/windows:v3.26.0
+        image: calico/windows:v3.26.1
         imagePullPolicy: Always
         args:
           - ".\\node\\node-service.ps1"
@@ -94,7 +94,7 @@ spec:
               apiVersion: v1
               fieldPath: spec.nodeName
       - name: felix
-        image: calico/windows:v3.26.0
+        image: calico/windows:v3.26.1
         imagePullPolicy: Always
         args:
         - ".\\felix\\felix-service.ps1"

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -4639,7 +4639,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4667,7 +4667,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4710,7 +4710,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4736,7 +4736,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4953,7 +4953,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/manifests/calicoctl-etcd.yaml
+++ b/manifests/calicoctl-etcd.yaml
@@ -1,7 +1,7 @@
 # Calico Version master
 # https://projectcalico.docs.tigera.io/releases#master
 # This manifest includes the following component versions:
-#   calico/ctl:v3.26.0
+#   calico/ctl:v3.26.1
 
 apiVersion: v1
 kind: Pod
@@ -14,7 +14,7 @@ spec:
   hostNetwork: true
   containers:
   - name: calicoctl
-    image: calico/ctl:v3.26.0
+    image: calico/ctl:v3.26.1
     command:
       - /calicoctl
     args:

--- a/manifests/calicoctl.yaml
+++ b/manifests/calicoctl.yaml
@@ -1,7 +1,7 @@
 # Calico Version master
 # https://projectcalico.docs.tigera.io/releases#master
 # This manifest includes the following component versions:
-#   calico/ctl:v3.26.0
+#   calico/ctl:v3.26.1
 
 apiVersion: v1
 kind: ServiceAccount
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: calicoctl
   containers:
   - name: calicoctl
-    image: calico/ctl:v3.26.0
+    image: calico/ctl:v3.26.1
     command:
       - /calicoctl
     args:

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -382,7 +382,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -452,7 +452,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -478,7 +478,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -774,7 +774,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # The location of the etcd cluster.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4648,7 +4648,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4697,7 +4697,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4723,7 +4723,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4951,7 +4951,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/manifests/csi-driver.yaml
+++ b/manifests/csi-driver.yaml
@@ -50,7 +50,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: calico-csi
-        image: calico/csi:v3.26.0
+        image: calico/csi:v3.26.1
         imagePullPolicy: IfNotPresent
         args:
         - --nodeid=$(KUBE_NODE_NAME)
@@ -75,7 +75,7 @@ spec:
           mountPath: /var/lib/kubelet/
           mountPropagation: "Bidirectional"
       - name: csi-node-driver-registrar
-        image: calico/node-driver-registrar:v3.26.0
+        image: calico/node-driver-registrar:v3.26.1
         imagePullPolicy: IfNotPresent
         args:
         - --v=5

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -4641,7 +4641,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
@@ -4669,7 +4669,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.26.0
+          image: docker.io/calico/cni:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4712,7 +4712,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4738,7 +4738,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.26.0
+          image: docker.io/calico/node:v3.26.1
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -4953,7 +4953,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.26.0
+          image: docker.io/calico/kube-controllers:v3.26.1
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/manifests/ocp/02-tigera-operator.yaml
+++ b/manifests/ocp/02-tigera-operator.yaml
@@ -66,7 +66,7 @@ spec:
             name: install-resources-script
       initContainers:
         - name: create-initial-resources
-          image: docker.io/calico/ctl:v3.26.0
+          image: docker.io/calico/ctl:v3.26.1
           env:
             - name: DATASTORE_TYPE
               value: kubernetes


### PR DESCRIPTION
This update does the following:

* Updates version values in `charts/calico/values.yaml` and `charts/tigera-operator/values.yaml`
* Regenerate manifests from these versions

This update is meant to test whether there are any issues in the build/test process or workflow that depends on these values remaining unchanged until just before release.