### PR TITLE
OpenStack packaging from release branch to testing PPA

### DIFF
--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -32,10 +32,18 @@ global_job_config:
 blocks:
   - name: 'Publish openstack packages'
     skip:
-      # Only run on master.
-      when: "branch != 'master'"
+      # Only run on branches, not PRs.
+      #
+      # This promotion is only _automatic_ for the master branch.  For other
+      # branches, it is an available promotion, but not automatic.  This makes
+      # it easy for a developer to trigger the building and publishing of
+      # release branch packages, simply by clicking the "Publish openstack
+      # packages" button in the Semaphore UI.  When building from the master
+      # branch, packages are published to the "master" PPA.  When building from
+      # any other branch, packages are published to the "testing" PPA.
+      when: "branch !~ '.+'"
     task:
       jobs:
       - name: 'packages'
         commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release/packaging release-publish; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release/packaging release-publish VERSION=$SEMAPHORE_GIT_BRANCH; fi

--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -69,17 +69,14 @@ function require_version {
     # Determine REPO_NAME.
     if [ $VERSION = master ]; then
 	: ${REPO_NAME:=master}
-	: ${CALICO_CHECKOUT:=master}
     elif [[ $VERSION =~ ^release-v ]]; then
 	: ${REPO_NAME:=testing}
-	: ${CALICO_CHECKOUT:=${VERSION}}
     elif [[ $VERSION =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-python2)?$ ]]; then
 	MAJOR=${BASH_REMATCH[1]}
 	MINOR=${BASH_REMATCH[2]}
 	PATCH=${BASH_REMATCH[3]}
 	PY2SUFFIX=${BASH_REMATCH[4]}
 	: ${REPO_NAME:=calico-${MAJOR}.${MINOR}${PY2SUFFIX}}
-	: ${CALICO_CHECKOUT:=v${MAJOR}.${MINOR}.${PATCH}${PY2SUFFIX}}
     else
 	echo "ERROR: Unhandled VERSION \"${VERSION}\""
 	exit 1
@@ -128,11 +125,11 @@ function precheck_bld_images {
 }
 
 function precheck_net_cal {
-    test -n "${CALICO_CHECKOUT}" || require_version
+    require_version
 }
 
 function precheck_felix {
-    test -n "${CALICO_CHECKOUT}" || require_version
+    require_version
 }
 
 function precheck_etcd3gw {


### PR DESCRIPTION
Also remove setting of the CALICO_CHECKOUT variable, which we no longer use because of Felix and networking-calico both living in the same monorepo as the packaging logic.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
