### PR TITLE
Fix nilpointer if CALICO_NETWORKING_BACKEND=none

### DIFF
--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -691,6 +691,11 @@ func evaluateENVBool(envVar string, defaultValue bool) bool {
 // in the environment, or is a no-op if not specified.
 // Returns true if the node object needs to be updated.
 func configureASNumber(node *libapi.Node) bool {
+	// If Calico is running in policy only mode we don't need to write BGP related
+	// details to the Node.
+	if os.Getenv("CALICO_NETWORKING_BACKEND") == "none" {
+		return false
+	}
 	// Extract the AS number from the environment
 	asStr := os.Getenv("AS")
 	if asStr != "" {


### PR DESCRIPTION
## Description

There is a nil pointer in the configureASNumber function if the networking backend is none (i.e. policy-only mode). Followup to https://github.com/projectcalico/calico/pull/7714

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
Part of https://github.com/projectcalico/calico/issues/7819

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Don't write AS number to node if running with CALICO_NETWORKING_BACKEND=none. This fixes a nil pointer exception.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.

<sub>Tobias Giese <tobias.giese@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub>