### PR TITLE
BPF Dump policies without assembly replaced with more condensed rule counters output

### DIFF
--- a/felix/fv/bpf_counters_test.go
+++ b/felix/fv/bpf_counters_test.go
@@ -237,7 +237,7 @@ func dumpRuleCounterMap(felix *infrastructure.Felix) counters.PolicyMapMem {
 }
 
 func checkRuleCounters(felix *infrastructure.Felix, ifName, hook, polName string, count int) {
-	out, err := felix.ExecOutput("calico-bpf", "policy", "dump", ifName, hook)
+	out, err := felix.ExecOutput("calico-bpf", "policy", "dump", ifName, hook, "--asm")
 	Expect(err).NotTo(HaveOccurred())
 	strOut := strings.Split(out, "\n")
 

--- a/felix/fv/bpf_policy_dump_test.go
+++ b/felix/fv/bpf_policy_dump_test.go
@@ -112,9 +112,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		pol = createPolicy(pol)
 		out := ""
 		ifaceStr := fmt.Sprintf("IfaceName: %s", w[0].InterfaceName)
-		// check ingress policy dump
+		// check ingress policy dump with eBPF assembler code
 		Eventually(func() string {
-			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "ingress")
+			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "ingress", "-a")
 			Expect(err).NotTo(HaveOccurred())
 			return out
 		}, "5s", "200ms").Should(ContainSubstring("Start of tier default"))
@@ -129,10 +129,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		Expect(string(out)).To(ContainSubstring("If source port is not within any of {8055,100-105}, skip to next rule"))
 		Expect(string(out)).To(ContainSubstring("If dest port is not within any of {9055,200-205}, skip to next rule"))
 
-		// check egress policy dump
+		// check egress policy dump with eBPF assembler code
 		out = ""
 		Eventually(func() string {
-			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "egress")
+			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "egress", "-a")
 			Expect(err).NotTo(HaveOccurred())
 			return out
 		}, "5s", "200ms").Should(ContainSubstring("Start of tier default"))
@@ -147,10 +147,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		Expect(string(out)).To(ContainSubstring("If source port is within any of {8055,100-105}, skip to next rule"))
 		Expect(string(out)).To(ContainSubstring("If dest port is within any of {9055,200-205}, skip to next rule"))
 
-		// Test calico-bpf policy dump all
+		// Test calico-bpf policy dump all with eBPF assembler code
 		out = ""
 		Eventually(func() string {
-			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "all")
+			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[0].InterfaceName, "all", "-a")
 			Expect(err).NotTo(HaveOccurred())
 			return out
 		}, "5s", "200ms").Should(ContainSubstring("Start of tier default"))
@@ -189,9 +189,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		pol = createPolicy(pol)
 		out := ""
 		ifaceStr := fmt.Sprintf("IfaceName: %s", w[1].InterfaceName)
-		// check ingress policy dump
+		// check ingress policy dump with eBPF assembler code
 		Eventually(func() string {
-			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[1].InterfaceName, "ingress")
+			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[1].InterfaceName, "ingress", "-a")
 			Expect(err).NotTo(HaveOccurred())
 			return out
 		}, "5s", "200ms").Should(ContainSubstring("Start of tier default"))
@@ -205,10 +205,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test policy dump"
 		Expect(string(out)).To(ContainSubstring("If source not in {11.0.0.8/32,10.0.0.8/32}, skip to next rule"))
 		Expect(string(out)).To(ContainSubstring("If dest not in {12.0.0.8/32,13.0.0.8/32}, skip to next rule"))
 
-		// check egress policy dump
+		// check egress policy dump with eBPF assembler code
 		out = ""
 		Eventually(func() string {
-			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[1].InterfaceName, "egress")
+			out, err = tc.Felixes[0].ExecOutput("calico-bpf", "policy", "dump", w[1].InterfaceName, "egress", "-a")
 			Expect(err).NotTo(HaveOccurred())
 			return out
 		}, "5s", "200ms").Should(ContainSubstring("Start of tier default"))

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -4337,7 +4337,7 @@ func bpfCheckIfPolicyProgrammed(felix *infrastructure.Felix, iface, hook, polNam
 }
 
 func bpfDumpPolicy(felix *infrastructure.Felix, iface, hook string) string {
-	out, err := felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook)
+	out, err := felix.ExecOutput("calico-bpf", "policy", "dump", iface, hook, "--asm")
 	Expect(err).NotTo(HaveOccurred())
 	return out
 }

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -85,7 +85,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			for _, felix := range tc.Felixes {
 				felix.Exec("iptables-save", "-c")
 				felix.Exec("ip", "r")
-				felix.Exec("calico-bpf", "policy", "dump", "eth0", "all")
+				felix.Exec("calico-bpf", "policy", "dump", "eth0", "all", "--asm")
 			}
 		}
 	})

--- a/felix/fv/ipip_test.go
+++ b/felix/fv/ipip_test.go
@@ -110,7 +110,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 				felix.Exec("ip", "r")
 				felix.Exec("ip", "a")
 				if BPFMode() {
-					felix.Exec("calico-bpf", "policy", "dump", "eth0", "all")
+					felix.Exec("calico-bpf", "policy", "dump", "eth0", "all", "--asm")
 				}
 			}
 		}


### PR DESCRIPTION
Currently the Calico BPF utility policy dump is very verbose and includes assembly which is not relevant to most users i.e. output from the command:
```kubectl exec calico-node-xyz -n calico-system -- calico-node -bpf policy dump cali2c5f0ef34cf ingress```

Therefore, this simple requirement is to omit the irrelevant assembly and instead present more condense output including the rule counters only e.g.
```
IfaceName: cali2c5f0ef34cf
Hook: tc egress
Error: 
Policy Info:
// Start of policy default.policy-tcp
// Start of rule action:"allow" protocol:<name:"tcp" > src_net:"11.0.0.8/32" src_net:"10.0.0.8/32" src_ports:<first:8055 last:8055 > src_ports:<first:100 last:105 > dst_net:"12.0.0.8/32" dst_net:"13.0.0.8/32" dst_ports:<first:9055 last:9055 > dst_ports:<first:200 last:205 > rule_id:"STaSnQYmIymqngjx" 
// count = 0
```
However, there is an option to append either `-a` or `--asm` to the command above to include the original verbose output as before i.e.
```kubectl exec calico-node-xyz -n calico-system -- calico-node -bpf policy dump cali2c5f0ef34cf ingress -a```
OR
```kubectl exec calico-node-xyz -n calico-system -- calico-node -bpf policy dump cali2c5f0ef34cf ingress --asm```

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
calico-node -bpf dump policy will now suppress the previous verbose output by default.  
If you would like to see the verbose output then please add the --verbose flag [or -v] 
for example calico-node -bpf dump policy --verbose
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
