### PR TITLE
Update GCP VM image name

### DIFF
--- a/hack/release/variables.tf
+++ b/hack/release/variables.tf
@@ -29,7 +29,7 @@ variable "disk_type" {
 variable "image" {
   type        = string
   description = "Select which image family to use."
-  default     = "ubuntu-1804-lts"
+  default     = "ubuntu-2004-lts"
 }
 
 variable "google_network" {


### PR DESCRIPTION
The old value, Ubuntu 18.04, is no longer available