### PR TITLE
BPF Remove old versions of maps after upgrade

### DIFF
--- a/felix/bpf/bpfmap/bpf_maps.go
+++ b/felix/bpf/bpfmap/bpf_maps.go
@@ -55,25 +55,20 @@ type Maps struct {
 	XDPJumpMap      maps.MapWithDeleteIfExists
 }
 
-func (m *Maps) Destroy() {
-	mps := []maps.Map{
-		m.IpsetsMap,
-		m.StateMap,
-		m.ArpMap,
-		m.FailsafesMap,
-		m.FrontendMap,
-		m.BackendMap,
-		m.AffinityMap,
-		m.RouteMap,
-		m.CtMap,
-		m.SrMsgMap,
-		m.CtNatsMap,
-		m.ProgramsMap,
-		m.JumpMap,
-		m.XDPProgramsMap,
-		m.XDPJumpMap,
+func (m *Maps) DeletePreviousVersion() error {
+	mps := m.extractMapSlice()
+	for _, m := range mps {
+		err := m.(pinnedMap).DeletePreviousVersion()
+		if err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+func (m *Maps) Destroy() {
+	mps := m.extractMapSlice()
 	for _, m := range mps {
 		os.Remove(m.(pinnedMap).Path())
 		m.(pinnedMap).Close()
@@ -169,7 +164,29 @@ func CreateBPFMaps(ipFamily int) (*Maps, error) {
 	return ret, nil
 }
 
+func (m *Maps) extractMapSlice() []maps.Map {
+	return []maps.Map{
+		m.IpsetsMap,
+		m.StateMap,
+		m.ArpMap,
+		m.FailsafesMap,
+		m.FrontendMap,
+		m.BackendMap,
+		m.AffinityMap,
+		m.RouteMap,
+		m.CtMap,
+		m.SrMsgMap,
+		m.CtNatsMap,
+		m.IfStateMap,
+		m.ProgramsMap,
+		m.JumpMap,
+		m.XDPProgramsMap,
+		m.XDPJumpMap,
+	}
+}
+
 type pinnedMap interface {
 	Path() string
 	Close() error
+	DeletePreviousVersion() error
 }

--- a/felix/bpf/mock/map.go
+++ b/felix/bpf/mock/map.go
@@ -153,6 +153,10 @@ func (m *Map) Delete(k []byte) error {
 	return nil
 }
 
+func (*Map) DeletePreviousVersion() error {
+	return nil
+}
+
 func (m *Map) DeleteIfExists(k []byte) error {
 	return m.Delete(k)
 }
@@ -252,6 +256,10 @@ func (*DummyMap) Get(k []byte) ([]byte, error) {
 }
 
 func (*DummyMap) Delete(k []byte) error {
+	return nil
+}
+
+func (*DummyMap) DeletePreviousVersion() error {
 	return nil
 }
 

--- a/felix/fv/bpf_map_delete_test.go
+++ b/felix/fv/bpf_map_delete_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2022 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/projectcalico/calico/felix/bpf/conntrack"
+	"github.com/projectcalico/calico/felix/bpf/nat"
+
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
+	"github.com/projectcalico/calico/felix/bpf/maps"
+	"github.com/projectcalico/calico/felix/bpf/state"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+)
+
+var (
+	tc infrastructure.TopologyContainers
+)
+
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test delete previous map", []apiconfig.DatastoreType{apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
+
+	if os.Getenv("FELIX_FV_ENABLE_BPF") != "true" {
+		// Non-BPF run.
+		return
+	}
+
+	var (
+		infra infrastructure.DatastoreInfra
+	)
+
+	BeforeEach(func() {
+		infra = getInfra()
+		opts := infrastructure.DefaultTopologyOptions()
+		tc, _ = infrastructure.StartNNodeTopology(1, opts, infra)
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			infra.DumpErrorData()
+		}
+
+		tc.Stop()
+		infra.Stop()
+	})
+
+	It("should delete previous maps after Felix restart", func() {
+
+		stateMap := state.Map()
+		stateCurrVersionedName := stateMap.(*maps.PinnedMap).VersionedName()
+		statePrevVersionedName := fmt.Sprintf("%s%d", stateMap.(*maps.PinnedMap).Name, stateMap.(*maps.PinnedMap).Version-1)
+		stateCmd := getMapCmd(statePrevVersionedName, "percpu_array", "4", "464", "2", "0")
+		tc.Felixes[0].Exec(stateCmd...)
+
+		frontendMap := nat.FrontendMap()
+		frontendCurrVersionedName := frontendMap.(*maps.PinnedMap).VersionedName()
+		frontendPrevVersionedName := fmt.Sprintf("%s%d", frontendMap.(*maps.PinnedMap).Name, frontendMap.(*maps.PinnedMap).Version-1)
+		frontendCmd := getMapCmd(frontendPrevVersionedName, "lpm_trie", "16", "20", "65536", "1")
+		tc.Felixes[0].Exec(frontendCmd...)
+
+		conntrackMap := conntrack.Map()
+		conntrackCurrVersionedName := conntrackMap.(*maps.PinnedMap).VersionedName()
+		conntrackPrevVersionedName := fmt.Sprintf("%s%d", conntrackMap.(*maps.PinnedMap).Name, conntrackMap.(*maps.PinnedMap).Version-1)
+		conntrackCmd := getMapCmd(conntrackPrevVersionedName, "hash", "16", "88", "512000", "1")
+		tc.Felixes[0].Exec(conntrackCmd...)
+
+		ifstateMap := ifstate.Map()
+		ifstateCurrVersionedName := ifstateMap.(*maps.PinnedMap).VersionedName()
+		ifstatePrevVersionedName := fmt.Sprintf("%s%d", ifstateMap.(*maps.PinnedMap).Name, ifstateMap.(*maps.PinnedMap).Version-1)
+		ifstateCmd := getMapCmd(ifstatePrevVersionedName, "hash", "4", "40", "1000", "1")
+		tc.Felixes[0].Exec(ifstateCmd...)
+
+		// Before Felix restart: both curr and prev maps exists.
+		eventuallyMapVersionShouldExist(stateCurrVersionedName)
+		eventuallyMapVersionShouldExist(statePrevVersionedName)
+		eventuallyMapVersionShouldExist(frontendCurrVersionedName)
+		eventuallyMapVersionShouldExist(frontendPrevVersionedName)
+
+		eventuallyMapVersionShouldExist(conntrackCurrVersionedName)
+		eventuallyMapVersionShouldExist(conntrackPrevVersionedName)
+		eventuallyMapVersionShouldExist(ifstateCurrVersionedName)
+		eventuallyMapVersionShouldExist(ifstatePrevVersionedName)
+
+		tc.Felixes[0].Restart()
+
+		// After Felix restart: only the curr maps now exists.
+		eventuallyMapVersionShouldExist(stateCurrVersionedName)
+		eventuallyMapVersionShouldNotExist(statePrevVersionedName)
+		eventuallyMapVersionShouldExist(frontendCurrVersionedName)
+		eventuallyMapVersionShouldNotExist(frontendPrevVersionedName)
+
+		eventuallyMapVersionShouldExist(conntrackCurrVersionedName)
+		eventuallyMapVersionShouldNotExist(conntrackPrevVersionedName)
+		eventuallyMapVersionShouldExist(ifstateCurrVersionedName)
+		eventuallyMapVersionShouldNotExist(ifstatePrevVersionedName)
+	})
+
+})
+
+func eventuallyMapVersionShouldExist(version string) {
+	Eventually(func() string {
+		out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+		Expect(err).NotTo(HaveOccurred())
+		return out
+	}, "5s", "200ms").Should(ContainSubstring(version))
+}
+
+func eventuallyMapVersionShouldNotExist(version string) {
+	Eventually(func() string {
+		out, err := tc.Felixes[0].ExecOutput("bpftool", "map", "show")
+		Expect(err).NotTo(HaveOccurred())
+		return out
+	}, "5s", "200ms").ShouldNot(ContainSubstring(version))
+}
+
+func getMapCmd(mapVersionedName, mapType, mapKey, mapValue, mapEntries, mapFlags string) []string {
+	return []string{
+		"bpftool",
+		"map",
+		"create",
+		bpfdefs.GlobalPinDir + mapVersionedName,
+		"type",
+		mapType,
+		"key",
+		mapKey,
+		"value",
+		mapValue,
+		"entries",
+		mapEntries,
+		"name",
+		mapVersionedName,
+		"flags",
+		mapFlags,
+	}
+}


### PR DESCRIPTION
Expose a `DeletePreviousVersion()` function to maps package which allows client code to explicitly delete previous version of a map after upgrade.  Proposal to expose this as a separate function to allow for more control in the code flow when the deletion can take place as there are many examples of map manipulation in [map_upgrade_test.go](https://github.com/projectcalico/calico/blob/master/felix/bpf/ut/map_upgrade_test.go) such that if the deletion was implicitly invoked in the private `upgrade()` function then this could break existing code and tests.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Remove old versions of maps after upgrade
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
