### PR TITLE
Reinstate PATH in calicoctl Dockerfile

### DIFF
--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -32,6 +32,7 @@ LABEL vendor="Project Calico"
 LABEL version=${GIT_VERSION}
 
 ENV CALICO_CTL_CONTAINER=TRUE
+ENV PATH=$PATH:/
 
 COPY --from=source / /
 


### PR DESCRIPTION
## Description

The 3.27 calicoctl image works fine with or without the leading / :
```
$ docker run --rm -ti --entrypoint calicoctl --name calicoctl calico/ctl:v3.27.0 version
Client Version:    v3.27.0
Git commit:        711528eeb
Unable to detect installed Calico version

$ docker run --rm -ti --entrypoint /calicoctl --name calicoctl calico/ctl:v3.27.0 version
Client Version:    v3.27.0
Git commit:        711528eeb
Unable to detect installed Calico version
```
But the current master version does not:
```
$ docker run --rm -ti --entrypoint calicoctl --name calicoctl calico/ctl:master version
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "calicoctl": executable file not found in $PATH: unknown.

$ docker run --rm -ti --entrypoint /calicoctl --name calicoctl calico/ctl:master version
Client Version:    v3.28.0-0.dev-250-gf0ea2794de5f
Git commit:        f0ea2794d
Unable to detect installed Calico version
```

This change in behaviour is due to removal of the ENV PATH from the calicoctl Dockerfile in https://github.com/projectcalico/calico/commit/86f77e3a46ce503cbbe47d1123376decedf8e010

This PR reinstates that ENV to maintain behaviour.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
