### PR TITLE
fv infra for runnign full ipv6 tests

### DIFF
--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -234,7 +234,12 @@ func (c *Checker) ActualConnectivity(isARetry bool) ([]*Result, []string) {
 
 			if res != nil {
 				if c.CheckSNAT {
-					srcIP := strings.Split(res.LastResponse.SourceAddr, ":")[0]
+					var srcIP string
+					if res.LastResponse.SourceAddr != "" && res.LastResponse.SourceAddr[0] == '[' {
+						srcIP = strings.Split(res.LastResponse.SourceAddr[1:], "]")[0]
+					} else {
+						srcIP = strings.Split(res.LastResponse.SourceAddr, ":")[0]
+					}
 					pretty[i] += " (from " + srcIP + ")"
 				}
 				if res.ClientMTU.Start != 0 {
@@ -439,7 +444,11 @@ type Response struct {
 }
 
 func (r *Response) SourceIP() string {
-	return strings.Split(r.SourceAddr, ":")[0]
+	if r.SourceAddr[0] != '[' {
+		return strings.Split(r.SourceAddr, ":")[0]
+	}
+
+	return strings.Split(r.SourceAddr[1:], "]")[0]
 }
 
 type ConnectionTarget interface {

--- a/felix/fv/containers/containers.go
+++ b/felix/fv/containers/containers.go
@@ -698,6 +698,9 @@ func (c *Container) SourceName() string {
 
 func (c *Container) SourceIPs() []string {
 	ips := []string{c.IP}
+	if c.IPv6 != "" {
+		ips = append(ips, c.IPv6)
+	}
 	ips = append(ips, c.ExtraSourceIPs...)
 	return ips
 }
@@ -830,4 +833,12 @@ func (c *Container) BPFNATHasBackendForService(svcIP string, svcPort, proto int,
 	}
 
 	return true
+}
+
+func GetIPv4(c *Container) string {
+	return c.IP
+}
+
+func GetIPv6(c *Container) string {
+	return c.IPv6
 }

--- a/felix/fv/containers/containers.go
+++ b/felix/fv/containers/containers.go
@@ -834,11 +834,3 @@ func (c *Container) BPFNATHasBackendForService(svcIP string, svcPort, proto int,
 
 	return true
 }
-
-func GetIPv4(c *Container) string {
-	return c.IP
-}
-
-func GetIPv6(c *Container) string {
-	return c.IPv6
-}

--- a/felix/fv/infrastructure/datastore_describe.go
+++ b/felix/fv/infrastructure/datastore_describe.go
@@ -21,7 +21,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 )
 
-type InfraFactory func() DatastoreInfra
+type InfraFactory func(...CreateOption) DatastoreInfra
 
 // DatastoreDescribe is a replacement for ginkgo.Describe which invokes Describe
 // multiple times for one or more different datastore drivers - passing in the

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -65,6 +65,8 @@ type Felix struct {
 	startupDelayed bool
 	restartDelayed bool
 	Workloads      []workload
+
+	TopologyOptions TopologyOptions
 }
 
 type workload interface {
@@ -223,8 +225,9 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 		"-P", "FORWARD", "DROP")
 
 	return &Felix{
-		Container:      c,
-		startupDelayed: options.DelayFelixStart,
+		Container:       c,
+		startupDelayed:  options.DelayFelixStart,
+		TopologyOptions: options,
 	}
 }
 

--- a/felix/fv/infrastructure/infra_etcd.go
+++ b/felix/fv/infrastructure/infra_etcd.go
@@ -42,7 +42,7 @@ type EtcdDatastoreInfra struct {
 	BadEndpoint string
 }
 
-func createEtcdDatastoreInfra() DatastoreInfra {
+func createEtcdDatastoreInfra(opts ...CreateOption) DatastoreInfra {
 	infra, err := GetEtcdDatastoreInfra()
 	Expect(err).NotTo(HaveOccurred())
 	return infra

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -71,6 +71,12 @@ type K8sDatastoreInfra struct {
 	needsCleanup bool
 
 	runningTest string
+
+	ipv6                  bool
+	serviceClusterIPRange string
+	apiServerBindIP       string
+	containerGetIP        func(*containers.Container) string
+	ipMask                string
 }
 
 var (
@@ -143,24 +149,40 @@ func TearDownK8sInfra(kds *K8sDatastoreInfra) {
 	log.Info("TearDownK8sInfra done")
 }
 
-func createK8sDatastoreInfra() DatastoreInfra {
-	infra, err := GetK8sDatastoreInfra(K8SInfraLocalCluster)
+func createK8sDatastoreInfra(opts ...CreateOption) DatastoreInfra {
+	infra, err := GetK8sDatastoreInfra(K8SInfraLocalCluster, opts...)
 	Expect(err).NotTo(HaveOccurred())
 	return infra
 }
 
-func GetK8sDatastoreInfra(index K8sInfraIndex) (*K8sDatastoreInfra, error) {
-	if K8sInfra[index] != nil {
-		if K8sInfra[index].runningTest != "" {
+func GetK8sDatastoreInfra(index K8sInfraIndex, opts ...CreateOption) (*K8sDatastoreInfra, error) {
+	var temp K8sDatastoreInfra
+
+	for _, o := range opts {
+		o(&temp)
+	}
+
+	kds := K8sInfra[index]
+
+	if kds != nil {
+		if kds.runningTest != "" {
 			ginkgo.Fail(fmt.Sprintf("Previous test didn't clean up the infra: %s", K8sInfra[index].runningTest))
 		}
-		K8sInfra[index].EnsureReady()
-		K8sInfra[index].PerTestSetup(index)
-		return K8sInfra[index], nil
+
+		resetAll := temp.ipv6 != kds.ipv6
+
+		if !resetAll {
+			kds.EnsureReady()
+			kds.PerTestSetup(index)
+			return kds, nil
+		}
+
+		TearDownK8sInfra(kds)
+		K8sInfra[index] = nil
 	}
 
 	var err error
-	K8sInfra[index], err = setupK8sDatastoreInfra()
+	K8sInfra[index], err = setupK8sDatastoreInfra(opts...)
 	if err == nil {
 		K8sInfra[index].PerTestSetup(index)
 	}
@@ -183,19 +205,15 @@ func (kds *K8sDatastoreInfra) PerTestSetup(index K8sInfraIndex) {
 	K8sInfra[index].runningTest = ginkgo.CurrentGinkgoTestDescription().FullTestText
 }
 
-func runK8sApiserver(etcdIp string) *containers.Container {
-	return containers.Run("apiserver",
-		containers.RunOpts{
-			AutoRemove: true,
-			StopSignal: "SIGKILL",
-		},
-		"-v", os.Getenv("CERTS_PATH")+":/home/user/certs", // Mount in location of certificates.
+func (kds *K8sDatastoreInfra) runK8sApiserver() {
+	args := []string{
+		"-v", os.Getenv("CERTS_PATH") + ":/home/user/certs", // Mount in location of certificates.
 		utils.Config.K8sImage,
 		"kube-apiserver",
 		"--v=0",
-		"--service-cluster-ip-range=10.101.0.0/16",
+		"--service-cluster-ip-range=" + kds.serviceClusterIPRange,
 		"--authorization-mode=RBAC",
-		fmt.Sprintf("--etcd-servers=http://%s:2379", etcdIp),
+		fmt.Sprintf("--etcd-servers=http://%s:2379", kds.containerGetIPForURL(kds.etcdContainer)),
 		"--service-account-key-file=/home/user/certs/service-account.pem",
 		"--service-account-signing-key-file=/home/user/certs/service-account-key.pem",
 		"--service-account-issuer=https://localhost:443",
@@ -206,19 +224,29 @@ func runK8sApiserver(etcdIp string) *containers.Container {
 		"--enable-priority-and-fairness=false",
 		"--max-mutating-requests-inflight=0",
 		"--max-requests-inflight=0",
-	)
-}
+	}
 
-func runK8sControllerManager(apiserverIp string) *containers.Container {
-	c := containers.Run("controller-manager",
+	if kds.apiServerBindIP != "" {
+		args = append(args, "--bind-address="+kds.apiServerBindIP)
+	}
+
+	apiserver := containers.Run("apiserver",
 		containers.RunOpts{
 			AutoRemove: true,
 			StopSignal: "SIGKILL",
 		},
-		"-v", os.Getenv("CERTS_PATH")+"/:/home/user/certs", // Mount in location of certificates.
+		args...,
+	)
+
+	kds.k8sApiContainer = apiserver
+}
+
+func (kds *K8sDatastoreInfra) runK8sControllerManager() {
+	args := []string{
+		"-v", os.Getenv("CERTS_PATH") + "/:/home/user/certs", // Mount in location of certificates.
 		utils.Config.K8sImage,
 		"kube-controller-manager",
-		fmt.Sprintf("--master=https://%v:6443", apiserverIp),
+		fmt.Sprintf("--master=https://%v:6443", kds.containerGetIPForURL(kds.k8sApiContainer)),
 		"--kubeconfig=/home/user/certs/kube-controller-manager.kubeconfig",
 		// We run trivially small clusters, so increase the QPS to get the
 		// cluster to start up as fast as possible.
@@ -233,15 +261,36 @@ func runK8sControllerManager(apiserverIp string) *containers.Container {
 		"--service-account-private-key-file=/home/user/certs/service-account-key.pem",
 		"--root-ca-file=/home/user/certs/ca.pem",
 		"--concurrent-gc-syncs=50",
+	}
+
+	if kds.serviceClusterIPRange != "" {
+		args = append(args, "--service-cluster-ip-range="+kds.serviceClusterIPRange)
+	}
+
+	c := containers.Run("controller-manager",
+		containers.RunOpts{
+			AutoRemove: true,
+			StopSignal: "SIGKILL",
+		},
+		args...,
 	)
-	return c
+
+	kds.k8sControllerManager = c
 }
 
-func setupK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
+func setupK8sDatastoreInfra(opts ...CreateOption) (*K8sDatastoreInfra, error) {
 	log.Info("Starting Kubernetes infrastructure")
 
 	log.Info("Starting etcd")
-	kds := &K8sDatastoreInfra{}
+	kds := &K8sDatastoreInfra{
+		serviceClusterIPRange: "10.101.0.0/16",
+		containerGetIP:        containers.GetIPv4,
+		ipMask:                "/32",
+	}
+
+	for _, o := range opts {
+		o(kds)
+	}
 
 	// Start etcd, which will back the k8s API server.
 	kds.etcdContainer = RunEtcd()
@@ -261,7 +310,7 @@ func setupK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 	// ClusterRoleBinding that gives the "system:anonymous" user unlimited power (aka the
 	// "cluster-admin" role).
 	log.Info("Starting API server")
-	kds.k8sApiContainer = runK8sApiserver(kds.etcdContainer.IP)
+	kds.runK8sApiserver()
 
 	if kds.k8sApiContainer == nil {
 		TearDownK8sInfra(kds)
@@ -275,7 +324,7 @@ func setupK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 		var err error
 		kds.K8sClient, err = kubernetes.NewForConfig(&rest.Config{
 			Transport: insecureTransport,
-			Host:      "https://" + kds.k8sApiContainer.IP + ":6443",
+			Host:      "https://" + kds.containerGetIPForURL(kds.k8sApiContainer) + ":6443",
 			QPS:       100,
 			Burst:     100,
 		})
@@ -301,7 +350,7 @@ func setupK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 			"--insecure-skip-tls-verify=true",
 			"--client-key=/home/user/certs/admin-key.pem",
 			"--client-certificate=/home/user/certs/admin.pem",
-			fmt.Sprintf("--server=https://%s:6443", kds.k8sApiContainer.IP),
+			fmt.Sprintf("--server=https://%s:6443", kds.containerGetIPForURL(kds.k8sApiContainer)),
 			"--clusterrole=cluster-admin",
 			"--user=system:anonymous",
 		)
@@ -338,7 +387,7 @@ func setupK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 	log.Info("List namespaces successfully.")
 
 	log.Info("Starting controller manager.")
-	kds.k8sControllerManager = runK8sControllerManager(kds.k8sApiContainer.IP)
+	kds.runK8sControllerManager()
 	if kds.k8sApiContainer == nil {
 		TearDownK8sInfra(kds)
 		return nil, errors.New("failed to create k8s controller manager container")
@@ -359,9 +408,9 @@ func setupK8sDatastoreInfra() (*K8sDatastoreInfra, error) {
 		return nil, err
 	}
 
-	kds.EndpointIP = kds.k8sApiContainer.IP
-	kds.Endpoint = fmt.Sprintf("https://%s:6443", kds.k8sApiContainer.IP)
-	kds.BadEndpoint = fmt.Sprintf("https://%s:1234", kds.k8sApiContainer.IP)
+	kds.EndpointIP = kds.containerGetIP(kds.k8sApiContainer)
+	kds.Endpoint = fmt.Sprintf("https://%s:6443", kds.containerGetIPForURL(kds.k8sApiContainer))
+	kds.BadEndpoint = fmt.Sprintf("https://%s:1234", kds.containerGetIPForURL(kds.k8sApiContainer))
 
 	start = time.Now()
 	for {
@@ -501,7 +550,7 @@ type cleanupFunc func(clientset *kubernetes.Clientset, calicoClient client.Inter
 func (kds *K8sDatastoreInfra) CleanUp() {
 	log.Info("Cleaning up kubernetes datastore")
 	startTime := time.Now()
-	for _, f := range []cleanupFunc{
+	cleanupFuncs := []cleanupFunc{
 		cleanupAllPods,
 		cleanupAllNodes,
 		cleanupAllNamespaces,
@@ -512,9 +561,12 @@ func (kds *K8sDatastoreInfra) CleanUp() {
 		cleanupAllHostEndpoints,
 		cleanupAllFelixConfigurations,
 		cleanupAllServices,
-	} {
+	}
+
+	for _, f := range cleanupFuncs {
 		f(kds.K8sClient, kds.calicoClient)
 	}
+
 	kds.needsCleanup = false
 	log.WithField("time", time.Since(startTime)).Info("Cleaned up kubernetes datastore")
 }
@@ -587,7 +639,9 @@ func (kds *K8sDatastoreInfra) SetExpectedVXLANTunnelAddr(felix *Felix, cidr *net
 }
 
 func (kds *K8sDatastoreInfra) SetExpectedVXLANV6TunnelAddr(felix *Felix, cidr *net.IPNet, idx int, needBGP bool) {
-	felix.ExpectedVXLANV6TunnelAddr = fmt.Sprintf("%x%x:%x%x:%x%x:%x%x:%x%x:%x%x:%d:0", cidr.IP[0], cidr.IP[1], cidr.IP[2], cidr.IP[3], cidr.IP[4], cidr.IP[5], cidr.IP[6], cidr.IP[7], cidr.IP[8], cidr.IP[9], cidr.IP[10], cidr.IP[11], idx)
+	felix.ExpectedVXLANV6TunnelAddr = net.ParseIP(fmt.Sprintf("%x%x:%x%x:%x%x:%x%x:%x%x:%x%x:%d:0",
+		cidr.IP[0], cidr.IP[1], cidr.IP[2], cidr.IP[3], cidr.IP[4], cidr.IP[5], cidr.IP[6],
+		cidr.IP[7], cidr.IP[8], cidr.IP[9], cidr.IP[10], cidr.IP[11], idx)).String()
 	felix.ExtraSourceIPs = append(felix.ExtraSourceIPs, felix.ExpectedVXLANV6TunnelAddr)
 }
 
@@ -599,12 +653,18 @@ func (kds *K8sDatastoreInfra) SetExpectedWireguardTunnelAddr(felix *Felix, cidr 
 
 func (kds *K8sDatastoreInfra) SetExpectedWireguardV6TunnelAddr(felix *Felix, cidr *net.IPNet, idx int, needWg bool) {
 	// Set to be the same as IPIP tunnel address.
-	felix.ExpectedWireguardV6TunnelAddr = fmt.Sprintf("%x%x:%x%x:%x%x:%x%x:%x%x:%x%x:%d:0", cidr.IP[0], cidr.IP[1], cidr.IP[2], cidr.IP[3], cidr.IP[4], cidr.IP[5], cidr.IP[6], cidr.IP[7], cidr.IP[8], cidr.IP[9], cidr.IP[10], cidr.IP[11], idx)
+	felix.ExpectedWireguardV6TunnelAddr = net.ParseIP(fmt.Sprintf("%x%x:%x%x:%x%x:%x%x:%x%x:%x%x:%d:0",
+		cidr.IP[0], cidr.IP[1], cidr.IP[2], cidr.IP[3], cidr.IP[4], cidr.IP[5], cidr.IP[6],
+		cidr.IP[7], cidr.IP[8], cidr.IP[9], cidr.IP[10], cidr.IP[11], idx)).String()
 	felix.ExtraSourceIPs = append(felix.ExtraSourceIPs, felix.ExpectedWireguardV6TunnelAddr)
 }
 
 func (kds *K8sDatastoreInfra) SetExternalIP(felix *Felix, idx int) {
-	felix.ExternalIP = fmt.Sprintf("111.222.%d.1", idx)
+	if felix.TopologyOptions.EnableIPv6 {
+		felix.ExternalIP = fmt.Sprintf("111:222::%d:1", idx)
+	} else {
+		felix.ExternalIP = fmt.Sprintf("111.222.%d.1", idx)
+	}
 	felix.ExtraSourceIPs = append(felix.ExtraSourceIPs, felix.ExternalIP)
 }
 
@@ -662,6 +722,9 @@ func (kds *K8sDatastoreInfra) AddNode(felix *Felix, v4CIDR *net.IPNet, v6CIDR *n
 	}
 	if felix.ExpectedWireguardTunnelAddr != "" {
 		nodeIn.Annotations["projectcalico.org/IPv4WireguardInterfaceAddr"] = felix.ExpectedWireguardTunnelAddr
+	}
+	if felix.ExpectedWireguardV6TunnelAddr != "" {
+		nodeIn.Annotations["projectcalico.org/IPv6WireguardInterfaceAddr"] = felix.ExpectedWireguardV6TunnelAddr
 	}
 	log.WithField("nodeIn", nodeIn).Debug("Node defined")
 	nodeOut, err := kds.K8sClient.CoreV1().Nodes().Create(context.Background(), nodeIn, metav1.CreateOptions{})
@@ -773,7 +836,7 @@ func (kds *K8sDatastoreInfra) AddAllowToDatastore(selector string) error {
 	policy.Spec.Egress = []api.Rule{{
 		Action: api.Allow,
 		Destination: api.EntityRule{
-			Nets: []string{kds.k8sApiContainer.IP + "/32"},
+			Nets: []string{kds.containerGetIPWithMask(kds.k8sApiContainer)},
 		},
 	}}
 	_, err := kds.calicoClient.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
@@ -846,6 +909,18 @@ func (kds *K8sDatastoreInfra) DumpErrorData() {
 			log.Info(spew.Sdump(hep))
 		}
 	}
+}
+
+func (kds *K8sDatastoreInfra) containerGetIPForURL(c *containers.Container) string {
+	if kds.ipv6 {
+		return "[" + kds.containerGetIP(c) + "]"
+	}
+
+	return kds.containerGetIP(c)
+}
+
+func (kds *K8sDatastoreInfra) containerGetIPWithMask(c *containers.Container) string {
+	return kds.containerGetIP(c) + kds.ipMask
 }
 
 var (
@@ -1055,4 +1130,30 @@ func cleanupAllServices(clientset *kubernetes.Clientset, calicoClient client.Int
 		}
 	}
 	log.Info("Cleaned up services")
+}
+
+func K8sWithServiceClusterIPRange(cidr string) CreateOption {
+	return func(ds DatastoreInfra) {
+		if kds, ok := ds.(*K8sDatastoreInfra); ok {
+			kds.serviceClusterIPRange = cidr
+		}
+	}
+}
+
+func K8sWithAPIServerBindAddress(ip string) CreateOption {
+	return func(ds DatastoreInfra) {
+		if kds, ok := ds.(*K8sDatastoreInfra); ok {
+			kds.apiServerBindIP = ip
+		}
+	}
+}
+
+func K8sWithIPv6() CreateOption {
+	return func(ds DatastoreInfra) {
+		if kds, ok := ds.(*K8sDatastoreInfra); ok {
+			kds.ipv6 = true
+			kds.containerGetIP = containers.GetIPv6
+			kds.ipMask = "/128"
+		}
+	}
 }

--- a/felix/fv/infrastructure/infrastructure.go
+++ b/felix/fv/infrastructure/infrastructure.go
@@ -109,3 +109,5 @@ func CreateDefaultProfile(c client.Interface, name string, labels map[string]str
 	_, err := c.Profiles().Create(utils.Ctx, d, utils.NoOptions)
 	Expect(err).NotTo(HaveOccurred())
 }
+
+type CreateOption func(DatastoreInfra)

--- a/felix/fv/latency_test.go
+++ b/felix/fv/latency_test.go
@@ -66,6 +66,7 @@ var _ = Context("_BPF-SAFE_ Latency tests with initialized Felix and etcd datast
 	BeforeEach(func() {
 		topologyOptions := infrastructure.DefaultTopologyOptions()
 		topologyOptions.EnableIPv6 = true
+		topologyOptions.IPIPEnabled = false
 		topologyOptions.ExtraEnvVars["FELIX_BPFLOGLEVEL"] = "off" // For best perf.
 
 		tc, etcd, client, infra = infrastructure.StartSingleNodeEtcdTopology(topologyOptions)

--- a/felix/fv/vxlan_test.go
+++ b/felix/fv/vxlan_test.go
@@ -63,7 +63,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before addin
 		brokenXSum := testConfig.BrokenXSum
 		enableIPv6 := testConfig.EnableIPv6
 
-		if BPFMode() && enableIPv6 && !BPFIPv6Support() {
+		if BPFMode() && enableIPv6 {
 			continue
 		}
 

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -157,12 +157,16 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 							&infra,
 							&topologyOptions,
 							&client,
-							fmt.Sprintf("dead:beef::100:%d:2", i),
+							fmt.Sprintf("dead:beef::0:%d:2", i),
 							fmt.Sprintf("wlv6-%d", i),
 							topologyContainers.Felixes[i])
 
 						// Prepare route entry.
-						routeEntriesV6[i] = fmt.Sprintf("dead:beef::100:%d:0/122 dev %s metric 1024 pref medium", i, wireguardInterfaceNameV6Default)
+						if i == 0 {
+							routeEntriesV6[i] = fmt.Sprintf("dead:beef::/122 dev %s metric 1024 pref medium", wireguardInterfaceNameV6Default)
+						} else {
+							routeEntriesV6[i] = fmt.Sprintf("dead:beef::%d:0/122 dev %s metric 1024 pref medium", i, wireguardInterfaceNameV6Default)
+						}
 					}
 					// Swap route entry to match between workloads.
 					routeEntriesV6[0], routeEntriesV6[1] = routeEntriesV6[1], routeEntriesV6[0]

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -140,7 +140,7 @@ func New(c *infrastructure.Felix, name, profile, ip, ports, protocol string, opt
 	interfaceName := conversion.NewConverter().VethNameForWorkload(profile, n)
 	spoofN := fmt.Sprintf("%s-spoof%v", name, workloadIdx)
 	spoofIfaceName := conversion.NewConverter().VethNameForWorkload(profile, spoofN)
-	if c.IP == ip {
+	if c.IP == ip || c.IPv6 == ip {
 		interfaceName = ""
 		spoofIfaceName = ""
 	}


### PR DESCRIPTION
## Description

    Pods and nodes have ipv6 addresses, so have tunnel interfaces.
    
    api server listens on ipv6 address.
    
    services have ipv6 addresses.
    
    In fact, the infra then runs in ipv4/6 dual mode.

refs https://github.com/projectcalico/calico/issues/4736

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
