### PR TITLE
[v3.27] [BPF] ClusterIP should reflect InternalTrafficPolicy=Local

### DIFF
--- a/felix/bpf/nat/maps.go
+++ b/felix/bpf/nat/maps.go
@@ -255,12 +255,16 @@ func (v FrontendValue) FlagsAsString() string {
 		flg := uint32(1 << i)
 		if flgs&flg != 0 {
 			fstr += flgTostr[int(flg)]
+			fstr += ", "
 		}
 		flgs &= ^flg
 		if flgs == 0 {
 			break
 		}
-		fstr += ", "
+	}
+
+	if fstr != "" {
+		return fstr[:len(fstr)-2]
 	}
 
 	return fstr

--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -780,7 +780,12 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 		cnt++
 	}
 
-	if err := s.writeSvc(sinfo, id, cnt, local, 0); err != nil {
+	flags := uint32(0)
+	if sinfo.InternalPolicyLocal() {
+		flags |= nat.NATFlgInternalLocal
+	}
+
+	if err := s.writeSvc(sinfo, id, cnt, local, flags); err != nil {
 		return 0, 0, err
 	}
 

--- a/felix/bpf/proxy/syncer_test.go
+++ b/felix/bpf/proxy/syncer_test.go
@@ -816,6 +816,8 @@ var _ = Describe("BPF Syncer", func() {
 			Expect(ok).To(BeTrue())
 			Expect(val1.Count()).To(Equal(uint32(4)))
 			Expect(val1.LocalCount()).To(Equal(uint32(2)))
+			// ClusterIP only reflects internal traffic policy, not the external one
+			Expect(val1.Flags()).To(Equal(uint32(nat.NATFlgInternalLocal)))
 
 			val2, ok := svcs.m[nat.NewNATKey(net.IPv4(192, 168, 0, 1), 4444, proxy.ProtoV1ToIntPanic(v1.ProtocolTCP))]
 			Expect(ok).To(BeTrue())


### PR DESCRIPTION
pick of https://github.com/projectcalico/calico/pull/8259

https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/

fixes https://github.com/projectcalico/calico/issues/8255

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: ClusterIP reflects InternalTrafficPolicy=Local
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
