### PR TITLE
Workaround Goland linter bug.

### DIFF
--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -846,19 +846,23 @@ type Upgradable interface {
 }
 
 type TypedMap[K Key, V Value] struct {
-	MapWithExistsCheck
+	untypedMap   MapWithExistsCheck
 	kConstructor func([]byte) K
 	vConstructor func([]byte) V
 }
 
+func (m *TypedMap[K, V]) ErrIsNotExists(err error) bool {
+	return m.untypedMap.ErrIsNotExists(err)
+}
+
 func (m *TypedMap[K, V]) Update(k K, v V) error {
-	return m.MapWithExistsCheck.Update(k.AsBytes(), v.AsBytes())
+	return m.untypedMap.Update(k.AsBytes(), v.AsBytes())
 }
 
 func (m *TypedMap[K, V]) Get(k K) (V, error) {
 	var res V
 
-	vb, err := m.MapWithExistsCheck.Get(k.AsBytes())
+	vb, err := m.untypedMap.Get(k.AsBytes())
 	if err != nil {
 		goto exit
 	}
@@ -870,14 +874,14 @@ exit:
 }
 
 func (m *TypedMap[K, V]) Delete(k K) error {
-	return m.MapWithExistsCheck.Delete(k.AsBytes())
+	return m.untypedMap.Delete(k.AsBytes())
 }
 
 func (m *TypedMap[K, V]) Load() (map[K]V, error) {
 
 	memMap := make(map[K]V)
 
-	err := m.MapWithExistsCheck.Iter(func(kb, vb []byte) IteratorAction {
+	err := m.untypedMap.Iter(func(kb, vb []byte) IteratorAction {
 		memMap[m.kConstructor(kb)] = m.vConstructor(vb)
 		return IterNone
 	})
@@ -887,8 +891,8 @@ func (m *TypedMap[K, V]) Load() (map[K]V, error) {
 
 func NewTypedMap[K Key, V Value](m MapWithExistsCheck, kConstructor func([]byte) K, vConstructor func([]byte) V) *TypedMap[K, V] {
 	return &TypedMap[K, V]{
-		MapWithExistsCheck: m,
-		kConstructor:       kConstructor,
-		vConstructor:       vConstructor,
+		untypedMap:   m,
+		kConstructor: kConstructor,
+		vConstructor: vConstructor,
 	}
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Refactor TypedMap to avoid shadowing the unnamed field's methods.  The unnamed field was only used to expose one method (I think) and it causes a persistent syntax error in Goland, which is very annoying!

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

https://youtrack.jetbrains.com/issue/GO-14724

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
