### PR TITLE
Run yoga devstack tests

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -163,11 +163,12 @@ ls -la /opt/stack
 
 # Stack!
 sudo -u stack -H -E bash -x <<'EOF'
-
-set
 cd /opt/stack/devstack
 ./stack.sh
+EOF
 
+sudo -u stack -H -E bash -x <<'EOF'
+cd /opt/stack/devstack
 if ! ${TEMPEST:-false}; then
     if [ x${SERVICE_HOST:-$HOSTNAME} = x$HOSTNAME ]; then
         # We're not running Tempest tests, and we're on the controller node.

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -167,7 +167,7 @@ sudo -u stack -H -E bash -x <<'EOF'
 set
 set -x
 cd /opt/stack/devstack
-sed -i '/set \+o xtrace/d' stack.sh
+sed -i '/set +o xtrace/d' stack.sh
 grep xtrace stack.sh
 
 ./stack.sh || true

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -167,6 +167,10 @@ cd /opt/stack/devstack
 ./stack.sh
 EOF
 
+# We use a fresh `sudo -u stack -H -E bash ...` invocation here, because with
+# OpenStack Yoga it appears there is something in the stack.sh setup that
+# closes stdin, and that means that bash doesn't read any further commands from
+# stdin after the exit of the ./stack.sh line.
 sudo -u stack -H -E bash -x <<'EOF'
 cd /opt/stack/devstack
 if ! ${TEMPEST:-false}; then

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -167,7 +167,11 @@ sudo -u stack -H -E bash -x <<'EOF'
 set
 set -x
 cd /opt/stack/devstack
-./stack.sh
+echo =======================
+tail -30 stack.sh
+echo =======================
+
+./stack.sh || true
 echo Reached here 1
 
 set

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -165,13 +165,8 @@ ls -la /opt/stack
 sudo -u stack -H -E bash -x <<'EOF'
 
 set
-set -x
 cd /opt/stack/devstack
 ./stack.sh
-echo Reached here 1
-
-set
-pwd
 
 if ! ${TEMPEST:-false}; then
     if [ x${SERVICE_HOST:-$HOSTNAME} = x$HOSTNAME ]; then
@@ -187,7 +182,5 @@ else
     cd /opt/stack/tempest
     tox -eall -- $DEVSTACK_GATE_TEMPEST_REGEX --concurrency=$TEMPEST_CONCURRENCY
 fi
-
-echo Reached here 2
 
 EOF

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -167,7 +167,7 @@ sudo -u stack -H -E bash -x <<'EOF'
 set
 set -x
 cd /opt/stack/devstack
-sed -i '/set +o xtrace/d' stack.sh
+sed -i '/set \+o xtrace/d' stack.sh
 grep xtrace stack.sh
 
 ./stack.sh || true

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -167,12 +167,12 @@ sudo -u stack -H -E bash -x <<'EOF'
 set
 set -x
 cd /opt/stack/devstack
-echo =======================
-tail -30 stack.sh
-echo =======================
 sed -i '/set \+o xtrace/d' stack.sh
+grep xtrace stack.sh
 
 ./stack.sh || true
+set -x
+set
 echo Reached here 1
 
 set

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -170,7 +170,6 @@ cd /opt/stack/devstack
 echo =======================
 tail -30 stack.sh
 echo =======================
-sed -i '/set \+o xtrace/d' stack.sh
 
 ./stack.sh || true
 echo Reached here 1

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -167,11 +167,7 @@ sudo -u stack -H -E bash -x <<'EOF'
 set
 set -x
 cd /opt/stack/devstack
-echo =======================
-tail -30 stack.sh
-echo =======================
-
-./stack.sh || true
+./stack.sh
 echo Reached here 1
 
 set

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -170,6 +170,7 @@ cd /opt/stack/devstack
 echo =======================
 tail -30 stack.sh
 echo =======================
+sed -i '/set \+o xtrace/d' stack.sh
 
 ./stack.sh || true
 echo Reached here 1

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -167,12 +167,12 @@ sudo -u stack -H -E bash -x <<'EOF'
 set
 set -x
 cd /opt/stack/devstack
+echo =======================
+tail -30 stack.sh
+echo =======================
 sed -i '/set \+o xtrace/d' stack.sh
-grep xtrace stack.sh
 
 ./stack.sh || true
-set -x
-set
 echo Reached here 1
 
 set

--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -165,8 +165,13 @@ ls -la /opt/stack
 sudo -u stack -H -E bash -x <<'EOF'
 
 set
+set -x
 cd /opt/stack/devstack
 ./stack.sh
+echo Reached here 1
+
+set
+pwd
 
 if ! ${TEMPEST:-false}; then
     if [ x${SERVICE_HOST:-$HOSTNAME} = x$HOSTNAME ]; then
@@ -182,5 +187,7 @@ else
     cd /opt/stack/tempest
     tox -eall -- $DEVSTACK_GATE_TEMPEST_REGEX --concurrency=$TEMPEST_CONCURRENCY
 fi
+
+echo Reached here 2
 
 EOF


### PR DESCRIPTION
Since doing the work for a DevStack setup with OpenStack Yoga - #7625 - we've had a successful DevStack setup in our CI, but haven't actually been running any tests!  A quick way of seeing this is that the CI job only takes 15 minutes when it should take about 25.  Obviously it can also be seen in the logs.

This change brings back the tests by splitting a single `sudo -u stack -H -E bash -x <<'EOF'` invocation, in networking-calico/devstack/bootstrap.sh, into two: one for the setup and one for the tests.  The presumed explanation for the problem is that something in the setup was closing stdin, which meant that bash would not read further commands after the exit of the `./stack.sh` line.