### PR TITLE
Make iptables recheck timer dynamic

### DIFF
--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -248,8 +248,8 @@ type Config struct {
 	DeviceRouteSourceAddressIPv6       net.IP            `config:"ipv6;"`
 	DeviceRouteProtocol                int               `config:"int;3"`
 	RemoveExternalRoutes               bool              `config:"bool;true"`
-	IptablesRefreshInterval            time.Duration     `config:"seconds;90"`
-	IptablesPostWriteCheckIntervalSecs time.Duration     `config:"seconds;1"`
+	IptablesRefreshInterval            time.Duration     `config:"seconds;180"`
+	IptablesPostWriteCheckIntervalSecs time.Duration     `config:"seconds;5"`
 	IptablesLockFilePath               string            `config:"file;/run/xtables.lock"`
 	IptablesLockTimeoutSecs            time.Duration     `config:"seconds;0"`
 	IptablesLockProbeIntervalMillis    time.Duration     `config:"millis;50"`

--- a/felix/iptables/table.go
+++ b/felix/iptables/table.go
@@ -252,6 +252,12 @@ type Table struct {
 	postWriteInterval        time.Duration
 	refreshInterval          time.Duration
 
+	// Estimates for the time taken to do an iptables save and restore.
+	// When a save/restore exceeds the one of these we update them immediately.
+	// When a save/restore takes less time we decay them exponentially.
+	peakIptablesSaveTime    time.Duration
+	peakIptablesRestoreTime time.Duration
+
 	// calicoXtablesLock, if enabled, our implementation of the xtables lock.
 	calicoXtablesLock sync.Locker
 
@@ -780,6 +786,17 @@ func (t *Table) getHashesAndRulesFromDataplane() (hashes map[string][]string, ru
 // attemptToGetHashesAndRulesFromDataplane starts an iptables-save subprocess and feeds its output to
 // readHashesAndRulesFrom() via a pipe.  It handles the various error cases.
 func (t *Table) attemptToGetHashesAndRulesFromDataplane() (hashes map[string][]string, rules map[string][]string, err error) {
+	startTime := t.timeNow()
+	defer func() {
+		saveDuration := t.timeNow().Sub(startTime)
+		t.peakIptablesSaveTime = t.peakIptablesSaveTime * 99 / 100
+		if saveDuration > t.peakIptablesSaveTime {
+			log.WithField("duration", saveDuration).Debug("Updating iptables-save peak duration.")
+			t.peakIptablesSaveTime = saveDuration
+		}
+	}()
+
+	t.logCxt.Debugf("Starting %s", t.iptablesSaveCmd)
 	cmd := t.newCmd(t.iptablesSaveCmd, "-t", t.Name)
 	countNumSaveCalls.Inc()
 
@@ -1274,6 +1291,22 @@ func (t *Table) applyUpdates() error {
 		t.postWriteInterval = t.initialPostWriteInterval
 	}
 
+	if t.postWriteInterval != 0 {
+		// If iptables-save/restore is taking a long time (as measured by
+		// the peakIptablesX fields), make sure that we don't try to
+		// recheck the iptables state too soon.
+		dynamicMinPostWriteInterval := (t.peakIptablesSaveTime + t.peakIptablesRestoreTime) * 2
+		if t.postWriteInterval < dynamicMinPostWriteInterval {
+			log.WithFields(log.Fields{
+				"dynamicMin":  dynamicMinPostWriteInterval,
+				"peakSave":    t.peakIptablesSaveTime,
+				"peakRestore": t.peakIptablesRestoreTime,
+			}).Debug(
+				"Post write interval shorter than time to read/write iptables, applying dynamic minimum.")
+			t.postWriteInterval = dynamicMinPostWriteInterval
+		}
+	}
+
 	// Now we've successfully updated iptables, clear the dirty sets.  We do this even if we
 	// found there was nothing to do above, since we may have found out that a dirty chain
 	// was actually a no-op update.
@@ -1294,6 +1327,16 @@ func (t *Table) applyUpdates() error {
 }
 
 func (t *Table) execIptablesRestore(buf *RestoreInputBuilder) error {
+	startTime := t.timeNow()
+	defer func() {
+		restoreDuration := t.timeNow().Sub(startTime)
+		t.peakIptablesRestoreTime = t.peakIptablesRestoreTime * 99 / 100
+		if restoreDuration > t.peakIptablesRestoreTime {
+			log.WithField("duration", restoreDuration).Debug("Updating iptables-restore peak duration.")
+			t.peakIptablesRestoreTime = restoreDuration
+		}
+	}()
+
 	features := t.featureDetector.GetFeatures()
 	inputBytes := buf.GetBytesAndReset()
 

--- a/felix/iptables/testutils/utils.go
+++ b/felix/iptables/testutils/utils.go
@@ -66,6 +66,7 @@ type MockDataplane struct {
 	CmdNames                       []string
 	FailNextRestore                bool
 	FailAllRestores                bool
+	OnPreSave                      func()
 	OnPreRestore                   func()
 	FailNextSaveRead               bool
 	FailNextSaveStdoutPipe         bool
@@ -431,6 +432,11 @@ func (d *saveCmd) Start() error {
 	if d.Dataplane.FailNextStart {
 		d.Dataplane.FailNextStart = false
 		return errors.New("dummy start failure")
+	}
+	if d.Dataplane.OnPreSave != nil {
+		log.Warn("OnPreSave set, calling it")
+		d.Dataplane.OnPreSave()
+		d.Dataplane.OnPreSave = nil
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Apply dynamic minimum to iptables recheck timer.
- Track the peak value of iptables save/restore with an exponential decay estimator.
- Set the minimum post-retry backoff to twice the combined save/restore time.

Increase default timeouts.  These were set aggressively low in the past to deal with other apps clobbering iptables state.  that problem no longer occurs since the iptables lock was widely adopted.  

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-9786
CORE-9780

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now adjusts the iptables post-write recheck interval dynamically: if iptables operations are taking longer, it will increase the time between iptables-save calls to compensate.  The default recheck time and resync intervals have also been increased.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
