### PR TITLE
Get node's IPv6 address with non-calico CNI

### DIFF
--- a/felix/calc/calc_graph.go
+++ b/felix/calc/calc_graph.go
@@ -374,7 +374,7 @@ func NewCalculationGraph(callbacks PipelineCallbacks, conf *config.Config, liveC
 	//         |
 	//      <dataplane>
 	//
-	hostIPPassthru := NewDataplanePassthru(callbacks)
+	hostIPPassthru := NewDataplanePassthru(callbacks, conf.Ipv6Support)
 	hostIPPassthru.RegisterWith(allUpdDispatcher)
 	cg.hostIPPassthru = hostIPPassthru
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -675,12 +675,12 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 
 	case *proto.HostMetadataUpdate:
 		if !m.ipv6Enabled && msg.Hostname == m.hostname {
-			log.WithField("HostMetadataUpdate", msg).Info("Host IP changed")
+			log.WithField("HostMetadataUpdate", msg).Infof("Host IP changed: %s", msg.Ipv4Addr)
 			m.updateHostIP(net.ParseIP(msg.Ipv4Addr))
 		}
 	case *proto.HostMetadataV6Update:
 		if m.ipv6Enabled && msg.Hostname == m.hostname {
-			log.WithField("HostMetadataV6Update", msg).Info("Host IPv6 changed")
+			log.WithField("HostMetadataV6Update", msg).Infof("Host IPv6 changed: %s", msg.Ipv6Addr)
 			m.updateHostIP(net.ParseIP(msg.Ipv6Addr))
 		}
 	case *proto.HostMetadataV4V6Update:
@@ -688,10 +688,10 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 			break
 		}
 		if m.ipv6Enabled {
-			log.WithField("HostMetadataV4V6Update", msg).Info("Host IPv6 changed")
+			log.WithField("HostMetadataV4V6Update", msg).Infof("Host IPv6 changed: %s", msg.Ipv6Addr)
 			m.updateHostIP(net.ParseIP(msg.Ipv6Addr))
 		} else {
-			log.WithField("HostMetadataV4V6Update", msg).Info("Host IP changed")
+			log.WithField("HostMetadataV4V6Update", msg).Infof("Host IP changed: %s", msg.Ipv4Addr)
 			m.updateHostIP(net.ParseIP(msg.Ipv4Addr))
 		}
 	case *proto.ServiceUpdate:


### PR DESCRIPTION
Without calico cni, Node.Spec.BGP is not populated. In v4 mode, libcalico falls back to getting the node's address from Node.Spec.Addresses. IPv6 detection takes a different path and always depended on Node.Spec.BPG being present. Do the same fallback in DataplanePassthru where the v6 updates are created.

This guarantees that we always know the node's IP in k8s environment. eBPF mode needs to know that to load its hep programs.

refs https://github.com/projectcalico/calico/issues/4736

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Node learns about it's ipv6 address in kubernetes even if BGP is turned off and CNI is not calico.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
