### PR TITLE
Tweak selector names in named port index tests.

### DIFF
--- a/felix/labelindex/named_port_index_test.go
+++ b/felix/labelindex/named_port_index_test.go
@@ -979,18 +979,19 @@ type namedPortState struct {
 func (s namedPortState) CheckRecordedState(t *testing.T, rec *testRecorder) {
 	t.Helper()
 	for setName, expected := range s.ExpectedIPSetOutputs {
+		setName := "s:" + setName
 		memberStrings := set.New[string]()
 		for m := range rec.ipsets[setName] {
 			memberStrings.Add(memberToProto(m))
 		}
 		ExpectWithOffset(1, memberStrings).To(Equal(set.FromArray(expected)),
-			fmt.Sprintf("%s: expected IP set %s to have entries: %v, not %v", s.Name, setName, expected, memberStrings.Slice()))
+			fmt.Sprintf("%s: expected IP set %s to have entries: %v, not %v, all: %v", s.Name, setName, expected, memberStrings.Slice(), rec.ipsets))
 	}
 	for setName, members := range rec.ipsets {
-		if _, ok := s.ExpectedIPSetOutputs[setName]; ok {
+		if _, ok := s.ExpectedIPSetOutputs[strings.TrimPrefix(setName, "s:")]; ok {
 			continue
 		}
-		ExpectWithOffset(1, members).To(HaveLen(0), "Unexpected IP set")
+		ExpectWithOffset(1, members).To(HaveLen(0), "Unexpected IP set: "+setName)
 	}
 }
 
@@ -1116,14 +1117,14 @@ func applyStateTransition(idx *SelectorAndNamedPortIndex, rec *testRecorder, s1,
 		}
 		k := k
 		s := s
-
+		ipSetID := "s:" + k
 		ops = append(ops, func() {
-			idx.UpdateIPSet(k, s.ParsedSelector(), s.Protocol, s.Port)
+			idx.UpdateIPSet(ipSetID, s.ParsedSelector(), s.Protocol, s.Port)
 		})
 		if !dupeDone {
 			// For coverage of "unchanged IP set" case.
 			ops = append(ops, func() {
-				idx.UpdateIPSet(k, s.ParsedSelector(), s.Protocol, s.Port)
+				idx.UpdateIPSet(ipSetID, s.ParsedSelector(), s.Protocol, s.Port)
 			})
 			dupeDone = true
 		}
@@ -1134,13 +1135,13 @@ func applyStateTransition(idx *SelectorAndNamedPortIndex, rec *testRecorder, s1,
 			continue
 		}
 		k := k
-
+		ipSetID := "s:" + k
 		ops = append(ops, func() {
-			idx.DeleteIPSet(k)
+			idx.DeleteIPSet(ipSetID)
 		})
 		if !dupeDone {
 			ops = append(ops, func() {
-				idx.DeleteIPSet(k)
+				idx.DeleteIPSet(ipSetID)
 			})
 			dupeDone = true
 		}
@@ -1164,7 +1165,8 @@ func applyStateTransition(idx *SelectorAndNamedPortIndex, rec *testRecorder, s1,
 		if _, ok := s2.IPSets[k]; ok {
 			continue
 		}
-		delete(rec.ipsets, k)
+		ipSetID := "s:" + k
+		delete(rec.ipsets, ipSetID)
 	}
 }
 


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
When merging to Enterprise, I realised the code there conditioned on the name prefix.  Add the expected prefix.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-9782
CORE-9780

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
