### PR TITLE
[CORE-10042] Fix AutoCreateServiceAccountTokenSecret param handling in install-calico-windows.ps1

### DIFF
--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -48,7 +48,6 @@ $argList = @(`
     "--enable-debugging-handlers",`
     "--cluster-dns=$env:DNS_NAME_SERVERS",`
     "--cluster-domain=cluster.local",`
-    "--kubeconfig=c:\k\config",`
     "--hairpin-mode=promiscuous-bridge",`
     "--cgroups-per-qos=false",`
     "--enforce-node-allocatable=""""",`

--- a/node/windows-packaging/install-calico-windows.ps1
+++ b/node/windows-packaging/install-calico-windows.ps1
@@ -266,12 +266,12 @@ function GetCalicoKubeConfig()
         $secretName=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretNamePrefix | select -first 1
         $ErrorActionPreference = 'Stop'
         if ([string]::IsNullOrEmpty($secretName)) {
-            if (-Not $AutoCreateServiceAccountTokenSecret) {
-                throw "$SecretName service account token secret does not exist."
-            } else {
-                # Otherwise create the serviceaccount token secret.
+            if ($AutoCreateServiceAccountTokenSecret -EQ "yes") {
+                # Create the serviceaccount token secret.
                 $secretName = "calico-node-token"
                 CreateTokenAccountSecret -Name $secretName -Namespace $CalicoNamespace -KubeConfigPath $KubeConfigPath
+            } else {
+                throw "$SecretName service account token secret does not exist."
             }
         }
         # CA from the k8s secret is already base64-encoded.


### PR DESCRIPTION

Also fix duplicated '--kubeconfig' param in kubelet-service.ps1

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/8290

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed AutoCreateServiceAccountTokenSecret param handling in install-calico-windows.ps1
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
