### PR TITLE
Remove outdated comments from the code that created veth

### DIFF
--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -192,7 +192,6 @@ func (d *linuxDataplane) DoNetworking(
 		d.logger.WithField("MAC", contVethMAC).Debug("Found MAC for container veth")
 
 		// At this point, the virtual ethernet pair has been created, and both ends have the right names.
-		// Both ends of the veth are still in the container's network namespace.
 
 		// Do the per-IP version set-up.  Add gateway routes etc.
 		if hasIPv4 {


### PR DESCRIPTION
In #7705, the host veth is created directly in the host namespace, rather than being created first in the container namespace.

Signed-off-by: iiiceoo <iiiceoo@foxmail.com>