### PR TITLE
[release-v3.26] Auto pick #7928: Update renamed windows AMIs

### DIFF
--- a/process/testing/winfv/cloudformation-windows-server.json
+++ b/process/testing/winfv/cloudformation-windows-server.json
@@ -232,7 +232,19 @@
                 "test" : "findstr calico-bgp c:\\k\\backend",
                 "waitAfterCompletion": "0"
               },
-              "2-run-fv" : {
+              "2-install-docker1-enable-containers" : {
+                "command": "powershell.exe -Command \"Install-WindowsFeature -Name Containers\"",
+                "waitAfterCompletion": "3"
+              },
+              "2-install-docker2-Restart-Computer" : {
+                "command": "powershell.exe -Command \"Restart-Computer -Force\"",
+                "waitAfterCompletion": "forever"
+              },
+              "2-install-docker3" : {
+                "command": "powershell.exe -Command \"Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1' -o install-docker-ce.ps1; ./install-docker-ce.ps1\"",
+                "waitAfterCompletion": "3"
+              },
+              "3-run-fv" : {
                 "command": "powershell.exe -Command \"start-process powershell -argument 'C:\\k\\run-fv.ps1' -WindowStyle hidden -RedirectStandardOutput c:\\k\\cf-fv-log.txt\" ",
                 "waitAfterCompletion": "0"
               }

--- a/process/testing/winfv/setup-fv.sh
+++ b/process/testing/winfv/setup-fv.sh
@@ -497,24 +497,12 @@ function lookup_win_cf_ami() {
   local WIN_AMI=`cat ${CF_WIN_JSON_FILE} | jq --arg region "${REGION}" --arg windows_os "${WINDOWS_OS}" -r '.Mappings.AWSRegion2AMI[$region][$windows_os]'`
 
   # windows AMI name filter strings
-  local AMI_1809_NAME="Windows_Server-2019-English-Core-ContainersLatest-*"
-  local AMI_1903_NAME="Windows_Server-1903-English-Core-ContainersLatest-*"
-  local AMI_1909_NAME="Windows_Server-1909-English-Core-ContainersLatest-*"
-  local AMI_2004_NAME="Windows_Server-2004-English-Core-ContainersLatest-*"
-  local AMI_20H2_NAME="Windows_Server-20H2-English-Core-ContainersLatest-*"
-  local AMI_2022_NAME="Windows_Server-2022-English-Core-ContainersLatest-*"
+  local AMI_1809_NAME="Windows_Server-2019-English-Core-Base-*"
+  local AMI_2022_NAME="Windows_Server-2022-English-Core-Base-*"
 
   AMI_NAME=""
   if [ $WINDOWS_OS == "Windows1809container" ];then
     AMI_NAME="${AMI_1809_NAME}"
-  elif [ $WINDOWS_OS == "Windows1903container" ];then
-    AMI_NAME="${AMI_1903_NAME}"
-  elif [ $WINDOWS_OS == "Windows1909container" ];then
-    AMI_NAME="${AMI_1909_NAME}"
-  elif [ $WINDOWS_OS == "Windows2004container" ];then
-    AMI_NAME="${AMI_2004_NAME}"
-  elif [ $WINDOWS_OS == "Windows20H2container" ];then
-    AMI_NAME="${AMI_20H2_NAME}"
   elif [ $WINDOWS_OS == "Windows2022container" ];then
     AMI_NAME="${AMI_2022_NAME}"
   fi


### PR DESCRIPTION
Cherry pick of #7928 on release-v3.26.

#7928: Update renamed windows AMIs

# Original PR Body below

Windows AMIs were renamed from 'Windows_Server-*-English-Core-ContainersLatest' to 'Windows_Server-*-English-Core-Base', update them accordingly.

Also remove mentions to unsupported windows versions (e.g 1903, 1909, 2004, 20H2).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.