### PR TITLE
feat: allow calico-typha to be scheduled on all nodes

### DIFF
--- a/manifests/calico-typha.yaml
+++ b/manifests/calico-typha.yaml
@@ -5104,6 +5104,9 @@ spec:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
+        # Be sure that the pod can schedule on all nodes
+        - effect: NoSchedule
+          operator: Exists
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We have an kubernetes cluster (aks) with 2 nodepools, one containing Spot VMs. We also have calico as NetworkPolicy enabled for our aks.

Aks tries to rollout the calico-typha deployment with 3 replicas in the calico-system namespace, which fails on the Spot VMs due to missing tolerations: 1 node(s) had untolerated taint {kubernetes.azure.com/scalesetpriority: spot}


## Related issues/PRs
fixes https://github.com/Azure/AKS/issues/3539
mentioned in https://github.com/kubernetes/kubernetes/pull/118331


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
Typha pods are allowed to be scheduled on all kind of nodes.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
