### PR TITLE
Add VM timeout for releases

### DIFF
--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -45,6 +45,12 @@ resource "google_compute_instance" "vm_instance" {
       // This empty field requests an Ephemeral IP
     }
   }
+
+  scheduling {
+    max_run_duration {
+      seconds = 11400
+    }
+  }
 }
 
 resource "null_resource" "configure_vm" {

--- a/hack/release/terraform.tf
+++ b/hack/release/terraform.tf
@@ -4,11 +4,18 @@ provider "google" {
   zone    = var.google_zone
 }
 
+provider "google-beta" {
+  project = var.google_project
+  region  = var.google_region
+  zone    = var.google_zone
+}
+
 resource "tls_private_key" "ssh" {
   algorithm = "RSA"
 }
 
 resource "google_compute_instance" "vm_instance" {
+  provider     = google-beta
   name         = "${var.prefix}-calico-release-executor"
   machine_type = var.machine_type
   zone         = var.google_zone


### PR DESCRIPTION
Currently our release promotion is set to terminate after three hours. When it does so, it doesn't run `terraform destroy`, and the VM continues to exist indefinitely, preventing future release promotions for running until the VM is manually deleted.

This PR adds a three hour and ten minute timeout to the VM itself, after which Google Cloud will destroy the VM automatically. Given that semaphore's timer starts a few minutes before Google's does, this ten minute buffer should be more than enough, while also not delaying re-runs significantly.