### PR TITLE
Add Tailscale to interface exclusion list

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_linux.go
@@ -20,5 +20,5 @@ var DEFAULT_INTERFACES_TO_EXCLUDE []string = []string{
 	"^virbr.*", "^lxcbr.*", "^veth.*", "^lo", "^br-.*",
 	"^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*",
 	"^vxlan\\.calico.*", "^vxlan-v6\\.calico.*", "^wireguard\\.cali.*", "^wg-v6\\.cali.*",
-	"^nodelocaldns.*",
+	"^nodelocaldns.*","^tailscale.*"
 }

--- a/node/pkg/lifecycle/startup/autodetection/autodetection_windows.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_windows.go
@@ -19,4 +19,5 @@ var DEFAULT_INTERFACES_TO_EXCLUDE = []string{
 	".*\\(nat\\).*",
 	".*Calico.*_ep", // Exclude our management endpoint.
 	"Loopback.*",
+	".*Tailscale.*",
 }

--- a/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
+++ b/node/pkg/lifecycle/startup/autodetection/interfaces_linux_test.go
@@ -95,4 +95,9 @@ var _ = DescribeTable("GetInterfaces",
 			return []net.Interface{{Index: 0, Name: "br-1234deadbeaf"}}, nil
 		},
 	}),
+	Entry("should skip tailscale", getInterfacesTestCase{
+		getInterfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 0, Name: "tailscale"}}, nil
+		},
+	}),
 )


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico/issues/7832.

It excludes Tailscale interfaces from being used for Calico.