### PR TITLE
BPF Remove old versions of maps after upgrade

### DIFF
--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -419,6 +419,33 @@ func (b *PinnedMap) Delete(k []byte) error {
 	return DeleteMapEntry(b.fd, k)
 }
 
+func (b *PinnedMap) deletePreviousVersion() error {
+	log.WithField("name", b.Name).Debug("delete previous version")
+	oldVersion, err := b.getOldMapVersion()
+	log.WithError(err).Debugf("Upgrading from %d", oldVersion)
+	if err != nil {
+		return err
+	}
+	// fresh install
+	if oldVersion == 0 {
+		return nil
+	}
+
+	// Get a pinnedMap handle for the old map
+	oldMapParams := b.GetMapParams(oldVersion)
+	oldBpfMap := NewPinnedMap(oldMapParams)
+
+	defer func() {
+		oldBpfMap.Close()
+		oldBpfMap.fd = 0
+
+		os.Remove(oldBpfMap.Path())
+		os.Remove(oldBpfMap.Path() + "_old")
+	}()
+
+	return nil
+}
+
 func (b *PinnedMap) DeleteIfExists(k []byte) error {
 	return DeleteMapEntryIfExists(b.fd, k)
 }
@@ -757,6 +784,12 @@ func (b *PinnedMap) CopyDeltaFromOldMap() error {
 	if err != nil {
 		return fmt.Errorf("error upgrading data from old map %s, err=%w", b.GetName(), err)
 	}
+
+	err = b.deletePreviousVersion()
+	if err != nil && !IsNotExists(err) {
+		return fmt.Errorf("failed to delete previous %s map, err=%w", b.Name, err)
+	}
+
 	if b.oldfd == 0 {
 		log.WithField("name", b.Name).Debug("CopyDeltaFromOldMap - no old map, done.")
 		return nil

--- a/felix/bpf/mock/map.go
+++ b/felix/bpf/mock/map.go
@@ -153,6 +153,10 @@ func (m *Map) Delete(k []byte) error {
 	return nil
 }
 
+func (*Map) DeletePreviousVersion() error {
+	return nil
+}
+
 func (m *Map) DeleteIfExists(k []byte) error {
 	return m.Delete(k)
 }
@@ -252,6 +256,10 @@ func (*DummyMap) Get(k []byte) ([]byte, error) {
 }
 
 func (*DummyMap) Delete(k []byte) error {
+	return nil
+}
+
+func (*DummyMap) DeletePreviousVersion() error {
 	return nil
 }
 

--- a/felix/fv/bpf_map_delete_test.go
+++ b/felix/fv/bpf_map_delete_test.go
@@ -18,14 +18,16 @@ package fv_test
 
 import (
 	"fmt"
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/calico/felix/bpf/arp"
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/failsafes"
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/state"
-	"os"
 
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"

--- a/felix/fv/bpf_map_delete_test.go
+++ b/felix/fv/bpf_map_delete_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/calico/felix/bpf/arp"
+	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
+	"github.com/projectcalico/calico/felix/bpf/failsafes"
+	"github.com/projectcalico/calico/felix/bpf/maps"
+	"github.com/projectcalico/calico/felix/bpf/state"
+	log "github.com/sirupsen/logrus"
+	"os"
+
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+)
+
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test delete previous map", []apiconfig.DatastoreType{apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
+
+	const (
+		MaxMapNumber = 99999
+	)
+
+	if os.Getenv("FELIX_FV_ENABLE_BPF") != "true" {
+		// Non-BPF run.
+		return
+	}
+
+	var (
+		infra infrastructure.DatastoreInfra
+		tc    infrastructure.TopologyContainers
+	)
+
+	BeforeEach(func() {
+		infra = getInfra()
+		opts := infrastructure.DefaultTopologyOptions()
+		tc, _ = infrastructure.StartNNodeTopology(1, opts, infra)
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			infra.DumpErrorData()
+		}
+
+		tc.Stop()
+		infra.Stop()
+	})
+
+	It("should delete previous maps after Felix restart", func() {
+
+		arpMap := arp.Map()
+		arpOldVersionedName := arpMap.(*maps.PinnedMap).VersionedName()
+		arpNewVersionedName := fmt.Sprintf("%s%d", arpMap.(*maps.PinnedMap).Name, MaxMapNumber)
+		log.Infof("%s", arpOldVersionedName)
+		log.Infof("%s", arpNewVersionedName)
+		arpCmd := getMapCmd(arpNewVersionedName, "lru_hash", "8", "12", "10000")
+		tc.Felixes[0].Exec(arpCmd...)
+
+		failsafesMap := failsafes.Map()
+		failsafesOldVersionedName := failsafesMap.(*maps.PinnedMap).VersionedName()
+		failsafesNewVersionedName := fmt.Sprintf("%s%d", failsafesMap.(*maps.PinnedMap).Name, MaxMapNumber)
+		log.Infof("%s", failsafesOldVersionedName)
+		log.Infof("%s", failsafesNewVersionedName)
+		failsafesCmd := getMapCmd(failsafesNewVersionedName, "lpm_trie", "12", "4", "65536")
+		tc.Felixes[0].Exec(failsafesCmd...)
+
+		stateMap := state.Map()
+		stateOldVersionedName := arpMap.(*maps.PinnedMap).VersionedName()
+		stateNewVersionedName := fmt.Sprintf("%s%d", stateMap.(*maps.PinnedMap).Name, MaxMapNumber)
+		log.Infof("%s", stateOldVersionedName)
+		log.Infof("%s", stateNewVersionedName)
+		stateCmd := getMapCmd(stateNewVersionedName, "percpu_array", "4", "464", "2")
+		tc.Felixes[0].Exec(stateCmd...)
+
+		// Before Felix restart: both old and new maps exists.
+		Eventually(func() string {
+			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+			Expect(err).NotTo(HaveOccurred())
+			return out
+		}, "5s", "200ms").Should(ContainSubstring(arpOldVersionedName))
+		Eventually(func() string {
+			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+			Expect(err).NotTo(HaveOccurred())
+			return out
+		}, "5s", "200ms").Should(ContainSubstring(failsafesOldVersionedName))
+		Eventually(func() string {
+			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+			Expect(err).NotTo(HaveOccurred())
+			return out
+		}, "5s", "200ms").Should(ContainSubstring(stateOldVersionedName))
+
+		tc.Felixes[0].Restart()
+
+		// After Felix restart: only the new maps now exists.
+		Eventually(func() string {
+			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+			Expect(err).NotTo(HaveOccurred())
+			return out
+		}, "5s", "200ms").ShouldNot(ContainSubstring(arpNewVersionedName))
+		Eventually(func() string {
+			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+			Expect(err).NotTo(HaveOccurred())
+			return out
+		}, "5s", "200ms").ShouldNot(ContainSubstring(failsafesNewVersionedName))
+		Eventually(func() string {
+			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+			Expect(err).NotTo(HaveOccurred())
+			return out
+		}, "5s", "200ms").ShouldNot(ContainSubstring(stateNewVersionedName))
+	})
+
+})
+
+func getMapCmd(mapVersionedName, mapType, mapKey, mapValue, mapEntries string) []string {
+	return []string{
+		"bpftool",
+		"map",
+		"create",
+		bpfdefs.GlobalPinDir + mapVersionedName,
+		"type",
+		mapType,
+		"key",
+		mapKey,
+		"value",
+		mapValue,
+		"entries",
+		mapEntries,
+		"name",
+		mapVersionedName,
+		"flags",
+		"0",
+	}
+}

--- a/felix/fv/bpf_map_delete_test.go
+++ b/felix/fv/bpf_map_delete_test.go
@@ -108,17 +108,33 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test delete previ
 			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
 			Expect(err).NotTo(HaveOccurred())
 			return out
-		}, "5s", "200ms").ShouldNot(ContainSubstring(arpOldVersionedName))
+		}, "5s", "200ms").Should(ContainSubstring(arpNewVersionedName))
 		Eventually(func() string {
 			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
 			Expect(err).NotTo(HaveOccurred())
 			return out
-		}, "5s", "200ms").ShouldNot(ContainSubstring(failsafesOldVersionedName))
+		}, "5s", "200ms").Should(ContainSubstring(failsafesNewVersionedName))
 		Eventually(func() string {
 			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
 			Expect(err).NotTo(HaveOccurred())
 			return out
-		}, "5s", "200ms").ShouldNot(ContainSubstring(stateOldVersionedName))
+		}, "5s", "200ms").Should(ContainSubstring(stateNewVersionedName))
+
+		//Eventually(func() string {
+		//	out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+		//	Expect(err).NotTo(HaveOccurred())
+		//	return out
+		//}, "5s", "200ms").ShouldNot(ContainSubstring(arpOldVersionedName))
+		//Eventually(func() string {
+		//	out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+		//	Expect(err).NotTo(HaveOccurred())
+		//	return out
+		//}, "5s", "200ms").ShouldNot(ContainSubstring(failsafesOldVersionedName))
+		//Eventually(func() string {
+		//	out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+		//	Expect(err).NotTo(HaveOccurred())
+		//	return out
+		//}, "5s", "200ms").ShouldNot(ContainSubstring(stateOldVersionedName))
 	})
 
 })

--- a/felix/fv/bpf_map_upgrade_test.go
+++ b/felix/fv/bpf_map_upgrade_test.go
@@ -42,7 +42,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test conntrack ma
 	var (
 		infra infrastructure.DatastoreInfra
 		tc    infrastructure.TopologyContainers
-		//client  client.Interface
 	)
 
 	BeforeEach(func() {
@@ -122,34 +121,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test conntrack ma
 		k3NatRevSnat := conntrack.NewKey(11, srcIP, 0, dstIP, 0)
 		val3NatRevSnat := conntrack.NewValueNATReverseSNAT(now, now, 0, leg3Normal, leg3Normal, tunIP, origIP, origSIP, 1234)
 
-		// Before Felix restart: both cali_v4_ct V2 and V3 maps exist.
-		Eventually(func() string {
-			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
-			Expect(err).NotTo(HaveOccurred())
-			return out
-		}, "5s", "200ms").Should(ContainSubstring("cali_v4_ct2"))
-		Eventually(func() string {
-			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
-			Expect(err).NotTo(HaveOccurred())
-			return out
-		}, "5s", "200ms").Should(ContainSubstring("cali_v4_ct3"))
-
 		tc.Felixes[0].Restart()
 		Eventually(func() conntrack.MapMem { return dumpCTMap(tc.Felixes[0]) }, "10s", "100ms").Should(HaveKeyWithValue(k3Normal, val3Normal))
 		Eventually(func() conntrack.MapMem { return dumpCTMap(tc.Felixes[0]) }, "10s", "100ms").Should(HaveKeyWithValue(k3NatFwd, val3NatFwd))
 		Eventually(func() conntrack.MapMem { return dumpCTMap(tc.Felixes[0]) }, "10s", "100ms").Should(HaveKeyWithValue(k3NatRev, val3NatRev))
 		Eventually(func() conntrack.MapMem { return dumpCTMap(tc.Felixes[0]) }, "10s", "100ms").Should(HaveKeyWithValue(k3NatRevSnat, val3NatRevSnat))
-
-		// After Felix restart: only cali_v4_ct V3 map exists.
-		Eventually(func() string {
-			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
-			Expect(err).NotTo(HaveOccurred())
-			return out
-		}, "5s", "200ms").Should(ContainSubstring("cali_v4_ct3"))
-		Eventually(func() string {
-			out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
-			Expect(err).NotTo(HaveOccurred())
-			return out
-		}, "60s", "200ms").ShouldNot(ContainSubstring("cali_v4_ct2"))
 	})
 })


### PR DESCRIPTION
UPDATE: closing PR and creating new PR [8012](https://github.com/projectcalico/calico/pull/8012)

_Expose a `deletePreviousVersion()` function to maps package which allows client code to explicitly delete previous version of a map after upgrade.  Proposal to expose this as a separate function to allow for more control in the code flow when the deletion can take place as there are many examples of map manipulation in [map_upgrade_test.go](https://github.com/projectcalico/calico/blob/master/felix/bpf/ut/map_upgrade_test.go) such that if the deletion was implicitly invoked in the private `upgrade()` function then this could break existing code and tests._

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Remove old versions of maps after upgrade
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
