### PR TITLE
[release-v3.26] Bump semaphore build machine for kube-controller images

### DIFF
--- a/.semaphore/push-images/kube-controllers.yml
+++ b/.semaphore/push-images/kube-controllers.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish kube-controllers images
 agent:
   machine:
-    type: e1-standard-2
+    type: e1-standard-4
     os_image: ubuntu2004
 
 execution_time_limit:


### PR DESCRIPTION
## Description

When building kube-controller images for all supported arches, e1-standard-2 free disk space is not enough. Bump the semaphore build machine type to e1-standard-4.

## Related issues/PRs

Pick https://github.com/projectcalico/calico/pull/8145 into release v3.26 branch.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
