### PR TITLE
Replace satori/go.uuid with google/uuid

### DIFF
--- a/cni-plugin/internal/pkg/testutils/utils_linux.go
+++ b/cni-plugin/internal/pkg/testutils/utils_linux.go
@@ -40,7 +40,7 @@ import (
 	k8sconversion "github.com/projectcalico/calico/libcalico-go/lib/backend/k8s/conversion"
 	"github.com/projectcalico/calico/libcalico-go/lib/names"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -469,7 +469,7 @@ func CheckSysctlValue(sysctlPath, value string) error {
 
 // Convert the netns name to a container ID.
 func netnsToContainerID(netns string) string {
-	u := uuid.NewV5(uuid.NamespaceURL, netns)
+	u := uuid.NewSHA1(uuid.NameSpaceURL, []byte(netns))
 	buf := make([]byte, 10)
 	hex.Encode(buf, u[0:5])
 	return string(buf)

--- a/cni-plugin/tests/calico_cni_ipam_test.go
+++ b/cni-plugin/tests/calico_cni_ipam_test.go
@@ -8,10 +8,10 @@ import (
 	"os"
 
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	uuid "github.com/satori/go.uuid"
 
 	"github.com/projectcalico/calico/cni-plugin/internal/pkg/testutils"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
@@ -37,7 +37,7 @@ var _ = Describe("Calico IPAM Tests", func() {
 		testutils.MustCreateNewIPPool(calicoClient, "fd80:24e2:f998:72d6::/64", false, false, true)
 
 		// Create a unique container ID for each test.
-		cid = uuid.NewV4().String()
+		cid = uuid.NewString()
 
 		// Create the node for these tests. The IPAM code requires a corresponding Calico node to exist.
 		var name string

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	github.com/prometheus/common v0.44.0
 	github.com/rakelkar/gonetsh v0.3.2
 	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1
-	github.com/satori/go.uuid v1.2.0
 	github.com/shirou/gopsutil v0.0.0-20190323131628-2cbc9195c892
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,6 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 h1:RpforrEYXWkmGwJHIGnLZ3tTWStkjVVstwzNGqxX2Ds=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/shirou/gopsutil v0.0.0-20190323131628-2cbc9195c892 h1:oiNB/s36DdNBEnulbhdj6zHS73U/wRQihnsoJwanqfM=

--- a/kube-controllers/pkg/controllers/pod/pod_controller_fv_test.go
+++ b/kube-controllers/pkg/controllers/pod/pod_controller_fv_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,7 +98,7 @@ var _ = Describe("Calico pod controller FV tests (etcd mode)", func() {
 
 	It("should not overwrite a workload endpoint's container ID", func() {
 		// Create a Pod
-		podName := fmt.Sprintf("pod-fv-container-id-%s", uuid.NewV4())
+		podName := fmt.Sprintf("pod-fv-container-id-%s", uuid.NewString())
 		podNamespace := "default"
 		nodeName := "127.0.0.1"
 		pod := v1.Pod{
@@ -270,7 +270,7 @@ var _ = Describe("Calico pod controller FV tests (etcd mode)", func() {
 		}, time.Second*10, 500*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// Create a Pod
-		podName := fmt.Sprintf("pod-fv-container-id-%s", uuid.NewV4())
+		podName := fmt.Sprintf("pod-fv-container-id-%s", uuid.NewString())
 		nodeName := "127.0.0.1"
 		pod := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -370,7 +370,7 @@ var _ = Describe("Calico pod controller FV tests (etcd mode)", func() {
 
 	It("should not create a workload endpoint when one does not already exist", func() {
 		// Create a Pod
-		podName := fmt.Sprintf("pod-fv-no-create-wep-%s", uuid.NewV4())
+		podName := fmt.Sprintf("pod-fv-no-create-wep-%s", uuid.NewString())
 		pod := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      podName,


### PR DESCRIPTION
## Description

Currently we are using two UUID packages:

1. `github.com/satori/go.uuid`
2. `github.com/google/uuid`

`github.com/satori/go.uuid` is no longer being actively maintained (last commit was 5 years ago [^1]). So we should just use the newer `github.com/google/uuid`.

[^1]: https://github.com/satori/go.uuid/commits/master/

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
