### PR TITLE
Fix --long usage in release versioning

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -202,7 +202,7 @@ ifeq ($(GIT_USE_SSH),true)
 endif
 
 # Get version from git.
-GIT_VERSION:=$(shell git describe --tags --dirty --long --always --abbrev=12)
+GIT_VERSION:=$(shell git describe --tags --dirty --always --abbrev=12)
 
 # Figure out version information.  To support builds from release tarballs, we default to
 # <unknown> if this isn't a git checkout.
@@ -212,7 +212,7 @@ BUILD_ID:=$(shell git rev-parse HEAD || uuidgen | sed 's/-//g')
 # Lazily set the git version we embed into the binaries we build. We want the
 # git tag at the time we build the binary.
 # Variables elsewhere that depend on this (such as LDFLAGS) must also be lazy.
-GIT_DESCRIPTION=$(shell git describe --tags --dirty --long --always --abbrev=12 || echo '<unknown>')
+GIT_DESCRIPTION=$(shell git describe --tags --dirty --always --abbrev=12 || echo '<unknown>')
 
 # Calculate a timestamp for any build artifacts.
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
## Description

Revert commit b4dbc9c80ac0185e41cbab025b989754445727c7, which seemed fine but turned out to cause problems for releases when generating versions at release time.

## Related issues/PRs

Reverts #8113
