### PR TITLE
Add test release build promotion

### DIFF
--- a/.semaphore/release/test-release-build.yml
+++ b/.semaphore/release/test-release-build.yml
@@ -1,0 +1,52 @@
+version: v1.0
+name: Test build official release
+agent:
+  machine:
+    type: e1-standard-4
+    os_image: ubuntu2004
+
+execution_time_limit:
+  minutes: 180
+
+blocks:
+  - name: "Test build official release"
+    skip:
+      # Only run on branches, not PRs.
+      when: "branch !~ '.+'"
+    task:
+      secrets:
+      - name: quay-robot-calico+semaphoreci
+      - name: docker
+      - name: oss-release-secrets
+      - name: google-service-account-for-gce
+      prologue:
+        commands:
+        # Load the github access secrets.  First fix the permissions.
+        - chmod 0600 /home/semaphore/.keys/git_ssh_rsa
+        - ssh-add /home/semaphore/.keys/git_ssh_rsa
+        # Checkout the code and unshallow it.
+        - checkout
+        - retry git fetch --unshallow
+        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+        # how much we churn docker containers during the build.  Disable it.
+        - sudo systemctl stop docker
+        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+        - sudo systemctl start docker
+        # Free up space on the build machine.
+        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
+        # Credentials for accessing gcloud, needed to create a GCP VM.
+        - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
+        - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      jobs:
+      - name: "Release on GCP VM"
+        env_vars:
+        - name: VAR_FILE
+          value: /home/semaphore/secrets/release-test.tfvars
+        commands:
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release apply; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release release; fi
+      epilogue:
+        always:
+          commands:
+          - make -C hack/release destroy

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -18,7 +18,9 @@ auto_cancel:
     when: "branch != 'master'"
 
 promotions:
-# Manual promotion for publishing a release.
+# Manual promotions for testing or publishing a release.
+- name: Test build official release
+  pipeline_file: release/test-release-build.yml
 - name: Publish official release
   pipeline_file: release/release.yml
 # Cleanup after ourselves if we are stopped-short.

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,9 @@ auto_cancel:
     when: "branch != 'master'"
 
 promotions:
-# Manual promotion for publishing a release.
+# Manual promotions for testing or publishing a release.
+- name: Test build official release
+  pipeline_file: release/test-release-build.yml
 - name: Publish official release
   pipeline_file: release/release.yml
 # Cleanup after ourselves if we are stopped-short.

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -16,7 +16,9 @@ auto_cancel:
     when: "branch != 'master'"
 
 promotions:
-# Manual promotion for publishing a release.
+# Manual promotions for testing or publishing a release.
+- name: Test build official release
+  pipeline_file: release/test-release-build.yml
 - name: Publish official release
   pipeline_file: release/release.yml
 # Cleanup after ourselves if we are stopped-short.


### PR DESCRIPTION
Add a duplicate of the existing release promotion, with the following changes:
* Do not publish the release images
* Do not publish the release tags
* Use a different name for the build VM on GCP (to avoid conflicts)

The goal is to be able to test the (nearly) full release process, in order to:
* Have a testbed for optimizing the release process itself
* Test ahead of time the release build process, in order to find issues which only occur during release builds (e.g. issues in container packaging, etc.)