### PR TITLE
calico-kube-controllers: Run as non-root by default for the s390x image

### DIFF
--- a/kube-controllers/Dockerfile.s390x
+++ b/kube-controllers/Dockerfile.s390x
@@ -11,9 +11,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+ARG UBI_IMAGE
+ARG QEMU_IMAGE
+
+FROM ${QEMU_IMAGE} as qemu
+FROM --platform=linux/s390x ${UBI_IMAGE} as ubi
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/
+
+# Add in top-level license file
+RUN mkdir /licenses
+COPY LICENSE /licenses
+
+# Make sure the status and pprof files are owned by our user.
+RUN mkdir /status /profiles
+RUN touch /status/status.json && chown 999 /status/status.json
+RUN touch /profiles/mem.pprof && chown 999 /profiles/mem.pprof
+RUN touch /profiles/cpu.pprof && chown 999 /profiles/cpu.pprof
+
 FROM scratch
 LABEL maintainer "LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
 
+COPY --from=ubi /licenses /licenses
+COPY --from=ubi /profiles /profiles
+COPY --from=ubi /status /status
+
 ADD bin/kube-controllers-linux-s390x /usr/bin/kube-controllers
 ADD bin/check-status-linux-s390x /usr/bin/check-status
+USER 999
 ENTRYPOINT ["/usr/bin/kube-controllers"]


### PR DESCRIPTION
## Description
Run as non-root by default for the s390x image

- create status and profiles folder
- create related files and chown to 999
 
## Related issues/PRs

fixes: https://github.com/projectcalico/calico/issues/7957

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
kube controllers run as a non-root user in s390x builds by default
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
