### PR TITLE
Fix node-driver-registrar build

### DIFF
--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -63,11 +63,11 @@ endif
 
 .PHONY: build-all
 ## Build the binaries for all architectures and platforms
-build-all: $(addprefix $(BINDIR)/flexvol-,$(VALIDARCHES)) $(addprefix $(BINDIR)/csi-driver-,$(VALIDARCHES)) $(addprefix $(BINDIR)/node-driver-registrar-,$(VALIDARCHES))
+build-all: $(addprefix bin/flexvol-,$(VALIDARCHES)) $(addprefix $(BINDIR)/csi-driver-,$(VALIDARCHES)) $(addprefix $(BINDIR)/node-driver-registrar-,$(VALIDARCHES))
 
 .PHONY: build
 ## Build the binary for the current architecture and platform
-build: $(BINDIR)/node-driver-registrar-$(ARCH) $(BINDIR)/flexvol-$(ARCH) $(BINDIR)/csi-driver-$(ARCH)
+build: $(BINDIR)/node-driver-registrar-$(ARCH) bin/flexvol-$(ARCH) $(BINDIR)/csi-driver-$(ARCH)
 
 # We need CGO to leverage Boring SSL.  However, pod2daemon doesn't perform any crypto,
 # so we can disable it across the board.
@@ -90,7 +90,7 @@ $(BINDIR)/csi-driver-amd64: $(SRC_FILES)
 ifeq ($(FIPS), true)
 	$(call build_static_cgo_boring_binary, csidriver/main.go, $@)
 else
-	$(call build_binary, csidriver/main.go, $@)
+	$(call build_static_binary, csidriver/main.go, $@)
 endif
 
 UPSTREAM_REGISTRAR_PROJECT ?= kubernetes-csi/$(REGISTRAR_IMAGE)
@@ -110,12 +110,12 @@ REGISTRAR_UPSTREAM_BUILD_CMD="cd /go/src/github.com/$(UPSTREAM_REGISTRAR_PROJECT
 ifeq ($(ARCH), $(filter $(ARCH),amd64))
 # We need CGO to leverage Boring SSL.  However, the cross-compile doesn't support CGO yet.
 REGISTRAR_BUILD_CMD=$(REGISTRAR_TIGERA_BUILD_CMD)
-ifeq ($(FIPS), true)
 CGO_ENABLED=1
+ifeq ($(FIPS), true)
 TAGS=fipsstrict
 GOEXPERIMENT=boringcrypto
 else
-CGO_ENABLED=0
+GOEXPERIMENT=""
 endif
 else ifeq ($(ARCH), $(filter $(ARCH),arm64))
 CGO_ENABLED=0


### PR DESCRIPTION
## Description

For non-fips image
1. Build csi-calico as a static binary
2. enable CGO for node-driver-registrar even for non-fips build

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
