### PR TITLE
Removing weak ciphers

### DIFF
--- a/apiserver/cmd/apiserver/server/options.go
+++ b/apiserver/cmd/apiserver/server/options.go
@@ -120,8 +120,6 @@ func (o *CalicoServerOptions) Config() (*apiserver.Config, error) {
 		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 	}
 	serverConfig.SecureServing.CipherSuites = cipherSuites
 	serverConfig.SecureServing.MinTLSVersion = tls.VersionTLS12


### PR DESCRIPTION
## Description

- Bug fix.
- 2x weak ciphers (TLS_RSA_WITH_AES_256_GCM_SHA384 and TLS_RSA_WITH_AES_128_GCM_SHA256) being removed as they do not provide perfect forward secrecy (PFS).
- Endpoint tested with testssl.sh and ciphers checked against SSLlabs and ciphersuite.info.
- calico-typha.


## Related issues/PRs
Fixes #7881 