### PR TITLE
Add Openstack package publishing to the test build promotion

### DIFF
--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -6,7 +6,7 @@ agent:
     os_image: ubuntu2004
 
 execution_time_limit:
-  minutes: 360
+  minutes: 600
 
 blocks:
   - name: "Publish official release"
@@ -19,6 +19,7 @@ blocks:
       - name: docker
       - name: oss-release-secrets
       - name: google-service-account-for-gce
+      - name: openstack-signing-publishing
       prologue:
         commands:
         # Load the github access secrets.  First fix the permissions.
@@ -43,6 +44,8 @@ blocks:
         - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
       jobs:
       - name: "Release on GCP VM"
+        execution_time_limit:
+          minutes: 180
         env_vars:
         - name: VAR_FILE
           value: /home/semaphore/secrets/release.tfvars
@@ -50,6 +53,20 @@ blocks:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release apply; fi
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release release; fi
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release release-publish; fi
+      - name: "Build Openstack Packages"
+        execution_time_limit:
+          minutes: 60
+        env_vars:
+        - name: SECRET_KEY
+          value: ~/secrets/launchpad-gpg-key-dfox.key
+        - name: GCLOUD_ARGS
+          value: --zone us-east1-c --project tigera-wp-tcp-redirect
+        - name: HOST
+          value: ubuntu@binaries-projectcalico-org
+        commands:
+        - sudo apt update
+        - sudo apt install -y moreutils
+        - make publish-openstack
       epilogue:
         always:
           commands:

--- a/.semaphore/release/test-release-build.yml
+++ b/.semaphore/release/test-release-build.yml
@@ -16,6 +16,7 @@ blocks:
       - name: docker
       - name: oss-release-secrets
       - name: google-service-account-for-gce
+      - name: openstack-signing-publishing
       prologue:
         commands:
         # Load the github access secrets.  First fix the permissions.
@@ -49,6 +50,18 @@ blocks:
         - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release generate-manifests-remote
         - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release commit-versions-remote
         - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release build-release-remote
+      - name: "Build Openstack Packages"
+        execution_time_limit:
+          minutes: 60
+        env_vars:
+        - name: SECRET_KEY
+          value: ~/secrets/launchpad-gpg-key-dfox.key
+        - name: GCLOUD_ARGS
+          value: --zone us-east1-c --project tigera-wp-tcp-redirect
+        - name: HOST
+          value: ubuntu@binaries-projectcalico-org
+        commands:
+        - make build-openstack
       epilogue:
         always:
           commands:

--- a/.semaphore/release/test-release-build.yml
+++ b/.semaphore/release/test-release-build.yml
@@ -61,6 +61,8 @@ blocks:
         - name: HOST
           value: ubuntu@binaries-projectcalico-org
         commands:
+        - sudo apt update
+        - sudo apt install -y moreutils
         - make build-openstack
       epilogue:
         always:

--- a/.semaphore/release/test-release-build.yml
+++ b/.semaphore/release/test-release-build.yml
@@ -37,19 +37,19 @@ blocks:
         - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
         - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
       jobs:
-      # - name: "Test release on GCP VM"
-      #   execution_time_limit:
-      #     minutes: 180
-      #   env_vars:
-      #   - name: VAR_FILE
-      #     value: /home/semaphore/secrets/release-test.tfvars
-      #   commands:
-      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release apply
-      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release git-fetch-remote
-      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release update-versions-remote
-      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release generate-manifests-remote
-      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release commit-versions-remote
-      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release build-release-remote
+      - name: "Test release on GCP VM"
+        execution_time_limit:
+          minutes: 180
+        env_vars:
+        - name: VAR_FILE
+          value: /home/semaphore/secrets/release-test.tfvars
+        commands:
+        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release apply
+        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release git-fetch-remote
+        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release update-versions-remote
+        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release generate-manifests-remote
+        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release commit-versions-remote
+        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release build-release-remote
       - name: "Build Openstack Packages"
         execution_time_limit:
           minutes: 60

--- a/.semaphore/release/test-release-build.yml
+++ b/.semaphore/release/test-release-build.yml
@@ -37,19 +37,19 @@ blocks:
         - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/secret.google-service-account-key.json
         - gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
       jobs:
-      - name: "Test release on GCP VM"
-        execution_time_limit:
-          minutes: 180
-        env_vars:
-        - name: VAR_FILE
-          value: /home/semaphore/secrets/release-test.tfvars
-        commands:
-        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release apply
-        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release git-fetch-remote
-        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release update-versions-remote
-        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release generate-manifests-remote
-        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release commit-versions-remote
-        - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release build-release-remote
+      # - name: "Test release on GCP VM"
+      #   execution_time_limit:
+      #     minutes: 180
+      #   env_vars:
+      #   - name: VAR_FILE
+      #     value: /home/semaphore/secrets/release-test.tfvars
+      #   commands:
+      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release apply
+      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release git-fetch-remote
+      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release update-versions-remote
+      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release generate-manifests-remote
+      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release commit-versions-remote
+      #   - make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} -C hack/release build-release-remote
       - name: "Build Openstack Packages"
         execution_time_limit:
           minutes: 60

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,18 @@ release-publish: hack/release/release hack/release/ghr
 create-release-branch: hack/release/release
 	@hack/release/release -new-branch
 
+# Currently our openstack builds either build *or* build and publish,
+# hence why we have two separate jobs here that do almost the same thing.
+build-openstack: bin/yq
+	$(eval VERSION=$(shell bin/yq '.version' charts/calico/values.yaml))
+	$(info Building openstack packages for version $(VERSION))
+	$(MAKE) -C hack/release/packaging release VERSION=$(VERSION)
+
+publish-openstack: bin/yq
+	$(eval VERSION=$(shell bin/yq '.version' charts/calico/values.yaml))
+	$(info Publishing openstack packages for version $(VERSION))
+	$(MAKE) -C hack/release/packaging release-publish VERSION=$(VERSION)
+
 ## Kicks semaphore job which syncs github released helm charts with helm index file
 .PHONY: helm-index
 helm-index:

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,13 @@ create-release-branch: hack/release/release
 build-openstack: bin/yq
 	$(eval VERSION=$(shell bin/yq '.version' charts/calico/values.yaml))
 	$(info Building openstack packages for version $(VERSION))
+	$(MAKE) -C hack/release/packaging set-git-identity
 	$(MAKE) -C hack/release/packaging release VERSION=$(VERSION)
 
 publish-openstack: bin/yq
 	$(eval VERSION=$(shell bin/yq '.version' charts/calico/values.yaml))
 	$(info Publishing openstack packages for version $(VERSION))
+	$(MAKE) -C hack/release/packaging set-git-identity
 	$(MAKE) -C hack/release/packaging release-publish VERSION=$(VERSION)
 
 ## Kicks semaphore job which syncs github released helm charts with helm index file

--- a/Makefile
+++ b/Makefile
@@ -128,13 +128,11 @@ create-release-branch: hack/release/release
 build-openstack: bin/yq
 	$(eval VERSION=$(shell bin/yq '.version' charts/calico/values.yaml))
 	$(info Building openstack packages for version $(VERSION))
-	$(MAKE) -C hack/release/packaging set-git-identity
 	$(MAKE) -C hack/release/packaging release VERSION=$(VERSION)
 
 publish-openstack: bin/yq
 	$(eval VERSION=$(shell bin/yq '.version' charts/calico/values.yaml))
 	$(info Publishing openstack packages for version $(VERSION))
-	$(MAKE) -C hack/release/packaging set-git-identity
 	$(MAKE) -C hack/release/packaging release-publish VERSION=$(VERSION)
 
 ## Kicks semaphore job which syncs github released helm charts with helm index file

--- a/hack/release/packaging/Makefile
+++ b/hack/release/packaging/Makefile
@@ -5,3 +5,7 @@ release-publish:
 	VERSION=$(VERSION) PUBLISH=true utils/create-update-packages.sh
 release:
 	VERSION=$(VERSION) utils/create-update-packages.sh
+set-git-identity:
+	$(info *** Setting git identity to Daniel Fox <dan.fox@tigera.io> (unless it is already set))
+	@git config --get user.name >/dev/null || git config user.name "Daniel Fox" && echo "Setting git user.name == Daniel Fox"
+	@git config --get user.email >/dev/null || git config user.email "dan.fox@tigera.io"

--- a/hack/release/packaging/Makefile
+++ b/hack/release/packaging/Makefile
@@ -5,7 +5,3 @@ release-publish:
 	VERSION=$(VERSION) PUBLISH=true utils/create-update-packages.sh
 release:
 	VERSION=$(VERSION) utils/create-update-packages.sh
-set-git-identity:
-	$(info *** Setting git identity to Daniel Fox <dan.fox@tigera.io> (unless it is already set))
-	@git config --get user.name >/dev/null || git config user.name "Daniel Fox" && echo "Setting git user.name == Daniel Fox"
-	@git config --get user.email >/dev/null || git config user.email "dan.fox@tigera.io"

--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -254,6 +254,8 @@ function do_dnsmasq {
     # Ubuntu Xenial
     git checkout 2.79test1calico1-2-xenial
     sed -i s/trusty/xenial/g debian/changelog
+    git config user.name "Marvin"
+    git config user.email "marvin@tigera.io"
     git commit -a -m "switch trusty to xenial in debian/changelog" --author="Marvin <marvin@tigera.io>"
     docker_run_rm calico-build/xenial dpkg-buildpackage -I -S
 


### PR DESCRIPTION
In order to automate more steps, add the building and publishing of openstack packages to the test-release process.