### PR TITLE
[CORE-10002] Add log grepping+printing to Windows FVs

### DIFF
--- a/cni-plugin/.semaphore/run-win-fv.sh
+++ b/cni-plugin/.semaphore/run-win-fv.sh
@@ -53,8 +53,8 @@ done
 
 # Print relevant snippets from logs
 log_regexps='(?<!Decode)Failure|SUCCESS|FV-TEST-START'
-compgen -G ./fv.log/*.log > /dev/null && \
-for log_file in ./fv.log/*.log; do
+compgen -G /home/semaphore/report/*.log > /dev/null && \
+for log_file in /home/semaphore/report/*.log; do
     prefix="[$(basename ${log_file})]"
     cat ${log_file} | iconv -f UTF-16 -t UTF-8 | sed 's/\r$//g' | grep --line-buffered --perl ${log_regexps} -B 2 -A 15 | sed 's/.*/'"${prefix}"' &/g'
 done;

--- a/cni-plugin/.semaphore/run-win-fv.sh
+++ b/cni-plugin/.semaphore/run-win-fv.sh
@@ -51,10 +51,18 @@ do
     sleep 30
 done
 
+# Print relevant snippets from logs
+log_regexps='(?<!Decode)Failure|SUCCESS|FV-TEST-START'
+compgen -G ./fv.log/*.log > /dev/null && \
+for log_file in ./fv.log/*.log; do
+    prefix="[$(basename ${log_file})]"
+    cat ${log_file} | iconv -f UTF-16 -t UTF-8 | sed 's/\r$//g' | grep --line-buffered --perl ${log_regexps} -B 2 -A 15 | sed 's/.*/'"${prefix}"' &/g'
+done;
+
 # Search for error code file
 if [ -f /home/semaphore/report/error-codes ];
 then
-    echo "Windows FV return error."
+    echo "Windows FV returned error(s)."
     exit 1
 fi
 

--- a/cni-plugin/.semaphore/run-win-fv.sh
+++ b/cni-plugin/.semaphore/run-win-fv.sh
@@ -53,8 +53,8 @@ done
 
 # Print relevant snippets from logs
 log_regexps='(?<!Decode)Failure|SUCCESS|FV-TEST-START'
-compgen -G /home/semaphore/report/*.log > /dev/null && \
-for log_file in /home/semaphore/report/*.log; do
+compgen -G /home/semaphore/fv.log/*.log > /dev/null && \
+for log_file in /home/semaphore/fv.log/*.log; do
     prefix="[$(basename ${log_file})]"
     cat ${log_file} | iconv -f UTF-16 -t UTF-8 | sed 's/\r$//g' | grep --line-buffered --perl ${log_regexps} -B 2 -A 15 | sed 's/.*/'"${prefix}"' &/g'
 done;

--- a/felix/.semaphore/run-win-fv
+++ b/felix/.semaphore/run-win-fv
@@ -63,8 +63,8 @@ done
 
 # Print relevant snippets from logs
 log_regexps='(?<!Decode)Failure|SUCCESS|FV-TEST-START'
-compgen -G /home/semaphore/report/*.log > /dev/null && \
-for log_file in /home/semaphore/report/*.log; do
+compgen -G /home/semaphore/fv.log/*.log > /dev/null && \
+for log_file in /home/semaphore/fv.log/*.log; do
     prefix="[$(basename ${log_file})]"
     cat ${log_file} | iconv -f UTF-16 -t UTF-8 | sed 's/\r$//g' | grep --line-buffered --perl ${log_regexps} -B 2 -A 15 | sed 's/.*/'"${prefix}"' &/g'
 done;

--- a/felix/.semaphore/run-win-fv
+++ b/felix/.semaphore/run-win-fv
@@ -63,8 +63,8 @@ done
 
 # Print relevant snippets from logs
 log_regexps='(?<!Decode)Failure|SUCCESS|FV-TEST-START'
-compgen -G ./fv.log/*.log > /dev/null && \
-for log_file in ./fv.log/*.log; do
+compgen -G /home/semaphore/report/*.log > /dev/null && \
+for log_file in /home/semaphore/report/*.log; do
     prefix="[$(basename ${log_file})]"
     cat ${log_file} | iconv -f UTF-16 -t UTF-8 | sed 's/\r$//g' | grep --line-buffered --perl ${log_regexps} -B 2 -A 15 | sed 's/.*/'"${prefix}"' &/g'
 done;

--- a/felix/.semaphore/run-win-fv
+++ b/felix/.semaphore/run-win-fv
@@ -61,10 +61,18 @@ do
     sleep 30
 done
 
+# Print relevant snippets from logs
+log_regexps='(?<!Decode)Failure|SUCCESS|FV-TEST-START'
+compgen -G ./fv.log/*.log > /dev/null && \
+for log_file in ./fv.log/*.log; do
+    prefix="[$(basename ${log_file})]"
+    cat ${log_file} | iconv -f UTF-16 -t UTF-8 | sed 's/\r$//g' | grep --line-buffered --perl ${log_regexps} -B 2 -A 15 | sed 's/.*/'"${prefix}"' &/g'
+done;
+
 # Search for error code file
 if [ -f /home/semaphore/report/error-codes ];
 then
-    echo "Windows FV return error."
+    echo "Windows FV returned error(s)."
     exit 1
 fi
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Print relevant Windows FV log snippets to the main semaphore log output by converting and grepping the artifacts retrieved from the Windows VMs.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
