### PR TITLE
Add version/manifest committing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ generate:
 	$(MAKE) -C app-policy protobuf
 	$(MAKE) gen-manifests
 
-gen-manifests: bin/helm
+gen-manifests: bin/helm bin/yq
 	cd ./manifests && \
 		OPERATOR_VERSION=$(OPERATOR_VERSION) \
 		CALICO_VERSION=$(CALICO_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,11 @@ ci-preflight-checks:
 	$(MAKE) check-dirty
 
 update-versions:
-	$(MAKE) -C hack/versions update-versions
+	@$(MAKE) -C hack/versions update-versions
+
+commit-versions-manifests: bin/yq
+	@hack/versions/commit_update_versions.sh
+	$(MAKE) check-dirty
 
 check-language:
 	./hack/check-language.sh

--- a/hack/release/Makefile
+++ b/hack/release/Makefile
@@ -18,6 +18,9 @@ test-remote-fetch: .vm.created
 update-versions-remote: .vm.created
 	./remote-execute.sh "cd calico && make update-versions generate"
 
+commit-versions-remote: .vm.created
+	./remote-execute.sh "cd calico && make commit-versions-manifests"
+
 test-remote-build-release: .vm.created
 	./remote-execute.sh "cd calico && make release"
 

--- a/hack/versions/commit_update_versions.sh
+++ b/hack/versions/commit_update_versions.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+GIT_TOPLEVEL=$(git rev-parse --show-toplevel)
+
+if [[ $(pwd) != $GIT_TOPLEVEL ]]; then
+    cd GIT_TOPLEVEL
+fi
+
+git add charts/calico/values.yaml charts/tigera-operator/values.yaml
+git add manifests/
+git commit -m "[CI] Updating charts and manifests for Calico $(bin/yq .version charts/calico/values.yaml)" \
+           -m "Automatic update from Semaphore release process"
+

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -7,11 +7,27 @@
 # Helm binary to use. Default to the one installed by the Makefile.
 HELM=${HELM:-../bin/helm}
 
+# yq binary to use for parsing component versions not found in charts. Default to the one installed by the Makefile.
+YQ=${YQ:-../bin/yq}
+
+if [[ ! -f $HELM ]]; then
+    echo "[ERROR] Helm binary ${HELM} not found."
+    exit 1
+fi
+if [[ ! -f $YQ ]]; then
+    echo "[ERROR] yq binary ${YQ} not found."
+    exit 1
+fi
+
 # Get versions to install.
-defaultCalicoVersion=$(cat ../charts/calico/values.yaml | grep version: | cut -d" " -f2)
+defaultCalicoVersion=$($YQ '.[0].title' ../calico/_data/versions.yml)
 CALICO_VERSION=${CALICO_VERSION:-$defaultCalicoVersion}
 
-defaultOperatorVersion=$(cat ../charts/tigera-operator/values.yaml | grep version: | cut -d" " -f4)
+defaultRegistry=quay.io
+REGISTRY=${REGISTRY:-$defaultRegistry}
+
+# Versions retrieved from charts.
+defaultOperatorVersion=$($YQ .tigeraOperator.version < ../charts/tigera-operator/values.yaml)
 OPERATOR_VERSION=${OPERATOR_VERSION:-$defaultOperatorVersion}
 
 NON_HELM_MANIFEST_IMAGES="calico/apiserver calico/windows calico/ctl calico/csi calico/node-driver-registrar calico/dikastes"

--- a/manifests/generate.sh
+++ b/manifests/generate.sh
@@ -20,7 +20,7 @@ if [[ ! -f $YQ ]]; then
 fi
 
 # Get versions to install.
-defaultCalicoVersion=$($YQ '.[0].title' ../calico/_data/versions.yml)
+defaultCalicoVersion=$($YQ '.version' ../charts/calico/values.yaml)
 CALICO_VERSION=${CALICO_VERSION:-$defaultCalicoVersion}
 
 defaultRegistry=quay.io


### PR DESCRIPTION
Add the ability to commit the version changes from `make update-versions` and `make generate`:

* Add `hack/versions/commit_update_versions.sh` script with some simple commands to commit the changes we make. Down the road, we will add in some more build metadata to these commits (e.g. the link to the semaphore pipeline/job)
* Add `commit-versions-manifests` top-level `Makefile` target to run the above script. It also calls `check-dirty` and fails if any filers are still dirty
* Add `commit-versions-remote` target to `hack/release/Makefile` to call `make commit-versions-manifests` on the remote server during releases

Also update `manifests/generate.sh` logic 