### PR TITLE
Add deduplicating syncer callbacks buffer.

### DIFF
--- a/charts/test/helm_suite_test.go
+++ b/charts/test/helm_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/testutils"
 
 	. "github.com/onsi/ginkgo"

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -33,6 +33,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/syncersv1/dedupebuffer"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/seedrng"
 
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -485,7 +487,7 @@ configRetry:
 	// which will feed the calculation graph with updates, bringing Felix into sync.
 	var syncer Startable
 	var typhaConnection *syncclient.SyncerClient
-	syncerToValidator := calc.NewSyncerCallbacksDecoupler()
+	syncerToValidator := dedupebuffer.New()
 
 	if typhaDiscoverer.TyphaEnabled() {
 		// Use a remote Syncer, via the Typha server.
@@ -629,7 +631,7 @@ configRetry:
 	// calculation graph.
 	validator := calc.NewValidationFilter(asyncCalcGraph, configParams)
 
-	go syncerToValidator.SendTo(validator)
+	go syncerToValidator.SendToSinkForever(validator)
 	asyncCalcGraph.Start()
 	log.Infof("Started the processing graph")
 	var stopSignalChans []chan<- *sync.WaitGroup

--- a/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer.go
+++ b/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dedupebuffer
+
+import (
+	"container/list"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
+)
+
+// DedupeBuffer buffer implements the syncer callbacks API on its
+// input, and calls another syncer callback on its output. In-between it
+// maintains an in-order queue of KV updates and a tracking map to record what
+// is in the queue.
+//
+// If an update comes in for a key that already has a value in the queue then
+// the value in the queue is replaced with the updated KV.
+//
+// This can cause reordering (which is allowed by the syncer API) but it
+// ensures that the amount of KVs in flight is bounded to the total size of
+// the datastore even under substantial overload. The effect is that the
+// client will periodically "skip ahead" to the more recent state of the
+// datatstore without seeing intermediate states.
+type DedupeBuffer struct {
+	lock sync.Mutex
+	cond *sync.Cond
+
+	// keyToPendingUpdate holds an entry for each updateWithStringKey in the
+	// pendingUpdates queue
+	keyToPendingUpdate map[string]*list.Element
+	sentKeys           set.Set[string]
+	pendingUpdates     list.List // Mix of api.SyncStatus and updateWithStringKey.
+
+	mostRecentStatus api.SyncStatus
+	stopped          bool
+}
+
+func New() *DedupeBuffer {
+	d := &DedupeBuffer{
+		keyToPendingUpdate: map[string]*list.Element{},
+		sentKeys:           set.New[string](),
+	}
+	d.cond = sync.NewCond(&d.lock)
+	return d
+}
+
+// OnStatusUpdated queues a status update to be sent to the sink.
+func (d *DedupeBuffer) OnStatusUpdated(status api.SyncStatus) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	// Statuses are idempotent so skip sending if the latest one in the queue
+	// was the same.
+	if d.mostRecentStatus == status {
+		return
+	}
+
+	// If the last message on the queue was a status message then replace it.
+	// this prevents us from growing the queue without bound if status is
+	// flapping. We can add at most one status to the queue for each
+	// non-status update and the number of non-status updates is bounded by
+	// the size of the datastore.
+	if back := d.pendingUpdates.Back(); back != nil {
+		if _, ok := back.Value.(api.SyncStatus); ok {
+			back.Value = status
+			d.mostRecentStatus = status
+			return
+		}
+	}
+
+	// Add the status to the queue.
+	queueWasEmpty := d.pendingUpdates.Len() == 0
+	d.pendingUpdates.PushBack(status)
+	d.mostRecentStatus = status
+	if queueWasEmpty {
+		// Only need to signal when the first item goes on the queue.
+		d.cond.Signal()
+	}
+}
+
+// OnUpdates adds a slice of updates to the buffer and does housekeeping to
+// deduplicate in-flight updates to the same keys.  It should only block for
+// short periods even if the downstream sink blocks for a long time.
+func (d *DedupeBuffer) OnUpdates(updates []api.Update) {
+	d.OnUpdatesKeysKnown(updates, nil)
+}
+
+// OnUpdatesKeysKnown is like OnUpdates, but it allows for the pre-serialised
+// keys of the KV pairs to be passed in.  If an entry in keys is "" or if keys
+// is shorter than updates the key will be computed.
+//
+// The updates and keys slices are not retained.
+func (d *DedupeBuffer) OnUpdatesKeysKnown(updates []api.Update, keys []string) {
+	debug := log.IsLevelEnabled(log.DebugLevel)
+	if debug {
+		log.WithField("numUpdates", len(updates)).Debug("Updates received")
+	}
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if debug {
+		log.WithFields(log.Fields{
+			"queueLen": d.pendingUpdates.Len(),
+		}).Debug("Acquired lock")
+	}
+
+	queueWasEmpty := d.pendingUpdates.Len() == 0
+	for i, u := range updates {
+		var key string
+		if i < len(keys) {
+			// Have a cached key.
+			key = keys[i]
+		}
+		if key == "" {
+			// No key provided, calculate it.
+			var err error
+			key, err = model.KeyToDefaultPath(u.Key)
+			if err != nil {
+				// Shouldn't happen, we get out keys from Typha which has already
+				// Encoding them once!
+				log.WithError(err).WithField("key", u.Key).Error(
+					"Failed to generate default path for key.  Will skip this update.")
+				continue
+			}
+		}
+
+		if element, ok := d.keyToPendingUpdate[key]; ok {
+			// Already got an in-flight update for this key.
+			if u.Value == nil && !d.sentKeys.Contains(key) {
+				// This is a deletion, but the key in question never made it
+				// off the queue, remove it entirely.
+				if debug {
+					log.WithField("key", key).Debug("Key deleted before being sent.")
+				}
+				delete(d.keyToPendingUpdate, key)
+				d.pendingUpdates.Remove(element)
+			} else {
+				// Update to a key that's already on the queue, swap in the
+				// most recent value.
+				if debug {
+					log.WithField("key", key).Debug("Key updated before being sent.")
+				}
+				usk := element.Value.(updateWithStringKey)
+				usk.update = u
+				element.Value = usk
+			}
+		} else {
+			// No in-flight entry for this key.  Add to queue and record that
+			// it's in flight.
+			if debug {
+				log.WithField("key", key).Debug("No in flight value for key, adding to queue.")
+			}
+			element = d.pendingUpdates.PushBack(updateWithStringKey{
+				key:    key,
+				update: u,
+			})
+			d.keyToPendingUpdate[key] = element
+		}
+	}
+	queueNowEmpty := d.pendingUpdates.Len() == 0
+	if queueWasEmpty && !queueNowEmpty {
+		// Only need to signal when the first item goes on the queue.
+		if debug {
+			log.Debug("Queue transitioned to non-empty; signalling.")
+		}
+		d.cond.Signal()
+	}
+}
+
+func (d *DedupeBuffer) SendToSinkForever(sink api.SyncerCallbacks) {
+	for !d.stopped {
+		d.sendNextBatchToSink(sink)
+	}
+}
+
+func (d *DedupeBuffer) Stop() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.stopped = true
+	d.cond.Signal()
+}
+
+type updateWithStringKey struct {
+	key    string
+	update api.Update
+}
+
+func (d *DedupeBuffer) sendNextBatchToSink(sink api.SyncerCallbacks) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	for d.pendingUpdates.Len() == 0 {
+		if d.stopped {
+			return
+		}
+		d.cond.Wait()
+	}
+	const batchSize = 100
+	buf := make([]any, 0, batchSize)
+	for d.pendingUpdates.Len() > 0 {
+		if d.stopped {
+			return
+		}
+
+		buf = d.pullNextBatch(buf, batchSize)
+		d.dropLockAndSendBatch(sink, buf)
+	}
+}
+
+func (d *DedupeBuffer) pullNextBatch(buf []any, batchSize int) []any {
+	// Grab a batch of updates off the queue.
+	buf = buf[:0]
+	for len(buf) < batchSize && d.pendingUpdates.Len() > 0 {
+		first := d.pendingUpdates.Front()
+		buf = append(buf, first.Value)
+		d.pendingUpdates.Remove(first)
+		if u, ok := first.Value.(updateWithStringKey); ok {
+			key := u.key
+			delete(d.keyToPendingUpdate, key)
+			// Update sentKeys now, before we drop the lock.  Once we drop
+			// the lock we're committed to sending these keys.
+			if u.update.Value == nil {
+				d.sentKeys.Discard(key)
+			} else {
+				d.sentKeys.Add(key)
+			}
+		}
+	}
+	return buf
+}
+
+func (d *DedupeBuffer) dropLockAndSendBatch(sink api.SyncerCallbacks, buf []any) {
+	// RELEASE(!) lock while we send updates downstream.
+	d.lock.Unlock()
+	defer d.lock.Lock()
+
+	debug := log.IsLevelEnabled(log.DebugLevel)
+	updates := make([]api.Update, 0, len(buf))
+	for _, msg := range buf {
+		switch msg := msg.(type) {
+		case updateWithStringKey:
+			updates = append(updates, msg.update)
+		case api.SyncStatus:
+			if len(updates) > 0 {
+				if debug {
+					log.WithField("updates", updates).Debug("Sending updates (pre status update)")
+				}
+				sink.OnUpdates(updates)
+				updates = updates[len(updates):] // Re-slice to end so we don't share storage.
+			}
+			if debug {
+				log.WithField("status", msg).Debug("Sending status update")
+			}
+			sink.OnStatusUpdated(msg)
+		default:
+			log.WithField("msg", msg).Panicf("Unexpected message on queue: %T", msg)
+		}
+	}
+	if len(updates) > 0 {
+		if debug {
+			log.WithField("updates", updates).Debug("Sending updates")
+		}
+		sink.OnUpdates(updates)
+		updates = updates[len(updates):] // Re-slice to end so we don't share storage.
+	}
+}
+
+var _ api.SyncerCallbacks = (*DedupeBuffer)(nil)

--- a/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
+++ b/libcalico-go/lib/backend/syncersv1/dedupebuffer/dedupe_buffer_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dedupebuffer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
+)
+
+func init() {
+	logrus.AddHook(&logutils.ContextHook{})
+	logrus.SetFormatter(&logutils.Formatter{})
+	logrus.SetLevel(logrus.DebugLevel)
+}
+
+func TestDedupeBuffer_SyncNoDupes(t *testing.T) {
+	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
+		t.Run(onUpdatesVersion, func(t *testing.T) {
+			RegisterTestingT(t)
+			d := New()
+			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
+			rec := NewReceiver()
+
+			d.OnStatusUpdated(api.WaitForDatastore)
+			d.OnStatusUpdated(api.ResyncInProgress)
+			onUpdates([]api.Update{KVUpdate("foo", "bar")})
+			onUpdates([]api.Update{KVUpdate("foo2", "bar2")})
+			d.OnStatusUpdated(api.InSync)
+
+			applyNextBatchSync(d, rec)
+
+			Expect(rec.FinalValues()).To(Equal(map[string]string{
+				"foo":  "bar",
+				"foo2": "bar2",
+			}))
+			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+			Expect(rec.UpdatesSeen()).To(Equal([]string{
+				// WaitForDatastore gets skipped since it's in the same batch.
+				string(api.ResyncInProgress),
+				"foo=bar",
+				"foo2=bar2",
+				string(api.InSync),
+			}))
+
+			// Now send in a deletion.
+			rec.ResetUpdatesSeen()
+			onUpdates([]api.Update{KVUpdate("foo", "")})
+			applyNextBatchSync(d, rec)
+			Expect(rec.FinalValues()).To(Equal(map[string]string{
+				"foo2": "bar2",
+			}))
+			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+			Expect(rec.UpdatesSeen()).To(Equal([]string{
+				"foo=",
+			}))
+
+			// Now send in a deletion, which is reverted before being sent.
+			rec.ResetUpdatesSeen()
+			onUpdates([]api.Update{KVUpdate("foo2", "")})
+			onUpdates([]api.Update{KVUpdate("foo2", "bar3")})
+			applyNextBatchSync(d, rec)
+			Expect(rec.FinalValues()).To(Equal(map[string]string{
+				"foo2": "bar3",
+			}))
+			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+			Expect(rec.UpdatesSeen()).To(Equal([]string{
+				"foo2=bar3",
+			}))
+
+			// Update both keys, should work as normal.
+			rec.ResetUpdatesSeen()
+			onUpdates([]api.Update{KVUpdate("foo", "bar")})
+			onUpdates([]api.Update{KVUpdate("foo2", "bar2")})
+			applyNextBatchSync(d, rec)
+			Expect(rec.FinalValues()).To(Equal(map[string]string{
+				"foo":  "bar",
+				"foo2": "bar2",
+			}))
+			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+			Expect(rec.UpdatesSeen()).To(Equal([]string{
+				// WaitForDatastore gets skipped since it's in the same batch.
+				"foo=bar",
+				"foo2=bar2",
+			}))
+		})
+	}
+}
+
+func TestDedupeBuffer_SyncWithDupes(t *testing.T) {
+	for _, onUpdatesVersion := range []string{"KeysKnown", "KeysNotKnown"} {
+		t.Run(onUpdatesVersion, func(t *testing.T) {
+			RegisterTestingT(t)
+			d := New()
+			onUpdates := wrapOnUpdates(d, onUpdatesVersion)
+			rec := NewReceiver()
+
+			d.OnStatusUpdated(api.WaitForDatastore)
+			d.OnStatusUpdated(api.ResyncInProgress)
+			onUpdates([]api.Update{KVUpdate("foo", "bar")})
+			onUpdates([]api.Update{KVUpdate("foo2", "bar2")})
+			onUpdates([]api.Update{KVUpdate("foo3", "bar3")})
+			onUpdates([]api.Update{KVUpdate("foo", "bar3")})
+			onUpdates([]api.Update{KVUpdate("foo2", "")})
+			d.OnStatusUpdated(api.InSync)
+			d.OnStatusUpdated(api.ResyncInProgress)
+			d.OnStatusUpdated(api.ResyncInProgress)
+			d.OnStatusUpdated(api.InSync)
+
+			applyNextBatchSync(d, rec)
+
+			Expect(rec.FinalValues()).To(Equal(map[string]string{
+				"foo":  "bar3",
+				"foo3": "bar3",
+			}))
+			Expect(rec.FinalSyncState()).To(Equal(api.InSync))
+			Expect(rec.UpdatesSeen()).To(Equal([]string{
+				// WaitForDatastore skipped.
+				string(api.ResyncInProgress),
+				"foo=bar3", // Update leap-frogs the original value.
+				"foo3=bar3",
+				string(api.InSync),
+			}))
+		})
+	}
+}
+
+func applyNextBatchSync(d *DedupeBuffer, r *Receiver) {
+	Expect(d.pendingUpdates.Len()).NotTo(BeZero(), "Nothing on queue, sendNextBatchToSink would block")
+	d.sendNextBatchToSink(r)
+}
+
+func wrapOnUpdates(d *DedupeBuffer, onUpdatesVersion string) func(updates []api.Update) {
+	onUpdates := d.OnUpdates
+	if onUpdatesVersion == "KeysKnown" {
+		onUpdates = func(updates []api.Update) {
+			var keys []string
+			for _, upd := range updates {
+				key, err := model.KeyToDefaultPath(upd.Key)
+				Expect(err).NotTo(HaveOccurred())
+				keys = append(keys, key)
+			}
+			d.OnUpdatesKeysKnown(updates, keys)
+		}
+	}
+	return onUpdates
+}
+
+func KVUpdate(key, value string) api.Update {
+	u := api.Update{
+		KVPair: model.KVPair{
+			Key: model.HostConfigKey{
+				Hostname: "foo",
+				Name:     key,
+			},
+		},
+	}
+	if value != "" {
+		u.KVPair.Value = value
+	}
+	return u
+}
+
+type Receiver struct {
+	mutex sync.Mutex
+
+	finalValues    map[string]string
+	updatesSeen    []string
+	finalSyncState api.SyncStatus
+}
+
+func (r *Receiver) FinalValues() map[string]string {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	fvCopy := map[string]string{}
+	for k, v := range r.finalValues {
+		fvCopy[k] = v
+	}
+	return fvCopy
+}
+
+func (r *Receiver) UpdatesSeen() []string {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	var usCopy []string
+	for _, v := range r.updatesSeen {
+		usCopy = append(usCopy, v)
+	}
+	return usCopy
+}
+
+func (r *Receiver) FinalSyncState() api.SyncStatus {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.finalSyncState
+}
+
+func (r *Receiver) OnStatusUpdated(status api.SyncStatus) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.updatesSeen = append(r.updatesSeen, string(status))
+	r.finalSyncState = status
+}
+
+func (r *Receiver) OnUpdates(updates []api.Update) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	for _, update := range updates {
+		k := update.Key.(model.HostConfigKey).Name
+		var v string
+		if update.Value == nil {
+			delete(r.finalValues, k)
+		} else {
+			v = update.Value.(string)
+			r.finalValues[k] = v
+		}
+		r.updatesSeen = append(r.updatesSeen, fmt.Sprintf("%s=%s", k, v))
+	}
+}
+
+func (r *Receiver) ResetUpdatesSeen() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.updatesSeen = nil
+}
+
+func NewReceiver() *Receiver {
+	return &Receiver{
+		finalValues: map[string]string{},
+	}
+}

--- a/typha/pkg/syncclient/sync_client.go
+++ b/typha/pkg/syncclient/sync_client.go
@@ -27,9 +27,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/golang/snappy"
+	log "github.com/sirupsen/logrus"
 
 	calicotls "github.com/projectcalico/calico/crypto/pkg/tls"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
@@ -124,13 +123,17 @@ func New(
 	if options == nil {
 		options = &Options{}
 	}
+	cbskn, ok := cbs.(callbacksWithKeysKnown)
+	if !ok {
+		cbskn = callbacksWithKeysKnownAdapter{cbs}
+	}
 	return &SyncerClient{
 		ID: id,
 		logCxt: log.WithFields(log.Fields{
 			"myID": id,
 			"type": options.SyncerType,
 		}),
-		callbacks:  cbs,
+		callbacks:  cbskn,
 		discoverer: discoverer,
 
 		myVersion:  myVersion,
@@ -159,8 +162,21 @@ type SyncerClient struct {
 	handshakeStatus             *handshakeStatus
 	supportsNodeResourceUpdates bool
 
-	callbacks api.SyncerCallbacks
+	callbacks callbacksWithKeysKnown
 	Finished  sync.WaitGroup
+}
+
+type callbacksWithKeysKnown interface {
+	api.SyncerCallbacks
+	OnUpdatesKeysKnown(updates []api.Update, keys []string)
+}
+
+type callbacksWithKeysKnownAdapter struct {
+	api.SyncerCallbacks
+}
+
+func (c callbacksWithKeysKnownAdapter) OnUpdatesKeysKnown(updates []api.Update, keys []string) {
+	c.OnUpdates(updates)
 }
 
 type handshakeStatus struct {
@@ -482,6 +498,7 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 			logCxt.Debug("Pong sent to Typha")
 		case syncproto.MsgKVs:
 			updates := make([]api.Update, 0, len(msg.KVs))
+			keys := make([]string, 0, len(msg.KVs))
 			if s.options.DebugDiscardKVUpdates {
 				// For simulating lots of clients in tests, just throw away the data.
 				continue
@@ -499,8 +516,9 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 					}).Debug("Decoded update from Typha")
 				}
 				updates = append(updates, update)
+				keys = append(keys, kv.Key)
 			}
-			s.callbacks.OnUpdates(updates)
+			s.callbacks.OnUpdatesKeysKnown(updates, keys)
 		case syncproto.MsgDecoderRestart:
 			if s.options.DisableDecoderRestart {
 				log.Error("Server sent MsgDecoderRestart but we signalled no support.")


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
The deduplicating buffer implements the syncer callbacks API on its input, and calls another syncer callback on its output. In-between it maintains an in-order queue of KV updates and a tracking map to record what is in the queue.

If an update comes in for a key that already has a value in the queue then the value in the queue is replaced with the updated KV.

This can cause reordering (which is allowed by the syncer API) but it ensures that the amount of KVs in flight is bounded to the total size of the datastore even under substantial overload. The effect is that the client will periodically "skip ahead" to the more recent state of the datatstore without seeing intermediate states.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add a decoupling buffer between the Typha client library and downstream code.  This prevents the Typha client from being blocked if the downstream code blocks for too long.  This prevents timeouts at very high scale.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
