### PR TITLE
fix: update calico-cni-plugin clusterrole rbac to include node/status patch and update

### DIFF
--- a/charts/calico/templates/calico-node-rbac.yaml
+++ b/charts/calico/templates/calico-node-rbac.yaml
@@ -191,6 +191,14 @@ rules:
       - namespaces
     verbs:
       - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
 {{- if eq .Values.datastore "kubernetes" }}
   - apiGroups: [""]
     resources:

--- a/manifests/calico-bpf.yaml
+++ b/manifests/calico-bpf.yaml
@@ -4608,6 +4608,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities

--- a/manifests/calico-etcd.yaml
+++ b/manifests/calico-etcd.yaml
@@ -214,6 +214,14 @@ rules:
       - namespaces
     verbs:
       - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
 ---
 # Source: calico/templates/calico-kube-controllers-rbac.yaml
 kind: ClusterRoleBinding

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -4585,6 +4585,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
 ---
 # Source: calico/templates/calico-kube-controllers-rbac.yaml
 kind: ClusterRoleBinding

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -4619,6 +4619,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities

--- a/manifests/calico-vxlan.yaml
+++ b/manifests/calico-vxlan.yaml
@@ -4603,6 +4603,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities

--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -4603,6 +4603,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -220,6 +220,14 @@ rules:
       - namespaces
     verbs:
       - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
 ---
 # Source: calico/templates/calico-node-rbac.yaml
 # Flannel ClusterRole

--- a/manifests/flannel-migration/calico.yaml
+++ b/manifests/flannel-migration/calico.yaml
@@ -4603,6 +4603,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities

--- a/node/tests/k8st/infra/calico-kdd.yaml
+++ b/node/tests/k8st/infra/calico-kdd.yaml
@@ -360,6 +360,14 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - blockaffinities


### PR DESCRIPTION
update calico-cni-plugin clusterrole rbac to include node/status patch and update. Currently there's issue with calicoctl when running command `calicoctl patch node` to patch ASN in order to enable bgp peering.
```
[execute] Hit error: updating existing resource: connection is unauthorized: nodes "<node-name>" is forbidden: User "system:serviceaccount:kube-system:calico-cni-plugin" cannot update resource "nodes/status" in API group "" at the cluster scope
```

we're using `calico-typha.yaml` manifest, but fixing in other manifests, too.