### PR TITLE
calico-kube-controller: fix panic caused by concurrent map iteration and map write

### DIFF
--- a/kube-controllers/pkg/controllers/pod/pod_controller.go
+++ b/kube-controllers/pkg/controllers/pod/pod_controller.go
@@ -321,7 +321,9 @@ func (c *podController) syncToCalico(key string) error {
 		new := wepData.(converter.WorkloadEndpointData)
 		if !reflect.DeepEqual(old, new) {
 			// The relevant wep data has changed - update the wep and write it to the datastore.
+			c.workloadEndpointCache.RLock()
 			log.Infof("Writing endpoint %s with updated data %#v to Calico datastore", key, new)
+			c.workloadEndpointCache.RUnlock()
 			converter.MergeWorkloadEndpointData(&wep, new)
 			_, err := c.calicoClient.WorkloadEndpoints().Update(c.ctx, &wep, options.SetOptions{})
 			if err != nil {


### PR DESCRIPTION
## Description

```
fatal error: concurrent map iteration and map write

goroutine 371 [running]:
reflect.mapiternext(0x4cff2f?)
	/usr/local/go/src/runtime/map.go:1380 +0x19
reflect.(*MapIter).Next(0xc001a708e8?)
	/usr/local/go/src/reflect/value.go:1924 +0x7e
internal/fmtsort.Sort({0x1c44800?, 0xc01610cbe0?, 0xc0005a42e8?})
	/usr/local/go/src/internal/fmtsort/sort.go:62 +0x1f0
fmt.(*pp).printValue(0xc0073bc340, {0x1c44800?, 0xc01610cbe0?, 0x0?}, 0x76, 0x1)
	/usr/local/go/src/fmt/print.go:816 +0x986
fmt.(*pp).printValue(0xc0073bc340, {0x1db3800?, 0xc01610cbc0?, 0x30?}, 0x76, 0x0)
	/usr/local/go/src/fmt/print.go:853 +0x120a
fmt.(*pp).printArg(0xc0073bc340, {0x1db3800?, 0xc01610cbc0}, 0x76)
	/usr/local/go/src/fmt/print.go:759 +0x756
fmt.(*pp).doPrintf(0xc0073bc340, {0x1facf6b, 0x3d}, {0xc001a71108?, 0x2, 0x2})
	/usr/local/go/src/fmt/print.go:1077 +0x387
fmt.Sprintf({0x1facf6b, 0x3d}, {0xc001a71108, 0x2, 0x2})
	/usr/local/go/src/fmt/print.go:239 +0x59
github.com/sirupsen/logrus.(*Entry).Logf(0xc01660e000, 0x4, {0x1facf6b?, 0x1db3800?}, {0xc001a71108?, 0xc001a71188?, 0xc01610cbc0?})
	/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/entry.go:349 +0x49
github.com/sirupsen/logrus.(*Logger).Logf(0xc000062080, 0x4, {0x1facf6b, 0x3d}, {0xc001a71108, 0x2, 0x2})
	/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/logger.go:154 +0x85
github.com/sirupsen/logrus.(*Logger).Infof(...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/logger.go:168
github.com/sirupsen/logrus.Infof(...)
	/go/pkg/mod/github.com/sirupsen/logrus@v1.9.0/exported.go:199
github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod.(*podController).syncToCalico(0xc00060e840, {0xc00ec454d0, 0x2f})
	/go/src/github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod/pod_controller.go:324 +0x90f
github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod.(*podController).processNextItem(0xc00060e840)
	/go/src/github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod/pod_controller.go:275 +0x70
github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod.(*podController).runWorker(0x4?)
	/go/src/github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod/pod_controller.go:260 +0x25
created by github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod.(*podController).Run
	/go/src/github.com/projectcalico/calico/kube-controllers/pkg/controllers/pod/pod_controller.go:251 +0x3c6
```

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

https://github.com/projectcalico/calico/issues/7972

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
