### PR TITLE
Defer flush of the policy resolver

### DIFF
--- a/felix/calc/calc_graph_fv_test.go
+++ b/felix/calc/calc_graph_fv_test.go
@@ -776,11 +776,16 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 			return nil
 		})
 		statsCollector.RegisterWith(calcGraph)
-		validationFilter = NewValidationFilter(calcGraph.AllUpdDispatcher, conf)
+		validationFilter = NewValidationFilter(calcGraph, conf)
 		sentInSync = false
 		lastState = empty
 		state = empty
 	})
+
+	flush := func() {
+		calcGraph.Flush()
+		eventBuf.Flush()
+	}
 
 	// iterStates iterates through the states in turn,
 	// executing the expectation function after each
@@ -800,11 +805,11 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 							validationFilter.OnStatusUpdated(api.InSync)
 							sentInSync = true
 						}
-						eventBuf.Flush()
+						flush()
 					}
 					if flushStrategy == afterEachKVAndDupe {
 						validationFilter.OnUpdates([]api.Update{kv})
-						eventBuf.Flush()
+						flush()
 					}
 				}
 				_, _ = fmt.Fprintln(GinkgoWriter, "       -- <<FLUSH>>")
@@ -813,7 +818,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 						validationFilter.OnStatusUpdated(api.InSync)
 						sentInSync = true
 					}
-					eventBuf.Flush()
+					flush()
 				}
 				if flushStrategy == afterEachState ||
 					flushStrategy == afterEachKV ||
@@ -824,7 +829,7 @@ func doStateSequenceTest(expandedTest StateList, flushStrategy flushStrategy) {
 			}
 			if flushStrategy == atEnd {
 				validationFilter.OnStatusUpdated(api.InSync)
-				eventBuf.Flush()
+				flush()
 				expectation()
 			}
 		}

--- a/felix/calc/policy_resolver.go
+++ b/felix/calc/policy_resolver.go
@@ -111,7 +111,6 @@ func (pr *PolicyResolver) OnUpdate(update api.Update) (filterOut bool) {
 			pr.markEndpointsMatchingPolicyDirty(key)
 		}
 	}
-	pr.maybeFlush()
 	gaugeNumActivePolicies.Set(float64(pr.policyIDToEndpointIDs.Len()))
 	return
 }
@@ -119,7 +118,6 @@ func (pr *PolicyResolver) OnUpdate(update api.Update) (filterOut bool) {
 func (pr *PolicyResolver) OnDatamodelStatus(status api.SyncStatus) {
 	if status == api.InSync {
 		pr.InSync = true
-		pr.maybeFlush()
 	}
 }
 
@@ -140,7 +138,6 @@ func (pr *PolicyResolver) OnPolicyMatch(policyKey model.PolicyKey, endpointKey i
 	pr.policyIDToEndpointIDs.Put(policyKey, endpointKey)
 	pr.endpointIDToPolicyIDs.Put(endpointKey, policyKey)
 	pr.dirtyEndpoints.Add(endpointKey)
-	pr.maybeFlush()
 }
 
 func (pr *PolicyResolver) OnPolicyMatchStopped(policyKey model.PolicyKey, endpointKey interface{}) {
@@ -154,10 +151,9 @@ func (pr *PolicyResolver) OnPolicyMatchStopped(policyKey model.PolicyKey, endpoi
 	}
 
 	pr.dirtyEndpoints.Add(endpointKey)
-	pr.maybeFlush()
 }
 
-func (pr *PolicyResolver) maybeFlush() {
+func (pr *PolicyResolver) Flush() {
 	if !pr.InSync {
 		log.Debugf("Not in sync, skipping flush")
 		return

--- a/felix/calc/policy_resolver_test.go
+++ b/felix/calc/policy_resolver_test.go
@@ -3,12 +3,14 @@ package calc
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
 )
 
 func TestPolicyResolver_OnUpdate(t *testing.T) {
-	pr := NewPolicyResolver()
+	pr, recorder := createPolicyResolver()
 
 	polKey := model.PolicyKey{
 		Name: "test-policy",
@@ -37,10 +39,46 @@ func TestPolicyResolver_OnUpdate(t *testing.T) {
 	if _, found := pr.allPolicies[polKey]; found {
 		t.Error("Deleting inactive policy - expected AllPolicies not to contain policy but it does")
 	}
+
+	// Haven't sent any endpoints or matches so should get nothing out.
+	pr.OnDatamodelStatus(api.InSync)
+	pr.Flush()
+	if len(recorder.updates) > 0 {
+		t.Error("Unexpected updates from policy resolver:", recorder.updates)
+	}
+}
+
+func createPolicyResolver() (*PolicyResolver, *policyResolverRecorder) {
+	pr := NewPolicyResolver()
+	recorder := newPolicyResolverRecorder()
+	pr.Callbacks = recorder
+	return pr, recorder
+}
+
+type policyResolverUpdate struct {
+	Key      model.Key
+	Endpoint interface{}
+	Tiers    []TierInfo
+}
+
+type policyResolverRecorder struct {
+	updates []policyResolverUpdate
+}
+
+func (p *policyResolverRecorder) OnEndpointTierUpdate(endpointKey model.Key, endpoint interface{}, filteredTiers []TierInfo) {
+	p.updates = append(p.updates, policyResolverUpdate{
+		Key:      endpointKey,
+		Endpoint: endpoint,
+		Tiers:    filteredTiers,
+	})
+}
+
+func newPolicyResolverRecorder() *policyResolverRecorder {
+	return &policyResolverRecorder{}
 }
 
 func TestPolicyResolver_OnPolicyMatch(t *testing.T) {
-	pr := NewPolicyResolver()
+	pr, recorder := createPolicyResolver()
 
 	polKey := model.PolicyKey{
 		Name: "test-policy",
@@ -51,9 +89,21 @@ func TestPolicyResolver_OnPolicyMatch(t *testing.T) {
 	endpointKey := model.WorkloadEndpointKey{
 		Hostname: "test-workload-ep",
 	}
+	pr.endpoints[endpointKey] = "the endpoint"
 
 	pr.allPolicies[polKey] = &pol
+
+	// Haven't sent any matches so should get nothing out.
+	pr.Flush()
+	if len(recorder.updates) > 0 {
+		t.Error("Unexpected updates from policy resolver:", recorder.updates)
+	}
+
 	pr.OnPolicyMatch(polKey, endpointKey)
+	if len(recorder.updates) > 0 {
+		// Shouldn't get any updates until we Flush()
+		t.Error("Unexpected updates from policy resolver before calling Flush():", recorder.updates)
+	}
 
 	if !pr.policyIDToEndpointIDs.ContainsKey(polKey) {
 		t.Error("Adding new policy - expected PolicyIDToEndpointIDs to contain new policy but it does not")
@@ -66,10 +116,31 @@ func TestPolicyResolver_OnPolicyMatch(t *testing.T) {
 	}
 
 	pr.OnPolicyMatch(polKey, endpointKey)
+	pr.OnDatamodelStatus(api.InSync)
+	pr.Flush()
+	if len(recorder.updates) != 1 {
+		t.Fatal("Expected only one update after Flush:", recorder.updates)
+	}
+	if d := cmp.Diff(recorder.updates[0], policyResolverUpdate{
+		Key:      endpointKey,
+		Endpoint: "the endpoint",
+		Tiers: []TierInfo{{
+			Name: "default",
+			OrderedPolicies: []PolKV{
+				{
+					Key:   polKey,
+					Value: &pol,
+				},
+			},
+		}},
+	}, cmp.AllowUnexported(PolKV{})); d != "" {
+		t.Error("Incorrect update:", d)
+	}
 }
 
 func TestPolicyResolver_OnPolicyMatchStopped(t *testing.T) {
-	pr := NewPolicyResolver()
+	pr, recorder := createPolicyResolver()
+	pr.OnDatamodelStatus(api.InSync)
 
 	polKey := model.PolicyKey{
 		Name: "test-policy",
@@ -81,9 +152,9 @@ func TestPolicyResolver_OnPolicyMatchStopped(t *testing.T) {
 		Hostname: "test-workload-ep",
 	}
 
-	pr.policyIDToEndpointIDs.Put(polKey, endpointKey)
-	pr.endpointIDToPolicyIDs.Put(endpointKey, polKey)
 	pr.policySorter.UpdatePolicy(polKey, &pol)
+
+	pr.OnPolicyMatch(polKey, endpointKey)
 	pr.OnPolicyMatchStopped(polKey, endpointKey)
 
 	if pr.policyIDToEndpointIDs.ContainsKey(polKey) {
@@ -97,4 +168,20 @@ func TestPolicyResolver_OnPolicyMatchStopped(t *testing.T) {
 	}
 
 	pr.OnPolicyMatchStopped(polKey, endpointKey)
+
+	if len(recorder.updates) > 0 {
+		// Shouldn't get any updates until we Flush()
+		t.Error("Unexpected updates from policy resolver before calling Flush():", recorder.updates)
+	}
+	pr.Flush()
+	if len(recorder.updates) != 1 {
+		t.Fatal("Expected one update after Flush:", recorder.updates)
+	}
+	if d := cmp.Diff(recorder.updates[0], policyResolverUpdate{
+		Key:      endpointKey,
+		Endpoint: nil,
+		Tiers:    []TierInfo{},
+	}); d != "" {
+		t.Error("Incorrect update:", d)
+	}
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Flushing after every match update causes high CPU usage for endpoints that are being added/removed with many matching policies.  Defer the sort and flush until we're ready to send data downstream.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix slow performance in Felix calculation graph when adding/removing an endpoint with many matching policies. Policy sort order was rechecked once for each added/removed policy match rather than once only.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
