### PR TITLE
OpenStack port spec issue backport to v3.25

### DIFF
--- a/networking-calico/.testr.conf
+++ b/networking-calico/.testr.conf
@@ -2,10 +2,9 @@
 test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
              OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-0} \
              OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v -s networking_calico/tests
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_election
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_plugin_etcd
-             ${PYTHON:-python} -m coverage run -a -m nose2 -v networking_calico.plugins.ml2.drivers.calico.test.test_compaction
+	     sh -c '\
+             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/tests $LISTOPT $IDOPTION && \
+             ${PYTHON:-python} -m coverage run -a -m subunit.run discover -t . networking_calico/plugins/ml2/drivers/calico/test $LISTOPT $IDOPTION'
 
 test_id_option=--load-list $IDFILE
 test_list_option=--list

--- a/networking-calico/Dockerfile
+++ b/networking-calico/Dockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/coreos/etcd:v3.3.11 as etcd
+FROM quay.io/coreos/etcd:v3.4.20 as etcd
 
 FROM python:3.8
 
 COPY --from=etcd /usr/local/bin/etcd /usr/local/bin/etcd
 
-RUN pip3 install tox
+RUN pip3 install tox==3.25.1

--- a/networking-calico/Dockerfile
+++ b/networking-calico/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/etcd:v3.4.20 as etcd
+FROM quay.io/coreos/etcd:v3.3.11 as etcd
 
 FROM python:3.8
 

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -7,5 +7,7 @@ include ../metadata.mk
 export BUILDKIT_PROGRESS=plain
 
 tox:
+	curl -L https://releases.openstack.org/constraints/upper/ussuri -o upper-constraints-ussuri.txt
+	sed -i '/etcd3gw/d' upper-constraints-ussuri.txt
 	docker build -t networking-calico-test .
-	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code --rm networking-calico-test tox
+	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code -e PIP_CONSTRAINT=/code/upper-constraints-ussuri.txt --rm networking-calico-test tox

--- a/networking-calico/Makefile
+++ b/networking-calico/Makefile
@@ -4,6 +4,8 @@ include ../metadata.mk
 # TODO: Release
 ###############################################################################
 
+export BUILDKIT_PROGRESS=plain
+
 tox:
 	docker build -t networking-calico-test .
 	docker run -it --user `id -u`:`id -g` -v `pwd`:/code -w /code -e HOME=/code --rm networking-calico-test tox

--- a/networking-calico/debian/control
+++ b/networking-calico/debian/control
@@ -2,7 +2,7 @@ Source: networking-calico
 Section: net
 Priority: optional
 Maintainer: Neil Jerram <neil@projectcalico.org>
-Build-Depends: debhelper (>= 8.0.0), dh-systemd, dh-python, python3-all, python3-setuptools
+Build-Depends: debhelper (>= 8.0.0), base-files (>= 11.1~) | dh-systemd, dh-python, python3-all, python3-setuptools
 Standards-Version: 3.9.4
 
 Package: calico-compute

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/policy.py
@@ -209,15 +209,17 @@ def _neutron_rule_to_etcd_rule(rule):
         entity_rule['nets'] = [rule['remote_ip_prefix']]
     LOG.debug("=> Entity rule %s" % entity_rule)
 
+    if port_spec is not None:
+        if rule['direction'] == 'ingress':
+            etcd_rule['destination'] = {'ports': port_spec}
+        else:
+            entity_rule['ports'] = port_spec
+
     # Store in source or destination field of the overall rule.
     if entity_rule:
         if rule['direction'] == 'ingress':
             etcd_rule['source'] = entity_rule
-            if port_spec is not None:
-                etcd_rule['destination'] = {'ports': port_spec}
         else:
-            if port_spec is not None:
-                entity_rule['ports'] = port_spec
             etcd_rule['destination'] = entity_rule
 
     LOG.debug("=> %s Calico rule %s" % (rule['direction'], etcd_rule))

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1203,6 +1203,63 @@ class TestPluginEtcd(TestPluginEtcdBase):
                 'ipVersion': 4,
             })
 
+    def test_sg_rule_ingress_no_remote_ip_prefix(self):
+        # SG ingress rule with ports but no remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "protocol": "tcp",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+        })
+
+    def test_sg_rule_egress_no_remote_ip_prefix(self):
+        # SG egress rule with ports but no remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "direction": "egress",
+            "protocol": "tcp",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+        })
+
+    def test_sg_rule_ingress_with_remote_ip_prefix(self):
+        # SG ingress rule with ports and remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "protocol": "tcp",
+            "remote_ip_prefix": "1.2.3.0/24",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+            'source': {'nets': ['1.2.3.0/24']},
+        })
+
+    def test_sg_rule_egress_with_remote_ip_prefix(self):
+        # SG egress rule with ports and remote IP prefix
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
+            "direction": "egress",
+            "protocol": "tcp",
+            "remote_ip_prefix": "1.2.3.0/24",
+            "port_range_min": 25,
+            "port_range_max": 34,
+        }), {
+            'action': 'Allow',
+            'destination': {'nets': ['1.2.3.0/24'], 'ports': ['25:34']},
+            'ipVersion': 4,
+            'protocol': 'TCP',
+        })
+
     def test_not_master_does_not_resync(self):
         """Test that a driver that is not master does not resync."""
         # Initialize the state early to put the elector in place, then override

--- a/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
+++ b/networking-calico/networking_calico/plugins/ml2/drivers/calico/test/test_plugin_etcd.py
@@ -1840,8 +1840,8 @@ class TestStatusWatcher(TestStatusWatcherBase):
             mock.call("hostname", "ep1", {"status": "up"}, priority="low"),
         ], any_order=True)
 
-        # Resync after deleting the Felix status.  We should see the other
-        # endpoint reported with status None.
+        # Resync after deleting the Felix status.  This does not affect the
+        # status of ep1.
         del self.etcd_data[felix_status_key]
         self.driver.on_felix_alive.reset_mock()
         self.driver.on_port_status_changed.reset_mock()
@@ -1849,7 +1849,7 @@ class TestStatusWatcher(TestStatusWatcherBase):
         self.watcher.start()
         self.driver.on_felix_alive.assert_not_called()
         self.driver.on_port_status_changed.assert_has_calls([
-            mock.call("hostname", "ep1", None, priority="low"),
+            mock.call("hostname", "ep1", {"status": "up"}, priority="low"),
         ], any_order=True)
 
         # Resync with some follow-on events; checks that the priority goes

--- a/networking-calico/requirements.txt
+++ b/networking-calico/requirements.txt
@@ -5,4 +5,4 @@
 Babel>=2.9.1 # BSD
 eventlet>=0.31.0  # MIT
 six>=1.10.0 # MIT
-etcd3gw>=1.0.1 # Apache-2.0
+etcd3gw==1.0.1 # Apache-2.0

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -20,6 +20,4 @@ etcd3gw==1.0.1 # Apache-2.0
 neutron>=16,<17
 neutron-lib==2.3.0
 mock>=3.0.0 # BSD
-pyroute2<0.6.0 # Apache v2
-
-nose2
+pyroute2 # Apache v2

--- a/networking-calico/test-requirements.txt
+++ b/networking-calico/test-requirements.txt
@@ -16,6 +16,7 @@ testrepository>=0.0.18 # Apache-2.0/BSD
 testscenarios>=0.4 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 
+etcd3gw==1.0.1 # Apache-2.0
 neutron>=16,<17
 neutron-lib==2.3.0
 mock>=3.0.0 # BSD

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -5,6 +5,9 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
+passenv =
+   HOME
+   PIP_CONSTRAINT
 setenv =
    VIRTUAL_ENV={envdir}
    PYTHONWARNINGS=default::DeprecationWarning,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:site,ignore:Using or importing the ABCs,ignore:dns.hash module,ignore:Please provide `is_available

--- a/networking-calico/tox.ini
+++ b/networking-calico/tox.ini
@@ -10,7 +10,6 @@ setenv =
    PYTHONWARNINGS=default::DeprecationWarning,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:site,ignore:Using or importing the ABCs,ignore:dns.hash module,ignore:Please provide `is_available
 deps = -r{toxinidir}/test-requirements.txt
 commands =
-    pip install -q -e "git+https://opendev.org/openstack/etcd3gw.git@1.0.1#egg=etcd3gw"
     coverage erase
     python setup.py testr --slowest --testr-args='{posargs}'
     coverage report -m


### PR DESCRIPTION
## Description

Pick #8026 to the release-v3.25 branch.
Plus copy a lot of other recent tweaks and fixes from master that are needed for UT CI to run correctly and successfully.

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Correct policy for OpenStack sec group with no remote_ip_prefix
```
