### PR TITLE
Windows HPC image publishing

### DIFF
--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -37,9 +37,15 @@ blocks:
       - name: quay-robot-calico+semaphoreci
       - name: docker
       jobs:
-      - name: "cni-plugin"
+      - name: "linux"
         env_vars:
         - name: DEV_REGISTRIES
           value: quay.io/calico docker.io/calico
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin image-all cd CONFIRM=true; fi
+      - name: "windows"
+        env_vars:
+        - name: DEV_REGISTRIES
+          value: quay.io/calico docker.io/calico
+        commands:
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin release-windows CONFIRM=true; fi

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -51,4 +51,4 @@ blocks:
         - name: DEV_REGISTRIES
           value: quay.io/calico docker.io/calico
         commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node build-windows-upgrade-archive image-tar-windows-all cd-windows-all CONFIRM=true; fi
+        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node release-windows CONFIRM=true; fi

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -521,7 +521,7 @@ blocks:
       - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
     - name: "Build Windows image"
       commands:
-      - ../.semaphore/run-and-monitor build-windows-archive.log make image-windows
+      - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
 
 - name: "e2e tests"
   run:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -519,6 +519,9 @@ blocks:
     - name: "Build Windows archive"
       commands:
       - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
+    - name: "Build Windows image"
+      commands:
+      - ../.semaphore/run-and-monitor build-windows-archive.log make image-windows
 
 - name: "e2e tests"
   run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -521,7 +521,7 @@ blocks:
       - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
     - name: "Build Windows image"
       commands:
-      - ../.semaphore/run-and-monitor build-windows-archive.log make image-windows
+      - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
 
 - name: "e2e tests"
   run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -519,6 +519,9 @@ blocks:
     - name: "Build Windows archive"
       commands:
       - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
+    - name: "Build Windows image"
+      commands:
+      - ../.semaphore/run-and-monitor build-windows-archive.log make image-windows
 
 - name: "e2e tests"
   run:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -519,7 +519,7 @@ blocks:
       - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
     - name: "Build Windows image"
       commands:
-      - ../.semaphore/run-and-monitor build-windows-archive.log make image-windows
+      - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
 
 - name: "e2e tests"
   run:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -517,6 +517,9 @@ blocks:
     - name: "Build Windows archive"
       commands:
       - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
+    - name: "Build Windows image"
+      commands:
+      - ../.semaphore/run-and-monitor build-windows-archive.log make image-windows
 
 - name: "e2e tests"
   run:

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -281,6 +281,9 @@ release-publish: release-prereqs .release-$(VERSION).published
 .release-$(VERSION).published:
 	$(MAKE) push-images-to-registries push-manifests IMAGETAG=$(VERSION) RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	$(MAKE) FIPS=true push-images-to-registries push-manifests IMAGETAG=$(VERSION)-fips RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
+
+	# Push Windows images.
+	$(MAKE) release-windows RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 	touch $@
 
 # WARNING: Only run this target if this release is the latest stable release. Do NOT
@@ -314,7 +317,7 @@ release-publish-latest: release-prereqs
 # 	done ;
 
 # # Build and push Windows image
-# release-windows: release-prereqs clean-windows
+# release-windows: var-require-one-of-CONFIRM-DRYRUN release-prereqs clean-windows
 # 	$(MAKE) image-windows PUSH=true
 
 WINDOWS_DIST = dist/windows
@@ -339,7 +342,7 @@ image-windows: setup-windows-builder
 	$(MAKE) sub-image-windows-$${version}; \
 	done;
 
-release-windows: clean-windows image-windows
+release-windows: var-require-one-of-CONFIRM-DRYRUN clean-windows image-windows
 	image_version="$${VERSION:-latest}"; \
 	for registry in $(DEV_REGISTRIES); do \
 		echo Pushing Windows images to $${registry}; \

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -320,6 +320,25 @@ release-publish-latest: release-prereqs
 # release-windows: var-require-one-of-CONFIRM-DRYRUN release-prereqs clean-windows
 # 	$(MAKE) image-windows PUSH=true
 
+# Windows image pushing is different because we do not build docker images directly.
+# Since the build machine is linux, we output the images to a tarball. (We can
+# produce images but there will be no output because docker images
+# built for Windows cannot be loaded on linux.)
+#
+# The resulting image tarball is then pushed to registries during cd/release.
+# The image tarballs are located in WINDOWS_DIST and have files names
+# with the format 'cni-windows-v3.21.0-2-abcdef-20H2.tar'.
+#
+# In addition to pushing the individual images, we also create the manifest
+# directly using 'docker manifest'. This is possible because Semaphore is using
+# a recent enough docker CLI version (20.10.0)
+#
+# - Create the manifest with 'docker manifest create' using the list of all images.
+# - For each windows version, 'docker manifest annotate' its image with "os.image: <windows_version>".
+#   <windows_version> is the version string that looks like, e.g. 10.0.19041.1288.
+#   Setting os.image in the manifest is required for Windows hosts to load the
+#   correct image in manifest.
+# - Finally we push the manifest, "purging" the local manifest.
 WINDOWS_DIST = dist/windows
 
 $(WINDOWS_DIST)/$(CNI_PLUGIN_IMAGE_WINDOWS)-$(GIT_VERSION)-%.tar: sub-image-windows-$*

--- a/hack/postrelease/test_images.py
+++ b/hack/postrelease/test_images.py
@@ -20,12 +20,13 @@ EXPECTED_IMAGES = [
   "calico/cni",
   "calico/kube-controllers",
   "calico/upgrade",
-  "calico/windows",
   "calico/flannel-migration-controller",
   "calico/dikastes",
   "calico/pilot-webhook",
   "calico/pod2daemon-flexvol",
   "calico/csi",
+  "calico/cni-windows",
+  "calico/node-windows",
 ]
 
 # Images that we exclude from the assertions below.
@@ -34,16 +35,17 @@ OPERATOR_EXCLUDED_IMAGES = EXCLUDED_IMAGES + [
     "calico/dikastes",
     "calico/flannel-migration-controller",
     "calico/ctl",
-    "calico/windows",
     "calico/csi",
 ]
 
 
 # Images that we expect to be published to GCR.
 GCR_IMAGES = [
-    "calico/node", 
-    "calico/cni", 
+    "calico/node",
+    "calico/cni",
     "calico/typha",
+    "calico/node-windows",
+    "calico/cni-windows",
 ]
 
 

--- a/hack/postrelease/test_images.py
+++ b/hack/postrelease/test_images.py
@@ -44,8 +44,6 @@ GCR_IMAGES = [
     "calico/node",
     "calico/cni",
     "calico/typha",
-    "calico/node-windows",
-    "calico/cni-windows",
 ]
 
 

--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -466,7 +466,7 @@ func (r *ReleaseBuilder) buildContainerImages(ver string) error {
 	}
 
 	for _, dir := range windowsReleaseDirs {
-		out, err := r.makeInDirectoryWithOutput(dir, "release-windows", env...)
+		out, err := r.makeInDirectoryWithOutput(dir, "image-windows", env...)
 		if err != nil {
 			logrus.Error(out)
 			return fmt.Errorf("Failed to build %s: %s", dir, err)

--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -65,11 +65,12 @@ func releaseImages(version, operatorVersion string) []string {
 		fmt.Sprintf("calico/cni:%s", version),
 		fmt.Sprintf("calico/apiserver:%s", version),
 		fmt.Sprintf("calico/kube-controllers:%s", version),
-		fmt.Sprintf("calico/windows:%s", version),
 		fmt.Sprintf("calico/dikastes:%s", version),
 		fmt.Sprintf("calico/pod2daemon-flexvol:%s", version),
 		fmt.Sprintf("calico/csi:%s", version),
 		fmt.Sprintf("calico/node-driver-registrar:%s", version),
+		fmt.Sprintf("calico/cni-windows:%s", version),
+		fmt.Sprintf("calico/node-windows:%s", version),
 	}
 }
 
@@ -287,7 +288,7 @@ func (r *ReleaseBuilder) publishPrereqs(ver string) error {
 //
 // - release-vX.Y.Z.tgz: contains images, manifests, and binaries.
 // - tigera-operator-vX.Y.Z.tgz: contains the helm v3 chart.
-// - calico-windows-vX.Y.Z.zip: Calico for Windows.
+// - calico-windows-vX.Y.Z.zip: Calico for Windows zip archive for non-HPC installation.
 // - calicoctl/bin: All calicoctl binaries.
 //
 // This function also generates checksums for each artifact that is uploaded to the release.
@@ -366,6 +367,7 @@ func (r *ReleaseBuilder) uploadDir(ver string) string {
 // Builds the complete release tar for upload to github.
 // - release-vX.Y.Z.tgz: contains images, manifests, and binaries.
 // TODO: We should produce a tar per architecture that we ship.
+// TODO: We should produce windows tars
 func (r *ReleaseBuilder) buildReleaseTar(ver string, targetDir string) error {
 	// Create tar files for container image that are shipped.
 	releaseBase := fmt.Sprintf("_output/release-%s", ver)
@@ -443,6 +445,11 @@ func (r *ReleaseBuilder) buildContainerImages(ver string) error {
 		"felix",
 	}
 
+	windowsReleaseDirs := []string{
+		"node",
+		"cni-plugin"
+	}
+
 	// Build env.
 	env := append(os.Environ(),
 		fmt.Sprintf("VERSION=%s", ver),
@@ -451,6 +458,15 @@ func (r *ReleaseBuilder) buildContainerImages(ver string) error {
 
 	for _, dir := range releaseDirs {
 		out, err := r.makeInDirectoryWithOutput(dir, "release-build", env...)
+		if err != nil {
+			logrus.Error(out)
+			return fmt.Errorf("Failed to build %s: %s", dir, err)
+		}
+		logrus.Info(out)
+	}
+
+	for _, dir := range windowsReleaseDirs {
+		out, err := r.makeInDirectoryWithOutput(dir, "release-windows", env...)
 		if err != nil {
 			logrus.Error(out)
 			return fmt.Errorf("Failed to build %s: %s", dir, err)
@@ -517,6 +533,11 @@ func (r *ReleaseBuilder) publishContainerImages(ver string) error {
 		"node",
 	}
 
+	windowsReleaseDirs := []string{
+		"node",
+		"cni-plugin"
+	}
+
 	env := append(os.Environ(),
 		fmt.Sprintf("IMAGETAG=%s", ver),
 		fmt.Sprintf("VERSION=%s", ver),
@@ -532,6 +553,25 @@ func (r *ReleaseBuilder) publishContainerImages(ver string) error {
 		attempt := 0
 		for {
 			out, err := r.makeInDirectoryWithOutput(dir, "release-publish", env...)
+			if err != nil {
+				if attempt < maxRetries {
+					logrus.WithField("attempt", attempt).WithError(err).Warn("Publish failed, retrying")
+					attempt++
+					continue
+				}
+				logrus.Error(out)
+				return fmt.Errorf("Failed to publish %s: %s", dir, err)
+			}
+
+			// Success - move on to the next directory.
+			logrus.Info(out)
+			break
+		}
+	}
+	for _, dir := range windowsReleaseDirs {
+		attempt := 0
+		for {
+			out, err := r.makeInDirectoryWithOutput(dir, "release-windows", env...)
 			if err != nil {
 				if attempt < maxRetries {
 					logrus.WithField("attempt", attempt).WithError(err).Warn("Publish failed, retrying")

--- a/node/Makefile
+++ b/node/Makefile
@@ -10,8 +10,6 @@ DEV_TAG_SUFFIX        ?=0.dev
 NODE_IMAGE            ?=node
 WINDOWS_IMAGE         ?=node-windows
 
-WINDOWS_VERSIONS?=1809 ltsc2022
-
 # We don't include the windows images here because we build them differently
 # using targets within this makefile.
 BUILD_IMAGES ?=$(NODE_IMAGE)

--- a/node/Makefile
+++ b/node/Makefile
@@ -611,8 +611,8 @@ $(WINDOWS_INSTALL_SCRIPT):
 # built for Windows cannot be loaded on linux.)
 #
 # The resulting image tarball is then pushed to registries during cd/release.
-# The image tarballs are located in WINDOWS_IMAGE_TAR_ROOT and have files names
-# with the format 'image-v3.21.0-2-abcdef-20H2.tar'.
+# The image tarballs are located in WINDOWS_DIST and have files names
+# with the format 'node-windows-v3.21.0-2-abcdef-20H2.tar'.
 #
 # In addition to pushing the individual images, we also create the manifest
 # directly using 'docker manifest'. This is possible because Semaphore is using

--- a/node/Makefile
+++ b/node/Makefile
@@ -9,9 +9,8 @@ DEV_TAG_SUFFIX        ?=0.dev
 # e.g., <registry>/<name>:<tag>
 NODE_IMAGE            ?=node
 WINDOWS_IMAGE         ?=node-windows
-WINDOWS_UPGRADE_IMAGE ?=windows-upgrade
 
-WINDOWS_VERSIONS?=1809 2004 20H2 ltsc2022
+WINDOWS_VERSIONS?=1809 ltsc2022
 
 # We don't include the windows images here because we build them differently
 # using targets within this makefile.
@@ -126,23 +125,6 @@ WINDOWS_ARCHIVE_FILES := \
 MICROSOFT_SDN_VERSION := 0d7593e5c8d4c2347079a7a6dbd9eb034ae19a44
 MICROSOFT_SDN_GITHUB_RAW_URL := https://raw.githubusercontent.com/microsoft/SDN/$(MICROSOFT_SDN_VERSION)
 
-WINDOWS_UPGRADE_ROOT         ?= windows-upgrade
-WINDOWS_UPGRADE_DIST          = dist/windows-upgrade
-
-# The directory for temporary files used to build the windows upgrade zip archive.
-WINDOWS_UPGRADE_DIST_STAGE    = $(WINDOWS_UPGRADE_DIST)/stage
-
-# Windows upgrade archive components.
-WINDOWS_UPGRADE_INSTALL_FILE ?= $(WINDOWS_UPGRADE_DIST_STAGE)/install-calico-windows.ps1
-WINDOWS_UPGRADE_INSTALL_ZIP  ?= $(WINDOWS_UPGRADE_DIST_STAGE)/calico-windows-$(WINDOWS_ARCHIVE_TAG).zip
-WINDOWS_UPGRADE_SCRIPT       ?= $(WINDOWS_UPGRADE_DIST_STAGE)/calico-upgrade.ps1
-
-# The directory for the upgrade image docker build context.
-WINDOWS_UPGRADE_BUILD        ?= $(WINDOWS_UPGRADE_ROOT)/build
-
-# The final zip archive used in the upgrade image.
-WINDOWS_UPGRADE_ARCHIVE      ?= $(WINDOWS_UPGRADE_BUILD)/calico-windows-upgrade.zip
-
 # The directory for windows image tarball
 WINDOWS_DIST        = dist/windows
 
@@ -193,8 +175,6 @@ clean: clean-windows
 	docker rmi $(NODE_IMAGE):latest-$(ARCH) || true
 	docker rmi $(NODE_IMAGE):latest-fips-$(ARCH) || true
 	docker rmi $(TEST_CONTAINER_NAME) || true
-	docker rmi $(addprefix $(WINDOWS_IMAGE):latest-,$(WINDOWS_VERSIONS)) || true
-	docker rmi $(addprefix $(WINDOWS_UPGRADE_IMAGE):latest-,$(WINDOWS_VERSIONS)) || true
 
 clean-windows: clean-windows-builder
 	-rm -f $(WINDOWS_ARCHIVE) $(WINDOWS_ARCHIVE_BINARY) $(WINDOWS_BINARY)
@@ -207,6 +187,7 @@ clean-windows: clean-windows-builder
 	-rm -rf "$(WINDOWS_DIST)"
 	-rm -rf "$(WINDOWS_UPGRADE_DIST)"
 	-rm -rf "$(WINDOWS_UPGRADE_BUILD)"
+	-docker rmi $(addprefix $(WINDOWS_IMAGE):latest-,$(WINDOWS_VERSIONS))
 
 ###############################################################################
 # Building the binary
@@ -502,10 +483,6 @@ release-build: .release-$(VERSION).created
 	$(MAKE) FIPS=true retag-build-images-with-registries RELEASE=true IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	# Generate the Windows zip archives.
 	$(MAKE) release-windows-archive
-	$(MAKE) release-windows-upgrade-archive
-	# Generate the Windows upgrade image tarballs (this must come after the
-	# upgrade archive)
-	$(MAKE) image-tar-windows-all
 	touch $@
 
 ## Produces the Windows installation ZIP archive for the release.
@@ -525,7 +502,7 @@ release-publish: release-prereqs .release-$(VERSION).published
 	$(MAKE) FIPS=true push-images-to-registries push-manifests IMAGETAG=$(VERSION)-fips RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 
 	# Push Windows images.
-	$(MAKE) cd-windows-all RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
+	$(MAKE) release-windows RELEASE=$(RELEASE) CONFIRM=$(CONFIRM)
 
 	touch $@
 
@@ -598,128 +575,11 @@ build-windows-archive: build $(WINDOWS_ARCHIVE_FILES) windows-packaging/nssm.zip
 $(WINDOWS_ARCHIVE_BINARY): $(WINDOWS_BINARY)
 	cp $< $@
 
-# Ensure the upgrade image docker build folder exists.
-$(WINDOWS_UPGRADE_BUILD):
-	-mkdir -p $(WINDOWS_UPGRADE_BUILD)
-
-# Ensure the directory for temporary files used to build the windows upgrade zip
-# archive exists.
-$(WINDOWS_UPGRADE_DIST_STAGE):
-	-mkdir -p $(WINDOWS_UPGRADE_DIST_STAGE)
-
-# Copy the upgrade script to the temporary directory where we build the windows
-# upgrade zip file.
-$(WINDOWS_UPGRADE_SCRIPT): $(WINDOWS_UPGRADE_DIST_STAGE)
-	cp $(WINDOWS_UPGRADE_ROOT)/calico-upgrade.ps1 $@
-
-# Copy the install zip archive to the temporary directory where we build the windows
-# upgrade zip file.
-$(WINDOWS_UPGRADE_INSTALL_ZIP): build-windows-archive $(WINDOWS_UPGRADE_DIST_STAGE)
-	cp $(WINDOWS_ARCHIVE) $@
-
 # Build the docs site and copy over the install-calico-windows.ps1 script.
 $(WINDOWS_INSTALL_SCRIPT):
 	-mkdir -p dist
 	cp $(CURDIR)/windows-packaging/install-calico-windows.ps1 $@
 	sed -i s/VERSION/$(GIT_VERSION)/g $@
-
-# Copy the install-calico-windows.ps1 script to the temporary directory where we
-# build the windows upgrade zip file.
-$(WINDOWS_UPGRADE_INSTALL_FILE): $(WINDOWS_UPGRADE_DIST_STAGE) $(WINDOWS_INSTALL_SCRIPT)
-	cp $(WINDOWS_INSTALL_SCRIPT) $@
-
-# Produces the Windows upgrade ZIP archive for the release.
-release-windows-upgrade-archive: release-prereqs
-	$(MAKE) build-windows-upgrade-archive WINDOWS_ARCHIVE_TAG=$(VERSION)
-
-# Build the Windows upgrade zip archive, which also builds the windows archive.
-build-windows-upgrade-archive: clean-windows $(WINDOWS_UPGRADE_INSTALL_ZIP) $(WINDOWS_UPGRADE_INSTALL_FILE) $(WINDOWS_UPGRADE_SCRIPT) $(WINDOWS_UPGRADE_BUILD)
-	rm $(WINDOWS_UPGRADE_ARCHIVE) || true
-	cd $(WINDOWS_UPGRADE_DIST_STAGE) && zip -r "$(CURDIR)/$(WINDOWS_UPGRADE_ARCHIVE)" *.zip *.ps1
-
-# Builds all the Windows image tarballs for each version in WINDOWS_VERSIONS
-image-tar-windows-all: setup-windows-builder $(addprefix sub-image-tar-windows-,$(WINDOWS_VERSIONS)) $(addprefix sub-image-tar-windows-upgrade-,$(WINDOWS_VERSIONS))
-
-# Uses the docker builder to create a Windows image tarball for a single Windows version.
-sub-image-tar-windows-%: $(WINDOWS_ARCHIVE_BINARY) dist/calico-windows-$(GIT_VERSION).zip $(WINDOWS_INSTALL_SCRIPT)
-	# ensure dir for windows image tars
-	-mkdir -p $(WINDOWS_DIST)
-	# ensure docker build dir exists
-	-mkdir -p $(WINDOWS_DIST_STAGE)
-	# copy dockerfile to staging dir
-	cp $(WINDOWS_PACKAGING_ROOT)/Dockerfile $(WINDOWS_DIST_STAGE)
-	# copy install entrypoint script to staging dir
-	cp $(WINDOWS_PACKAGING_ROOT)/host-process-install.ps1 $(WINDOWS_DIST_STAGE)
-	# build and copy install script to staging dir
-	cp $(WINDOWS_INSTALL_SCRIPT) $(WINDOWS_DIST_STAGE)
-	# copy calico install zip file to staging dir
-	cp dist/calico-windows-$(GIT_VERSION).zip $(WINDOWS_DIST_STAGE)/calico-windows.zip
-	cd $(WINDOWS_DIST_STAGE) && \
-	docker buildx build \
-		--platform windows/amd64 \
-		--output=type=docker,dest=$(CURDIR)/$(WINDOWS_DIST)/image-$(GIT_VERSION)-$*.tar \
-		--pull \
-		--build-arg=WINDOWS_VERSION=$* .
-
-# Uses the docker builder to create a Windows upgrade image tarball for a single Windows version.
-sub-image-tar-windows-upgrade-%:
-	-mkdir -p $(WINDOWS_UPGRADE_DIST)
-	cd $(WINDOWS_UPGRADE_ROOT) && \
-		docker buildx build \
-			--platform windows/amd64 \
-			--output=type=docker,dest=$(CURDIR)/$(WINDOWS_UPGRADE_DIST)/image-$(GIT_VERSION)-$*.tar \
-			--pull \
-			--no-cache \
-			--build-arg=WINDOWS_VERSION=$* .
-
-cd-windows-all:
-	$(MAKE) cd-windows-windows WINDOWS_IMAGE_TAR_ROOT=$(WINDOWS_DIST)
-	$(MAKE) cd-windows-windows-upgrade WINDOWS_IMAGE_TAR_ROOT=$(WINDOWS_UPGRADE_DIST)
-
-# Windows image pushing is different because we do not build docker images directly.
-# Since the build machine is linux, we output the images to a tarball. (We can
-# produce images but there will be no output because docker images
-# built for Windows cannot be loaded on linux.)
-#
-# The resulting image tarball is then pushed to registries during cd/release.
-# The image tarballs are located in WINDOWS_IMAGE_TAR_ROOT and have files names
-# with the format 'image-v3.21.0-2-abcdef-20H2.tar'.
-#
-# In addition to pushing the individual images, we also create the manifest
-# directly using 'docker manifest'. This is possible because Semaphore is using
-# a recent enough docker CLI version (20.10.0)
-#
-# - Create the manifest with 'docker manifest create' using the list of all images.
-# - For each windows version, 'docker manifest annotate' its image with "os.image: <windows_version>".
-#   <windows_version> is the version string that looks like, e.g. 10.0.19041.1288.
-#   Setting os.image in the manifest is required for Windows hosts to load the
-#   correct image in manifest.
-# - Finally we push the manifest, "purging" the local manifest.
-cd-windows-%:
-# WINDOWS_IMAGE_TAR_ROOT is the dir containing image tarballs to push.
-ifndef WINDOWS_IMAGE_TAR_ROOT
-	$(error WINDOWS_IMAGE_TAR_ROOT is not set)
-endif
-	for registry in $(DEV_REGISTRIES); do \
-		echo Pushing Windows images to $${registry}; \
-		all_images=""; \
-		manifest_image="$${registry}/$*:$(GIT_VERSION)"; \
-		for win_ver in $(WINDOWS_VERSIONS); do \
-			image_tar="$(WINDOWS_IMAGE_TAR_ROOT)/image-$(GIT_VERSION)-$${win_ver}.tar"; \
-			image="$${registry}/$*:$(GIT_VERSION)-windows-$${win_ver}"; \
-			echo Pushing image $${image} ...; \
-			$(CRANE_BINDMOUNT) push $${image_tar} $${image}$(double_quote) & \
-			all_images="$${all_images} $${image}"; \
-		done; \
-		wait; \
-		$(DOCKER_MANIFEST) create --amend $${manifest_image} $${all_images}; \
-		for win_ver in $(WINDOWS_VERSIONS); do \
-			version=$$(docker manifest inspect mcr.microsoft.com/windows/nanoserver:$${win_ver} | grep "os.version" | head -n 1 | awk -F\" '{print $$4}'); \
-			image="$${registry}/$*:$(GIT_VERSION)-windows-$${win_ver}"; \
-			$(DOCKER_MANIFEST) annotate --os windows --arch amd64 --os-version $${version} $${manifest_image} $${image}; \
-		done; \
-		$(DOCKER_MANIFEST) push --purge $${manifest_image}; \
-	done ;
 
 # FIXME: Use WINDOWS_HPC_VERSION and image instead of nanoserver and WINDOWS_VERSIONS when containerd v1.6 is EOL'd
 # .PHONY: image-windows release-windows
@@ -742,9 +602,28 @@ endif
 # 	done ;
 
 # # Build and push Windows image
-# release-windows: release-prereqs clean-windows
+# release-windows: var-require-one-of-CONFIRM-DRYRUN release-prereqs clean-windows
 # 	$(MAKE) image-windows PUSH=true
 
+# Windows image pushing is different because we do not build docker images directly.
+# Since the build machine is linux, we output the images to a tarball. (We can
+# produce images but there will be no output because docker images
+# built for Windows cannot be loaded on linux.)
+#
+# The resulting image tarball is then pushed to registries during cd/release.
+# The image tarballs are located in WINDOWS_IMAGE_TAR_ROOT and have files names
+# with the format 'image-v3.21.0-2-abcdef-20H2.tar'.
+#
+# In addition to pushing the individual images, we also create the manifest
+# directly using 'docker manifest'. This is possible because Semaphore is using
+# a recent enough docker CLI version (20.10.0)
+#
+# - Create the manifest with 'docker manifest create' using the list of all images.
+# - For each windows version, 'docker manifest annotate' its image with "os.image: <windows_version>".
+#   <windows_version> is the version string that looks like, e.g. 10.0.19041.1288.
+#   Setting os.image in the manifest is required for Windows hosts to load the
+#   correct image in manifest.
+# - Finally we push the manifest, "purging" the local manifest.
 $(WINDOWS_DIST)/$(WINDOWS_IMAGE)-$(GIT_VERSION)-%.tar: sub-image-windows-$*
 
 sub-image-windows-%: Dockerfile-windows $(WINDOWS_BINARY) $(WINDOWS_ARCHIVE_ROOT)/libs/hns/hns.psm1 $(WINDOWS_ARCHIVE_ROOT)/libs/calico/calico.psm1 $(WINDOWS_ARCHIVE_ROOT)/config-hpc.ps1 $(WINDOWS_ARCHIVE_ROOT)/felix/felix-service.ps1 $(WINDOWS_ARCHIVE_ROOT)/node/node-service.ps1 $(WINDOWS_ARCHIVE_ROOT)/uninstall-calico-hpc.ps1 windows-packaging/nssm.exe
@@ -765,7 +644,7 @@ image-windows: setup-windows-builder
 	$(MAKE) sub-image-windows-$${version}; \
 	done;
 
-release-windows: clean-windows image-windows
+release-windows: var-require-one-of-CONFIRM-DRYRUN clean-windows image-windows
 	image_version="$${VERSION:-latest}"; \
 	for registry in $(DEV_REGISTRIES); do \
 		echo Pushing Windows images to $${registry}; \


### PR DESCRIPTION
Windows HPC image publishing changes:
- add node and cni-plugin windows image pushing to semaphore scripts
- add requirement of CONFIRM/DRYRUN to release-windows make targets in node and cni-plugin
- add windows node and cni-plugin images to test_images.py
- add windows node and cni-plugin images builder.go
- clean up deprecated windows-upgrade make targets from node

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
