### PR TITLE
Tune iptables/calc graph logging

### DIFF
--- a/felix/calc/rule_scanner.go
+++ b/felix/calc/rule_scanner.go
@@ -15,6 +15,7 @@ package calc
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -102,6 +103,24 @@ type IPSetData struct {
 	// cachedUID holds the calculated unique ID of this IP set, or "" if it hasn't been calculated
 	// yet.
 	cachedUID string
+}
+
+func (d *IPSetData) String() string {
+	var parts []string
+	if d.Selector != nil {
+		parts = append(parts, fmt.Sprintf("selector:%q", d.Selector.String()))
+	}
+	if d.NamedPort != "" {
+		parts = append(parts, fmt.Sprintf("namedPort:%s(%s)", d.NamedPort, d.NamedPortProtocol.String()))
+	}
+	if d.Service != "" {
+		parts = append(parts, fmt.Sprintf("service:%q", d.Service))
+	}
+	if d.ServiceIncludePorts {
+		parts = append(parts, "serviceIncludePorts=true")
+	}
+	parts = append(parts, fmt.Sprintf("uniqueID:%q", d.UniqueID()))
+	return "IPSetData{" + strings.Join(parts, ", ") + "}"
 }
 
 func (d *IPSetData) UniqueID() string {

--- a/felix/dispatcher/dispatcher.go
+++ b/felix/dispatcher/dispatcher.go
@@ -90,15 +90,18 @@ func (d *Dispatcher) OnStatusUpdated(status api.SyncStatus) {
 // Dispatcher callbacks.
 
 func (d *Dispatcher) OnUpdate(update api.Update) (filterOut bool) {
-	log.Debugf("Dispatching %v", update)
 	keyType := reflect.TypeOf(update.Key)
-	log.Debug("Type: ", keyType)
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.Debugf("Dispatching %v of type %v", update, keyType)
+	}
 	if update.Value != nil && reflect.TypeOf(update.Value).Kind() == reflect.Struct {
 		log.Panicf("KVPair contained a struct instead of expected pointer: %#v", update)
 	}
 	typeSpecificHandlers := d.typeToHandler[keyType]
-	log.WithField("typeSpecificHandlers", typeSpecificHandlers).Debug(
-		"Looked up type-specific handlers")
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithField("typeSpecificHandlers", typeSpecificHandlers).Debug(
+			"Looked up type-specific handlers")
+	}
 	typeSpecificHandlers.DispatchToAll(update)
 	return
 }

--- a/felix/iptables/table.go
+++ b/felix/iptables/table.go
@@ -30,11 +30,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/libcalico-go/lib/set"
-
 	"github.com/projectcalico/calico/felix/environment"
 	"github.com/projectcalico/calico/felix/iptables/cmdshim"
 	"github.com/projectcalico/calico/felix/logutils"
+	logutilslc "github.com/projectcalico/calico/libcalico-go/lib/logutils"
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
 const (
@@ -261,7 +261,8 @@ type Table struct {
 	// implementation.
 	lockProbeInterval time.Duration
 
-	logCxt *log.Entry
+	logCxt               *log.Entry
+	updateRateLimitedLog *logutilslc.RateLimitedLogger
 
 	gaugeNumChains        prometheus.Gauge
 	gaugeNumRules         prometheus.Gauge
@@ -280,6 +281,7 @@ type Table struct {
 
 	onStillAlive func()
 	opReporter   logutils.OpRecorder
+	reason       string
 }
 
 type TableOptions struct {
@@ -386,6 +388,10 @@ func NewTable(
 		lookPath = options.LookPathOverride
 	}
 
+	logFields := log.Fields{
+		"ipVersion": ipVersion,
+		"table":     name,
+	}
 	table := &Table{
 		Name:                   name,
 		IPVersion:              ipVersion,
@@ -398,15 +404,13 @@ func NewTable(
 		dirtyChains:            set.New[string](),
 		chainToDataplaneHashes: map[string][]string{},
 		chainToFullRules:       map[string][]string{},
-		logCxt: log.WithFields(log.Fields{
-			"ipVersion": ipVersion,
-			"table":     name,
-		}),
-		hashCommentPrefix: hashPrefix,
-		hashCommentRegexp: hashCommentRegexp,
-		ourChainsRegexp:   ourChainsRegexp,
-		oldInsertRegexp:   oldInsertRegexp,
-		insertMode:        insertMode,
+		logCxt:                 log.WithFields(logFields),
+		updateRateLimitedLog:   logutilslc.NewRateLimitedLogger().WithFields(logFields),
+		hashCommentPrefix:      hashPrefix,
+		hashCommentRegexp:      hashCommentRegexp,
+		ourChainsRegexp:        ourChainsRegexp,
+		oldInsertRegexp:        oldInsertRegexp,
+		insertMode:             insertMode,
 
 		// Initialise the write tracking as if we'd just done a write, this will trigger
 		// us to recheck the dataplane at exponentially increasing intervals at startup.
@@ -505,7 +509,7 @@ func (t *Table) UpdateChains(chains []*Chain) {
 }
 
 func (t *Table) UpdateChain(chain *Chain) {
-	t.logCxt.WithField("chainName", chain.Name).Info("Queueing update of chain.")
+	t.updateRateLimitedLog.WithField("chainName", chain.Name).Info("Queueing update of chain.")
 	oldNumRules := 0
 
 	// Incref any newly-referenced chains, then decref the old ones.  By incrementing first we
@@ -536,7 +540,7 @@ func (t *Table) RemoveChains(chains []*Chain) {
 }
 
 func (t *Table) RemoveChainByName(name string) {
-	t.logCxt.WithField("chainName", name).Info("Queuing deletion of chain.")
+	t.updateRateLimitedLog.WithField("chainName", name).Debug("Queuing deletion of chain.")
 	if oldChain, known := t.chainNameToChain[name]; known {
 		t.gaugeNumRules.Sub(float64(len(oldChain.Rules)))
 		delete(t.chainNameToChain, name)
@@ -579,7 +583,7 @@ func (t *Table) increfChain(chainName string) {
 	log.WithField("chainName", chainName).Debug("Incref chain")
 	t.chainRefCounts[chainName] += 1
 	if t.chainRefCounts[chainName] == 1 {
-		log.WithField("chainName", chainName).Info("Chain became referenced, marking it for programming")
+		t.updateRateLimitedLog.WithField("chainName", chainName).Info("Chain became referenced, marking it for programming")
 		t.dirtyChains.Add(chainName)
 	}
 }
@@ -590,7 +594,7 @@ func (t *Table) decrefChain(chainName string) {
 	log.WithField("chainName", chainName).Debug("Decref chain")
 	t.chainRefCounts[chainName] -= 1
 	if t.chainRefCounts[chainName] == 0 {
-		log.WithField("chainName", chainName).Info("Chain no longer referenced, marking it for removal")
+		t.updateRateLimitedLog.WithField("chainName", chainName).Info("Chain no longer referenced, marking it for removal")
 		delete(t.chainRefCounts, chainName)
 		t.dirtyChains.Add(chainName)
 	}
@@ -943,10 +947,19 @@ func (t *Table) InvalidateDataplaneCache(reason string) {
 	}
 	logCxt.Debug("Invalidating dataplane cache")
 	t.inSyncWithDataPlane = false
+	t.reason = reason
 }
 
 func (t *Table) Apply() (rescheduleAfter time.Duration) {
 	now := t.timeNow()
+	defer func() {
+		if time.Since(now) > time.Second {
+			log.WithFields(log.Fields{
+				"applyTime":      time.Since(now),
+				"reasonForApply": t.reason,
+			}).Info("Updating iptables took >1s")
+		}
+	}()
 	// We _think_ we're in sync, check if there are any reasons to think we might
 	// not be in sync.
 	lastReadToNow := now.Sub(t.lastReadTime)

--- a/felix/iptables/table.go
+++ b/felix/iptables/table.go
@@ -405,12 +405,15 @@ func NewTable(
 		chainToDataplaneHashes: map[string][]string{},
 		chainToFullRules:       map[string][]string{},
 		logCxt:                 log.WithFields(logFields),
-		updateRateLimitedLog:   logutilslc.NewRateLimitedLogger().WithFields(logFields),
-		hashCommentPrefix:      hashPrefix,
-		hashCommentRegexp:      hashCommentRegexp,
-		ourChainsRegexp:        ourChainsRegexp,
-		oldInsertRegexp:        oldInsertRegexp,
-		insertMode:             insertMode,
+		updateRateLimitedLog: logutilslc.NewRateLimitedLogger(
+			logutilslc.OptInterval(30*time.Second),
+			logutilslc.OptBurst(100),
+		).WithFields(logFields),
+		hashCommentPrefix: hashPrefix,
+		hashCommentRegexp: hashCommentRegexp,
+		ourChainsRegexp:   ourChainsRegexp,
+		oldInsertRegexp:   oldInsertRegexp,
+		insertMode:        insertMode,
 
 		// Initialise the write tracking as if we'd just done a write, this will trigger
 		// us to recheck the dataplane at exponentially increasing intervals at startup.

--- a/libcalico-go/lib/logutils/ratelimitedlogger_test.go
+++ b/libcalico-go/lib/logutils/ratelimitedlogger_test.go
@@ -69,8 +69,8 @@ var _ = DescribeTable("First and Interval logging",
 		Expect(counter.entry.Data).To(HaveKeyWithValue("a", 1))
 		Expect(counter.entry.Data).To(HaveKeyWithValue("b", 2))
 		Expect(counter.entry.Data).To(HaveKeyWithValue("c", "3"))
-		Expect(counter.entry.Data).To(HaveKeyWithValue("logs-skipped", 0))
-		Expect(counter.entry.Data).To(HaveKey("next-log"))
+		Expect(counter.entry.Data).NotTo(HaveKey("logsSkipped"))
+		Expect(counter.entry.Data).To(HaveKey("nextLog"))
 		Expect(counter.entry.Data).To(HaveKey("error"))
 
 		// Next two log will be skipped.
@@ -87,8 +87,8 @@ var _ = DescribeTable("First and Interval logging",
 		Expect(counter.entry.Data).To(HaveKeyWithValue("a", 1))
 		Expect(counter.entry.Data).To(HaveKeyWithValue("b", 2))
 		Expect(counter.entry.Data).To(HaveKeyWithValue("c", "3"))
-		Expect(counter.entry.Data).To(HaveKeyWithValue("logs-skipped", 2))
-		Expect(counter.entry.Data).To(HaveKey("next-log"))
+		Expect(counter.entry.Data).To(HaveKeyWithValue("logsSkipped", 2))
+		Expect(counter.entry.Data).To(HaveKey("nextLog"))
 		Expect(counter.entry.Data).To(HaveKey("error"))
 
 		// Force, so next log will also be written.
@@ -98,9 +98,42 @@ var _ = DescribeTable("First and Interval logging",
 		Expect(counter.entry.Data).To(HaveKeyWithValue("a", 1))
 		Expect(counter.entry.Data).To(HaveKeyWithValue("b", 2))
 		Expect(counter.entry.Data).To(HaveKeyWithValue("c", "3"))
-		Expect(counter.entry.Data).To(HaveKeyWithValue("logs-skipped", 0))
-		Expect(counter.entry.Data).To(HaveKey("next-log"))
+		Expect(counter.entry.Data).NotTo(HaveKey("logsSkipped"))
+		Expect(counter.entry.Data).To(HaveKey("nextLog"))
 		Expect(counter.entry.Data).To(HaveKey("error"))
+
+		// Check burst.
+		logger = NewRateLimitedLogger(
+			OptInterval(200*time.Millisecond),
+			OptLogger(logrusLogger),
+			OptBurst(2),
+		)
+		logfn(logger) // First log, resets logging interval and burst count
+		Expect(counter.entry.Data).NotTo(HaveKey("nextLog"))
+		Expect(counter.entry.Data).NotTo(HaveKey("logsSkipped"))
+		logfn(logger) // First burst
+		Expect(counter.entry.Data).NotTo(HaveKey("nextLog"))
+		Expect(counter.entry.Data).NotTo(HaveKey("logsSkipped"))
+		logfn(logger) // Second burst
+		Expect(counter.entry.Data).To(HaveKey("nextLog"))
+		Expect(counter.entry.Data).NotTo(HaveKey("logsSkipped"))
+		logfn(logger) // Skipped
+		logfn(logger) // Skipped
+		Expect(counter.count).To(Equal(6))
+		// Wait for logging interval.
+		time.Sleep(200 * time.Millisecond)
+		logfn(logger) // First log, resets logging interval and burst count
+		Expect(counter.entry.Data).NotTo(HaveKey("nextLog"))
+		Expect(counter.entry.Data).To(HaveKeyWithValue("logsSkipped", 2))
+		logfn(logger) // First burst
+		Expect(counter.entry.Data).NotTo(HaveKey("nextLog"))
+		Expect(counter.entry.Data).NotTo(HaveKey("logsSkipped"))
+		logfn(logger) // Second burst
+		Expect(counter.entry.Data).To(HaveKey("nextLog"))
+		Expect(counter.entry.Data).NotTo(HaveKey("logsSkipped"))
+		logfn(logger) // Skipped
+		logfn(logger) // Skipped
+		Expect(counter.count).To(Equal(9))
 	},
 	Entry("Debug", log.DebugLevel, true, func(l *RateLimitedLogger) { l.Debug("log", "now") }),
 	Entry("Print", log.InfoLevel, false, func(l *RateLimitedLogger) { l.Print("log", "now") }),


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Avoid logrus.WithFields on the hot path in the calc graph.  It allocates, causing a lot of GC.
- Fix logging of IPSetData calc graph struct.  It was logging pointers and confusing nils.
- Add burst capability to RateLimitedLogger.  Use it to tune logging in the iptables logic.
- Tweak rate limited logger's field names to bring it in line with other uses.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix: use rate limited logging to reduce output from the iptables logic under heavy load.  Refine some other logging.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
