### PR TITLE
Split kindest/node version into a separate variable

### DIFF
--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -156,7 +156,7 @@ st:
 check-copyright:
 	@../hack/check-copyright.sh
 
-GITHUB_TEST_INTEGRATION_URI := https://raw.githubusercontent.com/kubernetes/kubernetes/$(KUBECTL_VERSION)/hack/lib
+GITHUB_TEST_INTEGRATION_URI := https://raw.githubusercontent.com/kubernetes/kubernetes/$(K8S_VERSION)/hack/lib
 
 hack-lib:
 	mkdir -p hack/lib/
@@ -175,7 +175,7 @@ run-kubernetes-server: run-k8s-controller-manager
 		--rm \
 		-v  $(CURDIR):/manifests \
 		-v $(CERTS_PATH):/home/user/certs \
-		bitnami/kubectl:$(subst v,,$(KUBECTL_VERSION)) \
+		bitnami/kubectl:$(subst v,,$(K8S_VERSION)) \
 		--kubeconfig=/home/user/certs/kubeconfig \
 		apply -f /manifests/test/mock-node.yaml
 
@@ -186,7 +186,7 @@ run-kubernetes-server: run-k8s-controller-manager
 		--rm \
 		-v  $(CURDIR):/manifests \
 		-v $(CERTS_PATH):/home/user/certs \
-		bitnami/kubectl:$(subst v,,$(KUBECTL_VERSION)) \
+		bitnami/kubectl:$(subst v,,$(K8S_VERSION)) \
 		--kubeconfig=/home/user/certs/kubeconfig \
 		apply -f /manifests/test/namespaces.yaml
 

--- a/confd/Makefile
+++ b/confd/Makefile
@@ -104,7 +104,7 @@ ut:
 
 
 bin/kubectl:
-	curl -sSf -L --retry 5 https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/linux/$(ARCH)/kubectl -o $@
+	curl -sSf -L --retry 5 https://storage.googleapis.com/kubernetes-release/release/$(K8S_VERSION)/bin/linux/$(ARCH)/kubectl -o $@
 	chmod +x $@
 
 bin/bird bin/bird6:

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -91,7 +91,7 @@ $(BINDIR)/check-status-linux-$(ARCH): $(SRC_FILES)
 	  $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) go build $(BUILD_TAGS) -buildvcs=false -v -o $@ -ldflags "$(LDFLAGS)" ./cmd/check-status/'
 
 $(BINDIR)/kubectl-$(ARCH):
-	wget https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/linux/$(subst armv7,arm,$(ARCH))/kubectl -O $@
+	wget https://storage.googleapis.com/kubernetes-release/release/$(K8S_VERSION)/bin/linux/$(subst armv7,arm,$(ARCH))/kubectl -O $@
 	chmod +x $@
 
 ###############################################################################

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -1312,7 +1312,7 @@ $(REPO_ROOT)/.$(KIND_NAME).created: $(KUBECTL) $(KIND)
 		--config $(KIND_CONFIG) \
 		--kubeconfig $(KIND_KUBECONFIG) \
 		--name $(KIND_NAME) \
-		--image kindest/node:$(K8S_VERSION)
+		--image kindest/node:$(KINDEST_NODE_VERSION)
 
 	# Wait for controller manager to be running and healthy, then create Calico CRDs.
 	while ! KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) get serviceaccount default; do echo "Waiting for default serviceaccount to be created..."; sleep 2; done

--- a/metadata.mk
+++ b/metadata.mk
@@ -5,14 +5,15 @@
 # The version of github.com/projectcalico/go-build to use.
 GO_BUILD_VER = v0.89
 
-# Version of Kubernetes to use for tests.
-K8S_VERSION     = v1.24.7
-# This is used for bitnami/kubectl and kubectl binary release.
-KUBECTL_VERSION = v1.24.14
+# Version of Kubernetes to use for tests, bitnami/kubectl, and kubectl binary release.
+K8S_VERSION=v1.26.8
 
 # Version of various tools used in the build and tests.
 COREDNS_VERSION=1.5.2
 ETCD_VERSION=v3.5.1
+# FIXME upgrading to kindest/node newer than v1.24.7 causes Node/kind-cluster and sig-network conformance
+# tests to timeout or fail.
+KINDEST_NODE_VERSION=v1.24.7
 PROTOC_VER=v0.1
 UBI_VERSION=8.7
 


### PR DESCRIPTION
## Description

This change splits `kindest/node` version variable into a separate one so that it won't interfere with our normal k8s upgrade. `kindest/node` image is normally behind the official k8s release and newer images also break our UT/FVs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
