### PR TITLE
RPF check - BPF IPv6

### DIFF
--- a/felix/bpf-gpl/ip_addr.h
+++ b/felix/bpf-gpl/ip_addr.h
@@ -47,6 +47,7 @@ static CALI_BPF_INLINE int ipv6_addr_t_cmp(ipv6_addr_t *x, ipv6_addr_t *y)
 }
 
 #define ip_void(ip)	((ip).a == 0 && (ip).b == 0 && (ip).c == 0 && (ip).d == 0)
+#define ip_link_local(ip)	(bpf_htonl((ip).a) == 0xfe800000)
 #define VOID_IP		({ipv6_addr_t x = {}; x;})
 #define ip_set_void(ip)	do {	\
 	(ip).a = 0;		\

--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -41,6 +41,9 @@ static CALI_BPF_INLINE int parse_packet_ip_v6(struct cali_tc_ctx *ctx) {
 	switch (protocol) {
 	case ETH_P_IPV6:
 		break;
+        case ETH_P_ARP:
+                CALI_DEBUG("ARP: allowing packet\n");
+                goto allow_no_fib;
 	case ETH_P_IP:
 		if (CALI_F_HEP) {
 			CALI_DEBUG("IPv4 on host interface: allow\n");

--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -42,6 +42,10 @@ static CALI_BPF_INLINE int parse_packet_ip_v6(struct cali_tc_ctx *ctx) {
 	case ETH_P_IPV6:
 		break;
 	case ETH_P_IP:
+		if (CALI_F_HEP) {
+			CALI_DEBUG("IPv4 on host interface: allow\n");
+			goto allow_no_fib;
+		}
 		CALI_DEBUG("Unexpected ipv4 packet, drop\n");
 		goto deny;
 	default:

--- a/felix/bpf-gpl/rpf.h
+++ b/felix/bpf-gpl/rpf.h
@@ -97,6 +97,16 @@ static CALI_BPF_INLINE bool hep_rpf_check(struct cali_tc_ctx *ctx)
 						debug_ip(ctx->state->ip_src), fib_params.ifindex);
 #endif
 			}
+			break;
+		case BPF_FIB_LKUP_RET_NOT_FWDED:
+#ifdef IPVER6
+			if (ip_link_local(ctx->state->ip_dst) && ip_link_local(ctx->state->ip_src)) {
+				ret = true;
+				CALI_DEBUG("Host RPF check disabled if src and dst are link local\n");
+			}
+#endif
+			break;
+
 	}
 
 #ifdef IPVER6


### PR DESCRIPTION
## Description

1) Allow IPv4 packets to HEP if in IPv6 mode.
2) Allow ARP
3) DHCPv6 reply packets are dropped because rpf checks fail at the host. The renewal is from the link-local address to ```ff02::1:2```. Whereas the reply is from DHCP relay's link local address. As a result ```bpf_fib_lookup``` fails with ```BPF_FIB_LKUP_RET_NOT_FWDED```. Don't do rpf checks for link-local addresses at the HEP.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
