### PR TITLE
fix: adding timeout to the typha server TLS handshake

### DIFF
--- a/typha/pkg/config/config_params.go
+++ b/typha/pkg/config/config_params.go
@@ -120,6 +120,7 @@ type Config struct {
 	ServerMinBatchingAgeThresholdSecs    time.Duration `config:"seconds;0.01"`
 	ServerPingIntervalSecs               time.Duration `config:"seconds;10"`
 	ServerPongTimeoutSecs                time.Duration `config:"seconds;60"`
+	ServerHandshakeTimeoutSecs           time.Duration `config:"seconds;10"`
 	ServerPort                           int           `config:"port;0"`
 
 	// Server-side TLS config for Typha's communication with Felix.  If any of these are

--- a/typha/pkg/daemon/daemon.go
+++ b/typha/pkg/daemon/daemon.go
@@ -394,6 +394,7 @@ func (t *TyphaDaemon) CreateServer() {
 			NewClientFallBehindGracePeriod: t.ConfigParams.ServerNewClientFallBehindGracePeriod,
 			PingInterval:                   t.ConfigParams.ServerPingIntervalSecs,
 			PongTimeout:                    t.ConfigParams.ServerPongTimeoutSecs,
+			HandshakeTimeout:               t.ConfigParams.ServerHandshakeTimeoutSecs,
 			DropInterval:                   t.ConfigParams.ConnectionDropIntervalSecs,
 			ShutdownTimeout:                t.ConfigParams.ShutdownTimeoutSecs,
 			ShutdownMaxDropInterval:        t.ConfigParams.ShutdownConnectionDropIntervalMaxSecs,

--- a/typha/pkg/syncserver/syncserver_test.go
+++ b/typha/pkg/syncserver/syncserver_test.go
@@ -41,6 +41,7 @@ var _ = Describe("With zero config", func() {
 			MinBatchingAgeThreshold:        100 * time.Millisecond,
 			PingInterval:                   10 * time.Second,
 			PongTimeout:                    60 * time.Second,
+			HandshakeTimeout:               10 * time.Second,
 			DropInterval:                   time.Second,
 			ShutdownTimeout:                300 * time.Second,
 			ShutdownMaxDropInterval:        time.Second,


### PR DESCRIPTION
## Description

This PR adds a timeout to the TLS handshake in the typha server equals to one Ping duration, the intention with this is to avoid misbehaving clients to take the typha server down when connections are left in an unclean state during the handshake.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
fixes #7908

## Todos

- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add a timeout to Typha's TLS handshake.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
