### PR TITLE
BPF: Split large policy programs into sub-programs.

### DIFF
--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -81,9 +81,9 @@ enum cali_jump_index {
 
 #if CALI_F_XDP
 
-#define cali_jump_prog_map map_symbol(xdp_cali_jump, 2)
+#define cali_jump_prog_map map_symbol(xdp_cali_jump, 3)
 
-CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 100, 0)
+CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 2400, 0)
 
 /* We on any path, we always jump to the PROG_INDEX_POLICY for policy, that one
  * is shared!
@@ -92,9 +92,9 @@ CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 100, 0)
 	bpf_tail_call((ctx)->xdp, &cali_jump_prog_map, (ctx)->xdp_globals->jumps[PROG_INDEX_POLICY])
 #else /* CALI_F_XDP */
 
-#define cali_jump_prog_map map_symbol(cali_jump, 2)
+#define cali_jump_prog_map map_symbol(cali_jump, 3)
 
-CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 10000, 0)
+CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 240000, 0)
 
 #define __CALI_JUMP_TO_POLICY(ctx, allow, deny, pol) do {	\
 	(ctx)->skb->cb[0] = (ctx)->globals->jumps[PROG_PATH(allow)];			\

--- a/felix/bpf/asm/asm.go
+++ b/felix/bpf/asm/asm.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -293,6 +294,7 @@ var (
 
 const InstructionSize = 8
 
+// Insn represents one 8-byte instruction.
 type Insn struct {
 	Instruction [InstructionSize]uint8 `json:"inst"`
 	Labels      []string               `json:"labels,omitempty"`
@@ -300,6 +302,7 @@ type Insn struct {
 	Annotation  string                 `json:"annotation,omitempty"`
 }
 
+// Insns represents a series of BPF instructions.
 type Insns []Insn
 
 func (ns Insns) AsBytes() []byte {
@@ -342,14 +345,35 @@ func (n Insn) Imm() int32 {
 	return int32(binary.LittleEndian.Uint32(n.Instruction[4:8]))
 }
 
+func (n Insn) IsNoOp() bool {
+	return n.OpCode() == Mov64 && n.Dst() == n.Src()
+}
+
+// Block is a "builder" object for a block of BPF instructions.  After
+// creating a new Block, call the instruction-named methods to add
+// instructions to the block and then call Assemble() to resolve the
+// bytecode.
+//
+// Block automatically skips unreachable instructions as they are added (this
+// is an optimisation to remove the need for a second pass over the code).
+// this assumes that all reachable instructions are reachable via *forward*
+// jumps.
+//
+// Block supports forwards jumps, including jumps that are longer than
+// a single eBPF jump allows.  It injects "trampoline" jump blocks where
+// needed.  Backwards jumps should also work but long backwards jumps are
+// not supported (there is no trampoline injection).
 type Block struct {
 	insns              Insns
-	fixUps             []fixUp
+	fixUps             map[string][]fixUp
 	labelToInsnIdx     map[string]int
 	insnIdxToLabels    map[int][]string
 	insnIdxToComments  map[int][]string
 	inUseJumpTargets   set.Set[string]
 	policyDebugEnabled bool
+	trampolineIdx      int
+	lastTrampolineAddr int
+	deferredErr        error
 }
 
 func NewBlock(policyDebugEnabled bool) *Block {
@@ -359,12 +383,16 @@ func NewBlock(policyDebugEnabled bool) *Block {
 		inUseJumpTargets:   set.New[string](),
 		insnIdxToComments:  map[int][]string{},
 		policyDebugEnabled: policyDebugEnabled,
+		fixUps:             map[string][]fixUp{},
 	}
 }
 
 type fixUp struct {
-	label       string
 	origInsnIdx int
+}
+
+func (b *Block) NoOp() {
+	b.Mov64(R0, R0)
 }
 
 func (b *Block) FromBE(dst Reg, size int32) {
@@ -640,10 +668,74 @@ func (b *Block) buildAnnotation(opcode OpCode, src, dst Reg, fo FieldOffset, imm
 
 type OffsetFixer func(origInsn Insn) Insn
 
+// Maximum jump distance is math.MaxInt16, we need to start writing the
+// trampoline before we reach that distance so that the whole trampoline fits
+// within the jump. Since we have at most a handful of labels outstanding,
+// (1-2 for a rule, one to jump to accept/deny/end-of-tier) this seems like
+// it should be enough.
+const trampolineHeadroom = 100
+const trampolineInterval = math.MaxInt16 - trampolineHeadroom
+
 func (b *Block) addInsnWithOffsetFixup(insn Insn, targetLabel string) {
-	insnLabel := strings.Join(b.insnIdxToLabels[len(b.insns)], ",")
+	b.maybeWriteTrampoline(insn)
+
+	b.addInsnWithOffsetFixupNoTrampoline(insn, targetLabel)
+}
+
+func (b *Block) maybeWriteTrampoline(nextInsn Insn) {
+	if len(b.insns)-b.lastTrampolineAddr < trampolineInterval {
+		return
+	}
+	if nextInsn.OpCode() == LoadImm64Pt2 {
+		// LoadImm64 is a 2-part instruction, we must not split it.
+		return
+	}
+	b.writeTrampoline()
+}
+
+func (b *Block) writeTrampoline() {
+	b.lastTrampolineAddr = len(b.insns)
+
+	if len(b.fixUps) == 0 {
+		return
+	}
+
+	// Find all the outstanding labels and add a jump for them.
+	labels := make([]string, 0, len(b.fixUps))
+	for label := range b.fixUps {
+		labels = append(labels, label)
+	}
+	// Sort for determinism.
+	sort.Strings(labels)
+
+	// Trampoline is written in the middle of other instructions, do an
+	// unconditional jump past the trampoline for the main execution flow.
+	// Using JumpNoTrampoline to avoid recursion here!
+	endLabel := fmt.Sprintf("skip-trampoline-%d", b.trampolineIdx)
+	b.trampolineIdx++
+	b.JumpNoTrampoline(endLabel)
+	for _, label := range labels {
+		b.LabelNextInsn(label)
+		b.JumpNoTrampoline(label)
+	}
+	b.LabelNextInsn(endLabel)
+}
+
+func (b *Block) JumpNoTrampoline(endLabel string) {
+	insn := MakeInsn(JumpA, 0, 0, 0, 0)
+	b.addInsnWithOffsetFixupNoTrampoline(insn, endLabel)
+}
+
+func (b *Block) addInsnWithOffsetFixupNoTrampoline(insn Insn, targetLabel string) {
+	var insnLabel string
+	debug := log.IsLevelEnabled(log.DebugLevel)
+	if debug {
+		insnLabel = strings.Join(b.insnIdxToLabels[len(b.insns)], ",")
+	}
 	if !b.nextInsnReachable() {
-		log.Debugf("Asm: %v UU:    %v [UNREACHABLE]", insnLabel, insn)
+		if debug {
+			log.Debugf("Asm: %v UU:    %v [UNREACHABLE]", insnLabel, insn)
+		}
 		for _, l := range b.insnIdxToLabels[len(b.insns)] {
 			delete(b.labelToInsnIdx, l)
 		}
@@ -654,14 +746,16 @@ func (b *Block) addInsnWithOffsetFixup(insn Insn, targetLabel string) {
 	if targetLabel != "" {
 		comment = " -> " + targetLabel
 	}
-	log.Debugf("Asm: %v %d:    %v%s", insnLabel, len(b.insns), insn, comment)
+	if debug {
+		log.Debugf("Asm: %v %d:    %v%s", insnLabel, len(b.insns), insn, comment)
+	}
 	b.insns = append(b.insns, insn)
 	if targetLabel != "" {
 		if b.policyDebugEnabled {
 			b.insns[len(b.insns)-1].Annotation = fmt.Sprintf("goto %s", targetLabel)
 		}
 		b.inUseJumpTargets.Add(targetLabel)
-		b.fixUps = append(b.fixUps, fixUp{label: targetLabel, origInsnIdx: len(b.insns) - 1})
+		b.fixUps[targetLabel] = append(b.fixUps[targetLabel], fixUp{origInsnIdx: len(b.insns) - 1})
 	}
 }
 
@@ -670,17 +764,15 @@ func (b *Block) TargetIsUsed(label string) bool {
 }
 
 func (b *Block) Assemble() (Insns, error) {
-	for _, f := range b.fixUps {
-		labelIdx, ok := b.labelToInsnIdx[f.label]
-		if !ok {
-			return nil, fmt.Errorf("missing label: %s", f.label)
+	if b.deferredErr != nil {
+		return nil, b.deferredErr
+	}
+
+	for label := range b.fixUps {
+		err := b.applyFixUps(label)
+		if err != nil {
+			return nil, err
 		}
-		// Offset is relative to the next instruction since the PC is auto-incremented.
-		offset := labelIdx - f.origInsnIdx - 1
-		if offset > math.MaxInt16 || offset < math.MinInt16 {
-			return nil, fmt.Errorf("calculated jump offset (%d) to label %s would exceed jump range", offset, f.label)
-		}
-		binary.LittleEndian.PutUint16(b.insns[f.origInsnIdx].Instruction[2:4], uint16(offset))
 	}
 
 	if b.policyDebugEnabled {
@@ -697,9 +789,44 @@ func (b *Block) Assemble() (Insns, error) {
 	return b.insns, nil
 }
 
+func (b *Block) applyFixUps(targetLabel string) error {
+	for _, f := range b.fixUps[targetLabel] {
+		labelIdx, ok := b.labelToInsnIdx[targetLabel]
+		if !ok {
+			return fmt.Errorf("missing label: %s", targetLabel)
+		}
+		// Offset is relative to the next instruction since the PC is auto-incremented.
+		offset := labelIdx - f.origInsnIdx - 1
+		if offset == -1 {
+			// This case is made more likely by the trampoline machinery
+			// since it's what we'd hit if a trampoline was generated but
+			// then the intended jump target was never added.
+			return fmt.Errorf("calculated jump offset (%d) to label %s would jump to same instruction", offset, targetLabel)
+		}
+		if offset > math.MaxInt16 || offset < math.MinInt16 {
+			return fmt.Errorf("calculated jump offset (%d) to label %s would exceed jump range", offset, targetLabel)
+		}
+		binary.LittleEndian.PutUint16(b.insns[f.origInsnIdx].Instruction[2:4], uint16(offset))
+	}
+	delete(b.fixUps, targetLabel)
+	return nil
+}
+
 func (b *Block) LabelNextInsn(label string) {
 	b.labelToInsnIdx[label] = len(b.insns)
 	b.insnIdxToLabels[len(b.insns)] = append(b.insnIdxToLabels[len(b.insns)], label)
+
+	// Eagerly apply fixUps now so that we can re-use the same label names
+	// when making trampolines.
+	err := b.applyFixUps(label)
+	if err != nil {
+		log.WithError(err).Error("Failed to apply fix-ups in BPF assembler; program generation will fail")
+		// Log a deferred error to be returned by Assemble().  This saves adding
+		// error checks throughout the policy program builder, for example.
+		if b.deferredErr == nil {
+			b.deferredErr = fmt.Errorf("failed to apply fix-ups when adding label %q @ %d: %w", label, len(b.insns), err)
+		}
+	}
 }
 
 func (b *Block) AddComment(comment string) {
@@ -712,17 +839,26 @@ func (b *Block) nextInsnReachable() bool {
 	if len(b.insns) == 0 {
 		return true // First instruction is always reachable.
 	}
-	for _, l := range b.insnIdxToLabels[len(b.insns)] {
-		if b.inUseJumpTargets.Contains(l) {
-			return true // Previous instruction jumps to this one, we're reachable.
-		}
-	}
 	lastInsn := b.insns[len(b.insns)-1]
-	switch lastInsn.OpCode() {
-	case JumpA, Exit:
-		// Previous instruction jumps or returns and it doesn't jump here so we're not reachable.
+	lastOpCode := lastInsn.OpCode()
+	if lastOpCode == JumpA /*Unconditional jump*/ || lastOpCode == Exit {
+		// Previous instruction doesn't fall through to this one, need
+		// to check if something else jumps here...
+		for _, l := range b.insnIdxToLabels[len(b.insns)] {
+			if b.inUseJumpTargets.Contains(l) {
+				return true // Previous instruction jumps to this one, we're reachable.
+			}
+		}
 		return false
-	default:
-		return true
 	}
+	return true
+}
+
+func (b *Block) ReserveInstructionCapacity(n int) {
+	if cap(b.insns) >= n {
+		return
+	}
+	newInsns := make(Insns, len(b.insns), n)
+	copy(newInsns, b.insns)
+	b.insns = newInsns
 }

--- a/felix/bpf/asm/asm_test.go
+++ b/felix/bpf/asm/asm_test.go
@@ -15,6 +15,7 @@
 package asm
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -96,29 +97,62 @@ func TestBlock_Mainline(t *testing.T) {
 	}))
 }
 
-func TestJumpTooFar(t *testing.T) {
+func TestSkipUnreachable(t *testing.T) {
 	RegisterTestingT(t)
-
-	// Jump exactly MaxInt16 should be OK.
 	b := NewBlock(false)
-	b.JumpEq32(R0, R1, "label")
-	for i := 0; i < math.MaxInt16; i++ {
-		b.MovImm32(R3, int32(i))
-	}
-	b.LabelNextInsn("label")
-	b.MovImm32(R3, 42)
-	_, err := b.Assemble()
+
+	// Unconditional jump, reachable because at start of program.
+	b.Jump("label-0")
+	// Not reachable, preceding jump skips it.
+	b.Jump("label-1")
+	// Reachable: first jump targets this.
+	b.LabelNextInsn("label-0")
+	b.JumpEq64(R1, R2, "label-2")
+	// Reachable: JumpEq64 may fall through.
+	b.Exit()
+	// Unreachable: Exit doesn't fall through and the jump to label-1 was
+	// unreachable too.
+	b.LabelNextInsn("label-1")
+	b.NoOp()
+	// Reachable: from the reachable JumpEq64.
+	b.LabelNextInsn("label-2")
+	b.Mov64(R1, R2)
+
+	insns, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
 
-	// But one more should fail.
-	b = NewBlock(false)
-	b.JumpEq32(R0, R1, "label")
-	for i := 0; i <= math.MaxInt16; i++ {
-		b.MovImm32(R3, int32(i))
+	Expect(insns).To(Equal(Insns{
+		MakeInsn(JumpA, 0, 0, 0, 0),
+		MakeInsn(JumpEq64, 1, 2, 1, 0),
+		MakeInsn(Exit, 0, 0, 0, 0),
+		MakeInsn(Mov64, 1, 2, 0, 0),
+	}))
+}
+
+func TestLongJump(t *testing.T) {
+	RegisterTestingT(t)
+
+	for numNoOps := math.MaxInt16 - 1200; numNoOps < math.MaxInt16+1200; numNoOps++ {
+		b := NewBlock(false)
+		b.ReserveInstructionCapacity(numNoOps + 5)
+		b.JumpEq32(R0, R1, "label")
+		for i := 0; i < numNoOps; i++ {
+			b.NoOp()
+		}
+		b.LabelNextInsn("label")
+		b.Exit()
+		_, err := b.Assemble()
+		Expect(err).NotTo(HaveOccurred())
 	}
-	b.LabelNextInsn("label")
-	b.MovImm32(R3, 42)
-	_, err = b.Assemble()
+}
+
+func TestJumpToSelf(t *testing.T) {
+	RegisterTestingT(t)
+
+	b := NewBlock(false)
+	b.LabelNextInsn("self")
+	b.Jump("self")
+	_, err := b.Assemble()
 	Expect(err).To(HaveOccurred())
 }
 
@@ -132,23 +166,334 @@ func TestJumpBackwardsTooFar(t *testing.T) {
 	// after the jump itself.
 	safeNumInsns := -math.MinInt16 - 1
 	for i := 0; i < safeNumInsns; i++ {
-		b.MovImm32(R3, int32(i))
+		b.NoOp()
 	}
 	b.JumpEq32(R0, R1, "label")
 	b.MovImm32(R3, 42)
 	_, err := b.Assemble()
 	Expect(err).NotTo(HaveOccurred())
 
-	// Jump backwards on eextra should fail.
+	// Jump backwards one extra instruction should fail.
 	b = NewBlock(false)
 	b.LabelNextInsn("label")
 	// Subtract one because the jump is relative to the instruction
 	// after the jump itself.
 	for i := 0; i <= safeNumInsns; i++ {
-		b.MovImm32(R3, int32(i))
+		b.NoOp()
 	}
 	b.JumpEq32(R0, R1, "label")
 	b.MovImm32(R3, 42)
 	_, err = b.Assemble()
 	Expect(err).To(HaveOccurred())
+}
+
+func TestSingleTrampoline(t *testing.T) {
+	RegisterTestingT(t)
+
+	b := NewBlock(false)
+
+	// Make a couple of long jumps, then lots of no-ops to trigger creation of
+	// a trampoline.
+	b.JumpEq64(R1, R2, "longB")
+	b.JumpEq64(R1, R2, "longA")
+	for i := 0; i < trampolineInterval; i++ {
+		b.NoOp()
+	}
+
+	// Some instructions to jump to...
+	b.LabelNextInsn("longA")
+	b.Mov64(R1, R2)
+	b.Exit()
+	b.LabelNextInsn("longB")
+	b.Exit()
+
+	insns, err := b.Assemble()
+	Expect(err).NotTo(HaveOccurred())
+	logSummarisingNoOps(t, insns)
+
+	// Calculate where the trampoline should be.  We sort the jumps within
+	// the trampoline for determinacy so longA will be before longB.
+	const (
+		trampolineStartAddr = trampolineInterval + iota
+		longATrampolineAddr
+		longBTrampolineAddr
+		trampolineEndAddr
+	)
+	const (
+		jumpToBAddr = iota
+		jumpToAAddr
+	)
+	Expect(insns[jumpToBAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longBTrampolineAddr-jumpToBAddr-1, 0)))
+	Expect(insns[jumpToAAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longATrampolineAddr-jumpToAAddr-1, 0)))
+
+	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
+	for i := 2; i < trampolineInterval-1; i++ {
+		Expect(insns[i]).To(Equal(noOp))
+	}
+
+	// Jump to skip the trampoline itself.
+	Expect(insns[trampolineStartAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 2, 0)))
+	// Jump to longA
+	Expect(insns[longATrampolineAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 3, 0)))
+	// Jump to longB
+	Expect(insns[longBTrampolineAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 4, 0)))
+
+	// 2 no-ops fall out of the trampoline interval because there are 2 user
+	// instructions in the block.
+	Expect(insns[trampolineEndAddr]).To(Equal(noOp))
+	Expect(insns[trampolineEndAddr+1]).To(Equal(noOp))
+
+	// longA
+	Expect(insns[trampolineEndAddr+2]).To(Equal(MakeInsn(Mov64, R1, R2, 0, 0)))
+	Expect(insns[trampolineEndAddr+3]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+	// longB
+	Expect(insns[trampolineEndAddr+4]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+}
+
+func TestTrampolineLoadImm64(t *testing.T) {
+	RegisterTestingT(t)
+
+	b := NewBlock(false)
+
+	// Make a couple of long jumps, then lots of no-ops to trigger creation of
+	// a trampoline.
+	b.JumpEq64(R1, R2, "longB")
+	b.JumpEq64(R1, R2, "longA")
+	for i := 0; i < trampolineInterval-3; i++ {
+		b.NoOp()
+	}
+	b.LoadImm64(R3, 1234)
+
+	// Some instructions to jump to...
+	// Since the trampoline was blocked by the LoadImm64, this longA
+	// label actually labels the first instruction of the trampoline, which
+	// means we don't get a "longA" jump inside the trampoline.
+	b.LabelNextInsn("longA")
+	b.Mov64(R1, R2)
+	b.Exit()
+	b.LabelNextInsn("longB")
+	b.Exit()
+
+	insns, err := b.Assemble()
+	Expect(err).NotTo(HaveOccurred())
+	logSummarisingNoOps(t, insns)
+
+	// Calculate where the trampoline should be.  We sort the jumps within
+	// the trampoline for determinacy so longA will be before longB.
+	const (
+		trampolineStartAddr = trampolineInterval + 1 + iota
+		longBTrampolineAddr
+		trampolineEndAddr
+	)
+	const (
+		jumpToBAddr = iota
+		jumpToAAddr
+	)
+	Expect(insns[jumpToBAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longBTrampolineAddr-jumpToBAddr-1, 0)))
+	Expect(insns[jumpToAAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, trampolineStartAddr-jumpToAAddr-1, 0)))
+
+	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
+	for i := 2; i < trampolineInterval-1; i++ {
+		Expect(insns[i]).To(Equal(noOp))
+	}
+
+	// Jump to skip the trampoline itself.
+	Expect(insns[trampolineStartAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 1, 0)))
+	// Jump to longB
+	Expect(insns[longBTrampolineAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 2, 0)))
+
+	// longA
+	Expect(insns[trampolineEndAddr]).To(Equal(MakeInsn(Mov64, R1, R2, 0, 0)))
+	Expect(insns[trampolineEndAddr+1]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+	// longB
+	Expect(insns[trampolineEndAddr+2]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+}
+
+func TestShortJumpAndTrampoline(t *testing.T) {
+	RegisterTestingT(t)
+
+	b := NewBlock(false)
+
+	// Make a couple of long jumps, then lots of no-ops to trigger creation of
+	// a trampoline.
+	b.JumpEq64(R1, R2, "shortA")
+	b.JumpEq64(R1, R2, "longA")
+	b.LabelNextInsn("shortA")
+	for i := 0; i < trampolineInterval; i++ {
+		b.NoOp()
+	}
+
+	// Some instructions to jump to...
+	b.LabelNextInsn("longA")
+	b.Mov64(R1, R2)
+	b.Exit()
+
+	insns, err := b.Assemble()
+	Expect(err).NotTo(HaveOccurred())
+	logSummarisingNoOps(t, insns)
+
+	// Calculate where the trampoline should be.  We sort the jumps within
+	// the trampoline for determinacy so longA will be before longB.
+	const (
+		trampolineStartAddr = trampolineInterval + iota
+		longATrampolineAddr
+		trampolineEndAddr
+	)
+	const (
+		jumpToShort = iota
+		jumpToLong
+	)
+
+	Expect(insns[jumpToShort]).To(Equal(MakeInsn(JumpEq64, R1, R2, 1, 0)))
+	Expect(insns[jumpToLong]).To(Equal(MakeInsn(JumpEq64, R1, R2, longATrampolineAddr-jumpToLong-1, 0)))
+
+	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
+	for i := 2; i < trampolineInterval-1; i++ {
+		Expect(insns[i]).To(Equal(noOp))
+	}
+
+	// Jump to skip the trampoline itself.
+	Expect(insns[trampolineStartAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 1, 0)))
+	// Jump to longA
+	Expect(insns[longATrampolineAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 2, 0)))
+
+	// 2 no-ops fall out of the trampoline interval because there are 2 user
+	// instructions in the block.
+	Expect(insns[trampolineEndAddr]).To(Equal(noOp))
+	Expect(insns[trampolineEndAddr+1]).To(Equal(noOp))
+
+	// longA
+	Expect(insns[trampolineEndAddr+2]).To(Equal(MakeInsn(Mov64, R1, R2, 0, 0)))
+	Expect(insns[trampolineEndAddr+3]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+}
+
+func TestDoubleTrampoline(t *testing.T) {
+	RegisterTestingT(t)
+
+	b := NewBlock(false)
+
+	// Make a couple of long jumps, then lots of no-ops to trigger creation of
+	// a trampoline.
+	b.JumpEq64(R1, R2, "longB")
+	b.JumpEq64(R1, R2, "longA")
+	for i := 0; i < trampolineInterval; i++ {
+		b.NoOp()
+	}
+
+	// Couple more jumps in the second trampoline interval.  longB will be a
+	// double jump only, longA will be a mix, longC will only jump one trampoline.
+	b.JumpEq64(R1, R2, "longA")
+	b.JumpEq64(R1, R3, "longC")
+
+	for i := 0; i < trampolineInterval; i++ {
+		b.NoOp()
+	}
+
+	// Some instructions to jump to...
+	b.LabelNextInsn("longA")
+	b.Mov64(R1, R2)
+	b.Exit()
+	b.LabelNextInsn("longB")
+	b.Exit()
+	b.LabelNextInsn("longC")
+	b.Exit()
+
+	insns, err := b.Assemble()
+	Expect(err).NotTo(HaveOccurred())
+	logSummarisingNoOps(t, insns)
+
+	// Calculate where the trampolines should be.  We sort the jumps within
+	// the trampoline for determinacy so longA will be before longB.
+	const (
+		trampoline0StartAddr = trampolineInterval + iota
+		longATrampoline0Addr
+		longBTrampoline0Addr
+		trampoline0EndAddr
+	)
+	const (
+		jumpToBAddr = iota
+		jumpToAAddr
+	)
+	const (
+		trampoline1StartAddr = trampolineInterval*2 + iota
+		longATrampoline1Addr
+		longBTrampoline1Addr
+		longCTrampoline1Addr
+		trampoline1EndAddr
+	)
+	const secondJumpToAAddr = trampoline0EndAddr + 2 // After the no-ops that fell out.
+	const jumpToCAddr = trampoline0EndAddr + 3
+
+	// Trampoline 1
+	// Similar to single-trampoline case but the jumps in the trampoline
+	// point to the second trampoline...
+	t.Log("Checking trampoline 0...")
+
+	// User-provided jumps should jump to the trampoline.
+	Expect(insns[jumpToBAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longBTrampoline0Addr-jumpToBAddr-1, 0)))
+	Expect(insns[jumpToAAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, longATrampoline0Addr-jumpToAAddr-1, 0)))
+	noOp := MakeInsn(Mov64, R0, R0, 0, 0)
+	for i := 2; i < trampolineInterval-1; i++ {
+		Expect(insns[i]).To(Equal(noOp))
+	}
+
+	// Jump to skip the trampoline itself.
+	Expect(insns[trampoline0StartAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 2, 0)))
+	// Jump to longA in the next trampoline...
+	Expect(insns[longATrampoline0Addr]).To(Equal(MakeInsn(JumpA, 0, 0, longATrampoline1Addr-longATrampoline0Addr-1, 0)))
+	// Jump to longB in the next trampoline...
+	Expect(insns[longBTrampoline0Addr]).To(Equal(MakeInsn(JumpA, 0, 0, longBTrampoline1Addr-longBTrampoline0Addr-1, 0)))
+
+	// Couple of no-ops fell out of first block.
+	for i := trampoline0EndAddr; i < secondJumpToAAddr; i++ {
+		Expect(insns[i]).To(Equal(noOp))
+	}
+
+	// Jump to longA
+	t.Log("Checking trampoline 1...")
+	Expect(insns[secondJumpToAAddr]).To(Equal(MakeInsn(JumpEq64, R1, R2, int16(longATrampoline1Addr-secondJumpToAAddr-1), 0)))
+	// Jump to longC
+	Expect(insns[jumpToCAddr]).To(Equal(MakeInsn(JumpEq64, R1, R3, int16(longCTrampoline1Addr-jumpToCAddr-1), 0)))
+	// No-ops
+	for i := jumpToCAddr + 1; i < trampoline1StartAddr; i++ {
+		Expect(insns[i]).To(Equal(noOp))
+	}
+
+	// Jump to skip the trampoline itself.
+	Expect(insns[trampoline1StartAddr]).To(Equal(MakeInsn(JumpA, 0, 0, 3, 0)))
+	// Jump to longA,B,C
+	Expect(insns[longATrampoline1Addr]).To(Equal(MakeInsn(JumpA, 0, 0, 9, 0)))
+	Expect(insns[longBTrampoline1Addr]).To(Equal(MakeInsn(JumpA, 0, 0, 10, 0)))
+	Expect(insns[longCTrampoline1Addr]).To(Equal(MakeInsn(JumpA, 0, 0, 10, 0)))
+
+	// 7 no-ops fall out.  2 for the previous no-ops, 2 for the jumps and
+	// 3 for the size of the first trampoline.
+	for i := trampoline1EndAddr; i < trampoline1EndAddr+7; i++ {
+		Expect(insns[i]).To(Equal(noOp))
+	}
+	// Then we should see mov, exit, exit, exit...
+
+	// longA
+	Expect(insns[trampoline1EndAddr+7]).To(Equal(MakeInsn(Mov64, R1, R2, 0, 0)))
+	Expect(insns[trampoline1EndAddr+8]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+	// longB
+	Expect(insns[trampoline1EndAddr+9]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+	// longC
+	Expect(insns[trampoline1EndAddr+10]).To(Equal(MakeInsn(Exit, 0, 0, 0, 0)))
+}
+
+func logSummarisingNoOps(t *testing.T, insns Insns) {
+	noOps := 0
+	for i, insn := range insns {
+		if insn.IsNoOp() {
+			noOps++
+			lastInsn := i == len(insns)-1
+			if lastInsn || !insns[i+1].IsNoOp() {
+				t.Log(fmt.Sprintf("%d-%d:", i+1-noOps, i), "NoOps")
+				noOps = 0
+			}
+			continue
+		}
+		t.Log(fmt.Sprintf("%d:", i), insn)
+	}
 }

--- a/felix/bpf/bpf_syscall.go
+++ b/felix/bpf/bpf_syscall.go
@@ -39,7 +39,7 @@ const defaultLogSize = 1024 * 1024
 const maxLogSize = 128 * 1024 * 1024
 
 func LoadBPFProgramFromInsns(insns asm.Insns, name, license string, progType uint32) (fd ProgFD, err error) {
-	log.Debugf("LoadBPFProgramFromInsns(%v, %v, %v)", insns, license, progType)
+	log.Debugf("LoadBPFProgramFromInsns(%v, %q, %v, %v)", insns, name, license, progType)
 	bpfutils.IncreaseLockedMemoryQuota()
 
 	// Occasionally see retryable errors here, retry silently a few times before going into log-collection mode.

--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -93,7 +93,15 @@ func KeyFromBytes(b []byte) Key {
 
 type Value [ValueSize]byte
 
-func NewValue(flags uint32, name string, xdpPol, ingressPol, egressPol, tcIngressFilter, tcEgressFilter int) Value {
+func NewValue(
+	flags uint32,
+	name string,
+	xdpPol,
+	ingressPol,
+	egressPol,
+	tcIngressFilter,
+	tcEgressFilter int,
+) Value {
 	var v Value
 
 	binary.LittleEndian.PutUint32(v[:], flags)

--- a/felix/bpf/jump/map.go
+++ b/felix/bpf/jump/map.go
@@ -21,17 +21,28 @@ import (
 )
 
 const (
-	MaxEntries    = 10000
-	XDPMaxEntries = 100
+	// MaxSubPrograms is the maximum number of policy sub-programs that
+	// we allow for a single hook.  BPF allows a maximum of 32 tail calls
+	// (so 33 chained programs in total) but we reserve some for our own use.
+	MaxSubPrograms = 24
+
+	// TCMaxEntryPoints is the maximum number of policy program entry points
+	// (i.e. first program in a chain of sub-programs for the policy).
+	TCMaxEntryPoints = 10000
+	// TCMaxEntries is the size fo the map, i.e. all possible sub-programs.
+	TCMaxEntries = TCMaxEntryPoints * MaxSubPrograms
+
+	XDPMaxEntryPoints = 100
+	XDPMaxEntries     = XDPMaxEntryPoints * MaxSubPrograms
 )
 
 var MapParameters = maps.MapParameters{
 	Type:       "prog_array",
 	KeySize:    4,
 	ValueSize:  4,
-	MaxEntries: MaxEntries,
+	MaxEntries: TCMaxEntries,
 	Name:       "cali_jump",
-	Version:    2,
+	Version:    3,
 }
 
 func Map() maps.Map {
@@ -44,7 +55,7 @@ var XDPMapParameters = maps.MapParameters{
 	ValueSize:  4,
 	MaxEntries: XDPMaxEntries,
 	Name:       "xdp_cali_jump",
-	Version:    2,
+	Version:    3,
 }
 
 func XDPMap() maps.Map {

--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -222,7 +222,7 @@ func ResetSizes() {
 
 func NewPinnedMap(params MapParameters) *PinnedMap {
 	if len(params.VersionedName()) >= unix.BPF_OBJ_NAME_LEN {
-		log.WithField("name", params.Name).Panic("Bug: BPF map name too long")
+		log.WithField("name", params.Name).Panicf("Bug: BPF map name too long (%d)", len(params.VersionedName()))
 	}
 	if val := Size(params.VersionedName()); val != 0 {
 		params.MaxEntries = val
@@ -333,10 +333,17 @@ func MapDeleteKeyCmd(m Map, key []byte) ([]string, error) {
 	return nil, errors.Errorf("unrecognized map type %T", m)
 }
 
+var ErrNotSupported = fmt.Errorf("prog_array iteration not supported")
+
 // Iter iterates over the map, passing each key/value pair to the provided callback function.  Warning:
 // The key and value are owned by the iterator and will be clobbered by the next iteration so they must not be
 // retained or modified.
 func (b *PinnedMap) Iter(f IterCallback) error {
+	if b.Type == "prog_array" {
+		// We currently have a bug in iteration of program array maps;
+		// the C code tight loops due to the empty slots.
+		return ErrNotSupported
+	}
 	valueSize := b.ValueSize
 	if b.perCPU {
 		valueSize = b.ValueSize * NumPossibleCPUs()

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -32,7 +32,15 @@ import (
 	"github.com/projectcalico/calico/felix/rules"
 )
 
+// Verifier imposes a limit on how many jumps can be on the same code path.
+const (
+	verifierMaxJumpsLimit      = 8192
+	maxJumpsHeadroom           = 200
+	defaultPerProgramJumpLimit = verifierMaxJumpsLimit - maxJumpsHeadroom
+)
+
 type Builder struct {
+	blocks          []*Block
 	b               *Block
 	tierID          int
 	policyID        int
@@ -42,12 +50,18 @@ type Builder struct {
 
 	ipSetMapFD         maps.FD
 	stateMapFD         maps.FD
-	jumpMapFD          maps.FD
+	staticJumpMapFD    maps.FD
+	policyJumpMapFD    maps.FD
+	policyMapIndex     int
+	policyMapStride    int
 	policyDebugEnabled bool
 	forIPv6            bool
 	allowJmp           int
 	denyJmp            int
 	useJmps            bool
+	maxJumpsPerProgram int
+	numRulesInProgram  int
+	xdp                bool
 }
 
 type ipSetIDProvider interface {
@@ -59,13 +73,15 @@ type Option func(b *Builder)
 
 func NewBuilder(
 	ipSetIDProvider ipSetIDProvider,
-	ipsetMapFD, stateMapFD, jumpMapFD maps.FD,
+	ipsetMapFD, stateMapFD, staticProgsMapFD, policyJumpMapFD maps.FD,
 	opts ...Option) *Builder {
 	b := &Builder{
-		ipSetIDProvider: ipSetIDProvider,
-		ipSetMapFD:      ipsetMapFD,
-		stateMapFD:      stateMapFD,
-		jumpMapFD:       jumpMapFD,
+		ipSetIDProvider:    ipSetIDProvider,
+		ipSetMapFD:         ipsetMapFD,
+		stateMapFD:         stateMapFD,
+		staticJumpMapFD:    staticProgsMapFD,
+		policyJumpMapFD:    policyJumpMapFD,
+		maxJumpsPerProgram: defaultPerProgramJumpLimit,
 	}
 
 	for _, option := range opts {
@@ -208,11 +224,13 @@ const (
 	TierEndPass  TierEndAction = "pass"
 )
 
-func (p *Builder) Instructions(rules Rules) (Insns, error) {
+func (p *Builder) Instructions(rules Rules) ([]Insns, error) {
+	p.xdp = rules.ForXDP
 	p.b = NewBlock(p.policyDebugEnabled)
+	p.blocks = append(p.blocks, p.b)
 	p.writeProgramHeader()
 
-	if rules.ForXDP {
+	if p.xdp {
 		// For an XDP program HostNormalTiers continues the untracked policy to enforce;
 		// other fields are unused.
 		goto normalPolicy
@@ -275,8 +293,17 @@ normalPolicy:
 		p.writeProfiles(rules.Profiles, "allow")
 	}
 
-	p.writeProgramFooter(rules.ForXDP)
-	return p.b.Assemble()
+	p.writeProgramFooter()
+
+	var progs []Insns
+	for i, b := range p.blocks {
+		insns, err := b.Assemble()
+		if err != nil {
+			return nil, fmt.Errorf("failed to assemble policy program %d: %w", i, err)
+		}
+		progs = append(progs, insns)
+	}
+	return progs, nil
 }
 
 // writeProgramHeader emits instructions to load the state from the state map, leaving
@@ -317,7 +344,7 @@ func (p *Builder) writeJumpIfToOrFromHost(label string) {
 }
 
 // writeProgramFooter emits the program exit jump targets.
-func (p *Builder) writeProgramFooter(forXDP bool) {
+func (p *Builder) writeProgramFooter() {
 	// Fall through here if there's no match.  Also used when we hit an error or if policy rejects packet.
 	p.b.LabelNextInsn("deny")
 
@@ -326,10 +353,10 @@ func (p *Builder) writeProgramFooter(forXDP bool) {
 	p.b.Store32(R9, R1, stateOffPolResult)
 
 	// Execute the tail call to drop program
-	p.b.Mov64(R1, R6)                      // First arg is the context.
-	p.b.LoadMapFD(R2, uint32(p.jumpMapFD)) // Second arg is the map.
+	p.b.Mov64(R1, R6)                            // First arg is the context.
+	p.b.LoadMapFD(R2, uint32(p.staticJumpMapFD)) // Second arg is the map.
 	if p.useJmps {
-		p.b.AddComment(fmt.Sprintf("Deny jump to %d", p.denyJmp))
+		p.b.AddCommentF("Deny jump to %d", p.denyJmp)
 		p.b.MovImm32(R3, int32(p.denyJmp)) // Third arg is the index (rather than a pointer to the index).
 	} else {
 		p.b.Load32(R3, R6, skbCb1) // Third arg is the index from skb->cb[1]).
@@ -337,15 +364,9 @@ func (p *Builder) writeProgramFooter(forXDP bool) {
 	p.b.Call(HelperTailCall)
 
 	// Fall through if tail call fails.
-	p.b.LabelNextInsn("exit")
-	if forXDP {
-		p.b.MovImm64(R0, 1 /* XDP_DROP */)
-	} else {
-		p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
-	}
-	p.b.Exit()
+	p.writeExitTarget()
 
-	if forXDP {
+	if p.xdp {
 		p.b.LabelNextInsn("xdp_pass")
 		p.b.MovImm64(R0, 2 /* XDP_PASS */)
 		p.b.Exit()
@@ -357,10 +378,10 @@ func (p *Builder) writeProgramFooter(forXDP bool) {
 		p.b.MovImm32(R1, int32(state.PolicyAllow))
 		p.b.Store32(R9, R1, stateOffPolResult)
 		// Execute the tail call.
-		p.b.Mov64(R1, R6)                      // First arg is the context.
-		p.b.LoadMapFD(R2, uint32(p.jumpMapFD)) // Second arg is the map.
+		p.b.Mov64(R1, R6)                            // First arg is the context.
+		p.b.LoadMapFD(R2, uint32(p.staticJumpMapFD)) // Second arg is the map.
 		if p.useJmps {
-			p.b.AddComment(fmt.Sprintf("Allow jump to %d", p.allowJmp))
+			p.b.AddCommentF("Allow jump to %d", p.allowJmp)
 			p.b.MovImm32(R3, int32(p.allowJmp)) // Third arg is the index (rather than a pointer to the index).
 		} else {
 			p.b.Load32(R3, R6, skbCb0) // Third arg is the index from skb->cb[0]).
@@ -370,13 +391,23 @@ func (p *Builder) writeProgramFooter(forXDP bool) {
 		// Fall through if tail call fails.
 		p.b.MovImm32(R1, state.PolicyTailCallFailed)
 		p.b.Store32(R9, R1, stateOffPolResult)
-		if forXDP {
+		if p.xdp {
 			p.b.MovImm64(R0, 1 /* XDP_DROP */)
 		} else {
 			p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
 		}
 		p.b.Exit()
 	}
+}
+
+func (p *Builder) writeExitTarget() {
+	p.b.LabelNextInsn("exit")
+	if p.xdp {
+		p.b.MovImm64(R0, 1 /* XDP_DROP */)
+	} else {
+		p.b.MovImm64(R0, 2 /* TC_ACT_SHOT */)
+	}
+	p.b.Exit()
 }
 
 func (p *Builder) writeRecordRuleID(id RuleMatchID, skipLabel string) {
@@ -460,7 +491,7 @@ func (p *Builder) writeTiers(tiers []Tier, destLeg matchLeg, allowLabel string) 
 		actionLabels["next-tier"] = endOfTierLabel
 
 		log.Debugf("Start of tier %d %q", p.tierID, tier.Name)
-		p.b.AddComment(fmt.Sprintf("Start of tier %s", tier.Name))
+		p.b.AddCommentF("Start of tier %s", tier.Name)
 		for _, pol := range tier.Policies {
 			p.writePolicy(pol, actionLabels, destLeg)
 		}
@@ -470,7 +501,7 @@ func (p *Builder) writeTiers(tiers []Tier, destLeg matchLeg, allowLabel string) 
 		if action == TierEndUndef {
 			action = TierEndDeny
 		}
-		p.b.AddComment(fmt.Sprintf("End of tier %s", tier.Name))
+		p.b.AddCommentF("End of tier %s", tier.Name)
 		log.Debugf("End of tier %d %q: %s", p.tierID, tier.Name, action)
 		p.writeRule(Rule{
 			Rule: &proto.Rule{},
@@ -495,8 +526,8 @@ func (p *Builder) writeProfiles(profiles []Policy, allowLabel string) {
 func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string, destLeg matchLeg) {
 	for ruleIdx, rule := range policy.Rules {
 		log.Debugf("Start of rule %d", ruleIdx)
-		p.b.AddComment(fmt.Sprintf("Start of rule %s", rule))
-		p.b.AddComment(fmt.Sprintf("Rule MatchID: %d", rule.MatchID))
+		p.b.AddCommentF("Start of rule %s", rule)
+		p.b.AddCommentF("Rule MatchID: %d", rule.MatchID)
 		action := strings.ToLower(rule.Action)
 		if action == "log" {
 			log.Debug("Skipping log rule.  Not supported in BPF mode.")
@@ -504,16 +535,16 @@ func (p *Builder) writePolicyRules(policy Policy, actionLabels map[string]string
 		}
 		p.writeRule(rule, actionLabels[action], destLeg)
 		log.Debugf("End of rule %d", ruleIdx)
-		p.b.AddComment(fmt.Sprintf("End of rule %s", rule.RuleId))
+		p.b.AddCommentF("End of rule %s", rule.RuleId)
 	}
 }
 
 func (p *Builder) writePolicy(policy Policy, actionLabels map[string]string, destLeg matchLeg) {
-	p.b.AddComment(fmt.Sprintf("Start of policy %s", policy.Name))
+	p.b.AddCommentF("Start of policy %s", policy.Name)
 	log.Debugf("Start of policy %q %d", policy.Name, p.policyID)
 	p.writePolicyRules(policy, actionLabels, destLeg)
 	log.Debugf("End of policy %q %d", policy.Name, p.policyID)
-	p.b.AddComment(fmt.Sprintf("End of policy %s", policy.Name))
+	p.b.AddCommentF("End of policy %s", policy.Name)
 	p.policyID++
 }
 
@@ -578,6 +609,8 @@ func (p *Builder) ipVersion() uint8 {
 }
 
 func (p *Builder) writeRule(r Rule, actionLabel string, destLeg matchLeg) {
+	p.maybeSplitProgram()
+
 	if actionLabel == "" {
 		log.Panic("empty action label")
 	}
@@ -697,6 +730,7 @@ func (p *Builder) writeRule(r Rule, actionLabel string, destLeg matchLeg) {
 	p.writeEndOfRule(r, actionLabel)
 	p.ruleID++
 	p.rulePartID = 0
+	p.numRulesInProgram++
 }
 
 func (p *Builder) writeStartOfRule() {
@@ -716,13 +750,11 @@ func (p *Builder) writeEndOfRule(rule Rule, actionLabel string) {
 }
 
 func (p *Builder) writeProtoMatch(negate bool, protocol *proto.Protocol) {
-	comment := ""
 	if negate {
-		comment = fmt.Sprintf("If protocol == %s, skip to next rule", protocolToName(protocol))
+		p.b.AddCommentF("If protocol == %s, skip to next rule", protocolToName(protocol))
 	} else {
-		comment = fmt.Sprintf("If protocol != %s, skip to next rule", protocolToName(protocol))
+		p.b.AddCommentF("If protocol != %s, skip to next rule", protocolToName(protocol))
 	}
-	p.b.AddComment(comment)
 
 	p.b.Load8(R1, R9, stateOffIPProto)
 	protoNum := protocolToNumber(protocol)
@@ -734,13 +766,11 @@ func (p *Builder) writeProtoMatch(negate bool, protocol *proto.Protocol) {
 }
 
 func (p *Builder) writeICMPTypeMatch(negate bool, icmpType uint8) {
-	comment := ""
 	if negate {
-		comment = fmt.Sprintf("If ICMP type == %d, skip to next rule", icmpType)
+		p.b.AddCommentF("If ICMP type == %d, skip to next rule", icmpType)
 	} else {
-		comment = fmt.Sprintf("If ICMP type != %d, skip to next rule", icmpType)
+		p.b.AddCommentF("If ICMP type != %d, skip to next rule", icmpType)
 	}
-	p.b.AddComment(comment)
 	p.b.Load8(R1, R9, stateOffICMPType)
 	if negate {
 		p.b.JumpEqImm64(R1, int32(icmpType), p.endOfRuleLabel())
@@ -750,13 +780,11 @@ func (p *Builder) writeICMPTypeMatch(negate bool, icmpType uint8) {
 }
 
 func (p *Builder) writeICMPTypeCodeMatch(negate bool, icmpType, icmpCode uint8) {
-	comment := ""
 	if negate {
-		comment = fmt.Sprintf("If ICMP type == %d and code == %d, skip to next rule", icmpType, icmpCode)
+		p.b.AddCommentF("If ICMP type == %d and code == %d, skip to next rule", icmpType, icmpCode)
 	} else {
-		comment = fmt.Sprintf("If ICMP type != %d or code != %d, skip to next rule", icmpType, icmpCode)
+		p.b.AddCommentF("If ICMP type != %d or code != %d, skip to next rule", icmpType, icmpCode)
 	}
-	p.b.AddComment(comment)
 	p.b.Load16(R1, R9, stateOffICMPType)
 	if negate {
 		p.b.JumpEqImm64(R1, (int32(icmpCode)<<8)|int32(icmpType), p.endOfRuleLabel())
@@ -766,7 +794,6 @@ func (p *Builder) writeICMPTypeCodeMatch(negate bool, icmpType, icmpCode uint8) 
 }
 func (p *Builder) writeCIDRSMatch(negate bool, leg matchLeg, cidrs []string) {
 	if p.policyDebugEnabled {
-		comment := ""
 		cidrStrings := "{"
 		if len(cidrs) == 0 {
 			cidrStrings = "{}"
@@ -778,12 +805,10 @@ func (p *Builder) writeCIDRSMatch(negate bool, leg matchLeg, cidrs []string) {
 		cidrStrings = cidrStrings[:len(cidrStrings)-1] + "}"
 
 		if negate {
-			comment = fmt.Sprintf("If %s in %s, skip to next rule", leg, cidrStrings)
+			p.b.AddCommentF("If %s in %s, skip to next rule", leg, cidrStrings)
 		} else {
-			comment = fmt.Sprintf("If %s not in %s, skip to next rule", leg, cidrStrings)
+			p.b.AddCommentF("If %s not in %s, skip to next rule", leg, cidrStrings)
 		}
-
-		p.b.AddComment(comment)
 	}
 
 	var onMatchLabel string
@@ -803,6 +828,9 @@ func (p *Builder) writeCIDRSMatch(negate bool, leg matchLeg, cidrs []string) {
 	addrU32 := make([]uint32, size)
 	maskU32 := make([]uint32, size)
 	for cidrIndex, cidrStr := range cidrs {
+		// Number of CIDRs isn't bounded so may need to split mid-rule.
+		p.maybeSplitProgram()
+
 		cidr := ip.MustParseCIDROrIP(cidrStr)
 		if p.forIPv6 {
 			addrU64P1, addrU64P2 := cidr.Addr().(ip.V6Addr).AsUint64Pair()
@@ -873,13 +901,12 @@ func (p *Builder) writeIPSetMatch(negate bool, leg matchLeg, ipSets []string) {
 		if id == 0 {
 			log.WithField("setID", ipSetID).Panic("Failed to look up IP set ID.")
 		}
-		comment := ""
+
 		if negate {
-			comment = fmt.Sprintf("If %s matches ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
+			p.b.AddCommentF("If %s matches ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
 		} else {
-			comment = fmt.Sprintf("If %s doesn't match ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
+			p.b.AddCommentF("If %s doesn't match ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
 		}
-		p.b.AddComment(comment)
 
 		keyOffset := leg.stackOffsetToIPSetKey()
 		p.setUpIPSetKey(id, keyOffset, leg.offsetToStateIPAddressField(), leg.offsetToStatePortField())
@@ -911,13 +938,11 @@ func (p *Builder) writeIPSetOrMatch(leg matchLeg, ipSets []string) {
 			log.WithField("setID", ipSetID).Panic("Failed to look up IP set ID.")
 		}
 
-		comment := ""
 		if len(ipSets) == 1 {
-			comment = fmt.Sprintf("If %s doesn't match ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
+			p.b.AddCommentF("If %s doesn't match ipset %s (0x%x), skip to next rule", leg, ipSetID, id)
 		} else {
-			comment = fmt.Sprintf("If %s doesn't match ipset %s (0x%x), jump to next ipset", leg, ipSetID, id)
+			p.b.AddCommentF("If %s doesn't match ipset %s (0x%x), jump to next ipset", leg, ipSetID, id)
 		}
-		p.b.AddComment(comment)
 
 		keyOffset := leg.stackOffsetToIPSetKey()
 		p.setUpIPSetKey(id, keyOffset, leg.offsetToStateIPAddressField(), leg.offsetToStatePortField())
@@ -933,8 +958,7 @@ func (p *Builder) writeIPSetOrMatch(leg matchLeg, ipSets []string) {
 
 	// If packet reaches here, it hasn't matched any of the IP sets.
 	if len(ipSets) > 1 {
-		comment := fmt.Sprintf("If %s doesn't match any of the IP sets, skip to next rule", leg)
-		p.b.AddComment(comment)
+		p.b.AddCommentF("If %s doesn't match any of the IP sets, skip to next rule", leg)
 	}
 	p.b.Jump(p.endOfRuleLabel())
 	// Label the next match so we can skip to it on success.
@@ -953,7 +977,6 @@ func (p *Builder) writePortsMatch(negate bool, leg matchLeg, ports []*proto.Port
 		onMatchLabel = p.freshPerRuleLabel()
 	}
 
-	comment := ""
 	if p.policyDebugEnabled {
 		portRangeStr := "{"
 		for idx, portRange := range ports {
@@ -964,11 +987,10 @@ func (p *Builder) writePortsMatch(negate bool, leg matchLeg, ports []*proto.Port
 		}
 		portRangeStr = portRangeStr + "}"
 		if negate {
-			comment = fmt.Sprintf("If %s port is within any of %s, skip to next rule", leg, portRangeStr)
+			p.b.AddCommentF("If %s port is within any of %s, skip to next rule", leg, portRangeStr)
 		} else {
-			comment = fmt.Sprintf("If %s port is not within any of %s, skip to next rule", leg, portRangeStr)
+			p.b.AddCommentF("If %s port is not within any of %s, skip to next rule", leg, portRangeStr)
 		}
-		p.b.AddComment(comment)
 	}
 	// R1 = port to test against.
 	p.b.Load16(R1, R9, leg.offsetToStatePortField())
@@ -990,6 +1012,13 @@ func (p *Builder) writePortsMatch(negate bool, leg matchLeg, ports []*proto.Port
 				p.b.LabelNextInsn(skipToNextPortLabel)
 			}
 		}
+
+		// Number of ports not bounded so may need to split mid-rule.
+		if p.maybeSplitProgram() {
+			// Program was split so the next instruction goes in the new program.
+			// Need to reload our register(s).
+			p.b.Load16(R1, R9, leg.offsetToStatePortField())
+		}
 	}
 
 	if p.policyDebugEnabled {
@@ -1002,14 +1031,15 @@ func (p *Builder) writePortsMatch(negate bool, leg matchLeg, ports []*proto.Port
 		}
 		namedPortStr = namedPortStr + "}"
 		if negate {
-			comment = fmt.Sprintf("If %s port is within any of the named ports %s, skip to next rule", leg, namedPortStr)
+			p.b.AddCommentF("If %s port is within any of the named ports %s, skip to next rule", leg, namedPortStr)
 		} else {
-			comment = fmt.Sprintf("If %s port is not within any of the named ports %s, skip to next rule", leg, namedPortStr)
+			p.b.AddCommentF("If %s port is not within any of the named ports %s, skip to next rule", leg, namedPortStr)
 		}
-		p.b.AddComment(comment)
 	}
 
 	for _, ipSetID := range namedPorts {
+		p.maybeSplitProgram()
+
 		id := p.ipSetIDProvider.GetNoAlloc(ipSetID)
 		if id == 0 {
 			log.WithField("setID", ipSetID).Panic("Failed to look up IP set ID.")
@@ -1046,6 +1076,106 @@ func (p *Builder) endOfcidrV6Match(cidrIndex int) string {
 	return fmt.Sprintf("rule_%d_cidr_%d_end", p.ruleID, cidrIndex)
 }
 
+// maybeSplitProgram checks how large/complex the program has become and, if
+// it reaches the threshold, starts a new policy program and adds it to
+// p.blocks.
+//
+// Returns true if the program was split.  After a split only the registers
+// initialised by writeProgramHeader are valid so, if the caller was using
+// any other registers, they must be recalculated if maybeSplitProgram returns
+// true.
+func (p *Builder) maybeSplitProgram() bool {
+	// Verifier imposes a limit on how many jumps can be on a path through
+	// the bytecode (taken or not).  Since our code falls through to the next
+	// rule by default, to first approximation, all our jumps are on the same
+	// path.
+	if p.b.NumJumps < p.maxJumpsPerProgram {
+		return false
+	}
+	if p.policyMapStride == 0 {
+		// Cannot split; parameters not set.  We'll just have to hope the
+		// program fits.
+		return false
+	}
+
+	p.b.SetTrampolinesEnabled(false) // We're about to write a special trampoline...
+	p.b.AddCommentF("Splitting program after %d jumps", p.b.NumJumps)
+	p.b.MovImm64(R0, 0)
+	p.b.Jump("next-program")
+
+	// Program footer takes care of "allow" "deny" "exit" labels.
+	p.writeProgramFooter()
+
+	// Find any jump targets that need to jump to the next program.  This may
+	// include a next-tier label or an internal rule label, if we're called
+	// from within a rule-writing method.
+	var targets []string
+	for _, t := range p.b.UnresolvedJumpTargets() {
+		if t == "next-program" {
+			// Skip our label, we're about to resolve that below.
+			continue
+		}
+		targets = append(targets, t)
+	}
+
+	// Write a landing pad for each dangling jump target.  Each landing pad
+	// sets R0 to a unique value before jumping to the next-program label.
+	log.WithFields(log.Fields{
+		"danglingTargets": targets,
+		"numRules":        p.numRulesInProgram,
+		"numJumps":        p.b.NumJumps,
+		"numProgs":        len(p.blocks),
+	}).Debug("Splitting policy program")
+	for i, t := range targets {
+		p.b.LabelNextInsn(t)
+		p.b.MovImm64(R0, int32(i+1))
+		if i != len(targets)-1 {
+			p.b.Jump("next-program")
+		}
+	}
+	p.b.LabelNextInsn("next-program")
+	// Stash the trampoline offset in the policy result so the next program
+	// can pick it up.
+	p.b.Store32(R9, R0, stateOffPolResult)
+	// Calculate the index of the next program.
+	// With a "stride" of 1000, the first sub-program is at position n, then
+	// the second goes at position 1000+n, then the next at 2000+n and so on.
+	// The current block is in p.blocks already so this will calculate 1000+n
+	// on the first time through.
+	jumpIdx := SubProgramJumpIdx(p.policyMapIndex, len(p.blocks), p.policyMapStride)
+
+	p.b.Mov64(R1, R6)                            // First arg is the context.
+	p.b.LoadMapFD(R2, uint32(p.policyJumpMapFD)) // Second arg is the map.
+	p.b.AddCommentF(fmt.Sprintf("Tail call to policy program at index %d * %d + %d = %d", p.policyMapStride, len(p.blocks), p.policyMapIndex, jumpIdx))
+	p.b.MovImm64(R3, int32(jumpIdx)) // Third arg is index to jump to.
+	p.b.Call(HelperTailCall)
+	p.writeExitTarget() // Drop if tail call fails.
+
+	// Now start the new program...
+	p.numRulesInProgram = 0
+	p.b = NewBlock(p.policyDebugEnabled)
+	p.blocks = append(p.blocks, p.b)
+	// Header initialises the long-lived registers.
+	p.b.AddCommentF(fmt.Sprintf("##### Start of program %d #####", len(p.blocks)-1))
+	p.writeProgramHeader()
+	// Then write our trampoline.
+	p.b.Load32(R0, R9, stateOffPolResult)
+	// Reset the policy result field to its default value.
+	p.b.MovImm32(R1, 0)
+	p.b.Store32(R9, R1, stateOffPolResult)
+	for i, t := range targets {
+		p.b.JumpEqImm64(R0, int32(i+1), t)
+	}
+	// If none of the trampoline jumps hit then we fall through.  This
+	// continues whatever code was being written when we were called.
+
+	return true
+}
+
+func SubProgramJumpIdx(polProgIdx, subProgIdx, stride int) int {
+	return polProgIdx + subProgIdx*stride
+}
+
 func protocolToNumber(protocol *proto.Protocol) uint8 {
 	var pcol uint8
 	switch p := protocol.NumberOrName.(type) {
@@ -1066,7 +1196,7 @@ func protocolToNumber(protocol *proto.Protocol) uint8 {
 	return pcol
 }
 
-// WithPolicyDebug enabled policy debug.
+// WithPolicyDebug enables policy debug.
 func WithPolicyDebugEnabled() Option {
 	return func(b *Builder) {
 		b.policyDebugEnabled = true
@@ -1084,6 +1214,19 @@ func WithAllowDenyJumps(allow, deny int) Option {
 func WithIPv6() Option {
 	return func(p *Builder) {
 		p.forIPv6 = true
+	}
+}
+
+// WithPolicyMapIndexAndStride tells the builder the "shape" of the policy
+// jump map, allowing it to split the program if it gets too large.
+// entryPointIdx is the jump map key for the first "entry point" program.
+// stride is the number of indexes to skip to get to the next sub-program.
+// If WithPolicyMapIndexAndStride is not provided, program-splitting is
+// disabled.
+func WithPolicyMapIndexAndStride(entryPointIdx, stride int) Option {
+	return func(b *Builder) {
+		b.policyMapIndex = entryPointIdx
+		b.policyMapStride = stride
 	}
 }
 

--- a/felix/bpf/polprog/pol_prog_builder_test.go
+++ b/felix/bpf/polprog/pol_prog_builder_test.go
@@ -15,6 +15,7 @@
 package polprog
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -23,6 +24,11 @@ import (
 	"github.com/projectcalico/calico/felix/idalloc"
 	"github.com/projectcalico/calico/felix/proto"
 )
+
+// These tests are just sanity checks and low-level UTs.  Most of the tests
+// of the policy program builder are in felix/bpf/ut/pol_prog_test.go because
+// that file has access to the eBPF test machinery (to allow verifying/running
+// the BPF programs "for real").
 
 func TestPolicySanityCheck(t *testing.T) {
 	// Just a basic sanity check with a kitchen sink policy.  The policy behaviour is tested "for real" in the
@@ -34,8 +40,8 @@ func TestPolicySanityCheck(t *testing.T) {
 		alloc.GetOrAlloc(id)
 		return id
 	}
-	pg := NewBuilder(alloc, 1, 2, 3, WithAllowDenyJumps(666, 777))
-	insns, err := pg.Instructions(Rules{
+	pg := NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777))
+	progs, err := pg.Instructions(Rules{
 		Tiers: []Tier{{
 			Policies: []Policy{{
 				Rules: []Rule{{
@@ -70,8 +76,8 @@ func TestPolicySanityCheck(t *testing.T) {
 	})
 
 	Expect(err).NotTo(HaveOccurred())
-	for i, in := range insns {
-		t.Log(i, ": ", in.Instruction)
+	for i, in := range progs[0] {
+		t.Log(i, ": ", in.String())
 	}
 }
 
@@ -79,7 +85,7 @@ func TestLogActionIgnored(t *testing.T) {
 	RegisterTestingT(t)
 	alloc := idalloc.New()
 
-	pg := NewBuilder(alloc, 1, 2, 3, WithAllowDenyJumps(666, 777))
+	pg := NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777))
 	insns, err := pg.Instructions(Rules{
 		Tiers: []Tier{{
 			Name: "default",
@@ -92,7 +98,7 @@ func TestLogActionIgnored(t *testing.T) {
 		}}})
 	Expect(err).NotTo(HaveOccurred())
 
-	pg = NewBuilder(alloc, 1, 2, 3, WithAllowDenyJumps(666, 777))
+	pg = NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777))
 	noOpInsns, err := pg.Instructions(Rules{
 		Tiers: []Tier{{
 			Name:     "default",
@@ -112,7 +118,7 @@ func TestPolicyDump(t *testing.T) {
 
 	checkLabelsAndComments := func(rule proto.Rule, expectedString string, matchLabelOrComment string) {
 
-		pg := NewBuilder(alloc, 1, 2, 3, WithAllowDenyJumps(666, 777), WithPolicyDebugEnabled())
+		pg := NewBuilder(alloc, 1, 2, 3, 4, WithAllowDenyJumps(666, 777), WithPolicyDebugEnabled())
 		rule.Action = "Allow"
 		rule.IpVersion = 4
 		insns, err := pg.Instructions(Rules{
@@ -126,7 +132,7 @@ func TestPolicyDump(t *testing.T) {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		labels, comments := aggregateCommentsAndLabels(&insns)
+		labels, comments := aggregateCommentsAndLabels(&insns[0])
 		if matchLabelOrComment == "label" {
 			Expect(labels).To(ContainElement(expectedString))
 		} else {
@@ -171,4 +177,59 @@ func aggregateCommentsAndLabels(insns *asm.Insns) ([]string, []string) {
 		comments = append(comments, in.Comments...)
 	}
 	return labels, comments
+}
+
+func TestProgramSplitting(t *testing.T) {
+	RegisterTestingT(t)
+	alloc := idalloc.New()
+	setID := func(id string) string {
+		alloc.GetOrAlloc(id)
+		return id
+	}
+	pg := NewBuilder(alloc, 1, 2, 3, 4,
+		WithAllowDenyJumps(666, 777),
+		WithPolicyMapIndexAndStride(15, 1000))
+
+	// First tier: 10k rules that do a mix of pass/deny.
+	tier0 := Tier{
+		Name: "tier0",
+	}
+	actions := []string{"pass", "deny"}
+	for i := 0; i < 250; i++ {
+		pol := Policy{}
+		for j := 0; j < 40; j++ {
+			pol.Rules = append(pol.Rules, Rule{Rule: &proto.Rule{
+				Action:      actions[j%len(actions)],
+				IpVersion:   4,
+				Protocol:    &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+				SrcIpSetIds: []string{setID(fmt.Sprintf("s:sbcdef12%08x", i+j))},
+			}})
+		}
+		tier0.Policies = append(tier0.Policies, pol)
+	}
+	// Second tier: 1k rules that do a mix of allow/deny.
+	actions = []string{"allow", "deny"}
+	tier1 := Tier{
+		Name: "tier0",
+	}
+	for i := 0; i < 25; i++ {
+		pol := Policy{}
+		for j := 0; j < 40; j++ {
+			pol.Rules = append(pol.Rules, Rule{Rule: &proto.Rule{
+				Action:      actions[j%len(actions)],
+				IpVersion:   4,
+				Protocol:    &proto.Protocol{NumberOrName: &proto.Protocol_Number{Number: 6}},
+				SrcIpSetIds: []string{setID(fmt.Sprintf("s:sbcdef12%08x", i+j))},
+			}})
+		}
+		tier1.Policies = append(tier1.Policies, pol)
+	}
+
+	tiers := []Tier{tier0, tier1}
+
+	progs, err := pg.Instructions(Rules{
+		Tiers: tiers,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(progs)).To(Equal(7))
 }

--- a/felix/bpf/polprog/pol_prog_builder_test.go
+++ b/felix/bpf/polprog/pol_prog_builder_test.go
@@ -231,5 +231,7 @@ func TestProgramSplitting(t *testing.T) {
 		Tiers: tiers,
 	})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(len(progs)).To(Equal(7))
+	// Allow leeway in program size for enterprise.
+	Expect(len(progs)).To(BeNumerically(">=", 6))
+	Expect(len(progs)).To(BeNumerically("<=", 8))
 }

--- a/felix/bpf/ut/precompilation_test.go
+++ b/felix/bpf/ut/precompilation_test.go
@@ -91,7 +91,7 @@ func createVethName(name string) netlink.Link {
 		PeerName:  name + "b",
 	}
 	err := netlink.LinkAdd(veth)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create test veth")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create test veth: %q", name))
 	return veth
 }
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -3063,6 +3063,15 @@ func (m *bpfEndpointManager) doUpdatePolicyProgram(
 			return nil, fmt.Errorf("failed to update %s policy jump map [%d]=%d: %w", hk, subProgIdx, progFD, err)
 		}
 	}
+	for i := len(progFDs); i < jump.MaxSubPrograms; i++ {
+		subProgIdx := polprog.SubProgramJumpIdx(polJumpMapIdx, i, stride)
+		if err := polProgsMap.Delete(jump.Key(subProgIdx)); err != nil {
+			if os.IsNotExist(err) {
+				break
+			}
+			log.WithError(err).Warn("Unexpected error while trying to clean up old policy programs.")
+		}
+	}
 
 	return insns, nil
 }

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -159,8 +159,12 @@ type bpfDataplane interface {
 
 type hasLoadPolicyProgram interface {
 	loadPolicyProgram(progName string,
-		ipFamily proto.IPVersion, rules polprog.Rules, progsMap maps.Map, opts ...polprog.Option) (
-		fileDescriptor, asm.Insns, error)
+		ipFamily proto.IPVersion,
+		rules polprog.Rules,
+		staticProgsMap maps.Map,
+		polProgsMap maps.Map,
+		opts ...polprog.Option,
+	) ([]fileDescriptor, []asm.Insns, error)
 }
 
 type bpfInterface struct {
@@ -282,9 +286,14 @@ type bpfEndpointManager struct {
 	// onStillAlive is called from loops to reset the watchdog.
 	onStillAlive func()
 
-	loadPolicyProgramFn func(progName string,
-		ipFamily proto.IPVersion, rules polprog.Rules, progsMap maps.Map, opts ...polprog.Option) (
-		fileDescriptor, asm.Insns, error)
+	loadPolicyProgramFn func(
+		progName string,
+		ipFamily proto.IPVersion,
+		rules polprog.Rules,
+		staticProgsMap maps.Map,
+		polProgsMap maps.Map,
+		opts ...polprog.Option,
+	) ([]fileDescriptor, []asm.Insns, error)
 	updatePolicyProgramFn func(rules polprog.Rules, polDir string, ap attachPoint) error
 
 	// HEP processing.
@@ -425,14 +434,12 @@ func newBPFEndpointManager(
 			maps.NewTypedMap[ifstate.Key, ifstate.Value](
 				bpfmaps.IfStateMap.(maps.MapWithExistsCheck), ifstate.KeyFromBytes, ifstate.ValueFromBytes,
 			)),
-		jumpMapAlloc: &jumpMapAlloc{
-			max:  jump.MaxEntries,
-			free: make(chan int, jump.MaxEntries),
-		},
-		xdpJumpMapAlloc: &jumpMapAlloc{
-			max:  jump.XDPMaxEntries,
-			free: make(chan int, jump.XDPMaxEntries),
-		},
+
+		// Note: the allocators only allocate a fraction of the map, the
+		// rest is reserved for sub-programs generated if a single program
+		// would be too large.
+		jumpMapAlloc:        newJumpMapAlloc(jump.TCMaxEntryPoints),
+		xdpJumpMapAlloc:     newJumpMapAlloc(jump.XDPMaxEntryPoints),
 		ruleRenderer:        iptablesRuleRenderer,
 		iptablesFilterTable: iptablesFilterTable,
 		onStillAlive:        livenessCallback,
@@ -550,6 +557,8 @@ func newBPFEndpointManager(
 
 	return m, nil
 }
+
+var _ hasLoadPolicyProgram = (*bpfEndpointManager)(nil)
 
 func (m *bpfEndpointManager) repinJumpMaps() error {
 	oldBase := path.Join(bpfdefs.GlobalPinDir, "old_jumps")
@@ -1093,15 +1102,17 @@ func (m *bpfEndpointManager) markExistingWEPDirty(wlID proto.WorkloadEndpointID,
 	}
 }
 
-func jumpMapDeleteEntry(m maps.Map, idx int) error {
-	if err := m.Delete(jump.Key(idx)); err != nil {
-		if maps.IsNotExists(err) {
-			log.WithError(err).WithField("idx", idx).
-				Warn("Policy program already not in table - inconsistency fixed!")
-			return nil
-		} else {
-			log.WithError(err).Warn("Policy program may leak.")
-			return err
+func jumpMapDeleteEntry(m maps.Map, idx, stride int) error {
+	for subProg := 0; subProg < jump.MaxSubPrograms; subProg++ {
+		if err := m.Delete(jump.Key(polprog.SubProgramJumpIdx(idx, subProg, stride))); err != nil {
+			if maps.IsNotExists(err) {
+				log.WithError(err).WithField("idx", idx).Debug(
+					"Policy program already gone from map.")
+				return nil
+			} else {
+				log.WithError(err).Warn("Failed to delete policy program from map; policy program may leak.")
+				return err
+			}
 		}
 	}
 
@@ -1132,7 +1143,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 					v.XDPPolicy,
 				} {
 					if idx := fn(); idx != -1 {
-						_ = jumpMapDeleteEntry(m.bpfmaps.XDPJumpMap, idx)
+						_ = jumpMapDeleteEntry(m.bpfmaps.XDPJumpMap, idx, jump.XDPMaxEntryPoints)
 					}
 				}
 				for _, fn := range []func() int{
@@ -1142,7 +1153,7 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 					v.TcEgressFilter,
 				} {
 					if idx := fn(); idx != -1 {
-						_ = jumpMapDeleteEntry(m.bpfmaps.JumpMap, idx)
+						_ = jumpMapDeleteEntry(m.bpfmaps.JumpMap, idx, jump.TCMaxEntryPoints)
 					}
 				}
 			} else {
@@ -1208,12 +1219,12 @@ func (m *bpfEndpointManager) syncIfStateMap() {
 	})
 
 	// Fill unallocated indexes.
-	for i := 0; i < jump.MaxEntries; i++ {
+	for i := 0; i < jump.TCMaxEntryPoints; i++ {
 		if !palloc.Contains(i) {
 			_ = m.jumpMapAlloc.Put(i)
 		}
 	}
-	for i := 0; i < jump.XDPMaxEntries; i++ {
+	for i := 0; i < jump.XDPMaxEntryPoints; i++ {
 		if !xdpPalloc.Contains(i) {
 			_ = m.xdpJumpMapAlloc.Put(i)
 		}
@@ -1974,8 +1985,12 @@ func (m *bpfEndpointManager) addHostPolicy(rules *polprog.Rules, hostEndpoint *p
 	rules.HostProfiles = m.extractProfiles(hostEndpoint.ProfileIds, polDirection)
 }
 
-func (m *bpfEndpointManager) attachDataIfaceProgram(ifaceName string, ep *proto.HostEndpoint,
-	polDirection PolDirection, policyIdx, filterIdx int) error {
+func (m *bpfEndpointManager) attachDataIfaceProgram(
+	ifaceName string,
+	ep *proto.HostEndpoint,
+	polDirection PolDirection,
+	policyIdx, filterIdx int,
+) error {
 
 	if m.hostIP == nil {
 		// Do not bother and wait
@@ -2793,7 +2808,7 @@ func (m *bpfEndpointManager) removePolicyDebugInfo(ifaceName string, ipFamily pr
 	}
 }
 
-func (m *bpfEndpointManager) writePolicyDebugInfo(insns asm.Insns, ifaceName string, ipFamily proto.IPVersion, polDir string, h hook.Hook, polErr error) error {
+func (m *bpfEndpointManager) writePolicyDebugInfo(insns []asm.Insns, ifaceName string, ipFamily proto.IPVersion, polDir string, h hook.Hook, polErr error) error {
 	if !m.bpfPolicyDebugEnabled {
 		return nil
 	}
@@ -2806,10 +2821,20 @@ func (m *bpfEndpointManager) writePolicyDebugInfo(insns asm.Insns, ifaceName str
 		errStr = polErr.Error()
 	}
 
-	var policyDebugInfo = bpf.PolicyDebugInfo{
+	// We may have >1 sub-program; it seems to work reasonably well to just
+	// concatenate the instructions.  The policy program builder writes
+	// comments that delineate the programs.
+	var combinedInsns asm.Insns
+	if len(insns) > 0 {
+		combinedInsns = insns[0]
+		for _, ins := range insns[1:] {
+			combinedInsns = append(combinedInsns, ins...)
+		}
+	}
+	policyDebugInfo := bpf.PolicyDebugInfo{
 		IfaceName:  ifaceName,
 		Hook:       "tc " + h.String(),
-		PolicyInfo: insns,
+		PolicyInfo: combinedInsns,
 		Error:      errStr,
 	}
 
@@ -2849,8 +2874,14 @@ func (m *bpfEndpointManager) updatePolicyProgram(rules polprog.Rules, polDir str
 		}
 		opts = append(opts, polprog.WithAllowDenyJumps(allow, deny))
 	}
-	insns, err := m.doUpdatePolicyProgram(ap.HookName(), progName,
-		ap.PolicyJmp(), rules, ipFamily, opts...)
+	insns, err := m.doUpdatePolicyProgram(
+		ap.HookName(),
+		progName,
+		ap.PolicyJmp(),
+		rules,
+		ipFamily,
+		opts...,
+	)
 	perr := m.writePolicyDebugInfo(insns, ap.IfaceName(), ipFamily, polDir, ap.HookName(), err)
 	if perr != nil {
 		log.WithError(perr).Warn("error writing policy debug information")
@@ -2907,17 +2938,34 @@ func policyProgramName(iface, polDir string, ipFamily proto.IPVersion) string {
 	return fmt.Sprintf("p%v%c_%s", version, polDir[0], iface)
 }
 
-func (m *bpfEndpointManager) loadPolicyProgram(progName string,
-	ipFamily proto.IPVersion, rules polprog.Rules, progsMap maps.Map, opts ...polprog.Option) (
-	fileDescriptor, asm.Insns, error) {
+func (m *bpfEndpointManager) loadPolicyProgram(
+	progName string,
+	ipFamily proto.IPVersion,
+	rules polprog.Rules,
+	staticProgsMap maps.Map,
+	polProgsMap maps.Map,
+	opts ...polprog.Option,
+) (
+	fd []fileDescriptor, insns []asm.Insns, err error,
+) {
+	log.WithFields(log.Fields{
+		"progName": progName,
+		"ipFamily": ipFamily,
+	}).Debug("Generating policy program...")
 
 	if ipFamily == proto.IPVersion_IPV6 {
 		opts = append(opts, polprog.WithIPv6())
 	}
 
-	pg := polprog.NewBuilder(m.ipSetIDAlloc, m.bpfmaps.IpsetsMap.MapFD(),
-		m.bpfmaps.StateMap.MapFD(), progsMap.MapFD(), opts...)
-	insns, err := pg.Instructions(rules)
+	pg := polprog.NewBuilder(
+		m.ipSetIDAlloc,
+		m.bpfmaps.IpsetsMap.MapFD(),
+		m.bpfmaps.StateMap.MapFD(),
+		staticProgsMap.MapFD(),
+		polProgsMap.MapFD(),
+		opts...,
+	)
+	programs, err := pg.Instructions(rules)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate policy bytecode v%v: %w", ipFamily, err)
 	}
@@ -2925,46 +2973,95 @@ func (m *bpfEndpointManager) loadPolicyProgram(progName string,
 	if rules.ForXDP {
 		progType = unix.BPF_PROG_TYPE_XDP
 	}
-	progFD, err := bpf.LoadBPFProgramFromInsns(insns, progName, "Apache-2.0", uint32(progType))
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load BPF policy program %v: %w", ipFamily, err)
-	}
 
-	return progFD, insns, nil
+	progFDs := make([]fileDescriptor, 0, len(programs))
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		for _, progFD := range progFDs {
+			if err := progFD.Close(); err != nil {
+				log.WithError(err).Panic("Failed to close program FD.")
+			}
+		}
+	}()
+	for i, p := range programs {
+		subProgName := progName
+		if i > 0 {
+			if len(subProgName) > 12 {
+				subProgName = subProgName[:12]
+			}
+			subProgName = fmt.Sprintf("%s_%d", subProgName, i)
+		}
+		progFD, err := bpf.LoadBPFProgramFromInsns(p, subProgName, "Apache-2.0", uint32(progType))
+		if err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"name":       subProgName,
+				"subProgram": i,
+			}).Error("Failed to load BPF policy program")
+			return nil, nil, fmt.Errorf("failed to load BPF policy program %v: %w", ipFamily, err)
+		}
+		progFDs = append(progFDs, progFD)
+	}
+	success = true
+	return progFDs, programs, nil
 }
 
-func (m *bpfEndpointManager) doUpdatePolicyProgram(hk hook.Hook, progName string, jmp int, rules polprog.Rules,
-	ipFamily proto.IPVersion, opts ...polprog.Option) (asm.Insns, error) {
-
+func (m *bpfEndpointManager) doUpdatePolicyProgram(
+	hk hook.Hook,
+	progName string,
+	polJumpMapIdx int,
+	rules polprog.Rules,
+	ipFamily proto.IPVersion,
+	opts ...polprog.Option,
+) ([]asm.Insns, error) {
 	if m.bpfPolicyDebugEnabled {
 		opts = append(opts, polprog.WithPolicyDebugEnabled())
 	}
 
-	progsMap := m.bpfmaps.ProgramsMap
+	staticProgsMap := m.bpfmaps.ProgramsMap
 	if hk == hook.XDP {
-		progsMap = m.bpfmaps.XDPProgramsMap
+		staticProgsMap = m.bpfmaps.XDPProgramsMap
 	}
 
-	progFD, insns, err := m.loadPolicyProgramFn(progName, ipFamily, rules, progsMap, opts...)
+	// If we have to break a program up into sub-programs to please the
+	// verifier then we store the sub-programs at
+	// polJumpMapIdx + subProgNo * stride.
+	polProgsMap := m.bpfmaps.JumpMap
+	stride := jump.TCMaxEntryPoints
+	if hk == hook.XDP {
+		polProgsMap = m.bpfmaps.XDPJumpMap
+		stride = jump.XDPMaxEntryPoints
+	}
+	opts = append(opts, polprog.WithPolicyMapIndexAndStride(polJumpMapIdx, stride))
+	progFDs, insns, err := m.loadPolicyProgramFn(
+		progName,
+		ipFamily,
+		rules,
+		staticProgsMap,
+		polProgsMap,
+		opts...,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	defer func() {
-		// Once we've put the program in the map, we don't need its FD anymore.
-		err := progFD.Close()
-		if err != nil {
-			log.WithError(err).Panic("Failed to close program FD.")
+		for _, progFD := range progFDs {
+			// Once we've put the programs in the map, we don't need their FDs.
+			if err := progFD.Close(); err != nil {
+				log.WithError(err).Panic("Failed to close program FD.")
+			}
 		}
 	}()
 
-	jumpMap := m.bpfmaps.JumpMap
-	if hk == hook.XDP {
-		jumpMap = m.bpfmaps.XDPJumpMap
-	}
-
-	if err := jumpMap.Update(jump.Key(jmp), jump.Value(progFD.FD())); err != nil {
-		return nil, fmt.Errorf("failed to update %s policy jump map [%d]=%d: %w", hk, jmp, progFD, err)
+	for i, progFD := range progFDs {
+		subProgIdx := polprog.SubProgramJumpIdx(polJumpMapIdx, i, stride)
+		log.Debugf("Putting sub-program %d at position %d", i, subProgIdx)
+		if err := polProgsMap.Update(jump.Key(subProgIdx), jump.Value(progFD.FD())); err != nil {
+			return nil, fmt.Errorf("failed to update %s policy jump map [%d]=%d: %w", hk, subProgIdx, progFD, err)
+		}
 	}
 
 	return insns, nil
@@ -2976,11 +3073,13 @@ func (m *bpfEndpointManager) jumpMapDelete(h hook.Hook, idx int) error {
 	}
 
 	jumpMap := m.bpfmaps.JumpMap
+	stride := jump.TCMaxEntryPoints
 	if h == hook.XDP {
 		jumpMap = m.bpfmaps.XDPJumpMap
+		stride = jump.XDPMaxEntryPoints
 	}
 
-	return jumpMapDeleteEntry(jumpMap, idx)
+	return jumpMapDeleteEntry(jumpMap, idx, stride)
 }
 
 func (m *bpfEndpointManager) removePolicyProgram(ap attachPoint) error {
@@ -2996,14 +3095,16 @@ func (m *bpfEndpointManager) removePolicyProgram(ap attachPoint) error {
 		}
 
 		var pm maps.Map
-
+		var stride int
 		if ap.HookName() == hook.XDP {
-			pm = m.bpfmaps.JumpMap
-		} else {
+			stride = jump.XDPMaxEntryPoints
 			pm = m.bpfmaps.XDPJumpMap
+		} else {
+			stride = jump.TCMaxEntryPoints
+			pm = m.bpfmaps.JumpMap
 		}
 
-		if err := jumpMapDeleteEntry(pm, idx); err != nil {
+		if err := jumpMapDeleteEntry(pm, idx, stride); err != nil {
 			return fmt.Errorf("removing policy iface %s hook %s: %w", ap.IfaceName(), ap.HookName(), err)
 		}
 
@@ -3259,6 +3360,13 @@ func (m *bpfEndpointManager) ruleMatchID(dir, action, owner, name string, idx in
 	h := fnv.New64a()
 	h.Write([]byte(action + owner + dir + strconv.Itoa(idx) + name))
 	return h.Sum64()
+}
+
+func newJumpMapAlloc(entryPoints int) *jumpMapAlloc {
+	return &jumpMapAlloc{
+		max:  entryPoints,
+		free: make(chan int, entryPoints),
+	}
 }
 
 type jumpMapAlloc struct {

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -223,12 +223,19 @@ type mockProgMapDP struct {
 	*mockDataplane
 }
 
-func (m *mockProgMapDP) loadPolicyProgram(_ string, _ proto.IPVersion, _ polprog.Rules, _ maps.Map, _ ...polprog.Option) (
-	fileDescriptor, asm.Insns, error) {
+func (m *mockProgMapDP) loadPolicyProgram(progName string,
+	ipFamily proto.IPVersion,
+	rules polprog.Rules,
+	staticProgsMap maps.Map,
+	polProgsMap maps.Map,
+	opts ...polprog.Option,
+) ([]fileDescriptor, []asm.Insns, error) {
 	fdCounter++
 
-	return mockFD(fdCounter), []asm.Insn{{Comments: []string{"blah"}}}, nil
+	return []fileDescriptor{mockFD(fdCounter)}, []asm.Insns{{{Comments: []string{"blah"}}}}, nil
 }
+
+var _ hasLoadPolicyProgram = (*mockProgMapDP)(nil)
 
 type mockFD uint32
 

--- a/felix/fv/bpf_pol_scale_test.go
+++ b/felix/fv/bpf_pol_scale_test.go
@@ -19,6 +19,7 @@ package fv_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -101,7 +102,7 @@ var _ = Context("_BPF-SAFE_ BPF policy scale tests", func() {
 
 		cc.ExpectNone(w[0], w[1])
 		cc.ExpectNone(w[1], w[0])
-		cc.CheckConnectivity()
+		cc.CheckConnectivityWithTimeout(30 * time.Second)
 
 		cc.ResetExpectations()
 		ns := api.NewGlobalNetworkSet()
@@ -115,6 +116,6 @@ var _ = Context("_BPF-SAFE_ BPF policy scale tests", func() {
 
 		cc.ExpectSome(w[0], w[1])
 		cc.ExpectNone(w[1], w[0])
-		cc.CheckConnectivity()
+		cc.CheckConnectivityWithTimeout(30 * time.Second)
 	})
 })

--- a/felix/fv/bpf_pol_scale_test.go
+++ b/felix/fv/bpf_pol_scale_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/felix/fv/connectivity"
+	"github.com/projectcalico/calico/felix/fv/containers"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+var _ = Context("_BPF-SAFE_ BPF policy scale tests", func() {
+	if !BPFMode() {
+		// Non-BPF run.
+		return
+	}
+
+	var (
+		etcd     *containers.Container
+		tc       infrastructure.TopologyContainers
+		felixPID int
+		client   client.Interface
+		infra    infrastructure.DatastoreInfra
+		w        [2]*workload.Workload
+		cc       *connectivity.Checker
+	)
+
+	BeforeEach(func() {
+		topologyOptions := infrastructure.DefaultTopologyOptions()
+		topologyOptions.FelixLogSeverity = "Info"
+		topologyOptions.EnableIPv6 = false
+		topologyOptions.ExtraEnvVars["FELIX_BPFLogLevel"] = "off"
+		topologyOptions.ExtraEnvVars["FELIX_BPFMapSizeIPSets"] = "10000000"
+		logrus.SetLevel(logrus.InfoLevel)
+		tc, etcd, client, infra = infrastructure.StartSingleNodeEtcdTopology(topologyOptions)
+		felixPID = tc.Felixes[0].GetFelixPID()
+		_ = felixPID
+		w[0] = workload.Run(tc.Felixes[0], "w0", "default", "10.65.0.2", "8085", "tcp")
+		w[1] = workload.Run(tc.Felixes[0], "w1", "default", "10.65.0.3", "8085", "tcp")
+		cc = &connectivity.Checker{}
+	})
+
+	AfterEach(func() {
+		for _, wl := range w {
+			wl.Stop()
+		}
+		tc.Stop()
+
+		if CurrentGinkgoTestDescription().Failed {
+			etcd.Exec("etcdctl", "get", "/", "--prefix", "--keys-only")
+		}
+		etcd.Stop()
+		infra.Stop()
+	})
+
+	It("should handle thousands of policy rules", func() {
+		// This test activates thousands of rules on one endpoint, which
+		// requires the policy program to be split into sub-programs.
+
+		// 12500 rules
+		const (
+			numPols        = 250
+			numRulesPerPol = 50
+			numSets        = numPols * numRulesPerPol
+		)
+		createNetworkSetPolicies(client, numPols, numRulesPerPol)
+
+		By("Creating a workload, activating the policies")
+		// Create a workload that uses the policy.
+		w[0].ConfigureInInfra(infra)
+		w[1].ConfigureInInfra(infra)
+
+		Eventually(tc.Felixes[0].BPFNumPolProgramsFn(w[0].InterfaceName, "ingress"), "240s", "1s").Should(
+			BeNumerically(">", 5))
+		Eventually(tc.Felixes[0].BPFNumPolProgramsFn(w[1].InterfaceName, "ingress"), "20s", "1s").Should(
+			BeNumerically(">", 5))
+
+		cc.ExpectNone(w[0], w[1])
+		cc.ExpectNone(w[1], w[0])
+		cc.CheckConnectivity()
+
+		cc.ResetExpectations()
+		ns := api.NewGlobalNetworkSet()
+		ns.Name = "netset-extra"
+		ns.Labels = map[string]string{
+			"netset": fmt.Sprintf("netset-%d", numSets-42),
+		}
+		ns.Spec.Nets = []string{w[0].IPNet()}
+		_, err := client.GlobalNetworkSets().Create(context.TODO(), ns, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		cc.ExpectSome(w[0], w[1])
+		cc.ExpectNone(w[1], w[0])
+		cc.CheckConnectivity()
+	})
+})

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -414,7 +414,6 @@ func (f *Felix) BPFNumPolProgramsByEntryPoint(entryPointIdx int) (contiguous, to
 		)
 		if err != nil {
 			gapSeen = true
-			break
 		}
 		if strings.Contains(out, "value:") {
 			total++


### PR DESCRIPTION
## Description

BPF policy programs were limited in size by the verifier.
In particular, the limit on the number of jumps on a
particular codepath seemed to be the lowest bound.

- Have the policy program builder split programs that reach
  a certain number of jumps into multiple sub-programs.
- Expand the policy jump map to make room for 24 sub-programs
  for each slot.
- Store the entry point program at position N (as before).
  Store sub-programs at positions N+10k N+20k N+30k etc...
- Lots of plumbing and fix-ups to flow through the new
  structure. Policy program builder need to know the map
  file descriptor and sub-program "stride".

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-9955
CORE-9971
CORE-9969

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
eBPF: Support many more active policy rules per endpoint+direction.  The BPF policy compiler now supports splitting policy programs if they get larger than the kernel would allow.  The exact number of policy rules per endpoint depends on the details of the rules but for some real-world examples we see an increase from approximately 2k rules to approx 15k rules per endpoint direction.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
