### PR TITLE
Set group write permission on /etc/service in calico node image

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -199,6 +199,9 @@ COPY filesystem/licenses/ /licenses
 COPY filesystem/usr/ /usr
 COPY filesystem/sbin/* /usr/sbin/
 
+# Ensure non-root user (for nonPrivileged=Enabled) has group write access to /etc/service
+RUN chmod 0775 /etc/service
+
 # Change permissions to make confd templates and output available in /etc/calico
 # to all container users.
 RUN chgrp -R 0 /etc/calico && \

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -219,6 +219,9 @@ COPY filesystem/licenses/ /licenses
 COPY filesystem/usr/ /usr
 COPY filesystem/sbin/* /usr/sbin/
 
+# Ensure non-root user (for nonPrivileged=Enabled) has group write access to /etc/service
+RUN chmod 0775 /etc/service
+
 # Change permissions to make confd templates and output available in /etc/calico
 # to all container users.
 RUN chgrp -R 0 /etc/calico && \

--- a/node/Dockerfile.armv7
+++ b/node/Dockerfile.armv7
@@ -37,6 +37,9 @@ COPY --from=bird /bird* /bin/
 # Copy in the filesystem - this contains felix, calico-bgp-daemon etc...
 COPY filesystem/ /
 
+# Ensure non-root user (for nonPrivileged=Enabled) has group write access to /etc/service
+RUN chmod 0775 /etc/service
+
 # Copy in the calico-node binary
 COPY dist/bin/calico-node-${ARCH} /bin/calico-node
 

--- a/node/Dockerfile.ppc64le
+++ b/node/Dockerfile.ppc64le
@@ -43,6 +43,9 @@ COPY --from=bird /bird* /bin/
 # Copy in the filesystem - this contains felix, calico-bgp-daemon etc...
 COPY filesystem/ /
 
+# Ensure non-root user (for nonPrivileged=Enabled) has group write access to /etc/service
+RUN chmod 0775 /etc/service
+
 # Copy in the calico-node binary
 COPY dist/bin/calico-node-${ARCH} /bin/calico-node
 

--- a/node/Dockerfile.s390x
+++ b/node/Dockerfile.s390x
@@ -35,6 +35,9 @@ COPY --from=bird /bird* /bin/
 # Copy in the filesystem - this contains felix, calico-bgp-daemon etc...
 COPY filesystem/ /
 
+# Ensure non-root user (for nonPrivileged=Enabled) has group write access to /etc/service
+RUN chmod 0775 /etc/service
+
 # Copy in the calico-node binary
 COPY dist/bin/calico-node-${ARCH} /bin/calico-node
 


### PR DESCRIPTION
## Description

When setting nonPrivileged=Enabled in the tigera-operator installation CR, the non-root user needs write access to /etc/service. Otherwise, calico-node readiness check fails with these errors:

  mkdir: cannot create directory '/etc/service/enabled': Permission denied
  cp: cannot create directory '/etc/service/enabled/': Permission denied
  runsvdir /etc/service/enabled: warning: unable to stat /etc/service/enabled: file does not exist

and calico-node enters CrashLoopBackoff.

The current Dockerfile copies the permissions set on the node/filesystem/etc/service directory in the Calico git repository, which may or may not have group write permission. Setting the permission explicitly ensures that it is set correctly regardless of how the git repository was checked out.

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/8016

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Set group write permission for /etc/service explicitly in calico-node Dockerfile
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
