### PR TITLE
cherry pick #8347: handle source IP spoofing annotation for etcd datastore mode

### DIFF
--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -429,6 +429,13 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		}
 	}
 
+	// Handle source IP spoofing annotation
+	sourcePrefixes, err := k8sconversion.HandleSourceIPSpoofingAnnotation(annot)
+	if err != nil {
+		return nil, err
+	}
+	endpoint.Spec.AllowSpoofedSourcePrefixes = sourcePrefixes
+
 	// List of DNAT ipaddrs to map to this workload endpoint
 	floatingIPs := annot["cni.projectcalico.org/floatingIPs"]
 

--- a/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -182,24 +182,9 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 	}
 
 	// Handle source IP spoofing annotation
-	var sourcePrefixes []string
-	if annotation, ok := pod.Annotations["cni.projectcalico.org/allowedSourcePrefixes"]; ok && annotation != "" {
-		// Parse Annotation data
-		var requestedSourcePrefixes []string
-		err := json.Unmarshal([]byte(annotation), &requestedSourcePrefixes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse '%s' as JSON: %s", annotation, err)
-		}
-
-		// Filter out any invalid entries and normalize the CIDRs.
-		for _, prefix := range requestedSourcePrefixes {
-			if _, n, err := cnet.ParseCIDR(prefix); err != nil {
-				return nil, fmt.Errorf("failed to parse '%s' as a CIDR: %s", prefix, err)
-			} else {
-				sourcePrefixes = append(sourcePrefixes, n.String())
-			}
-		}
-
+	sourcePrefixes, err := HandleSourceIPSpoofingAnnotation(pod.Annotations)
+	if err != nil {
+		return nil, err
 	}
 
 	// Map any named ports through.
@@ -282,4 +267,28 @@ func (wc defaultWorkloadEndpointConverter) podToDefaultWorkloadEndpoint(pod *kap
 		Revision: pod.ResourceVersion,
 	}
 	return &kvp, nil
+}
+
+// HandleSourceIPSpoofingAnnotation parses the allowedSourcePrefixes annotation if present,
+// and returns the allowed prefixes as a slice of strings.
+func HandleSourceIPSpoofingAnnotation(annot map[string]string) ([]string, error) {
+	var sourcePrefixes []string
+	if annotation, ok := annot["cni.projectcalico.org/allowedSourcePrefixes"]; ok && annotation != "" {
+		// Parse Annotation data
+		var requestedSourcePrefixes []string
+		err := json.Unmarshal([]byte(annotation), &requestedSourcePrefixes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse '%s' as JSON: %s", annotation, err)
+		}
+
+		// Filter out any invalid entries and normalize the CIDRs.
+		for _, prefix := range requestedSourcePrefixes {
+			if _, n, err := cnet.ParseCIDR(prefix); err != nil {
+				return nil, fmt.Errorf("failed to parse '%s' as a CIDR: %s", prefix, err)
+			} else {
+				sourcePrefixes = append(sourcePrefixes, n.String())
+			}
+		}
+	}
+	return sourcePrefixes, nil
 }


### PR DESCRIPTION
## Description

Cherry pick of #8347 on release v3.27.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix source IP spoofing annotation being ignored in etcd datastore mode
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
