### PR TITLE
[windows HPC] wrap felix to restart it for config changes

### DIFF
--- a/node/windows-packaging/CalicoWindows/felix/felix-service.ps1
+++ b/node/windows-packaging/CalicoWindows/felix/felix-service.ps1
@@ -36,5 +36,15 @@ if ($env:CNI_IPAM_TYPE -EQ "host-local") {
     $env:USE_POD_CIDR = "false"
 }
 
-# Run the calico-felix binary.
-.\calico-node.exe -felix
+# Run the calico-felix binary. Wrap it in a loop and restart when felix exits due
+# to a config change (return code 129).
+while ($true) {
+    Write-Host "[felix-service.ps1] Starting calico felix process"
+    .\calico-node.exe -felix
+    Write-Host "[felix-service.ps1] calico felix process stopped, RC=$LASTEXITCODE"
+    if ($LASTEXITCODE -eq 129) {
+        Write-Host "[felix-service.ps1] Restarting calico felix process for config reload"
+        continue
+    }
+    Write-Host "[felix-service.ps1] Exiting due to non-config shutdown, RC=$LASTEXITCODE"
+}


### PR DESCRIPTION
Wrap the calico felix call in felix-service.ps1 in a loop to restart felix when it exits due to a config change (return code 129).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
