### PR TITLE
Add additional IP set types and tests

### DIFF
--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017,2019-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2023 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/big"
 	"math/bits"
 	"net"
 	"strings"
@@ -50,6 +51,8 @@ type Addr interface {
 	AsCalicoNetIP() calinet.IP
 	AsCIDR() CIDR
 	String() string
+	AsBinary() string
+	Add(int) Addr
 	NthBit(uint) int
 }
 
@@ -84,6 +87,31 @@ func (a V4Addr) NthBit(n uint) int {
 
 func (a V4Addr) String() string {
 	return a.AsNetIP().String()
+}
+
+func (a V4Addr) AsBinary() string {
+	var ipInBinary string = ""
+	ipInBinary = fmt.Sprintf("%04b", 4)
+	for ii := 0; ii < net.IPv4len; ii++ {
+		temp := fmt.Sprintf("%08b", a[ii])
+		ipInBinary += temp
+	}
+
+	return ipInBinary
+}
+
+func (a V4Addr) Add(n int) Addr {
+	myValue := int(binary.BigEndian.Uint32(a[:]))
+	offsetValue := (uint32)(myValue + n)
+	var newAddr V4Addr
+	binary.BigEndian.PutUint32(newAddr[:], offsetValue)
+	return newAddr
+}
+
+func Int2NetIP(addr uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, addr)
+	return ip
 }
 
 type V6Addr [16]byte
@@ -126,12 +154,40 @@ func (a V6Addr) String() string {
 	return a.AsNetIP().String()
 }
 
+func (a V6Addr) AsBinary() string {
+	var ipInBinary string = ""
+	ipInBinary = fmt.Sprintf("%04b", 6)
+	for ii := 0; ii < net.IPv6len; ii++ {
+		temp := fmt.Sprintf("%08b", a[ii])
+		ipInBinary += temp
+	}
+
+	return ipInBinary
+}
+
+func (a V6Addr) Add(n int) Addr {
+	var myVal, nVal, newVal big.Int
+
+	myVal.SetBytes(a[:])
+	nVal.SetInt64(int64(n))
+	newVal.Add(&myVal, &nVal)
+
+	var newAddr V6Addr
+	b := newVal.Bytes()
+	bLen := len(b)
+	offset := len(a) - bLen
+	copy(newAddr[offset:], b)
+
+	return newAddr
+}
+
 type CIDR interface {
 	Version() uint8
 	Addr() Addr
 	Prefix() uint8
 	String() string
 	ToIPNet() net.IPNet
+	AsBinary() string
 	Contains(addr Addr) bool
 }
 
@@ -178,6 +234,17 @@ func (c V4CIDR) ContainsV4(addr V4Addr) bool {
 
 func (c V4CIDR) String() string {
 	return fmt.Sprintf("%s/%v", c.addr.String(), c.prefix)
+}
+
+func (c V4CIDR) AsBinary() string {
+	var ipInBinary string = ""
+	ipInBinary = fmt.Sprintf("%04b", 4)
+	for ii := 0; ii < net.IPv4len; ii++ {
+		temp := fmt.Sprintf("%08b", c.addr[ii])
+		ipInBinary += temp
+	}
+
+	return ipInBinary[0 : c.prefix+4]
 }
 
 type V6CIDR struct {
@@ -231,8 +298,24 @@ func (c V6CIDR) String() string {
 	return fmt.Sprintf("%s/%v", c.addr.String(), c.prefix)
 }
 
+func (c V6CIDR) AsBinary() string {
+	var ipInBinary string = ""
+	ipInBinary = fmt.Sprintf("%04b", 6)
+	for ii := 0; ii < net.IPv6len; ii++ {
+		temp := fmt.Sprintf("%08b", c.addr[ii])
+		ipInBinary += temp
+	}
+	return ipInBinary[0 : c.prefix+4]
+}
+
 func FromString(s string) Addr {
 	return FromNetIP(net.ParseIP(s))
+}
+
+// Parses an IP or CIDR string and returns the IP.
+func FromIPOrCIDRString(s string) Addr {
+	parts := strings.Split(s, "/")
+	return FromNetIP(net.ParseIP(parts[0]))
 }
 
 func FromNetIP(netIP net.IP) Addr {
@@ -262,6 +345,14 @@ func CIDRFromString(cidrStr string) (CIDR, error) {
 
 func CIDRFromCalicoNet(ipNet calinet.IPNet) CIDR {
 	return CIDRFromIPNet(&ipNet.IPNet)
+}
+
+func CIDRsFromCalicoNets(ipNets []calinet.IPNet) []CIDR {
+	cidrs := make([]CIDR, 0, len(ipNets))
+	for _, ipNet := range ipNets {
+		cidrs = append(cidrs, CIDRFromCalicoNet(ipNet))
+	}
+	return cidrs
 }
 
 func FromCalicoIP(ip calinet.IP) Addr {
@@ -337,4 +428,13 @@ func IPNetsEqual(net1, net2 *net.IPNet) bool {
 		return false
 	}
 	return CIDRFromIPNet(net1) == CIDRFromIPNet(net2)
+}
+
+func ParseIPAs16Byte(ip string) (ipb [16]byte, ok bool) {
+	ipn := net.ParseIP(ip)
+	if ipn != nil {
+		ok = true
+		copy(ipb[:], ipn.To16())
+	}
+	return
 }

--- a/felix/ip/ip_addr.go
+++ b/felix/ip/ip_addr.go
@@ -90,8 +90,7 @@ func (a V4Addr) String() string {
 }
 
 func (a V4Addr) AsBinary() string {
-	var ipInBinary string = ""
-	ipInBinary = fmt.Sprintf("%04b", 4)
+	ipInBinary := fmt.Sprintf("%04b", 4)
 	for ii := 0; ii < net.IPv4len; ii++ {
 		temp := fmt.Sprintf("%08b", a[ii])
 		ipInBinary += temp
@@ -155,8 +154,7 @@ func (a V6Addr) String() string {
 }
 
 func (a V6Addr) AsBinary() string {
-	var ipInBinary string = ""
-	ipInBinary = fmt.Sprintf("%04b", 6)
+	ipInBinary := fmt.Sprintf("%04b", 6)
 	for ii := 0; ii < net.IPv6len; ii++ {
 		temp := fmt.Sprintf("%08b", a[ii])
 		ipInBinary += temp
@@ -237,8 +235,7 @@ func (c V4CIDR) String() string {
 }
 
 func (c V4CIDR) AsBinary() string {
-	var ipInBinary string = ""
-	ipInBinary = fmt.Sprintf("%04b", 4)
+	ipInBinary := fmt.Sprintf("%04b", 4)
 	for ii := 0; ii < net.IPv4len; ii++ {
 		temp := fmt.Sprintf("%08b", c.addr[ii])
 		ipInBinary += temp
@@ -299,8 +296,7 @@ func (c V6CIDR) String() string {
 }
 
 func (c V6CIDR) AsBinary() string {
-	var ipInBinary string = ""
-	ipInBinary = fmt.Sprintf("%04b", 6)
+	ipInBinary := fmt.Sprintf("%04b", 6)
 	for ii := 0; ii < net.IPv6len; ii++ {
 		temp := fmt.Sprintf("%08b", c.addr[ii])
 		ipInBinary += temp

--- a/felix/ipsets/ipset_defs.go
+++ b/felix/ipsets/ipset_defs.go
@@ -81,6 +81,14 @@ const (
 	IPSetTypeHashNetNet IPSetType = "hash:net,net"
 )
 
+var AllIPSetTypes = []IPSetType{
+	IPSetTypeHashIP,
+	IPSetTypeHashIPPort,
+	IPSetTypeHashNet,
+	IPSetTypeBitmapPort,
+	IPSetTypeHashNetNet,
+}
+
 func (t IPSetType) SetType() string {
 	return string(t)
 }
@@ -241,7 +249,7 @@ func (nn netNet) String() string {
 
 func (t IPSetType) IsValid() bool {
 	switch t {
-	case IPSetTypeHashIP, IPSetTypeHashNet, IPSetTypeHashIPPort, IPSetTypeHashNetNet:
+	case IPSetTypeHashIP, IPSetTypeHashNet, IPSetTypeHashIPPort, IPSetTypeHashNetNet, IPSetTypeBitmapPort:
 		return true
 	}
 	return false

--- a/felix/ipsets/ipset_defs.go
+++ b/felix/ipsets/ipset_defs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,6 +68,8 @@ func init() {
 
 const MaxIPSetNameLength = 31
 
+const IPSetNamePrefix = "cali"
+
 // IPSetType constants for the different kinds of IP set.
 type IPSetType string
 
@@ -75,6 +77,8 @@ const (
 	IPSetTypeHashIP     IPSetType = "hash:ip"
 	IPSetTypeHashIPPort IPSetType = "hash:ip,port"
 	IPSetTypeHashNet    IPSetType = "hash:net"
+	IPSetTypeBitmapPort IPSetType = "bitmap:port"
+	IPSetTypeHashNetNet IPSetType = "hash:net,net"
 )
 
 func (t IPSetType) SetType() string {
@@ -101,12 +105,33 @@ func (p V6IPPort) String() string {
 	return fmt.Sprintf("%s,%s:%d", p.IP.String(), p.Protocol.String(), p.Port)
 }
 
+type Port uint16
+
+func (p Port) String() string {
+	return fmt.Sprintf("%d", p)
+}
+
 func (t IPSetType) IsMemberIPV6(member string) bool {
 	switch t {
 	case IPSetTypeHashIP, IPSetTypeHashNet:
 		return strings.Contains(member, ":")
 	case IPSetTypeHashIPPort:
 		return strings.Contains(strings.Split(member, ",")[0], ":")
+	case IPSetTypeHashNetNet:
+		cidrs := strings.Split(member, ",")
+		if len(cidrs) != 2 {
+			log.WithField("member", member).Panic("Is not type IPSetTypeHashNetNet")
+		}
+		cidr1 := strings.Contains(cidrs[0], ":")
+		cidr2 := strings.Contains(cidrs[1], ":")
+
+		if cidr1 != cidr2 {
+			log.WithField("member", member).Panic("Each cidr has different version")
+		}
+
+		return cidr1
+	case IPSetTypeBitmapPort:
+		return strings.HasPrefix("v6,", member)
 	}
 	log.WithField("type", string(t)).Panic("Unknown IPSetType")
 	return false
@@ -118,7 +143,7 @@ func (t IPSetType) CanonicaliseMember(member string) IPSetMember {
 	switch t {
 	case IPSetTypeHashIP:
 		// Convert the string into our ip.Addr type, which is backed by an array.
-		ipAddr := ip.FromString(member)
+		ipAddr := ip.FromIPOrCIDRString(member)
 		if ipAddr == nil {
 			// This should be prevented by validation in libcalico-go.
 			log.WithField("ip", member).Panic("Failed to parse IP")
@@ -176,6 +201,21 @@ func (t IPSetType) CanonicaliseMember(member string) IPSetMember {
 		// pretty-printing, the hash:net ipset type prints IPs with no "/32" or "/128"
 		// suffix.
 		return ip.MustParseCIDROrIP(member)
+	case IPSetTypeBitmapPort:
+		// Trim the family if it exists
+		if member[0] == 'v' {
+			member = member[3:]
+		}
+		port, err := strconv.Atoi(member)
+		if err == nil && port >= 0 && port <= 0xffff {
+			return Port(port)
+		}
+	case IPSetTypeHashNetNet:
+		cidrs := strings.Split(member, ",")
+		return netNet{
+			cidr1: ip.MustParseCIDROrIP(cidrs[0]),
+			cidr2: ip.MustParseCIDROrIP(cidrs[1]),
+		}
 	}
 	log.WithField("type", string(t)).Panic("Unknown IPSetType")
 	return nil
@@ -191,9 +231,17 @@ type IPSetMember interface {
 	String() string
 }
 
+type netNet struct {
+	cidr1, cidr2 ip.CIDR
+}
+
+func (nn netNet) String() string {
+	return nn.cidr1.String() + "," + nn.cidr2.String()
+}
+
 func (t IPSetType) IsValid() bool {
 	switch t {
-	case IPSetTypeHashIP, IPSetTypeHashNet, IPSetTypeHashIPPort:
+	case IPSetTypeHashIP, IPSetTypeHashNet, IPSetTypeHashIPPort, IPSetTypeHashNetNet:
 		return true
 	}
 	return false
@@ -226,9 +274,11 @@ func (f IPFamily) Version() int {
 
 // IPSetMetadata contains the metadata for a particular IP set, such as its name, type and size.
 type IPSetMetadata struct {
-	SetID   string
-	Type    IPSetType
-	MaxSize int
+	SetID    string
+	Type     IPSetType
+	MaxSize  int
+	RangeMin int
+	RangeMax int
 }
 
 // IPVersionConfig wraps up the metadata for a particular IP version.  It can be used by
@@ -324,4 +374,12 @@ func combineAndTrunc(prefix, suffix string, maxLength int) string {
 	} else {
 		return combined
 	}
+}
+
+func StripIPSetNamePrefix(ipSetName string) string {
+	prefixLen := len(IPSetNamePrefix) + 2 // "cali40"
+	if len(ipSetName) < prefixLen {
+		return ""
+	}
+	return ipSetName[prefixLen:]
 }

--- a/felix/ipsets/ipsets.go
+++ b/felix/ipsets/ipsets.go
@@ -627,10 +627,11 @@ func (s *IPSets) tryResync() (err error) {
 	return
 }
 
-func parseRange(s string) (min int, max int, err error) {
+func ParseRange(s string) (min int, max int, err error) {
 	parts := strings.Split(s, "-")
 	if len(parts) != 2 {
 		err = fmt.Errorf("failed to parse range %q", s)
+		return
 	}
 	if min, err = strconv.Atoi(parts[0]); err != nil {
 		err = fmt.Errorf("failed to parse range %q (%w)", s, err)

--- a/felix/ipsets/ipsets.go
+++ b/felix/ipsets/ipsets.go
@@ -470,6 +470,9 @@ func (s *IPSets) tryResync() (err error) {
 				continue
 			}
 			parts := strings.Split(line, " ")
+			meta := dataplaneMetadata{
+				Type: ipSetType,
+			}
 			for idx, p := range parts {
 				if p == "maxelem" {
 					if idx+1 >= len(parts) {
@@ -483,11 +486,7 @@ func (s *IPSets) tryResync() (err error) {
 							"Failed to parse ipset list Header line.")
 						break
 					}
-					meta := dataplaneMetadata{
-						Type:    ipSetType,
-						MaxSize: maxElem,
-					}
-					s.setNameToProgrammedMetadata.Dataplane().Set(ipSetName, meta)
+					meta.MaxSize = maxElem
 					break
 				}
 				if p == "range" {
@@ -497,21 +496,18 @@ func (s *IPSets) tryResync() (err error) {
 						break
 					}
 					// For bitmaps, we see "range 123-456"
-					rMin, rMAx, err := parseRange(parts[idx+1])
+					rMin, rMAx, err := ParseRange(parts[idx+1])
 					if err != nil {
 						log.WithError(err).WithField("line", line).Error(
 							"Failed to parse ipset list Header line.")
 						break
 					}
-					meta := dataplaneMetadata{
-						Type:     ipSetType,
-						RangeMin: rMin,
-						RangeMax: rMAx,
-					}
-					s.setNameToProgrammedMetadata.Dataplane().Set(ipSetName, meta)
+					meta.RangeMin = rMin
+					meta.RangeMax = rMAx
 					break
 				}
 			}
+			s.setNameToProgrammedMetadata.Dataplane().Set(ipSetName, meta)
 		}
 		if strings.HasPrefix(line, "Members:") {
 			// Start of a Members entry, following this, there'll be one member per

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2023 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,6 +130,21 @@ var _ = Describe("IPSetTypeHashIP", func() {
 	})
 	It("should panic on bad IP", func() {
 		Expect(func() { IPSetTypeHashIP.CanonicaliseMember("foobar") }).To(Panic())
+	})
+})
+
+var _ = Describe("IPSetTypeHashIP", func() {
+	It("should canonicalise a raw port", func() {
+		Expect(IPSetTypeBitmapPort.CanonicaliseMember("10")).
+			To(Equal(Port(10)))
+	})
+	It("should canonicalise an IPv4 port", func() {
+		Expect(IPSetTypeBitmapPort.CanonicaliseMember("v4,10")).
+			To(Equal(Port(10)))
+	})
+	It("should canonicalise an IPv6 port", func() {
+		Expect(IPSetTypeBitmapPort.CanonicaliseMember("v6,10")).
+			To(Equal(Port(10)))
 	})
 })
 
@@ -679,7 +694,7 @@ var _ = Describe("IP sets dataplane", func() {
 			})
 			It("should panic eventually", func() {
 				ipsets.AddMembers(ipSetID, []string{"10.0.0.5"})
-				Expect(ipsets.ApplyUpdates).To(Panic())
+				Expect(func() { ipsets.ApplyUpdates() }).To(Panic())
 				Expect(dataplane.CumulativeSleep).To(BeNumerically(">", time.Second))
 			})
 		})
@@ -689,7 +704,7 @@ var _ = Describe("IP sets dataplane", func() {
 			})
 			It("should panic eventually", func() {
 				ipsets.QueueResync()
-				Expect(ipsets.ApplyUpdates).To(Panic())
+				Expect(func() { ipsets.ApplyUpdates() }).To(Panic())
 				Expect(dataplane.CumulativeSleep).To(BeNumerically(">", time.Second))
 			})
 		})
@@ -700,7 +715,7 @@ var _ = Describe("IP sets dataplane", func() {
 			})
 			It("should panic eventually", func() {
 				ipsets.QueueResync()
-				Expect(ipsets.ApplyUpdates).To(Panic())
+				Expect(func() { ipsets.ApplyUpdates() }).To(Panic())
 				Expect(dataplane.CumulativeSleep).To(BeNumerically(">", time.Second))
 			})
 		})
@@ -916,5 +931,8 @@ var _ = Describe("Standard IPv4 IPVersionConfig", func() {
 	It("should not own other chains", func() {
 		Expect(v4VersionConf.OwnsIPSet("foobar")).To(BeFalse())
 		Expect(v4VersionConf.OwnsIPSet("noncali")).To(BeFalse())
+	})
+	It("should work with StripPrefix", func() {
+		Expect(StripIPSetNamePrefix(v4VersionConf.NameForMainIPSet(ipSetID))).To(HavePrefix(ipSetID[:20]))
 	})
 })

--- a/felix/ipsets/ipsets_test.go
+++ b/felix/ipsets/ipsets_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/felix/ip"
@@ -46,6 +47,14 @@ const (
 var (
 	v4Members1And2 = []string{"10.0.0.1", "10.0.0.2"}
 )
+
+var exampleMembersByType = map[IPSetType][]string{
+	IPSetTypeHashIP:     {"10.0.0.1", "10.0.0.2", "10.0.1.0"},
+	IPSetTypeHashIPPort: {"10.0.0.1,tcp:8080", "10.0.0.1,tcp:8081", "10.0.0.2,udp:1234"},
+	IPSetTypeHashNet:    {"10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/25"},
+	IPSetTypeBitmapPort: {"8080", "80", "443"},
+	IPSetTypeHashNetNet: {"10.0.0.0/24,10.0.0.1/32", "10.0.1.0/24,10.0.0.2/32", "10.0.2.0/25,10.0.0.3/32"},
+}
 
 var _ = Describe("IPSetType", func() {
 	It("should treat invalid strings as invalid", func() {
@@ -344,6 +353,111 @@ var _ = Describe("IP sets dataplane", func() {
 			}))
 			// It shouldn't try to double-delete the temp IP set.
 			Expect(dataplane.TriedToDeleteNonExistent).To(BeFalse())
+		})
+	})
+
+	for _, ipSetType := range AllIPSetTypes {
+		dataplaneMeta := setMetadata{
+			Name:   v4MainIPSetName,
+			Family: "inet",
+			Type:   ipSetType,
+		}
+		if ipSetType == IPSetTypeBitmapPort {
+			dataplaneMeta.RangeMin = 10
+			dataplaneMeta.RangeMax = 1024
+		} else {
+			dataplaneMeta.MaxSize = 1024
+		}
+
+		ipSetType := ipSetType
+		Describe("Resync re-use tests for "+ipSetType.SetType(), func() {
+			members := exampleMembersByType[ipSetType]
+
+			BeforeEach(func() {
+				Expect(len(members)).To(BeNumerically(">=", 3),
+					"Need at least 3 example members of type "+ipSetType)
+				dataplane.IPSetMembers = map[string]set.Set[string]{
+					v4MainIPSetName: set.FromArray(members[0:2]),
+				}
+				dataplane.IPSetMetadata = map[string]setMetadata{
+					v4MainIPSetName: dataplaneMeta,
+				}
+			})
+
+			It("should be a valid IP set type", func() {
+				Expect(ipSetType.IsValid()).To(BeTrue(), "IP set type didn't this it was valid")
+			})
+
+			It("IP set should get reused if metadata is compatible", func() {
+				ipsets.AddOrReplaceIPSet(IPSetMetadata{
+					// Copy the dataplane metadata.  Only MaxSize or the Range values will be non-0.
+					MaxSize:  dataplaneMeta.MaxSize,
+					RangeMin: dataplaneMeta.RangeMin,
+					RangeMax: dataplaneMeta.RangeMax,
+
+					SetID: ipSetID,
+					Type:  ipSetType,
+				}, []string{members[0], members[2]})
+				apply()
+				dataplane.ExpectMembers(map[string][]string{
+					v4MainIPSetName: {members[0], members[2]},
+				})
+				Expect(dataplane.LinesExecuted).To(Equal([]string{
+					"del " + v4MainIPSetName + " " + members[1] + " --exist",
+					"add " + v4MainIPSetName + " " + members[2],
+					"COMMIT",
+				}), "Expected a minimal update to add/del one entry")
+			})
+
+			It("should get rewritten if metadata is not compatible", func() {
+				metadata := IPSetMetadata{
+					SetID: ipSetID,
+					Type:  ipSetType,
+				}
+				var headerStr string
+				if dataplaneMeta.MaxSize > 0 {
+					// Hash-based IP set.
+					metadata.MaxSize = dataplaneMeta.MaxSize + 1
+					headerStr = fmt.Sprintf("family inet maxelem %d", metadata.MaxSize)
+				} else {
+					// Bitmap-based IP set ahs a range, not a maxelems.
+					metadata.RangeMin = dataplaneMeta.RangeMin + 1
+					metadata.RangeMax = dataplaneMeta.RangeMax + 1
+					headerStr = fmt.Sprintf("range %d-%d", metadata.RangeMin, metadata.RangeMax)
+				}
+				ipsets.AddOrReplaceIPSet(metadata, []string{members[0]})
+				apply()
+				dataplane.ExpectMembers(map[string][]string{
+					v4MainIPSetName: {members[0]},
+				})
+				Expect(dataplane.LinesExecuted).To(Equal([]string{
+					"create cali4t0 " + ipSetType.SetType() + " " + headerStr,
+					"add cali4t0 " + members[0],
+					"swap " + v4MainIPSetName + " cali4t0",
+					"COMMIT",
+				}), "Expected a full rewrite")
+			})
+		})
+	}
+
+	Describe("with an unsupported calico IP set type in the dataplane", func() {
+		BeforeEach(func() {
+			dataplane.IPSetMembers = map[string]set.Set[string]{
+				v4MainIPSetName: set.From("unsupported-member"),
+			}
+			dataplane.IPSetMetadata = map[string]setMetadata{
+				v4MainIPSetName: {
+					Name:    v4MainIPSetName,
+					Family:  "inet",
+					Type:    "unknown:type",
+					MaxSize: 1234,
+				},
+			}
+		})
+
+		It("IP set should get cleaned up", func() {
+			apply()
+			dataplane.ExpectMembers(map[string][]string{})
 		})
 	})
 
@@ -936,3 +1050,23 @@ var _ = Describe("Standard IPv4 IPVersionConfig", func() {
 		Expect(StripIPSetNamePrefix(v4VersionConf.NameForMainIPSet(ipSetID))).To(HavePrefix(ipSetID[:20]))
 	})
 })
+
+var _ = DescribeTable("ParseRange tests",
+	func(input string, expMin, expMax int, errorExpected bool) {
+		rMin, rMax, err := ParseRange(input)
+		if errorExpected {
+			Expect(err).To(HaveOccurred())
+			return
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		Expect(rMin).To(Equal(expMin))
+		Expect(rMax).To(Equal(expMax))
+	},
+	Entry("0-20", "0-20", 0, 20, false),
+	Entry("1-20", "1-20", 1, 20, false),
+	Entry("1-FOO", "1-FOO", 0, 0, true),
+	Entry("FOO-1", "FOO-1", 0, 0, true),
+	Entry("FOO", "FOO", 0, 0, true),
+)

--- a/felix/ipsets/utils_for_test.go
+++ b/felix/ipsets/utils_for_test.go
@@ -65,6 +65,7 @@ type mockDataplane struct {
 	TriedToDeleteNonExistent bool
 	TriedToAddExistent       bool
 
+	LinesExecuted     []string
 	AttemptedDestroys []string
 
 	CumulativeSleep time.Duration
@@ -271,35 +272,50 @@ func (c *restoreCmd) main() {
 			"line":    line,
 			"subCmd":  subCmd,
 		}).Info("Mock dataplane, analysing ipset restore line")
+		c.Dataplane.LinesExecuted = append(c.Dataplane.LinesExecuted, line)
 		if subCmd != "COMMIT" {
 			Expect(commitSeen).To(BeFalse())
 		}
 		switch subCmd {
 		case "create":
-			Expect(len(parts)).To(Equal(7))
-
 			name := parts[1]
 			Expect(len(name)).To(BeNumerically("<=", MaxIPSetNameLength))
 			Expect(name).To(HavePrefix("cali"))
 
 			ipSetType := IPSetType(parts[2])
-			Expect(ipSetType.IsValid()).To(BeTrue())
+			Expect(ipSetType.IsValid()).To(BeTrue(), "Invalid IP set type: "+parts[2])
 
-			Expect(parts[3]).To(Equal("family"))
-			ipFamily := IPFamily(parts[4])
-			Expect(ipFamily.IsValid()).To(BeTrue())
+			var meta setMetadata
+			if ipSetType == IPSetTypeBitmapPort {
+				// Has no "family".
+				// create cali4t0 bitmap:port range 10-1024
+				Expect(parts).To(HaveLen(5))
+				Expect(parts[3]).To(Equal("range"))
+				rMin, rMax, err := ParseRange(parts[4])
+				Expect(err).NotTo(HaveOccurred())
+				meta = setMetadata{
+					Name:     name,
+					RangeMin: rMin,
+					RangeMax: rMax,
+					Type:     ipSetType,
+				}
+			} else {
+				Expect(parts).To(HaveLen(7))
+				Expect(parts[3]).To(Equal("family"))
+				ipFamily := IPFamily(parts[4])
+				Expect(ipFamily.IsValid()).To(BeTrue())
 
-			Expect(parts[5]).To(Equal("maxelem"))
-			maxElem, err := strconv.Atoi(parts[6])
-			Expect(err).NotTo(HaveOccurred())
-
-			setMetadata := setMetadata{
-				Name:    name,
-				Family:  ipFamily,
-				MaxSize: maxElem,
-				Type:    ipSetType,
+				Expect(parts[5]).To(Equal("maxelem"))
+				maxElem, err := strconv.Atoi(parts[6])
+				Expect(err).NotTo(HaveOccurred())
+				meta = setMetadata{
+					Name:    name,
+					Family:  ipFamily,
+					MaxSize: maxElem,
+					Type:    ipSetType,
+				}
 			}
-			log.WithField("setMetadata", setMetadata).Info("Set created")
+			log.WithField("setMetadata", meta).Info("Set created")
 
 			if _, ok := c.Dataplane.IPSetMembers[name]; ok {
 				_, _ = c.Stderr.Write([]byte("set exists"))
@@ -308,7 +324,7 @@ func (c *restoreCmd) main() {
 			}
 
 			c.Dataplane.IPSetMembers[name] = set.New[string]()
-			c.Dataplane.IPSetMetadata[name] = setMetadata
+			c.Dataplane.IPSetMetadata[name] = meta
 		case "destroy":
 			Expect(len(parts)).To(Equal(2))
 			name := parts[1]
@@ -420,10 +436,12 @@ func (d *restoreCmd) CombinedOutput() ([]byte, error) {
 }
 
 type setMetadata struct {
-	Name    string
-	Family  IPFamily
-	Type    IPSetType
-	MaxSize int
+	Name     string
+	Family   IPFamily
+	Type     IPSetType
+	MaxSize  int
+	RangeMin int
+	RangeMax int
 }
 
 type destroyCmd struct {
@@ -679,7 +697,13 @@ func (c *listCmd) main() {
 			}
 		}
 		fmt.Fprintf(c.Stdout, "Type: %s\n", meta.Type)
-		fmt.Fprintf(c.Stdout, "Header: family %s hashsize 1024 maxelem %d\n", meta.Family, meta.MaxSize)
+		if meta.Type == IPSetTypeBitmapPort {
+			fmt.Fprintf(c.Stdout, "Header: family %s range %d-%d\n", meta.Family, meta.RangeMin, meta.RangeMax)
+		} else if meta.Type == "unknown:type" {
+			fmt.Fprintf(c.Stdout, "Header: floop\n")
+		} else {
+			fmt.Fprintf(c.Stdout, "Header: family %s hashsize 1024 maxelem %d\n", meta.Family, meta.MaxSize)
+		}
 		fmt.Fprint(c.Stdout, "Field: foobar\n") // Dummy field, should get ignored.
 		fmt.Fprint(c.Stdout, "Members:\n")
 		members.Iter(func(member string) error {

--- a/felix/rules/rule_defs.go
+++ b/felix/rules/rule_defs.go
@@ -36,7 +36,7 @@ const (
 	ChainNamePrefix = "cali-"
 	// IPSetNamePrefix: similarly for IP sets, we use the following prefix; the IP sets layer
 	// adds its own "-" so it isn't included here.
-	IPSetNamePrefix = "cali"
+	IPSetNamePrefix = ipsets.IPSetNamePrefix
 
 	ChainFilterInput   = ChainNamePrefix + "INPUT"
 	ChainFilterForward = ChainNamePrefix + "FORWARD"


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR:
* Upstreams support for bitmap IP sets from Enterprise; the Enterprise code had drifted out of sync.
* Adds tests for all the IP set types, including proper handling of unknown types.
* Fixes a couple of minor issues found:
  * `bitmap:port` sets weren't in the valid list.
  * `caliXXX` Sets of unknown types weren't cleaned up (this is an issue after downgrade, for example, if the newer Calico version was using a new type of IP set).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
