### PR TITLE
OpenStack packaging: support really publishing from any branch

### DIFF
--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -33,16 +33,9 @@ if "${PUBLISH:-false}"; then
     pub_steps="pub_debs pub_rpms"
 fi
 
-if [ "${SEMAPHORE_GIT_PR_NUMBER}${SEMAPHORE_GIT_BRANCH}" = master -o -z "${SEMAPHORE_GIT_BRANCH}" ]; then
-    # Normally - if not Semaphore, or if this is Semaphore running on
-    # the master branch and not for a PR - do all the steps including
-    # publication.
-    : ${STEPS:=bld_images net_cal felix etcd3gw dnsmasq nettle ${pub_steps}}
-else
-    # For Semaphore building a PR or a branch other than master, build
-    # packages but do not publish them.
-    : ${STEPS:=bld_images net_cal felix etcd3gw dnsmasq nettle}
-fi
+# We used to have some Semaphore environment-dependent logic here, but we now
+# place that in the Semaphore YAML (which is a more appropriate place for it).
+: ${STEPS:=bld_images net_cal felix etcd3gw dnsmasq nettle ${pub_steps}}
 
 function check_bin {
     which $1 > /dev/null


### PR DESCRIPTION
We now have gating for whether to run this packaging process in the Semaphore YAML - see the comment after "skip:" in .semaphore/push-images/packaging.yaml. So we don't need similar gating here, and we _do_ want this script to support publication from a release branch to the testing PPA.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
