### PR TITLE
Fix felix_label_index_strategy_evals prometheus metric

### DIFF
--- a/felix/fv/label_index_metrics_test.go
+++ b/felix/fv/label_index_metrics_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/felix/fv/metrics"
+
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ label index metrics tests", []apiconfig.DatastoreType{apiconfig.Kubernetes, apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
+	var (
+		tc     infrastructure.TopologyContainers
+		infra  infrastructure.DatastoreInfra
+		client client.Interface
+		w      [2]*workload.Workload
+	)
+
+	BeforeEach(func() {
+		infra = getInfra()
+		opts := infrastructure.DefaultTopologyOptions()
+		opts.ExtraEnvVars["FELIX_PROMETHEUSMETRICSENABLED"] = "true"
+		opts.ExtraEnvVars["FELIX_PROMETHEUSMETRICSHOST"] = "0.0.0.0"
+		tc, client = infrastructure.StartNNodeTopology(1, opts, infra)
+
+		for i := range w {
+			w[i] = workload.Run(
+				tc.Felixes[0],
+				"w",
+				"default",
+				"10.65.0.1",
+				"8080",
+				"tcp",
+			)
+			w[i].WorkloadEndpoint.Labels["common"] = "x"
+			w[i].WorkloadEndpoint.Labels["foo"] = fmt.Sprint(i)
+		}
+		w[1].WorkloadEndpoint.Namespace = "another"
+	})
+
+	It("should report expected prometheus stats with various policies", func() {
+		By("Reporting 0 at start of day")
+		Eventually(metrics.GetFelixMetricIntFn(tc.Felixes[0].IP, "felix_label_index_num_endpoints")).Should(BeNumerically("==", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_selector_evals{result=\"false\"}")).To(BeNumerically("==", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_selector_evals{result=\"true\"}")).To(BeNumerically("==", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"false\"}")).To(BeNumerically("==", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"true\"}")).To(BeNumerically("==", 0))
+
+		By("responding to an endpoint")
+		w[0].ConfigureInInfra(infra)
+		Eventually(metrics.GetFelixMetricIntFn(tc.Felixes[0].IP, "felix_label_index_num_endpoints")).Should(BeNumerically("==", 1))
+
+		By("responding to a second endpoint")
+		w[1].ConfigureInInfra(infra)
+		Eventually(metrics.GetFelixMetricIntFn(tc.Felixes[0].IP, "felix_label_index_num_endpoints")).Should(BeNumerically("==", 2))
+
+		// Create a policy with a selector.
+		By("responding to a selector")
+		pol := v3.NewGlobalNetworkPolicy()
+		pol.Name = "test"
+		pol.Spec.Selector = "all()"
+		pol.Spec.Ingress = []v3.Rule{
+			{
+				Action: "Allow",
+				Source: v3.EntityRule{
+					Selector: "foo == '0'",
+				},
+			},
+		}
+		pol, err := client.GlobalNetworkPolicies().Create(context.TODO(), pol, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(metrics.GetFelixMetricIntFn(tc.Felixes[0].IP, "felix_label_index_strategy_evals{strategy=\"endpoint-single-value\"}")).Should(BeNumerically("==", 1))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_selector_evals{result=\"true\"}")).To(BeNumerically(">", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_selector_evals{result=\"false\"}")).To(BeNumerically("==", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"false\"}")).To(BeNumerically("==", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"true\"}")).To(BeNumerically("==", 1))
+
+		By("responding to an unoptimized selector")
+		pol2 := v3.NewGlobalNetworkPolicy()
+		pol2.Name = "test2"
+		pol2.Spec.Selector = "all()"
+		pol2.Spec.Ingress = []v3.Rule{
+			{
+				Action: "Allow",
+				Source: v3.EntityRule{
+					Selector: "bar == 'biff' || foo == '1'",
+				},
+			},
+		}
+		pol2, err = client.GlobalNetworkPolicies().Create(context.TODO(), pol2, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(metrics.GetFelixMetricIntFn(tc.Felixes[0].IP, "felix_label_index_strategy_evals{strategy=\"endpoint-single-value\"}")).Should(BeNumerically("==", 1))
+		Eventually(metrics.GetFelixMetricIntFn(tc.Felixes[0].IP, "felix_label_index_strategy_evals{strategy=\"endpoint-full-scan\"}")).Should(BeNumerically("==", 1))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_selector_evals{result=\"false\"}")).To(BeNumerically(">", 0))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"false\"}")).To(BeNumerically("==", 1))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"true\"}")).To(BeNumerically("==", 1))
+
+		if _, ok := infra.(*infrastructure.EtcdDatastoreInfra); ok {
+			// etcd infra doesn't create realistic enough namespaces.
+			return
+		}
+
+		By("responding to a namespace selector")
+		pol3 := v3.NewGlobalNetworkPolicy()
+		pol3.Name = "test3"
+		pol3.Spec.Selector = "all()"
+		pol3.Spec.Ingress = []v3.Rule{
+			{
+				Action: "Allow",
+				Source: v3.EntityRule{
+					NamespaceSelector: "projectcalico.org/name == 'another'",
+					Selector:          "common == 'x'",
+				},
+			},
+		}
+		pol3, err = client.GlobalNetworkPolicies().Create(context.TODO(), pol3, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(metrics.GetFelixMetricIntFn(tc.Felixes[0].IP, "felix_label_index_strategy_evals{strategy=\"parent-single-value\"}")).Should(BeNumerically("==", 1),
+			"Expected namespace selector with a less useful endpoint selector to result in a parent scan.")
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"false\"}")).To(BeNumerically("==", 1))
+		Expect(metrics.GetFelixMetricInt(tc.Felixes[0].IP, "felix_label_index_num_active_selectors{optimized=\"true\"}")).To(BeNumerically("==", 2))
+	})
+
+	AfterEach(func() {
+		tc.Stop()
+		if CurrentGinkgoTestDescription().Failed {
+			infra.DumpErrorData()
+		}
+		infra.Stop()
+	})
+})

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -332,7 +332,9 @@ func (w *Workload) RemoveFromDatastore(client client.Interface) {
 // ConfigureInInfra creates the workload endpoint for this Workload.
 func (w *Workload) ConfigureInInfra(infra infrastructure.DatastoreInfra) {
 	wep := w.WorkloadEndpoint
-	wep.Namespace = "default"
+	if wep.Namespace == "" {
+		wep.Namespace = "default"
+	}
 	wep.Spec.Workload = w.Name
 	wep.Spec.Endpoint = w.Name
 	wep.Spec.InterfaceName = w.InterfaceName

--- a/felix/labelindex/labelnamevalueindex/label_name_value_index.go
+++ b/felix/labelindex/labelnamevalueindex/label_name_value_index.go
@@ -349,5 +349,5 @@ func (s FullScanStrategy[ItemID, Item]) Scan(f func(id ItemID) bool) {
 }
 
 func (s FullScanStrategy[ItemID, Item]) Name() string {
-	return "all"
+	return "full-scan"
 }

--- a/felix/labelindex/labelnamevalueindex/label_name_value_index_test.go
+++ b/felix/labelindex/labelnamevalueindex/label_name_value_index_test.go
@@ -77,12 +77,12 @@ func TestLabelValueIndexStrategies(t *testing.T) {
 	idx.Add("c2", labels{"a": "a2", "b": "b2"})
 	idx.Add("c3", labels{"a": "a3", "b": "b3"})
 
-	t.Log("All strategy...")
+	t.Log("Full-scan strategy...")
 	strat := idx.StrategyFor("a", parser.LabelRestriction{})
 	Expect(strat).To(BeAssignableToTypeOf(FullScanStrategy[string, labels]{}))
 	Expect(scan(strat)).To(ConsistOf("a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"))
 	Expect(strat.EstimatedItemsToScan()).To(Equal(9))
-	Expect(strat.Name()).To(Equal("all"))
+	Expect(strat.Name()).To(Equal("full-scan"))
 
 	t.Log("Label name strategy...")
 	strat = idx.StrategyFor("a", parser.LabelRestriction{MustBePresent: true})

--- a/felix/labelindex/named_port_index.go
+++ b/felix/labelindex/named_port_index.go
@@ -934,7 +934,7 @@ func (idx *SelectorAndNamedPortIndex) iterEndpointCandidates(ipsetID string, f f
 
 	if bestEPStrategy.EstimatedItemsToScan() <= bestParentEndpointEstimate {
 		log.Debugf("Selector %s using endpoint scan strategy: %s", sel.String(), bestEPStrategy.String())
-		counterVecScanStrat.WithLabelValues("endpoint-" + bestEPStrategy.Name())
+		counterVecScanStrat.WithLabelValues("endpoint-" + bestEPStrategy.Name()).Inc()
 		bestEPStrategy.Scan(func(id any) bool {
 			ep, _ := idx.endpointKVIdx.Get(id)
 			f(id, ep)
@@ -943,7 +943,7 @@ func (idx *SelectorAndNamedPortIndex) iterEndpointCandidates(ipsetID string, f f
 	} else {
 		log.Debugf("Selector %s using parent scan strategy: %s", sel.String(), bestParentStrategy.String())
 		seenEPIDs := set.New[any]()
-		counterVecScanStrat.WithLabelValues("parent-" + bestParentStrategy.Name())
+		counterVecScanStrat.WithLabelValues("parent-" + bestParentStrategy.Name()).Inc()
 		bestParentStrategy.Scan(func(parentID string) bool {
 			parent, _ := idx.parentKVIdx.Get(parentID)
 			parent.IterEndpointIDs(func(id any) error {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fix the above metric (it was created but not incremented) and add a basic FV to cover it.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

- Introduced by #8015
- CORE-9782
- CORE-9780

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
