### PR TITLE
Generic multidict.

### DIFF
--- a/felix/calc/active_rules_calculator.go
+++ b/felix/calc/active_rules_calculator.go
@@ -65,8 +65,8 @@ type ActiveRulesCalculator struct {
 	allALPPolicies set.Set[model.PolicyKey]
 
 	// Policy/profile ID to matching endpoint sets.
-	policyIDToEndpointKeys  multidict.IfaceToIface
-	profileIDToEndpointKeys multidict.IfaceToIface
+	policyIDToEndpointKeys  multidict.Multidict[any, any]
+	profileIDToEndpointKeys multidict.Multidict[string, any]
 
 	// Label index, matching policy selectors against local endpoints.
 	labelIndex *labelindex.InheritIndex
@@ -96,8 +96,8 @@ func NewActiveRulesCalculator() *ActiveRulesCalculator {
 		allALPPolicies: set.New[model.PolicyKey](),
 
 		// Policy/profile ID to matching endpoint sets.
-		policyIDToEndpointKeys:  multidict.NewIfaceToIface(),
-		profileIDToEndpointKeys: multidict.NewIfaceToIface(),
+		policyIDToEndpointKeys:  multidict.New[any, any](),
+		profileIDToEndpointKeys: multidict.New[string, any](),
 		missingProfiles:         set.New[string](),
 
 		// Cache of profile IDs by local endpoint.

--- a/felix/calc/event_sequencer.go
+++ b/felix/calc/event_sequencer.go
@@ -49,8 +49,8 @@ type EventSequencer struct {
 	// updates and generate updates in dependency order.
 	pendingAddedIPSets           map[string]proto.IPSetUpdate_IPSetType
 	pendingRemovedIPSets         set.Set[string]
-	pendingAddedIPSetMembers     multidict.StringToIface
-	pendingRemovedIPSetMembers   multidict.StringToIface
+	pendingAddedIPSetMembers     multidict.Multidict[string, labelindex.IPSetMember]
+	pendingRemovedIPSetMembers   multidict.Multidict[string, labelindex.IPSetMember]
 	pendingPolicyUpdates         map[model.PolicyKey]*ParsedRules
 	pendingPolicyDeletes         set.Set[model.PolicyKey]
 	pendingProfileUpdates        map[model.ProfileRulesKey]*ParsedRules
@@ -131,8 +131,8 @@ func NewEventSequencer(conf configInterface) *EventSequencer {
 		config:                     conf,
 		pendingAddedIPSets:         map[string]proto.IPSetUpdate_IPSetType{},
 		pendingRemovedIPSets:       set.New[string](),
-		pendingAddedIPSetMembers:   multidict.NewStringToIface(),
-		pendingRemovedIPSetMembers: multidict.NewStringToIface(),
+		pendingAddedIPSetMembers:   multidict.New[string, labelindex.IPSetMember](),
+		pendingRemovedIPSetMembers: multidict.New[string, labelindex.IPSetMember](),
 
 		pendingPolicyUpdates:         map[model.PolicyKey]*ParsedRules{},
 		pendingPolicyDeletes:         set.New[model.PolicyKey](),
@@ -763,8 +763,7 @@ func (buf *EventSequencer) flushAddedIPSets() {
 	for setID, setType := range buf.pendingAddedIPSets {
 		log.WithField("setID", setID).Debug("Flushing added IP set")
 		members := make([]string, 0)
-		buf.pendingAddedIPSetMembers.Iter(setID, func(value interface{}) {
-			member := value.(labelindex.IPSetMember)
+		buf.pendingAddedIPSetMembers.Iter(setID, func(member labelindex.IPSetMember) {
 			members = append(members, memberToProto(member))
 		})
 		buf.pendingAddedIPSetMembers.DiscardKey(setID)
@@ -874,12 +873,10 @@ func (buf *EventSequencer) flushAddsOrRemoves(setID string) {
 	deltaUpdate := proto.IPSetDeltaUpdate{
 		Id: setID,
 	}
-	buf.pendingAddedIPSetMembers.Iter(setID, func(item interface{}) {
-		member := item.(labelindex.IPSetMember)
+	buf.pendingAddedIPSetMembers.Iter(setID, func(member labelindex.IPSetMember) {
 		deltaUpdate.AddedMembers = append(deltaUpdate.AddedMembers, memberToProto(member))
 	})
-	buf.pendingRemovedIPSetMembers.Iter(setID, func(item interface{}) {
-		member := item.(labelindex.IPSetMember)
+	buf.pendingRemovedIPSetMembers.Iter(setID, func(member labelindex.IPSetMember) {
 		deltaUpdate.RemovedMembers = append(deltaUpdate.RemovedMembers, memberToProto(member))
 	})
 	buf.pendingAddedIPSetMembers.DiscardKey(setID)

--- a/felix/calc/policy_resolver.go
+++ b/felix/calc/policy_resolver.go
@@ -50,8 +50,8 @@ func init() {
 // expects to be told via its OnPolicyMatch(Stopped) methods which policies match
 // which endpoints.  The ActiveRulesCalculator does that calculation.
 type PolicyResolver struct {
-	policyIDToEndpointIDs multidict.IfaceToIface
-	endpointIDToPolicyIDs multidict.IfaceToIface
+	policyIDToEndpointIDs multidict.Multidict[model.PolicyKey, any]
+	endpointIDToPolicyIDs multidict.Multidict[any, model.PolicyKey]
 	allPolicies           map[model.PolicyKey]*model.Policy
 	sortedTierData        *TierInfo
 	endpoints             map[model.Key]interface{}
@@ -67,8 +67,8 @@ type PolicyResolverCallbacks interface {
 
 func NewPolicyResolver() *PolicyResolver {
 	return &PolicyResolver{
-		policyIDToEndpointIDs: multidict.NewIfaceToIface(),
-		endpointIDToPolicyIDs: multidict.NewIfaceToIface(),
+		policyIDToEndpointIDs: multidict.New[model.PolicyKey, any](),
+		endpointIDToPolicyIDs: multidict.New[any, model.PolicyKey](),
 		allPolicies:           map[model.PolicyKey]*model.Policy{},
 		sortedTierData:        NewTierInfo("default"),
 		endpoints:             make(map[model.Key]interface{}),

--- a/felix/calc/rule_scanner.go
+++ b/felix/calc/rule_scanner.go
@@ -73,9 +73,9 @@ type RuleScanner struct {
 	ipSetsByUID map[string]*IPSetData
 	// rulesIDToUIDs maps from policy/profile ID to the set of IP set UIDs that are
 	// referenced by that policy/profile.
-	rulesIDToUIDs multidict.IfaceToString
+	rulesIDToUIDs multidict.Multidict[any, string]
 	// uidsToRulesIDs maps from IP set UID to the set of policy/profile IDs that use it.
-	uidsToRulesIDs multidict.StringToIface
+	uidsToRulesIDs multidict.Multidict[string, any]
 
 	OnIPSetActive   func(ipSet *IPSetData)
 	OnIPSetInactive func(ipSet *IPSetData)
@@ -146,8 +146,8 @@ func (d *IPSetData) DataplaneProtocolType() proto.IPSetUpdate_IPSetType {
 func NewRuleScanner() *RuleScanner {
 	calc := &RuleScanner{
 		ipSetsByUID:    make(map[string]*IPSetData),
-		rulesIDToUIDs:  multidict.NewIfaceToString(),
-		uidsToRulesIDs: multidict.NewStringToIface(),
+		rulesIDToUIDs:  multidict.New[any, string](),
+		uidsToRulesIDs: multidict.New[string, any](),
 	}
 	return calc
 }

--- a/felix/multidict/multidict_test.go
+++ b/felix/multidict/multidict_test.go
@@ -22,9 +22,9 @@ import (
 )
 
 var _ = Describe("StringToString", func() {
-	var s2s StringToString
+	var s2s Multidict[string, string]
 	BeforeEach(func() {
-		s2s = NewStringToString()
+		s2s = New[string, string]()
 		s2s.Put("a", "b")
 		s2s.Put("a", "c")
 		s2s.Put("b", "d")
@@ -55,7 +55,7 @@ var _ = Describe("StringToString", func() {
 		s2s.Discard("e", "f")
 		Expect(s2s.Contains("a", "b")).To(BeTrue())
 	})
-	It("should have idempotent insett", func() {
+	It("should have idempotent insert", func() {
 		s2s.Put("a", "b")
 		Expect(s2s.Contains("a", "b")).To(BeTrue())
 	})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Noticed that MultiDict still had an awkward non-generic interface and multiple specialised variants for strings only.

* Make the MultiDict object generic; remove specialised string variants.
* Bump to Go 1.20 in the go.mod so that interfaces satisfy "comparable" 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
