### PR TITLE
Include OS release and package metadata in Typha images

### DIFF
--- a/typha/docker-image/Dockerfile.amd64
+++ b/typha/docker-image/Dockerfile.amd64
@@ -37,6 +37,10 @@ LABEL name="Calico Typha" \
       description="Calico Typha is a fan-out datastore proxy" \
       maintainer="Shaun Crampton <shaun@tigera.io>"
 
+# Copy OS release and package metadata
+COPY --from=ubi /var/lib/rpm/* var/lib/rpm
+COPY --from=ubi /etc/redhat-release /etc/redhat-release
+
 COPY --from=ubi /sbin/tini /sbin/tini
 COPY --from=ubi /licenses /licenses
 

--- a/typha/docker-image/Dockerfile.arm64
+++ b/typha/docker-image/Dockerfile.arm64
@@ -33,6 +33,12 @@ RUN chmod +x /sbin/tini
 FROM scratch
 COPY --from=base /sbin/tini /sbin/tini
 
+# Copy OS release and package metadata
+COPY --from=base /var/lib/dpkg/status /var/lib/dpkg/status
+COPY --from=base /var/lib/dpkg/available /var/lib/dpkg/available
+COPY --from=base /var/lib/apt/lists /var/lib/apt/lists
+COPY --from=base /etc/debian_version /etc/debian_version
+
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.
 ADD bin/calico-typha-arm64 /code/calico-typha

--- a/typha/docker-image/Dockerfile.ppc64le
+++ b/typha/docker-image/Dockerfile.ppc64le
@@ -33,6 +33,12 @@ RUN chmod +x /sbin/tini
 FROM scratch
 COPY --from=base /sbin/tini /sbin/tini
 
+# Copy OS release and package metadata
+COPY --from=base /var/lib/dpkg/status /var/lib/dpkg/status
+COPY --from=base /var/lib/dpkg/available /var/lib/dpkg/available
+COPY --from=base /var/lib/apt/lists /var/lib/apt/lists
+COPY --from=base /etc/debian_version /etc/debian_version
+
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.
 ADD bin/calico-typha-ppc64le /code/calico-typha

--- a/typha/docker-image/Dockerfile.s390x
+++ b/typha/docker-image/Dockerfile.s390x
@@ -33,6 +33,12 @@ RUN chmod +x /sbin/tini
 FROM scratch
 COPY --from=base /sbin/tini /sbin/tini
 
+# Copy OS release and package metadata
+COPY --from=base /var/lib/dpkg/status /var/lib/dpkg/status
+COPY --from=base /var/lib/dpkg/available /var/lib/dpkg/available
+COPY --from=base /var/lib/apt/lists /var/lib/apt/lists
+COPY --from=base /etc/debian_version /etc/debian_version
+
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.
 ADD bin/calico-typha-s390x /code/calico-typha


### PR DESCRIPTION
## Description

Without operating system and package details in the Docker image after starting with a FROM scratch statement in the Dockerfile, security scanners like Trivy won't be able to find vulnerabilities in the image. This PR fixes that by adding the necessary COPY commands to include this info in the final image. This way, Trivy and other scanners can identify vulnerabilities in the Typha images.

## Related issues/PRs

fixes [ISSUE 8051](https://github.com/projectcalico/calico/issues/8051)


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
