### PR TITLE
Parallel ip set updates

### DIFF
--- a/felix/bpf/ipsets/ipsets.go
+++ b/felix/bpf/ipsets/ipsets.go
@@ -219,8 +219,8 @@ func (m *bpfIPSets) GetTypeOf(setID string) (ipsets.IPSetType, error) {
 	return ipSet.Type, nil
 }
 
-func (m *bpfIPSets) GetMembers(setID string) (set.Set[string], error) {
-	// GetMembers is only called from XDPState, and XDPState does not coexist with
+func (m *bpfIPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
+	// GetDesiredMembers is only called from XDPState, and XDPState does not coexist with
 	// config.BPFEnabled.
 	panic("Not implemented")
 }
@@ -354,8 +354,9 @@ func (m *bpfIPSets) ApplyUpdates() {
 
 // ApplyDeletions tries to delete any IP sets that are no longer needed.
 // Failures are ignored, deletions will be retried the next time we do a resync.
-func (m *bpfIPSets) ApplyDeletions() {
+func (m *bpfIPSets) ApplyDeletions() bool {
 	// No-op.
+	return false
 }
 
 func (m *bpfIPSets) markIPSetDirty(data *bpfIPSet) {

--- a/felix/dataplane/common/ipsets_mgr.go
+++ b/felix/dataplane/common/ipsets_mgr.go
@@ -29,10 +29,10 @@ type IPSetsDataplane interface {
 	RemoveIPSet(setID string)
 	GetIPFamily() ipsets.IPFamily
 	GetTypeOf(setID string) (ipsets.IPSetType, error)
-	GetMembers(setID string) (set.Set[string], error)
+	GetDesiredMembers(setID string) (set.Set[string], error)
 	QueueResync()
 	ApplyUpdates()
-	ApplyDeletions()
+	ApplyDeletions() (reschedule bool)
 }
 
 // Except for domain IP sets, IPSetsManager simply passes through IP set updates from the datastore
@@ -66,7 +66,7 @@ func (m *IPSetsManager) GetIPSetType(setID string) (typ ipsets.IPSetType, err er
 
 func (m *IPSetsManager) GetIPSetMembers(setID string) (members set.Set[string], err error) {
 	for _, dp := range m.dataplanes {
-		members, err = dp.GetMembers(setID)
+		members, err = dp.GetDesiredMembers(setID)
 		if err == nil {
 			break
 		}

--- a/felix/dataplane/common/mock_ipsets.go
+++ b/felix/dataplane/common/mock_ipsets.go
@@ -79,7 +79,7 @@ func (s *MockIPSets) GetIPFamily() ipsets.IPFamily {
 	return ipsets.IPFamilyV4
 }
 
-func (s *MockIPSets) GetMembers(setID string) (set.Set[string], error) {
+func (s *MockIPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
 	return s.Members[setID], nil
 }
 
@@ -95,8 +95,9 @@ func (s *MockIPSets) ApplyUpdates() {
 	// Not implemented for UT.
 }
 
-func (s *MockIPSets) ApplyDeletions() {
+func (s *MockIPSets) ApplyDeletions() bool {
 	// Not implemented for UT.
+	return false
 }
 
 func (s *MockIPSets) SetFilter(ipSetNames set.Set[string]) {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -2162,15 +2163,24 @@ func (d *InternalDataplane) apply() {
 	iptablesWG.Wait()
 
 	// Now clean up any left-over IP sets.
+	var ipSetsNeedsReschedule atomic.Bool
 	for _, ipSets := range d.ipSets {
 		ipSetsWG.Add(1)
 		go func(s common.IPSetsDataplane) {
-			s.ApplyDeletions()
+			reschedule := s.ApplyDeletions()
+			if reschedule {
+				ipSetsNeedsReschedule.Store(true)
+			}
 			d.reportHealth()
 			ipSetsWG.Done()
 		}(ipSets)
 	}
 	ipSetsWG.Wait()
+	if ipSetsNeedsReschedule.Load() {
+		if reschedDelay == 0 || reschedDelay > 100*time.Millisecond {
+			reschedDelay = 100 * time.Millisecond
+		}
+	}
 
 	// Wait for the route updates to finish.
 	routesWG.Wait()

--- a/felix/dataplane/windows/ipsets/ipsets.go
+++ b/felix/dataplane/windows/ipsets/ipsets.go
@@ -180,8 +180,8 @@ func (m *IPSets) GetTypeOf(setID string) (IPSetType, error) {
 	panic("Not implemented")
 }
 
-func (m *IPSets) GetMembers(setID string) (set.Set[string], error) {
-	// GetMembers is only called from XDPState, and XDPState does not coexist with
+func (m *IPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
+	// GetDesiredMembers is only called from XDPState, and XDPState does not coexist with
 	// config.BPFEnabled.
 	panic("Not implemented")
 }
@@ -189,7 +189,8 @@ func (m *IPSets) GetMembers(setID string) (set.Set[string], error) {
 func (m *IPSets) ApplyUpdates() {
 }
 
-func (m *IPSets) ApplyDeletions() {
+func (m *IPSets) ApplyDeletions() bool {
+	return false
 }
 
 func (s *IPSets) SetFilter(ipSetNames set.Set[string]) {

--- a/felix/deltatracker/delta_set.go
+++ b/felix/deltatracker/delta_set.go
@@ -79,6 +79,10 @@ func (s *DesiredSetView[K]) asMapView() *DesiredView[K, struct{}] {
 	return (*DesiredView[K, struct{}])(s)
 }
 
+func (s *DesiredSetView[K]) LenUpperBound() int {
+	return len(s.inDataplaneAndDesired) + len(s.desiredUpdates)
+}
+
 type DataplaneSetView[K comparable] DesiredView[K, struct{}]
 
 func (s *SetDeltaTracker[K]) Dataplane() *DataplaneSetView[K] {

--- a/felix/deltatracker/delta_tracker.go
+++ b/felix/deltatracker/delta_tracker.go
@@ -362,6 +362,7 @@ type IterAction int
 const (
 	IterActionNoOp IterAction = iota
 	IterActionUpdateDataplane
+	IterActionNoOpStopIteration
 )
 
 type PendingUpdatesView[K comparable, V any] DeltaTracker[K, V]
@@ -421,6 +422,8 @@ func (c *PendingDeletionsView[K, V]) Iter(f func(k K) IterAction) {
 			// Ignore.
 		case IterActionUpdateDataplane:
 			delete(c.inDataplaneNotDesired, k)
+		case IterActionNoOpStopIteration:
+			break
 		}
 	}
 }

--- a/felix/fv/ipsets_test.go
+++ b/felix/fv/ipsets_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/fv/containers"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+var _ = Context("_IPSets_ Tests for IPset rendering", func() {
+
+	var (
+		etcd     *containers.Container
+		tc       infrastructure.TopologyContainers
+		felixPID int
+		client   client.Interface
+		infra    infrastructure.DatastoreInfra
+		w        *workload.Workload
+	)
+
+	BeforeEach(func() {
+		topologyOptions := infrastructure.DefaultTopologyOptions()
+		topologyOptions.FelixLogSeverity = "Info"
+		topologyOptions.EnableIPv6 = false
+		logrus.SetLevel(logrus.InfoLevel)
+		tc, etcd, client, infra = infrastructure.StartSingleNodeEtcdTopology(topologyOptions)
+		felixPID = tc.Felixes[0].GetFelixPID()
+		_ = felixPID
+		w = workload.Run(tc.Felixes[0], "w", "default", "10.65.0.2", "8085", "tcp")
+	})
+
+	AfterEach(func() {
+		w.Stop()
+		tc.Stop()
+
+		if CurrentGinkgoTestDescription().Failed {
+			etcd.Exec("etcdctl", "get", "/", "--prefix", "--keys-only")
+		}
+		etcd.Stop()
+		infra.Stop()
+	})
+
+	It("should render 10000 IP sets quickly", func() {
+		// Make 1000 network sets
+		sizes := []int{100, 1, 1, 1, 2, 3, 4, 5, 10, 10, 100, 200, 1000}
+		const numSets = 10000
+		for i := 0; i < numSets; i++ {
+			ns := api.NewGlobalNetworkSet()
+			ns.Name = fmt.Sprintf("netset-%d", i)
+			ns.Labels = map[string]string{
+				"netset": fmt.Sprintf("netset-%d", i),
+			}
+			ns.Spec.Nets = generateIPv4s(sizes[i%len(sizes)])
+			_, err := client.GlobalNetworkSets().Create(context.TODO(), ns, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+		logrus.Info(">>> CREATED NetworkSets")
+		// Make a policy that activates them
+		for i := 0; i < numSets; i++ {
+			pol := api.NewGlobalNetworkPolicy()
+			pol.Name = fmt.Sprintf("pol-%d", i)
+			pol.Spec.Ingress = []api.Rule{
+				{
+					Action: "Allow",
+					Source: api.EntityRule{
+						Selector: fmt.Sprintf("netset == 'netset-%d'", i),
+					},
+				},
+			}
+			pol.Spec.Selector = "all()"
+			_, err := client.GlobalNetworkPolicies().Create(context.TODO(), pol, options.SetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+		logrus.Info(">>> CREATED NetworkPolicies")
+		// Create a workload that uses the policy.
+		baseNumSets := getNumIPSets(tc.Felixes[0].Container)
+		wep := w.WorkloadEndpoint.DeepCopy()
+		w.ConfigureInInfra(infra)
+		startTime := time.Now()
+		logrus.Info(">>> CREATED Workload")
+		Eventually(func() int { return getNumIPSets(tc.Felixes[0].Container) }, "240s", "1s").Should(BeNumerically(">", baseNumSets))
+		logrus.Info(">>> First IP set programmed at ", time.Since(startTime))
+		Eventually(func() int { return getNumIPSets(tc.Felixes[0].Container) }, "240s", "1s").Should(BeNumerically(">=", numSets+baseNumSets))
+		logrus.Info(">>> All IP sets programmed at ", time.Since(startTime))
+		w.RemoveFromInfra(infra)
+		logrus.Info(">>> DELETED Workload")
+		Eventually(func() int { return getNumIPSets(tc.Felixes[0].Container) }, "240s", "1s").Should(BeNumerically("<", numSets+baseNumSets))
+		logrus.Info(">>> IP sets started being deleted at ", time.Since(startTime))
+		w.WorkloadEndpoint = wep
+		w.ConfigureInInfra(infra)
+		logrus.Info(">>> RECREATED Workload")
+		Eventually(func() int { return getNumIPSets(tc.Felixes[0].Container) }, "240s", "1s").Should(BeNumerically(">=", numSets+baseNumSets))
+		logrus.Info(">>> All IP sets programmed at ", time.Since(startTime))
+		time.Sleep(10 * time.Second)
+	})
+})
+
+func getNumIPSets(c *containers.Container) int {
+	ipsetsOutput, err := c.ExecOutput("ipset", "list", "-name")
+	Expect(err).NotTo(HaveOccurred())
+	return strings.Count(ipsetsOutput, "\n")
+}

--- a/felix/ipsets/ipset_defs.go
+++ b/felix/ipsets/ipset_defs.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/labelindex"
-	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
 var (
@@ -182,6 +181,12 @@ func (t IPSetType) CanonicaliseMember(member string) IPSetMember {
 	return nil
 }
 
+type rawIPSetMember string
+
+func (r rawIPSetMember) String() string {
+	return string(r)
+}
+
 type IPSetMember interface {
 	String() string
 }
@@ -194,7 +199,7 @@ func (t IPSetType) IsValid() bool {
 	return false
 }
 
-// IPSetType constants for the names that the ipset command uses for the IP versions.
+// IPFamily constants for the names that the ipset command uses for the IP versions.
 type IPFamily string
 
 const (
@@ -224,29 +229,6 @@ type IPSetMetadata struct {
 	SetID   string
 	Type    IPSetType
 	MaxSize int
-}
-
-// ipSet holds the state for a particular IP set.
-type ipSet struct {
-	IPSetMetadata
-
-	MainIPSetName string
-
-	// members either contains the members that we've programmed or is nil, indicating that
-	// we're out of sync.
-	members set.Set[IPSetMember]
-
-	// pendingReplace is either nil to indicate that there is no pending replace or a set
-	// containing all the entries that we want to write.
-	pendingReplace set.Set[IPSetMember]
-	// pendingAdds contains members that are queued up to add to the IP set.  If pendingReplace
-	// is non-nil then pendingAdds is empty (and we add members directly to pendingReplace
-	// instead).
-	pendingAdds set.Set[IPSetMember]
-	// pendingDeletions contains members that are queued up for deletion.  If pendingReplace
-	// is non-nil then pendingDeletions is empty (and we delete members directly from
-	// pendingReplace instead).
-	pendingDeletions set.Set[IPSetMember]
 }
 
 // IPVersionConfig wraps up the metadata for a particular IP version.  It can be used by

--- a/felix/ipsets/ipsets.go
+++ b/felix/ipsets/ipsets.go
@@ -21,10 +21,12 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/projectcalico/calico/felix/deltatracker"
 	"github.com/projectcalico/calico/felix/logutils"
@@ -32,7 +34,9 @@ import (
 )
 
 const (
+	MaxIPSetParallelUpdates       = 10
 	MaxIPSetDeletionsPerIteration = 1
+	RestoreChunkSize              = 5000
 )
 
 type dataplaneMetadata struct {
@@ -45,6 +49,9 @@ type dataplaneMetadata struct {
 type IPSets struct {
 	IPVersionConfig *IPVersionConfig
 
+	// mutex protects setNameToProgrammedMetadata, nextTempIPSetIdx, and ipSetsWithDirtyMembers,
+	// which are updated from the apply worker goroutines.
+	mutex sync.Mutex
 	// setNameToAllMetadata contains an entry for each IP set that has been
 	// added by a call to AddOrReplaceIPSet (and not subsequently removed).
 	// It is *not* filtered by neededIPSetNames.
@@ -80,15 +87,7 @@ type IPSets struct {
 
 	logCxt *log.Entry
 
-	// restoreInCopy holds a copy of the stdin that we send to ipset restore.  It is reset
-	// after each use.
-	restoreInCopy bytes.Buffer
-	// stdoutCopy holds a copy of the the stdout emitted by ipset restore. It is reset after
-	// each use.
-	stdoutCopy bytes.Buffer
-	// stderrCopy holds a copy of the the stderr emitted by ipset restore. It is reset after
-	// each use.
-	stderrCopy bytes.Buffer
+	bufPool sync.Pool
 
 	opReporter logutils.OpRecorder
 
@@ -139,6 +138,7 @@ func NewIPSetsWithShims(
 		logCxt: log.WithFields(log.Fields{
 			"family": ipVersionConfig.Family,
 		}),
+		bufPool:    sync.Pool{New: func() any { return &bytes.Buffer{} }},
 		opReporter: recorder,
 	}
 }
@@ -593,33 +593,99 @@ func (s *IPSets) tryResync() (err error) {
 	return
 }
 
-// tryUpdates attempts to create and/or update IP sets.  It attempts to do the updates as a single
-// 'ipset restore' session in order to minimise process forking overhead.  Note: unlike
-// 'iptables-restore', 'ipset restore' is not atomic, updates are applied individually.
+// tryUpdates attempts to create and/or update IP sets.  It starts background goroutines, each
+// running one "ipset restore" session.  Note: unlike 'iptables-restore', 'ipset restore' is
+// not atomic, updates are applied individually.
 func (s *IPSets) tryUpdates() error {
-	var dirtyIPSets []string
-	s.ipSetsWithDirtyMembers.Iter(func(setName string) error {
-		if _, ok := s.setNameToProgrammedMetadata.Desired().Get(setName); !ok {
-			// Skip deletions and IP sets that aren't needed due to the filter.
-			return nil
-		}
-		dirtyIPSets = append(dirtyIPSets, setName)
-		return nil
-	})
-	s.setNameToProgrammedMetadata.PendingUpdates().Iter(func(setName string, v dataplaneMetadata) deltatracker.IterAction {
-		if !s.ipSetsWithDirtyMembers.Contains(setName) {
-			dirtyIPSets = append(dirtyIPSets, setName)
-		}
-		return deltatracker.IterActionNoOp
-	})
-	if len(dirtyIPSets) == 0 {
+	ipSetChunks, total, totalLines := s.chunkUpDirtyIPSets()
+	if total == 0 {
 		s.logCxt.Debug("No dirty IP sets.")
 		return nil
 	}
 	s.opReporter.RecordOperation(fmt.Sprint("update-ipsets-", s.IPVersionConfig.Family.Version()))
 
+	var errg errgroup.Group
+	errg.SetLimit(MaxIPSetParallelUpdates)
 	start := time.Now()
+	for _, setIDs := range ipSetChunks {
+		setIDs := setIDs
+		errg.Go(func() error {
+			return s.writeIPSetChunk(setIDs)
+		})
+	}
+
+	log.Debug("Waiting for background IP set updates to finish...")
+	err := errg.Wait()
+	log.Debug("Background IP set updates finished.")
+	if err != nil {
+		return fmt.Errorf("failed to write one or more IP set: %v", err)
+	}
+	log.Infof("Updated %d IPSets in %d chunks (%d lines) in %v", total, len(ipSetChunks), totalLines, time.Since(start))
+
+	// If we get here, the writes were successful, reset the IP sets delta tracking now the
+	// dataplane should be in sync.
+	s.ipSetsWithDirtyMembers.Clear()
+
+	return nil
+}
+
+// chunkUpDirtyIPSets breaks up the dirtyIPSetIDs set into slices for processing in parallel.
+func (s *IPSets) chunkUpDirtyIPSets() (chunks [][]string, numIPSets, numLines int) {
+	// We try to make sure that each chunk has a reasonable number of ipset input lines
+	// in it.  If we simply made each ipset into its own chunk then we'd pay the overhead of
+	// launching the ipset binary for every IP set, even if there was only 1 update per IP
+	// set.
+	var chunk []string
+	var estimatedNumLinesInChunk int
+	s.ipSetsWithDirtyMembers.Iter(func(setName string) error {
+		if _, ok := s.setNameToProgrammedMetadata.Desired().Get(setName); !ok {
+			// Skip deletions and IP sets that aren't needed due to the filter.
+			return nil
+		}
+		chunk = append(chunk, setName)
+		numIPSets++
+		numLinesForIPSet := s.estimateUpdateSize(setName)
+		estimatedNumLinesInChunk += numLinesForIPSet
+		numLines += numLinesForIPSet
+		if estimatedNumLinesInChunk >= RestoreChunkSize {
+			chunks = append(chunks, chunk)
+			chunk = nil
+			estimatedNumLinesInChunk = 0
+		}
+		return nil
+	})
+	s.setNameToProgrammedMetadata.PendingUpdates().Iter(func(setName string, v dataplaneMetadata) deltatracker.IterAction {
+		if !s.ipSetsWithDirtyMembers.Contains(setName) {
+			chunk = append(chunk, setName)
+			numIPSets++
+			estimatedNumLinesInChunk += s.estimateUpdateSize(setName)
+			if estimatedNumLinesInChunk >= RestoreChunkSize {
+				chunks = append(chunks, chunk)
+				chunk = nil
+				estimatedNumLinesInChunk = 0
+			}
+		}
+		return deltatracker.IterActionNoOp
+	})
+	if chunk != nil {
+		chunks = append(chunks, chunk)
+	}
+
+	if len(chunks) > MaxIPSetParallelUpdates {
+		chunks2 := make([][]string, MaxIPSetParallelUpdates)
+		for i, c := range chunks {
+			chunks2[i%len(chunks2)] = append(chunks2[i%len(chunks2)], c...)
+		}
+		return chunks2, numIPSets, numLines
+	}
+	return
+}
+
+func (s *IPSets) writeIPSetChunk(setNames []string) error {
 	// Set up an ipset restore session.
+	if log.IsLevelEnabled(log.DebugLevel) {
+		log.WithField("setNames", setNames).Debug("Started goroutine to update IP sets.")
+	}
 	countNumIPSetCalls.Inc()
 	cmd := s.newCmd("ipset", "restore")
 	// Get the pipe for stdin.
@@ -629,16 +695,17 @@ func (s *IPSets) tryUpdates() error {
 		return err
 	}
 
+	restoreInCopy := s.bufPool.Get().(*bytes.Buffer)
+	stdoutCopy := s.bufPool.Get().(*bytes.Buffer)
+	stderrCopy := s.bufPool.Get().(*bytes.Buffer)
+
 	// "Tee" the data that we write to stdin to a buffer so we can dump it to the log on
 	// failure.
-	stdin := io.MultiWriter(&s.restoreInCopy, rawStdin)
-	defer s.restoreInCopy.Reset()
+	stdin := io.MultiWriter(restoreInCopy, rawStdin)
 
 	// Channel stdout/err to buffers so we can include them in the log on failure.
-	cmd.SetStderr(&s.stderrCopy)
-	defer s.stderrCopy.Reset()
-	cmd.SetStdout(&s.stdoutCopy)
-	defer s.stdoutCopy.Reset()
+	cmd.SetStderr(stderrCopy)
+	cmd.SetStdout(stdoutCopy)
 
 	// Actually start the child process.
 	startTime := time.Now()
@@ -654,9 +721,8 @@ func (s *IPSets) tryUpdates() error {
 	}
 	summaryExecStart.Observe(float64(time.Since(startTime).Nanoseconds()) / 1000.0)
 
-	// Ask each dirty IP set to write its updates to the stream.
 	var writeErr error
-	for _, setName := range dirtyIPSets {
+	for _, setName := range setNames {
 		// Ask IP set to write its updates to the stream.
 		if log.IsLevelEnabled(log.DebugLevel) {
 			log.WithField("setName", setName).Debug("Writing updates to IP set.")
@@ -678,17 +744,19 @@ func (s *IPSets) tryUpdates() error {
 			"flushErr":   flushErr,
 			"closeErr":   closeErr,
 			"processErr": processErr,
-			"stdout":     s.stdoutCopy.String(),
-			"stderr":     s.stderrCopy.String(),
-			"input":      s.restoreInCopy.String(),
+			"stdout":     stdoutCopy.String(),
+			"stderr":     stderrCopy.String(),
+			"input":      restoreInCopy.String(),
 		}).Warning("Failed to complete ipset restore, IP sets may be out-of-sync.")
-		return fmt.Errorf("failed to write one or more IP set: %v", err)
+		return err
 	}
-	log.Debugf("Updated %d IPSets in %v", len(dirtyIPSets), time.Since(start))
 
-	// If we get here, the writes were successful, reset the IP sets delta tracking now the
-	// dataplane should be in sync.
-	s.ipSetsWithDirtyMembers.Clear()
+	restoreInCopy.Reset()
+	s.bufPool.Put(restoreInCopy)
+	stdoutCopy.Reset()
+	s.bufPool.Put(stdoutCopy)
+	stderrCopy.Reset()
+	s.bufPool.Put(stderrCopy)
 
 	return nil
 }
@@ -696,10 +764,13 @@ func (s *IPSets) tryUpdates() error {
 func (s *IPSets) writeUpdates(setName string, w io.Writer) (err error) {
 	logCxt := s.logCxt.WithField("setName", setName)
 
+	s.mutex.Lock()
 	desiredMeta, desiredExists := s.setNameToProgrammedMetadata.Desired().Get(setName)
 	dpMeta, dpExists := s.setNameToProgrammedMetadata.Dataplane().Get(setName)
-
+	// Note: we'll update members below without the lock.  This is safe because
+	// we only update it from one worker at a time.
 	members, membersExists := s.mainSetNameToMembers[setName]
+	s.mutex.Unlock()
 
 	if !desiredExists {
 		log.WithField("setName", setName).Panic("writeUpdates called for pending deletion?")
@@ -775,6 +846,7 @@ func (s *IPSets) writeUpdates(setName string, w io.Writer) (err error) {
 		return
 	}
 
+	s.mutex.Lock()
 	if needCreate || needTempIPSet {
 		if needTempIPSet {
 			// After the swap, the temp IP set has the _old_ dataplane metadata.
@@ -783,6 +855,7 @@ func (s *IPSets) writeUpdates(setName string, w io.Writer) (err error) {
 		// The main IP set now has the correct metadata.
 		s.setNameToProgrammedMetadata.Dataplane().Set(setName, desiredMeta)
 	}
+	s.mutex.Unlock()
 	return
 }
 
@@ -791,6 +864,8 @@ func (s *IPSets) writeUpdates(setName string, w io.Writer) (err error) {
 // around the fact that we sometimes see transient failures to remove
 // temporary IP sets.
 func (s *IPSets) nextFreeTempIPSetName() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	for {
 		candidateName := s.IPVersionConfig.NameForTempIPSet(s.nextTempIPSetIdx)
 		s.nextTempIPSetIdx++
@@ -909,6 +984,27 @@ func firstNonNilErr(errs ...error) error {
 		}
 	}
 	return nil
+}
+
+func (s *IPSets) estimateUpdateSize(name string) int {
+	desiredMeta, desExists := s.setNameToProgrammedMetadata.Desired().Get(name)
+	dpMeta, dpExists := s.setNameToProgrammedMetadata.Dataplane().Get(name)
+	if !desExists {
+		return 0 // Deletions are handled elsewhere.
+	}
+	memberTracker := s.mainSetNameToMembers[name]
+	if dpExists {
+		if desiredMeta != dpMeta {
+			// Full rewrite needed to change metadata.
+			return 1 /*create*/ + memberTracker.Desired().LenUpperBound() + 1 /*swap*/
+		} else {
+			// Metadata up to date, just need to apply updates.
+			return memberTracker.PendingUpdates().Len() + memberTracker.PendingDeletions().Len()
+		}
+	} else {
+		// Full rewrite needed to create IPs set
+		return 1 /*create*/ + memberTracker.Desired().LenUpperBound()
+	}
 }
 
 func (s *IPSets) updateDirtiness(name string) {

--- a/felix/ipsets/ipsets.go
+++ b/felix/ipsets/ipsets.go
@@ -19,36 +19,56 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/libcalico-go/lib/set"
-
+	"github.com/projectcalico/calico/felix/deltatracker"
 	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
+
+const (
+	MaxIPSetDeletionsPerIteration = 1
+)
+
+type dataplaneMetadata struct {
+	Type         IPSetType
+	MaxSize      int
+	DeleteFailed bool
+}
 
 // IPSets manages a whole "plane" of IP sets, i.e. all the IPv4 sets, or all the IPv6 IP sets.
 type IPSets struct {
 	IPVersionConfig *IPVersionConfig
 
-	ipSetIDToIPSet       map[string]*ipSet
-	mainIPSetNameToIPSet map[string]*ipSet
+	// setNameToAllMetadata contains an entry for each IP set that has been
+	// added by a call to AddOrReplaceIPSet (and not subsequently removed).
+	// It is *not* filtered by neededIPSetNames.
+	setNameToAllMetadata map[string]dataplaneMetadata
+	// setNameToProgrammedMetadata tracks the IP sets that we want to program and
+	// those that are actually in the dataplane.  It's Desired() map is the
+	// subset of setNameToAllMetadata that matches the neededIPSetNames filter.
+	// Its Dataplane() map contains all IP sets matching the IPVersionConfig
+	// that we think are in the dataplane.  This includes any temporary IP
+	// sets and IP sets that we discovered on a resync (neither of which will
+	// have entries in the Desired() map).
+	setNameToProgrammedMetadata *deltatracker.DeltaTracker[string, dataplaneMetadata]
+	// mainSetNameToMembers contains entries for all IP sets that are in
+	// setNameToAllMetadata along with entries for "main" (non-temporary) IP
+	// sets that we think are still in the dataplane.  It is not filtered by
+	// neededIPSetNames.  For IP sets that are in setNameToAllMetadata, the
+	// Desired() side of the tracker contains the members that we've been told
+	// about.  Otherwise, Desired() is empty.  The Dataplane() side of the
+	// tracker contains the members that are thought to be in the dataplane.
+	mainSetNameToMembers   map[string]*deltatracker.SetDeltaTracker[IPSetMember]
+	nextTempIPSetIdx       uint
+	ipSetsWithDirtyMembers set.Set[string]
 
-	existingIPSetNames set.Set[string]
-	nextTempIPSetIdx   uint
-
-	// dirtyIPSetIDs contains IDs of IP sets that need updating.
-	dirtyIPSetIDs  set.Set[string]
 	resyncRequired bool
-
-	// pendingTempIPSetDeletions contains names of temporary IP sets that need to be deleted.  We use it to
-	// attempt an early deletion of temporary IP sets, if possible.
-	pendingTempIPSetDeletions set.Set[string]
-	// pendingIPSetDeletions contains names of IP sets that need to be deleted (including temporary ones).
-	pendingIPSetDeletions set.Set[string]
 
 	// Factory for command objects; shimmed for UT mocking.
 	newCmd cmdFactory
@@ -97,16 +117,22 @@ func NewIPSetsWithShims(
 	return &IPSets{
 		IPVersionConfig: ipVersionConfig,
 
-		ipSetIDToIPSet:       map[string]*ipSet{},
-		mainIPSetNameToIPSet: map[string]*ipSet{},
+		setNameToAllMetadata: map[string]dataplaneMetadata{},
+		setNameToProgrammedMetadata: deltatracker.New[string, dataplaneMetadata](
+			deltatracker.WithValuesEqualFn[string, dataplaneMetadata](func(a, b dataplaneMetadata) bool {
+				return a == b
+			}),
+			deltatracker.WithLogCtx[string, dataplaneMetadata](log.WithFields(log.Fields{
+				"ipsetFamily": ipVersionConfig.Family,
+			})),
+		),
+		mainSetNameToMembers: map[string]*deltatracker.SetDeltaTracker[IPSetMember]{},
 
-		dirtyIPSetIDs:             set.New[string](),
-		pendingTempIPSetDeletions: set.New[string](),
-		pendingIPSetDeletions:     set.New[string](),
-		newCmd:                    cmdFactory,
-		sleep:                     sleep,
-		existingIPSetNames:        set.New[string](),
-		resyncRequired:            true,
+		ipSetsWithDirtyMembers: set.New[string](),
+		resyncRequired:         true,
+
+		newCmd: cmdFactory,
+		sleep:  sleep,
 
 		gaugeNumIpsets: gaugeVecNumCalicoIpsets.WithLabelValues(familyStr),
 
@@ -124,109 +150,116 @@ func (s *IPSets) AddOrReplaceIPSet(setMetadata IPSetMetadata, members []string) 
 	// We need to convert members to a canonical representation (which may be, for example,
 	// an ip.Addr instead of a string) so that we can compare them with members that we read
 	// back from the dataplane.  This also filters out IPs of the incorrect IP version.
+	setID := setMetadata.SetID
 	s.logCxt.WithFields(log.Fields{
-		"setID":   setMetadata.SetID,
+		"setID":   setID,
 		"setType": setMetadata.Type,
 	}).Info("Queueing IP set for creation")
-	canonMembers := s.filterAndCanonicaliseMembers(setMetadata.Type, members)
 
-	// Create the IP set struct and store it off.
-	setID := setMetadata.SetID
-	ipSet := &ipSet{
-		IPSetMetadata:    setMetadata,
-		MainIPSetName:    s.IPVersionConfig.NameForMainIPSet(setID),
-		pendingReplace:   canonMembers,
-		pendingAdds:      set.New[IPSetMember](),
-		pendingDeletions: set.New[IPSetMember](),
+	// Mark that we want this IP set to exist and with the correct size etc.
+	// If the IP set exists, but it has the wrong metadata then the
+	// DeltaTracker will catch that and mark it for recreation.
+	mainIPSetName := s.IPVersionConfig.NameForMainIPSet(setID)
+	dpMeta := dataplaneMetadata{
+		Type:    setMetadata.Type,
+		MaxSize: setMetadata.MaxSize,
 	}
-	s.ipSetIDToIPSet[setID] = ipSet
-	s.mainIPSetNameToIPSet[ipSet.MainIPSetName] = ipSet
+	s.setNameToAllMetadata[mainIPSetName] = dpMeta
+	if s.ipSetNeeded(mainIPSetName) {
+		s.setNameToProgrammedMetadata.Desired().Set(mainIPSetName, dpMeta)
+	}
 
-	// Mark IP set dirty so ApplyUpdates() will rewrite it.
-	s.dirtyIPSetIDs.Add(setID)
+	// Set the desired contents of the IP set.
+	canonMembers := s.filterAndCanonicaliseMembers(setMetadata.Type, members)
+	memberTracker := s.getOrCreateMemberTracker(mainIPSetName)
 
-	// The IP set may have been previously queued for deletion, undo that.
-	s.pendingIPSetDeletions.Discard(ipSet.MainIPSetName)
+	desiredMembers := memberTracker.Desired()
+	desiredMembers.Iter(func(k IPSetMember) {
+		if canonMembers.Contains(k) {
+			canonMembers.Discard(k)
+		} else {
+			desiredMembers.Delete(k)
+		}
+	})
+	canonMembers.Iter(func(m IPSetMember) error {
+		desiredMembers.Add(m)
+		return nil
+	})
+	s.updateDirtiness(mainIPSetName)
+}
+
+func (s *IPSets) getOrCreateMemberTracker(mainIPSetName string) *deltatracker.SetDeltaTracker[IPSetMember] {
+	dt := s.mainSetNameToMembers[mainIPSetName]
+	if dt == nil {
+		dt = deltatracker.NewSetDeltaTracker[IPSetMember]()
+		s.mainSetNameToMembers[mainIPSetName] = dt
+	}
+	return dt
 }
 
 // RemoveIPSet queues up the removal of an IP set, it need not be empty.  The IP sets will be
 // removed on the next call to ApplyDeletions().
 func (s *IPSets) RemoveIPSet(setID string) {
 	s.logCxt.WithField("setID", setID).Info("Queueing IP set for removal")
-	delete(s.ipSetIDToIPSet, setID)
-	mainIPSetName := s.IPVersionConfig.NameForMainIPSet(setID)
-	delete(s.mainIPSetNameToIPSet, mainIPSetName)
-	s.dirtyIPSetIDs.Discard(setID)
-	s.pendingIPSetDeletions.Add(mainIPSetName)
+	// Mark that we no longer need this IP set.  The DeltaTracker will keep track of the metadata
+	// until we actually delete the IP set.  We clean up mainSetNameToMembers only when we actually
+	// delete it.
+	setName := s.nameForMainIPSet(setID)
+	delete(s.setNameToAllMetadata, setName)
+	s.setNameToProgrammedMetadata.Desired().Delete(setName)
+	if _, ok := s.setNameToProgrammedMetadata.Dataplane().Get(setName); ok {
+		s.mainSetNameToMembers[setName].Desired().DeleteAll()
+	} else {
+		// If it's not in the dataplane, clean it up.
+		delete(s.mainSetNameToMembers, setName)
+	}
+	s.updateDirtiness(setName)
+}
+
+func (s *IPSets) nameForMainIPSet(setID string) string {
+	return s.IPVersionConfig.NameForMainIPSet(setID)
 }
 
 // AddMembers adds the given members to the IP set.  Filters out members that are of the incorrect
 // IP version.
 func (s *IPSets) AddMembers(setID string, newMembers []string) {
-	ipSet := s.ipSetIDToIPSet[setID]
-	setType := ipSet.Type
-	canonMembers := s.filterAndCanonicaliseMembers(setType, newMembers)
+	setName := s.nameForMainIPSet(setID)
+	setMeta, ok := s.setNameToAllMetadata[setName]
+	if !ok {
+		log.WithField("setName", setName).Panic("AddMembers called for non-existent IP set.")
+	}
+	canonMembers := s.filterAndCanonicaliseMembers(setMeta.Type, newMembers)
 	if canonMembers.Len() == 0 {
+		s.logCxt.Debug("After filtering, found no members to add")
 		return
 	}
-	s.logCxt.WithFields(log.Fields{
-		"setID":           setID,
-		"filteredMembers": canonMembers,
-	}).Debug("Adding new members to IP set")
-	if ipSet.pendingReplace != nil {
-		canonMembers.Iter(func(m IPSetMember) error {
-			ipSet.pendingReplace.Add(m)
-			return nil
-		})
-	} else {
-		// Do a delta update.
-		canonMembers.Iter(func(m IPSetMember) error {
-			ipSet.pendingDeletions.Discard(m)
-			if ipSet.members.Contains(m) {
-				// IP already in the set, this happens if the IP is removed and then
-				// re-added in between updates to the dataplane.
-				return nil
-			}
-			ipSet.pendingAdds.Add(m)
-			return nil
-		})
-	}
-	s.dirtyIPSetIDs.Add(setID)
+	membersTracker := s.mainSetNameToMembers[setName]
+	canonMembers.Iter(func(member IPSetMember) error {
+		membersTracker.Desired().Add(member)
+		return nil
+	})
+	s.updateDirtiness(setName)
 }
 
 // RemoveMembers queues up removal of the given members from an IP set.  Members of the wrong IP
 // version are ignored.
 func (s *IPSets) RemoveMembers(setID string, removedMembers []string) {
-	ipSet := s.ipSetIDToIPSet[setID]
-	setType := ipSet.Type
-	canonMembers := s.filterAndCanonicaliseMembers(setType, removedMembers)
+	setName := s.nameForMainIPSet(setID)
+	setMeta, ok := s.setNameToAllMetadata[setName]
+	if !ok {
+		log.WithField("setName", setName).Panic("RemoveMembers called for non-existent IP set.")
+	}
+	canonMembers := s.filterAndCanonicaliseMembers(setMeta.Type, removedMembers)
 	if canonMembers.Len() == 0 {
 		s.logCxt.Debug("After filtering, found no members to remove")
 		return
 	}
-	s.logCxt.WithFields(log.Fields{
-		"setID":           setID,
-		"filteredMembers": canonMembers,
-	}).Debug("Removing members from IP set")
-	if ipSet.pendingReplace != nil {
-		canonMembers.Iter(func(m IPSetMember) error {
-			ipSet.pendingReplace.Discard(m)
-			return nil
-		})
-	} else {
-		// Do a delta update.
-		canonMembers.Iter(func(m IPSetMember) error {
-			ipSet.pendingAdds.Discard(m)
-			if !ipSet.members.Contains(m) {
-				// IP not in the dataplane, this occurs if the IP was added and
-				// then removed without any calls to ApplyUpdates().
-				return nil
-			}
-			ipSet.pendingDeletions.Add(m)
-			return nil
-		})
-	}
-	s.dirtyIPSetIDs.Add(setID)
+	membersTracker := s.mainSetNameToMembers[setName]
+	canonMembers.Iter(func(member IPSetMember) error {
+		membersTracker.Desired().Delete(member)
+		return nil
+	})
+	s.updateDirtiness(setName)
 }
 
 // QueueResync forces a resync with the dataplane on the next ApplyUpdates() call.
@@ -240,23 +273,12 @@ func (s *IPSets) GetIPFamily() IPFamily {
 }
 
 func (s *IPSets) GetTypeOf(setID string) (IPSetType, error) {
-	ipSet, ok := s.ipSetIDToIPSet[setID]
+	setName := s.nameForMainIPSet(setID)
+	setMeta, ok := s.setNameToAllMetadata[setName]
 	if !ok {
 		return "", fmt.Errorf("ipset %s not found", setID)
 	}
-	return ipSet.Type, nil
-}
-
-func ipSetMemberSetToStringSet(ipsetMembers set.Set[IPSetMember]) set.Set[string] {
-	if ipsetMembers == nil {
-		return nil
-	}
-	stringSet := set.New[string]()
-	ipsetMembers.Iter(func(member IPSetMember) error {
-		stringSet.Add(member.String())
-		return nil
-	})
-	return stringSet
+	return setMeta.Type, nil
 }
 
 func (s *IPSets) filterAndCanonicaliseMembers(ipSetType IPSetType, members []string) set.Set[IPSetMember] {
@@ -272,29 +294,23 @@ func (s *IPSets) filterAndCanonicaliseMembers(ipSetType IPSetType, members []str
 	return filtered
 }
 
-func (s *IPSets) GetMembers(setID string) (set.Set[string], error) {
-	ipSet, ok := s.ipSetIDToIPSet[setID]
+func (s *IPSets) GetDesiredMembers(setID string) (set.Set[string], error) {
+	setName := s.nameForMainIPSet(setID)
+
+	_, ok := s.setNameToAllMetadata[setName]
 	if !ok {
 		return nil, fmt.Errorf("ipset %s not found", setID)
 	}
 
-	if ipSet.pendingReplace != nil {
-		return ipSetMemberSetToStringSet(ipSet.pendingReplace), nil
+	memberTracker, ok := s.mainSetNameToMembers[setName]
+	if !ok {
+		return nil, fmt.Errorf("ipset %s not found in members tracker", setID)
 	}
-
-	realMembers := ipSet.members.Copy()
-
-	ipSet.pendingAdds.Iter(func(m IPSetMember) error {
-		realMembers.Add(m)
-		return nil
+	strs := set.New[string]()
+	memberTracker.Desired().Iter(func(k IPSetMember) {
+		strs.Add(k.String())
 	})
-
-	ipSet.pendingDeletions.Iter(func(m IPSetMember) error {
-		realMembers.Discard(m)
-		return nil
-	})
-
-	return ipSetMemberSetToStringSet(realMembers), nil
+	return strs, nil
 }
 
 func (s *IPSets) ApplyUpdates() {
@@ -314,29 +330,21 @@ func (s *IPSets) ApplyUpdates() {
 			s.logCxt.Debug("Resyncing ipsets with dataplane.")
 			s.opReporter.RecordOperation(fmt.Sprint("resync-ipsets-v", s.IPVersionConfig.Family.Version()))
 
-			numProblems, err := s.tryResync()
-			if err != nil {
+			if err := s.tryResync(); err != nil {
 				s.logCxt.WithError(err).Warning("Failed to resync with dataplane")
 				backOff()
 				continue
 			}
-			if numProblems > 0 {
-				s.logCxt.WithField("numProblems", numProblems).Warn(
-					"Found inconsistencies in IP sets in dataplane")
-			}
 			s.resyncRequired = false
 		}
 
-		numTempSets := s.pendingTempIPSetDeletions.Len()
-		if numTempSets > 0 {
-			log.WithField("numTempSets", numTempSets).Info(
-				"There are left-over temporary IP sets, attempting cleanup")
-			s.tryTempIPSetDeletions()
-		}
+		// Opportunistically delete some temporary IP sets.  It's possible
+		// that ApplyDeletions doesn't get called if there's another failure
+		// and deleting some temp sets might free up some room.
+		s.tryTempIPSetDeletions()
 
 		if err := s.tryUpdates(); err != nil {
-			// While failed deletions don't cause immediate problems, update failures may mean that our iptables
-			// updates fail.  We need to do an immediate resync.
+			// Update failures may mean that our iptables updates fail.  We need to do an immediate resync.
 			s.logCxt.WithError(err).Warning("Failed to update IP sets. Marking dataplane for resync.")
 			s.resyncRequired = true
 			countNumIPSetErrors.Inc()
@@ -351,18 +359,20 @@ func (s *IPSets) ApplyUpdates() {
 		s.dumpIPSetsToLog()
 		s.logCxt.Panic("Failed to update IP sets after multiple retries.")
 	}
-	gaugeNumTotalIpsets.Set(float64(s.existingIPSetNames.Len()))
+	gaugeNumTotalIpsets.Set(float64(s.setNameToProgrammedMetadata.Dataplane().Len()))
 }
 
 // tryResync attempts to bring our state into sync with the dataplane.  It scans the contents of the
 // IP sets in the dataplane and queues up updates to any IP sets that are out-of-sync.
-func (s *IPSets) tryResync() (numProblems int, err error) {
+func (s *IPSets) tryResync() (err error) {
 	// Log the time spent as we exit the function.
 	resyncStart := time.Now()
 	defer func() {
 		s.logCxt.WithFields(log.Fields{
-			"resyncDuration":          time.Since(resyncStart),
-			"numInconsistenciesFound": numProblems,
+			"resyncDuration":           time.Since(resyncStart),
+			"ipSetsWithDirtyMembers":   s.ipSetsWithDirtyMembers.Len(),
+			"ipSetsToCreateOrRecreate": s.setNameToProgrammedMetadata.PendingUpdates().Len(),
+			"ipSetsToDelete":           s.setNameToProgrammedMetadata.PendingDeletions().Len(),
 		}).Debug("Finished IPSets resync")
 	}()
 
@@ -407,36 +417,73 @@ func (s *IPSets) tryResync() (numProblems int, err error) {
 		return
 	}
 	summaryExecStart.Observe(float64(time.Since(execStartTime).Nanoseconds()) / 1000.0)
-	// Clear the set of known IP sets names, we'll fill it back in as we scan.
-	s.existingIPSetNames.Clear()
+
 	// Use a scanner to chunk the input into lines.
 	scanner := bufio.NewScanner(out)
+
+	// Values of the last-seen header fields.
 	ipSetName := ""
+	var ipSetType IPSetType
 
 	// Figure out if debug logging is enabled so we can disable some expensive-to-calculate logs
 	// in the tight loop below if they're not going to be emitted.  This speeds up the loop
 	// by a factor of 3-4x!
 	debug := log.GetLevel() >= log.DebugLevel
 
+	// Clear the dataplane metadata view, we'll build it back up again as we
+	// scan.
+	s.setNameToProgrammedMetadata.Dataplane().DeleteAll()
 	for scanner.Scan() {
 		line := scanner.Text()
+		if debug {
+			s.logCxt.Debugf("Parsing line: %q", line)
+		}
 		if strings.HasPrefix(line, "Name:") {
 			ipSetName = strings.Split(line, " ")[1]
-			s.existingIPSetNames.Add(ipSetName)
-			s.logCxt.WithField("setName", ipSetName).Debug("Parsing IP set.")
+			if debug {
+				s.logCxt.WithField("setName", ipSetName).Debug("Parsing IP set.")
+			}
+		}
+		if strings.HasPrefix(line, "Type:") {
+			ipSetType = IPSetType(strings.Split(line, " ")[1])
+			if debug {
+				s.logCxt.WithField("type", ipSetType).Debug("Parsed type of IP set.")
+			}
+		}
+		if strings.HasPrefix(line, "Header:") {
+			// When we hit the Header line we should know the name, and type of the IP set, which lets
+			// us update the tracker.
+			if !s.IPVersionConfig.OwnsIPSet(ipSetName) {
+				s.logCxt.WithField("name", ipSetName).Debug("Skip non-Calico/wrong version IP set.")
+				continue
+			}
+			parts := strings.Split(line, " ")
+			for idx, p := range parts {
+				if p == "maxelem" {
+					maxElem, err := strconv.Atoi(parts[idx+1])
+					if err != nil {
+						log.WithError(err).WithField("line", line).Error(
+							"Failed to parse ipset list Header line.")
+						break
+					}
+					meta := dataplaneMetadata{
+						Type:    ipSetType,
+						MaxSize: maxElem,
+					}
+					s.setNameToProgrammedMetadata.Dataplane().Set(ipSetName, meta)
+					break
+				}
+			}
 		}
 		if strings.HasPrefix(line, "Members:") {
 			// Start of a Members entry, following this, there'll be one member per
 			// line then EOF or a blank line.
 
 			// Look up to see if this is one of our IP sets.
-			ipSet := s.mainIPSetNameToIPSet[ipSetName]
-			logCxt := s.logCxt.WithField("setName", ipSetName)
-			if ipSet == nil || ipSet.members == nil {
-				// Either this is not one of our IP sets, or it's one that we're
-				// about to rewrite.  Either way, we don't care about its members
-				// so simply scan past them.
-				logCxt.Debug("Skipping IP set, either not ours or about to rewrite")
+			if !s.IPVersionConfig.OwnsIPSet(ipSetName) || s.IPVersionConfig.IsTempIPSetName(ipSetName) {
+				if debug {
+					s.logCxt.WithField("name", ipSetName).Debug("Skip parsing members of IP set.")
+				}
 				for scanner.Scan() {
 					line := scanner.Bytes()
 					if len(line) == 0 {
@@ -445,116 +492,65 @@ func (s *IPSets) tryResync() (numProblems int, err error) {
 					}
 				}
 				ipSetName = ""
+				ipSetType = ""
 				continue
 			}
 
-			// One of our IP sets and we're not planning to rewrite it; we need to
-			// load its members and compare them.
-			logCxt = s.logCxt.WithField("setID", ipSet.SetID)
-			dataplaneMembers := set.New[IPSetMember]()
-			for scanner.Scan() {
-				line := scanner.Text()
-				if line == "" {
-					// End of members
-					break
-				}
-				canonMember := ipSet.Type.CanonicaliseMember(line)
-				dataplaneMembers.Add(canonMember)
-				if debug {
-					logCxt.WithFields(log.Fields{
-						"member": line,
-						"canon":  canonMember,
-					}).Debug("Found member in dataplane")
-				}
+			if !ipSetType.IsValid() {
+				s.logCxt.WithFields(log.Fields{
+					"setName": ipSetName,
+					"type":    string(ipSetType),
+				}).Warning("Dataplane IP set has unknown type.")
 			}
-			ipSetName = ""
-			if scanner.Err() != nil {
+
+			// One of our IP sets; we need to parse its members.
+			logCxt := s.logCxt.WithField("setName", ipSetName)
+			memberTracker := s.getOrCreateMemberTracker(ipSetName)
+			numExtrasExpected := memberTracker.PendingDeletions().Len()
+			err = memberTracker.Dataplane().ReplaceFromIter(func(f func(k IPSetMember)) error {
+				for scanner.Scan() {
+					line := scanner.Text()
+					if line == "" {
+						// End of members
+						break
+					}
+					var canonMember IPSetMember
+					if ipSetType.IsValid() {
+						canonMember = ipSetType.CanonicaliseMember(line)
+					} else {
+						// Unknown type found in dataplane, record it as
+						// a raw string.  Then we'll clean up the IP set
+						// when we go to sync.
+						canonMember = rawIPSetMember(line)
+					}
+					if debug {
+						logCxt.WithFields(log.Fields{
+							"member": line,
+							"canon":  canonMember,
+						}).Debug("Found member in dataplane")
+					}
+					f(canonMember)
+				}
+				return scanner.Err()
+			})
+			if err != nil {
 				logCxt.WithError(err).Error("Failed to read members from 'ipset list'.")
 				break
 			}
 
-			// If we get here, we've read all the members of the IP set.  Compare them
-			// with what we expect and queue up any fixes.
-			numMissing := 0
-			ipSet.members.Iter(func(m IPSetMember) error {
-				if dataplaneMembers.Contains(m) {
-					// Mainline (correct) case, member is in memory and in the
-					// dataplane.
-					dataplaneMembers.Discard(m)
-					return nil
-				}
-
-				logCxt := logCxt.WithField("member", m.String())
-				numProblems++
-				if ipSet.pendingDeletions.Contains(m) {
-					// We were trying to delete this item anyway, record that
-					// it's already gone.  We commonly hit this case when we're
-					// doing a retry after a failure and we're not sure which
-					// deltas got applied.
-					logCxt.Debug("Resync found member missing from " +
-						"dataplane. (Already queued for deletion.)")
-					ipSet.pendingDeletions.Discard(m)
-					return set.RemoveItem
-				}
-
-				// The item should be in the dataplane but it's not, queue up an
-				// add to add it back in.
-				if numMissing == 0 {
-					logCxt.Warning("Resync found member missing from " +
-						"dataplane. Queueing up an add to reinstate it. " +
-						"Further inconsistencies will be logged at DEBUG.")
-				} else {
-					logCxt.Debug("Found another member missing")
-				}
-				numMissing++
-				s.dirtyIPSetIDs.Add(ipSet.SetID)
-				ipSet.pendingAdds.Add(m)
-				return set.RemoveItem
-			})
-			if numMissing > 0 {
-				logCxt.WithField("numMissing", numMissing).Warn(
+			if numMissing := memberTracker.PendingUpdates().Len(); numMissing > 0 {
+				logCxt.WithField("numMissing", numMissing).Info(
 					"Resync found members missing from dataplane.")
 			}
-
-			// Now look for any members which are in the dataplane but are not expected.
-			// We removed the members we were expecting above so dataplaneMembers now
-			// contains only unexpected members.
-			numExtras := 0
-			dataplaneMembers.Iter(func(m IPSetMember) error {
-				logCxt := logCxt.WithField("member", m.String())
-
-				// Record that this member really is in the dataplane.
-				ipSet.members.Add(m)
-				numProblems++
-
-				if ipSet.pendingAdds.Contains(m) {
-					// We were trying to add this item anyway, record that
-					// it's already there.  We commonly hit this case when we're
-					// doing a retry after a failure and we're not sure which
-					// deltas got applied.
-					logCxt.Debug("Resync found unexpected member in " +
-						"dataplane. (Was about to add it anyway.)")
-					ipSet.pendingAdds.Discard(m)
-					return nil
-				}
-
-				// We weren't planning on adding this member, queue up a deletion.
-				if numExtras == 0 {
-					logCxt.Warning("Resync found unexpected member in " +
-						"dataplane. Queueing it for removal.  Further " +
-						"inconsistencies will be logged at DEBUG.")
-				} else {
-					logCxt.Debug("Found another extra member.")
-				}
-				numExtras++
-				s.dirtyIPSetIDs.Add(ipSet.SetID)
-				ipSet.pendingDeletions.Add(m)
-				return nil
-			})
-			if numExtras > 0 {
-				logCxt.WithField("numExtras", numExtras).Warn(
+			if numExtras := memberTracker.PendingDeletions().Len() - numExtrasExpected; numExtras > 0 {
+				logCxt.WithField("numExtras", numExtras).Info(
 					"Resync found extra members in dataplane.")
 			}
+
+			s.updateDirtiness(ipSetName)
+
+			ipSetName = ""
+			ipSetType = ""
 		}
 	}
 	closeErr := out.Close()
@@ -575,49 +571,24 @@ func (s *IPSets) tryResync() (numProblems int, err error) {
 		return
 	}
 
-	// Scan for IP sets that need to be cleaned up.  Create list containing the IP sets that we expect to be there.
-	expectedIPSets := set.New[string]()
-	for _, ipSet := range s.ipSetIDToIPSet {
-		if !s.ipSetNeeded(ipSet.SetID) {
+	// Mark any IP sets that we didn't see as empty.
+	for name, members := range s.mainSetNameToMembers {
+		if _, ok := s.setNameToProgrammedMetadata.Dataplane().Get(name); ok {
+			// In the dataplane, we should have updated its members above.
 			continue
 		}
-		expectedIPSets.Add(ipSet.MainIPSetName)
-		s.logCxt.WithFields(log.Fields{
-			"ID":       ipSet.SetID,
-			"mainName": ipSet.MainIPSetName,
-		}).Debug("Marking IP set as expected.")
+		if _, ok := s.setNameToAllMetadata[name]; !ok {
+			// Defensive: this IP set is not in the dataplane, and it's not
+			// one we are tracking, clean up its member tracker.
+			log.WithField("name", name).Warn(
+				"Cleaning up leaked(?) IP set member tracker.")
+			delete(s.mainSetNameToMembers, name)
+			continue
+		}
+		// We're tracking this IP set, but we didn't find it in the dataplane;
+		// reset the members set to empty.
+		members.Dataplane().DeleteAll()
 	}
-
-	// Include any pending deletions in the expected set; this is mainly to separate cleanup logs
-	// from explicit deletion logs.
-	s.pendingIPSetDeletions.Iter(func(item string) error {
-		expectedIPSets.Add(item)
-		return nil
-	})
-
-	// Now look for any left-over IP sets that we should delete and queue up the deletions.
-	s.existingIPSetNames.Iter(func(setName string) error {
-		if !s.IPVersionConfig.OwnsIPSet(setName) {
-			s.logCxt.WithField("setName", setName).Debug(
-				"Skipping IP set: non Calico or wrong IP version for this pass.")
-			return nil
-		}
-		if expectedIPSets.Contains(setName) {
-			s.logCxt.WithField("setName", setName).Debug("Skipping expected Calico IP set.")
-			return nil
-		}
-		if s.IPVersionConfig.IsTempIPSetName(setName) {
-			// Temporary IP sets get leaked after a failure but they should never be in use by iptables so
-			// we try to delete them early in the processing to free up IP set space.
-			s.logCxt.WithField("setName", setName).Info(
-				"Resync found left-over temporary IP set. Queueing early deletion.")
-			s.pendingTempIPSetDeletions.Add(setName)
-		}
-		s.logCxt.WithField("setName", setName).Info(
-			"Resync found left-over Calico IP set. Queueing deletion.")
-		s.pendingIPSetDeletions.Add(setName)
-		return nil
-	})
 
 	return
 }
@@ -626,25 +597,28 @@ func (s *IPSets) tryResync() (numProblems int, err error) {
 // 'ipset restore' session in order to minimise process forking overhead.  Note: unlike
 // 'iptables-restore', 'ipset restore' is not atomic, updates are applied individually.
 func (s *IPSets) tryUpdates() error {
-	needUpdates := false
-	if s.neededIPSetNames == nil {
-		needUpdates = s.dirtyIPSetIDs.Len() > 0
-	} else {
-		s.dirtyIPSetIDs.Iter(func(setID string) error {
-			if s.ipSetNeeded(setID) {
-				needUpdates = true
-				return set.StopIteration
-			}
+	var dirtyIPSets []string
+	s.ipSetsWithDirtyMembers.Iter(func(setName string) error {
+		if _, ok := s.setNameToProgrammedMetadata.Desired().Get(setName); !ok {
+			// Skip deletions and IP sets that aren't needed due to the filter.
 			return nil
-		})
-	}
-	if !needUpdates {
+		}
+		dirtyIPSets = append(dirtyIPSets, setName)
+		return nil
+	})
+	s.setNameToProgrammedMetadata.PendingUpdates().Iter(func(setName string, v dataplaneMetadata) deltatracker.IterAction {
+		if !s.ipSetsWithDirtyMembers.Contains(setName) {
+			dirtyIPSets = append(dirtyIPSets, setName)
+		}
+		return deltatracker.IterActionNoOp
+	})
+	if len(dirtyIPSets) == 0 {
 		s.logCxt.Debug("No dirty IP sets.")
 		return nil
 	}
-
 	s.opReporter.RecordOperation(fmt.Sprint("update-ipsets-", s.IPVersionConfig.Family.Version()))
 
+	start := time.Now()
 	// Set up an ipset restore session.
 	countNumIPSetCalls.Inc()
 	cmd := s.newCmd("ipset", "restore")
@@ -654,6 +628,7 @@ func (s *IPSets) tryUpdates() error {
 		s.logCxt.WithError(err).Error("Failed to create pipe for ipset restore.")
 		return err
 	}
+
 	// "Tee" the data that we write to stdin to a buffer so we can dump it to the log on
 	// failure.
 	stdin := io.MultiWriter(&s.restoreInCopy, rawStdin)
@@ -681,17 +656,14 @@ func (s *IPSets) tryUpdates() error {
 
 	// Ask each dirty IP set to write its updates to the stream.
 	var writeErr error
-	s.dirtyIPSetIDs.Iter(func(setID string) error {
-		if !s.ipSetNeeded(setID) {
-			return nil
+	for _, setName := range dirtyIPSets {
+		// Ask IP set to write its updates to the stream.
+		if log.IsLevelEnabled(log.DebugLevel) {
+			log.WithField("setName", setName).Debug("Writing updates to IP set.")
 		}
-		ipSet := s.ipSetIDToIPSet[setID]
-		writeErr = s.writeUpdates(ipSet, stdin)
-		if writeErr != nil {
-			return set.StopIteration
-		}
-		return nil
-	})
+		writeErr = s.writeUpdates(setName, stdin)
+	}
+
 	// Finish off the input, then flush and close the input, or the command won't terminate.
 	// We need to close and wait whether we hit a write error or not so we defer the error
 	// handling.
@@ -710,78 +682,38 @@ func (s *IPSets) tryUpdates() error {
 			"stderr":     s.stderrCopy.String(),
 			"input":      s.restoreInCopy.String(),
 		}).Warning("Failed to complete ipset restore, IP sets may be out-of-sync.")
-		return err
+		return fmt.Errorf("failed to write one or more IP set: %v", err)
 	}
+	log.Debugf("Updated %d IPSets in %v", len(dirtyIPSets), time.Since(start))
 
 	// If we get here, the writes were successful, reset the IP sets delta tracking now the
-	// dataplane should be in sync.  If we bail out above, then the resync logic will kick in
-	// and figure out how much of our update succeeded.
-	s.dirtyIPSetIDs.Iter(func(setID string) error {
-		if !s.ipSetNeeded(setID) {
-			return nil
-		}
-		ipSet := s.ipSetIDToIPSet[setID]
-		if ipSet.pendingReplace != nil {
-			ipSet.members = ipSet.pendingReplace
-			ipSet.pendingReplace = nil
-
-			// Doing a rewrite creates the main IP set.
-			s.existingIPSetNames.Add(ipSet.MainIPSetName)
-		} else {
-			ipSet.pendingAdds.Iter(func(m IPSetMember) error {
-				ipSet.members.Add(m)
-				return set.RemoveItem
-			})
-			ipSet.pendingDeletions.Iter(func(m IPSetMember) error {
-				ipSet.members.Discard(m)
-				return set.RemoveItem
-			})
-		}
-		return set.RemoveItem
-	})
+	// dataplane should be in sync.
+	s.ipSetsWithDirtyMembers.Clear()
 
 	return nil
 }
 
-func (s *IPSets) writeUpdates(ipSet *ipSet, w io.Writer) error {
-	logCxt := s.logCxt.WithField("setID", ipSet.SetID)
-	if ipSet.members != nil {
-		logCxt = logCxt.WithField("numMembersInDataplane", ipSet.members.Len())
+func (s *IPSets) writeUpdates(setName string, w io.Writer) (err error) {
+	logCxt := s.logCxt.WithField("setName", setName)
+
+	desiredMeta, desiredExists := s.setNameToProgrammedMetadata.Desired().Get(setName)
+	dpMeta, dpExists := s.setNameToProgrammedMetadata.Dataplane().Get(setName)
+
+	members, membersExists := s.mainSetNameToMembers[setName]
+
+	if !desiredExists {
+		log.WithField("setName", setName).Panic("writeUpdates called for pending deletion?")
 	}
-	if ipSet.pendingReplace != nil {
-		logCxt = logCxt.WithField("numMembersInPendingReplace", ipSet.pendingReplace.Len())
-	} else {
-		logCxt = logCxt.WithFields(log.Fields{
-			"numDeltaAdds":    ipSet.pendingAdds.Len(),
-			"numDeltaDeletes": ipSet.pendingDeletions.Len(),
-		})
+	if !membersExists {
+		log.WithField("setName", setName).Panic("writeUpdates called for missing IP set?")
 	}
 
-	if ipSet.pendingReplace == nil {
-		// In delta-writing mode:
-		// - pendingReplace is nil
-		// - membersInDataplane non-nil
-		// - pendingAdds/Deletions hold the deltas.
-		if ipSet.pendingAdds.Len() == 0 && ipSet.pendingDeletions.Len() == 0 {
-			// We hit this case if an IP is added, then removed before we actually
-			// write it, nothing to do.
-			logCxt.Debug("Skipping delta write, IP set not dirty.")
-			return nil
-		}
-		logCxt.Info("Calculating deltas to IP set")
-		return s.writeDeltas(ipSet, w, logCxt)
-	}
-	// In full-rewrite mode.
-	// - pendingReplace is non-nil
-	// - membersInDataplane nil
-	// - pendingAdds/Deletions empty.
-	logCxt.Info("Doing full IP set rewrite")
-	return s.writeFullRewrite(ipSet, w, logCxt)
-}
+	// If the metadata needs to change then we have to write to a temporary IP
+	// set and swap it into place.
+	needTempIPSet := dpExists && dpMeta != desiredMeta
+	// If the IP set doesn't exist yet, we need to create it.
+	needCreate := !dpExists
 
-// writeFullRewrite calculates the ipset restore input required to do a full, atomic, idempotent
-// rewrite of the IP set and writes it to the given io.Writer.
-func (s *IPSets) writeFullRewrite(ipSet *ipSet, out io.Writer, logCxt log.FieldLogger) (err error) {
 	// writeLine until an error occurs, writeLine writes a line to the output, after an error,
 	// it is a no-op.
 	writeLine := func(format string, a ...interface{}) {
@@ -791,7 +723,7 @@ func (s *IPSets) writeFullRewrite(ipSet *ipSet, out io.Writer, logCxt log.FieldL
 		line := fmt.Sprintf(format, a...) + "\n"
 		logCxt.WithField("line", line).Debug("Writing line to ipset restore")
 		lineBytes := []byte(line)
-		_, err = out.Write(lineBytes)
+		_, err = w.Write(lineBytes)
 		if err != nil {
 			logCxt.WithError(err).WithFields(log.Fields{
 				"line": lineBytes,
@@ -801,43 +733,68 @@ func (s *IPSets) writeFullRewrite(ipSet *ipSet, out io.Writer, logCxt log.FieldL
 		countNumIPSetLinesExecuted.Inc()
 	}
 
-	// Our general approach is to create a temporary IP set with the right contents, then
-	// atomically swap it into place.
-	mainSetName := ipSet.MainIPSetName
-	if !s.existingIPSetNames.Contains(mainSetName) {
-		// Create empty main IP set so we can share the atomic swap logic below.
-		// Note: we can't use the -exist flag (which should make the create idempotent)
-		// because it still fails if the IP set was previously created with different
-		// parameters.
-		logCxt.WithField("setID", ipSet.SetID).Debug("Pre-creating main IP set")
-		writeLine("create %s %s family %s maxelem %d",
-			mainSetName, ipSet.Type, s.IPVersionConfig.Family, ipSet.MaxSize)
+	var targetSet, tempSet string
+	if needTempIPSet {
+		tempSet = s.nextFreeTempIPSetName()
+		targetSet = tempSet
+		// Temp IP set is empty.
+		members.Dataplane().DeleteAll()
+	} else {
+		targetSet = setName
 	}
-	tempSetName := s.nextFreeTempIPSetName()
-	// Create the temporary IP set with the current parameters.
-	writeLine("create %s %s family %s maxelem %d",
-		tempSetName, ipSet.Type, s.IPVersionConfig.Family, ipSet.MaxSize)
-	// Write all the members into the temporary IP set.
-	ipSet.pendingReplace.Iter(func(member IPSetMember) error {
-		writeLine("add %s %s", tempSetName, member)
-		return nil
+	if needCreate || needTempIPSet {
+		logCxt.WithField("ipSetToCreate", targetSet).Debug("Creating IP set")
+		writeLine("create %s %s family %s maxelem %d",
+			targetSet, desiredMeta.Type, s.IPVersionConfig.Family, desiredMeta.MaxSize)
+	}
+	if err != nil {
+		return
+	}
+	members.PendingDeletions().Iter(func(member IPSetMember) deltatracker.IterAction {
+		writeLine("del %s %s --exist", targetSet, member)
+		if err != nil {
+			// Note, just exiting early here to save a load of no-ops.
+			// If we exit with an error, the dataplane state will be resynced.
+			return deltatracker.IterActionNoOpStopIteration
+		}
+		return deltatracker.IterActionUpdateDataplane
 	})
-	// Atomically swap the temporary set into place.
-	writeLine("swap %s %s", mainSetName, tempSetName)
-	// Then remove the temporary set (which was the old main set).
-	writeLine("destroy %s", tempSetName)
+	members.PendingUpdates().Iter(func(member IPSetMember) deltatracker.IterAction {
+		writeLine("add %s %s", targetSet, member)
+		if err != nil {
+			// Note, just exiting early here to save a load of no-ops.
+			// If we exit with an error, the dataplane state will be resynced.
+			return deltatracker.IterActionNoOpStopIteration
+		}
+		return deltatracker.IterActionUpdateDataplane
+	})
+	if needTempIPSet {
+		writeLine("swap %s %s", setName, targetSet)
+	}
+	if err != nil {
+		return
+	}
 
+	if needCreate || needTempIPSet {
+		if needTempIPSet {
+			// After the swap, the temp IP set has the _old_ dataplane metadata.
+			s.setNameToProgrammedMetadata.Dataplane().Set(tempSet, dpMeta)
+		}
+		// The main IP set now has the correct metadata.
+		s.setNameToProgrammedMetadata.Dataplane().Set(setName, desiredMeta)
+	}
 	return
 }
 
-// nextFreeTempIPSetName picks a name for a temporary IP set avoiding any that appear to be in use already.
-// Giving each temporary IP set a new name works around the fact that we sometimes see transient failures to
-// remove temporary IP sets.
+// nextFreeTempIPSetName picks a name for a temporary IP set avoiding any that
+// appear to be in use already. Giving each temporary IP set a new name works
+// around the fact that we sometimes see transient failures to remove
+// temporary IP sets.
 func (s *IPSets) nextFreeTempIPSetName() string {
 	for {
 		candidateName := s.IPVersionConfig.NameForTempIPSet(s.nextTempIPSetIdx)
 		s.nextTempIPSetIdx++
-		if s.existingIPSetNames.Contains(candidateName) {
+		if _, ok := s.setNameToProgrammedMetadata.Dataplane().Get(candidateName); ok {
 			log.WithField("candidate", candidateName).Warning(
 				"Skipping in-use temporary IP set name (previous cleanup failure?)")
 			continue
@@ -846,74 +803,78 @@ func (s *IPSets) nextFreeTempIPSetName() string {
 	}
 }
 
-// writeDeltas calculates the ipset restore input required to apply the pending adds/deletes to the
-// main IP set.
-func (s *IPSets) writeDeltas(ipSet *ipSet, out io.Writer, logCxt log.FieldLogger) (err error) {
-	mainSetName := ipSet.MainIPSetName
-	ipSet.pendingDeletions.Iter(func(member IPSetMember) error {
-		logCxt.WithField("member", member).Debug("Writing del")
-		_, err = fmt.Fprintf(out, "del %s %s --exist\n", mainSetName, member)
-		if err != nil {
-			return set.StopIteration
-		}
-		countNumIPSetLinesExecuted.Inc()
-		return nil
-	})
-	if err != nil {
-		return
-	}
-	ipSet.pendingAdds.Iter(func(member IPSetMember) error {
-		logCxt.WithField("member", member).Debug("Writing add")
-		_, err = fmt.Fprintf(out, "add %s %s\n", mainSetName, member)
-		if err != nil {
-			return set.StopIteration
-		}
-		countNumIPSetLinesExecuted.Inc()
-		return nil
-	})
-	return
-}
-
 // ApplyDeletions tries to delete any IP sets that are no longer needed.
 // Failures are ignored, deletions will be retried the next time we do a resync.
-func (s *IPSets) ApplyDeletions() {
-	s.pendingIPSetDeletions.Iter(func(setName string) error {
-		logCxt := s.logCxt.WithField("setName", setName)
-		if s.existingIPSetNames.Contains(setName) {
-			logCxt.Info("Deleting IP set.")
-			if err := s.deleteIPSet(setName); err != nil {
-				// Note: we used to set the resyncRequired flag on this path but that can lead to excessive retries if
-				// the problem isn't something that we can fix (for example an external app has made a reference to
-				// our IP set).  Instead, wait for the next timed resync.
-				logCxt.WithError(err).Warning("Failed to delete IP set. Will retry on next resync.")
-			}
+func (s *IPSets) ApplyDeletions() bool {
+	numDeletions := 0
+	s.setNameToProgrammedMetadata.PendingDeletions().Iter(func(setName string) deltatracker.IterAction {
+		if numDeletions >= MaxIPSetDeletionsPerIteration {
+			// Deleting IP sets is slow (40ms) and serialised in the kernel.  Avoid holding up the main loop
+			// for too long.  We'll leave the remaining sets pending deletion and mop them up next time.
+			log.Debugf("Deleted batch of %d IP sets, rate limiting further IP set deletions.", MaxIPSetDeletionsPerIteration)
+			// Leave the item in the set, so we'll do another batch of deletions next time around the loop.
+			return deltatracker.IterActionNoOpStopIteration
 		}
-		// Always remove the item so we don't retry until the next timed resync.
-		return set.RemoveItem
+		meta, _ := s.setNameToProgrammedMetadata.Dataplane().Get(setName)
+		if meta.DeleteFailed {
+			// We previously failed to delete this IP set, skip it until
+			// the next resync.
+			return deltatracker.IterActionNoOp
+		}
+		logCxt := s.logCxt.WithField("setName", setName)
+		logCxt.Info("Deleting IP set.")
+		if err := s.deleteIPSet(setName); err != nil {
+			// Note: we used to set the resyncRequired flag on this path but that can lead to excessive retries if
+			// the problem isn't something that we can fix (for example an external app has made a reference to
+			// our IP set).  Instead, wait for the next timed resync.
+			logCxt.WithError(err).Warning("Failed to delete IP set. Will retry on next resync.")
+			meta.DeleteFailed = true
+			s.setNameToProgrammedMetadata.Dataplane().Set(setName, meta)
+			return deltatracker.IterActionNoOp
+		}
+		numDeletions++
+		if _, ok := s.setNameToAllMetadata[setName]; !ok {
+			// IP set is not just filtered out, clean up the members cache.
+			delete(s.mainSetNameToMembers, setName)
+		} else {
+			// We're still tracking this IP set in case it needs to be recreated.
+			// Record that the dataplane is now empty.
+			s.mainSetNameToMembers[setName].Dataplane().DeleteAll()
+		}
+		return deltatracker.IterActionUpdateDataplane
 	})
-
-	// ApplyDeletions() marks the end of the two-phase "apply".  Piggy back on that to
+	// ApplyDeletions() marks the end of the two-phase "apply". Piggyback on that to
 	// update the gauge that records how many IP sets we own.
-	s.gaugeNumIpsets.Set(float64(len(s.ipSetIDToIPSet)))
+	numDeletionsPending := s.setNameToProgrammedMetadata.Dataplane().Len()
+	s.gaugeNumIpsets.Set(float64(numDeletionsPending))
+	return numDeletionsPending > 0 && numDeletions > 0
 }
 
-// tryTempIPSetDeletions tries to delete any temporary IP sets found by the last resync.
 func (s *IPSets) tryTempIPSetDeletions() {
-	s.pendingTempIPSetDeletions.Iter(func(setName string) error {
-		logCxt := s.logCxt.WithField("setName", setName)
-		if s.existingIPSetNames.Contains(setName) {
-			logCxt.Info("Deleting IP set.")
-			if err := s.deleteIPSet(setName); err != nil {
-				// Log and carry on; we'll try again in ApplyDeletions().
-				logCxt.WithError(err).Warning("Failed to delete temporary IP set. Will retry...")
-			} else {
-				// Success! Remove from the main pending deletions set too.
-				logCxt.WithField("setName", setName).Info("Successfully removed left-over temporary IP set.")
-				s.pendingIPSetDeletions.Discard(setName)
-			}
+	numDeletions := 0
+	s.setNameToProgrammedMetadata.PendingDeletions().Iter(func(setName string) deltatracker.IterAction {
+		if numDeletions >= MaxIPSetDeletionsPerIteration {
+			// Deleting IP sets is slow (40ms) and serialised in the kernel.  Avoid holding up the main loop
+			// for too long.  We'll leave the remaining sets pending deletion and mop them up next time.
+			log.Debugf("Deleted batch of 20 temp IP sets, rate limiting further IP set deletions.")
+			// Leave the item in the set, so we'll do another batch of deletions next time around the loop.
+			return deltatracker.IterActionNoOpStopIteration
 		}
-		// Always remove the item so we don't retry until the next timed resync.
-		return set.RemoveItem
+		if !s.IPVersionConfig.IsTempIPSetName(setName) {
+			return deltatracker.IterActionNoOp
+		}
+		meta, _ := s.setNameToProgrammedMetadata.Dataplane().Get(setName)
+		if meta.DeleteFailed {
+			return deltatracker.IterActionNoOp
+		}
+		logCxt := s.logCxt.WithField("setName", setName)
+		logCxt.Info("Deleting IP set.")
+		if err := s.deleteIPSet(setName); err != nil {
+			logCxt.WithError(err).Warning("Failed to delete temp IP set. Will retry...")
+			return deltatracker.IterActionNoOp
+		}
+		numDeletions++
+		return deltatracker.IterActionUpdateDataplane
 	})
 }
 
@@ -927,31 +888,7 @@ func (s *IPSets) deleteIPSet(setName string) error {
 		}).Warn("Failed to delete IP set, may be out-of-sync.")
 		return err
 	}
-	// Success, update the cache.
 	s.logCxt.WithField("setName", setName).Info("Deleted IP set")
-	s.existingIPSetNames.Discard(setName)
-	if ipSet := s.mainIPSetNameToIPSet[setName]; ipSet != nil {
-		// We are still tracking this IP set; it has been deleted because it's not currently
-		// in the "needed" set.
-		if s.ipSetNeeded(ipSet.SetID) {
-			s.logCxt.Errorf("Unexpected deletion of an IP set %v that is still needed", ipSet.SetID)
-		}
-		// If we don't already have a pending complete IP set membership...
-		if ipSet.pendingReplace == nil {
-			// Reconstruct what the IP set membership should be from what was
-			// programmed, plus any pending additions, minus any pending deletions.
-			ipSet.pendingReplace = ipSet.members
-			ipSet.members = nil
-			ipSet.pendingAdds.Iter(func(m IPSetMember) error {
-				ipSet.pendingReplace.Add(m)
-				return set.RemoveItem
-			})
-			ipSet.pendingDeletions.Iter(func(m IPSetMember) error {
-				ipSet.pendingReplace.Discard(m)
-				return set.RemoveItem
-			})
-		}
-	}
 	return nil
 }
 
@@ -974,40 +911,47 @@ func firstNonNilErr(errs ...error) error {
 	return nil
 }
 
-func (s *IPSets) SetFilter(ipSetNames set.Set[string]) {
-	s.logCxt.Debugf("Filtering to needed IP set names: %v", ipSetNames)
-	markDirty := func(ipSetName string) {
-		if ipSet := s.mainIPSetNameToIPSet[ipSetName]; ipSet != nil {
-			s.dirtyIPSetIDs.Add(ipSet.SetID)
-		}
+func (s *IPSets) updateDirtiness(name string) {
+	memberTracker, ok := s.mainSetNameToMembers[name]
+	if !ok {
+		s.ipSetsWithDirtyMembers.Discard(name)
+		return
 	}
-	if s.neededIPSetNames != nil {
-		s.neededIPSetNames.Iter(func(item string) error {
-			if ipSetNames != nil && !ipSetNames.Contains(item) {
-				// Name was needed before and now isn't, so mark as dirty.
-				markDirty(item)
-			}
-			return nil
-		})
+	if !s.ipSetNeeded(name) {
+		// If the IP set is filtered out we don't program its members.
+		s.ipSetsWithDirtyMembers.Discard(name)
+		return
 	}
-	if ipSetNames != nil {
-		ipSetNames.Iter(func(item string) error {
-			if s.neededIPSetNames != nil && !s.neededIPSetNames.Contains(item) {
-				// Name wasn't needed before and now is, so mark as dirty.
-				markDirty(item)
-			}
-			return nil
-		})
+	if memberTracker.InSync() {
+		s.ipSetsWithDirtyMembers.Discard(name)
+	} else {
+		s.ipSetsWithDirtyMembers.Add(name)
 	}
-	s.neededIPSetNames = ipSetNames
 }
 
-func (s *IPSets) ipSetNeeded(id string) bool {
+func (s *IPSets) SetFilter(ipSetNames set.Set[string]) {
+	oldSetNames := s.neededIPSetNames
+	if oldSetNames == nil && ipSetNames == nil {
+		return
+	}
+	s.logCxt.Debugf("Filtering to needed IP set names: %v", ipSetNames)
+	s.neededIPSetNames = ipSetNames
+	for name, meta := range s.setNameToAllMetadata {
+		if s.ipSetNeeded(name) {
+			s.setNameToProgrammedMetadata.Desired().Set(name, meta)
+		} else {
+			s.setNameToProgrammedMetadata.Desired().Delete(name)
+		}
+		s.updateDirtiness(name)
+	}
+}
+
+func (s *IPSets) ipSetNeeded(name string) bool {
 	if s.neededIPSetNames == nil {
 		// We're not filtering down to a "needed" set, so all IP sets are needed.
 		return true
 	}
 
 	// We are filtering down, so compare against the needed set.
-	return s.neededIPSetNames.Contains(s.IPVersionConfig.NameForMainIPSet(id))
+	return s.neededIPSetNames.Contains(name)
 }

--- a/felix/ipsets/ipsets_suite_test.go
+++ b/felix/ipsets/ipsets_suite_test.go
@@ -33,7 +33,7 @@ func init() {
 	logrus.SetFormatter(&logutils.Formatter{})
 }
 
-func TestCalculationGraph(t *testing.T) {
+func TestIPSets(t *testing.T) {
 	RegisterFailHandler(Fail)
 	junitReporter := reporters.NewJUnitReporter("../report/ipsets_suite.xml")
 	RunSpecsWithDefaultAndCustomReporters(t, "IP sets Suite", []Reporter{junitReporter})

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -15,7 +15,9 @@
 package ipsets_test
 
 import (
+	"encoding/binary"
 	"fmt"
+	"net"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -278,6 +280,59 @@ var _ = Describe("IP sets dataplane", func() {
 		dataplane.ExpectMembers(map[string][]string{
 			v4MainIPSetName: {"10.0.0.2", "10.0.0.3"},
 		})
+	})
+
+	It("with medium IP sets, should not use more than one chunk for initial resync", func() {
+		ips := generateIPs("10.0.0.0", RestoreChunkSize-10)
+		ipsets.AddOrReplaceIPSet(meta, ips)
+		ipsets.AddOrReplaceIPSet(meta2, ips)
+		ipsets.ApplyUpdates()
+		dataplane.ExpectMembers(map[string][]string{
+			v4MainIPSetName:  ips,
+			v4MainIPSetName2: ips,
+		})
+
+		// Check that batching is working as expected.
+		Expect(dataplane.NumRestoreCalls()).To(Equal(1))
+	})
+
+	It("with large IP sets, should use more than one chunk for initial resync", func() {
+		ips := generateIPs("10.0.0.0", RestoreChunkSize)
+		ipsets.AddOrReplaceIPSet(meta, ips)
+		ipsets.AddOrReplaceIPSet(meta2, ips)
+		ipsets.ApplyUpdates()
+		dataplane.ExpectMembers(map[string][]string{
+			v4MainIPSetName:  ips,
+			v4MainIPSetName2: ips,
+		})
+
+		// Check that batching is working as expected.
+		Expect(dataplane.NumRestoreCalls()).To(Equal(2))
+	})
+
+	It("with large deltas, should use more than one chunk", func() {
+		ips := generateIPs("10.0.0.0", 1)
+		ipsets.AddOrReplaceIPSet(meta, ips)
+		ipsets.AddOrReplaceIPSet(meta2, ips)
+		ipsets.ApplyUpdates()
+		dataplane.ExpectMembers(map[string][]string{
+			v4MainIPSetName:  ips,
+			v4MainIPSetName2: ips,
+		})
+		// Check that batching is working as expected.
+		Expect(dataplane.NumRestoreCalls()).To(Equal(1))
+
+		ips = generateIPs("11.0.0.0", RestoreChunkSize)
+		ipsets.AddOrReplaceIPSet(meta, ips)
+		ipsets.AddOrReplaceIPSet(meta2, ips)
+		ipsets.ApplyUpdates()
+		dataplane.ExpectMembers(map[string][]string{
+			v4MainIPSetName:  ips,
+			v4MainIPSetName2: ips,
+		})
+
+		// Check that batching is working as expected.
+		Expect(dataplane.NumRestoreCalls()).To(Equal(3))
 	})
 
 	It("should not mark set as dirty if all IPs of wrong version", func() {
@@ -885,6 +940,17 @@ var _ = Describe("IP sets dataplane", func() {
 		dataplane.ExpectMembers(map[string][]string{"noncali": v4Members1And2})
 	})
 })
+
+func generateIPs(baseIP string, size int) []string {
+	var ips []string
+	scratchIP := net.ParseIP(baseIP).To4()
+	baseInt := binary.BigEndian.Uint32(scratchIP)
+	for i := 0; i < size; i++ {
+		binary.BigEndian.PutUint32(scratchIP, uint32(i)+baseInt)
+		ips = append(ips, scratchIP.String())
+	}
+	return ips
+}
 
 var _ = Describe("Standard IPv4 IPVersionConfig", func() {
 	v4VersionConf := NewIPVersionConfig(

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -15,10 +15,11 @@
 package ipsets_test
 
 import (
+	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"time"
 
 	"github.com/projectcalico/calico/felix/ip"
 	. "github.com/projectcalico/calico/felix/ipsets"
@@ -31,6 +32,9 @@ import (
 const (
 	ipSetID  = "s:qMt7iLlGDhvLnCjM0l9nzxbabcd"
 	ipSetID2 = "t:qMt7iLlGDhvLnCjM0l9nzxbabcd"
+	ipSetID3 = "u:qMt7iLlGDhvLnCjM0l9nzxbabcd"
+	ipSetID4 = "v:qMt7iLlGDhvLnCjM0l9nzxbabcd"
+	ipSetID5 = "w:qMt7iLlGDhvLnCjM0l9nzxbabcd"
 
 	v4MainIPSetName  = "cali40s:qMt7iLlGDhvLnCjM0l9nzxb"
 	v4TempIPSetName0 = "cali4t0"
@@ -194,6 +198,21 @@ var _ = Describe("IP sets dataplane", func() {
 		SetID:   ipSetID2,
 		Type:    IPSetTypeHashIP,
 	}
+	meta3 := IPSetMetadata{
+		MaxSize: 1234,
+		SetID:   ipSetID3,
+		Type:    IPSetTypeHashIP,
+	}
+	meta4 := IPSetMetadata{
+		MaxSize: 1234,
+		SetID:   ipSetID4,
+		Type:    IPSetTypeHashIP,
+	}
+	meta5 := IPSetMetadata{
+		MaxSize: 1234,
+		SetID:   ipSetID5,
+		Type:    IPSetTypeHashIP,
+	}
 	metaCIDRs := IPSetMetadata{
 		MaxSize: 1234,
 		SetID:   ipSetID,
@@ -207,9 +226,10 @@ var _ = Describe("IP sets dataplane", func() {
 	)
 	// v6VersionConf := NewIPVersionConfig(IPFamilyV6, "cali", nil, nil)
 
+	reschedRequested := false
 	apply := func() {
 		ipsets.ApplyUpdates()
-		ipsets.ApplyDeletions()
+		reschedRequested = ipsets.ApplyDeletions()
 	}
 
 	resyncAndApply := func() {
@@ -245,6 +265,9 @@ var _ = Describe("IP sets dataplane", func() {
 		dataplane.ExpectMembers(map[string][]string{
 			v4MainIPSetName: {"10.0.0.2", "10.0.0.3"},
 		})
+
+		// Check that batching is working as expected.
+		Expect(dataplane.NumRestoreCalls()).To(Equal(1))
 	})
 
 	It("mainline: should ignore IPs of wrong version", func() {
@@ -284,9 +307,17 @@ var _ = Describe("IP sets dataplane", func() {
 			}
 		})
 
-		It("should clean everything up on first apply()", func() {
+		It("should rate limit clean up", func() {
 			apply()
+			// Should delete one temp and one normal IP set.
+			Expect(dataplane.IPSetMembers).To(HaveLen(1))
+			Expect(reschedRequested).To(BeTrue(),
+				"should reschedule if there are some IP sets still to delete")
+			apply()
+			// Should delete one temp and one normal IP set.
 			Expect(dataplane.IPSetMembers).To(BeEmpty())
+			Expect(reschedRequested).To(BeFalse(),
+				"should not reschedule if there are no IP sets to delete")
 		})
 
 		It("should rewrite IP set correctly and clean up temp set", func() {
@@ -300,8 +331,45 @@ var _ = Describe("IP sets dataplane", func() {
 		})
 	})
 
+	Describe("with many left-over IP sets in place", func() {
+		BeforeEach(func() {
+			for i := 0; i < MaxIPSetDeletionsPerIteration*3; i++ {
+				setName := fmt.Sprintf("cali40s:%d", i)
+				dataplane.IPSetMembers[setName] = set.From("10.0.0.1")
+			}
+		})
+
+		It("should have limit on number of deletions per attempt", func() {
+			apply()
+			Expect(dataplane.IPSetMembers).To(HaveLen(MaxIPSetDeletionsPerIteration * 2))
+			apply()
+			Expect(dataplane.IPSetMembers).To(HaveLen(MaxIPSetDeletionsPerIteration))
+			apply()
+			Expect(dataplane.IPSetMembers).To(HaveLen(0))
+			Expect(dataplane.TriedToDeleteNonExistent).To(BeFalse())
+		})
+
+		It("should rewrite IP set correctly and clean up temp set", func() {
+			ipsets.AddOrReplaceIPSet(meta, []string{"10.0.0.1", "10.0.0.2"})
+			apply()
+			Expect(dataplane.IPSetMembers[v4MainIPSetName]).To(Equal(set.From("10.0.0.1", "10.0.0.2")))
+			// It shouldn't try to double-delete the temp IP set.
+			Expect(dataplane.TriedToDeleteNonExistent).To(BeFalse())
+		})
+	})
+
 	Describe("with a persistent failure to delete a new temporary IP set", func() {
 		BeforeEach(func() {
+			// writeFullRewrite will only use a temp IP set if the main IP set exists
+			// and it has the wrong maxelems.
+			dataplane.IPSetMembers[v4MainIPSetName] = set.New[string]()
+			dataplane.IPSetMetadata[v4MainIPSetName] = setMetadata{
+				Name:    "v4MainIPSetName",
+				Family:  "inet",
+				Type:    "hash:ip",
+				MaxSize: 5678,
+			}
+
 			// Lay the trap: this should be the first temp IP set to get used.
 			dataplane.FailDestroyNames.Add(v4TempIPSetName0)
 		})
@@ -324,11 +392,6 @@ var _ = Describe("IP sets dataplane", func() {
 
 			By("Using the correct sequence of destroys")
 			Expect(dataplane.AttemptedDestroys).To(Equal([]string{
-				v4TempIPSetName0, // Failed "ipset restore" deletion after successful write/swap.
-				// Resync happens here.
-				v4TempIPSetName0, // Attempted pre-update deletion.
-				// Since initial write of ip set failed, we try a full rewrite, using a new temp IP set name...
-				v4TempIPSetName1, // Deletion of new temp IP set.
 				v4TempIPSetName0, // Attempted deletion in ApplyDeletions().
 			}))
 
@@ -359,17 +422,9 @@ var _ = Describe("IP sets dataplane", func() {
 		Describe("after first apply()", func() {
 			BeforeEach(apply)
 
-			It("should clean up what it can on the first apply()", func() {
-				Expect(dataplane.IPSetMembers).To(Equal(map[string]set.Set[string]{
-					v4TempIPSetName1: set.From("10.0.0.2"),
-				}))
-				Expect(dataplane.AttemptedDestroys).To(ConsistOf(
-					v4TempIPSetName2,
-					v4TempIPSetName1,
-					v4MainIPSetName,
-					v4MainIPSetName2,
-					v4TempIPSetName1, // Temp IP set will get a second try at deletion
-				))
+			It("should clean up one IP set of each kind on first apply()", func() {
+				Expect(dataplane.IPSetMembers).To(HaveLen(2))
+				Expect(dataplane.IPSetMembers).To(HaveKey(v4TempIPSetName1))
 			})
 
 			It("second apply shouldn't retry deletions", func() {
@@ -379,29 +434,17 @@ var _ = Describe("IP sets dataplane", func() {
 				Expect(dataplane.IPSetMembers).To(Equal(map[string]set.Set[string]{
 					v4TempIPSetName1: set.From("10.0.0.2"),
 				}))
-				Expect(dataplane.AttemptedDestroys).To(BeEmpty())
-			})
 
-			It("second apply after resync should retry deletions", func() {
 				dataplane.AttemptedDestroys = nil
 				ipsets.QueueResync()
 				apply()
 
-				Expect(dataplane.IPSetMembers).To(Equal(map[string]set.Set[string]{
-					v4TempIPSetName1: set.From("10.0.0.2"),
-				}))
 				Expect(dataplane.AttemptedDestroys).To(ConsistOf(
 					v4TempIPSetName1,
 					v4TempIPSetName1,
 				))
 
-				By("And should be idempotent")
-				dataplane.AttemptedDestroys = nil
-				apply()
-				Expect(dataplane.AttemptedDestroys).To(BeEmpty())
-			})
-
-			It("successful temp set deletion retry should clean up", func() {
+				By("should succeed once error is cleared")
 				dataplane.FailDestroyNames.Clear()
 				dataplane.AttemptedDestroys = nil
 				ipsets.QueueResync()
@@ -424,6 +467,31 @@ var _ = Describe("IP sets dataplane", func() {
 				v4TempIPSetName1: set.From("10.0.0.2"),
 				v4MainIPSetName:  set.From("10.0.0.1", "10.0.0.2"),
 			}))
+		})
+	})
+
+	Context("with filtering to two IP sets", func() {
+		BeforeEach(func() {
+			ipsets.SetFilter(set.From(v4MainIPSetName2, v4MainIPSetName))
+			ipsets.QueueResync()
+			apply()
+		})
+
+		It("should create only those two", func() {
+			// Regression test for a bug hit during development; we were breaking out of
+			// the loop when we hit an ignored IP set.  Make sure we have a few IP sets
+			// so it's very unlikely to pass by chance.
+			ipsets.AddOrReplaceIPSet(meta, []string{"10.0.0.1", "10.0.0.2"})
+			ipsets.AddOrReplaceIPSet(meta2, []string{"10.0.0.2", "10.0.0.3"})
+			ipsets.AddOrReplaceIPSet(meta3, []string{"10.0.0.3", "10.0.0.4"})
+			ipsets.AddOrReplaceIPSet(meta4, []string{"10.0.0.4", "10.0.0.5"})
+			ipsets.AddOrReplaceIPSet(meta5, []string{"10.0.0.5", "10.0.0.6"})
+			apply()
+
+			dataplane.ExpectMembers(map[string][]string{
+				v4MainIPSetName:  {"10.0.0.1", "10.0.0.2"},
+				v4MainIPSetName2: {"10.0.0.2", "10.0.0.3"},
+			})
 		})
 	})
 
@@ -506,14 +574,11 @@ var _ = Describe("IP sets dataplane", func() {
 			Context("with filtering to single IP set", func() {
 				BeforeEach(func() {
 					ipsets.SetFilter(set.From(v4MainIPSetName2))
-					ipsets.QueueResync()
 					apply()
 				})
 
 				It("should delete the non-needed IP set", func() {
 					Expect(dataplane.AttemptedDestroys).To(Equal([]string{
-						v4TempIPSetName0,
-						v4TempIPSetName1,
 						v4MainIPSetName,
 					}))
 					dataplane.ExpectMembers(map[string][]string{
@@ -738,7 +803,7 @@ var _ = Describe("IP sets dataplane", func() {
 		Describe("with a write failure to the pipe when writing an IP", describeRetryTests("write-ip"))
 		Describe("with an update failure before any updates succeed", describeRetryTests("pre-update"))
 		Describe("with an update failure after updates succeed", describeRetryTests("post-update"))
-		Describe("with a couple of failures", describeRetryTests("post-update", "pre-update"))
+		Describe("with a couple of failures", describeRetryTests("pre-update", "post-update"))
 	})
 
 	Describe("with an IP set using non-canon CIDRs", func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

At high scale, do IP set updates in parallel
    
When there are man IP set updates to do at once,
do multiple updates in parallel on background goroutines.
    
Since launching an ipset process is fairly expensive,
only lauch multiple goroutines if there are thousands of
updates to make.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Based on #8054 
CORE-9785
CORE-9780

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
