### PR TITLE
Update flannel to v0.23.0

### DIFF
--- a/charts/calico/values.yaml
+++ b/charts/calico/values.yaml
@@ -14,7 +14,7 @@ kubeControllers:
   image: docker.io/calico/kube-controllers
 flannel:
   image: docker.io/flannel/flannel
-  tag: v0.21.3
+  tag: v0.23.0
 flannelMigration:
   image: docker.io/calico/flannel-migration
 dikastes:

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -607,7 +607,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: docker.io/flannel/flannel:v0.21.3
+          image: docker.io/flannel/flannel:v0.23.0
           imagePullPolicy: IfNotPresent
           env:
             # The location of the etcd cluster.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4966,7 +4966,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: docker.io/flannel/flannel:v0.21.3
+          image: docker.io/flannel/flannel:v0.23.0
           imagePullPolicy: IfNotPresent
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:


### PR DESCRIPTION
## Description

Updates flannel to v0.23.0

Tested with:
* Talos v1.5.4
* Kernel 6.1.58
* Kubernetes v1.28.1




