### PR TITLE
[BPF] ipv6 core programs

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -195,7 +195,8 @@ protobuf proto/felixbackend.pb.go: proto/felixbackend.proto
 
 # We pre-build lots of different variants of the TC programs, defer to the script.
 BPF_GPL_O_FILES:=$(addprefix bpf-gpl/,$(shell bpf-gpl/list-objs))
-BPF_GPL_O_FILES+=bpf-gpl/bin/tc_preamble.o bpf-gpl/bin/xdp_preamble.o bpf-gpl/bin/policy_default.o
+BPF_GPL_O_FILES+=bpf-gpl/bin/tc_preamble.o bpf-gpl/bin/tc_preamble_v6.o \
+		 bpf-gpl/bin/xdp_preamble.o bpf-gpl/bin/policy_default.o
 
 # There's a one-to-one mapping from UT C files to objects and the same for the apache programs..
 BPF_GPL_UT_O_FILES:=$(BPF_GPL_UT_C_FILES:.c=.o) $(addprefix bpf-gpl/,$(shell bpf-gpl/list-ut-objs))

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -55,7 +55,7 @@ OBJS+=bin/tc_preamble.o
 OBJS+=bin/tc_preamble_v6.o
 OBJS+=bin/xdp_preamble.o
 OBJS+=bin/policy_default.o
-C_FILES:=tc_preamble.c tc.c connect_balancer.c connect_balancer_v6.c xdp_preamble.c xdp.c policy_default.c
+C_FILES:=tc_preamble.c tc.c connect_balancer.c connect_balancer_v46.c connect_balancer_v6.c xdp_preamble.c xdp.c policy_default.c
 
 all: $(OBJS)
 ut-objs: $(UT_OBJS)
@@ -63,8 +63,10 @@ ut-objs: $(UT_OBJS)
 COMPILE=$(CC) $(CFLAGS) `./calculate-flags $@` -c $< -o $@
 connect_time_%v4.ll: connect_balancer.c connect_balancer.d calculate-flags
 	$(COMPILE)
-connect_time_%v6.ll: connect_balancer_v6.c connect_balancer_v6.d calculate-flags
+connect_time_%v46.ll: connect_balancer_v46.c connect_balancer_v46.d calculate-flags
 	$(COMPILE)
+connect_time_%v6.ll: connect_balancer_v6.c connect_balancer_v6.d calculate-flags
+	$(COMPILE) -DIPVER6
 
 UT_CFLAGS=\
 	-D__BPFTOOL_LOADER__ \
@@ -127,9 +129,13 @@ bin/xdp%.o: xdp%.ll | bin
 	$(LINK)
 bin/connect_time_%v4.o: connect_time_%v4.ll | bin
 	$(LINK)
+bin/connect_time_%v46.o: connect_time_%v46.ll | bin
+	$(LINK)
 bin/connect_time_%v6.o: connect_time_%v6.ll | bin
 	$(LINK)
 bin/connect_time_%v4_co-re.o: connect_time_%v4.ll | bin
+	$(LINK)
+bin/connect_time_%v46_co-re.o: connect_time_%v46.ll | bin
 	$(LINK)
 bin/connect_time_%v6_co-re.o: connect_time_%v6.ll | bin
 	$(LINK)

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -102,12 +102,7 @@
 #define CALI_FIB_LOOKUP_ENABLED true
 #endif
 
-#ifdef IPVER6
-#undef CALI_FIB_LOOKUP_ENABLED
-#define CALI_FIB_LOOKUP_ENABLED false
-#else
 #define CALI_FIB_ENABLED (!CALI_F_L3 && CALI_FIB_LOOKUP_ENABLED && (CALI_F_TO_HOST || CALI_F_TO_HEP))
-#endif
 
 #define COMPILE_TIME_ASSERT(expr) {typedef char array[(expr) ? 1 : -1];}
 static CALI_BPF_INLINE void __compile_asserts(void) {

--- a/felix/bpf-gpl/connect.h
+++ b/felix/bpf-gpl/connect.h
@@ -40,7 +40,7 @@ static CALI_BPF_INLINE int do_nat_common(struct bpf_sock_addr *ctx, __u8 proto, 
 
 	__u64 cookie = bpf_get_socket_cookie(ctx);
 	CALI_DEBUG("Store: ip=%x port=%d cookie=%x\n",
-			bpf_ntohl(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
+			debug_ip(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
 
 	/* For all protocols, record recent NAT operations in an LRU map; other BPF programs use this
 	 * cache to reverse our DNAT so they can do pre-DNAT policy. */
@@ -65,7 +65,7 @@ static CALI_BPF_INLINE int do_nat_common(struct bpf_sock_addr *ctx, __u8 proto, 
 		 * check the source on the return packets. */
 		__u64 cookie = bpf_get_socket_cookie(ctx);
 		CALI_DEBUG("Store: ip=%x port=%d cookie=%x\n",
-				bpf_ntohl(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
+				debug_ip(nat_dest->addr), bpf_ntohs((__u16)dport_be), cookie);
 		struct sendrec_key key = {
 			.ip	= nat_dest->addr,
 			.port	= dport_be,
@@ -86,7 +86,7 @@ out:
 	return err;
 }
 
-static CALI_BPF_INLINE int connect_v4(struct bpf_sock_addr *ctx, ipv46_addr_t *dst)
+static CALI_BPF_INLINE int connect(struct bpf_sock_addr *ctx, ipv46_addr_t *dst)
 {
 	int ret = 1; /* OK value */
 

--- a/felix/bpf-gpl/connect_balancer.c
+++ b/felix/bpf-gpl/connect_balancer.c
@@ -25,7 +25,7 @@ int calico_connect_v4(struct bpf_sock_addr *ctx)
 {
 	CALI_DEBUG("calico_connect_v4\n");
 
-	return connect_v4(ctx, &ctx->user_ip4);
+	return connect(ctx, &ctx->user_ip4);
 }
 
 SEC("cgroup/sendmsg4")

--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -1,0 +1,127 @@
+// Project Calico BPF dataplane programs.
+// Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+#include <linux/bpf.h>
+
+// socket_type.h contains the definition of SOCK_XXX constants that we need
+// but it's supposed to be imported via socket.h, which we can't import due
+// to lack of std lib support for BPF.  Bypass its check for now.
+#define _SYS_SOCKET_H
+#include <bits/socket_type.h>
+
+#include <stdbool.h>
+
+#include "bpf.h"
+#include "log.h"
+#include "globals.h"
+#include "ctlb.h"
+
+#include "sendrecv.h"
+#include "connect.h"
+
+SEC("cgroup/connect6")
+int calico_connect_v46(struct bpf_sock_addr *ctx)
+{
+	int ret = 1;
+	__be32 ipv4;
+
+	CALI_DEBUG("connect_v46 ip[0-1] %x%x\n",
+			ctx->user_ip6[0],
+			ctx->user_ip6[1]);
+	CALI_DEBUG("connect_v46 ip[2-3] %x%x\n",
+			ctx->user_ip6[2],
+			ctx->user_ip6[3]);
+
+	/* check if it is a IPv4 mapped as IPv6 and if so, use the v4 table */
+	if (ctx->user_ip6[0] == 0 && ctx->user_ip6[1] == 0 &&
+			ctx->user_ip6[2] == bpf_htonl(0x0000ffff)) {
+		goto v4;
+	}
+
+	CALI_DEBUG("connect_v46: not implemented for v6 yet\n");
+	goto out;
+
+v4:
+	ipv4 = ctx->user_ip6[3];
+
+ 	if ((ret = connect(ctx, &ipv4)) != 1) {
+		goto out;
+	}
+
+	ctx->user_ip6[3] = ipv4;
+
+out:
+	return ret;
+}
+
+SEC("cgroup/sendmsg6")
+int calico_sendmsg_v46(struct bpf_sock_addr *ctx)
+{
+	CALI_DEBUG("sendmsg_v46\n");
+
+	return 1;
+}
+
+SEC("cgroup/recvmsg6")
+int calico_recvmsg_v46(struct bpf_sock_addr *ctx)
+{
+	if (CTLB_EXCLUDE_UDP) {
+		goto out;
+	}
+
+	__be32 ipv4;
+
+	CALI_DEBUG("recvmsg_v46 ip[0-1] %x%x\n",
+			ctx->user_ip6[0],
+			ctx->user_ip6[1]);
+	CALI_DEBUG("recvmsg_v46 ip[2-3] %x%x\n",
+			ctx->user_ip6[2],
+			ctx->user_ip6[3]);
+
+	/* check if it is a IPv4 mapped as IPv6 and if so, use the v4 table */
+	if (ctx->user_ip6[0] == 0 && ctx->user_ip6[1] == 0 &&
+			ctx->user_ip6[2] == bpf_htonl(0x0000ffff)) {
+		goto v4;
+	}
+
+	CALI_DEBUG("recvmsg_v46: not implemented for v6 yet\n");
+	goto out;
+
+
+v4:
+	ipv4 = ctx->user_ip6[3];
+	CALI_DEBUG("recvmsg_v46 %x:%d\n", bpf_ntohl(ipv4), ctx_port_to_host(ctx->user_port));
+
+	if (ctx->type != SOCK_DGRAM) {
+		CALI_INFO("unexpected sock type %d\n", ctx->type);
+		goto out;
+	}
+
+	struct sendrec_key key = {
+		.ip	= ipv4,
+		.port	= ctx->user_port,
+		.cookie	= bpf_get_socket_cookie(ctx),
+	};
+
+	struct sendrec_val *revnat = cali_srmsg_lookup_elem(&key);
+
+	if (revnat == NULL) {
+		CALI_DEBUG("revnat miss for %x:%d\n",
+				bpf_ntohl(ipv4), ctx_port_to_host(ctx->user_port));
+		/* we are past policy and the packet was allowed. Either the
+		 * mapping does not exist anymore and if the app cares, it
+		 * should check the addresses. It is more likely a packet sent
+		 * to server from outside and no mapping is expected.
+		 */
+		goto out;
+	}
+
+	ctx->user_ip6[3] = revnat->ip;
+	ctx->user_port = revnat->port;
+	CALI_DEBUG("recvmsg_v46 v4 rev nat to %x:%d\n",
+			bpf_ntohl(ipv4), ctx_port_to_host(ctx->user_port));
+
+out:
+	return 1;
+}

--- a/felix/bpf-gpl/failsafe.h
+++ b/felix/bpf-gpl/failsafe.h
@@ -13,14 +13,18 @@ struct failsafe_key {
 	__u16 port;
 	__u8 ip_proto;
 	__u8 flags;
-	__u32 addr;
+	ipv46_addr_t addr;
 };
 
 struct failsafe_val {
 	__u32 unused;
 };
 
-CALI_MAP(cali_v4_fsafes, 2,
+#ifdef IPVER6
+CALI_MAP_NAMED(cali_v6_fsafes, cali_fsafes, 2,
+#else
+CALI_MAP_NAMED(cali_v4_fsafes, cali_fsafes, 2,
+#endif
 		BPF_MAP_TYPE_LPM_TRIE,
 		struct failsafe_key, struct failsafe_val,
 		65536,
@@ -44,7 +48,7 @@ static CALI_BPF_INLINE bool is_failsafe_in(__u8 ip_proto, __u16 dport, ipv46_add
 		.flags = 0,
 		.addr = ip,
 	};
-	if (cali_v4_fsafes_lookup_elem(&key)) {
+	if (cali_fsafes_lookup_elem(&key)) {
 		return true;
 	}
 #else
@@ -62,7 +66,7 @@ static CALI_BPF_INLINE bool is_failsafe_out(__u8 ip_proto, __u16 dport, ipv46_ad
 		.flags = CALI_FSAFE_OUT,
 		.addr = ip,
 	};
-	if (cali_v4_fsafes_lookup_elem(&key)) {
+	if (cali_fsafes_lookup_elem(&key)) {
 		return true;
 	}
 #else

--- a/felix/bpf-gpl/ip_addr.h
+++ b/felix/bpf-gpl/ip_addr.h
@@ -23,20 +23,20 @@ static CALI_BPF_INLINE bool ipv6_addr_t_eq(ipv6_addr_t x, ipv6_addr_t y)
 	return x.a == y.a && x.b == y.b && x.c == y.c && x.d == y.d;
 }
 
-static CALI_BPF_INLINE int ipv6_addr_t_cmp(ipv6_addr_t x, ipv6_addr_t y)
+static CALI_BPF_INLINE int ipv6_addr_t_cmp(ipv6_addr_t *x, ipv6_addr_t *y)
 {
-	if (x.a < y.a) {
+	if (x->a < y->a) {
 		return -1;
-	} else if (x.a == y.a) {
-		if (x.b < y.b) {
+	} else if (x->a == y->a) {
+		if (x->b < y->b) {
 			return -1;
-		} else if (x.b == y.b) {
-			if (x.c < y.c) {
+		} else if (x->b == y->b) {
+			if (x->c < y->c) {
 				return -1;
-			} else if (x.c == y.c) {
-				if (x.d < y.d) {
+			} else if (x->c == y->c) {
+				if (x->d < y->d) {
 					return -1;
-				} else if (x.d == y.d) {
+				} else if (x->d == y->d) {
 					return 0;
 				}
 			}
@@ -74,6 +74,30 @@ static CALI_BPF_INLINE void ipv6_addr_t_to_ipv6hdr_ip(struct in6_addr *lnx, ipv6
 	lnx->in6_u.u6_addr32[3] = us->d;
 }
 
+static CALI_BPF_INLINE void ipv6hdr_ip_to_be32_4_ip(__be32 *bpf, struct in6_addr *lnx)
+{
+	bpf[0] = lnx->in6_u.u6_addr32[0];
+	bpf[1] = lnx->in6_u.u6_addr32[1];
+	bpf[2] = lnx->in6_u.u6_addr32[2];
+	bpf[3] = lnx->in6_u.u6_addr32[3];
+}
+
+static CALI_BPF_INLINE void ipv6_addr_t_to_be32_4_ip(__be32 *bpf, ipv6_addr_t *us)
+{
+	bpf[0] = us->a;
+	bpf[1] = us->b;
+	bpf[2] = us->c;
+	bpf[3] = us->d;
+}
+
+static CALI_BPF_INLINE void be32_4_ip_to_ipv6_addr_t(ipv6_addr_t *us, __be32 *bpf)
+{
+	us->a = bpf[0];
+	us->b = bpf[1];
+	us->c = bpf[2];
+	us->d = bpf[3];
+}
+
 typedef ipv6_addr_t ipv46_addr_t;
 
 #define DECLARE_IP_ADDR(name)	ipv6_addr_t name
@@ -85,7 +109,7 @@ typedef ipv6_addr_t ipv46_addr_t;
 #define ip_set_void(ip)	((ip) = 0)
 #define NP_SPECIAL_IP	0xffffffff
 #define ip_equal(a, b)	((a) == (b))
-#define ip_lt(a, b)	((a) < (b))
+#define ip_lt(a, b)	(*(a) < *(b))
 
 typedef ipv4_addr_t ipv46_addr_t;
 

--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -54,11 +54,7 @@ CALI_MAP_V1(cali_jump_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 200, 0)
 	bpf_tail_call((ctx)->skb, &cali_jump_map, (ctx)->globals->jumps[PROG_PATH(index)]);	\
 } while (0)
 
-#ifdef IPVER6
-#define CALI_JUMP_TO(ctx, index) __CALI_JUMP_TO(ctx, index ## _V6)
-#else
 #define CALI_JUMP_TO(ctx, index) __CALI_JUMP_TO(ctx, index)
-#endif
 
 #endif
 
@@ -81,24 +77,6 @@ enum cali_jump_index {
 	PROG_INDEX_HOST_CT_CONFLICT_DEBUG,
 	PROG_INDEX_ICMP_INNER_NAT_DEBUG,
 	PROG_INDEX_NEW_FLOW_DEBUG,
-
-	PROG_INDEX_MAIN_V6,
-	PROG_INDEX_POLICY_V6,
-	PROG_INDEX_ALLOWED_V6,
-	PROG_INDEX_ICMP_V6,
-	PROG_INDEX_DROP_V6,
-	PROG_INDEX_HOST_CT_CONFLICT_V6,
-	PROG_INDEX_ICMP_INNER_NAT_V6,
-	PROG_INDEX_NEW_FLOW_V6,
-
-	PROG_INDEX_MAIN_V6_DEBUG,
-	PROG_INDEX_POLICY_V6_DEBUG,
-	PROG_INDEX_ALLOWED_V6_DEBUG,
-	PROG_INDEX_ICMP_V6_DEBUG,
-	PROG_INDEX_DROP_V6_DEBUG,
-	PROG_INDEX_HOST_CT_CONFLICT_V6_DEBUG,
-	PROG_INDEX_ICMP_INNER_NAT_V6_DEBUG,
-	PROG_INDEX_NEW_FLOW_V6_DEBUG,
 };
 
 #if CALI_F_XDP
@@ -127,14 +105,8 @@ CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 10000, 0)
 	bpf_tail_call((ctx)->skb, &cali_jump_prog_map, (ctx)->globals->jumps[pol]);	\
 } while (0)
 
-#ifdef IPVER6
-#define CALI_JUMP_TO_POLICY(ctx) \
-	__CALI_JUMP_TO_POLICY(ctx, PROG_INDEX_ALLOWED_V6, PROG_INDEX_DROP_V6, PROG_INDEX_POLICY_V6)
-#else
 #define CALI_JUMP_TO_POLICY(ctx) \
 	__CALI_JUMP_TO_POLICY(ctx, PROG_INDEX_ALLOWED, PROG_INDEX_DROP, PROG_INDEX_POLICY)
-#endif
-
 #endif
 
 #endif /* __CALI_BPF_JUMP_H__ */

--- a/felix/bpf-gpl/list-objs
+++ b/felix/bpf-gpl/list-objs
@@ -22,7 +22,9 @@ emit_filename() {
 for log_level in debug info no_log; do
   echo "bin/connect_time_${log_level}_v4.o"
   echo "bin/connect_time_${log_level}_v6.o"
+  echo "bin/connect_time_${log_level}_v46.o"
   echo "bin/connect_time_${log_level}_v4_co-re.o"
+  echo "bin/connect_time_${log_level}_v46_co-re.o"
   echo "bin/connect_time_${log_level}_v6_co-re.o"
   echo "bin/xdp_${log_level}.o"
 

--- a/felix/bpf-gpl/nat6.h
+++ b/felix/bpf-gpl/nat6.h
@@ -2,8 +2,8 @@
 // Copyright (c) 2020-2023 Tigera, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
-#ifndef __CALI_NAT4_H__
-#define __CALI_NAT4_H__
+#ifndef __CALI_NAT6_H__
+#define __CALI_NAT6_H__
 
 #include <stddef.h>
 
@@ -110,4 +110,4 @@ static CALI_BPF_INLINE bool vxlan_vni_is_valid(struct cali_tc_ctx *ctx)
 	return *((__u8*)&vxlan->flags) & (1 << 3);
 }
 
-#endif /* __CALI_NAT4_H__ */
+#endif /* __CALI_NAT6_H__ */

--- a/felix/bpf-gpl/parsing.h
+++ b/felix/bpf-gpl/parsing.h
@@ -173,6 +173,12 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx, b
 			}
 		}
 		break;
+#ifdef IPVER6
+	case IPPROTO_ICMPV6:
+		/* XXX for now, just allow */
+		CALI_DEBUG("ICMPv6: allow");
+		goto allow;
+#else
 	case IPPROTO_ICMP:
 		ctx->state->icmp_type = icmp_hdr(ctx)->type;
 		ctx->state->icmp_code = icmp_hdr(ctx)->code;
@@ -180,6 +186,7 @@ static CALI_BPF_INLINE int tc_state_fill_from_nexthdr(struct cali_tc_ctx *ctx, b
 		CALI_DEBUG("ICMP; type=%d code=%d\n",
 				icmp_hdr(ctx)->type, icmp_hdr(ctx)->code);
 		break;
+#endif
 	case IPPROTO_IPIP:
 		if (CALI_F_TUNNEL | CALI_F_L3_DEV) {
 			// IPIP should never be sent down the tunnel.

--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -41,6 +41,9 @@ static CALI_BPF_INLINE int parse_packet_ip_v6(struct cali_tc_ctx *ctx) {
 	switch (protocol) {
 	case ETH_P_IPV6:
 		break;
+	case ETH_P_IP:
+		CALI_DEBUG("Unexpected ipv4 packet, drop\n");
+		goto deny;
 	default:
 		if (CALI_F_WEP) {
 			CALI_DEBUG("Unknown ethertype (%x), drop\n", protocol);
@@ -162,7 +165,7 @@ static CALI_BPF_INLINE void tc_state_fill_from_iphdr_v6(struct cali_tc_ctx *ctx)
 	}
 
 out:
-	CALI_DEBUG("IP ihl=%d bytes\n", ctx->ipheader_len);
+	CALI_DEBUG("IP ihl=%d bytes ip nexthdr %d\n", ctx->ipheader_len, ctx->state->ip_proto);
 	return;
 
 deny:

--- a/felix/bpf-gpl/policy.h
+++ b/felix/bpf-gpl/policy.h
@@ -24,20 +24,30 @@ struct cidr {
 
 // WARNING: must be kept in sync with the definitions in bpf/polprog/pol_prog_builder.go.
 // WARNING: must be kept in sync with the definitions in bpf/ipsets/map.go.
-struct ip4_set_key {
+struct ip_set_key {
 	__u32 mask;
 	__be64 set_id;
-	__be32 addr;
+	ipv46_addr_t addr;
 	__u16 port;
 	__u8 protocol;
 	__u8 pad;
 } __attribute__((packed));
 
-union ip4_set_lpm_key {
+union ip_set_lpm_key {
 	struct bpf_lpm_trie_key lpm;
-	struct ip4_set_key ip;
+	struct ip_set_key ip;
 };
-CALI_MAP_V1(cali_v4_ip_sets, BPF_MAP_TYPE_LPM_TRIE, union ip4_set_lpm_key, __u32, 1024*1024, BPF_F_NO_PREALLOC)
+
+#ifdef IPVER6
+CALI_MAP_NAMED(cali_v6_ip_sets, cali_ip_sets,,
+#else
+CALI_MAP_NAMED(cali_v4_ip_sets, cali_ip_sets,,
+#endif
+	BPF_MAP_TYPE_LPM_TRIE,
+	union ip_set_lpm_key,
+	__u32,
+	1024*1024,
+	BPF_F_NO_PREALLOC)
 
 #define RULE_START(id)
 

--- a/felix/bpf-gpl/sendrecv.h
+++ b/felix/bpf-gpl/sendrecv.h
@@ -9,6 +9,9 @@ struct sendrec_key {
 	__u64 cookie;
 	ipv46_addr_t ip;
 	__u32 port; /* because bpf_sock_addr uses 32bit and we would need padding */
+#ifdef IPVER6
+	__u8 pad[4];
+#endif
 };
 
 struct sendrec_val {
@@ -30,7 +33,11 @@ struct ct_nats_key {
 	ipv46_addr_t ip;
 	__u32 port; /* because bpf_sock_addr uses 32bit */
 	__u8 proto;
+#ifdef IPVER6
+	__u8 pad[3];
+#else
 	__u8 pad[7];
+#endif
 };
 
 #ifdef IPVER6

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -16,13 +16,12 @@ const volatile struct cali_tc_globals __globals;
 
 #ifdef IPVER6
 #define IPV " v6"
-#define JUMP_IDX(idx) (idx ## _V6)
-#define JUMP_IDX_DEBUG(idx) (idx ## _V6_DEBUG)
 #else
 #define IPV " v4"
+#endif
+
 #define JUMP_IDX(idx) (idx)
 #define JUMP_IDX_DEBUG(idx) (idx ## _DEBUG)
-#endif
 
 #define JUMP(idx) globals->jumps[JUMP_IDX(idx)]
 #define JUMP_DEBUG(idx) globals->jumps[JUMP_IDX_DEBUG(idx)]

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -205,6 +205,8 @@ struct cali_tc_ctx {
 			x;							\
 	})									\
 
+#define fib_params(x) ((struct bpf_fib_lookup *)((x)->scratch))
+
 #ifdef IPVER6
 static CALI_BPF_INLINE struct ipv6hdr* ip_hdr(struct cali_tc_ctx *ctx)
 {

--- a/felix/bpf/ipsets/map6.go
+++ b/felix/bpf/ipsets/map6.go
@@ -74,7 +74,7 @@ func (e IPSetEntryV6) PrefixLen() uint32 {
 }
 
 func (e IPSetEntryV6) Protocol() uint8 {
-	return e[20]
+	return e[30]
 }
 
 func (e IPSetEntryV6) Port() uint16 {
@@ -101,7 +101,7 @@ func MakeBPFIPSetEntryV6(setID uint64, cidr ip.V6CIDR, port uint16, proto uint8)
 	ipv6 := cidr.Addr().(ip.V6Addr)
 	copy(entry[12:28], ipv6[:])
 	binary.LittleEndian.PutUint16(entry[28:30], port)
-	entry[31] = proto
+	entry[30] = proto
 	return entry
 }
 

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -94,9 +94,14 @@ const (
 
 var (
 	// Stack offsets.  These are defined locally.
-	offStateKey    = nextOffset(4, 4)
-	offSrcIPSetKey = nextOffset(ipsets.IPSetEntrySize, 8)
-	offDstIPSetKey = nextOffset(ipsets.IPSetEntrySize, 8)
+	offStateKey = nextOffset(4, 4)
+	// Even for v4 progrtams, we have the v6 layout
+	// N.B. we can use 64bit stack stores in ipv6 because of the 4 byte alignment
+	// preceded by the 4 bytes of StateKey. That makes the ip within the src key
+	// 8 bytes aligned. And since the ip is followed by 4 bytes of
+	// port+proto+pad, the dst key is also aligned in the same way. <sweat :-)>
+	offSrcIPSetKey = nextOffset(ipsets.IPSetEntryV6Size, 4)
+	offDstIPSetKey = nextOffset(ipsets.IPSetEntryV6Size, 4)
 
 	// Offsets within the cal_tc_state struct.
 	// WARNING: must be kept in sync with the definitions in bpf-gpl/types.h.
@@ -126,8 +131,8 @@ var (
 	skbCb0 = FieldOffset{Offset: 12*4 + 0*4, Field: "skb->cb[0]"}
 	skbCb1 = FieldOffset{Offset: 12*4 + 1*4, Field: "skb->cb[1]"}
 
-	// Compile-time check that IPSetEntrySize hasn't changed; if it changes, the code will need to change.
-	_ = [1]struct{}{{}}[20-ipsets.IPSetEntrySize]
+	// Compile-time check that IPSetEntryV6Size hasn't changed; if it changes, the code will need to change.
+	_ = [1]struct{}{{}}[32-ipsets.IPSetEntryV6Size]
 
 	// Offsets within struct ip4_set_key.
 	// WARNING: must be kept in sync with the definitions in bpf/ipsets/map.go.
@@ -202,10 +207,6 @@ const (
 	TierEndDeny  TierEndAction = "deny"
 	TierEndPass  TierEndAction = "pass"
 )
-
-func (p *Builder) EnableIPv6Mode() {
-	p.forIPv6 = true
-}
 
 func (p *Builder) Instructions(rules Rules) (Insns, error) {
 	p.b = NewBlock(p.policyDebugEnabled)
@@ -406,20 +407,36 @@ func (p *Builder) writeRecordRuleHit(r Rule, skipLabel string) {
 }
 
 func (p *Builder) setUpIPSetKey(ipsetID uint64, keyOffset int16, ipOffset, portOffset FieldOffset) {
+	v6Adjust := int16(0)
+	prefixLen := int32(128)
+
+	if p.forIPv6 {
+		v6Adjust = 12
+		prefixLen += 96
+	}
+
 	// TODO track whether we've already done an initialisation and skip the parts that don't change.
 	// Zero the padding.
 	p.b.MovImm64(R1, 0) // R1 = 0
-	p.b.StoreStack8(R1, keyOffset+ipsKeyPad)
-	p.b.MovImm64(R1, 128) // R1 = 128
+	p.b.StoreStack8(R1, keyOffset+ipsKeyPad+v6Adjust)
+	p.b.MovImm64(R1, prefixLen) // R1 = 128
 	p.b.StoreStack32(R1, keyOffset+ipsKeyPrefix)
 
 	// Store the IP address, port and protocol.
-	p.b.Load32(R1, R9, ipOffset)
-	p.b.StoreStack32(R1, keyOffset+ipsKeyAddr)
+	if !p.forIPv6 {
+		p.b.Load32(R1, R9, ipOffset)
+		p.b.StoreStack32(R1, keyOffset+ipsKeyAddr)
+	} else {
+		p.b.Load64(R1, R9, ipOffset)
+		p.b.StoreStack64(R1, keyOffset+ipsKeyAddr)
+		ipOffset.Offset += 8
+		p.b.Load64(R1, R9, ipOffset)
+		p.b.StoreStack64(R1, keyOffset+ipsKeyAddr+8)
+	}
 	p.b.Load16(R1, R9, portOffset)
-	p.b.StoreStack16(R1, keyOffset+ipsKeyPort)
+	p.b.StoreStack16(R1, keyOffset+ipsKeyPort+v6Adjust)
 	p.b.Load8(R1, R9, stateOffIPProto)
-	p.b.StoreStack8(R1, keyOffset+ipsKeyProto)
+	p.b.StoreStack8(R1, keyOffset+ipsKeyProto+v6Adjust)
 
 	// Store the IP set ID.  It is 64-bit but, since it's a packed struct, we have to write it in two
 	// 32-bit chunks.
@@ -856,9 +873,9 @@ func (p *Builder) writeIPSetMatch(negate bool, leg matchLeg, ipSets []string) {
 		}
 		comment := ""
 		if negate {
-			comment = fmt.Sprintf("If %s matches ipset %s, skip to next rule", leg, ipSetID)
+			comment = fmt.Sprintf("If %s matches ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
 		} else {
-			comment = fmt.Sprintf("If %s doesn't match ipset %s, skip to next rule", leg, ipSetID)
+			comment = fmt.Sprintf("If %s doesn't match ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
 		}
 		p.b.AddComment(comment)
 
@@ -894,9 +911,9 @@ func (p *Builder) writeIPSetOrMatch(leg matchLeg, ipSets []string) {
 
 		comment := ""
 		if len(ipSets) == 1 {
-			comment = fmt.Sprintf("If %s doesn't match ipset %s, skip to next rule", leg, ipSetID)
+			comment = fmt.Sprintf("If %s doesn't match ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
 		} else {
-			comment = fmt.Sprintf("If %s doesn't match ipset %s, jump to next ipset", leg, ipSetID)
+			comment = fmt.Sprintf("If %s doesn't match ipset %s (0x%x), jump to next ipset", leg, ipSetID, id)
 		}
 		p.b.AddComment(comment)
 

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -411,6 +411,8 @@ func (p *Builder) setUpIPSetKey(ipsetID uint64, keyOffset int16, ipOffset, portO
 	prefixLen := int32(128)
 
 	if p.forIPv6 {
+		// IPv6 addresses are 12 bytes longer and so everything beyond the
+		// address is shifted by 12 bytes.
 		v6Adjust = 12
 		prefixLen += 96
 	}

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -1062,6 +1062,12 @@ func WithAllowDenyJumps(allow, deny int) Option {
 	}
 }
 
+func WithIPv6() Option {
+	return func(p *Builder) {
+		p.forIPv6 = true
+	}
+}
+
 func protocolToName(protocol *proto.Protocol) string {
 	var pcol string
 	switch p := protocol.NumberOrName.(type) {

--- a/felix/bpf/polprog/pol_prog_builder_test.go
+++ b/felix/bpf/polprog/pol_prog_builder_test.go
@@ -152,10 +152,10 @@ func TestPolicyDump(t *testing.T) {
 	checkLabelsAndComments(proto.Rule{NotSrcNamedPortIpSetIds: []string{setID("n:abcdef1234567890")}}, "If source port is within any of the named ports {n:abcdef1234567890}, skip to next rule", "comment")
 	checkLabelsAndComments(proto.Rule{NotDstNamedPortIpSetIds: []string{setID("n:foo1234567890")}}, "If dest port is within any of the named ports {n:foo1234567890}, skip to next rule", "comment")
 
-	checkLabelsAndComments(proto.Rule{SrcIpSetIds: []string{setID("s:sbcdef1234567890")}}, "If source doesn't match ipset s:sbcdef1234567890, skip to next rule", "comment")
-	checkLabelsAndComments(proto.Rule{NotSrcIpSetIds: []string{setID("s:sbcdef1234567890")}}, "If source matches ipset s:sbcdef1234567890, skip to next rule", "comment")
-	checkLabelsAndComments(proto.Rule{DstIpSetIds: []string{setID("d:sbcdef1234567890")}}, "If dest doesn't match ipset d:sbcdef1234567890, skip to next rule", "comment")
-	checkLabelsAndComments(proto.Rule{NotDstIpSetIds: []string{setID("d:sbcdef1234567890")}}, "If dest matches ipset d:sbcdef1234567890, skip to next rule", "comment")
+	checkLabelsAndComments(proto.Rule{SrcIpSetIds: []string{setID("s:sbcdef1234567890")}}, "If source doesn't match ipset s:sbcdef1234567890 (0xc9e0b8362d2ae7aa), skip to next rule", "comment")
+	checkLabelsAndComments(proto.Rule{NotSrcIpSetIds: []string{setID("s:sbcdef1234567890")}}, "If source matches ipset s:sbcdef1234567890 (0xc9e0b8362d2ae7aa), skip to next rule", "comment")
+	checkLabelsAndComments(proto.Rule{DstIpSetIds: []string{setID("d:sbcdef1234567890")}}, "If dest doesn't match ipset d:sbcdef1234567890 (0x8cc518c2047a26bb), skip to next rule", "comment")
+	checkLabelsAndComments(proto.Rule{NotDstIpSetIds: []string{setID("d:sbcdef1234567890")}}, "If dest matches ipset d:sbcdef1234567890 (0x8cc518c2047a26bb), skip to next rule", "comment")
 
 	checkLabelsAndComments(proto.Rule{Icmp: &proto.Rule_IcmpTypeCode{IcmpTypeCode: &proto.IcmpTypeAndCode{Type: 10, Code: 12}}}, "If ICMP type != 10 or code != 12, skip to next rule", "comment")
 	checkLabelsAndComments(proto.Rule{NotIcmp: &proto.Rule_NotIcmpTypeCode{NotIcmpTypeCode: &proto.IcmpTypeAndCode{Type: 10, Code: 12}}}, "If ICMP type == 10 and code == 12, skip to next rule", "comment")

--- a/felix/bpf/ut/pol_prog_test.go
+++ b/felix/bpf/ut/pol_prog_test.go
@@ -121,6 +121,11 @@ func TestPolicyLoadKitchenSinkPolicy(t *testing.T) {
 		return id
 	}
 
+	jumpMap = jump.Map()
+	_ = unix.Unlink(jumpMap.Path())
+	err := jumpMap.EnsureExists()
+	Expect(err).NotTo(HaveOccurred())
+
 	cleanIPSetMap()
 
 	pg := polprog.NewBuilder(alloc, ipsMap.MapFD(), stateMap.MapFD(), jumpMap.MapFD(),

--- a/felix/bpf/ut/pol_prog_test.go
+++ b/felix/bpf/ut/pol_prog_test.go
@@ -1716,6 +1716,28 @@ var polProgramTests = []polProgramTest{
 		},
 	},
 	{
+		PolicyName: "allow to named ports - v6",
+		Policy: makeRulesSingleTier([]*proto.Rule{{
+			Action:               "Allow",
+			DstNamedPortIpSetIds: []string{"setA", "setB"},
+		}}),
+		AllowedPackets: []packet{
+			udpPkt("[10::2]:12345", "[123::1]:1024"),
+			tcpPkt("[10::1]:31245", "[10::2]:80")},
+		DroppedPackets: []packet{
+			packetNoPorts(253, "11::2", "10::2"),    // Wrong proto, no ports
+			tcpPkt("[11::1]:12345", "[10::2]:8080"), // Wrong port
+			udpPkt("[10::1]:31245", "[10::2]:80"),   // Wrong proto
+			tcpPkt("[10::2]:80", "[10::1]:31245"),   // Src/dest confusion
+			tcpPkt("[10::2]:31245", "[10::1]:80"),   // Wrong dest
+		},
+		IPSets: map[string][]string{
+			"setA": {"10::2/128,tcp:80"},
+			"setB": {"123::1/128,udp:1024"},
+		},
+		ForIPv6: true,
+	},
+	{
 		PolicyName: "allow to mixed ports",
 		Policy: makeRulesSingleTier([]*proto.Rule{{
 			Action: "Allow",

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2807,9 +2807,6 @@ func (m *bpfEndpointManager) loadPolicyProgram(progName string,
 
 	pg := polprog.NewBuilder(m.ipSetIDAlloc, m.bpfmaps.IpsetsMap.MapFD(),
 		m.bpfmaps.StateMap.MapFD(), progsMap.MapFD(), opts...)
-	if ipFamily == proto.IPVersion_IPV6 {
-		pg.EnableIPv6Mode()
-	}
 	insns, err := pg.Instructions(rules)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate policy bytecode v%v: %w", ipFamily, err)

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -765,7 +765,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				}
 			}
 			// Activate the connect-time load balancer.
-			err = bpfnat.InstallConnectTimeLoadBalancer(
+			err = bpfnat.InstallConnectTimeLoadBalancer(4,
 				config.BPFCgroupV2, logLevel, config.BPFConntrackTimeouts.UDPLastSeen, excludeUDP)
 			if err != nil {
 				log.WithError(err).Panic("BPFConnTimeLBEnabled but failed to attach connect-time load balancer, bailing out.")


### PR DESCRIPTION
## Description

    - ICMPv6 is blindly allowed as (a) processing it is not implemented yet
      and (b) it performs arp's function

    - ipv6 ipsets in policy

    - bpf v6 CTLB and FIB implementation
    
    - Some code reshuffling due to stack limitations.

refs https://github.com/projectcalico/calico/issues/4736

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
