### PR TITLE
Fixed issues with uninstallation process

### DIFF
--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -122,6 +122,14 @@ rules:
     verbs:
       - create
       - delete
+  # In addition to the above, the operator should have the ability to delete their own resources during uninstallation.
+  - apiGroups:
+      - operator.tigera.io
+    resources:
+      - installations
+      - apiservers
+    verbs:
+      - delete
   - apiGroups:
     - networking.k8s.io
     resources:

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -122,6 +122,14 @@ rules:
     verbs:
       - create
       - delete
+  # In addition to the above, the operator should have the ability to delete their own resources during uninstallation.
+  - apiGroups:
+      - operator.tigera.io
+    resources:
+      - installations
+      - apiservers
+    verbs:
+      - delete
   - apiGroups:
     - networking.k8s.io
     resources:

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -25105,6 +25105,14 @@ rules:
     verbs:
       - create
       - delete
+  # In addition to the above, the operator should have the ability to delete their own resources during uninstallation.
+  - apiGroups:
+      - operator.tigera.io
+    resources:
+      - installations
+      - apiservers
+    verbs:
+      - delete
   - apiGroups:
     - networking.k8s.io
     resources:


### PR DESCRIPTION
## Description

bug fix. 

Helm chart for tigera-operator since v3.27.0 fails to uninstall due to missing delete permission on installations resource required by Job tigera-operator-uninstall, which is run as a Helm pre-delete hook.

[ERROR] installations.operator.tigera.io "default" is forbidden: User "system:serviceaccount:tigera-operator:tigera-operator" cannot delete resource "installations" in API group "operator.tigera.io" at the cluster scopeFailed to complete pre-delete hook
[ERROR] apiservers.operator.tigera.io "default" is forbidden: User "system:serviceaccount:tigera-operator:tigera-operator" cannot delete resource "apiservers" in API group "operator.tigera.io" at the cluster scopeFailed to complete pre-delete hook

link to the related issue:
https://github.com/projectcalico/calico/issues/8389

Tested on dev and local env.

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/8389

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix missing permissions when uninstalling tigera-operator. 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
