### PR TITLE
Disable checksum offload on the IPIP tunnel for kernels <v5.7

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -795,8 +795,10 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 	dp.RegisterManager(newFloatingIPManager(natTableV4, ruleRenderer, 4, config.FloatingIPsEnabled))
 	dp.RegisterManager(newMasqManager(ipSetsV4, natTableV4, ruleRenderer, config.MaxIPSetSize, 4))
 	if config.RulesConfig.IPIPEnabled {
+		log.Info("IPIP enabled, starting thread to keep tunnel configuration in sync.")
 		// Add a manager to keep the all-hosts IP set up to date.
 		dp.ipipManager = newIPIPManager(ipSetsV4, config.MaxIPSetSize, config.ExternalNodesCidrs)
+		go dp.ipipManager.KeepIPIPDeviceInSync(config.IPIPMTU, config.RulesConfig.IPIPTunnelAddress, dataplaneFeatures.ChecksumOffloadBroken)
 		dp.RegisterManager(dp.ipipManager) // IPv4-only
 	} else {
 		// Only clean up IPIP addresses if IPIP is implicitly disabled (no IPIP pools and not explicitly set in FelixConfig)
@@ -1393,16 +1395,6 @@ func (d *InternalDataplane) doStaticDataplaneConfig() {
 		d.setUpIptablesBPF()
 	} else {
 		d.setUpIptablesNormal()
-	}
-
-	if d.config.RulesConfig.IPIPEnabled {
-		log.Info("IPIP enabled, starting thread to keep tunnel configuration in sync.")
-		go d.ipipManager.KeepIPIPDeviceInSync(
-			d.config.IPIPMTU,
-			d.config.RulesConfig.IPIPTunnelAddress,
-		)
-	} else {
-		log.Info("IPIP disabled. Not starting tunnel update thread.")
 	}
 }
 

--- a/felix/dataplane/linux/ipip_mgr.go
+++ b/felix/dataplane/linux/ipip_mgr.go
@@ -15,6 +15,7 @@
 package intdataplane
 
 import (
+	"fmt"
 	"net"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/projectcalico/calico/felix/dataplane/common"
+	"github.com/projectcalico/calico/felix/ethtool"
 	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
@@ -80,10 +82,10 @@ func newIPIPManagerWithShim(
 
 // KeepIPIPDeviceInSync is a goroutine that configures the IPIP tunnel device, then periodically
 // checks that it is still correctly configured.
-func (d *ipipManager) KeepIPIPDeviceInSync(mtu int, address net.IP) {
+func (d *ipipManager) KeepIPIPDeviceInSync(mtu int, address net.IP, xsumBroken bool) {
 	log.Info("IPIP thread started.")
 	for {
-		err := d.configureIPIPDevice(mtu, address)
+		err := d.configureIPIPDevice(mtu, address, xsumBroken)
 		if err != nil {
 			log.WithError(err).Warn("Failed configure IPIP tunnel device, retrying...")
 			time.Sleep(1 * time.Second)
@@ -94,7 +96,7 @@ func (d *ipipManager) KeepIPIPDeviceInSync(mtu int, address net.IP) {
 }
 
 // configureIPIPDevice ensures the IPIP tunnel device is up and configures correctly.
-func (d *ipipManager) configureIPIPDevice(mtu int, address net.IP) error {
+func (d *ipipManager) configureIPIPDevice(mtu int, address net.IP, xsumBroken bool) error {
 	logCxt := log.WithFields(log.Fields{
 		"mtu":        mtu,
 		"tunnelAddr": address,
@@ -128,6 +130,14 @@ func (d *ipipManager) configureIPIPDevice(mtu int, address net.IP) error {
 		}
 		logCxt.Info("Updated tunnel MTU")
 	}
+
+	// If required, disable checksum offload.
+	if xsumBroken {
+		if err := ethtool.EthtoolTXOff("tunl0"); err != nil {
+			return fmt.Errorf("failed to disable checksum offload: %s", err)
+		}
+	}
+
 	if attrs.Flags&net.FlagUp == 0 {
 		logCxt.WithField("flags", attrs.Flags).Info("Tunnel wasn't admin up, enabling it")
 		if err := d.dataplane.LinkSetUp(link); err != nil {

--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -64,7 +64,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 		}
 
 		BeforeEach(func() {
-			err = ipipMgr.configureIPIPDevice(1400, ip)
+			err = ipipMgr.configureIPIPDevice(1400, ip, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -85,7 +85,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 		Describe("after second call with same params", func() {
 			BeforeEach(func() {
 				dataplane.ResetCalls()
-				err := ipipMgr.configureIPIPDevice(1400, ip)
+				err := ipipMgr.configureIPIPDevice(1400, ip, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should avoid creating the interface", func() {
@@ -105,7 +105,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 		Describe("after second call with different params", func() {
 			BeforeEach(func() {
 				dataplane.ResetCalls()
-				err = ipipMgr.configureIPIPDevice(1500, ip2)
+				err = ipipMgr.configureIPIPDevice(1500, ip2, false)
 				Expect(err).ToNot(HaveOccurred())
 
 			})
@@ -127,7 +127,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 		Describe("after second call with nil IP", func() {
 			BeforeEach(func() {
 				dataplane.ResetCalls()
-				err := ipipMgr.configureIPIPDevice(1500, nil)
+				err := ipipMgr.configureIPIPDevice(1500, nil, false)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should avoid creating the interface", func() {
@@ -147,7 +147,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 
 	Describe("after calling configureIPIPDevice with no IP", func() {
 		BeforeEach(func() {
-			err := ipipMgr.configureIPIPDevice(1400, nil)
+			err := ipipMgr.configureIPIPDevice(1400, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -170,7 +170,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 	const expNumCalls = 8
 	It("a successful call should only call into dataplane expected number of times", func() {
 		// This spec is a sanity-check that we've got the expNumCalls constant correct.
-		err := ipipMgr.configureIPIPDevice(1400, ip)
+		err := ipipMgr.configureIPIPDevice(1400, ip, false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dataplane.NumCalls).To(BeNumerically("==", expNumCalls))
 	})
@@ -185,7 +185,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 			})
 
 			It("should return the error", func() {
-				Expect(ipipMgr.configureIPIPDevice(1400, ip)).To(Equal(mockFailure))
+				Expect(ipipMgr.configureIPIPDevice(1400, ip, false)).To(Equal(mockFailure))
 			})
 
 			Describe("with an IP to remove", func() {
@@ -196,7 +196,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 						})
 				})
 				It("should return the error", func() {
-					Expect(ipipMgr.configureIPIPDevice(1400, ip)).To(Equal(mockFailure))
+					Expect(ipipMgr.configureIPIPDevice(1400, ip, false)).To(Equal(mockFailure))
 				})
 			})
 		})

--- a/felix/environment/feature_detect_common.go
+++ b/felix/environment/feature_detect_common.go
@@ -10,7 +10,7 @@ type Features struct {
 	RestoreSupportsLock bool
 	// ChecksumOffloadBroken is true for kernels that have broken checksum offload for packets with SNATted source
 	// ports. See https://github.com/projectcalico/calico/issues/3145.  On such kernels we disable checksum offload
-	// on our VXLAN device.
+	// on our VXLAN and IPIP device.
 	ChecksumOffloadBroken bool
 	// IPIPDeviceIsL3 represent if ipip tunnels acts like other l3 devices
 	IPIPDeviceIsL3 bool


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The combination of iptables MASQUERADE --random-fully and such kernels results in broken checksum calculations on IPIP tunnel. This is a part of https://github.com/projectcalico/felix/pull/2811

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

fixes https://github.com/projectcalico/calico/issues/7807

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Disable IPIP tunnel checksum offload on kernels <v5.7
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
