### PR TITLE
OpenStack port spec issue backport to v3.26

### DIFF
--- a/networking-calico/devstack/bootstrap.sh
+++ b/networking-calico/devstack/bootstrap.sh
@@ -17,7 +17,7 @@
 set -ex
 
 sudo pip uninstall -y setuptools
-sudo rm -rf /usr/local/lib/python3.8/dist-packages/setuptools-67.8.0.dist-info
+sudo rm -rf /usr/local/lib/python3.8/dist-packages/setuptools-*.dist-info
 sudo find / -name "*setuptools*" || true
 sudo pip list || true
 

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -209,15 +209,17 @@ def _neutron_rule_to_etcd_rule(rule):
         entity_rule['nets'] = [rule['remote_ip_prefix']]
     LOG.debug("=> Entity rule %s" % entity_rule)
 
+    if port_spec is not None:
+        if rule['direction'] == 'ingress':
+            etcd_rule['destination'] = {'ports': port_spec}
+        else:
+            entity_rule['ports'] = port_spec
+
     # Store in source or destination field of the overall rule.
     if entity_rule:
         if rule['direction'] == 'ingress':
             etcd_rule['source'] = entity_rule
-            if port_spec is not None:
-                etcd_rule['destination'] = {'ports': port_spec}
         else:
-            if port_spec is not None:
-                entity_rule['ports'] = port_spec
             etcd_rule['destination'] = entity_rule
 
     LOG.debug("=> %s Calico rule %s" % (rule['direction'], etcd_rule))

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1203,6 +1203,63 @@ class TestPluginEtcd(TestPluginEtcdBase):
                 'ipVersion': 4,
             })
 
+    def test_sg_rule_ingress_no_remote_ip_prefix(self):
+        # SG ingress rule with ports but no remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "protocol": "tcp",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+        })
+
+    def test_sg_rule_egress_no_remote_ip_prefix(self):
+        # SG egress rule with ports but no remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "direction": "egress",
+            "protocol": "tcp",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+        })
+
+    def test_sg_rule_ingress_with_remote_ip_prefix(self):
+        # SG ingress rule with ports and remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "protocol": "tcp",
+            "remote_ip_prefix": "1.2.3.0/24",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+            'source': {'nets': ['1.2.3.0/24']},
+        })
+
+    def test_sg_rule_egress_with_remote_ip_prefix(self):
+        # SG egress rule with ports and remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "direction": "egress",
+            "protocol": "tcp",
+            "remote_ip_prefix": "1.2.3.0/24",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'nets': ['1.2.3.0/24'], 'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+        })
+
     def test_not_master_does_not_resync(self):
         """Test that a driver that is not master does not resync."""
         # Initialize the state early to put the elector in place, then override

--- a/networking-calico/requirements.txt
+++ b/networking-calico/requirements.txt
@@ -5,4 +5,4 @@
 Babel>=2.9.1 # BSD
 eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
-etcd3gw>=1.0.1 # Apache-2.0
+etcd3gw==1.0.1 # Apache-2.0

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -16,6 +16,7 @@ testrepository>=0.0.18 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 
+etcd3gw==1.0.1 # Apache-2.0
 neutron
 neutron-lib
 mock>=3.0.0 # BSD

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -13,7 +13,6 @@ setenv =
    PYTHONWARNINGS=default::DeprecationWarning,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:site,ignore:Using or importing the ABCs,ignore:dns.hash module,ignore:Please provide `is_available
 deps = -r{toxinidir}/test-requirements.txt
 commands =
-    pip install -q -e "git+https://opendev.org/openstack/etcd3gw.git@1.0.1#egg=etcd3gw"
     coverage erase
     python setup.py testr --slowest --testr-args='{posargs}'
     coverage report -m


### PR DESCRIPTION
## Description

Pick #8028 and #8026 to release-v3.26 branch.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Correct policy for OpenStack sec group with no remote_ip_prefix
```
