### PR TITLE
Fix BIRD configuration issues

### DIFF
--- a/networking-calico/devstack/auto-bird-conf.sh
+++ b/networking-calico/devstack/auto-bird-conf.sh
@@ -23,9 +23,9 @@ HOST_IPV6=$1
 # In a sub-shell, periodically write our own IP into etcd.
 (
     while true; do
-        $ETCDCTL set ${MY_ETCD_DIR}/$HOST_IP $HOST_IP --ttl 600
+        $ETCDCTL put ${MY_ETCD_DIR}/$HOST_IP $HOST_IP
         if test -n "$HOST_IPV6"; then
-            $ETCDCTL set ${MY_ETCD_DIR}/$HOST_IPV6 $HOST_IPV6 --ttl 600
+            $ETCDCTL put ${MY_ETCD_DIR}/$HOST_IPV6 $HOST_IPV6
         fi
         sleep 300
     done
@@ -69,6 +69,6 @@ while true; do
     fi
 
     # Wait for the next change.
-    $ETCDCTL watch ${MY_ETCD_DIR} --recursive
+    $ETCDCTL watch --prefix ${MY_ETCD_DIR}
 
 done

--- a/networking-calico/devstack/auto-bird-conf.sh
+++ b/networking-calico/devstack/auto-bird-conf.sh
@@ -4,6 +4,7 @@ set -x
 
 HOST_IP=$1
 ETCDCTL=${2:-etcdctl}
+export ETCDCTL_ENDPOINTS=${3-http://${HOST_IP}:2379}
 
 # Automatically generate full mesh BIRD config for a multi-node
 # Calico/DevStack deployment.
@@ -37,7 +38,7 @@ while true; do
     # IPs that are in etcd now.
     peer_ips=
     peer_ipv6s=
-    for key in `$ETCDCTL get ${MY_ETCD_DIR} --prefix --keys-only`; do
+    for key in `$ETCDCTL get --prefix --keys-only ${MY_ETCD_DIR}`; do
         key=`basename $key`
         case $key in
             *:* )

--- a/networking-calico/devstack/auto-bird-conf.sh
+++ b/networking-calico/devstack/auto-bird-conf.sh
@@ -5,6 +5,7 @@ set -x
 HOST_IP=$1
 ETCDCTL=${2:-etcdctl}
 export ETCDCTL_ENDPOINTS=${3-http://${HOST_IP}:2379}
+export ETCDCTL_API=3
 
 # Automatically generate full mesh BIRD config for a multi-node
 # Calico/DevStack deployment.

--- a/networking-calico/devstack/auto-bird-conf.sh
+++ b/networking-calico/devstack/auto-bird-conf.sh
@@ -38,7 +38,10 @@ while true; do
     # IPs that are in etcd now.
     peer_ips=
     peer_ipv6s=
-    for key in `$ETCDCTL get --prefix --keys-only ${MY_ETCD_DIR}`; do
+    cmd="$ETCDCTL get --prefix --keys-only ${MY_ETCD_DIR}"
+    echo "Running: $cmd"
+    $cmd
+    for key in `$cmd`; do
         key=`basename $key`
         case $key in
             *:* )

--- a/networking-calico/devstack/plugin.sh
+++ b/networking-calico/devstack/plugin.sh
@@ -132,7 +132,7 @@ EOF
 		    export ETCDCTL_API=3
 		    export ETCDCTL_ENDPOINTS=http://$SERVICE_HOST:$ETCD_PORT
 		    run_process calico-bird \
-                      "${DEST}/calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl"
+                      "${DEST}/calico/devstack/auto-bird-conf.sh ${HOST_IP} ${ETCD_BIN_DIR}/etcdctl ${ETCDCTL_ENDPOINTS}"
 
 		    # Run the Calico DHCP agent.
 		    sudo mkdir /var/log/neutron || true


### PR DESCRIPTION
We don't need BIRD for our DevStack CI, because it all runs on a single node, but it's nice to start cleaning up the multitude of BIRD-related errors that get logged.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
