### PR TITLE
Add bounds check to BPF assembler jump fixup.

### DIFF
--- a/felix/bpf/asm/asm.go
+++ b/felix/bpf/asm/asm.go
@@ -19,6 +19,7 @@ package asm
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -676,6 +677,9 @@ func (b *Block) Assemble() (Insns, error) {
 		}
 		// Offset is relative to the next instruction since the PC is auto-incremented.
 		offset := labelIdx - f.origInsnIdx - 1
+		if offset > math.MaxInt16 || offset < math.MinInt16 {
+			return nil, fmt.Errorf("calculated jump offset (%d) to label %s would exceed jump range", offset, f.label)
+		}
 		binary.LittleEndian.PutUint16(b.insns[f.origInsnIdx].Instruction[2:4], uint16(offset))
 	}
 

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -569,7 +569,7 @@ func (leg matchLeg) stackOffsetToIPSetKey() (keyOffset int16) {
 	return
 }
 
-func (p Builder) ipVersion() uint8 {
+func (p *Builder) ipVersion() uint8 {
 	if p.forIPv6 {
 		return uint8(proto.IPVersion_IPV6)
 	} else {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

If the program is too big, the jump offset could wrap when converted to int16, fail cleanly in that case instead of offering a malformed program to the kernel.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix incorrect conversion to 16-bit offset in the BPF assembler.  Fail if the value would wrap.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
