### PR TITLE
OpenStack CI fixes

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -17,7 +17,7 @@
 set -ex
 
 sudo pip uninstall -y setuptools
-sudo rm -rf /usr/local/lib/python3.8/dist-packages/setuptools-67.8.0.dist-info
+sudo rm -rf /usr/local/lib/python3.8/dist-packages/setuptools-*.dist-info
 sudo find / -name "*setuptools*" || true
 sudo pip list || true
 

--- a/networking-calico/requirements.txt
+++ b/networking-calico/requirements.txt
@@ -5,4 +5,4 @@
 Babel>=2.9.1 # BSD
 eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
-etcd3gw>=1.0.1 # Apache-2.0
+etcd3gw==1.0.1 # Apache-2.0

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -16,6 +16,7 @@ testrepository>=0.0.18 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 
+etcd3gw==1.0.1 # Apache-2.0
 neutron
 neutron-lib
 mock>=3.0.0 # BSD

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -13,7 +13,6 @@ setenv =
    PYTHONWARNINGS=default::DeprecationWarning,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:site,ignore:Using or importing the ABCs,ignore:dns.hash module,ignore:Please provide `is_available
 deps = -r{toxinidir}/test-requirements.txt
 commands =
-    pip install -q -e "git+https://opendev.org/openstack/etcd3gw.git@1.0.1#egg=etcd3gw"
     coverage erase
     python setup.py testr --slowest --testr-args='{posargs}'
     coverage report -m


### PR DESCRIPTION
## Description

Fixes for two problems that have recently developed in our CI...

### Install etcd3gw 1.0.1 normally

In the Ussuri CI (`make -C networking-calico tox-ussuri`), we recently started getting this error
when executing the pip install line for etcd3gw:

    Traceback (most recent call last):
      File "<string>", line 2, in <module>
      File "<pip-setuptools-caller>", line 34, in <module>
      File "/code/.tox/py38/src/etcd3gw/setup.py", line 27, in <module>
        setuptools.setup(
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/__init__.py", line 103, in setup
        return distutils.core.setup(**attrs)
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 185, in setup
        return run_commands(dist)
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
        dist.run_commands()
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
        self.run_command(cmd)
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/dist.py", line 1001, in run_command
        super().run_command(command)
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
        cmd_obj.run()
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/command/develop.py", line 34, in run
        self.install_for_development()
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/command/develop.py", line 124, in install_for_development
        self.process_distribution(None, self.dist, not self.no_deps)
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/command/easy_install.py", line 770, in process_distribution
        self.install_egg_scripts(dist)
      File "/code/.tox/py38/lib/python3.8/site-packages/setuptools/command/develop.py", line 151, in install_egg_scripts
        self.install_wrapper_scripts(dist)
      File "/code/.tox/py38/lib/python3.8/site-packages/pbr/packaging.py", line 450, in install_wrapper_scripts
        for args in override_get_script_args(dist):
      File "/code/.tox/py38/lib/python3.8/site-packages/pbr/packaging.py", line 436, in override_get_script_args
        header = easy_install.get_script_header("", executable, is_wininst)
    AttributeError: module 'setuptools.command.easy_install' has no attribute 'get_script_header'

I don't understand why, but anyway I realized that we no longer (since updating to v1.0.1) need to
install etcd3gw in this slightly odd way; we can just put `etcd3gw==1.0.1` in the requirements
files.  And it turns out that that fixes the problem at that point in the CI setup.

### Generalize setuptools removal hack

The pre-installed version of setuptools on Semaphore - which we need to uninstall - has moved from
67.8.0 to 68.0.0, so generalize our removal incantations accordingly.
