### PR TITLE
Update timeout to be per-job and not per-promotion

### DIFF
--- a/.semaphore/release/test-release-build.yml
+++ b/.semaphore/release/test-release-build.yml
@@ -5,9 +5,6 @@ agent:
     type: e1-standard-4
     os_image: ubuntu2004
 
-execution_time_limit:
-  minutes: 180
-
 blocks:
   - name: "Test build official release"
     skip:
@@ -40,6 +37,8 @@ blocks:
         - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
       jobs:
       - name: "Release on GCP VM"
+        execution_time_limit:
+          minutes: 180
         env_vars:
         - name: VAR_FILE
           value: /home/semaphore/secrets/release-test.tfvars

--- a/.semaphore/release/test-release-build.yml
+++ b/.semaphore/release/test-release-build.yml
@@ -5,6 +5,9 @@ agent:
     type: e1-standard-4
     os_image: ubuntu2004
 
+execution_time_limit:
+  minutes: 600
+
 blocks:
   - name: "Test build official release"
     skip:


### PR DESCRIPTION
The current promotion job has a tendency to time out, due to the fact that the timeout is per-promotion. Currently that means that the whole promotion, including waiting for a Semaphore executor, is timed.

Moving the timeout into the job itself will only start the timer once an executor is available and the job has started, reducing the likelihood of a timeout cancelling a job.

Testing on the test-release-build promotion first.