### PR TITLE
Fix GPG key path for OpenStack publishing [cp #8304][master]

### DIFF
--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -57,7 +57,7 @@ blocks:
           minutes: 60
         env_vars:
         - name: SECRET_KEY
-          value: ~/secrets/launchpad-gpg-key-dfox.key
+          value: /home/semaphore/secrets/launchpad-gpg-key-dfox.key
         - name: GCLOUD_ARGS
           value: --zone us-east1-c --project tigera-wp-tcp-redirect
         - name: HOST


### PR DESCRIPTION
Fix the GPG key path in Semaphore to fix OpenStack publishing. Cherry-pick of #8304.