### PR TITLE
BPF: fix that no IP set filter was set at start-of-day.

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -604,10 +604,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		tc.CleanUpProgramsAndPins()
 	} else {
 		// In BPF mode we still use iptables for raw egress policy.
-		dp.RegisterManager(newRawEgressPolicyManager(rawTableV4, ruleRenderer, 4,
-			func(neededIPSets set.Set[string]) {
-				ipSetsV4.SetFilter(neededIPSets)
-			}))
+		dp.RegisterManager(newRawEgressPolicyManager(rawTableV4, ruleRenderer, 4, ipSetsV4.SetFilter))
 	}
 
 	interfaceRegexes := make([]string, len(config.RulesConfig.WorkloadIfacePrefixes))

--- a/felix/dataplane/linux/policy_mgr.go
+++ b/felix/dataplane/linux/policy_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2023 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,14 +29,15 @@ import (
 // policyManager simply renders policy/profile updates into iptables.Chain objects and sends
 // them to the dataplane layer.
 type policyManager struct {
-	rawTable       IptablesTable
-	mangleTable    IptablesTable
-	filterTable    IptablesTable
-	ruleRenderer   policyRenderer
-	ipVersion      uint8
-	rawEgressOnly  bool
-	neededIPSets   map[proto.PolicyID]set.Set[string]
-	ipSetsCallback func(neededIPSets set.Set[string])
+	rawTable         IptablesTable
+	mangleTable      IptablesTable
+	filterTable      IptablesTable
+	ruleRenderer     policyRenderer
+	ipVersion        uint8
+	rawEgressOnly    bool
+	ipSetFilterDirty bool // Only used in "raw only" mode.
+	neededIPSets     map[proto.PolicyID]set.Set[string]
+	ipSetsCallback   func(neededIPSets set.Set[string])
 }
 
 type policyRenderer interface {
@@ -56,39 +57,27 @@ func newPolicyManager(rawTable, mangleTable, filterTable IptablesTable, ruleRend
 
 func newRawEgressPolicyManager(rawTable IptablesTable, ruleRenderer policyRenderer, ipVersion uint8,
 	ipSetsCallback func(neededIPSets set.Set[string])) *policyManager {
+	ipSetsCallback(set.New[string]())
 	return &policyManager{
-		rawTable:       rawTable,
-		mangleTable:    iptables.NewNoopTable(),
-		filterTable:    iptables.NewNoopTable(),
-		ruleRenderer:   ruleRenderer,
-		ipVersion:      ipVersion,
-		rawEgressOnly:  true,
-		neededIPSets:   make(map[proto.PolicyID]set.Set[string]),
-		ipSetsCallback: ipSetsCallback,
+		rawTable:      rawTable,
+		mangleTable:   iptables.NewNoopTable(),
+		filterTable:   iptables.NewNoopTable(),
+		ruleRenderer:  ruleRenderer,
+		ipVersion:     ipVersion,
+		rawEgressOnly: true,
+		// Nake sure we set the filter at start-of-day, even if there are no policies.
+		ipSetFilterDirty: true,
+		neededIPSets:     make(map[proto.PolicyID]set.Set[string]),
+		ipSetsCallback:   ipSetsCallback,
 	}
-}
-
-func (m *policyManager) mergeNeededIPSets(id *proto.PolicyID, neededIPSets set.Set[string]) {
-	if neededIPSets != nil {
-		m.neededIPSets[*id] = neededIPSets
-	} else {
-		delete(m.neededIPSets, *id)
-	}
-	merged := set.New[string]()
-	for _, ipSets := range m.neededIPSets {
-		ipSets.Iter(func(item string) error {
-			merged.Add(item)
-			return nil
-		})
-	}
-	m.ipSetsCallback(merged)
 }
 
 func (m *policyManager) OnUpdate(msg interface{}) {
 	switch msg := msg.(type) {
 	case *proto.ActivePolicyUpdate:
 		if m.rawEgressOnly && !msg.Policy.Untracked {
-			log.WithField("id", msg.Id).Debug("Ignore non-untracked policy")
+			log.WithField("id", msg.Id).Debug("Clean up non-untracked policy.")
+			m.cleanUpPolicy(msg.Id)
 			return
 		}
 		log.WithField("id", msg.Id).Debug("Updating policy chains")
@@ -103,7 +92,7 @@ func (m *policyManager) OnUpdate(msg interface{}) {
 				}
 			}
 			chains = filteredChains
-			m.mergeNeededIPSets(msg.Id, neededIPSets)
+			m.updateNeededIPSets(msg.Id, neededIPSets)
 		}
 		// We can't easily tell whether the policy is in use in a particular table, and, if the policy
 		// type gets changed it may move between tables.  Hence, we put the policy into all tables.
@@ -113,18 +102,7 @@ func (m *policyManager) OnUpdate(msg interface{}) {
 		m.filterTable.UpdateChains(chains)
 	case *proto.ActivePolicyRemove:
 		log.WithField("id", msg.Id).Debug("Removing policy chains")
-		if m.rawEgressOnly {
-			m.mergeNeededIPSets(msg.Id, nil)
-		}
-		inName := rules.PolicyChainName(rules.PolicyInboundPfx, msg.Id)
-		outName := rules.PolicyChainName(rules.PolicyOutboundPfx, msg.Id)
-		// As above, we need to clean up in all the tables.
-		m.filterTable.RemoveChainByName(inName)
-		m.filterTable.RemoveChainByName(outName)
-		m.mangleTable.RemoveChainByName(inName)
-		m.mangleTable.RemoveChainByName(outName)
-		m.rawTable.RemoveChainByName(inName)
-		m.rawTable.RemoveChainByName(outName)
+		m.cleanUpPolicy(msg.Id)
 	case *proto.ActiveProfileUpdate:
 		if m.rawEgressOnly {
 			log.WithField("id", msg.Id).Debug("Ignore non-untracked profile")
@@ -144,7 +122,46 @@ func (m *policyManager) OnUpdate(msg interface{}) {
 	}
 }
 
+func (m *policyManager) cleanUpPolicy(id *proto.PolicyID) {
+	if m.rawEgressOnly {
+		m.updateNeededIPSets(id, nil)
+	}
+	inName := rules.PolicyChainName(rules.PolicyInboundPfx, id)
+	outName := rules.PolicyChainName(rules.PolicyOutboundPfx, id)
+	// As above, we need to clean up in all the tables.
+	m.filterTable.RemoveChainByName(inName)
+	m.filterTable.RemoveChainByName(outName)
+	m.mangleTable.RemoveChainByName(inName)
+	m.mangleTable.RemoveChainByName(outName)
+	m.rawTable.RemoveChainByName(inName)
+	m.rawTable.RemoveChainByName(outName)
+}
+
+func (m *policyManager) updateNeededIPSets(id *proto.PolicyID, neededIPSets set.Set[string]) {
+	if neededIPSets != nil {
+		m.neededIPSets[*id] = neededIPSets
+	} else {
+		delete(m.neededIPSets, *id)
+	}
+	m.ipSetFilterDirty = true
+}
+
 func (m *policyManager) CompleteDeferredWork() error {
-	// Nothing to do, we don't defer any work.
+	if !m.rawEgressOnly {
+		return nil
+	}
+	if !m.ipSetFilterDirty {
+		return nil
+	}
+	m.ipSetFilterDirty = false
+
+	merged := set.New[string]()
+	for _, ipSets := range m.neededIPSets {
+		ipSets.Iter(func(item string) error {
+			merged.Add(item)
+			return nil
+		})
+	}
+	m.ipSetsCallback(merged)
 	return nil
 }


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
In BPF mode, we don't want to program linux IP sets unless we're using "untracked" policy, which is partially implemented in iptables.  The filter to prevent IP set programming was only set after a policy churn.

- Defer calculation of the filter until CompleteDeferredWork.
- Make sure the "dirty" flag is set at start of day so that the programming triggers before the first dataplane apply().

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
CORE-9898

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
