### PR TITLE
[release-v3.27] Auto pick #8421: Fix confd on Windows HPC

### DIFF
--- a/confd/pkg/config/config.go
+++ b/confd/pkg/config/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/projectcalico/calico/confd/pkg/resource/template"
 
 	"github.com/projectcalico/calico/typha/pkg/syncclientutils"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/winutils"
 )
 
 var (
@@ -60,7 +62,7 @@ func init() {
 // It returns an error if any.
 func InitConfig(ignoreFlags bool) (*Config, error) {
 	if configFile == "" {
-		if _, err := os.Stat(defaultConfigFile); !os.IsNotExist(err) {
+		if _, err := os.Stat(winutils.GetHostPath(defaultConfigFile)); !os.IsNotExist(err) {
 			configFile = defaultConfigFile
 		}
 	}
@@ -71,7 +73,7 @@ func InitConfig(ignoreFlags bool) (*Config, error) {
 	// have independent settings, so honour CONFD_ also.  Longer-term it would be nice to
 	// coalesce around CALICO_, so support that as well.
 	config := Config{
-		ConfDir:  "/etc/confd",
+		ConfDir:  winutils.GetHostPath("/etc/confd"),
 		Interval: 600,
 		Prefix:   "",
 		Typha:    syncclientutils.ReadTyphaConfig([]string{"CONFD_", "FELIX_", "CALICO_"}),
@@ -81,7 +83,7 @@ func InitConfig(ignoreFlags bool) (*Config, error) {
 		log.Info("Skipping confd config file.")
 	} else {
 		log.Info("Loading " + configFile)
-		configBytes, err := os.ReadFile(configFile)
+		configBytes, err := os.ReadFile(winutils.GetHostPath(configFile))
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +124,7 @@ type ConfigVisitor struct {
 func (c *ConfigVisitor) setConfigFromFlag(f *flag.Flag) {
 	switch f.Name {
 	case "confdir":
-		c.config.ConfDir = confdir
+		c.config.ConfDir = winutils.GetHostPath(confdir)
 	case "interval":
 		c.config.Interval = interval
 	case "noop":

--- a/libcalico-go/lib/winutils/winutils.go
+++ b/libcalico-go/lib/winutils/winutils.go
@@ -32,16 +32,19 @@ import (
 )
 
 func Powershell(args ...string) (string, string, error) {
-	// Add default powershell to PATH
-	path := os.Getenv("PATH")
-	err := os.Setenv("PATH", path+";C:/Windows/System32/WindowsPowerShell/v1.0/")
+	// Add default powershell to PATH if it can't be found
+	_, err := exec.LookPath("powershell.exe")
 	if err != nil {
-		return "", "", err
+		path := os.Getenv("PATH")
+		err = os.Setenv("PATH", path+";C:/Windows/System32/WindowsPowerShell/v1.0/")
+		if err != nil {
+			return "", "", fmt.Errorf("Cannot add powershell to Windows PATH: %s", err.Error())
+		}
 	}
 
 	ps, err := exec.LookPath("powershell.exe")
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("Cannot find powershell.exe: %s", err.Error())
 	}
 
 	args = append([]string{"-NoProfile", "-NonInteractive"}, args...)

--- a/node/Makefile
+++ b/node/Makefile
@@ -95,7 +95,7 @@ WINDOWS_MOD_CACHED_FILES := \
     windows-packaging/conf.d/blocks.toml \
     windows-packaging/conf.d/peerings.toml \
     windows-packaging/templates/blocks.ps1.template \
-    windows-packaging/templates/peerings.ps1.template \
+    windows-packaging/templates/peerings.ps1.template
 
 # Files to include in the Windows ZIP archive.  We need to list some of these explicitly
 # because we need to force them to be built/copied into place. We also have
@@ -569,5 +569,12 @@ WINDOWS_IMAGE_REQS := \
 	$(WINDOWS_ARCHIVE_ROOT)/felix/felix-service.ps1 \
 	$(WINDOWS_ARCHIVE_ROOT)/node/node-service.ps1 \
 	$(WINDOWS_ARCHIVE_ROOT)/uninstall-calico-hpc.ps1 \
+	$(WINDOWS_ARCHIVE_ROOT)/confd/confd-service.ps1 \
+	$(WINDOWS_ARCHIVE_ROOT)/confd/config-bgp.ps1 \
+	$(WINDOWS_ARCHIVE_ROOT)/confd/config-bgp.psm1 \
+	$(WINDOWS_ARCHIVE_ROOT)/confd/conf.d/blocks.toml \
+	$(WINDOWS_ARCHIVE_ROOT)/confd/conf.d/peerings.toml \
+	$(WINDOWS_ARCHIVE_ROOT)/confd/templates/blocks.ps1.template \
+	$(WINDOWS_ARCHIVE_ROOT)/confd/templates/peerings.ps1.template \
 	windows-packaging/nssm.exe
 image-windows: $(WINDOWS_IMAGE_REQS)

--- a/typha/pkg/syncclientutils/config.go
+++ b/typha/pkg/syncclientutils/config.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/winutils"
 )
 
 // TyphaConfig specifies the sync-client connection parameters
@@ -71,6 +73,12 @@ func ReadTyphaConfig(supportedPrefixes []string) TyphaConfig {
 				} else if field.Type.Name() == "bool" {
 					reflect.ValueOf(typhaConfig).Elem().FieldByName(field.Name).SetBool(value == "true")
 				} else {
+					// File paths must use winutils.GetHostPath() to prepend the necessary
+					// mount path env var when running on Windows HPC containers.
+					// These are KeyFile, CertFile and CAFile.
+					if strings.HasSuffix(field.Name, "File") {
+						value = winutils.GetHostPath(value)
+					}
 					reflect.ValueOf(typhaConfig).Elem().FieldByName(field.Name).Set(reflect.ValueOf(value))
 				}
 				break


### PR DESCRIPTION
Cherry pick of #8421 on release-v3.27.

#8421: Fix confd on Windows HPC

# Original PR Body below

Use winutils.GetHostPath() for file paths on confd and typha so that they work correctly on windows HPC (typha runs on linux only, but confd reuses the env vars and code that deals with cert mounts).

Add necessary confd files to cnx-node-windows image so that the confd container functions correctly.

Add the correct dir for powershell.exe to $PATH so that confd can use it properly on windows HPC.

Only add powershell path to $PATH if it can't be found in the first place.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix confd issues when running on Windows operator installations (using HPC).
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.