### PR TITLE
Clean up release promotions

### DIFF
--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -110,5 +110,5 @@ blocks:
       epilogue:
         always:
           commands:
-          - test -d hack/release/packaging/output hack/release/packaging/openstack
+          - test -d hack/release/packaging/output  && mv -v hack/release/packaging/output hack/release/packaging/openstack
           - artifact push workflow hack/release/packaging/openstack

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -86,9 +86,6 @@ blocks:
         - ssh-add /home/semaphore/.keys/git_ssh_rsa
         # Checkout the code and unshallow it.
         - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
         # Free up space on the build machine.
         - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
       jobs:

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -68,7 +68,32 @@ blocks:
         commands:
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} release; fi
         - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make GIT_BRANCH=${SEMAPHORE_GIT_BRANCH} release-publish; fi
+  - name: "Publish official release"
+    skip:
+      # Only run on branches, not PRs.
+      when: "branch !~ '.+'"
+    task:
+      secrets:
+      - name: quay-robot-calico+semaphoreci
+      - name: docker
+      - name: oss-release-secrets
+      - name: google-service-account-for-gce
+      - name: openstack-signing-publishing
+      prologue:
+        commands:
+        # Load the github access secrets.  First fix the permissions.
+        - chmod 0600 /home/semaphore/.keys/git_ssh_rsa
+        - ssh-add /home/semaphore/.keys/git_ssh_rsa
+        # Checkout the code and unshallow it.
+        - checkout
+        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+        # how much we churn docker containers during the build.  Disable it.
+        # Free up space on the build machine.
+        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
+      jobs:
       - name: "Build Openstack Packages"
+        dependencies: ["Publish official release"]
         execution_time_limit:
           minutes: 60
         env_vars:
@@ -82,3 +107,8 @@ blocks:
         - sudo apt update
         - sudo apt install -y moreutils
         - make publish-openstack
+      epilogue:
+        always:
+          commands:
+          - test -d hack/release/packaging/output hack/release/packaging/openstack
+          - artifact push workflow hack/release/packaging/openstack


### PR DESCRIPTION
Split up the release promotions from two parallel jobs to dependent jobs (so that we don't try to push openstack packages before we have the release done and the tags created).
