### PR TITLE
[v3.26] The can-reach parameter supports multiple target values

### DIFF
--- a/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
@@ -65,7 +65,12 @@ func AutoDetectCIDR(method string, version int, k8sNode *v1.Node, getInterfaces 
 	} else if strings.HasPrefix(method, AUTODETECTION_METHOD_CAN_REACH) {
 		// Autodetect the IP by connecting a UDP socket to a supplied address.
 		destStr := strings.TrimPrefix(method, AUTODETECTION_METHOD_CAN_REACH)
-		return autoDetectCIDRByReach(destStr, version)
+		matches := []string{}
+		for _, r := range regexp.MustCompile(`\s*,\s*`).Split(destStr, -1) {
+			matches = append(matches, r)
+		}
+
+		return autoDetectCIDRByReach(matches, version)
 	} else if strings.HasPrefix(method, AUTODETECTION_METHOD_SKIP_INTERFACE) {
 		// Autodetect the Ip by enumerating all interfaces (excluding
 		// known internal interfaces and any interfaces whose name
@@ -135,7 +140,7 @@ func autoDetectCIDRByCIDR(matches []cnet.IPNet, version int) *cnet.IPNet {
 
 // autoDetectCIDRByReach auto-detects the IP and Network by setting up a UDP
 // connection to a "reach" address.
-func autoDetectCIDRByReach(dest string, version int) *cnet.IPNet {
+func autoDetectCIDRByReach(dest []string, version int) *cnet.IPNet {
 	if cidr, err := ReachDestination(dest, version); err != nil {
 		log.Warnf("Unable to auto-detect IPv%d address by connecting to %s: %s", version, dest, err)
 		return nil

--- a/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
@@ -140,12 +140,12 @@ func autoDetectCIDRByCIDR(matches []cnet.IPNet, version int) *cnet.IPNet {
 
 // autoDetectCIDRByReach auto-detects the IP and Network by setting up a UDP
 // connection to a "reach" address.
-func autoDetectCIDRByReach(dest []string, version int) *cnet.IPNet {
-	if cidr, err := ReachDestination(dest, version); err != nil {
-		log.Warnf("Unable to auto-detect IPv%d address by connecting to %s: %s", version, dest, err)
+func autoDetectCIDRByReach(dests []string, version int) *cnet.IPNet {
+	if cidr, err := ReachDestination(dests, version); err != nil {
+		log.Warnf("Unable to auto-detect IPv%d address by connecting to %s: %s", version, dests, err)
 		return nil
 	} else {
-		log.Infof("Using autodetected IPv%d address %s, detected by connecting to %s", version, cidr.String(), dest)
+		log.Infof("Using autodetected IPv%d address %s, detected by connecting to %s", version, cidr.String(), dests)
 		return cidr
 	}
 }

--- a/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
@@ -150,7 +150,7 @@ func autoDetectCIDRByReach(dest []string, version int) *cnet.IPNet {
 	}
 }
 
-// autoDetectCIDRBySkipInterface auto-detects the first valid Network on the interfaces
+// autoDetectCIDRBySkipInterface auto-detects the first valid Network on the all interfaces
 // matching the supplied interface regexes.
 func autoDetectCIDRBySkipInterface(ifaceRegexes []string, version int) *cnet.IPNet {
 	incl := []string{}

--- a/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
+++ b/node/pkg/lifecycle/startup/autodetection/autodetection_methods.go
@@ -150,7 +150,7 @@ func autoDetectCIDRByReach(dests []string, version int) *cnet.IPNet {
 	}
 }
 
-// autoDetectCIDRBySkipInterface auto-detects the first valid Network on the all interfaces
+// autoDetectCIDRBySkipInterface auto-detects the first valid Network on the interfaces
 // matching the supplied interface regexes.
 func autoDetectCIDRBySkipInterface(ifaceRegexes []string, version int) *cnet.IPNet {
 	incl := []string{}

--- a/node/pkg/lifecycle/startup/autodetection/reachaddr.go
+++ b/node/pkg/lifecycle/startup/autodetection/reachaddr.go
@@ -22,7 +22,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
-// ReachDestination auto-detects the interface Network by setting up a UDP
+// ReachDestination auto-detects the all interface Network by setting up a UDP
 // connection to a "reach" destination.
 func ReachDestination(dests []string, version int) (*net.IPNet, error) {
 	var allErr string


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

Our cluster needs to take into account a variety of unstable situations, and the cluster cannot be connected to the external network, so we want to use the parameter CAN-reach, and it can support multiple target values, so I made some changes, so far the effect is good

- [x] Tests
  In our cluster, All nodes have only master01-master03 resolution in /etc/hosts

![image](https://github.com/projectcalico/calico/assets/56577113/10ea84de-3227-45b7-861e-8c41d4c924b1)
 

In the yaml resource of calico-node I set IP_AUTODETECTION_METHOD to  can-reach=master08,master09,master01
![image](https://github.com/projectcalico/calico/assets/56577113/1161fecd-37a8-41b5-a8e5-3215b346ab57)


Looking at calico-node's log, it turns out that he correctly found the available IP

![image](https://github.com/projectcalico/calico/assets/56577113/5db50246-d7c9-4482-ae35-e50fac2d0e06)


- [x] Documentation
You can set the value of can-reach to multiple target values similar to cidr
`- name: IP_AUTODETECTION_METHOD
  value: can-reach=master08,master09,master01`

- [ ] Release note
The can-reach parameter supports multiple target values


## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```
