### PR TITLE
Fix release timeout issues [v3.27]

### DIFF
--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -6,7 +6,7 @@ agent:
     os_image: ubuntu2004
 
 execution_time_limit:
-  minutes: 600
+  minutes: 800
 
 blocks:
   - name: "Publish official release"
@@ -45,7 +45,7 @@ blocks:
       jobs:
       - name: "Release on GCP VM"
         execution_time_limit:
-          minutes: 180
+          minutes: 360
         env_vars:
         - name: VAR_FILE
           value: /home/semaphore/secrets/release.tfvars

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -872,7 +872,7 @@ retag-build-images-with-registry-%:
 # retag-build-image-with-registry-% retags the build arch images specified by $* and VALIDARCHES with the
 # registry specified by REGISTRY.
 retag-build-image-with-registry-%: var-require-all-REGISTRY-BUILD_IMAGES
-	$(MAKE) $(addprefix retag-build-image-arch-with-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(call unescapefs,$*)
+	$(MAKE) -j12 $(addprefix retag-build-image-arch-with-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(call unescapefs,$*)
 
 # retag-build-image-arch-with-registry-% retags the build / arch image specified by $* and BUILD_IMAGE with the
 # registry specified by REGISTRY.
@@ -895,13 +895,13 @@ push-images-to-registry-%:
 # push-image-to-registry-% pushes the build / arch images specified by $* and VALIDARCHES to the registry
 # specified by REGISTRY.
 push-image-to-registry-%:
-	$(MAKE) $(addprefix push-image-arch-to-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(call unescapefs,$*)
+	$(MAKE) -j6 $(addprefix push-image-arch-to-registry-,$(VALIDARCHES)) BUILD_IMAGE=$(call unescapefs,$*)
 
 # push-image-arch-to-registry-% pushes the build / arch image specified by $* and BUILD_IMAGE to the registry
 # specified by REGISTRY.
 push-image-arch-to-registry-%:
 # If the registry we want to push to doesn't not support manifests don't push the ARCH image.
-	$(DOCKER) push $(call filter-registry,$(REGISTRY))$(BUILD_IMAGE):$(IMAGETAG)-$*
+	$(DOCKER) push --quiet $(call filter-registry,$(REGISTRY))$(BUILD_IMAGE):$(IMAGETAG)-$*
 	$(if $(filter $*,amd64),\
 		$(DOCKER) push $(REGISTRY)/$(BUILD_IMAGE):$(IMAGETAG),\
 		$(NOECHO) $(NOOP)\


### PR DESCRIPTION
Changes to reduce the chances that calico releases will time out, including:
* Increase release pipeline timeout to 800 minutes
* Increase build/publish timeout to 6 hours
* Retag images in parallel (up to 12 threads)
* Push images in parallel (up to 6 threads)