### PR TITLE
Create Dependabot Configuation to support Docker and go module updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /node/windows-packaging
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /networking-calico
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /hack/postrelease
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /api
+  schedule:
+    interval: weekly


### PR DESCRIPTION

Enable Dependabot for Dockerfile and go.mod updates.
This will update images in Dockerfile `FROM` statements, and go modules.

This PR is created by a script. Please let me know if we should modify any values.
