### PR TITLE
Update BIRD to pull in https://github.com/projectcalico/bird/pull/113

### DIFF
--- a/metadata.mk
+++ b/metadata.mk
@@ -26,7 +26,7 @@ ORGANIZATION = projectcalico
 GIT_USE_SSH = true
 
 # The version of BIRD to use for calico/node builds and confd tests.
-BIRD_VERSION=v0.3.3-206-g0f4d6086
+BIRD_VERSION=v0.3.3-208-g1e2ff99d
 
 # DEV_REGISTRIES configures the container image registries which are built from this
 # repository. By default, just build images with calico/. Allow this variable to be overridden,


### PR DESCRIPTION
Fixes #8378 , see the issue for more details.

I've tested this by building and deploying the following `Dockerfile` (the resulting image is published as `docker.io/lbogdan/calico-node:v3.27.0-1`):

```dockerfile
FROM calico/bird:v0.3.3-208-g1e2ff99d AS bird
FROM quay.io/centos/centos:stream8 AS centos
FROM calico/node:v3.27.0

COPY --from=bird /bird* /bin/
COPY --from=centos /bin/chmod /bin/
RUN chmod -v u+s /bin/bird /bin/bird6 && \
    rm -v /bin/chmod
```
