### PR TITLE
[release-v3.26] Auto pick #7550 #7821: remove node update calls in calico-node startup

### DIFF
--- a/node/filesystem/etc/rc.local
+++ b/node/filesystem/etc/rc.local
@@ -36,8 +36,10 @@ if [ -z "$CALICO_DISABLE_FELIX" ]; then
   cp -a /etc/service/available/felix /etc/service/enabled/
 fi
 
-# Monitor change in node IP addresses and subnets.
-cp -a /etc/service/available/monitor-addresses  /etc/service/enabled/
+if [ "$CALICO_NETWORKING_BACKEND" != "none" ]; then
+  # Monitor change in node IP addresses and subnets.
+  cp -a /etc/service/available/monitor-addresses  /etc/service/enabled/
+fi
 
 # Enable the allocate tunnel IP service
 cp -a /etc/service/available/allocate-tunnel-addrs  /etc/service/enabled/

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -690,6 +690,11 @@ func evaluateENVBool(envVar string, defaultValue bool) bool {
 // in the environment, or is a no-op if not specified.
 // Returns true if the node object needs to be updated.
 func configureASNumber(node *libapi.Node) bool {
+	// If Calico is running in policy only mode we don't need to write BGP related
+	// details to the Node.
+	if os.Getenv("CALICO_NETWORKING_BACKEND") == "none" {
+		return false
+	}
 	// Extract the AS number from the environment
 	asStr := os.Getenv("AS")
 	if asStr != "" {

--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -109,21 +109,24 @@ var _ = DescribeTable("Node IP detection failure cases",
 		Expect(err).NotTo(HaveOccurred())
 
 		node := libapi.Node{}
-		if rrCId != "" {
+		if networkingBackend != "none" && rrCId != "" {
 			node.Spec.BGP = &libapi.NodeBGPSpec{RouteReflectorClusterID: rrCId}
 		}
 
 		updated := configureAndCheckIPAddressSubnets(context.Background(), c, &node, &v1.Node{})
 		Expect(updated).To(Equal(expectedUpdate))
 		Expect(my_ec).To(Equal(expectedExitCode))
-		if rrCId != "" {
+		if networkingBackend != "none" && rrCId != "" {
 			Expect(node.Spec.BGP).NotTo(BeNil())
+		}
+		if networkingBackend == "none" {
+			Expect(node.Spec.BGP).To(BeNil())
 		}
 	},
 
 	Entry("startup should terminate if IP is set to none and Calico is used for networking", "bird", 1, "", false),
 	Entry("startup should NOT terminate if IP is set to none and Calico is policy-only", "none", 0, "", false),
-	Entry("startup should NOT terminate and BGPSpec shouldn't be set to nil", "none", 0, "rrClusterID", true),
+	Entry("startup should NOT terminate and BGPSpec shouldn't be set", "none", 0, "rrClusterID", false),
 )
 
 var _ = Describe("Default IPv4 pool CIDR", func() {


### PR DESCRIPTION
## Description

Cherry pick of #7714 and #7821 on release-v3.26.

Fixes https://github.com/projectcalico/calico/issues/7819

## Related issues/PRs

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
When running Calico in policy-only mode, do not write the IP annotations to the node. (@skmatti)
```

```release-note
Don't write AS number to node if running with CALICO_NETWORKING_BACKEND=none.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
