### PR TITLE
Extract out delta-tracking logic from CachingMap

### DIFF
--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -277,7 +277,7 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 
 	// Walk the frontend bpf map that was read into memory and match it against the
 	// references build from the state
-	s.bpfSvcs.IterDataplaneCache(func(svck nat.FrontendKey, svcv nat.FrontendValue) {
+	s.bpfSvcs.IterDataplane(func(svck nat.FrontendKey, svcv nat.FrontendValue) {
 		xref, ok := svcRef[svck]
 		if !ok {
 			return
@@ -313,7 +313,7 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 		}
 		for i := 0; i < count; i++ {
 			epk := nat.NewNATBackendKey(id, uint32(i))
-			ep, ok := s.bpfEps.GetDataplaneCache(epk)
+			ep, ok := s.bpfEps.GetDataplane(epk)
 			if !ok {
 				log.Warnf("inconsistent backed map, missing ep %s", epk)
 				inconsistent = true

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -277,7 +277,7 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 
 	// Walk the frontend bpf map that was read into memory and match it against the
 	// references build from the state
-	s.bpfSvcs.IterDataplane(func(svck nat.FrontendKey, svcv nat.FrontendValue) {
+	s.bpfSvcs.Dataplane().Iter(func(svck nat.FrontendKey, svcv nat.FrontendValue) {
 		xref, ok := svcRef[svck]
 		if !ok {
 			return
@@ -313,7 +313,7 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 		}
 		for i := 0; i < count; i++ {
 			epk := nat.NewNATBackendKey(id, uint32(i))
-			ep, ok := s.bpfEps.GetDataplane(epk)
+			ep, ok := s.bpfEps.Dataplane().Get(epk)
 			if !ok {
 				log.Warnf("inconsistent backed map, missing ep %s", epk)
 				inconsistent = true
@@ -539,8 +539,8 @@ func (s *Syncer) apply(state DPSyncerState) error {
 
 	// Start with a completely empty slate (in memory).  We'll then repopulate both maps from scratch and
 	// let CachingMap calculate deltas...
-	s.bpfSvcs.DeleteAllDesired()
-	s.bpfEps.DeleteAllDesired()
+	s.bpfSvcs.Desired().DeleteAll()
+	s.bpfEps.Desired().DeleteAll()
 
 	// insert or update existing services
 	for sname, sinfo := range state.SvcMap {
@@ -772,7 +772,7 @@ func (s *Syncer) writeSvcBackend(svcID uint32, idx uint32, ep k8sp.Endpoint) err
 		return errors.Errorf("no port for endpoint %q: %s", ep, err)
 	}
 	val := nat.NewNATBackendValue(ip, uint16(tgtPort))
-	s.bpfEps.SetDesired(key, val)
+	s.bpfEps.Desired().Set(key, val)
 
 	if s.stickyEps[svcID] != nil {
 		s.stickyEps[svcID][val] = struct{}{}
@@ -837,14 +837,14 @@ func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, c
 		if log.GetLevel() >= log.DebugLevel {
 			log.Debugf("bpf map writing %s:%s", key, val)
 		}
-		s.bpfSvcs.SetDesired(key, val)
+		s.bpfSvcs.Desired().Set(key, val)
 	}
 	key, err = getSvcNATKey(svc)
 	if err != nil {
 		return err
 	}
 	val = nat.NewNATValue(svcID, nat.BlackHoleCount, uint32(0), uint32(0))
-	s.bpfSvcs.SetDesired(key, val)
+	s.bpfSvcs.Desired().Set(key, val)
 	return nil
 }
 
@@ -864,7 +864,7 @@ func (s *Syncer) writeSvc(svc k8sp.ServicePort, svcID uint32, count, local int, 
 	if log.GetLevel() >= log.DebugLevel {
 		log.Debugf("bpf map writing %s:%s", key, val)
 	}
-	s.bpfSvcs.SetDesired(key, val)
+	s.bpfSvcs.Desired().Set(key, val)
 
 	var affkey nat.FrontEndAffinityKey
 	copy(affkey[:], key.Affinitykey())

--- a/felix/cachingmap/caching_map.go
+++ b/felix/cachingmap/caching_map.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/deltatracker"
 )
 
 // DataplaneMap is an interface of the underlying map that is being cached by the
@@ -38,27 +40,20 @@ type DataplaneMap[K comparable, V comparable] interface {
 // with IterDataplaneCache and GetDataplaneCache.
 type CachingMap[K comparable, V comparable] struct {
 	// dpMap is the backing map in the dataplane
-	dpMap DataplaneMap[K, V]
-	name  string
-
-	// desiredStateOfDataplane stores the complete set of key/value pairs that we _want_ to
-	// be in the dataplane.  Calling ApplyAllChanges attempts to bring the dataplane into
-	// sync.
-	//
-	// For occupancy's sake we may want to drop this copy and instead maintain the invariant:
-	// desiredStateOfDataplane = cacheOfDataplane - pendingDeletions + pendingUpdates.
-	desiredStateOfDataplane map[K]V
-
-	cacheOfDataplane map[K]V
-	pendingUpdates   map[K]V
-	pendingDeletions map[K]V
+	dpMap        DataplaneMap[K, V]
+	name         string
+	deltaTracker *deltatracker.DeltaTracker[K, V]
+	cacheLoaded  bool
 }
 
 func New[K comparable, V comparable](name string, dpMap DataplaneMap[K, V]) *CachingMap[K, V] {
 	cm := &CachingMap[K, V]{
-		name:                    name,
-		dpMap:                   dpMap,
-		desiredStateOfDataplane: make(map[K]V),
+		name:  name,
+		dpMap: dpMap,
+		deltaTracker: deltatracker.New[K, V](deltatracker.WithValuesEqualFn[K, V](func(a, b V) bool {
+			// Since we require V to be comparable, can just use '==' here.
+			return a == b
+		})),
 	}
 	return cm
 }
@@ -67,68 +62,22 @@ func New[K comparable, V comparable](name string, dpMap DataplaneMap[K, V]) *Cac
 // GetDataplaneCache and IterDataplaneCache.
 func (c *CachingMap[K, V]) LoadCacheFromDataplane() error {
 	logrus.WithField("name", c.name).Debug("Loading cache of dataplane state.")
-	c.initCache()
 	dp, err := c.dpMap.Load()
-
 	if err != nil {
 		logrus.WithError(err).WithField("name", c.name).Warn("Failed to load cache of dataplane map")
-		c.clearCache()
 		return err
 	}
-	c.cacheOfDataplane = dp
-	logrus.WithField("name", c.name).WithField("count", len(c.cacheOfDataplane)).Info(
-		"Loaded cache from dataplane.")
-	c.recalculatePendingOperations()
+	err = c.deltaTracker.ReplaceDataplaneCacheFromIter(func(f func(k K, v V)) error {
+		for k, v := range dp {
+			f(k, v)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	c.cacheLoaded = true
 	return nil
-}
-
-func (c *CachingMap[K, V]) initCache() {
-	c.pendingUpdates = make(map[K]V)
-	c.pendingDeletions = make(map[K]V)
-}
-
-func (c *CachingMap[K, V]) clearCache() {
-	logrus.WithField("name", c.name).Debug("Clearing cache of dataplane map")
-	c.cacheOfDataplane = nil
-	c.pendingDeletions = nil
-	c.pendingUpdates = nil
-}
-
-// recalculatePendingOperations compares the dataplane cache against he desired state and adds entries to
-// pendingUpdates/pendingDeletions that would bring the dataplane into sync with the desired state.
-func (c *CachingMap[K, V]) recalculatePendingOperations() {
-	debug := logrus.GetLevel() >= logrus.DebugLevel
-
-	// Look for any discrepancies and queue up updates.
-	for k, desiredVal := range c.desiredStateOfDataplane {
-		actualVal := c.cacheOfDataplane[k]
-		if actualVal != desiredVal {
-			c.pendingUpdates[k] = desiredVal
-		}
-	}
-
-	// Scan for any dataplane keys that are not in the desired map at all and
-	// queue up deletions.
-	for k, actualVal := range c.cacheOfDataplane {
-		desiredVal, ok := c.desiredStateOfDataplane[k]
-		if debug {
-			logrus.WithFields(logrus.Fields{
-				"k":        k,
-				"v":        actualVal,
-				"expected": desiredVal,
-			}).Debug("Checking cache against desired")
-		}
-		if !ok {
-			c.pendingDeletions[k] = actualVal
-		}
-	}
-
-	logrus.WithFields(logrus.Fields{
-		"cached":         len(c.cacheOfDataplane),
-		"pendingDels":    len(c.pendingDeletions),
-		"pendingUpdates": len(c.pendingUpdates),
-		"name":           c.name,
-	}).Info("Recalculated pending operations")
 }
 
 // SetDesired sets the desired state of the given key to the given value. This is an in-memory operation,
@@ -137,22 +86,7 @@ func (c *CachingMap[K, V]) SetDesired(k K, v V) {
 	if logrus.GetLevel() >= logrus.DebugLevel {
 		logrus.WithFields(logrus.Fields{"name": c.name, "k": k, "v": v}).Debug("SetDesired")
 	}
-	c.desiredStateOfDataplane[k] = v
-	if c.cacheOfDataplane == nil {
-		logrus.Debug("SetDesired: initial sync pending.")
-		return // Initial sync is pending, we're not tracking deltas yet.
-	}
-	delete(c.pendingDeletions, k)
-
-	// Check if we think we need to update the dataplane as a result.
-	currentVal, ok := c.cacheOfDataplane[k]
-	if ok && currentVal == v {
-		// Dataplane already agrees with the new value so clear any pending update.
-		logrus.Debug("SetDesired: Key in dataplane already, ignoring.")
-		delete(c.pendingUpdates, k)
-		return
-	}
-	c.pendingUpdates[k] = v
+	c.deltaTracker.SetDesired(k, v)
 }
 
 // DeleteDesired deletes the given key from the desired state of the dataplane. This is an in-memory operation,
@@ -161,46 +95,26 @@ func (c *CachingMap[K, V]) DeleteDesired(k K) {
 	if logrus.GetLevel() >= logrus.DebugLevel {
 		logrus.WithFields(logrus.Fields{"name": c.name, "k": k}).Debug("DeleteDesired")
 	}
-	delete(c.desiredStateOfDataplane, k)
-	if c.cacheOfDataplane == nil {
-		logrus.Debug("DeleteDesired: initial sync pending.")
-		return // Initial sync is pending, we're not tracking deltas yet.
-	}
-	delete(c.pendingUpdates, k)
-
-	// Check if we need to update the dataplane.
-	currentVal, ok := c.cacheOfDataplane[k]
-	if !ok {
-		// We don't think this value is in the dataplane so clear any pending delete.
-		logrus.Debug("DeleteDesired: Key not in dataplane, ignoring.")
-		delete(c.pendingDeletions, k)
-		return
-	}
-	c.pendingDeletions[k] = currentVal
+	c.deltaTracker.DeleteDesired(k)
 }
 
 // DeleteAllDesired deletes all entries from the in-memory desired state of the map.  It doesn't actually touch
 // the dataplane.
 func (c *CachingMap[K, V]) DeleteAllDesired() {
 	logrus.WithField("name", c.name).Debug("DeleteAll")
-	for k := range c.desiredStateOfDataplane {
-		c.DeleteDesired(k)
-	}
+	c.deltaTracker.DeleteAllDesired()
 }
 
 // IterDataplaneCache iterates over the cache of the dataplane. The cache must have previously been loaded with
 // a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
 func (c *CachingMap[K, V]) IterDataplaneCache(f func(k K, v V)) {
-	for k, v := range c.cacheOfDataplane {
-		f(k, v)
-	}
+	c.deltaTracker.IterDataplane(f)
 }
 
 // GetDataplaneCache gets a single value from the cache of the dataplane. The cache must have previously been
 // loaded with a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
 func (c *CachingMap[K, V]) GetDataplaneCache(k K) (V, bool) {
-	v, ok := c.cacheOfDataplane[k]
-	return v, ok
+	return c.deltaTracker.GetDataplane(k)
 }
 
 // ApplyAllChanges attempts to bring the dataplane map into sync with the desired state.
@@ -221,13 +135,10 @@ func (c *CachingMap[K, V]) ApplyAllChanges() error {
 }
 
 func (c *CachingMap[K, V]) maybeLoadCache() error {
-	if c.cacheOfDataplane == nil {
-		err := c.LoadCacheFromDataplane()
-		if err != nil {
-			return err
-		}
+	if c.cacheLoaded {
+		return nil
 	}
-	return nil
+	return c.LoadCacheFromDataplane()
 }
 
 // ApplyUpdatesOnly applies any pending adds/updates to the dataplane map.  It doesn't delete any keys that are no
@@ -239,16 +150,15 @@ func (c *CachingMap[K, V]) ApplyUpdatesOnly() error {
 		return err
 	}
 	var errs ErrSlice
-	for k, v := range c.pendingUpdates {
+	c.deltaTracker.IterPendingUpdates(func(k K, v V) deltatracker.IterAction {
 		err := c.dpMap.Update(k, v)
 		if err != nil {
 			logrus.WithError(err).Warn("Error while updating DP map")
 			errs = append(errs, err)
-		} else {
-			delete(c.pendingUpdates, k)
-			c.cacheOfDataplane[k] = v
+			return deltatracker.IterActionNoOp
 		}
-	}
+		return deltatracker.IterActionUpdateDataplane
+	})
 	if len(errs) > 0 {
 		return errs
 	}
@@ -264,16 +174,15 @@ func (c *CachingMap[K, V]) ApplyDeletionsOnly() error {
 		return err
 	}
 	var errs ErrSlice
-	for k := range c.pendingDeletions {
+	c.deltaTracker.IterPendingDeletions(func(k K) deltatracker.IterAction {
 		err := c.dpMap.Delete(k)
 		if err != nil && !c.dpMap.ErrIsNotExists(err) {
 			logrus.WithError(err).Warn("Error while deleting from DP map")
 			errs = append(errs, err)
-		} else {
-			delete(c.pendingDeletions, k)
-			delete(c.cacheOfDataplane, k)
+			return deltatracker.IterActionNoOp
 		}
-	}
+		return deltatracker.IterActionUpdateDataplane
+	})
 	if len(errs) > 0 {
 		return errs
 	}

--- a/felix/cachingmap/caching_map.go
+++ b/felix/cachingmap/caching_map.go
@@ -37,7 +37,7 @@ type DataplaneMap[K comparable, V comparable] interface {
 //
 // CachingMap will load a cache of the dataplane state on the first call to ApplyXXX, or the cache can be loaded
 // explicitly by calling LoadCacheFromDataplane().  This allows for client code to inspect the dataplane cache
-// with IterDataplaneCache and GetDataplaneCache.
+// with IterDataplane and GetDataplane.
 type CachingMap[K comparable, V comparable] struct {
 	// dpMap is the backing map in the dataplane
 	dpMap        DataplaneMap[K, V]
@@ -50,32 +50,27 @@ func New[K comparable, V comparable](name string, dpMap DataplaneMap[K, V]) *Cac
 	cm := &CachingMap[K, V]{
 		name:  name,
 		dpMap: dpMap,
-		deltaTracker: deltatracker.New[K, V](deltatracker.WithValuesEqualFn[K, V](func(a, b V) bool {
-			// Since we require V to be comparable, can just use '==' here.
-			return a == b
-		})),
+		deltaTracker: deltatracker.New[K, V](
+			deltatracker.WithValuesEqualFn[K, V](func(a, b V) bool {
+				// Since we require V to be comparable, can just use '==' here.
+				return a == b
+			}),
+			deltatracker.WithLogCtx[K, V](logrus.WithField("bpfMap", name)),
+		),
 	}
 	return cm
 }
 
 // LoadCacheFromDataplane loads the contents of the DP map into the dataplane cache, allowing it to be queried with
-// GetDataplaneCache and IterDataplaneCache.
+// GetDataplane and IterDataplane.
 func (c *CachingMap[K, V]) LoadCacheFromDataplane() error {
-	logrus.WithField("name", c.name).Debug("Loading cache of dataplane state.")
+	logrus.WithField("name", c.name).Debug("Loading BPF map from dataplane.")
 	dp, err := c.dpMap.Load()
 	if err != nil {
 		logrus.WithError(err).WithField("name", c.name).Warn("Failed to load cache of dataplane map")
 		return err
 	}
-	err = c.deltaTracker.ReplaceDataplaneCacheFromIter(func(f func(k K, v V)) error {
-		for k, v := range dp {
-			f(k, v)
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
+	c.deltaTracker.ReplaceDataplaneCacheFromMap(dp)
 	c.cacheLoaded = true
 	return nil
 }
@@ -83,37 +78,30 @@ func (c *CachingMap[K, V]) LoadCacheFromDataplane() error {
 // SetDesired sets the desired state of the given key to the given value. This is an in-memory operation,
 // it doesn't actually touch the dataplane.
 func (c *CachingMap[K, V]) SetDesired(k K, v V) {
-	if logrus.GetLevel() >= logrus.DebugLevel {
-		logrus.WithFields(logrus.Fields{"name": c.name, "k": k, "v": v}).Debug("SetDesired")
-	}
 	c.deltaTracker.SetDesired(k, v)
 }
 
 // DeleteDesired deletes the given key from the desired state of the dataplane. This is an in-memory operation,
 // it doesn't actually touch the dataplane.
 func (c *CachingMap[K, V]) DeleteDesired(k K) {
-	if logrus.GetLevel() >= logrus.DebugLevel {
-		logrus.WithFields(logrus.Fields{"name": c.name, "k": k}).Debug("DeleteDesired")
-	}
 	c.deltaTracker.DeleteDesired(k)
 }
 
 // DeleteAllDesired deletes all entries from the in-memory desired state of the map.  It doesn't actually touch
 // the dataplane.
 func (c *CachingMap[K, V]) DeleteAllDesired() {
-	logrus.WithField("name", c.name).Debug("DeleteAll")
 	c.deltaTracker.DeleteAllDesired()
 }
 
-// IterDataplaneCache iterates over the cache of the dataplane. The cache must have previously been loaded with
+// IterDataplane iterates over the cache of the dataplane. The cache must have previously been loaded with
 // a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
-func (c *CachingMap[K, V]) IterDataplaneCache(f func(k K, v V)) {
+func (c *CachingMap[K, V]) IterDataplane(f func(k K, v V)) {
 	c.deltaTracker.IterDataplane(f)
 }
 
-// GetDataplaneCache gets a single value from the cache of the dataplane. The cache must have previously been
+// GetDataplane gets a single value from the cache of the dataplane. The cache must have previously been
 // loaded with a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
-func (c *CachingMap[K, V]) GetDataplaneCache(k K) (V, bool) {
+func (c *CachingMap[K, V]) GetDataplane(k K) (V, bool) {
 	return c.deltaTracker.GetDataplane(k)
 }
 

--- a/felix/cachingmap/caching_map_test.go
+++ b/felix/cachingmap/caching_map_test.go
@@ -57,7 +57,7 @@ func TestCachingMap_Errors(t *testing.T) {
 	Expect(mockMap.Contents).To(BeEmpty())
 
 	// Now check errors on update
-	cm.SetDesired("1, 1", "1, 2, 4, 4")
+	cm.Desired().Set("1, 1", "1, 2, 4, 4")
 	mockMap.UpdateErr = ErrFail
 	err = cm.ApplyAllChanges()
 	Expect(err).To(HaveOccurred())
@@ -72,7 +72,7 @@ func TestCachingMap_Errors(t *testing.T) {
 
 	// And delete.
 	mockMap.DeleteErr = ErrFail
-	cm.DeleteAllDesired()
+	cm.Desired().DeleteAll()
 	err = cm.ApplyAllChanges()
 	Expect(err).To(HaveOccurred())
 
@@ -102,9 +102,9 @@ func TestCachingMap_SplitUpdateAndDelete(t *testing.T) {
 		"1, 3": "1, 2, 4, 4",
 	}
 
-	cm.SetDesired("1, 1", "1, 2, 4, 3") // Same value for existing key.
-	cm.SetDesired("1, 2", "1, 2, 3, 6") // New value for existing key.
-	cm.SetDesired("1, 4", "1, 2, 3, 5") // New K/V
+	cm.Desired().Set("1, 1", "1, 2, 4, 3") // Same value for existing key.
+	cm.Desired().Set("1, 2", "1, 2, 3, 6") // New value for existing key.
+	cm.Desired().Set("1, 4", "1, 2, 3, 5") // New K/V
 	// Shouldn't do anything until we hit apply.
 	Expect(mockMap.OpCount()).To(Equal(0))
 
@@ -152,9 +152,9 @@ func TestCachingMap_ApplyAll(t *testing.T) {
 		"1, 3": "1, 2, 4, 4",
 	}
 
-	cm.SetDesired("1, 1", "1, 2, 4, 3") // Same value for existing key.
-	cm.SetDesired("1, 2", "1, 2, 3, 6") // New value for existing key.
-	cm.SetDesired("1, 4", "1, 2, 3, 5") // New K/V
+	cm.Desired().Set("1, 1", "1, 2, 4, 3") // Same value for existing key.
+	cm.Desired().Set("1, 2", "1, 2, 3, 6") // New value for existing key.
+	cm.Desired().Set("1, 4", "1, 2, 3, 5") // New K/V
 	// Shouldn't do anything until we hit apply.
 	Expect(mockMap.OpCount()).To(Equal(0))
 
@@ -178,7 +178,7 @@ func TestCachingMap_ApplyAll(t *testing.T) {
 	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount))
 
 	// Finish with a DeleteAll()
-	cm.DeleteAllDesired()
+	cm.Desired().DeleteAll()
 	Expect(mockMap.OpCount()).To(Equal(preApplyOpCount)) // No immediate change
 	err = cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
@@ -201,12 +201,12 @@ func TestCachingMap_DeleteBeforeLoad(t *testing.T) {
 		"1, 3": "1, 2, 4, 4",
 	}
 
-	cm.SetDesired("1, 1", "1, 2, 4, 3") // Same value for existing key.
-	cm.SetDesired("1, 2", "1, 2, 3, 6") // New value for existing key.
-	cm.SetDesired("1, 4", "1, 2, 3, 5") // New K/V
-	cm.DeleteDesired("1, 2")            // Changed my mind.
-	cm.DeleteDesired("1, 4")            // Changed my mind.
-	cm.DeleteDesired("1, 8")            // Delete of non-existent key is a no-op.
+	cm.Desired().Set("1, 1", "1, 2, 4, 3") // Same value for existing key.
+	cm.Desired().Set("1, 2", "1, 2, 3, 6") // New value for existing key.
+	cm.Desired().Set("1, 4", "1, 2, 3, 5") // New K/V
+	cm.Desired().Delete("1, 2")            // Changed my mind.
+	cm.Desired().Delete("1, 4")            // Changed my mind.
+	cm.Desired().Delete("1, 8")            // Delete of non-existent key is a no-op.
 	// Shouldn't do anything until we hit apply.
 	Expect(mockMap.OpCount()).To(Equal(0))
 
@@ -242,19 +242,19 @@ func TestCachingMap_PreLoad(t *testing.T) {
 	Expect(mockMap.OpCount()).To(Equal(1))
 
 	// Check we can query the cache.
-	v, ok := cm.GetDataplane("1, 1")
+	v, ok := cm.Dataplane().Get("1, 1")
 	Expect(ok).To(BeTrue())
 	Expect(v).To(Equal("1, 2, 4, 3"))
 	seenValues := make(map[string]string)
-	cm.IterDataplane(func(k string, v string) {
+	cm.Dataplane().Iter(func(k string, v string) {
 		seenValues[k] = v
 	})
 	Expect(seenValues).To(Equal(mockMap.Contents))
 
-	cm.SetDesired("1, 1", "1, 2, 4, 3") // Same value for existing key.
-	cm.SetDesired("1, 2", "1, 2, 3, 6") // New value for existing key.
-	cm.SetDesired("1, 4", "1, 2, 3, 5") // New K/V
-	cm.DeleteDesired("1, 8")            // Delete of non-existent key is a no-op.
+	cm.Desired().Set("1, 1", "1, 2, 4, 3") // Same value for existing key.
+	cm.Desired().Set("1, 2", "1, 2, 3, 6") // New value for existing key.
+	cm.Desired().Set("1, 4", "1, 2, 3, 5") // New K/V
+	cm.Desired().Delete("1, 8")            // Delete of non-existent key is a no-op.
 
 	err = cm.ApplyAllChanges()
 	Expect(err).NotTo(HaveOccurred())
@@ -291,9 +291,9 @@ func TestCachingMap_Resync(t *testing.T) {
 	Expect(mockMap.LoadCount).To(Equal(1))
 	Expect(mockMap.OpCount()).To(Equal(1))
 
-	cm.SetDesired("1, 1", "1, 2, 4, 3") // Same value for existing key.
-	cm.SetDesired("1, 2", "1, 2, 3, 6") // New value for existing key.
-	cm.SetDesired("1, 4", "1, 2, 3, 5") // New K/V
+	cm.Desired().Set("1, 1", "1, 2, 4, 3") // Same value for existing key.
+	cm.Desired().Set("1, 2", "1, 2, 3, 6") // New value for existing key.
+	cm.Desired().Set("1, 4", "1, 2, 3, 5") // New K/V
 
 	// At this point we've got some updates and a deletion queued up. Change the contents
 	// of the map:

--- a/felix/cachingmap/caching_map_test.go
+++ b/felix/cachingmap/caching_map_test.go
@@ -242,11 +242,11 @@ func TestCachingMap_PreLoad(t *testing.T) {
 	Expect(mockMap.OpCount()).To(Equal(1))
 
 	// Check we can query the cache.
-	v, ok := cm.GetDataplaneCache("1, 1")
+	v, ok := cm.GetDataplane("1, 1")
 	Expect(ok).To(BeTrue())
 	Expect(v).To(Equal("1, 2, 4, 3"))
 	seenValues := make(map[string]string)
-	cm.IterDataplaneCache(func(k string, v string) {
+	cm.IterDataplane(func(k string, v string) {
 		seenValues[k] = v
 	})
 	Expect(seenValues).To(Equal(mockMap.Contents))

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -743,7 +743,7 @@ func (m *bpfEndpointManager) updateIfaceStateMap(name string, iface *bpfInterfac
 			iface.dpState.filterIdx[hook.Ingress],
 			iface.dpState.filterIdx[hook.Egress],
 		)
-		m.ifStateMap.SetDesired(k, v)
+		m.ifStateMap.Desired().Set(k, v)
 	} else {
 		if err := m.jumpMapDelete(hook.XDP, iface.dpState.policyIdx[hook.XDP]); err != nil {
 			log.WithError(err).Warn("Policy program may leak.")
@@ -780,7 +780,7 @@ func (m *bpfEndpointManager) updateIfaceStateMap(name string, iface *bpfInterfac
 			log.WithError(err).Error("Ingress")
 		}
 
-		m.ifStateMap.DeleteDesired(k)
+		m.ifStateMap.Desired().Delete(k)
 		iface.dpState.clearJumps()
 	}
 }
@@ -1074,13 +1074,13 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
 
-	m.ifStateMap.IterDataplane(func(k ifstate.Key, v ifstate.Value) {
+	m.ifStateMap.Dataplane().Iter(func(k ifstate.Key, v ifstate.Value) {
 		ifindex := int(k.IfIndex())
 		netiface, err := m.dp.interfaceByIndex(ifindex)
 		if err != nil {
 			// "net" does not export the strings or err types :(
 			if strings.Contains(err.Error(), "no such network interface") {
-				m.ifStateMap.DeleteDesired(k)
+				m.ifStateMap.Desired().Delete(k)
 				// Device does not exist anymore so delete all associated policies we know
 				// about as we will not hear about that device again.
 				for _, fn := range []func() int{
@@ -1102,7 +1102,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 		} else if m.isDataIface(netiface.Name) || m.isWorkloadIface(netiface.Name) || m.isL3Iface(netiface.Name) {
 			// We only add iface that we still manage as configuration could have changed.
 
-			m.ifStateMap.SetDesired(k, v)
+			m.ifStateMap.Desired().Set(k, v)
 
 			m.withIface(netiface.Name, func(iface *bpfInterface) bool {
 				if netiface.Flags&net.FlagUp != 0 {
@@ -1152,7 +1152,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 			})
 		} else {
 			// We no longer manage this device
-			m.ifStateMap.DeleteDesired(k)
+			m.ifStateMap.Desired().Delete(k)
 		}
 	})
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1074,7 +1074,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 	m.ifacesLock.Lock()
 	defer m.ifacesLock.Unlock()
 
-	m.ifStateMap.IterDataplaneCache(func(k ifstate.Key, v ifstate.Value) {
+	m.ifStateMap.IterDataplane(func(k ifstate.Key, v ifstate.Value) {
 		ifindex := int(k.IfIndex())
 		netiface, err := m.dp.interfaceByIndex(ifindex)
 		if err != nil {

--- a/felix/deltatracker/delta_set.go
+++ b/felix/deltatracker/delta_set.go
@@ -21,86 +21,110 @@ package deltatracker
 // its use but(!) this is a pure in-memory datastructure; it doesn't actually
 // interact with the dataplane directly.
 //
-// The desired and dataplane sets can be updated directly via their
-// SetXXX/DeleteXXX methods and they each have a corresponding IterXXX method to
-// iterate over them.  The dataplane set has an additional
-// ReplaceDataplaneCacheFromIter, which allows for the whole contents of the
+// The desired and dataplane sets are exposed via the Desired() and Dataplane()
+// methods, which each return a similar set API featuring Set(...) Contains(...)
+// Delete(...) and Iter(...). The dataplane set view has an additional
+// ReplaceAllIter method, which allows for the whole contents of the
 // dataplane set to be replaced via an iterator; this is more efficient than
 // doing an external iteration and Set/Delete calls.
 //
 // In addition to the desired and dataplane sets, the differences between them
-// are tracked in two other sets: the "pending updates" set and the "pending
-// deletions" set "Pending updates" contains all keys that are in the "desired"
-// set but not in the dataplane set (or that have a different value in the
-// desired set vs the dataplane set). "Pending deletions" contains keys that are
-// in the dataplane set but not in the desired set.
-type SetDeltaTracker[K comparable] struct {
-	dt *DeltaTracker[K, struct{}]
-}
+// are continuously tracked in two other sets: the "pending updates" set and
+// the "pending deletions" set. "Pending updates" contains all keys that are
+// in the "desired" set but not in the dataplane set. "Pending deletions" contains
+// keys that are in the dataplane set but not in the desired set.  The
+// pending sets are exposed via the IterPendingUpdates and IterPendingDeletions
+// methods.
+type SetDeltaTracker[K comparable] DeltaTracker[K, struct{}]
 
 func NewSetDeltaTracker[K comparable]() *SetDeltaTracker[K] {
+	// Implementation: we use a map delta tracker with empty struct as keys.
 	dt := New[K, struct{}](WithValuesEqualFn[K, struct{}](func(a, b struct{}) bool {
 		return true // empty struct always equals itself.
 	}))
-	return &SetDeltaTracker[K]{dt: dt}
+	return (*SetDeltaTracker[K])(dt)
 }
 
-func (s *SetDeltaTracker[K]) AddDesired(k K) {
-	s.dt.SetDesired(k, struct{}{})
+type DesiredSetView[K comparable] DesiredView[K, struct{}]
+
+func (s *SetDeltaTracker[K]) Desired() *DesiredSetView[K] {
+	mapDT := (*DeltaTracker[K, struct{}])(s)
+	return (*DesiredSetView[K])(mapDT.Desired())
 }
 
-func (s *SetDeltaTracker[K]) ContainsDesired(k K) bool {
-	_, exists := s.dt.GetDesired(k)
+func (s *DesiredSetView[K]) Add(k K) {
+	s.asMapView().Set(k, struct{}{})
+}
+
+func (s *DesiredSetView[K]) Contains(k K) bool {
+	_, exists := s.asMapView().Get(k)
 	return exists
 }
 
-func (s *SetDeltaTracker[K]) DeleteDesired(k K) {
-	s.dt.DeleteDesired(k)
+func (s *DesiredSetView[K]) Delete(k K) {
+	s.asMapView().Delete(k)
 }
 
-func (s *SetDeltaTracker[K]) DeleteAllDesired() {
-	s.dt.DeleteAllDesired()
+func (s *DesiredSetView[K]) DeleteAll() {
+	s.asMapView().DeleteAll()
 }
 
-func (s *SetDeltaTracker[K]) IterDesired(f func(k K)) {
-	s.dt.IterDesired(func(k K, _ struct{}) {
+func (s *DesiredSetView[K]) Iter(f func(k K)) {
+	s.asMapView().Iter(func(k K, _ struct{}) {
 		f(k)
 	})
 }
 
-func (s *SetDeltaTracker[K]) ReplaceDataplaneCacheFromIter(iter func(func(k K)) error) error {
-	return s.dt.ReplaceDataplaneCacheFromIter(func(f func(k K, v struct{})) error {
+func (s *DesiredSetView[K]) asMapView() *DesiredView[K, struct{}] {
+	return (*DesiredView[K, struct{}])(s)
+}
+
+type DataplaneSetView[K comparable] DesiredView[K, struct{}]
+
+func (s *SetDeltaTracker[K]) Dataplane() *DataplaneSetView[K] {
+	mapDT := (*DeltaTracker[K, struct{}])(s)
+	return (*DataplaneSetView[K])(mapDT.Dataplane())
+}
+
+func (s *DataplaneSetView[K]) ReplaceFromIter(iter func(func(k K)) error) error {
+	return s.asMapView().ReplaceAllIter(func(f func(k K, v struct{})) error {
 		return iter(func(k K) {
 			f(k, struct{}{})
 		})
 	})
 }
 
-func (s *SetDeltaTracker[K]) AddDataplane(k K) {
-	s.dt.SetDataplane(k, struct{}{})
+func (s *DataplaneSetView[K]) Add(k K) {
+	s.asMapView().Set(k, struct{}{})
 }
 
-func (s *SetDeltaTracker[K]) DeleteDataplane(k K) {
-	s.dt.DeleteDataplane(k)
+func (s *DataplaneSetView[K]) Delete(k K) {
+	s.asMapView().Delete(k)
 }
 
-func (s *SetDeltaTracker[K]) ContainsDataplane(k K) bool {
-	_, exists := s.dt.GetDataplane(k)
+func (s *DataplaneSetView[K]) Contains(k K) bool {
+	_, exists := s.asMapView().Get(k)
 	return exists
 }
 
-func (s *SetDeltaTracker[K]) IterDataplane(f func(k K)) {
-	s.dt.IterDataplane(func(k K, v struct{}) {
+func (s *DataplaneSetView[K]) Iter(f func(k K)) {
+	s.asMapView().Iter(func(k K, v struct{}) {
 		f(k)
 	})
 }
 
+func (s *DataplaneSetView[K]) asMapView() *DataplaneView[K, struct{}] {
+	return (*DataplaneView[K, struct{}])(s)
+}
+
 func (s *SetDeltaTracker[K]) IterPendingUpdates(f func(k K) IterAction) {
-	s.dt.IterPendingUpdates(func(k K, v struct{}) IterAction {
+	mapDT := (*DeltaTracker[K, struct{}])(s)
+	mapDT.IterPendingUpdates(func(k K, v struct{}) IterAction {
 		return f(k)
 	})
 }
 
 func (s *SetDeltaTracker[K]) IterPendingDeletions(f func(k K) IterAction) {
-	s.dt.IterPendingDeletions(f)
+	mapDT := (*DeltaTracker[K, struct{}])(s)
+	mapDT.IterPendingDeletions(f)
 }

--- a/felix/deltatracker/delta_set.go
+++ b/felix/deltatracker/delta_set.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deltatracker
+
+// SetDeltaTracker (conceptually) tracks the differences between two sets
+// the "desired" set contains the members that we _want_ to be in the
+// dataplane; the "dataplane" set contains the members that we think are
+// _actually_ in the dataplane. The name "dataplane" set is intended to hint at
+// its use but(!) this is a pure in-memory datastructure; it doesn't actually
+// interact with the dataplane directly.
+//
+// The desired and dataplane sets can be updated directly via their
+// SetXXX/DeleteXXX methods and they each have a corresponding IterXXX method to
+// iterate over them.  The dataplane set has an additional
+// ReplaceDataplaneCacheFromIter, which allows for the whole contents of the
+// dataplane set to be replaced via an iterator; this is more efficient than
+// doing an external iteration and Set/Delete calls.
+//
+// In addition to the desired and dataplane sets, the differences between them
+// are tracked in two other sets: the "pending updates" set and the "pending
+// deletions" set "Pending updates" contains all keys that are in the "desired"
+// set but not in the dataplane set (or that have a different value in the
+// desired set vs the dataplane set). "Pending deletions" contains keys that are
+// in the dataplane set but not in the desired set.
+type SetDeltaTracker[K comparable] struct {
+	dt *DeltaTracker[K, struct{}]
+}
+
+func NewSetDeltaTracker[K comparable]() *SetDeltaTracker[K] {
+	dt := New[K, struct{}](WithValuesEqualFn[K, struct{}](func(a, b struct{}) bool {
+		return true // empty struct always equals itself.
+	}))
+	return &SetDeltaTracker[K]{dt: dt}
+}
+
+func (s *SetDeltaTracker[K]) AddDesired(k K) {
+	s.dt.SetDesired(k, struct{}{})
+}
+
+func (s *SetDeltaTracker[K]) ContainsDesired(k K) bool {
+	_, exists := s.dt.GetDesired(k)
+	return exists
+}
+
+func (s *SetDeltaTracker[K]) DeleteDesired(k K) {
+	s.dt.DeleteDesired(k)
+}
+
+func (s *SetDeltaTracker[K]) DeleteAllDesired() {
+	s.dt.DeleteAllDesired()
+}
+
+func (s *SetDeltaTracker[K]) IterDesired(f func(k K)) {
+	s.dt.IterDesired(func(k K, _ struct{}) {
+		f(k)
+	})
+}
+
+func (s *SetDeltaTracker[K]) ReplaceDataplaneCacheFromIter(iter func(func(k K)) error) error {
+	return s.dt.ReplaceDataplaneCacheFromIter(func(f func(k K, v struct{})) error {
+		return iter(func(k K) {
+			f(k, struct{}{})
+		})
+	})
+}
+
+func (s *SetDeltaTracker[K]) AddDataplane(k K) {
+	s.dt.SetDataplane(k, struct{}{})
+}
+
+func (s *SetDeltaTracker[K]) DeleteDataplane(k K) {
+	s.dt.DeleteDataplane(k)
+}
+
+func (s *SetDeltaTracker[K]) ContainsDataplane(k K) bool {
+	_, exists := s.dt.GetDataplane(k)
+	return exists
+}
+
+func (s *SetDeltaTracker[K]) IterDataplane(f func(k K)) {
+	s.dt.IterDataplane(func(k K, v struct{}) {
+		f(k)
+	})
+}
+
+func (s *SetDeltaTracker[K]) IterPendingUpdates(f func(k K) IterAction) {
+	s.dt.IterPendingUpdates(func(k K, v struct{}) IterAction {
+		return f(k)
+	})
+}
+
+func (s *SetDeltaTracker[K]) IterPendingDeletions(f func(k K) IterAction) {
+	s.dt.IterPendingDeletions(f)
+}

--- a/felix/deltatracker/delta_set_test.go
+++ b/felix/deltatracker/delta_set_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deltatracker
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
+)
+
+// SetDeltaTracker is a light wrapper around DeltaTracker, so we're really just
+// testing that the wrapper calls the right methods.
+
+func TestDeltaSet_DesiredSet(t *testing.T) {
+	ds := NewSetDeltaTracker[int]()
+	ds.AddDesired(1)
+	ds.AddDesired(2)
+
+	desired := set.New[int]()
+	ds.IterDesired(func(k int) {
+		if desired.Contains(k) {
+			t.Errorf("IterDesired returned duplicate key: %v", k)
+		}
+		desired.Add(k)
+	})
+
+	if !ds.ContainsDesired(1) {
+		t.Errorf("ContainsDesired(1) should be true")
+	}
+	if ds.ContainsDesired(3) {
+		t.Errorf("ContainsDesired(3) should be false")
+	}
+	ds.DeleteDesired(1)
+	if ds.ContainsDesired(1) {
+		t.Errorf("ContainsDesired(1) should be false after removing that item")
+	}
+	if !ds.ContainsDesired(2) {
+		t.Errorf("ContainsDesired(2) should be true")
+	}
+	ds.DeleteAllDesired()
+	if ds.ContainsDesired(2) {
+		t.Errorf("ContainsDesired(2) should be false after DeleteAllDesired")
+	}
+}
+
+func TestDeltaSet_DataplaneSet(t *testing.T) {
+	ds := NewSetDeltaTracker[int]()
+	ds.AddDataplane(1)
+	ds.AddDataplane(2)
+
+	dp := set.New[int]()
+	ds.IterDataplane(func(k int) {
+		if dp.Contains(k) {
+			t.Errorf("IterDataplane returned duplicate key: %v", k)
+		}
+		dp.Add(k)
+	})
+
+	if !ds.ContainsDataplane(1) {
+		t.Errorf("ContainsDataplane(1) should be true")
+	}
+	if ds.ContainsDataplane(3) {
+		t.Errorf("ContainsDataplane(3) should be false")
+	}
+	ds.DeleteDataplane(1)
+	if ds.ContainsDataplane(1) {
+		t.Errorf("ContainsDataplane(1) should be false after removing that item")
+	}
+	if !ds.ContainsDataplane(2) {
+		t.Errorf("ContainsDataplane(2) should be true")
+	}
+}
+
+func TestDeltaSet_Resync(t *testing.T) {
+	RegisterTestingT(t)
+	ds := NewSetDeltaTracker[int]()
+	ds.AddDesired(1)
+	ds.AddDesired(2)
+
+	err := ds.ReplaceDataplaneCacheFromIter(func(f func(k int)) error {
+		f(1)
+		f(3)
+		return nil
+	})
+	if err != nil {
+		t.Errorf("Unexpected error from ReplaceDataplaneCacheFromIter: %v", err)
+	}
+
+	updates := set.New[int]()
+	ds.IterPendingUpdates(func(k int) IterAction {
+		if updates.Contains(k) {
+			t.Errorf("IterPendingUpdates returned duplicate key: %v", k)
+		}
+		updates.Add(k)
+		return IterActionUpdateDataplane
+	})
+	Expect(updates).To(Equal(set.From(2)))
+
+	deletions := set.New[int]()
+	ds.IterPendingDeletions(func(k int) IterAction {
+		if deletions.Contains(k) {
+			t.Errorf("IterPendingDeletions returned duplicate key: %v", k)
+		}
+		deletions.Add(k)
+		return IterActionUpdateDataplane
+	})
+	Expect(deletions).To(Equal(set.From(3)))
+}
+
+func TestDeltaSet_ResyncError(t *testing.T) {
+	RegisterTestingT(t)
+	ds := NewSetDeltaTracker[int]()
+
+	err := ds.ReplaceDataplaneCacheFromIter(func(f func(k int)) error {
+		f(1)
+		f(3)
+		return fmt.Errorf("dummy error")
+	})
+	if err == nil {
+		t.Errorf("Missing error from ReplaceDataplaneCacheFromIter")
+	}
+}

--- a/felix/deltatracker/delta_set_test.go
+++ b/felix/deltatracker/delta_set_test.go
@@ -28,60 +28,60 @@ import (
 
 func TestDeltaSet_DesiredSet(t *testing.T) {
 	ds := NewSetDeltaTracker[int]()
-	ds.AddDesired(1)
-	ds.AddDesired(2)
+	ds.Desired().Add(1)
+	ds.Desired().Add(2)
 
 	desired := set.New[int]()
-	ds.IterDesired(func(k int) {
+	ds.Desired().Iter(func(k int) {
 		if desired.Contains(k) {
-			t.Errorf("IterDesired returned duplicate key: %v", k)
+			t.Errorf("Iter returned duplicate key: %v", k)
 		}
 		desired.Add(k)
 	})
 
-	if !ds.ContainsDesired(1) {
+	if !ds.Desired().Contains(1) {
 		t.Errorf("ContainsDesired(1) should be true")
 	}
-	if ds.ContainsDesired(3) {
+	if ds.Desired().Contains(3) {
 		t.Errorf("ContainsDesired(3) should be false")
 	}
-	ds.DeleteDesired(1)
-	if ds.ContainsDesired(1) {
+	ds.Desired().Delete(1)
+	if ds.Desired().Contains(1) {
 		t.Errorf("ContainsDesired(1) should be false after removing that item")
 	}
-	if !ds.ContainsDesired(2) {
+	if !ds.Desired().Contains(2) {
 		t.Errorf("ContainsDesired(2) should be true")
 	}
-	ds.DeleteAllDesired()
-	if ds.ContainsDesired(2) {
-		t.Errorf("ContainsDesired(2) should be false after DeleteAllDesired")
+	ds.Desired().DeleteAll()
+	if ds.Desired().Contains(2) {
+		t.Errorf("ContainsDesired(2) should be false after DeleteAll")
 	}
 }
 
 func TestDeltaSet_DataplaneSet(t *testing.T) {
 	ds := NewSetDeltaTracker[int]()
-	ds.AddDataplane(1)
-	ds.AddDataplane(2)
+	ds.Dataplane().Add(1)
+	ds.Dataplane().Add(2)
 
 	dp := set.New[int]()
-	ds.IterDataplane(func(k int) {
+	ds.Dataplane().Iter(func(k int) {
 		if dp.Contains(k) {
-			t.Errorf("IterDataplane returned duplicate key: %v", k)
+			t.Errorf("Iter returned duplicate key: %v", k)
 		}
 		dp.Add(k)
 	})
 
-	if !ds.ContainsDataplane(1) {
+	if !ds.Dataplane().Contains(1) {
 		t.Errorf("ContainsDataplane(1) should be true")
 	}
-	if ds.ContainsDataplane(3) {
+	if ds.Dataplane().Contains(3) {
 		t.Errorf("ContainsDataplane(3) should be false")
 	}
-	ds.DeleteDataplane(1)
-	if ds.ContainsDataplane(1) {
+	ds.Dataplane().Delete(1)
+	if ds.Dataplane().Contains(1) {
 		t.Errorf("ContainsDataplane(1) should be false after removing that item")
 	}
-	if !ds.ContainsDataplane(2) {
+	if !ds.Dataplane().Contains(2) {
 		t.Errorf("ContainsDataplane(2) should be true")
 	}
 }
@@ -89,16 +89,16 @@ func TestDeltaSet_DataplaneSet(t *testing.T) {
 func TestDeltaSet_Resync(t *testing.T) {
 	RegisterTestingT(t)
 	ds := NewSetDeltaTracker[int]()
-	ds.AddDesired(1)
-	ds.AddDesired(2)
+	ds.Desired().Add(1)
+	ds.Desired().Add(2)
 
-	err := ds.ReplaceDataplaneCacheFromIter(func(f func(k int)) error {
+	err := ds.Dataplane().ReplaceFromIter(func(f func(k int)) error {
 		f(1)
 		f(3)
 		return nil
 	})
 	if err != nil {
-		t.Errorf("Unexpected error from ReplaceDataplaneCacheFromIter: %v", err)
+		t.Errorf("Unexpected error from ReplaceAllIter: %v", err)
 	}
 
 	updates := set.New[int]()
@@ -126,12 +126,12 @@ func TestDeltaSet_ResyncError(t *testing.T) {
 	RegisterTestingT(t)
 	ds := NewSetDeltaTracker[int]()
 
-	err := ds.ReplaceDataplaneCacheFromIter(func(f func(k int)) error {
+	err := ds.Dataplane().ReplaceFromIter(func(f func(k int)) error {
 		f(1)
 		f(3)
 		return fmt.Errorf("dummy error")
 	})
 	if err == nil {
-		t.Errorf("Missing error from ReplaceDataplaneCacheFromIter")
+		t.Errorf("Missing error from ReplaceAllIter")
 	}
 }

--- a/felix/deltatracker/delta_tracker.go
+++ b/felix/deltatracker/delta_tracker.go
@@ -103,7 +103,7 @@ func New[K comparable, V any](opts ...Option[K, V]) *DeltaTracker[K, V] {
 }
 
 // SetDesired sets the desired state of the given key to the given value. If the value differs from what
-// the dataplane cache records as being in the dataplane, the update is added ot the pending updates set.
+// the dataplane cache records as being in the dataplane, the update is added to the pending updates set.
 // Removes the key from the pending deletions set.
 func (c *DeltaTracker[K, V]) SetDesired(k K, v V) {
 	if logrus.GetLevel() >= logrus.DebugLevel {

--- a/felix/deltatracker/delta_tracker.go
+++ b/felix/deltatracker/delta_tracker.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deltatracker
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DeltaTracker (conceptually) tracks the differences between two key/value maps
+// the "desired" map contains the KV-pairs that we _want_ to be in the
+// dataplane; the "dataplane" map contains the KV-pairs that we think are
+// _actually_ in the dataplane. The name "dataplane" map is intended to hint at
+// its use but(!) this is a pure in-memory datastructure; it doesn't actually
+// interact with the dataplane directly.
+//
+// The desired and dataplane maps can be updated directly via their
+// SetXXX/DeleteXXX methods and they each have a corresponding IterXXX method to
+// iterate over them.  The dataplane map has an additional
+// ReplaceDataplaneCacheFromIter, which allows for the whole contents of the
+// dataplane map to be replaced via an iterator; this is more efficient than
+// doing an external iteration and Set/Delete calls.
+//
+// In addition to the desired and dataplane maps, the differences between them
+// are tracked in two other maps: the "pending updates" map and the "pending
+// deletions" map "Pending updates" contains all keys that are in the "desired"
+// map but not in the dataplane map (or that have a different value in the
+// desired map vs the dataplane map). "Pending deletions" contains keys that are
+// in the dataplane map but not in the desired map.
+type DeltaTracker[K comparable, V any] struct {
+	// To reduce occupancy, we treat the set of KVs in the dataplane and in the
+	// desired state like a Venn diagram, and we only store each region once
+	// (with the caveat below[1]).
+	//
+	//   Desired        In-dataplane
+	//         ____   ____
+	//        /    \ /    \
+	//       /      X      \
+	//      /      / \      \
+	//      |   o | o |   o---- inDataplaneNotDesired
+	//      \   |  \ X      /
+	//       \  |   X \    /
+	//        \_|__/ \_\__/
+	//         /        \
+	//   desiredUpdates  inDataplaneAndDesired
+	//
+	// We can then reconstruct the desired and dataplane states as follows:
+	//
+	//    desired state             = inDataplaneAndDesired + desiredUpdates
+	//    actual state of dataplane = inDataplaneAndDesired + inDataplaneNotDesired
+	//
+	// When we're told about an update to the dataplane (for example during a resync),
+	// we may need to shuffle KVs between the different sets.
+	//
+	// [1] A key can only appear in one of the inDataplaneXXX maps at a time.
+	// However, the desiredUpdates map may contain a key that also exists in one
+	// of the other maps if and only if the value in desiredUpdates differs from
+	// that in the other map.  This means that the KV is in the dataplane, but it
+	// has the wrong value, and it needs to be updated.
+
+	inDataplaneAndDesired map[K]V
+	inDataplaneNotDesired map[K]V
+	desiredUpdates        map[K]V
+
+	// valuesEqual is the comparison function for the value type, it defaults to
+	// reflect.DeepEqual.
+	valuesEqual func(a, b V) bool
+}
+
+type Option[K comparable, V any] func(tracker *DeltaTracker[K, V])
+
+func WithValuesEqualFn[K comparable, V any](f func(a, b V) bool) Option[K, V] {
+	return func(tracker *DeltaTracker[K, V]) {
+		tracker.valuesEqual = f
+	}
+}
+
+func New[K comparable, V any](opts ...Option[K, V]) *DeltaTracker[K, V] {
+	cm := &DeltaTracker[K, V]{
+		inDataplaneAndDesired: make(map[K]V),
+		inDataplaneNotDesired: make(map[K]V),
+		desiredUpdates:        make(map[K]V),
+		valuesEqual:           func(a, b V) bool { return reflect.DeepEqual(a, b) },
+	}
+	for _, o := range opts {
+		o(cm)
+	}
+	return cm
+}
+
+// SetDesired sets the desired state of the given key to the given value. If the value differs from what
+// the dataplane cache records as being in the dataplane, the update is added ot the pending updates set.
+// Removes the key from the pending deletions set.
+func (c *DeltaTracker[K, V]) SetDesired(k K, v V) {
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		logrus.WithFields(logrus.Fields{"k": k, "v": v}).Debug("SetDesired")
+	}
+	if v, ok := c.inDataplaneNotDesired[k]; ok {
+		c.inDataplaneAndDesired[k] = v
+	}
+	delete(c.inDataplaneNotDesired, k)
+
+	// Check if we think we need to update the dataplane as a result.
+	currentVal, ok := c.inDataplaneAndDesired[k]
+	if ok && c.valuesEqual(currentVal, v) {
+		// Dataplane already agrees with the new value so clear any pending update.
+		logrus.Debug("SetDesired: Key in dataplane already, ignoring.")
+		delete(c.desiredUpdates, k)
+		return
+	}
+	c.desiredUpdates[k] = v
+}
+
+// GetDesired gets a single value from the desired map.
+func (c *DeltaTracker[K, V]) GetDesired(k K) (V, bool) {
+	if v, ok := c.desiredUpdates[k]; ok {
+		return v, ok
+	}
+	v, ok := c.inDataplaneAndDesired[k]
+	return v, ok
+}
+
+// DeleteDesired deletes the given key from the desired state of the dataplane. If the KV is in the dataplane
+// cache, it is added to the pending deletions set.  Removes the key from the pending updates set.
+func (c *DeltaTracker[K, V]) DeleteDesired(k K) {
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		logrus.WithFields(logrus.Fields{"k": k}).Debug("DeleteDesired")
+	}
+	delete(c.desiredUpdates, k)
+
+	// Check if we need to update the dataplane.
+	if currentVal, ok := c.inDataplaneAndDesired[k]; ok {
+		// Value is in dataplane, move it to pending deletions.
+		c.inDataplaneNotDesired[k] = currentVal
+		delete(c.inDataplaneAndDesired, k)
+	}
+}
+
+// DeleteAllDesired deletes all entries from the in-memory desired state, updating pending updates/deletions
+// accordingly.
+func (c *DeltaTracker[K, V]) DeleteAllDesired() {
+	logrus.Debug("DeleteAll")
+	c.IterDesired(func(k K, v V) {
+		c.DeleteDesired(k)
+	})
+}
+
+// IterDesired iterates over the desired KVs.
+func (c *DeltaTracker[K, V]) IterDesired(f func(k K, v V)) {
+	for k, v := range c.desiredUpdates {
+		f(k, v)
+	}
+	for k, v := range c.inDataplaneAndDesired {
+		if _, ok := c.desiredUpdates[k]; ok {
+			continue
+		}
+		f(k, v)
+	}
+}
+
+// ReplaceDataplaneCacheFromIter clears the dataplane cache and replaces its contents with the KVs returned
+// by the iterator.  The pending update and deletion tracking is updated accordingly.
+func (c *DeltaTracker[K, V]) ReplaceDataplaneCacheFromIter(iter func(func(k K, v V)) error) error {
+	logrus.Debug("Loading cache of dataplane state.")
+
+	// To reduce occupancy and to do the update in one pass, we use the old maps as scratch space.
+	// As we iterate over the new values, we add them to the newXXX maps and delete them from the old.
+	// Then, at the end, the oldXXX maps will contain only the values that are now missing from the
+	// dataplane, we then handle those at the bottom.
+	oldInDPDesired := c.inDataplaneAndDesired
+	newInDPDesired := make(map[K]V)
+	oldInDPNotDesired := c.inDataplaneNotDesired
+	newInDPNotDesired := make(map[K]V)
+
+	err := iter(func(k K, v V) {
+		// Figure out if we _want_ it to exist and tee up update/deletion accordingly.
+		if desiredV, desired := c.GetDesired(k); desired {
+			// Record that this key exists in the new copy of the cache.
+			newInDPDesired[k] = v
+
+			// Check if the value is correct,
+			if c.valuesEqual(desiredV, v) {
+				// Value in dataplane is correct, clean up any pending update.
+				delete(c.desiredUpdates, k)
+			} else {
+				// Value in dataplane is incorrect.  Queue up an update (if there isn't one already).
+				c.desiredUpdates[k] = desiredV
+			}
+		} else {
+			// We don't want this key, but it's in the dataplane.  Queue up deletion.
+			newInDPNotDesired[k] = v
+		}
+
+		// Remove the key from the old cache, we'll then scan the old cache to find keys that are missing.
+		delete(oldInDPDesired, k)
+		delete(oldInDPNotDesired, k)
+	})
+	if err != nil {
+		// We may have failed mid-iteration, if we just returned an error here, we'd leave our internal
+		// state broken because we've removed all the keys that we've seen from oldInDPDesired and
+		// oldInDPNotDesired, and updated c.desiredUpdates to match the new KV's from the iterator.
+		// Fix that up by applying the new keys to the old in-DP maps:
+		for k, v := range newInDPDesired {
+			oldInDPDesired[k] = v
+		}
+		for k, v := range newInDPNotDesired {
+			oldInDPNotDesired[k] = v
+		}
+		return fmt.Errorf("failed to iterate over dataplane state: %w", err)
+	}
+
+	// oldInDPDesired now only contains KVs that we _thought_ were in the dataplane but are now gone.
+	for k := range oldInDPDesired {
+		if desiredV, desired := c.GetDesired(k); desired {
+			// We want this key, but it's missing, queue up an add.
+			c.desiredUpdates[k] = desiredV
+		} // else we don't want it, and it's gone; nothing to do.
+		delete(oldInDPDesired, k)
+	}
+
+	// Now done with oldInDPDesired, replace it.
+	c.inDataplaneAndDesired = newInDPDesired
+	c.inDataplaneNotDesired = newInDPNotDesired
+	logrus.WithFields(logrus.Fields{
+		"totalNumInDP":          len(c.inDataplaneAndDesired),
+		"desiredUpdates":        len(c.desiredUpdates),
+		"inDataplaneNotDesired": len(c.inDataplaneNotDesired),
+	}).Debug("Updated dataplane state.")
+
+	return nil
+}
+
+// SetDataplane updates a key in the dataplane cache.  I.e. it tells this tracker that the dataplane
+// has the given KV.  Updated the pending update/deletion set if the new KV differs from what is
+// desired.
+func (c *DeltaTracker[K, V]) SetDataplane(k K, v V) {
+	desiredV, desired := c.GetDesired(k)
+	if desired {
+		// Dataplane key has a corresponding desired key.  Check if the values match.
+		c.inDataplaneAndDesired[k] = v
+		if !c.valuesEqual(desiredV, v) {
+			// Desired value is different, queue up an update.
+			c.desiredUpdates[k] = desiredV
+		} else {
+			delete(c.desiredUpdates, k)
+		}
+	} else {
+		// Dataplane key has no corresponding desired key, queue up a deletion.
+		c.inDataplaneNotDesired[k] = v
+	}
+}
+
+// DeleteDataplane deletes a key from the dataplane cache.  I.e. it tells this tracker that the key
+// no longer exists in the dataplane.
+func (c *DeltaTracker[K, V]) DeleteDataplane(k K) {
+	desiredV, desired := c.GetDesired(k)
+	delete(c.inDataplaneAndDesired, k)
+	delete(c.inDataplaneNotDesired, k)
+	if desired {
+		// We've now been told this KV is not in the dataplane but the desired state says it should be there.
+		c.desiredUpdates[k] = desiredV
+	}
+}
+
+// IterDataplane iterates over the cache of the dataplane.
+func (c *DeltaTracker[K, V]) IterDataplane(f func(k K, v V)) {
+	for k, v := range c.inDataplaneAndDesired {
+		f(k, v)
+	}
+	for k, v := range c.inDataplaneNotDesired {
+		f(k, v)
+	}
+}
+
+// GetDataplane gets a single value from the cache of the dataplane. The cache must have previously been
+// loaded with a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
+func (c *DeltaTracker[K, V]) GetDataplane(k K) (V, bool) {
+	v, ok := c.inDataplaneAndDesired[k]
+	if !ok {
+		v, ok = c.inDataplaneNotDesired[k]
+	}
+	return v, ok
+}
+
+type IterAction int
+
+const (
+	IterActionNoOp IterAction = iota
+	IterActionUpdateDataplane
+)
+
+// IterPendingUpdates iterates over the pending updates. If the passed in function returns
+// IterActionUpdateDataplane then the pending update is cleared, and, the KV is applied
+// to the dataplane cache (as if the function had called SetDataplane(k, v)).
+func (c *DeltaTracker[K, V]) IterPendingUpdates(f func(k K, v V) IterAction) {
+	for k, v := range c.desiredUpdates {
+		updateDataplane := f(k, v)
+		switch updateDataplane {
+		case IterActionNoOp:
+			// Ignore.
+		case IterActionUpdateDataplane:
+			delete(c.desiredUpdates, k)
+			c.inDataplaneAndDesired[k] = v
+		}
+	}
+}
+
+// IterPendingDeletions iterates over the pending deletion set. If the passed in function returns
+// IterActionUpdateDataplane then the pending deletion is cleared, and, the KV is applied
+// to the dataplane cache (as if the function had called DeleteDataplane(k)).
+func (c *DeltaTracker[K, V]) IterPendingDeletions(f func(k K) IterAction) {
+	for k := range c.inDataplaneNotDesired {
+		updateDataplane := f(k)
+		switch updateDataplane {
+		case IterActionNoOp:
+			// Ignore.
+		case IterActionUpdateDataplane:
+			delete(c.inDataplaneNotDesired, k)
+		}
+	}
+}

--- a/felix/deltatracker/delta_tracker.go
+++ b/felix/deltatracker/delta_tracker.go
@@ -28,19 +28,21 @@ import (
 // its use but(!) this is a pure in-memory datastructure; it doesn't actually
 // interact with the dataplane directly.
 //
-// The desired and dataplane maps can be updated directly via their
-// SetXXX/DeleteXXX methods and they each have a corresponding IterXXX method to
-// iterate over them.  The dataplane map has an additional
-// ReplaceDataplaneCacheFromIter, which allows for the whole contents of the
+// The desired and dataplane maps are exposed via the Desired() and Dataplane()
+// methods, which each return a similar map API featuring Set(...) Get(...)
+// Delete() and Iter(...). The dataplane map view has an additional
+// ReplaceAllIter method, which allows for the whole contents of the
 // dataplane map to be replaced via an iterator; this is more efficient than
 // doing an external iteration and Set/Delete calls.
 //
 // In addition to the desired and dataplane maps, the differences between them
-// are tracked in two other maps: the "pending updates" map and the "pending
-// deletions" map "Pending updates" contains all keys that are in the "desired"
-// map but not in the dataplane map (or that have a different value in the
-// desired map vs the dataplane map). "Pending deletions" contains keys that are
-// in the dataplane map but not in the desired map.
+// are continuously tracked in two other maps: the "pending updates" map and
+// the "pending deletions" map. "Pending updates" contains all keys that are
+// in the "desired" map but not in the dataplane map (or that have a different
+// value in the desired map vs the dataplane map). "Pending deletions" contains
+// keys that are in the dataplane map but not in the desired map.  The
+// pending maps are exposed via the IterPendingUpdates and IterPendingDeletions
+// methods.
 type DeltaTracker[K comparable, V any] struct {
 	// To reduce occupancy, we treat the set of KVs in the dataplane and in the
 	// desired state like a Venn diagram, and we only store each region once
@@ -76,6 +78,9 @@ type DeltaTracker[K comparable, V any] struct {
 	inDataplaneNotDesired map[K]V
 	desiredUpdates        map[K]V
 
+	desiredView   *DesiredView[K, V]
+	dataplaneView *DataplaneView[K, V]
+
 	// valuesEqual is the comparison function for the value type, it defaults to
 	// reflect.DeepEqual.
 	valuesEqual func(a, b V) bool
@@ -104,18 +109,26 @@ func New[K comparable, V any](opts ...Option[K, V]) *DeltaTracker[K, V] {
 		valuesEqual:           func(a, b V) bool { return reflect.DeepEqual(a, b) },
 		logCtx:                logrus.WithFields(nil),
 	}
+	cm.desiredView = (*DesiredView[K, V])(cm)
+	cm.dataplaneView = (*DataplaneView[K, V])(cm)
 	for _, o := range opts {
 		o(cm)
 	}
 	return cm
 }
 
-// SetDesired sets the desired state of the given key to the given value. If the value differs from what
+type DesiredView[K comparable, V any] DeltaTracker[K, V]
+
+func (c *DeltaTracker[K, V]) Desired() *DesiredView[K, V] {
+	return c.desiredView
+}
+
+// Set sets the desired state of the given key to the given value. If the value differs from what
 // the dataplane cache records as being in the dataplane, the update is added to the pending updates set.
 // Removes the key from the pending deletions set.
-func (c *DeltaTracker[K, V]) SetDesired(k K, v V) {
+func (c *DesiredView[K, V]) Set(k K, v V) {
 	if logrus.GetLevel() >= logrus.DebugLevel {
-		c.logCtx.WithFields(logrus.Fields{"k": k, "v": v}).Debug("SetDesired")
+		c.logCtx.WithFields(logrus.Fields{"k": k, "v": v}).Debug("Set")
 	}
 
 	currentVal, presentInDP := c.inDataplaneNotDesired[k]
@@ -132,7 +145,7 @@ func (c *DeltaTracker[K, V]) SetDesired(k K, v V) {
 	// Check if we think we need to update the dataplane as a result.
 	if presentInDP && c.valuesEqual(currentVal, v) {
 		// Dataplane already agrees with the new value so clear any pending update.
-		c.logCtx.Debug("SetDesired: Key in dataplane already, ignoring.")
+		c.logCtx.Debug("Set: Key in dataplane already, ignoring.")
 		delete(c.desiredUpdates, k)
 		return
 	}
@@ -141,8 +154,8 @@ func (c *DeltaTracker[K, V]) SetDesired(k K, v V) {
 	c.desiredUpdates[k] = v
 }
 
-// GetDesired gets a single value from the desired map.
-func (c *DeltaTracker[K, V]) GetDesired(k K) (V, bool) {
+// Get gets a single value from the desired map.
+func (c *DesiredView[K, V]) Get(k K) (V, bool) {
 	if v, ok := c.desiredUpdates[k]; ok {
 		return v, ok
 	}
@@ -150,11 +163,11 @@ func (c *DeltaTracker[K, V]) GetDesired(k K) (V, bool) {
 	return v, ok
 }
 
-// DeleteDesired deletes the given key from the desired state of the dataplane. If the KV is in the dataplane
+// Delete deletes the given key from the desired state of the dataplane. If the KV is in the dataplane
 // cache, it is added to the pending deletions set.  Removes the key from the pending updates set.
-func (c *DeltaTracker[K, V]) DeleteDesired(k K) {
+func (c *DesiredView[K, V]) Delete(k K) {
 	if logrus.GetLevel() >= logrus.DebugLevel {
-		c.logCtx.WithFields(logrus.Fields{"k": k}).Debug("DeleteDesired")
+		c.logCtx.WithFields(logrus.Fields{"k": k}).Debug("Delete")
 	}
 	delete(c.desiredUpdates, k)
 
@@ -166,17 +179,17 @@ func (c *DeltaTracker[K, V]) DeleteDesired(k K) {
 	}
 }
 
-// DeleteAllDesired deletes all entries from the in-memory desired state, updating pending updates/deletions
+// DeleteAll deletes all entries from the in-memory desired state, updating pending updates/deletions
 // accordingly.
-func (c *DeltaTracker[K, V]) DeleteAllDesired() {
+func (c *DesiredView[K, V]) DeleteAll() {
 	c.logCtx.Debug("DeleteAll")
-	c.IterDesired(func(k K, v V) {
-		c.DeleteDesired(k)
+	c.Iter(func(k K, v V) {
+		c.Delete(k)
 	})
 }
 
-// IterDesired iterates over the desired KVs.
-func (c *DeltaTracker[K, V]) IterDesired(f func(k K, v V)) {
+// Iter iterates over the desired KVs.
+func (c *DesiredView[K, V]) Iter(f func(k K, v V)) {
 	for k, v := range c.desiredUpdates {
 		f(k, v)
 	}
@@ -188,29 +201,35 @@ func (c *DeltaTracker[K, V]) IterDesired(f func(k K, v V)) {
 	}
 }
 
-// ReplaceDataplaneCacheFromMap replaces the state of the dataplane map with the KVs from
+type DataplaneView[K comparable, V any] DeltaTracker[K, V]
+
+func (c *DeltaTracker[K, V]) Dataplane() *DataplaneView[K, V] {
+	return c.dataplaneView
+}
+
+// ReplaceAllMap replaces the state of the dataplane map with the KVs from
 // dpKVs; the input map is not modified or retained.  The pending update and deletion
 // tracking is updated accordingly.
-func (c *DeltaTracker[K, V]) ReplaceDataplaneCacheFromMap(dpKVs map[K]V) {
-	err := c.ReplaceDataplaneCacheFromIter(func(f func(k K, v V)) error {
+func (c *DataplaneView[K, V]) ReplaceAllMap(dpKVs map[K]V) {
+	err := c.ReplaceAllIter(func(f func(k K, v V)) error {
 		for k, v := range dpKVs {
 			f(k, v)
 		}
 		return nil
 	})
 	if err != nil {
-		// Should be impossible to hit because ReplaceDataplaneCacheFromIter only returns errors
+		// Should be impossible to hit because ReplaceAllIter only returns errors
 		// from the iterator.
-		c.logCtx.WithError(err).Panic("Unexpected error from ReplaceDataplaneCacheFromIter")
+		c.logCtx.WithError(err).Panic("Unexpected error from ReplaceAllIter")
 	}
 }
 
-// ReplaceDataplaneCacheFromIter clears the dataplane cache and replaces its contents with the KVs returned
+// ReplaceAllIter clears the dataplane cache and replaces its contents with the KVs returned
 // by the iterator.  The pending update and deletion tracking is updated accordingly.
 //
 // Only returns an error if the iterator returns an error.  In case of error, the dataplane state is
 // partially updated with the keys that have already been seen.
-func (c *DeltaTracker[K, V]) ReplaceDataplaneCacheFromIter(iter func(func(k K, v V)) error) error {
+func (c *DataplaneView[K, V]) ReplaceAllIter(iter func(func(k K, v V)) error) error {
 	c.logCtx.Debug("Loading cache of dataplane state.")
 
 	// To reduce occupancy and to do the update in one pass, we use the old maps as scratch space.
@@ -224,7 +243,7 @@ func (c *DeltaTracker[K, V]) ReplaceDataplaneCacheFromIter(iter func(func(k K, v
 
 	err := iter(func(k K, v V) {
 		// Figure out if we _want_ it to exist and tee up update/deletion accordingly.
-		if desiredV, desired := c.GetDesired(k); desired {
+		if desiredV, desired := c.desiredView.Get(k); desired {
 			// Record that this key exists in the new copy of the cache.
 			newInDPDesired[k] = v
 
@@ -261,7 +280,7 @@ func (c *DeltaTracker[K, V]) ReplaceDataplaneCacheFromIter(iter func(func(k K, v
 
 	// oldInDPDesired now only contains KVs that we _thought_ were in the dataplane but are now gone.
 	for k := range oldInDPDesired {
-		if desiredV, desired := c.GetDesired(k); desired {
+		if desiredV, desired := c.desiredView.Get(k); desired {
 			// We want this key, but it's missing, queue up an add.
 			c.desiredUpdates[k] = desiredV
 		} // else we don't want it, and it's gone; nothing to do.
@@ -280,11 +299,11 @@ func (c *DeltaTracker[K, V]) ReplaceDataplaneCacheFromIter(iter func(func(k K, v
 	return nil
 }
 
-// SetDataplane updates a key in the dataplane cache.  I.e. it tells this tracker that the dataplane
+// Set updates a key in the dataplane cache.  I.e. it tells this tracker that the dataplane
 // has the given KV.  Updated the pending update/deletion set if the new KV differs from what is
 // desired.
-func (c *DeltaTracker[K, V]) SetDataplane(k K, v V) {
-	desiredV, desired := c.GetDesired(k)
+func (c *DataplaneView[K, V]) Set(k K, v V) {
+	desiredV, desired := c.desiredView.Get(k)
 	if desired {
 		// Dataplane key has a corresponding desired key.  Check if the values match.
 		c.inDataplaneAndDesired[k] = v
@@ -300,10 +319,10 @@ func (c *DeltaTracker[K, V]) SetDataplane(k K, v V) {
 	}
 }
 
-// DeleteDataplane deletes a key from the dataplane cache.  I.e. it tells this tracker that the key
+// Delete deletes a key from the dataplane cache.  I.e. it tells this tracker that the key
 // no longer exists in the dataplane.
-func (c *DeltaTracker[K, V]) DeleteDataplane(k K) {
-	desiredV, desired := c.GetDesired(k)
+func (c *DataplaneView[K, V]) Delete(k K) {
+	desiredV, desired := c.desiredView.Get(k)
 	delete(c.inDataplaneAndDesired, k)
 	delete(c.inDataplaneNotDesired, k)
 	if desired {
@@ -312,8 +331,8 @@ func (c *DeltaTracker[K, V]) DeleteDataplane(k K) {
 	}
 }
 
-// IterDataplane iterates over the cache of the dataplane.
-func (c *DeltaTracker[K, V]) IterDataplane(f func(k K, v V)) {
+// Iter iterates over the cache of the dataplane.
+func (c *DataplaneView[K, V]) Iter(f func(k K, v V)) {
 	for k, v := range c.inDataplaneAndDesired {
 		f(k, v)
 	}
@@ -322,9 +341,9 @@ func (c *DeltaTracker[K, V]) IterDataplane(f func(k K, v V)) {
 	}
 }
 
-// GetDataplane gets a single value from the cache of the dataplane. The cache must have previously been
+// Get gets a single value from the cache of the dataplane. The cache must have previously been
 // loaded with a successful call to LoadCacheFromDataplane() or one of the ApplyXXX methods.
-func (c *DeltaTracker[K, V]) GetDataplane(k K) (V, bool) {
+func (c *DataplaneView[K, V]) Get(k K) (V, bool) {
 	v, ok := c.inDataplaneAndDesired[k]
 	if !ok {
 		v, ok = c.inDataplaneNotDesired[k]
@@ -341,7 +360,7 @@ const (
 
 // IterPendingUpdates iterates over the pending updates. If the passed in function returns
 // IterActionUpdateDataplane then the pending update is cleared, and, the KV is applied
-// to the dataplane cache (as if the function had called SetDataplane(k, v)).
+// to the dataplane cache (as if the function had called Set(k, v)).
 func (c *DeltaTracker[K, V]) IterPendingUpdates(f func(k K, v V) IterAction) {
 	for k, v := range c.desiredUpdates {
 		updateDataplane := f(k, v)
@@ -357,7 +376,7 @@ func (c *DeltaTracker[K, V]) IterPendingUpdates(f func(k K, v V) IterAction) {
 
 // IterPendingDeletions iterates over the pending deletion set. If the passed in function returns
 // IterActionUpdateDataplane then the pending deletion is cleared, and, the KV is applied
-// to the dataplane cache (as if the function had called DeleteDataplane(k)).
+// to the dataplane cache (as if the function had called Delete(k)).
 func (c *DeltaTracker[K, V]) IterPendingDeletions(f func(k K) IterAction) {
 	for k := range c.inDataplaneNotDesired {
 		updateDataplane := f(k)

--- a/felix/deltatracker/delta_tracker_test.go
+++ b/felix/deltatracker/delta_tracker_test.go
@@ -33,11 +33,11 @@ func init() {
 // TestDeltaTracker_Empty verifies loading of an empty map with no changes queued.
 func TestDeltaTracker_Empty(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
-	dt.IterDesired(func(k string, v string) {
-		t.Errorf("IterDesired unexpectedly called func with %v, %v", k, v)
+	dt.Desired().Iter(func(k string, v string) {
+		t.Errorf("Iter unexpectedly called func with %v, %v", k, v)
 	})
-	dt.IterDataplane(func(k string, v string) {
-		t.Errorf("IterDesired unexpectedly called func with %v, %v", k, v)
+	dt.Dataplane().Iter(func(k string, v string) {
+		t.Errorf("Iter unexpectedly called func with %v, %v", k, v)
 	})
 	dt.IterPendingUpdates(func(k string, v string) IterAction {
 		t.Errorf("IterPendingUpdates unexpectedly called func with %v, %v", k, v)
@@ -52,7 +52,7 @@ func TestDeltaTracker_Empty(t *testing.T) {
 // TestDeltaTracker_CleanUp verifies cleaning up of a whole map.
 func TestDeltaTracker_CleanUp(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
-	err := dt.ReplaceDataplaneCacheFromIter(mapIter(map[string]string{
+	err := dt.Dataplane().ReplaceAllIter(mapIter(map[string]string{
 		"1": "A1",
 		"2": "B1",
 	}))
@@ -67,9 +67,9 @@ func TestDeltaTracker_CleanUp(t *testing.T) {
 func pendingDeletions(dt *DeltaTracker[string, string], action IterAction) map[string]string {
 	result := map[string]string{}
 	dt.IterPendingDeletions(func(k string) IterAction {
-		v, ok := dt.GetDataplane(k)
+		v, ok := dt.Dataplane().Get(k)
 		if !ok {
-			panic(fmt.Sprintf("IterPendingDeletions iterated over key that wasn't returned by GetDataplane: %v", k))
+			panic(fmt.Sprintf("IterPendingDeletions iterated over key that wasn't returned by Get: %v", k))
 		}
 		result[k] = v
 		return action
@@ -88,7 +88,7 @@ func pendingUpdates(dt *DeltaTracker[string, string], action IterAction) map[str
 
 func allDesired(dt *DeltaTracker[string, string]) map[string]string {
 	result := map[string]string{}
-	dt.IterDesired(func(k string, v string) {
+	dt.Desired().Iter(func(k string, v string) {
 		result[k] = v
 	})
 	return result
@@ -96,7 +96,7 @@ func allDesired(dt *DeltaTracker[string, string]) map[string]string {
 
 func allDataplane(dt *DeltaTracker[string, string]) map[string]string {
 	result := map[string]string{}
-	dt.IterDataplane(func(k string, v string) {
+	dt.Dataplane().Iter(func(k string, v string) {
 		result[k] = v
 	})
 	return result
@@ -115,30 +115,30 @@ func TestDeltaTracker_GetDesired(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
 
 	// Empty dataplane, set followed by get should return what we just set!
-	dt.SetDesired("1", "A1")
-	if v, ok := dt.GetDesired("1"); !ok {
+	dt.Desired().Set("1", "A1")
+	if v, ok := dt.Desired().Get("1"); !ok {
 		t.Errorf("DeltaTracker failed to get desired key that we just set")
 	} else if v != "A1" {
 		t.Errorf("DeltaTracker returned incorrect value: %q", v)
 	}
 
 	// Delete it again.  Should no longer be returned.
-	dt.DeleteDesired("1")
-	if _, ok := dt.GetDesired("1"); ok {
-		t.Fatal("DeleteDesired had no effect?")
+	dt.Desired().Delete("1")
+	if _, ok := dt.Desired().Get("1"); ok {
+		t.Fatal("Delete had no effect?")
 	}
 
 	// Recreate, so we can test adding the value to the dataplane.
-	dt.SetDesired("1", "A1")
-	if v, ok := dt.GetDesired("1"); !ok {
+	dt.Desired().Set("1", "A1")
+	if v, ok := dt.Desired().Get("1"); !ok {
 		t.Errorf("DeltaTracker failed to get desired key that we just set")
 	} else if v != "A1" {
 		t.Errorf("DeltaTracker returned incorrect value: %q", v)
 	}
 
 	// Adding to the dataplane shouldn't affect the desired state.
-	dt.SetDataplane("1", "A1")
-	if v, ok := dt.GetDesired("1"); !ok {
+	dt.Dataplane().Set("1", "A1")
+	if v, ok := dt.Desired().Get("1"); !ok {
 		t.Errorf("DeltaTracker failed to get desired key once it was also in DP")
 	} else if v != "A1" {
 		t.Errorf("DeltaTracker returned incorrect value once it was also in DP: %q", v)
@@ -146,49 +146,49 @@ func TestDeltaTracker_GetDesired(t *testing.T) {
 
 	// Delete the desired while the value is in the dataplane.  Again, should be independent
 	// of whether it's in the dataplane.
-	dt.DeleteDesired("1")
-	if _, ok := dt.GetDesired("1"); ok {
-		t.Fatal("DeleteDesired had no effect?")
+	dt.Desired().Delete("1")
+	if _, ok := dt.Desired().Get("1"); ok {
+		t.Fatal("Delete had no effect?")
 	}
 
 	// Recreate the desired key while it is in the dataplane.
-	dt.SetDesired("1", "A1")
-	if v, ok := dt.GetDesired("1"); !ok {
+	dt.Desired().Set("1", "A1")
+	if v, ok := dt.Desired().Get("1"); !ok {
 		t.Errorf("DeltaTracker failed to get desired key that we just recreated")
 	} else if v != "A1" {
 		t.Errorf("DeltaTracker returned incorrect value: %q", v)
 	}
 
 	// Delete from dataplane while the key is in the desired map, should not impact desired.
-	dt.DeleteDataplane("1")
-	if v, ok := dt.GetDesired("1"); !ok {
+	dt.Dataplane().Delete("1")
+	if v, ok := dt.Desired().Get("1"); !ok {
 		t.Errorf("DeltaTracker failed to get desired after deleting from DP")
 	} else if v != "A1" {
 		t.Errorf("DeltaTracker returned incorrect value after deleting from DP: %q", v)
 	}
 
 	// Adding a different value to the dataplane shouldn't affact desired.
-	dt.SetDataplane("1", "A2")
-	if v, ok := dt.GetDesired("1"); !ok {
+	dt.Dataplane().Set("1", "A2")
+	if v, ok := dt.Desired().Get("1"); !ok {
 		t.Errorf("DeltaTracker failed to get desired key with different value in DP")
 	} else if v != "A1" {
 		t.Errorf("DeltaTracker returned incorrect value with different value in DP: %q", v)
 	}
 
 	// Delete it again.
-	dt.DeleteDesired("1")
-	if _, ok := dt.GetDesired("1"); ok {
-		t.Fatal("DeleteDesired had no effect?")
+	dt.Desired().Delete("1")
+	if _, ok := dt.Desired().Get("1"); ok {
+		t.Fatal("Delete had no effect?")
 	}
-	if v, ok := dt.GetDataplane("1"); !ok {
-		t.Fatal("DeleteDesired removed dataplane key")
+	if v, ok := dt.Dataplane().Get("1"); !ok {
+		t.Fatal("Delete removed dataplane key")
 	} else if v != "A2" {
-		t.Fatal("DeleteDesired changed dataplane key")
+		t.Fatal("Delete changed dataplane key")
 	}
 
 	// Recreate while there's a different dataplane key...
-	dt.SetDesired("1", "A1")
-	if v, ok := dt.GetDesired("1"); !ok {
+	dt.Desired().Set("1", "A1")
+	if v, ok := dt.Desired().Get("1"); !ok {
 		t.Errorf("DeltaTracker failed to get desired key that we just recreated")
 	} else if v != "A1" {
 		t.Errorf("DeltaTracker returned incorrect value: %q", v)
@@ -198,9 +198,9 @@ func TestDeltaTracker_GetDesired(t *testing.T) {
 func TestDeltaTracker_DeleteAll(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
 
-	dt.SetDesired("1", "A1") // Same value for existing key.
-	dt.SetDesired("2", "B1") // New value for existing key.
-	dt.SetDesired("4", "D1") // New K/V
+	dt.Desired().Set("1", "A1") // Same value for existing key.
+	dt.Desired().Set("2", "B1") // New value for existing key.
+	dt.Desired().Set("4", "D1") // New K/V
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"1": "A1",
 		"2": "B1",
@@ -208,7 +208,7 @@ func TestDeltaTracker_DeleteAll(t *testing.T) {
 	}))
 	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
 
-	dt.DeleteAllDesired()
+	dt.Desired().DeleteAll()
 
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
 	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
@@ -225,7 +225,7 @@ func ExampleDeltaTracker_resync() {
 		"two": 2,
 	}
 	for k, v := range desired {
-		dt.SetDesired(k, v)
+		dt.Desired().Set(k, v)
 	}
 	fmt.Printf("Desired state: %v\n", desired)
 
@@ -235,7 +235,7 @@ func ExampleDeltaTracker_resync() {
 		"three": 3,
 	}
 	fmt.Printf("Initial dataplane state: %v\n", mockDataplane)
-	_ = dt.ReplaceDataplaneCacheFromIter(func(f func(k string, v int)) error {
+	_ = dt.Dataplane().ReplaceAllIter(func(f func(k string, v int)) error {
 		// Replace this with the actual dataplane loading logic.
 		for k, v := range mockDataplane {
 			f(k, v)
@@ -272,9 +272,9 @@ func ExampleDeltaTracker_resync() {
 func TestDeltaTracker_UpdateThenReplaceDataplaneCacheFromIter(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
 
-	dt.SetDesired("1", "A1") // Same value for existing key.
-	dt.SetDesired("2", "B1") // New value for existing key.
-	dt.SetDesired("4", "D1") // New K/V
+	dt.Desired().Set("1", "A1") // Same value for existing key.
+	dt.Desired().Set("2", "B1") // New value for existing key.
+	dt.Desired().Set("4", "D1") // New K/V
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"1": "A1",
 		"2": "B1",
@@ -288,7 +288,7 @@ func TestDeltaTracker_UpdateThenReplaceDataplaneCacheFromIter(t *testing.T) {
 		"2": "B2",
 		"3": "C1",
 	}
-	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	err := dt.Dataplane().ReplaceAllIter(mapIter(dpContents))
 	Expect(err).NotTo(HaveOccurred())
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"2": "B1",
@@ -304,7 +304,7 @@ func TestDeltaTracker_UpdateThenReplaceDataplaneCacheFromIter(t *testing.T) {
 		"2": "B2",
 		"5": "E1",
 	}
-	err = dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	err = dt.Dataplane().ReplaceAllIter(mapIter(dpContents))
 	Expect(err).NotTo(HaveOccurred())
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"1": "A1",
@@ -324,12 +324,12 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterThenUpdate(t *testing.T) {
 		"2": "B2",
 		"3": "C1",
 	}
-	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	err := dt.Dataplane().ReplaceAllIter(mapIter(dpContents))
 	Expect(err).NotTo(HaveOccurred())
 
-	dt.SetDesired("1", "A1") // Same value for existing key.
-	dt.SetDesired("2", "B1") // New value for existing key.
-	dt.SetDesired("4", "D1") // New K/V
+	dt.Desired().Set("1", "A1") // Same value for existing key.
+	dt.Desired().Set("2", "B1") // New value for existing key.
+	dt.Desired().Set("4", "D1") // New K/V
 
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"2": "B1",
@@ -340,7 +340,7 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterThenUpdate(t *testing.T) {
 	}))
 
 	// Make expected updates to dataplane, should update the pending sets accordingly.
-	dt.SetDataplane("2", "B1")
+	dt.Dataplane().Set("2", "B1")
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"4": "D1",
 	}))
@@ -348,19 +348,19 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterThenUpdate(t *testing.T) {
 		"3": "C1",
 	}))
 
-	dt.SetDataplane("4", "D1")
+	dt.Dataplane().Set("4", "D1")
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
 	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"3": "C1",
 	}))
 
-	dt.DeleteDataplane("3")
+	dt.Dataplane().Delete("3")
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
 	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
 
 	// Disrupt a desired key, add a key that shouldn't be there.
-	dt.SetDataplane("1", "A2")
-	dt.SetDataplane("3", "C3")
+	dt.Dataplane().Set("1", "A2")
+	dt.Dataplane().Set("3", "C3")
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"1": "A1",
 	}))
@@ -369,7 +369,7 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterThenUpdate(t *testing.T) {
 	}))
 
 	// Delete a key that was in sync.
-	dt.DeleteDataplane("2")
+	dt.Dataplane().Delete("2")
 	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
 		"1": "A1",
 		"2": "B1",
@@ -382,15 +382,15 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterThenUpdate(t *testing.T) {
 func TestDeltaTracker_IterPendingActions(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
 
-	dt.SetDesired("1", "A1") // Same value for existing key.
-	dt.SetDesired("2", "B1") // New value for existing key.
-	dt.SetDesired("4", "D1") // New K/V
+	dt.Desired().Set("1", "A1") // Same value for existing key.
+	dt.Desired().Set("2", "B1") // New value for existing key.
+	dt.Desired().Set("4", "D1") // New K/V
 	dpContents := map[string]string{
 		"1": "A1",
 		"2": "B2",
 		"3": "C1",
 	}
-	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	err := dt.Dataplane().ReplaceAllIter(mapIter(dpContents))
 	Expect(err).NotTo(HaveOccurred())
 
 	// Loop to check IterActionNoOp really is a no-op
@@ -430,22 +430,22 @@ func TestDeltaTracker_IterPendingActions(t *testing.T) {
 }
 
 // TestDeltaTracker_ReplaceDataplaneCacheFromIterErrors tests error handling of
-// ReplaceDataplaneCacheFromIter.
+// ReplaceAllIter.
 func TestDeltaTracker_ReplaceDataplaneCacheFromIterErrors(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
 
 	// Set up our usual 3 keys...
-	dt.SetDesired("1", "A1") // Same value for existing key.
-	dt.SetDesired("2", "B1") // New value for existing key.
-	dt.SetDesired("4", "D1") // New K/V
+	dt.Desired().Set("1", "A1") // Same value for existing key.
+	dt.Desired().Set("2", "B1") // New value for existing key.
+	dt.Desired().Set("4", "D1") // New K/V
 
 	// Do a dataplane resync but fail after 2 keys have been produced.
-	err := dt.ReplaceDataplaneCacheFromIter(func(f func(k string, v string)) error {
+	err := dt.Dataplane().ReplaceAllIter(func(f func(k string, v string)) error {
 		f("3", "C1")
 		f("2", "B2")
 		return fmt.Errorf("dummy error")
 	})
-	Expect(err).To(HaveOccurred(), "ReplaceDataplaneCacheFromIter should propagate errors")
+	Expect(err).To(HaveOccurred(), "ReplaceAllIter should propagate errors")
 
 	Expect(allDesired(dt)).To(Equal(map[string]string{
 		"1": "A1",
@@ -467,12 +467,12 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterErrors(t *testing.T) {
 
 	// Do another failed resync but this time we emit a key that matches the desired
 	// and one that is in the pending deletions.
-	err = dt.ReplaceDataplaneCacheFromIter(func(f func(k string, v string)) error {
+	err = dt.Dataplane().ReplaceAllIter(func(f func(k string, v string)) error {
 		f("1", "A1")
 		f("3", "C1")
 		return fmt.Errorf("dummy error")
 	})
-	Expect(err).To(HaveOccurred(), "ReplaceDataplaneCacheFromIter should propagate errors")
+	Expect(err).To(HaveOccurred(), "ReplaceAllIter should propagate errors")
 	Expect(allDesired(dt)).To(Equal(map[string]string{
 		"1": "A1",
 		"2": "B1",
@@ -497,7 +497,7 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterErrors(t *testing.T) {
 		"2": "B2",
 		"3": "C1",
 	}
-	err = dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	err = dt.Dataplane().ReplaceAllIter(mapIter(dpContents))
 	Expect(err).NotTo(HaveOccurred())
 	Expect(allDesired(dt)).To(Equal(map[string]string{
 		"1": "A1",
@@ -521,9 +521,9 @@ func TestDeltaTracker_ReplaceDataplaneCacheFromIterErrors(t *testing.T) {
 func TestDeltaTracker_IterDesired(t *testing.T) {
 	dt := setupDeltaTrackerTest(t)
 
-	dt.SetDesired("1", "A1") // Same value for existing key.
-	dt.SetDesired("2", "B1") // New value for existing key.
-	dt.SetDesired("4", "D1") // New K/V
+	dt.Desired().Set("1", "A1") // Same value for existing key.
+	dt.Desired().Set("2", "B1") // New value for existing key.
+	dt.Desired().Set("4", "D1") // New K/V
 	Expect(allDesired(dt)).To(Equal(map[string]string{
 		"1": "A1",
 		"2": "B1",
@@ -535,7 +535,7 @@ func TestDeltaTracker_IterDesired(t *testing.T) {
 		"2": "B2",
 		"3": "C1",
 	}
-	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	err := dt.Dataplane().ReplaceAllIter(mapIter(dpContents))
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(allDesired(dt)).To(Equal(map[string]string{

--- a/felix/deltatracker/delta_tracker_test.go
+++ b/felix/deltatracker/delta_tracker_test.go
@@ -1,0 +1,538 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deltatracker
+
+import (
+	"fmt"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/logutils"
+)
+
+func init() {
+	logutils.ConfigureEarlyLogging()
+	log.SetLevel(log.DebugLevel)
+}
+
+// TestDeltaTracker_Empty verifies loading of an empty map with no changes queued.
+func TestDeltaTracker_Empty(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+	dt.IterDesired(func(k string, v string) {
+		t.Errorf("IterDesired unexpectedly called func with %v, %v", k, v)
+	})
+	dt.IterDataplane(func(k string, v string) {
+		t.Errorf("IterDesired unexpectedly called func with %v, %v", k, v)
+	})
+	dt.IterPendingUpdates(func(k string, v string) IterAction {
+		t.Errorf("IterPendingUpdates unexpectedly called func with %v, %v", k, v)
+		return IterActionNoOp
+	})
+	dt.IterPendingDeletions(func(k string) IterAction {
+		t.Errorf("IterPendingDeletions unexpectedly called func with %v", k)
+		return IterActionNoOp
+	})
+}
+
+// TestDeltaTracker_CleanUp verifies cleaning up of a whole map.
+func TestDeltaTracker_CleanUp(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+	err := dt.ReplaceDataplaneCacheFromIter(mapIter(map[string]string{
+		"1": "A1",
+		"2": "B1",
+	}))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+	}))
+}
+
+func pendingDeletions(dt *DeltaTracker[string, string], action IterAction) map[string]string {
+	result := map[string]string{}
+	dt.IterPendingDeletions(func(k string) IterAction {
+		v, ok := dt.GetDataplane(k)
+		if !ok {
+			panic(fmt.Sprintf("IterPendingDeletions iterated over key that wasn't returned by GetDataplane: %v", k))
+		}
+		result[k] = v
+		return action
+	})
+	return result
+}
+
+func pendingUpdates(dt *DeltaTracker[string, string], action IterAction) map[string]string {
+	result := map[string]string{}
+	dt.IterPendingUpdates(func(k string, v string) IterAction {
+		result[k] = v
+		return action
+	})
+	return result
+}
+
+func allDesired(dt *DeltaTracker[string, string]) map[string]string {
+	result := map[string]string{}
+	dt.IterDesired(func(k string, v string) {
+		result[k] = v
+	})
+	return result
+}
+
+func allDataplane(dt *DeltaTracker[string, string]) map[string]string {
+	result := map[string]string{}
+	dt.IterDataplane(func(k string, v string) {
+		result[k] = v
+	})
+	return result
+}
+
+func mapIter(m map[string]string) func(func(k string, v string)) error {
+	return func(f func(k string, v string)) error {
+		for k, v := range m {
+			f(k, v)
+		}
+		return nil
+	}
+}
+
+func TestDeltaTracker_GetDesired(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+	dt.SetDesired("1", "A1")
+	if v, ok := dt.GetDesired("1"); !ok {
+		t.Errorf("DeltaTracker failed to get desired key that we just set")
+	} else if v != "A1" {
+		t.Errorf("DeltaTracker returned incorrect value: %q", v)
+	}
+
+	// Delete it again.
+	dt.DeleteDesired("1")
+	if _, ok := dt.GetDesired("1"); ok {
+		t.Fatal("DeleteDesired had no effect?")
+	}
+
+	// Recreate...
+	dt.SetDesired("1", "A1")
+	if v, ok := dt.GetDesired("1"); !ok {
+		t.Errorf("DeltaTracker failed to get desired key that we just set")
+	} else if v != "A1" {
+		t.Errorf("DeltaTracker returned incorrect value: %q", v)
+	}
+
+	// Make sure we get the desired value even if the key is also in the dataplane.
+	dt.SetDataplane("1", "A1")
+	if v, ok := dt.GetDesired("1"); !ok {
+		t.Errorf("DeltaTracker failed to get desired key once it was also in DP")
+	} else if v != "A1" {
+		t.Errorf("DeltaTracker returned incorrect value once it was also in DP: %q", v)
+	}
+
+	// Delete it again.
+	dt.DeleteDesired("1")
+	if _, ok := dt.GetDesired("1"); ok {
+		t.Fatal("DeleteDesired had no effect?")
+	}
+
+	// Recreate...
+	dt.SetDesired("1", "A1")
+	if v, ok := dt.GetDesired("1"); !ok {
+		t.Errorf("DeltaTracker failed to get desired key that we just recreated")
+	} else if v != "A1" {
+		t.Errorf("DeltaTracker returned incorrect value: %q", v)
+	}
+
+	// Make sure we still get the value even if it agrees with dataplane.
+	dt.SetDataplane("1", "A1")
+	if v, ok := dt.GetDesired("1"); !ok {
+		t.Errorf("DeltaTracker failed to get desired key once it matched in DP")
+	} else if v != "A1" {
+		t.Errorf("DeltaTracker returned incorrect value once it matched in DP: %q", v)
+	}
+
+	// Delete it again.
+	dt.DeleteDesired("1")
+	if _, ok := dt.GetDesired("1"); ok {
+		t.Fatal("DeleteDesired had no effect?")
+	}
+
+	// Recreate...
+	dt.SetDesired("1", "A1")
+	if v, ok := dt.GetDesired("1"); !ok {
+		t.Errorf("DeltaTracker failed to get desired key that we just recreated")
+	} else if v != "A1" {
+		t.Errorf("DeltaTracker returned incorrect value: %q", v)
+	}
+}
+
+func TestDeltaTracker_DeleteAll(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+
+	dt.SetDesired("1", "A1") // Same value for existing key.
+	dt.SetDesired("2", "B1") // New value for existing key.
+	dt.SetDesired("4", "D1") // New K/V
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
+
+	dt.DeleteAllDesired()
+
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
+}
+
+func ExampleDeltaTracker_resync() {
+	dt := New[string, int](WithValuesEqualFn[string, int](func(a, b int) bool {
+		return a == b // ints support simple comparison.
+	}))
+
+	// Set up our desired state.
+	desired := map[string]int{
+		"one": 1,
+		"two": 2,
+	}
+	for k, v := range desired {
+		dt.SetDesired(k, v)
+	}
+	fmt.Printf("Desired state: %v\n", desired)
+
+	// Resync with the dataplane
+	mockDataplane := map[string]int{
+		"one":   1,
+		"three": 3,
+	}
+	fmt.Printf("Initial dataplane state: %v\n", mockDataplane)
+	_ = dt.ReplaceDataplaneCacheFromIter(func(f func(k string, v int)) error {
+		// Replace this with the actual dataplane loading logic.
+		for k, v := range mockDataplane {
+			f(k, v)
+		}
+		return nil
+	})
+
+	// Check the deltas.
+	dt.IterPendingUpdates(func(k string, v int) IterAction {
+		fmt.Printf("Applying pending update: %s = %v\n", k, v)
+		mockDataplane[k] = v
+		// Tell the tracker that we updated the dataplane.
+		return IterActionUpdateDataplane
+	})
+
+	dt.IterPendingDeletions(func(k string) IterAction {
+		fmt.Printf("Applying pending deletion: %v\n", k)
+		delete(mockDataplane, k)
+		// Tell the tracker that we updated the dataplane.
+		return IterActionUpdateDataplane
+	})
+
+	// Dataplane should now be in sync.
+	fmt.Printf("Updated dataplane state: %v\n", mockDataplane)
+
+	// Output:
+	// Desired state: map[one:1 two:2]
+	// Initial dataplane state: map[one:1 three:3]
+	// Applying pending update: two = 2
+	// Applying pending deletion: three
+	// Updated dataplane state: map[one:1 two:2]
+}
+
+func TestDeltaTracker_UpdateThenReplaceDataplaneCacheFromIter(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+
+	dt.SetDesired("1", "A1") // Same value for existing key.
+	dt.SetDesired("2", "B1") // New value for existing key.
+	dt.SetDesired("4", "D1") // New K/V
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
+
+	// Do a successful resync.
+	dpContents := map[string]string{
+		"1": "A1",
+		"2": "B2",
+		"3": "C1",
+	}
+	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+
+	// Do a second one but this time some keys have been removed. "1" should
+	// move to the pending updates and "3" should disappear from the deletions.
+	dpContents = map[string]string{
+		"2": "B2",
+		"5": "E1",
+	}
+	err = dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"5": "E1",
+	}))
+}
+
+func TestDeltaTracker_ReplaceDataplaneCacheFromIterThenUpdate(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+
+	dpContents := map[string]string{
+		"1": "A1",
+		"2": "B2",
+		"3": "C1",
+	}
+	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	Expect(err).NotTo(HaveOccurred())
+
+	dt.SetDesired("1", "A1") // Same value for existing key.
+	dt.SetDesired("2", "B1") // New value for existing key.
+	dt.SetDesired("4", "D1") // New K/V
+
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+
+	// Make expected updates to dataplane, should update the pending sets accordingly.
+	dt.SetDataplane("2", "B1")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+
+	dt.SetDataplane("4", "D1")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+
+	dt.DeleteDataplane("3")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
+
+	// Disrupt a desired key, add a key that shouldn't be there.
+	dt.SetDataplane("1", "A2")
+	dt.SetDataplane("3", "C3")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"1": "A1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C3",
+	}))
+
+	// Delete a key that was in sync.
+	dt.DeleteDataplane("2")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C3",
+	}))
+}
+
+func TestDeltaTracker_IterPendingActions(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+
+	dt.SetDesired("1", "A1") // Same value for existing key.
+	dt.SetDesired("2", "B1") // New value for existing key.
+	dt.SetDesired("4", "D1") // New K/V
+	dpContents := map[string]string{
+		"1": "A1",
+		"2": "B2",
+		"3": "C1",
+	}
+	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	Expect(err).NotTo(HaveOccurred())
+
+	// Loop to check IterActionNoOp really is a no-op
+	for i := 0; i < 2; i++ {
+		Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+			"2": "B1",
+			"4": "D1",
+		}))
+		Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+			"3": "C1",
+		}))
+		Expect(allDataplane(dt)).To(Equal(dpContents))
+	}
+
+	// Return IterActionUpdateDataplane, pending ops should go away.
+	Expect(pendingUpdates(dt, IterActionUpdateDataplane)).To(Equal(map[string]string{
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionUpdateDataplane)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(BeEmpty())
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(BeEmpty())
+
+	// Dataplane should be updated, desired should be correct.
+	Expect(allDataplane(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(allDesired(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}))
+}
+
+// TestDeltaTracker_ReplaceDataplaneCacheFromIterErrors tests error handling of
+// ReplaceDataplaneCacheFromIter.
+func TestDeltaTracker_ReplaceDataplaneCacheFromIterErrors(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+
+	// Set up our usual 3 keys...
+	dt.SetDesired("1", "A1") // Same value for existing key.
+	dt.SetDesired("2", "B1") // New value for existing key.
+	dt.SetDesired("4", "D1") // New K/V
+
+	// Do a dataplane resync but fail after 2 keys have been produced.
+	err := dt.ReplaceDataplaneCacheFromIter(func(f func(k string, v string)) error {
+		f("3", "C1")
+		f("2", "B2")
+		return fmt.Errorf("dummy error")
+	})
+	Expect(err).To(HaveOccurred(), "ReplaceDataplaneCacheFromIter should propagate errors")
+
+	Expect(allDesired(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}), "Error during resync shouldn't corrupt desired KVs")
+	Expect(allDataplane(dt)).To(Equal(map[string]string{
+		"3": "C1",
+		"2": "B2",
+	}), "Keys seen during resync should be recorded.")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+
+	// Do another failed resync but this time we emit a key that matches the desired
+	// and one that is in the pending deletions.
+	err = dt.ReplaceDataplaneCacheFromIter(func(f func(k string, v string)) error {
+		f("1", "A1")
+		f("3", "C1")
+		return fmt.Errorf("dummy error")
+	})
+	Expect(err).To(HaveOccurred(), "ReplaceDataplaneCacheFromIter should propagate errors")
+	Expect(allDesired(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}), "Error during resync shouldn't corrupt desired KVs")
+	Expect(allDataplane(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"3": "C1",
+		"2": "B2",
+	}), "Keys seen during resync should be recorded.")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+
+	// Do a successful resync.
+	dpContents := map[string]string{
+		"1": "A1",
+		"2": "B2",
+		"3": "C1",
+	}
+	err = dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(allDesired(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}), "Resync shouldn't corrupt desired KVs")
+	Expect(allDataplane(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"3": "C1",
+		"2": "B2",
+	}), "Keys seen during resync should be recorded.")
+	Expect(pendingUpdates(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"2": "B1",
+		"4": "D1",
+	}))
+	Expect(pendingDeletions(dt, IterActionNoOp)).To(Equal(map[string]string{
+		"3": "C1",
+	}))
+}
+
+func TestDeltaTracker_IterDesired(t *testing.T) {
+	dt := setupDeltaTrackerTest(t)
+
+	dt.SetDesired("1", "A1") // Same value for existing key.
+	dt.SetDesired("2", "B1") // New value for existing key.
+	dt.SetDesired("4", "D1") // New K/V
+	Expect(allDesired(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}))
+
+	dpContents := map[string]string{
+		"1": "A1",
+		"2": "B2",
+		"3": "C1",
+	}
+	err := dt.ReplaceDataplaneCacheFromIter(mapIter(dpContents))
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(allDesired(dt)).To(Equal(map[string]string{
+		"1": "A1",
+		"2": "B1",
+		"4": "D1",
+	}), "Refreshing dataplane shouldn't affect desired values")
+}
+
+func setupDeltaTrackerTest(t *testing.T) *DeltaTracker[string, string] {
+	RegisterTestingT(t)
+
+	dt := New[string, string]()
+
+	return dt
+}


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR extracts out the algorithmic work from the BPF `CachingMap` struct so that it can be reused elsewhere.  While I was touching that, I also made the optimisations that were in TODOs so that we avoid storing two copies of the map.

I plan to use the DeltaTracker in an upcoming PR to improve IP set programming perf.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
