### PR TITLE
hack/release/pkg/builder: fix dropped error

### DIFF
--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -236,6 +236,9 @@ func (r *ReleaseBuilder) NewBranch() error {
 	// Determine the name of the new branch.
 	nextBranchVersion := strings.Split(out, "-0.dev")[0]
 	sv, err := semver.NewVersion(strings.TrimPrefix(nextBranchVersion, "v"))
+	if err != nil {
+		return fmt.Errorf("error creating new semver version: %w", err)
+	}
 	branchName := fmt.Sprintf("release-v%d.%d", sv.Major, sv.Minor)
 	logrus.WithField("branch", branchName).Info("Next release branch")
 


### PR DESCRIPTION
This fixes a dropped `err` variable in `hack/release/pkg/builder`.