### PR TITLE
Fix startup unit test for policy only mode

### DIFF
--- a/node/pkg/lifecycle/startup/startup_test.go
+++ b/node/pkg/lifecycle/startup/startup_test.go
@@ -109,21 +109,24 @@ var _ = DescribeTable("Node IP detection failure cases",
 		Expect(err).NotTo(HaveOccurred())
 
 		node := libapi.Node{}
-		if rrCId != "" {
+		if networkingBackend != "none" && rrCId != "" {
 			node.Spec.BGP = &libapi.NodeBGPSpec{RouteReflectorClusterID: rrCId}
 		}
 
 		updated := configureAndCheckIPAddressSubnets(context.Background(), c, &node, &v1.Node{})
 		Expect(updated).To(Equal(expectedUpdate))
 		Expect(my_ec).To(Equal(expectedExitCode))
-		if rrCId != "" {
+		if networkingBackend != "none" && rrCId != "" {
 			Expect(node.Spec.BGP).NotTo(BeNil())
+		}
+		if networkingBackend == "none" {
+			Expect(node.Spec.BGP).To(BeNil())
 		}
 	},
 
 	Entry("startup should terminate if IP is set to none and Calico is used for networking", "bird", 1, "", false),
 	Entry("startup should NOT terminate if IP is set to none and Calico is policy-only", "none", 0, "", false),
-	Entry("startup should NOT terminate and BGPSpec shouldn't be set to nil", "none", 0, "rrClusterID", true),
+	Entry("startup should NOT terminate and BGPSpec shouldn't be set", "none", 0, "rrClusterID", false),
 )
 
 var _ = Describe("Default IPv4 pool CIDR", func() {


### PR DESCRIPTION
## Description

Policy only mode will no longer update the BGP spec. Thus, the unit test should be fixed as well.

## Related issues/PRs

Follow-up of https://github.com/projectcalico/calico/pull/7714
Related to https://github.com/projectcalico/calico/pull/7824

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.

<sub>Tobias Giese <tobias.giese@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub>