### PR TITLE
Avoid conntrack cleanup of IPv6 host networked workloads in BPF Fvs.

### DIFF
--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1352,7 +1352,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							// Wait for the pool change to take effect
 							Eventually(func() string {
 								return bpfDumpRoutes(tc.Felixes[0])
-							}, "60s", "1s").ShouldNot(ContainSubstring("workload in-pool nat-out"))
+							}, "5s", "1s").ShouldNot(ContainSubstring("workload in-pool nat-out"))
 
 							cc.ResetExpectations()
 							cc.ExpectSNAT(w[0][0], w[0][0].IP, hostW[1])
@@ -1366,7 +1366,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 							// Wait for the pool change to take effect
 							Eventually(func() string {
 								return bpfDumpRoutes(tc.Felixes[0])
-							}, "60s", "1s").Should(ContainSubstring("workload in-pool nat-out"))
+							}, "5s", "1s").Should(ContainSubstring("workload in-pool nat-out"))
 
 							cc.ResetExpectations()
 							cc.ExpectSNAT(w[0][0], felixIP(0), hostW[1])
@@ -5034,7 +5034,8 @@ func conntrackFlushWorkloadEntries(felixes []*infrastructure.Felix) func() {
 	return func() {
 		for _, felix := range felixes {
 			for _, w := range felix.Workloads {
-				if w.GetIP() == felix.GetIP() {
+				wIP := w.GetIP()
+				if wIP == felix.GetIP() || wIP == felix.GetIPv6() {
 					continue // Skip host-networked workloads.
 				}
 				for _, dirn := range []string{"--orig-src", "--orig-dst", "--reply-dst", "--reply-src"} {


### PR DESCRIPTION
## Description

This PR is to fix the flake with NAT outgoing taking a lot of time in IPv6 eBPF FVs.
Before the IPPool is updated in the FVs, conntrack cleaner cleans up the conntrack corresponding to API server and felix-0.
As a result, IPPool update doesn't reach felix on time and APIServer keeps re transmitting the packet. 

Fix - Skip cleanup of conntrack for IPv6 host networked workloads.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes https://tigera.atlassian.net/browse/CORE-9896


If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
