### PR TITLE
Add ipam_last_sync_timestamp_seconds metric

### DIFF
--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -79,7 +79,7 @@ const (
 
 func init() {
 	lastSyncTimestampGauges = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "ipam_last_sync_timestamp",
+		Name: "ipam_last_sync_timestamp_seconds",
 		Help: "Timestamp of the last IPAM sync",
 	}, []string{"status"})
 	prometheus.MustRegister(lastSyncTimestampGauges)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

IPAM Controller runs a single loop, and the metrics is dumped at the end of each sync operation. In case the sync is halting, the metrics will not be updated, and there is no way for monitoring system to know that the controller has stopped working.

This change adds `ipam_last_sync_timestamp_seconds` metric to export timestamp after each sync with status as label. So the monitoring system can easily create alerts based on that.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add ipam_last_sync_timestamp_seconds metric to kube-controllers
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
