### PR TITLE
Streamline app-policy multi-arch builds

### DIFF
--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -85,22 +85,14 @@ build:
 	$(MAKE) $(BINDIR)/dikastes-$(ARCH) ARCH=$(ARCH)
 	$(MAKE) $(BINDIR)/healthz-$(ARCH) ARCH=$(ARCH)
 
-$(BINDIR)/dikastes-amd64: ARCH=amd64
-$(BINDIR)/dikastes-arm64: ARCH=arm64
-$(BINDIR)/dikastes-ppc64le: ARCH=ppc64le
-$(BINDIR)/dikastes-s390x: ARCH=s390x
-$(BINDIR)/dikastes-%: protobuf $(SRC_FILES)
+$(BINDIR)/dikastes-$(ARCH): protobuf $(SRC_FILES)
 ifeq ($(FIPS),true)
 	$(call build_cgo_boring_binary, ./cmd/dikastes, $@)
 else
 	$(call build_binary, ./cmd/dikastes, $@)
 endif
 
-$(BINDIR)/healthz-amd64: ARCH=amd64
-$(BINDIR)/healthz-arm64: ARCH=arm64
-$(BINDIR)/healthz-ppc64le: ARCH=ppc64le
-$(BINDIR)/healthz-s390x: ARCH=s390x
-$(BINDIR)/healthz-%: protobuf $(SRC_FILES)
+$(BINDIR)/healthz-$(ARCH): protobuf $(SRC_FILES)
 ifeq ($(FIPS),true)
 	$(call build_cgo_boring_binary, ./cmd/healthz, $@)
 else


### PR DESCRIPTION
## Description

This changeset simplifies app-policy `make build` targets for multi-arches. It is manually by building binaries for all supported arches.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
