### PR TITLE
Add calc graph benchmarks

### DIFF
--- a/felix/calc/calc_graph_bench_test.go
+++ b/felix/calc/calc_graph_bench_test.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/calico/felix/config"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+	calinet "github.com/projectcalico/calico/libcalico-go/lib/net"
+	"github.com/sirupsen/logrus"
+)
+
+const numNamespaces = 100
+
+func BenchmarkInitialSnapshot200Local250kTotal10000TagPols(b *testing.B) {
+	benchInitialSnap(b, 250_000, 200, 10000, 0)
+}
+
+func BenchmarkInitialSnapshot200Local10kTotal1000NetsetPols(b *testing.B) {
+	benchInitialSnap(b, 10000, 200, 0, 1000)
+}
+
+func BenchmarkInitialSnapshot200Local10kTotal10000NetsetPols(b *testing.B) {
+	benchInitialSnap(b, 10000, 200, 0, 10000)
+}
+
+func benchInitialSnap(b *testing.B, numEndpoints int, numLocalEndpoints int, numTagPols int, netSetsAndPols int) {
+	RegisterTestingT(b)
+	defer logrus.SetLevel(logrus.GetLevel())
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	epUpdates := makeEndpointUpdates(numEndpoints, "remotehost")
+	localUpdates := makeEndpointUpdates(numLocalEndpoints, "localhost")
+	polUpdates := makeTagPolicies(numTagPols)
+	profUpdates := makeNamespaceUpdates(numNamespaces)
+	netSetUpdates := makeNetSetAndPolUpdates(netSetsAndPols)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		runtime.GC()
+		logrus.SetLevel(logrus.ErrorLevel)
+
+		conf := config.New()
+		conf.FelixHostname = "localhost"
+		es := NewEventSequencer(conf)
+		cg := NewCalculationGraph(es, conf, func() {})
+
+		logrus.SetLevel(logrus.WarnLevel)
+		b.StartTimer()
+		b.ReportAllocs()
+		startTime := time.Now()
+		cg.AllUpdDispatcher.OnUpdates(polUpdates)
+		cg.AllUpdDispatcher.OnUpdates(profUpdates)
+		cg.AllUpdDispatcher.OnUpdates(epUpdates)
+		cg.AllUpdDispatcher.OnUpdates(netSetUpdates)
+		cg.AllUpdDispatcher.OnUpdates(localUpdates)
+		cg.AllUpdDispatcher.OnDatamodelStatus(api.InSync)
+
+		Expect(es.pendingEndpointTierUpdates).To(HaveLen(numLocalEndpoints))
+		b.ReportMetric(float64(time.Since(startTime).Seconds()), "s")
+		b.ReportMetric(float64(len(es.pendingAddedIPSets)), "IPSets")
+		b.ReportMetric(float64(len(es.pendingPolicyUpdates)), "Policies")
+	}
+}
+
+func makeNetSetAndPolUpdates(num int) []api.Update {
+	updates := make([]api.Update, 0, num)
+	for i := 0; i < num; i++ {
+		// Make one netset and a matching policy.
+		name := fmt.Sprintf("network-set-%d", i)
+		netset := &model.NetworkSet{
+			Nets: generateNetSetIPs(),
+			Labels: map[string]string{
+				"network-set-name": name,
+			},
+		}
+		updates = append(updates, api.Update{
+			KVPair: model.KVPair{
+				Key:   model.NetworkSetKey{Name: name},
+				Value: netset,
+			},
+		})
+
+		pol := &model.Policy{}
+		pol.Selector = "all()"
+		pol.InboundRules = append(pol.InboundRules, model.Rule{
+			Action:      "Allow",
+			SrcSelector: fmt.Sprintf("network-set-name == '%s'", name),
+		})
+		updates = append(updates, api.Update{
+			KVPair: model.KVPair{
+				Key:   model.PolicyKey{Name: fmt.Sprintf("network-set-pol-%d", i)},
+				Value: pol,
+			},
+		})
+	}
+	return updates
+}
+
+var nextNetSetIP uint32 = 0xa000001
+var nextNetSetSizeIdx int
+var netSetSizes = []int{
+	1, 1, 1, 1, 2, 3, 4, 5,
+	100,
+	1000,
+}
+
+func generateNetSetIPs() (ips []calinet.IPNet) {
+	size := netSetSizes[nextNetSetSizeIdx%len(netSetSizes)]
+	nextNetSetSizeIdx++
+	for i := 0; i < size; i++ {
+		theIP := net.IPv4(0, 0, 0, 0)
+		binary.BigEndian.PutUint32(theIP, nextNetSetIP)
+		_, n, _ := calinet.ParseCIDROrIP(theIP.String())
+		ips = append(ips, *n)
+		nextNetSetIP++
+	}
+	return
+}
+
+func makeNamespaceUpdates(num int) []api.Update {
+	const rulesPerPol = 5
+	updates := make([]api.Update, 0, num)
+	for i := 0; i < num; i++ {
+		name := fmt.Sprintf("namespace-%d", i)
+		prof := &v3.Profile{
+			Spec: v3.ProfileSpec{
+				LabelsToApply: map[string]string{
+					conversion.NamespaceLabelPrefix + conversion.NameLabel: name,
+				},
+			},
+		}
+
+		updates = append(updates, api.Update{
+			KVPair: model.KVPair{
+				Key:   model.ResourceKey{Kind: v3.KindProfile, Name: conversion.NamespaceProfileNamePrefix + name},
+				Value: prof,
+			},
+		})
+		updates = append(updates, api.Update{
+			KVPair: model.KVPair{
+				Key: model.ProfileRulesKey{
+					model.ProfileKey{Name: conversion.NamespaceProfileNamePrefix + name},
+				},
+				Value: &model.ProfileRules{
+					InboundRules:  nil,
+					OutboundRules: nil,
+				},
+			},
+		})
+	}
+	return updates
+}
+
+var nextTagPolID int
+
+func makeTagPolicies(num int) []api.Update {
+	const rulesPerPol = 5
+	updates := make([]api.Update, 0, num)
+	for i := 0; i < num; i++ {
+		pol := &model.Policy{}
+		pol.Selector = fmt.Sprintf("has(%s)", markerLabels[i%len(markerLabels)])
+		for j := 0; j < rulesPerPol; j++ {
+			pol.InboundRules = append(pol.InboundRules, model.Rule{
+				Action:      "Allow",
+				SrcSelector: fmt.Sprintf("has(%s)", markerLabels[(nextTagPolID+j)%len(markerLabels)]),
+			})
+		}
+
+		updates = append(updates, api.Update{
+			KVPair: model.KVPair{
+				Key:   model.PolicyKey{Name: fmt.Sprintf("tag-pol-%d", nextTagPolID)},
+				Value: pol,
+			},
+		})
+
+		nextTagPolID++
+	}
+	return updates
+}
+
+func makeEndpointUpdates(num int, host string) []api.Update {
+	updates := make([]api.Update, num)
+	for n := 0; n < num; n++ {
+		key := model.WorkloadEndpointKey{
+			Hostname:       host,
+			OrchestratorID: "k8s",
+			WorkloadID:     fmt.Sprintf("wep-%d", n),
+			EndpointID:     "eth0",
+		}
+		ipNet := getNextIP()
+		updates[n] = api.Update{
+			KVPair: model.KVPair{
+				Key: key,
+				Value: &model.WorkloadEndpoint{
+					Labels:     generateLabels(),
+					IPv4Nets:   []calinet.IPNet{ipNet},
+					ProfileIDs: []string{fmt.Sprintf(conversion.NamespaceProfileNamePrefix+"namespace-%d", n%numNamespaces)},
+				},
+			},
+		}
+	}
+	return updates
+}
+
+var nextIP uint32 = 0xa000001
+
+func getNextIP() calinet.IPNet {
+	theIP := net.IPv4(0, 0, 0, 0)
+	binary.BigEndian.PutUint32(theIP, nextIP)
+	nextIP++
+	return calinet.IPNet{IPNet: net.IPNet{
+		IP:   theIP,
+		Mask: net.CIDRMask(32, 32),
+	}}
+}
+
+var markerLabels = []string{
+	"FOO_BAR",
+	"FOO_BAR",
+	"BIFF_BOP",
+	"calico/FizzBuzz",
+	"calico/BoffBip",
+	"calico/Bazzle",
+	"calico/Razzle",
+	"calico/DoopDeeDoo",
+	"calico/SOME_LABEL",
+	"calico/BORED_NOW",
+	"MyMarkerLabel",
+	"xFOO_BAR",
+	"xBIFF_BOP",
+	"xcalico/FizzBuzz",
+	"xcalico/BoffBip",
+	"xcalico/Bazzle",
+	"xcalico/Razzle",
+	"xcalico/DoopDeeDoo",
+	"xcalico/SOME_LABEL",
+	"xcalico/BORED_NOW",
+	"yxMyMarkerLabel",
+	"yxFOO_BAR",
+	"yxBIFF_BOP",
+	"yxcalico/FizzBuzz",
+	"yxcalico/BoffBip",
+	"yxcalico/Bazzle",
+	"yxcalico/Razzle",
+	"yxcalico/DoopDeeDoo",
+	"yxcalico/SOME_LABEL",
+	"yxcalico/BORED_NOW",
+	"yxMyMarkerLabel",
+}
+
+var labelSeed int
+
+func generateLabels() map[string]string {
+	labelSeed++
+	labels := map[string]string{}
+	for _, n := range []int{10, 11, 20, 30, 40} {
+		labels[fmt.Sprintf("one-in-%d", n)] = fmt.Sprintf("value-%d", labelSeed%n)
+	}
+	labels[markerLabels[labelSeed%len(markerLabels)]] = "true"
+	return labels
+}


### PR DESCRIPTION
Mimic a couple of scenarios seen in the wild:

- One with many pods and labels used as "tags".
- One with many static network sets, used to implement global baseline policy.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Mimic a couple of scenarios seen in the wild:

- One with many pods and labels used as "tags".
- One with many static network sets, used to implement global baseline policy.
## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
