### PR TITLE
Make operator.tigera.io cluster-role user settable

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -96,8 +96,7 @@ rules:
       - update
   - apiGroups:
       - operator.tigera.io
-    resources:
-      - '*'
+    resources: {{ toYaml .Values.clusterrole.operatorResources | nindent 4 }}
     verbs:
       - create
       - get

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -59,3 +59,6 @@ calicoctl:
   tag: master
 
 kubeletVolumePluginPath: /var/lib/kubelet
+
+clusterrole:
+  operatorResources: ["*"]


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
### Make operator.tigera.io cluster-role user settable. 

In order to achieve [Rbac - Least privilege](https://kubernetes.io/docs/concepts/security/rbac-good-practices/#least-privilege), we should allow user to setup customer resource scope.

Otherwise we should list down the necessary reasons we need a wildcard here.

