### PR TITLE
Add LOCAL_CRANE option to lib.Makefile

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -497,8 +497,13 @@ git-commit:
 # different implementation.
 ###############################################################################
 
+ifdef LOCAL_CRANE
+CRANE_CMD         = bash -c $(double_quote)crane
+else
 CRANE_CMD         = docker run -t --entrypoint /bin/sh -v $(DOCKER_CONFIG):/root/.docker/config.json $(CALICO_BUILD) -c \
                     $(double_quote)crane
+endif
+
 GIT_CMD           = git
 DOCKER_CMD        = docker
 


### PR DESCRIPTION
Currently the default method of calling `crane` involves running a (large) docker container which includes the `crane` binary, and which requires mounting your docker `config.json` into the container. For configurations which involve more secure credential helpers (e.g. `gcloud`, `secretservice`, `wincred`, etc.), this breaks, and requires storing highly-privileged plaintext credentials on the local system in order to mount into the docker container (which defeats the security purpose of using credential helpers).

This PR adds a simple `LOCAL_CRANE` define, which will use a locally installed `crane` binary, and thus the locally installed credential helpers, whenever `crane` is required. If this variable is not defined, the standard (docker-based) approach will be used.