### PR TITLE
change calico's default cni name from k8s-pod-network to calico

### DIFF
--- a/app-policy/config/install/05-calico-jenkins.yaml
+++ b/app-policy/config/install/05-calico-jenkins.yaml
@@ -11,7 +11,7 @@ data:
   veth_mtu: "1440"
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.0",
       "plugins": [
         {

--- a/app-policy/config/install/05-calico.yaml
+++ b/app-policy/config/install/05-calico.yaml
@@ -130,7 +130,7 @@ data:
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.0",
       "plugins": [
         {

--- a/charts/calico/templates/calico-config.yaml
+++ b/charts/calico/templates/calico-config.yaml
@@ -102,7 +102,7 @@ data:
 {{- else }}
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -306,7 +306,7 @@ func isValidJSON(s string) error {
 
 func writeCNIConfig(c config) {
 	netconf := `{
-  "name": "k8s-pod-network",
+  "name": "calico",
   "cniVersion": "0.3.1",
   "plugins": [
     {

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var expectedDefaultConfig string = `{
-  "name": "k8s-pod-network",
+  "name": "calico",
   "cniVersion": "0.3.1",
   "plugins": [
     {

--- a/cni-plugin/pkg/upgrade/migrate.go
+++ b/cni-plugin/pkg/upgrade/migrate.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	ipAllocPath = "/var/lib/cni/networks/k8s-pod-network"
+	ipAllocPath = "/var/lib/cni/networks/calico"
 )
 
 var (
@@ -303,7 +303,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 		}
 
 		// Store allocation to Calico datastore.
-		handleID := utils.GetHandleID("k8s-pod-network", containerID, "")
+		handleID := utils.GetHandleID("calico", containerID, "")
 		logCtxt.Info("assigning pod IP to Calico IPAM...")
 		if err = c.IPAM().AssignIP(ctxt, ipam.AssignIPArgs{
 			IP:       *ip,

--- a/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
@@ -1146,7 +1146,7 @@ var _ = Describe("Test Pod conversion", func() {
 				Annotations: map[string]string{
 					"k8s.v1.cni.cncf.io/network-status": `
 					[{
-						"name": "k8s-pod-network",
+						"name": "calico",
 						"ips": [
 							"172.16.166.191"
 						],
@@ -1165,7 +1165,7 @@ var _ = Describe("Test Pod conversion", func() {
 
 		Expect(wep.Value.(*libapiv3.WorkloadEndpoint).Annotations).Should(HaveKeyWithValue("k8s.v1.cni.cncf.io/network-status", `
 					[{
-						"name": "k8s-pod-network",
+						"name": "calico",
 						"ips": [
 							"172.16.166.191"
 						],

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -63,7 +63,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -84,7 +84,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -72,7 +72,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -74,7 +74,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -58,7 +58,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -58,7 +58,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -65,7 +65,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -58,7 +58,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -58,7 +58,7 @@ data:
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
-      "name": "k8s-pod-network",
+      "name": "calico",
       "cniVersion": "0.3.1",
       "plugins": [
         {


### PR DESCRIPTION
## Description

change calico's default cni name from k8s-pod-network to calico
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

https://github.com/projectcalico/calico/issues/7837

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
change calico's default cni name from k8s-pod-network to calico
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
