### PR TITLE
Fix bug in '--listen-any-ip' parsing on felix/bin/test-workload

### DIFF
--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -75,7 +75,7 @@ func main() {
 	panicIfError(err)
 
 	listenAnyIP := false
-	if _, ok := arguments["--listen-any-ip"]; ok {
+	if arg, ok := arguments["--listen-any-ip"]; ok && arg.(bool) {
 		listenAnyIP = true
 	}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

There is a bug in these lines: https://github.com/projectcalico/calico/blob/v3.26.4/felix/fv/test-workload/test-workload.go#L77-L80

I'm not sure if this changed with a docopts version, but currently, `arguments["--listen-any-ip"]` is always present (so `ok` is `true`), but with a value of `false`. So `test-workload` is effectively always binding to the `any` address, regardless of if a specific address is passed as an argument: https://github.com/projectcalico/calico/blob/v3.26.4/felix/fv/test-workload/test-workload.go#L414


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
