### PR TITLE
[BPF] ipv6 kube-proxy

### DIFF
--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -80,9 +80,23 @@ func (m *Maps) Destroy() {
 	}
 }
 
-func CreateBPFMaps() (*Maps, error) {
+func CreateBPFMaps(ipFamily int) (*Maps, error) {
 	mps := []maps.Map{}
 	ret := new(Maps)
+
+	getmap := func(v4, v6 func() maps.Map) maps.Map {
+		if ipFamily == 4 {
+			return v4()
+		}
+		return v6()
+	}
+
+	getmapWithExistsCheck := func(v4, v6 func() maps.MapWithExistsCheck) maps.MapWithExistsCheck {
+		if ipFamily == 4 {
+			return v4()
+		}
+		return v6()
+	}
 
 	ret.IpsetsMap = ipsets.Map()
 	mps = append(mps, ret.IpsetsMap)
@@ -90,31 +104,31 @@ func CreateBPFMaps() (*Maps, error) {
 	ret.StateMap = state.Map()
 	mps = append(mps, ret.StateMap)
 
-	ret.ArpMap = arp.Map()
+	ret.ArpMap = getmap(arp.Map, arp.MapV6)
 	mps = append(mps, ret.ArpMap)
 
 	ret.FailsafesMap = failsafes.Map()
 	mps = append(mps, ret.FailsafesMap)
 
-	ret.FrontendMap = nat.FrontendMap()
+	ret.FrontendMap = getmapWithExistsCheck(nat.FrontendMap, nat.FrontendMapV6)
 	mps = append(mps, ret.FrontendMap)
 
-	ret.BackendMap = nat.BackendMap()
+	ret.BackendMap = getmapWithExistsCheck(nat.BackendMap, nat.BackendMapV6)
 	mps = append(mps, ret.BackendMap)
 
-	ret.AffinityMap = nat.AffinityMap()
+	ret.AffinityMap = getmap(nat.AffinityMap, nat.AffinityMapV6)
 	mps = append(mps, ret.AffinityMap)
 
-	ret.RouteMap = routes.Map()
+	ret.RouteMap = getmap(routes.Map, routes.MapV6)
 	mps = append(mps, ret.RouteMap)
 
-	ret.CtMap = conntrack.Map()
+	ret.CtMap = getmap(conntrack.Map, conntrack.MapV6)
 	mps = append(mps, ret.CtMap)
 
-	ret.SrMsgMap = nat.SendRecvMsgMap()
+	ret.SrMsgMap = getmap(nat.SendRecvMsgMap, nat.SendRecvMsgMapV6)
 	mps = append(mps, ret.SrMsgMap)
 
-	ret.CtNatsMap = nat.AllNATsMsgMap()
+	ret.CtNatsMap = getmap(nat.AllNATsMsgMap, nat.AllNATsMsgMapV6)
 	mps = append(mps, ret.CtNatsMap)
 
 	ret.IfStateMap = ifstate.Map()

--- a/felix/bpf/nat/maps.go
+++ b/felix/bpf/nat/maps.go
@@ -101,11 +101,26 @@ var ZeroCIDR = ip.MustParseCIDROrIP("0.0.0.0/0").(ip.V4CIDR)
 
 type FrontendKey [frontendKeySize]byte
 
+type FrontendKeyInterface interface {
+	Proto() uint8
+	Addr() net.IP
+	Port() uint16
+	SrcPrefixLen() uint32
+	SrcCIDR() ip.CIDR
+	AffinityKeyCopy() FrontEndAffinityKeyInterface
+	String() string
+	AsBytes() []byte
+}
+
 func NewNATKey(addr net.IP, port uint16, protocol uint8) FrontendKey {
 	return NewNATKeySrc(addr, port, protocol, ZeroCIDR)
 }
 
-func NewNATKeySrc(addr net.IP, port uint16, protocol uint8, cidr ip.V4CIDR) FrontendKey {
+func NewNATKeyIntf(addr net.IP, port uint16, protocol uint8) FrontendKeyInterface {
+	return NewNATKey(addr, port, protocol)
+}
+
+func NewNATKeySrc(addr net.IP, port uint16, protocol uint8, cidr ip.CIDR) FrontendKey {
 	var k FrontendKey
 	prefixlen := ZeroCIDRPrefixLen
 	addr = addr.To4()
@@ -118,6 +133,10 @@ func NewNATKeySrc(addr net.IP, port uint16, protocol uint8, cidr ip.V4CIDR) Fron
 	k[10] = protocol
 	copy(k[11:15], cidr.Addr().AsNetIP().To4())
 	return k
+}
+
+func NewNATKeySrcIntf(addr net.IP, port uint16, protocol uint8, cidr ip.CIDR) FrontendKeyInterface {
+	return NewNATKeySrc(addr, port, protocol, cidr)
 }
 
 func (k FrontendKey) Proto() uint8 {
@@ -159,11 +178,17 @@ func (k FrontendKey) Affinitykey() []byte {
 	return k[4:12]
 }
 
+func (k FrontendKey) AffinityKeyCopy() FrontEndAffinityKeyInterface {
+	var affkey FrontEndAffinityKey
+	copy(affkey[:], k.Affinitykey())
+	return affkey
+}
+
 func (k FrontendKey) String() string {
 	return fmt.Sprintf("NATKey{Proto:%v Addr:%v Port:%v SrcAddr:%v}", k.Proto(), k.Addr(), k.Port(), k.SrcCIDR())
 }
 
-func FrontendKeyFromBytes(b []byte) FrontendKey {
+func FrontendKeyFromBytes(b []byte) FrontendKeyInterface {
 	var k FrontendKey
 	copy(k[:], b)
 	return k
@@ -284,6 +309,13 @@ func BackendKeyFromBytes(b []byte) BackendKey {
 
 type BackendValue [backendValueSize]byte
 
+type BackendValueInterface interface {
+	Addr() net.IP
+	Port() uint16
+	String() string
+	AsBytes() []byte
+}
+
 func NewNATBackendValue(addr net.IP, port uint16) BackendValue {
 	var k BackendValue
 	addr = addr.To4()
@@ -293,6 +325,10 @@ func NewNATBackendValue(addr net.IP, port uint16) BackendValue {
 	copy(k[:4], addr)
 	binary.LittleEndian.PutUint16(k[4:6], port)
 	return k
+}
+
+func NewNATBackendValueIntf(addr net.IP, port uint16) BackendValueInterface {
+	return NewNATBackendValue(addr, port)
 }
 
 func (k BackendValue) Addr() net.IP {
@@ -311,7 +347,7 @@ func (k BackendValue) AsBytes() []byte {
 	return k[:]
 }
 
-func BackendValueFromBytes(b []byte) BackendValue {
+func BackendValueFromBytes(b []byte) BackendValueInterface {
 	var v BackendValue
 	copy(v[:], b)
 	return v
@@ -468,7 +504,20 @@ const affinityKeySize = frontendAffKeySize + 8
 // the client's IP
 type AffinityKey [affinityKeySize]byte
 
+type AffinityKeyInterface interface {
+	ClientIP() net.IP
+	FrontendAffinityKey() FrontEndAffinityKeyInterface
+	String() string
+}
+
 type FrontEndAffinityKey [frontendAffKeySize]byte
+
+type FrontEndAffinityKeyInterface interface {
+	Proto() uint8
+	Addr() net.IP
+	Port() uint16
+	AsBytes() []byte
+}
 
 func (k FrontEndAffinityKey) AsBytes() []byte {
 	return k[:]
@@ -510,7 +559,7 @@ func (k AffinityKey) ClientIP() net.IP {
 }
 
 // FrontendKey returns the FrontendKey part of the key
-func (k AffinityKey) FrontendAffinityKey() FrontEndAffinityKey {
+func (k AffinityKey) FrontendAffinityKey() FrontEndAffinityKeyInterface {
 	var f FrontEndAffinityKey
 	copy(f[:], k[:frontendAffKeySize])
 
@@ -526,6 +575,16 @@ func (k AffinityKey) AsBytes() []byte {
 	return k[:]
 }
 
+func AffinityKeyFromBytes(b []byte) AffinityKey {
+	var v AffinityKey
+	copy(v[:], b)
+	return v
+}
+
+func AffinityKeyIntfFromBytes(b []byte) AffinityKeyInterface {
+	return AffinityKeyFromBytes(b)
+}
+
 // struct calico_nat_v4_affinity_val {
 //    struct calico_nat_dest;
 //    uint64_t ts;
@@ -536,6 +595,11 @@ const affinityValueSize = backendValueSize + 8
 // AffinityValue represents a backend picked by the affinity and the timestamp
 // of its creating
 type AffinityValue [affinityValueSize]byte
+
+type AffinityValueInterface interface {
+	Timestamp() time.Duration
+	Backend() BackendValueInterface
+}
 
 // NewAffinityValue creates a value from a timestamp and a backend
 func NewAffinityValue(ts uint64, backend BackendValue) AffinityValue {
@@ -557,7 +621,7 @@ func (v AffinityValue) Timestamp() time.Duration {
 }
 
 // Backend returns the backend the affinity ties the frontend + client to.
-func (v AffinityValue) Backend() BackendValue {
+func (v AffinityValue) Backend() BackendValueInterface {
 	var b BackendValue
 
 	copy(b[:], v[:backendValueSize])
@@ -572,6 +636,16 @@ func (v AffinityValue) String() string {
 // AsBytes returns the value as []byte
 func (v AffinityValue) AsBytes() []byte {
 	return v[:]
+}
+
+func AffinityValueFromBytes(b []byte) AffinityValue {
+	var v AffinityValue
+	copy(v[:], b)
+	return v
+}
+
+func AffinityValueIntfFromBytes(b []byte) AffinityValueInterface {
+	return AffinityValueFromBytes(b)
 }
 
 // AffinityMapParameters describe the AffinityMap

--- a/felix/bpf/nat/maps6.go
+++ b/felix/bpf/nat/maps6.go
@@ -77,7 +77,11 @@ func NewNATKeyV6(addr net.IP, port uint16, protocol uint8) FrontendKeyV6 {
 	return NewNATKeyV6Src(addr, port, protocol, ZeroCIDRV6)
 }
 
-func NewNATKeyV6Src(addr net.IP, port uint16, protocol uint8, cidr ip.V6CIDR) FrontendKeyV6 {
+func NewNATKeyV6Intf(addr net.IP, port uint16, protocol uint8) FrontendKeyInterface {
+	return NewNATKeyV6(addr, port, protocol)
+}
+
+func NewNATKeyV6Src(addr net.IP, port uint16, protocol uint8, cidr ip.CIDR) FrontendKeyV6 {
 	var k FrontendKeyV6
 	prefixlen := ZeroCIDRV6PrefixLen
 	addr = addr.To16()
@@ -87,6 +91,10 @@ func NewNATKeyV6Src(addr net.IP, port uint16, protocol uint8, cidr ip.V6CIDR) Fr
 	k[22] = protocol
 	copy(k[23:39], cidr.Addr().AsNetIP().To16())
 	return k
+}
+
+func NewNATKeyV6SrcIntf(addr net.IP, port uint16, protocol uint8, cidr ip.CIDR) FrontendKeyInterface {
+	return NewNATKeyV6Src(addr, port, protocol, cidr)
 }
 
 func (k FrontendKeyV6) Proto() uint8 {
@@ -128,11 +136,17 @@ func (k FrontendKeyV6) Affinitykey() []byte {
 	return k[4:12]
 }
 
+func (k FrontendKeyV6) AffinityKeyCopy() FrontEndAffinityKeyInterface {
+	var affkey FrontEndAffinityKeyV6
+	copy(affkey[:], k.Affinitykey())
+	return affkey
+}
+
 func (k FrontendKeyV6) String() string {
 	return fmt.Sprintf("NATKeyV6{Proto:%v Addr:%v Port:%v SrcAddr:%v}", k.Proto(), k.Addr(), k.Port(), k.SrcCIDR())
 }
 
-func FrontendKeyV6FromBytes(b []byte) FrontendKeyV6 {
+func FrontendKeyV6FromBytes(b []byte) FrontendKeyInterface {
 	var k FrontendKeyV6
 	copy(k[:], b)
 	return k
@@ -178,6 +192,10 @@ func NewNATBackendValueV6(addr net.IP, port uint16) BackendValueV6 {
 	return k
 }
 
+func NewNATBackendValueV6Intf(addr net.IP, port uint16) BackendValueInterface {
+	return NewNATBackendValueV6(addr, port)
+}
+
 func (k BackendValueV6) Addr() net.IP {
 	return k[:16]
 }
@@ -194,7 +212,7 @@ func (k BackendValueV6) AsBytes() []byte {
 	return k[:]
 }
 
-func BackendValueV6FromBytes(b []byte) BackendValueV6 {
+func BackendValueV6FromBytes(b []byte) BackendValueInterface {
 	var v BackendValueV6
 	copy(v[:], b)
 	return v
@@ -390,7 +408,7 @@ func (k AffinityKeyV6) ClientIP() net.IP {
 }
 
 // FrontendKeyV6 returns the FrontendKeyV6 part of the key
-func (k AffinityKeyV6) FrontendAffinityKey() FrontEndAffinityKeyV6 {
+func (k AffinityKeyV6) FrontendAffinityKey() FrontEndAffinityKeyInterface {
 	var f FrontEndAffinityKeyV6
 	copy(f[:], k[:frontendAffKeySize])
 
@@ -404,6 +422,16 @@ func (k AffinityKeyV6) String() string {
 // AsBytes returns the key as []byte
 func (k AffinityKeyV6) AsBytes() []byte {
 	return k[:]
+}
+
+func AffinityKeyV6FromBytes(b []byte) AffinityKeyV6 {
+	var v AffinityKeyV6
+	copy(v[:], b)
+	return v
+}
+
+func AffinityKeyV6IntfFromBytes(b []byte) AffinityKeyInterface {
+	return AffinityKeyV6FromBytes(b)
 }
 
 // struct calico_nat_v4_affinity_val {
@@ -437,7 +465,7 @@ func (v AffinityValueV6) Timestamp() time.Duration {
 }
 
 // Backend returns the backend the affinity ties the frontend + client to.
-func (v AffinityValueV6) Backend() BackendValueV6 {
+func (v AffinityValueV6) Backend() BackendValueInterface {
 	var b BackendValueV6
 
 	copy(b[:], v[:backendValueSize])
@@ -452,6 +480,16 @@ func (v AffinityValueV6) String() string {
 // AsBytes returns the value as []byte
 func (v AffinityValueV6) AsBytes() []byte {
 	return v[:]
+}
+
+func AffinityValueV6FromBytes(b []byte) AffinityValueV6 {
+	var v AffinityValueV6
+	copy(v[:], b)
+	return v
+}
+
+func AffinityValueV6IntfFromBytes(b []byte) AffinityValueInterface {
+	return AffinityValueV6FromBytes(b)
 }
 
 // AffinityMapParameters describe the AffinityMap

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -215,17 +215,14 @@ func (kp *KubeProxy) OnHostIPsUpdate(IPs []net.IP) {
 }
 
 // OnRouteUpdate should be used to update the internal state of routing tables
-func (kp *KubeProxy) OnRouteUpdate(k routes.Key, v routes.Value) {
-	if err := kp.rt.Update(k, v); err != nil {
-		log.WithField("error", err).Error("kube-proxy: OnRouteUpdate")
-	} else {
-		log.WithFields(log.Fields{"key": k, "value": v}).Debug("kube-proxy: OnRouteUpdate")
-	}
+func (kp *KubeProxy) OnRouteUpdate(k routes.KeyInterface, v routes.ValueInterface) {
+	kp.rt.Update(k, v)
+	log.WithFields(log.Fields{"key": k, "value": v}).Debug("kube-proxy: OnRouteUpdate")
 }
 
 // OnRouteDelete should be used to update the internal state of routing tables
-func (kp *KubeProxy) OnRouteDelete(k routes.Key) {
-	_ = kp.rt.Delete(k)
+func (kp *KubeProxy) OnRouteDelete(k routes.KeyInterface) {
+	kp.rt.Delete(k)
 	log.WithField("key", k).Debug("kube-proxy: OnRouteDelete")
 }
 

--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -25,9 +25,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/maps"
-	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/routes"
-	"github.com/projectcalico/calico/felix/cachingmap"
 )
 
 func init() {
@@ -41,6 +39,7 @@ type KubeProxy struct {
 	proxy  Proxy
 	syncer DPSyncer
 
+	ipFamily      int
 	hostIPUpdates chan []net.IP
 	stopOnce      sync.Once
 	lock          sync.RWMutex
@@ -65,6 +64,7 @@ func StartKubeProxy(k8s kubernetes.Interface, hostname string,
 
 	kp := &KubeProxy{
 		k8s:         k8s,
+		ipFamily:    4,
 		hostname:    hostname,
 		frontendMap: bpfMaps.FrontendMap.(maps.MapWithExistsCheck),
 		backendMap:  bpfMaps.BackendMap.(maps.MapWithExistsCheck),
@@ -93,6 +93,10 @@ func StartKubeProxy(k8s kubernetes.Interface, hostname string,
 	return kp, nil
 }
 
+func (kp *KubeProxy) setIpFamily(ipFamily int) {
+	kp.ipFamily = ipFamily
+}
+
 // Stop stops KubeProxy and waits for it to exit
 func (kp *KubeProxy) Stop() {
 	kp.stopOnce.Do(func() {
@@ -115,16 +119,7 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 	copy(withLocalNP, hostIPs)
 	withLocalNP = append(withLocalNP, podNPIP)
 
-	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-		maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
-			kp.frontendMap, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes,
-		))
-	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-		maps.NewTypedMap[nat.BackendKey, nat.BackendValue](
-			kp.backendMap, nat.BackendKeyFromBytes, nat.BackendValueFromBytes,
-		))
-
-	syncer, err := NewSyncer(withLocalNP, feCache, beCache, kp.affinityMap, kp.rt)
+	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt)
 	if err != nil {
 		return errors.WithMessage(err, "new bpf syncer")
 	}

--- a/felix/bpf/proxy/lb_src_range_test.go
+++ b/felix/bpf/proxy/lb_src_range_test.go
@@ -17,9 +17,7 @@ package proxy_test
 import (
 	"net"
 
-	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/nat"
-	"github.com/projectcalico/calico/felix/cachingmap"
 	"github.com/projectcalico/calico/felix/logutils"
 
 	. "github.com/onsi/ginkgo"
@@ -50,12 +48,7 @@ func testfn(makeIPs func(ips []string) proxy.K8sServicePortOption) {
 	externalIP := makeIPs([]string{"35.0.0.2"})
 	twoExternalIPs := makeIPs([]string{"35.0.0.2", "45.0.1.2"})
 
-	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-		maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-		maps.NewTypedMap[nat.BackendKey, nat.BackendValue](eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
-
-	s, _ := proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -208,13 +201,7 @@ func testfn(makeIPs func(ips []string) proxy.K8sServicePortOption) {
 				externalIP,
 				proxy.K8sSvcWithLBSourceRangeIPs([]string{"35.0.1.2/24"}),
 			)
-			feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-				maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
-					svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-			beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-				maps.NewTypedMap[nat.BackendKey, nat.BackendValue](
-					eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
-			s, _ = proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(3))
@@ -227,13 +214,7 @@ func testfn(makeIPs func(ips []string) proxy.K8sServicePortOption) {
 				v1.ProtocolTCP,
 				externalIP,
 			)
-			feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-				maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
-					svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-			beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-				maps.NewTypedMap[nat.BackendKey, nat.BackendValue](
-					eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
-			s, _ = proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(svcs.m).To(HaveLen(2))

--- a/felix/bpf/proxy/options.go
+++ b/felix/bpf/proxy/options.go
@@ -75,3 +75,10 @@ func WithTopologyNodeZone(nodeZone string) Option {
 		return nil
 	})
 }
+
+func WithIPFamily(ipFamily int) Option {
+	return func(p Proxy) error {
+		p.setIpFamily(ipFamily)
+		return nil
+	}
+}

--- a/felix/bpf/proxy/proxy_bench_test.go
+++ b/felix/bpf/proxy/proxy_bench_test.go
@@ -24,11 +24,6 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/projectcalico/calico/felix/cachingmap"
-
-	"github.com/projectcalico/calico/felix/bpf/maps"
-	"github.com/projectcalico/calico/felix/bpf/nat"
-
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,17 +41,10 @@ func benchmarkProxyUpdates(b *testing.B, svcN, epsN int) {
 		eps := makeEps(svcN, epsN)
 		k8s := fake.NewSimpleClientset(append(svcs, eps...)...)
 
-		feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-			maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
-				&mock.DummyMap{}, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-		beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-			maps.NewTypedMap[nat.BackendKey, nat.BackendValue](
-				&mock.DummyMap{}, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
-
-		syncer, err := proxy.NewSyncer(
+		syncer, err := proxy.NewSyncer(4,
 			[]net.IP{net.IPv4(1, 1, 1, 1)},
-			feCache,
-			beCache,
+			&mock.DummyMap{},
+			&mock.DummyMap{},
 			&mock.DummyMap{},
 			proxy.NewRTCache(),
 		)

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -416,7 +416,7 @@ type expandMiss struct {
 }
 
 func (s *Syncer) expandAndApplyNodePorts(sname k8sp.ServicePortName, sinfo k8sp.ServicePort,
-	eps []k8sp.Endpoint, nport int, rtLookup func(addr ip.Addr) (routes.Value, bool)) *expandMiss {
+	eps []k8sp.Endpoint, nport int, rtLookup func(addr ip.Addr) (routes.ValueInterface, bool)) *expandMiss {
 
 	ipToEp, miss := s.expandNodePorts(sname, sinfo, eps, nport, rtLookup)
 
@@ -434,7 +434,7 @@ func (s *Syncer) expandNodePorts(
 	sinfo k8sp.ServicePort,
 	eps []k8sp.Endpoint,
 	nport int,
-	rtLookup func(addr ip.Addr) (routes.Value, bool),
+	rtLookup func(addr ip.Addr) (routes.ValueInterface, bool),
 ) (map[ip.V4Addr][]k8sp.Endpoint, *expandMiss) {
 	ipToEp := make(map[ip.V4Addr][]k8sp.Endpoint)
 	var miss *expandMiss
@@ -1051,7 +1051,7 @@ func (s *Syncer) runExpandNPFixup(misses []*expandMiss) {
 
 			// We do one pass rightaway since we cannot know whether there
 			// was an update or not before we got here
-			s.rt.WaitAfter(ctx, func(lookup func(addr ip.Addr) (routes.Value, bool)) bool {
+			s.rt.WaitAfter(ctx, func(lookup func(addr ip.Addr) (routes.ValueInterface, bool)) bool {
 				log.Debug("Woke up")
 				missesChanged := false
 				var again []*expandMiss

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -105,8 +105,8 @@ type stickyFrontend struct {
 // Syncer is an implementation of DPSyncer interface. It is not thread safe and
 // should be called only once at a time
 type Syncer struct {
-	bpfSvcs *cachingmap.CachingMap[nat.FrontendKey, nat.FrontendValue]
-	bpfEps  *cachingmap.CachingMap[nat.BackendKey, nat.BackendValue]
+	bpfSvcs *cachingmap.CachingMap[nat.FrontendKeyInterface, nat.FrontendValue]
+	bpfEps  *cachingmap.CachingMap[nat.BackendKey, nat.BackendValueInterface]
 	bpfAff  maps.Map
 
 	nextSvcID uint32
@@ -137,12 +137,18 @@ type Syncer struct {
 	stop     chan struct{}
 	stopOnce sync.Once
 
-	stickySvcs map[nat.FrontEndAffinityKey]stickyFrontend
-	stickyEps  map[uint32]map[nat.BackendValue]struct{}
+	stickySvcs map[nat.FrontEndAffinityKeyInterface]stickyFrontend
+	stickyEps  map[uint32]map[nat.BackendValueInterface]struct{}
 
 	// triggerFn is called when one of the syncer's background threads needs to trigger an Apply().
 	// The proxy sets this to the runner's Run() method.  We assume that the method doesn't block.
 	triggerFn func()
+
+	newFrontendKey         func(addr net.IP, port uint16, protocol uint8) nat.FrontendKeyInterface
+	newFrontendKeySrc      func(addr net.IP, port uint16, protocol uint8, cidr ip.CIDR) nat.FrontendKeyInterface
+	newBackendValue        func(addr net.IP, port uint16) nat.BackendValueInterface
+	affinityKeyFromBytes   func([]byte) nat.AffinityKeyInterface
+	affinityValueFromBytes func([]byte) nat.AffinityValueInterface
 }
 
 type ipPort struct {
@@ -193,20 +199,51 @@ func uniqueIPs(ips []net.IP) []net.IP {
 }
 
 // NewSyncer returns a new Syncer
-func NewSyncer(nodePortIPs []net.IP,
-	svcsmap *cachingmap.CachingMap[nat.FrontendKey, nat.FrontendValue],
-	epsmap *cachingmap.CachingMap[nat.BackendKey, nat.BackendValue],
-	affmap maps.Map, rt Routes) (*Syncer, error) {
+func NewSyncer(family int, nodePortIPs []net.IP,
+	frontendMap maps.MapWithExistsCheck, backendMap maps.MapWithExistsCheck,
+	affmap maps.Map, rt Routes,
+) (*Syncer, error) {
 
 	s := &Syncer{
-		bpfSvcs:     svcsmap,
-		bpfEps:      epsmap,
 		bpfAff:      affmap,
 		rt:          rt,
 		nodePortIPs: uniqueIPs(nodePortIPs),
 		prevSvcMap:  make(map[svcKey]svcInfo),
 		prevEpsMap:  make(k8sp.EndpointsMap),
 		stop:        make(chan struct{}),
+	}
+
+	switch family {
+	case 4:
+		s.bpfSvcs = cachingmap.New[nat.FrontendKeyInterface, nat.FrontendValue](nat.FrontendMapParameters.Name,
+			maps.NewTypedMap[nat.FrontendKeyInterface, nat.FrontendValue](
+				frontendMap, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes,
+			))
+		s.bpfEps = cachingmap.New[nat.BackendKey, nat.BackendValueInterface](nat.BackendMapParameters.Name,
+			maps.NewTypedMap[nat.BackendKey, nat.BackendValueInterface](
+				backendMap, nat.BackendKeyFromBytes, nat.BackendValueFromBytes,
+			))
+		s.newFrontendKey = nat.NewNATKeyIntf
+		s.newFrontendKeySrc = nat.NewNATKeySrcIntf
+		s.newBackendValue = nat.NewNATBackendValueIntf
+		s.affinityKeyFromBytes = nat.AffinityKeyIntfFromBytes
+		s.affinityValueFromBytes = nat.AffinityValueIntfFromBytes
+	case 6:
+		s.bpfSvcs = cachingmap.New[nat.FrontendKeyInterface, nat.FrontendValue](nat.FrontendMapParameters.Name,
+			maps.NewTypedMap[nat.FrontendKeyInterface, nat.FrontendValue](
+				frontendMap, nat.FrontendKeyV6FromBytes, nat.FrontendValueFromBytes,
+			))
+		s.bpfEps = cachingmap.New[nat.BackendKey, nat.BackendValueInterface](nat.BackendMapParameters.Name,
+			maps.NewTypedMap[nat.BackendKey, nat.BackendValueInterface](
+				backendMap, nat.BackendKeyFromBytes, nat.BackendValueV6FromBytes,
+			))
+		s.newFrontendKey = nat.NewNATKeyV6Intf
+		s.newFrontendKeySrc = nat.NewNATKeyV6SrcIntf
+		s.newBackendValue = nat.NewNATBackendValueV6Intf
+		s.affinityKeyFromBytes = nat.AffinityKeyV6IntfFromBytes
+		s.affinityValueFromBytes = nat.AffinityValueV6IntfFromBytes
+	default:
+		return nil, fmt.Errorf("unknwn family %d", family)
 	}
 
 	if err := s.loadOrigs(); err != nil {
@@ -235,8 +272,8 @@ type syncRef struct {
 
 // svcMapToIPPortProtoMap takes the kubernetes service representation and makes an index
 // so we can cross reference with the values we learn from the dataplane.
-func (s *Syncer) svcMapToIPPortProtoMap(svcs k8sp.ServicePortMap) map[nat.FrontendKey]syncRef {
-	ref := make(map[nat.FrontendKey]syncRef, len(svcs))
+func (s *Syncer) svcMapToIPPortProtoMap(svcs k8sp.ServicePortMap) map[nat.FrontendKeyInterface]syncRef {
+	ref := make(map[nat.FrontendKeyInterface]syncRef, len(svcs))
 
 	for key, svc := range svcs {
 		clusterIP := svc.ClusterIP()
@@ -245,22 +282,22 @@ func (s *Syncer) svcMapToIPPortProtoMap(svcs k8sp.ServicePortMap) map[nat.Fronte
 
 		xref := syncRef{key, svc}
 
-		ref[nat.NewNATKey(clusterIP, port, proto)] = xref
+		ref[s.newFrontendKey(clusterIP, port, proto)] = xref
 
 		np := uint16(0)
 
 		if svc.NodePort() != 0 {
 			np = uint16(svc.NodePort())
 
-			ref[nat.NewNATKey(clusterIP, np, proto)] = xref
+			ref[s.newFrontendKey(clusterIP, np, proto)] = xref
 
 			for _, npIP := range s.nodePortIPs {
-				ref[nat.NewNATKey(npIP, np, proto)] = xref
+				ref[s.newFrontendKey(npIP, np, proto)] = xref
 			}
 		}
 
 		for _, extIP := range svc.ExternalIPStrings() {
-			ref[nat.NewNATKey(net.ParseIP(extIP), port, proto)] = xref
+			ref[s.newFrontendKey(net.ParseIP(extIP), port, proto)] = xref
 		}
 	}
 
@@ -277,7 +314,7 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 
 	// Walk the frontend bpf map that was read into memory and match it against the
 	// references build from the state
-	s.bpfSvcs.Dataplane().Iter(func(svck nat.FrontendKey, svcv nat.FrontendValue) {
+	s.bpfSvcs.Dataplane().Iter(func(svck nat.FrontendKeyInterface, svcv nat.FrontendValue) {
 		xref, ok := svcRef[svck]
 		if !ok {
 			return
@@ -666,8 +703,8 @@ func (s *Syncer) Apply(state DPSyncerState) error {
 	defer s.mapsLck.Unlock()
 
 	// preallocate maps to track sticky services for cleanup
-	s.stickySvcs = make(map[nat.FrontEndAffinityKey]stickyFrontend)
-	s.stickyEps = make(map[uint32]map[nat.BackendValue]struct{})
+	s.stickySvcs = make(map[nat.FrontEndAffinityKeyInterface]stickyFrontend)
+	s.stickyEps = make(map[uint32]map[nat.BackendValueInterface]struct{})
 
 	defer func() {
 		// not needed anymore
@@ -700,7 +737,7 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 	if sinfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
 		// since we write the backend before we write the frontend, we need to
 		// preallocate the map for it
-		s.stickyEps[id] = make(map[nat.BackendValue]struct{})
+		s.stickyEps[id] = make(map[nat.BackendValueInterface]struct{})
 	}
 
 	for _, ep := range eps {
@@ -771,7 +808,7 @@ func (s *Syncer) writeSvcBackend(svcID uint32, idx uint32, ep k8sp.Endpoint) err
 	if err != nil {
 		return errors.Errorf("no port for endpoint %q: %s", ep, err)
 	}
-	val := nat.NewNATBackendValue(ip, uint16(tgtPort))
+	val := s.newBackendValue(ip, uint16(tgtPort))
 	s.bpfEps.Desired().Set(key, val)
 
 	if s.stickyEps[svcID] != nil {
@@ -781,19 +818,19 @@ func (s *Syncer) writeSvcBackend(svcID uint32, idx uint32, ep k8sp.Endpoint) err
 	return nil
 }
 
-func getSvcNATKey(svc k8sp.ServicePort) (nat.FrontendKey, error) {
+func (s *Syncer) getSvcNATKey(svc k8sp.ServicePort) (nat.FrontendKeyInterface, error) {
 	ip := svc.ClusterIP()
 	port := svc.Port()
 	proto, err := ProtoV1ToInt(svc.Protocol())
 	if err != nil {
-		return nat.FrontendKey{}, err
+		return s.newFrontendKey(ip, uint16(port), proto), err
 	}
 
-	key := nat.NewNATKey(ip, uint16(port), proto)
+	key := s.newFrontendKey(ip, uint16(port), proto)
 	return key, nil
 }
 
-func getSvcNATKeyLBSrcRange(svc k8sp.ServicePort) ([]nat.FrontendKey, error) {
+func (s *Syncer) getSvcNATKeyLBSrcRange(svc k8sp.ServicePort) ([]nat.FrontendKeyInterface, error) {
 	ipaddr := svc.ClusterIP()
 	port := svc.Port()
 	loadBalancerSourceRanges := svc.LoadBalancerSourceRanges()
@@ -805,21 +842,21 @@ func getSvcNATKeyLBSrcRange(svc k8sp.ServicePort) ([]nat.FrontendKey, error) {
 		return nil, err
 	}
 
-	keys := make([]nat.FrontendKey, 0, len(loadBalancerSourceRanges))
+	keys := make([]nat.FrontendKeyInterface, 0, len(loadBalancerSourceRanges))
 
 	for _, src := range loadBalancerSourceRanges {
 		// Ignore IPv6 addresses
 		if strings.Contains(src, ":") {
 			continue
 		}
-		key := nat.NewNATKeySrc(ipaddr, uint16(port), proto, ip.MustParseCIDROrIP(src).(ip.V4CIDR))
+		key := s.newFrontendKeySrc(ipaddr, uint16(port), proto, ip.MustParseCIDROrIP(src).(ip.V4CIDR))
 		keys = append(keys, key)
 	}
 	return keys, nil
 }
 
 func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, count, local int, flags uint32) error {
-	var key nat.FrontendKey
+	var key nat.FrontendKeyInterface
 	affinityTimeo := uint32(0)
 	if svc.SessionAffinityType() == v1.ServiceAffinityClientIP {
 		affinityTimeo = uint32(svc.StickyMaxAgeSeconds())
@@ -828,7 +865,7 @@ func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, c
 	if len(svc.LoadBalancerSourceRanges()) == 0 {
 		return nil
 	}
-	keys, err := getSvcNATKeyLBSrcRange(svc)
+	keys, err := s.getSvcNATKeyLBSrcRange(svc)
 	if err != nil {
 		return err
 	}
@@ -839,7 +876,7 @@ func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, c
 		}
 		s.bpfSvcs.Desired().Set(key, val)
 	}
-	key, err = getSvcNATKey(svc)
+	key, err = s.getSvcNATKey(svc)
 	if err != nil {
 		return err
 	}
@@ -849,7 +886,7 @@ func (s *Syncer) writeLBSrcRangeSvcNATKeys(svc k8sp.ServicePort, svcID uint32, c
 }
 
 func (s *Syncer) writeSvc(svc k8sp.ServicePort, svcID uint32, count, local int, flags uint32) error {
-	key, err := getSvcNATKey(svc)
+	key, err := s.getSvcNATKey(svc)
 	if err != nil {
 		return err
 	}
@@ -866,10 +903,9 @@ func (s *Syncer) writeSvc(svc k8sp.ServicePort, svcID uint32, count, local int, 
 	}
 	s.bpfSvcs.Desired().Set(key, val)
 
-	var affkey nat.FrontEndAffinityKey
-	copy(affkey[:], key.Affinitykey())
 	// we must have written the backends by now so the map exists
 	if s.stickyEps[svcID] != nil {
+		affkey := key.AffinityKeyCopy()
 		s.stickySvcs[affkey] = stickyFrontend{
 			id:    svcID,
 			timeo: time.Duration(affinityTimeo) * time.Second,
@@ -911,7 +947,7 @@ func (s *Syncer) newSvcID() uint32 {
 	return id
 }
 
-func (s *Syncer) matchBpfSvc(bpfSvc nat.FrontendKey, k8sSvc k8sp.ServicePortName, k8sInfo k8sp.ServicePort) *svcKey {
+func (s *Syncer) matchBpfSvc(bpfSvc nat.FrontendKeyInterface, k8sSvc k8sp.ServicePortName, k8sInfo k8sp.ServicePort) *svcKey {
 	matchNP := func() *svcKey {
 		if bpfSvc.Port() == uint16(k8sInfo.NodePort()) {
 			for _, nip := range s.nodePortIPs {
@@ -1111,19 +1147,11 @@ func (s *Syncer) cleanupSticky() error {
 	debug := log.GetLevel() >= log.DebugLevel
 	_ = debug // Work around linter false-positive.
 
-	var (
-		key nat.AffinityKey
-		val nat.AffinityValue
-	)
-
-	ks := len(nat.AffinityKey{})
-	vs := len(nat.AffinityValue{})
-
 	now := time.Duration(bpf.KTimeNanos())
 
 	err := s.bpfAff.Iter(func(k, v []byte) maps.IteratorAction {
-		copy(key[:], k[:ks])
-		copy(val[:], v[:vs])
+		key := s.affinityKeyFromBytes(k)
+		val := s.affinityValueFromBytes(v)
 
 		fend, ok := s.stickySvcs[key.FrontendAffinityKey()]
 		if !ok {

--- a/felix/bpf/proxy/syncer_bench_test.go
+++ b/felix/bpf/proxy/syncer_bench_test.go
@@ -76,8 +76,8 @@ func makeState(svcCnt, epCnt int, opts ...K8sServicePortOption) DPSyncerState {
 }
 
 func stateToBPFMaps(state DPSyncerState) (
-	*cachingmap.CachingMap[nat.FrontendKey, nat.FrontendValue],
-	*cachingmap.CachingMap[nat.BackendKey, nat.BackendValue],
+	*cachingmap.CachingMap[nat.FrontendKeyInterface, nat.FrontendValue],
+	*cachingmap.CachingMap[nat.BackendKey, nat.BackendValueInterface],
 ) {
 	fe := mock.NewMockMap(nat.FrontendMapParameters)
 	be := mock.NewMockMap(nat.BackendMapParameters)
@@ -103,10 +103,10 @@ func stateToBPFMaps(state DPSyncerState) (
 		id++
 	}
 
-	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-		maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](fe, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-		maps.NewTypedMap[nat.BackendKey, nat.BackendValue](be, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
+	feCache := cachingmap.New[nat.FrontendKeyInterface, nat.FrontendValue](nat.FrontendMapParameters.Name,
+		maps.NewTypedMap[nat.FrontendKeyInterface, nat.FrontendValue](fe, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
+	beCache := cachingmap.New[nat.BackendKey, nat.BackendValueInterface](nat.BackendMapParameters.Name,
+		maps.NewTypedMap[nat.BackendKey, nat.BackendValueInterface](be, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
 
 	return feCache, beCache
 }
@@ -124,6 +124,11 @@ func benchmarkStartupSync(b *testing.B, svcCnt, epCnt int) {
 				prevEpsMap: make(k8sp.EndpointsMap),
 				bpfSvcs:    origSvcs,
 				bpfEps:     origEps,
+
+				newFrontendKey:         nat.NewNATKeyIntf,
+				newFrontendKeySrc:      nat.NewNATKeySrcIntf,
+				affinityKeyFromBytes:   nat.AffinityKeyIntfFromBytes,
+				affinityValueFromBytes: nat.AffinityValueIntfFromBytes,
 			}
 			Expect(origSvcs.LoadCacheFromDataplane()).NotTo(HaveOccurred())
 			Expect(origEps.LoadCacheFromDataplane()).NotTo(HaveOccurred())
@@ -163,18 +168,10 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 	state := makeState(svcCnt, epCnt, opts...)
 
 	if mockMaps {
-
-		feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-			maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
-				&mock.DummyMap{}, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-		beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-			maps.NewTypedMap[nat.BackendKey, nat.BackendValue](
-				&mock.DummyMap{}, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
-
-		syncer, err = NewSyncer(
+		syncer, err = NewSyncer(4,
 			[]net.IP{net.IPv4(1, 1, 1, 1)},
-			feCache,
-			beCache,
+			&mock.DummyMap{},
+			&mock.DummyMap{},
 			&mock.DummyMap{},
 			NewRTCache(),
 		)
@@ -187,17 +184,10 @@ func runBenchmarkServiceUpdate(b *testing.B, svcCnt, epCnt int, mockMaps bool, o
 		err = beMap.EnsureExists()
 		Expect(err).ShouldNot(HaveOccurred())
 
-		feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-			maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
-				feMap, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-		beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-			maps.NewTypedMap[nat.BackendKey, nat.BackendValue](
-				beMap, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
-
-		syncer, err = NewSyncer(
+		syncer, err = NewSyncer(4,
 			[]net.IP{net.IPv4(1, 1, 1, 1)},
-			feCache,
-			beCache,
+			&mock.DummyMap{},
+			&mock.DummyMap{},
 			&mock.DummyMap{},
 			NewRTCache(),
 		)

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -597,7 +597,7 @@ var _ = Describe("BPF Syncer", func() {
 					logrus.WithError(err).Info("Syncer result")
 				}()
 			})
-			_ = rt.Update(
+			rt.Update(
 				routes.NewKey(ip.CIDRFromAddrAndPrefix(ip.FromString("10.2.1.0"), 24).(ip.V4CIDR)),
 				routes.NewValueWithNextHop(
 					routes.FlagsRemoteWorkload,
@@ -633,7 +633,7 @@ var _ = Describe("BPF Syncer", func() {
 		}))
 
 		By("adding an unrelated route does not change anything", makestep(func() {
-			_ = rt.Update(
+			rt.Update(
 				routes.NewKey(ip.CIDRFromAddrAndPrefix(ip.FromString("10.2.55.0"), 24).(ip.V4CIDR)),
 				routes.NewValueWithNextHop(
 					routes.FlagsRemoteWorkload,
@@ -651,7 +651,7 @@ var _ = Describe("BPF Syncer", func() {
 		}))
 
 		By("adding route should fix another missing expanded NP", makestep(func() {
-			_ = rt.Update(
+			rt.Update(
 				routes.NewKey(ip.CIDRFromAddrAndPrefix(ip.FromString("10.2.3.0"), 24).(ip.V4CIDR)),
 				routes.NewValueWithNextHop(
 					routes.FlagsRemoteWorkload,
@@ -727,13 +727,13 @@ var _ = Describe("BPF Syncer", func() {
 				&k8sp.BaseEndpointInfo{Ready: true, Endpoint: "10.2.3.1:2222"},
 			}
 
-			_ = rt.Update(
+			rt.Update(
 				routes.NewKey(ip.CIDRFromAddrAndPrefix(ip.FromString("10.2.2.0"), 24).(ip.V4CIDR)),
 				routes.NewValueWithNextHop(
 					routes.FlagsRemoteWorkload,
 					ip.FromString("10.123.0.112").(ip.V4Addr)),
 			)
-			_ = rt.Update(
+			rt.Update(
 				routes.NewKey(ip.CIDRFromAddrAndPrefix(ip.FromString("10.2.3.0"), 24).(ip.V4CIDR)),
 				routes.NewValueWithNextHop(
 					routes.FlagsRemoteWorkload,

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/nat"
-	"github.com/projectcalico/calico/felix/cachingmap"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -57,14 +56,7 @@ var _ = Describe("BPF Syncer", func() {
 	nodeIPs := []net.IP{net.IPv4(192, 168, 0, 1), net.IPv4(10, 123, 0, 1)}
 	rt := proxy.NewRTCache()
 
-	feCache := cachingmap.New[nat.FrontendKey, nat.FrontendValue](nat.FrontendMapParameters.Name,
-		maps.NewTypedMap[nat.FrontendKey, nat.FrontendValue](
-			svcs, nat.FrontendKeyFromBytes, nat.FrontendValueFromBytes))
-	beCache := cachingmap.New[nat.BackendKey, nat.BackendValue](nat.BackendMapParameters.Name,
-		maps.NewTypedMap[nat.BackendKey, nat.BackendValue](
-			eps, nat.BackendKeyFromBytes, nat.BackendValueFromBytes))
-
-	s, _ := proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
+	s, _ := proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt)
 
 	svcKey := k8sp.ServicePortName{
 		NamespacedName: types.NamespacedName{
@@ -402,7 +394,7 @@ var _ = Describe("BPF Syncer", func() {
 		}))
 
 		By("resyncing after creating a new syncer with the same result", makestep(func() {
-			s, _ = proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt)
 			checkAfterResync()
 		}))
 
@@ -410,7 +402,7 @@ var _ = Describe("BPF Syncer", func() {
 			svcs.m[nat.NewNATKey(net.IPv4(5, 5, 5, 5), 1111, 6)] = nat.NewNATValue(0xdeadbeef, 2, 2, 0)
 			eps.m[nat.NewNATBackendKey(0xdeadbeef, 0)] = nat.NewNATBackendValue(net.IPv4(6, 6, 6, 6), 666)
 			eps.m[nat.NewNATBackendKey(0xdeadbeef, 1)] = nat.NewNATBackendValue(net.IPv4(7, 7, 7, 7), 777)
-			s, _ = proxy.NewSyncer(nodeIPs, feCache, beCache, aff, rt)
+			s, _ = proxy.NewSyncer(4, nodeIPs, svcs, eps, aff, rt)
 			checkAfterResync()
 		}))
 
@@ -558,7 +550,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("inserting non-local eps for a NodePort - no route", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(append(nodeIPs, net.IPv4(255, 255, 255, 255)), feCache, beCache, aff, rt)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, aff, rt)
 			state.SvcMap[svcKey2] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,
@@ -711,7 +703,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("inserting only non-local eps for a NodePort - multiple nodes & pods/node", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(append(nodeIPs, net.IPv4(255, 255, 255, 255)), feCache, beCache, aff, rt)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, aff, rt)
 			state.SvcMap[svcKey2] = proxy.NewK8sServicePort(
 				net.IPv4(10, 0, 0, 2),
 				2222,
@@ -791,7 +783,7 @@ var _ = Describe("BPF Syncer", func() {
 
 		By("restarting Syncer to check if NodePortRemotes are picked up correctly", makestep(func() {
 			// use the meta node IP for nodeports as well
-			s, _ = proxy.NewSyncer(append(nodeIPs, net.IPv4(255, 255, 255, 255)), feCache, beCache, aff, rt)
+			s, _ = proxy.NewSyncer(4, append(nodeIPs, net.IPv4(255, 255, 255, 255)), svcs, eps, aff, rt)
 			err := s.Apply(state)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -46,7 +46,7 @@ import (
 func TestAttach(t *testing.T) {
 	RegisterTestingT(t)
 
-	bpfmaps, err := bpfmap.CreateBPFMaps()
+	bpfmaps, err := bpfmap.CreateBPFMaps(4)
 	Expect(err).NotTo(HaveOccurred())
 
 	programs := bpfmaps.ProgramsMap.(*hook.ProgramsMap)

--- a/felix/bpf/ut/maps_test.go
+++ b/felix/bpf/ut/maps_test.go
@@ -58,7 +58,7 @@ func TestMapResize(t *testing.T) {
 	bpfmaps.EnableRepin()
 	defer bpfmaps.DisableRepin()
 
-	maps, err := bpfmap.CreateBPFMaps()
+	maps, err := bpfmap.CreateBPFMaps(4)
 	Expect(err).NotTo(HaveOccurred())
 	defer restoreMaps(maps)
 	// New CT map should have max_entries as 600
@@ -79,7 +79,7 @@ func TestMapResizeWithCopy(t *testing.T) {
 
 	// Resize the CT map to 600. New map should have the entry in the old map
 	conntrack.SetMapSize(600)
-	maps, err := bpfmap.CreateBPFMaps()
+	maps, err := bpfmap.CreateBPFMaps(4)
 	Expect(err).NotTo(HaveOccurred())
 	defer restoreMaps(maps)
 	val, err := maps.CtMap.Get(k.AsBytes())
@@ -107,7 +107,7 @@ func TestMapDownSize(t *testing.T) {
 
 	// New map creation should panic as the number of entries in old map is more than what the new map can
 	// accommodate
-	maps, err := bpfmap.CreateBPFMaps()
+	maps, err := bpfmap.CreateBPFMaps(4)
 	defer restoreMaps(maps)
 	expectedError := fmt.Sprintf("failed to create %s map, err=new map cannot hold all the data from the old map %s", ctMap.GetName(), ctMap.GetName())
 	Expect(err.Error()).To(Equal(expectedError))
@@ -121,7 +121,7 @@ func TestCTDeltaMigration(t *testing.T) {
 	// Resize the ctmap
 	conntrack.SetMapSize(666)
 
-	maps, err := bpfmap.CreateBPFMaps()
+	maps, err := bpfmap.CreateBPFMaps(4)
 	Expect(err).NotTo(HaveOccurred())
 
 	defer restoreMaps(maps)

--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -79,8 +79,8 @@ type bpfRouteManager struct {
 	// Callbacks used to tell kube-proxy about the relevant routes.
 	cbLck           sync.RWMutex
 	hostIPsUpdateCB func([]net.IP)
-	routesUpdateCB  func(routes.Key, routes.Value)
-	routesDeleteCB  func(routes.Key)
+	routesUpdateCB  func(routes.KeyInterface, routes.ValueInterface)
+	routesDeleteCB  func(routes.KeyInterface)
 
 	opReporter logutils.OpRecorder
 
@@ -639,7 +639,7 @@ func (m *bpfRouteManager) setHostIPUpdatesCallBack(cb func([]net.IP)) {
 	m.hostIPsUpdateCB = cb
 }
 
-func (m *bpfRouteManager) setRoutesCallBacks(update func(routes.Key, routes.Value), del func(routes.Key)) {
+func (m *bpfRouteManager) setRoutesCallBacks(update func(routes.KeyInterface, routes.ValueInterface), del func(routes.KeyInterface)) {
 	m.cbLck.Lock()
 	defer m.cbLck.Unlock()
 
@@ -647,7 +647,7 @@ func (m *bpfRouteManager) setRoutesCallBacks(update func(routes.Key, routes.Valu
 	m.routesDeleteCB = del
 }
 
-func (m *bpfRouteManager) onRouteUpdateCB(k routes.Key, v routes.Value) {
+func (m *bpfRouteManager) onRouteUpdateCB(k routes.KeyInterface, v routes.ValueInterface) {
 	m.cbLck.RLock()
 	defer m.cbLck.RUnlock()
 	if m.routesUpdateCB != nil {
@@ -655,7 +655,7 @@ func (m *bpfRouteManager) onRouteUpdateCB(k routes.Key, v routes.Value) {
 	}
 }
 
-func (m *bpfRouteManager) onRouteDeleteCB(k routes.Key) {
+func (m *bpfRouteManager) onRouteDeleteCB(k routes.KeyInterface) {
 	m.cbLck.RLock()
 	defer m.cbLck.RUnlock()
 	if m.routesDeleteCB != nil {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -716,6 +716,10 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			bpfproxyOpts = append(bpfproxyOpts, bpfproxy.WithTopologyNodeZone(config.NodeZone))
 		}
 
+		if config.BPFIpv6Enabled {
+			bpfproxyOpts = append(bpfproxyOpts, bpfproxy.WithIPFamily(6))
+		}
+
 		if config.KubeClientSet != nil {
 			// We have a Kubernetes connection, start watching services and populating the NAT maps.
 			kp, err := bpfproxy.StartKubeProxy(

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -639,7 +639,11 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	if config.BPFEnabled {
 		log.Info("BPF enabled, starting BPF endpoint manager and map manager.")
 		var err error
-		bpfMaps, err = bpfmap.CreateBPFMaps()
+		ipFamily := 4
+		if config.BPFIpv6Enabled {
+			ipFamily = 6
+		}
+		bpfMaps, err = bpfmap.CreateBPFMaps(ipFamily)
 		if err != nil {
 			log.WithError(err).Panic("error creating bpf maps")
 		}

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -2246,7 +2246,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								Expect(aff).To(HaveLen(1))
 								Expect(aff).To(HaveKey(mkey))
 
-								return aff[mkey].Backend()
+								return aff[mkey].Backend().(nat.BackendValue)
 							}, 60*time.Second, time.Second).ShouldNot(Equal(mVal.Backend()))
 						})
 					}


### PR DESCRIPTION
## Description

This PR introduces IPv6 version of kube-proxy and ipv6 versions of related bpf map types. Either v4 or v6 kube-proxy is instantiated depending on which ip version for the dataplane is selected.

refs https://github.com/projectcalico/calico/issues/4736

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
