### PR TITLE
Move calicoctl binary to standard executable search path

### DIFF
--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -17,7 +17,7 @@ FROM scratch as source
 ARG TARGETARCH
 
 COPY LICENSE /licenses/LICENSE
-COPY bin/calicoctl-linux-${TARGETARCH} /calicoctl
+COPY bin/calicoctl-linux-${TARGETARCH} /usr/bin/calicoctl
 
 FROM calico/base
 
@@ -35,4 +35,4 @@ ENV CALICO_CTL_CONTAINER=TRUE
 
 COPY --from=source / /
 
-ENTRYPOINT ["/calicoctl"]
+ENTRYPOINT ["/usr/bin/calicoctl"]

--- a/manifests/calicoctl-etcd.yaml
+++ b/manifests/calicoctl-etcd.yaml
@@ -16,7 +16,7 @@ spec:
   - name: calicoctl
     image: calico/ctl:master
     command:
-      - /calicoctl
+      - calicoctl
     args:
       - version
       - --poll=1m

--- a/manifests/calicoctl.yaml
+++ b/manifests/calicoctl.yaml
@@ -25,7 +25,7 @@ spec:
   - name: calicoctl
     image: calico/ctl:master
     command:
-      - /calicoctl
+      - calicoctl
     args:
       - version
       - --poll=1m

--- a/node/tests/k8st/infra/calicoctl.yaml
+++ b/node/tests/k8st/infra/calicoctl.yaml
@@ -29,9 +29,9 @@ spec:
   serviceAccountName: calicoctl
   containers:
   - name: calicoctl
-    image: docker.io/calico/ctl:latest-amd64
+    image: calico/ctl:master
     command:
-      - /calicoctl
+      - calicoctl
     args:
       - version
       - --poll=1m

--- a/node/tests/k8st/utils/utils.py
+++ b/node/tests/k8st/utils/utils.py
@@ -220,7 +220,7 @@ def kubectl(args, logerr=True, allow_fail=False, allow_codes=[], timeout=0, retu
                returnerr=returnerr)
 
 def calicoctl(args, allow_fail=False):
-    return kubectl("exec -i -n kube-system calicoctl -- /calicoctl --allow-version-mismatch " + args,
+    return kubectl("exec -i -n kube-system calicoctl -- calicoctl --allow-version-mismatch " + args,
                    allow_fail=allow_fail)
 
 

--- a/process/testing/winfv/create_kubeadm_cluster.sh
+++ b/process/testing/winfv/create_kubeadm_cluster.sh
@@ -82,12 +82,12 @@ echo "Calico is running."
 kubectl taint nodes --all node-role.kubernetes.io/master-
 
 # strict affinity
-curl -O -L  https://github.com/projectcalico/calicoctl/releases/download/v3.17.1/calicoctl
+curl -sSf -L --retry 5 https://github.com/projectcalico/calico/releases/download/v3.27.0/calicoctl-linux-amd64 -o calicoctl
 chmod +x calicoctl
 export CALICO_DATASTORE_TYPE=kubernetes
 export CALICO_KUBECONFIG=~/.kube/config
-./calicoctl get node
-./calicoctl ipam configure --strictaffinity=true
+./calicoctl --allow-version-mismatch get node
+./calicoctl --allow-version-mismatch ipam configure --strictaffinity=true
 echo "ipam configured"
 
 pushd $ROOT/infra


### PR DESCRIPTION
## Description

This change moves calicoctl binary to the standard executable search path so that it can be found without using an absolute path.

## Related issues/PRs

Alternative fix for https://github.com/projectcalico/calico/pull/8362.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
