### PR TITLE
[release-v3.25] Auto pick #7979: Typha tolerate

### DIFF
--- a/charts/calico/templates/calico-typha.yaml
+++ b/charts/calico/templates/calico-typha.yaml
@@ -71,11 +71,11 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
-        # this taint is set by all kubelets running `--cloud-provider=external`
-        # so we should tolerate it to schedule typha pods
-        - key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
-          effect: NoSchedule
+        # Make sure Typha can get scheduled on any nodes. 
+        - effect: NoSchedule 
+          operator: Exists 
+        - effect: NoExecute 
+          operator: Exists           
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/charts/calico/templates/calico-typha.yaml
+++ b/charts/calico/templates/calico-typha.yaml
@@ -71,6 +71,11 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        # this taint is set by all kubelets running `--cloud-provider=external`
+        # so we should tolerate it to schedule typha pods
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/manifests/calico-policy-only.yaml
+++ b/manifests/calico-policy-only.yaml
@@ -4768,6 +4768,11 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        # Make sure Typha can get scheduled on any nodes. 
+        - effect: NoSchedule 
+          operator: Exists 
+        - effect: NoExecute 
+          operator: Exists           
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node

--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -4872,6 +4872,11 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        # Make sure Typha can get scheduled on any nodes. 
+        - effect: NoSchedule 
+          operator: Exists 
+        - effect: NoExecute 
+          operator: Exists           
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node


### PR DESCRIPTION
Cherry pick of #7979 on release-v3.25.

#7979: Typha tolerate

# Original PR Body below

## Description

Allow typha deployment to tolerate the taint set via kubelet when used with --cloud-provider=external flag. We need typha to be able to schedule as soon as possible on new nodes since calico-node relies on it.

## Related issues/PRs

Related Slack thread:
https://calicousers.slack.com/archives/C0BCA117T/p1693469918340899

## Todos

Someone should run the respective make target to generate manifests picking up this change.
## Release Note

```release-note
Update Typha Deployment tolerations to helm charts so that it can be scheduled on any node.
```