### PR TITLE
[BPF][v3.25] do not check value size in DeleteMapEntry

### DIFF
--- a/felix/bpf/bpf_syscall.go
+++ b/felix/bpf/bpf_syscall.go
@@ -299,10 +299,8 @@ func GetMapInfo(fd MapFD) (*MapInfo, error) {
 	}, nil
 }
 
-func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
-	log.Debugf("DeleteMapEntry(%v, %v, %v)", mapFD, k, valueSize)
-
-	err := checkMapIfDebug(mapFD, len(k), valueSize)
+func DeleteMapEntry(mapFD MapFD, k []byte) error {
+	err := checkMapIfDebug(mapFD, len(k), -1)
 	if err != nil {
 		return err
 	}
@@ -316,8 +314,8 @@ func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
 	return nil
 }
 
-func DeleteMapEntryIfExists(mapFD MapFD, k []byte, valueSize int) error {
-	err := DeleteMapEntry(mapFD, k, valueSize)
+func DeleteMapEntryIfExists(mapFD MapFD, k []byte) error {
+	err := DeleteMapEntry(mapFD, k)
 	if err == unix.ENOENT {
 		// Delete failed because entry did not exist.
 		err = nil

--- a/felix/bpf/bpf_syscall_stub.go
+++ b/felix/bpf/bpf_syscall_stub.go
@@ -58,11 +58,11 @@ func GetMapInfo(fd MapFD) (*MapInfo, error) {
 	panic("BPF syscall stub")
 }
 
-func DeleteMapEntry(mapFD MapFD, k []byte, valueSize int) error {
+func DeleteMapEntry(mapFD MapFD, k []byte) error {
 	panic("BPF syscall stub")
 }
 
-func DeleteMapEntryIfExists(mapFD MapFD, k []byte, valueSize int) error {
+func DeleteMapEntryIfExists(mapFD MapFD, k []byte) error {
 	panic("BPF syscall stub")
 }
 

--- a/felix/bpf/maps.go
+++ b/felix/bpf/maps.go
@@ -324,7 +324,7 @@ func (b *PinnedMap) Iter(f IterCallback) error {
 		if action == IterDelete {
 			// The previous iteration asked us to delete its key; do that now before we check for the end of
 			// the iteration.
-			err := DeleteMapEntry(b.MapFD(), keyToDelete, valueSize)
+			err := DeleteMapEntry(b.MapFD(), keyToDelete)
 			if err != nil && !IsNotExists(err) {
 				return fmt.Errorf("failed to delete map entry: %w", err)
 			}
@@ -370,12 +370,8 @@ func (b *PinnedMap) Get(k []byte) ([]byte, error) {
 }
 
 func (b *PinnedMap) Delete(k []byte) error {
-	valueSize := b.ValueSize
-	if b.perCPU {
-		valueSize = b.ValueSize * NumPossibleCPUs()
-		logrus.Debugf("Set value size to %v for deleting an entry from Per-CPU map", valueSize)
-	}
-	return DeleteMapEntry(b.fd, k, valueSize)
+	return DeleteMapEntry(b.fd, k)
+
 }
 
 func (b *PinnedMap) updateDeltaEntries() error {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -1330,18 +1330,18 @@ func TestJumpMap(t *testing.T) {
 	err = bpf.UpdateMapEntry(jumpMapFD, k, v)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = bpf.DeleteMapEntry(jumpMapFD, k, 4)
+	err = bpf.DeleteMapEntry(jumpMapFD, k)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = bpf.UpdateMapEntry(jumpMapFD, k, v)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = bpf.DeleteMapEntryIfExists(jumpMapFD, k, 4)
+	err = bpf.DeleteMapEntryIfExists(jumpMapFD, k)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = bpf.DeleteMapEntryIfExists(jumpMapFD, k, 4)
+	err = bpf.DeleteMapEntryIfExists(jumpMapFD, k)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = bpf.DeleteMapEntry(jumpMapFD, k, 4)
+	err = bpf.DeleteMapEntry(jumpMapFD, k)
 	Expect(err).To(HaveOccurred())
 }

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2115,7 +2115,7 @@ func (m *bpfEndpointManager) removePolicyProgram(jumpMapFD bpf.MapFD, ap attachP
 }
 
 func (m *bpfEndpointManager) doRemovePolicyProgram(jumpMapFD bpf.MapFD, ipFamily proto.IPVersion) error {
-	err := bpf.DeleteMapEntryIfExists(jumpMapFD, jumpPolicyKey(ipFamily), 4)
+	err := bpf.DeleteMapEntryIfExists(jumpMapFD, jumpPolicyKey(ipFamily))
 	if err != nil {
 		return fmt.Errorf("failed to update jump map: %w", err)
 	}


### PR DESCRIPTION
Passing value size is unnecessary and is incorrectly checked when debug mode is turned on as at the place of the check we do not know whether a map is per-cpu or not.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixes felix panic upon restart in debug mode when there are existing policy counters
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
