### PR TITLE
Uninstall the setuptools that is present on Semaphore nodes

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -16,6 +16,11 @@
 
 set -ex
 
+sudo pip uninstall -y setuptools
+sudo rm -rf /usr/local/lib/python3.8/dist-packages/setuptools-67.8.0.dist-info
+sudo find / -name "*setuptools*"
+sudo pip list || true
+
 #------------------------------------------------------------------------------
 # IMPORTANT - Review before use!
 #


### PR DESCRIPTION
There is loads of stuff pre-installed on a Semaphore ubuntu2004 node, including Python stuff that is:

- distribution-installed (apt-get), in /usr/...

- sudo pip installed, in /usr/local/...

- pip installed in various specific Python virtual environments.

Yesterday there was an update to that - https://docs.semaphoreci.com/reference/semaphore-changelog/ - and that has caused our OpenStack Yoga testing to fail.  Removing the pre-installed /usr/local/ setuptools brings it back to green again.
