### PR TITLE
[BPF] do not check value size in DeleteMapEntry

### DIFF
--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -360,7 +360,7 @@ func (b *PinnedMap) Iter(f IterCallback) error {
 		if action == IterDelete {
 			// The previous iteration asked us to delete its key; do that now before we check for the end of
 			// the iteration.
-			err := DeleteMapEntry(b.MapFD(), keyToDelete, valueSize)
+			err := DeleteMapEntry(b.MapFD(), keyToDelete)
 			if err != nil && !IsNotExists(err) {
 				return fmt.Errorf("failed to delete map entry: %w", err)
 			}
@@ -416,21 +416,11 @@ func (b *PinnedMap) Get(k []byte) ([]byte, error) {
 }
 
 func (b *PinnedMap) Delete(k []byte) error {
-	valueSize := b.ValueSize
-	if b.perCPU {
-		valueSize = b.ValueSize * NumPossibleCPUs()
-		log.Debugf("Set value size to %v for deleting an entry from Per-CPU map", valueSize)
-	}
-	return DeleteMapEntry(b.fd, k, valueSize)
+	return DeleteMapEntry(b.fd, k)
 }
 
 func (b *PinnedMap) DeleteIfExists(k []byte) error {
-	valueSize := b.ValueSize
-	if b.perCPU {
-		valueSize = b.ValueSize * NumPossibleCPUs()
-		log.Debugf("Set value size to %v for deleting an entry from Per-CPU map", valueSize)
-	}
-	return DeleteMapEntryIfExists(b.fd, k, valueSize)
+	return DeleteMapEntryIfExists(b.fd, k)
 }
 
 func (b *PinnedMap) updateDeltaEntries() error {

--- a/felix/bpf/maps/syscall.go
+++ b/felix/bpf/maps/syscall.go
@@ -156,10 +156,10 @@ func GetMapInfo(fd FD) (*MapInfo, error) {
 	}, nil
 }
 
-func DeleteMapEntry(mapFD FD, k []byte, valueSize int) error {
-	log.Debugf("DeleteMapEntry(%v, %v, %v)", mapFD, k, valueSize)
+func DeleteMapEntry(mapFD FD, k []byte) error {
+	log.Debugf("DeleteMapEntry(%v, %v)", mapFD, k)
 
-	err := checkMapIfDebug(mapFD, len(k), valueSize)
+	err := checkMapIfDebug(mapFD, len(k), -1)
 	if err != nil {
 		return err
 	}
@@ -173,8 +173,8 @@ func DeleteMapEntry(mapFD FD, k []byte, valueSize int) error {
 	return nil
 }
 
-func DeleteMapEntryIfExists(mapFD FD, k []byte, valueSize int) error {
-	err := DeleteMapEntry(mapFD, k, valueSize)
+func DeleteMapEntryIfExists(mapFD FD, k []byte) error {
+	err := DeleteMapEntry(mapFD, k)
 	if err == unix.ENOENT {
 		// Delete failed because entry did not exist.
 		err = nil

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1510,18 +1510,18 @@ func TestJumpMap(t *testing.T) {
 	err = maps.UpdateMapEntry(jumpMapFD, k, v)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = maps.DeleteMapEntry(jumpMapFD, k, 4)
+	err = maps.DeleteMapEntry(jumpMapFD, k)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = maps.UpdateMapEntry(jumpMapFD, k, v)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = maps.DeleteMapEntryIfExists(jumpMapFD, k, 4)
+	err = maps.DeleteMapEntryIfExists(jumpMapFD, k)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = maps.DeleteMapEntryIfExists(jumpMapFD, k, 4)
+	err = maps.DeleteMapEntryIfExists(jumpMapFD, k)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = maps.DeleteMapEntry(jumpMapFD, k, 4)
+	err = maps.DeleteMapEntry(jumpMapFD, k)
 	Expect(err).To(HaveOccurred())
 }


### PR DESCRIPTION
Passing value size is unnecessary and is incorrectly checked when debug mode is turned on as at the place of the check we do not know whether a map is per-cpu or not.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixes felix panic upon restart in debug mode when there are existing policy counters
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
