### PR TITLE
Don't let OpenStack debugging cause a flake

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -18,7 +18,7 @@ set -ex
 
 sudo pip uninstall -y setuptools
 sudo rm -rf /usr/local/lib/python3.8/dist-packages/setuptools-67.8.0.dist-info
-sudo find / -name "*setuptools*"
+sudo find / -name "*setuptools*" || true
 sudo pip list || true
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
I just saw [a CI run](https://tigera.semaphoreci.com/jobs/8faf9151-768f-49a4-8bee-08210c95c2fd) which failed like this:

```
+ sudo find / -name '*setuptools*'
...
find: ‘/proc/3645’: No such file or directory
```

which is a thing that can be caused by a short lived process at the wrong time.

This is a small correction to #7747 

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
