### PR TITLE
Loosen the rate limit restriction in IPAMController

### DIFF
--- a/kube-controllers/pkg/controllers/node/node_deleter.go
+++ b/kube-controllers/pkg/controllers/node/node_deleter.go
@@ -94,7 +94,8 @@ func (c *nodeDeleter) deleteStaleNodes() error {
 		}
 		if k8sNodeName != "" && !kNodeIdx[k8sNodeName] {
 			// No matching Kubernetes node with that name.
-			time.Sleep(c.rl.When(RateLimitCalicoDelete))
+			rlKey := rateLimiterItemKey{Type: RateLimitCalicoDelete, Name: k8sNodeName}
+			time.Sleep(c.rl.When(rlKey))
 
 			// Re-confirm that the node is actually missing. This minimizes the potential that the node was
 			// deleted and then re-created between the initial List() call above, and the decision to delete the
@@ -108,7 +109,7 @@ func (c *nodeDeleter) deleteStaleNodes() error {
 					return err
 				}
 			}
-			c.rl.Forget(RateLimitCalicoDelete)
+			c.rl.Forget(rlKey)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Mitigates #7839.

IPAMController uses the `workqueue.RateLimiter` for all the actions it takes (mainly GC related), which may wait up to 1000s between each actions it take. Which causes the GC (and the whole control loop) to halt after a few (17) consecutive action failures.

Per design, the `workqueue.RateLimiter` takes an item as key to make sure the rate limit is applied differently for each retried item. But `IPAMController` only uses fixed items for `ratelimiter.Wait()` calls, which means the failure accumulates across all calls.

This change address the issue in two ways:

- replace `workqueue.DefaultControllerRateLimiter()` with a customized rate limiter that cap the max retry wait time to 30s
- use fine-grind item for `ratelimiter.Wait()` calls, so the wait time only accumulates against a single action instead all actions

The test has been done in our cluster by using the same configuration mentioned in https://github.com/projectcalico/calico/issues/7839#issuecomment-1630778815. The GC happened after `leakGracePeriod` expires. Although it takes roughly 50 minutes to complete, the frozen issue is resolved.

<img width="798" alt="image" src="https://github.com/projectcalico/calico/assets/687367/01e21a82-e8d3-4ee4-8a66-ec7aa5493009">

## Related issues/PRs

N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
Prevent GC from frozen when under high GC load
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
