### PR TITLE
[BPF] fix ct cleaning for host processes w/o ctlb using service

### DIFF
--- a/felix/bpf/conntrack/cleanup.go
+++ b/felix/bpf/conntrack/cleanup.go
@@ -212,14 +212,17 @@ func NewStaleNATScanner(frontendHasBackend NATChecker) *StaleNATScanner {
 }
 
 // Check checks the conntrack entry
-func (sns *StaleNATScanner) Check(k KeyInterface, v ValueInterface, _ EntryGet) ScanVerdict {
+func (sns *StaleNATScanner) Check(k KeyInterface, v ValueInterface, get EntryGet) ScanVerdict {
 	debug := log.GetLevel() >= log.DebugLevel
+
+again:
 
 	switch v.Type() {
 	case TypeNormal:
 		// skip non-NAT entry
 
 	case TypeNATReverse:
+
 		proto := k.Proto()
 		ipA := k.AddrA()
 		ipB := k.AddrB()
@@ -288,8 +291,16 @@ func (sns *StaleNATScanner) Check(k KeyInterface, v ValueInterface, _ EntryGet) 
 				svcIP = kA
 				svcPort = kAport
 			} else {
-				log.WithFields(log.Fields{"key": k, "value": v}).Error("Mismatch between key and rev key")
-				return ScanVerdictOK // don't touch, will get deleted when expired
+				rv, err := get(revKey)
+				if err != nil {
+					// There is no match for the reverse key, delete it, its useless - we
+					// can get here due to host networked program accessing service
+					// without ctlb when the backed is accessible via tunnel.
+					return ScanVerdictDelete
+				}
+				k = revKey
+				v = rv
+				goto reverse // handle it based on the reverse entry
 			}
 		} else {
 			// snatPort is the new client port. It does not match the client
@@ -316,8 +327,16 @@ func (sns *StaleNATScanner) Check(k KeyInterface, v ValueInterface, _ EntryGet) 
 				svcIP = kA
 				svcPort = kAport
 			} else {
-				log.WithFields(log.Fields{"key": k, "value": v}).Error("Mismatch between key and rev key")
-				return ScanVerdictOK // don't touch, will get deleted when expired
+				rv, err := get(revKey)
+				if err != nil {
+					// There is no match for the reverse key, delete it, its useless - we
+					// can get here due to host networked program accessing service
+					// without ctlb when the backed is accessible via tunnel.
+					return ScanVerdictDelete
+				}
+				k = revKey
+				v = rv
+				goto reverse // handle it based on the reverse entry
 			}
 		}
 
@@ -336,6 +355,13 @@ func (sns *StaleNATScanner) Check(k KeyInterface, v ValueInterface, _ EntryGet) 
 	}
 
 	return ScanVerdictOK
+
+reverse:
+	if v.Type() == TypeNATReverse {
+		goto again
+	}
+
+	return ScanVerdictDelete
 }
 
 // IterationStart satisfies EntryScannerSynced

--- a/felix/bpf/conntrack/conntrack_test.go
+++ b/felix/bpf/conntrack/conntrack_test.go
@@ -174,6 +174,9 @@ var _ = Describe("BPF Conntrack StaleNATScanner", func() {
 	backendIP := net.IPv4(2, 2, 2, 2)
 	backendPort := uint16(2222)
 
+	backendIP2 := net.IPv4(2, 2, 2, 3)
+	backendPort2 := uint16(223)
+
 	snatPort := uint16(456)
 
 	withSNATPort := func(snatport uint16, v conntrack.Value) conntrack.Value {
@@ -182,12 +185,17 @@ var _ = Describe("BPF Conntrack StaleNATScanner", func() {
 	}
 
 	DescribeTable("forward entries",
-		func(k conntrack.Key, v conntrack.Value, verdict conntrack.ScanVerdict) {
+		func(k conntrack.Key, v conntrack.Value, verdict conntrack.ScanVerdict, getFn ...conntrack.EntryGet) {
 			staleNATScanner := conntrack.NewStaleNATScanner(dummyNATChecker{
 				check: func(fIP net.IP, fPort uint16, bIP net.IP, bPort uint16, proto uint8) bool {
 					Expect(proto).To(Equal(uint8(123)))
 					Expect(fIP.Equal(svcIP)).To(BeTrue())
 					Expect(fPort).To(Equal(svcPort))
+
+					if bIP.Equal(backendIP2) && bPort == backendPort2 {
+						return true
+					}
+
 					Expect(bIP.Equal(backendIP)).To(BeTrue())
 					Expect(bPort).To(Equal(backendPort))
 					return false
@@ -195,7 +203,12 @@ var _ = Describe("BPF Conntrack StaleNATScanner", func() {
 			},
 			)
 
-			Expect(verdict).To(Equal(staleNATScanner.Check(k, v, nil)))
+			var get conntrack.EntryGet
+			if len(getFn) == 1 {
+				get = getFn[0]
+			}
+
+			Expect(verdict).To(Equal(staleNATScanner.Check(k, v, get)))
 		},
 		Entry("keyA - revA",
 			conntrack.NewKey(123, clientIP, clientPort, svcIP, svcPort),
@@ -217,25 +230,22 @@ var _ = Describe("BPF Conntrack StaleNATScanner", func() {
 			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, clientPort)),
 			conntrack.ScanVerdictDelete,
 		),
-		Entry("mismatch key port",
-			conntrack.NewKey(123, svcIP, svcPort, clientIP, 54545),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, clientPort)),
+		Entry("mismatch IP",
+			conntrack.NewKey(123, svcIP, svcPort, net.IPv4(6, 6, 6, 6), clientPort),
+			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP2, backendPort2, clientIP, clientPort)),
 			conntrack.ScanVerdictOK,
+			func(conntrack.KeyInterface) (conntrack.ValueInterface, error) {
+				return conntrack.NewValueNATReverse(0, 0, 0, conntrack.Leg{}, conntrack.Leg{},
+					net.IPv4(0, 0, 0, 0), svcIP, svcPort), nil
+			},
 		),
-		Entry("mismatch key IP",
-			conntrack.NewKey(123, svcIP, svcPort, net.IPv4(2, 1, 2, 1), clientPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, clientPort)),
-			conntrack.ScanVerdictOK,
-		),
-		Entry("mismatch rev port",
-			conntrack.NewKey(123, svcIP, svcPort, clientIP, clientPort),
-			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, clientIP, 12321)),
-			conntrack.ScanVerdictOK,
-		),
-		Entry("mismatch rev IP",
+		Entry("mismatch rev IP missing rev",
 			conntrack.NewKey(123, svcIP, svcPort, clientIP, clientPort),
 			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, net.IPv4(3, 2, 2, 3), clientPort)),
-			conntrack.ScanVerdictOK,
+			conntrack.ScanVerdictDelete,
+			func(conntrack.KeyInterface) (conntrack.ValueInterface, error) {
+				return nil, fmt.Errorf("no reverse entry")
+			},
 		),
 		Entry("snatport keyA - revA",
 			conntrack.NewKey(123, clientIP, clientPort, svcIP, svcPort),

--- a/felix/bpf/conntrack/conntrack_test.go
+++ b/felix/bpf/conntrack/conntrack_test.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/projectcalico/calico/felix/timeshim/mocktime"
 
 	. "github.com/onsi/ginkgo"
@@ -244,7 +246,7 @@ var _ = Describe("BPF Conntrack StaleNATScanner", func() {
 			conntrack.NewValueNATForward(0, 0, 0, conntrack.NewKey(123, backendIP, backendPort, net.IPv4(3, 2, 2, 3), clientPort)),
 			conntrack.ScanVerdictDelete,
 			func(conntrack.KeyInterface) (conntrack.ValueInterface, error) {
-				return nil, fmt.Errorf("no reverse entry")
+				return nil, unix.ENOENT
 			},
 		),
 		Entry("snatport keyA - revA",

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -3255,7 +3255,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 								// Also try host networked pods, both on a local and remote node.
 								cc.Expect(Some, hostW[0], TargetIP(clusterIP), ports, hostW0SrcIP)
-								//cc.Expect(Some, hostW[1], TargetIP(clusterIP), ports, hostW1SrcIP)
+								cc.Expect(Some, hostW[1], TargetIP(clusterIP), ports, hostW1SrcIP)
 
 								if testOpts.protocol == "tcp" && !testOpts.ipv6 {
 									// Also excercise ipv4 as ipv6


### PR DESCRIPTION
If there is an overlay, forwarding entry may not have a matching client IP as it may start with host's main IP, but then it is turned into host's tunnel IP. We cannot determine what is the client/service/backend from that entry only. We need to lookup the reverse entry. If the reverse entry does not exist, we delete the forarding entry anyway as there is no use for it without the reverse half.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
