### PR TITLE
Only program failsafe rules for IP version of the CIDR

### DIFF
--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -485,6 +485,8 @@ func (r *DefaultRuleRenderer) failsafeInChain(table string, ipVersion uint8) *Ch
 					Protocol(protoPort.Protocol).
 					DestPorts(protoPort.Port).
 					SourceNet(protoPort.Net)
+			} else {
+				continue // don't add the rule
 			}
 		}
 		rules = append(rules, rule)
@@ -514,6 +516,8 @@ func (r *DefaultRuleRenderer) failsafeInChain(table string, ipVersion uint8) *Ch
 						Protocol(protoPort.Protocol).
 						SourcePorts(protoPort.Port).
 						SourceNet(protoPort.Net)
+				} else {
+					continue // don't add the rule
 				}
 			}
 			rules = append(rules, rule)
@@ -548,6 +552,8 @@ func (r *DefaultRuleRenderer) failsafeOutChain(table string, ipVersion uint8) *C
 					Protocol(protoPort.Protocol).
 					DestPorts(protoPort.Port).
 					DestNet(protoPort.Net)
+			} else {
+				continue // don't add the rule
 			}
 		}
 		rules = append(rules, rule)
@@ -576,7 +582,9 @@ func (r *DefaultRuleRenderer) failsafeOutChain(table string, ipVersion uint8) *C
 					rule.Match = Match().
 						Protocol(protoPort.Protocol).
 						SourcePorts(protoPort.Port).
-						SourceNet(protoPort.Net)
+						DestNet(protoPort.Net)
+				} else {
+					continue // don't add the rule
 				}
 			}
 			rules = append(rules, rule)

--- a/felix/rules/static_test.go
+++ b/felix/rules/static_test.go
@@ -94,7 +94,8 @@ var _ = Describe("Static", func() {
 					IPSetConfigV6:         ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil),
 					FailsafeInboundHostPorts: []config.ProtoPort{
 						{Net: "0.0.0.0/0", Protocol: "tcp", Port: 22},
-						{Net: "0.0.0.0/0", Protocol: "tcp", Port: 1022},
+						{Net: "10.0.0.0/24", Protocol: "tcp", Port: 1022},
+						{Net: "::/0", Protocol: "tcp", Port: 1022},
 					},
 					FailsafeOutboundHostPorts: []config.ProtoPort{
 						{Net: "0.0.0.0/0", Protocol: "tcp", Port: 23},
@@ -174,37 +175,27 @@ var _ = Describe("Static", func() {
 					expRawFailsafeIn := &Chain{
 						Name: "cali-failsafe-in",
 						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(22), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1022), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(23), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(1023), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("::/0"), Action: AcceptAction{}},
 						},
 					}
 
 					expRawFailsafeOut := &Chain{
 						Name: "cali-failsafe-out",
 						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(23), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1023), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(22), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").SourcePorts(1022), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").SourcePorts(1022).DestNet("::/0"), Action: AcceptAction{}},
 						},
 					}
 
 					expFailsafeIn := &Chain{
 						Name: "cali-failsafe-in",
 						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(22), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1022), Action: AcceptAction{}},
+							{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("::/0"), Action: AcceptAction{}},
 						},
 					}
 
 					expFailsafeOut := &Chain{
-						Name: "cali-failsafe-out",
-						Rules: []Rule{
-							{Match: Match().Protocol("tcp").DestPorts(23), Action: AcceptAction{}},
-							{Match: Match().Protocol("tcp").DestPorts(1023), Action: AcceptAction{}},
-						},
+						Name:  "cali-failsafe-out",
+						Rules: []Rule{},
 					}
 
 					if ipVersion == 4 {
@@ -212,7 +203,7 @@ var _ = Describe("Static", func() {
 							Name: "cali-failsafe-in",
 							Rules: []Rule{
 								{Match: Match().Protocol("tcp").DestPorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-								{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("10.0.0.0/24"), Action: AcceptAction{}},
 								{Match: Match().Protocol("tcp").SourcePorts(23).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
 								{Match: Match().Protocol("tcp").SourcePorts(1023).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
 							},
@@ -223,8 +214,8 @@ var _ = Describe("Static", func() {
 							Rules: []Rule{
 								{Match: Match().Protocol("tcp").DestPorts(23).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
 								{Match: Match().Protocol("tcp").DestPorts(1023).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
-								{Match: Match().Protocol("tcp").SourcePorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-								{Match: Match().Protocol("tcp").SourcePorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").SourcePorts(22).DestNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").SourcePorts(1022).DestNet("10.0.0.0/24"), Action: AcceptAction{}},
 							},
 						}
 
@@ -232,7 +223,7 @@ var _ = Describe("Static", func() {
 							Name: "cali-failsafe-in",
 							Rules: []Rule{
 								{Match: Match().Protocol("tcp").DestPorts(22).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
-								{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("0.0.0.0/0"), Action: AcceptAction{}},
+								{Match: Match().Protocol("tcp").DestPorts(1022).SourceNet("10.0.0.0/24"), Action: AcceptAction{}},
 							},
 						}
 


### PR DESCRIPTION
If there is no CIDR, program it for both v4 and v6. However, if the CIDR indicates a specific version, include it only for that version.

Previously the port was included in the other ip version as well just without the CIDR, which is not user's intention.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Only program failsafe rules for IP version of the CIDR
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
