### PR TITLE
[BPF] when host IPs change kube-proxy replaces only Syncer

### DIFF
--- a/felix/bpf/proxy/kube-proxy.go
+++ b/felix/bpf/proxy/kube-proxy.go
@@ -30,7 +30,7 @@ import (
 // KubeProxy is a wrapper of Proxy that deals with higher level issue like
 // configuration, restarting etc.
 type KubeProxy struct {
-	proxy  Proxy
+	proxy  ProxyFrontend
 	syncer DPSyncer
 
 	ipFamily      int
@@ -133,25 +133,42 @@ func (kp *KubeProxy) run(hostIPs []net.IP) error {
 		return errors.WithMessage(err, "new bpf syncer")
 	}
 
-	proxy, err := New(kp.k8s, syncer, kp.hostname, kp.opts...)
-	if err != nil {
-		return errors.WithMessage(err, "new proxy")
-	}
+	kp.proxy.SetSyncer(syncer)
 
-	log.Infof("kube-proxy v%d started, hostname=%q hostIPs=%+v", kp.ipFamily, kp.hostname, hostIPs)
+	log.Infof("kube-proxy v%d node info updated, hostname=%q hostIPs=%+v", kp.ipFamily, kp.hostname, hostIPs)
 
-	kp.proxy = proxy
 	kp.syncer = syncer
 
 	return nil
 }
 
 func (kp *KubeProxy) start() error {
+	var withLocalNP []net.IP
+	if kp.ipFamily == 4 {
+		withLocalNP = append(withLocalNP, podNPIP)
+	} else {
+		withLocalNP = append(withLocalNP, podNPIPV6)
+	}
+
+	syncer, err := NewSyncer(kp.ipFamily, withLocalNP, kp.frontendMap, kp.backendMap, kp.affinityMap, kp.rt)
+	if err != nil {
+		return errors.WithMessage(err, "new bpf syncer")
+	}
+
+	proxy, err := New(kp.k8s, syncer, kp.hostname, kp.opts...)
+	if err != nil {
+		return errors.WithMessage(err, "new proxy")
+	}
+
+	kp.lock.Lock()
+	kp.proxy = proxy
+	kp.syncer = syncer
+	kp.lock.Unlock()
 
 	// wait for the initial update
 	hostIPs := <-kp.hostIPUpdates
 
-	err := kp.run(hostIPs)
+	err = kp.run(hostIPs)
 	if err != nil {
 		return err
 	}
@@ -160,39 +177,19 @@ func (kp *KubeProxy) start() error {
 	go func() {
 		defer kp.wg.Done()
 		for {
-			hostIPs, ok := <-kp.hostIPUpdates
-			if !ok {
-				defer log.Error("kube-proxy stopped since hostIPUpdates closed")
-				kp.proxy.Stop()
-				return
-			}
-
-			stopped := make(chan struct{})
-
-			go func() {
-				defer close(stopped)
-				defer log.Info("kube-proxy stopped to restart with updated host IPs")
-				kp.proxy.Stop()
-			}()
-
-		waitforstop:
-			for {
-				select {
-				case hostIPs, ok = <-kp.hostIPUpdates:
-					if !ok {
-						log.Error("kube-proxy: hostIPUpdates closed")
-						return
-					}
-				case <-kp.exiting:
-					log.Info("kube-proxy: exiting")
+			select {
+			case hostIPs, ok := <-kp.hostIPUpdates:
+				if !ok {
+					log.Error("kube-proxy: hostIPUpdates closed")
 					return
-				case <-stopped:
-					err = kp.run(hostIPs)
-					if err != nil {
-						log.Panic("kube-proxy failed to start after host IPs update")
-					}
-					break waitforstop
 				}
+				err = kp.run(hostIPs)
+				if err != nil {
+					log.Panic("kube-proxy failed to resync after host IPs update")
+				}
+			case <-kp.exiting:
+				log.Info("kube-proxy: exiting")
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
Restarting the whole proxy is an overkill, only the syncer eed the set of host IPs. Also the health check servers created by kube-proxy frontend are not easily carried over and thus restarting kube-proxy cannot restart the health checks.

As a side-effect, the "restart" logic in kube-proxy is much simpler as we do no tneed to stop that much.

fixes https://github.com/projectcalico/calico/issues/8112

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixed leakage of nodeport healthcheck servers
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
