### PR TITLE
Update ciphers for tls 1.2, tls 1.3 for non-fips mode

### DIFF
--- a/crypto/pkg/tls/tls.go
+++ b/crypto/pkg/tls/tls.go
@@ -20,14 +20,31 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Ciphers supported by TLS 1.2
-var tls12Ciphers = []uint16{
+// Ciphers supported by TLS 1.2 in fips mode
+var tls12CiphersFIPS = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+}
+
+// Ciphers supported by TLS 1.2
+var tls12Ciphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
 }
 
 // Ciphers supported by TLS 1.3
@@ -52,13 +69,14 @@ func NewTLSConfig(fipsMode bool) *tls.Config {
 		MaxVersion: tls.VersionTLS13,
 	}
 
-	cfg.CipherSuites = append(cfg.CipherSuites, tls12Ciphers...)
 	if fipsMode {
 		cfg.CurvePreferences = []tls.CurveID{tls.CurveP384, tls.CurveP256}
+		cfg.CipherSuites = tls12CiphersFIPS
 		// Our certificate for FIPS validation not mention validation for v1.3.
 		cfg.MaxVersion = tls.VersionTLS12
 		cfg.Renegotiation = tls.RenegotiateNever
 	} else {
+		cfg.CipherSuites = tls12Ciphers
 		cfg.CipherSuites = append(cfg.CipherSuites, tls13Ciphers...)
 	}
 	return cfg

--- a/crypto/pkg/tls/tls.go
+++ b/crypto/pkg/tls/tls.go
@@ -20,6 +20,23 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Ciphers supported by TLS 1.2
+var tls12Ciphers = []uint16{
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+}
+
+// Ciphers supported by TLS 1.3
+var tls13Ciphers = []uint16{
+	tls.TLS_AES_256_GCM_SHA384,
+	tls.TLS_CHACHA20_POLY1305_SHA256,
+	tls.TLS_AES_128_GCM_SHA256,
+}
+
 // NewTLSConfig returns a tls.Config with the recommended default settings for Calico Enterprise components.
 // Read more recommendations here in Chapter 3:
 // https://www.gsa.gov/cdnstatic/SSL_TLS_Implementation_%5BCIO_IT_Security_14-69_Rev_6%5D_04-06-2021docx.pdf
@@ -35,19 +52,14 @@ func NewTLSConfig(fipsMode bool) *tls.Config {
 		MaxVersion: tls.VersionTLS13,
 	}
 
+	cfg.CipherSuites = append(cfg.CipherSuites, tls12Ciphers...)
 	if fipsMode {
-		cfg.CipherSuites = []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-		}
 		cfg.CurvePreferences = []tls.CurveID{tls.CurveP384, tls.CurveP256}
 		// Our certificate for FIPS validation not mention validation for v1.3.
 		cfg.MaxVersion = tls.VersionTLS12
 		cfg.Renegotiation = tls.RenegotiateNever
+	} else {
+		cfg.CipherSuites = append(cfg.CipherSuites, tls13Ciphers...)
 	}
 	return cfg
 }


### PR DESCRIPTION
## Description

Now that we build separate fips and non-fips images,
1. Will support TLS 1.2, 1.3 in non-fips mode
2. Will support additional TLS 1.3 ciphers.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
