### PR TITLE
workloadEndpoint.spec.mac is empty

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/constants.go
+++ b/libcalico-go/lib/backend/k8s/conversion/constants.go
@@ -41,6 +41,12 @@ const (
 	// on older Pods.
 	AnnotationContainerID = "cni.projectcalico.org/containerID"
 
+	// AnnotationHwAddr is used to store the desired MAC address that will be assigned to a network interface
+	// on a pod. If a desired MAC address is not specified by the user, the Calico CNI plugin will still set
+	// the current MAC address in this annotation. This allows for both the specification of a custom MAC
+	// address and the automatic handling of MAC addresses by the plugin.
+	AnnotationHwAddr = "cni.projectcalico.org/hwAddr"
+
 	// NameLabel is a label that can be used to match a serviceaccount or namespace
 	// name exactly.
 	NameLabel = "projectcalico.org/name"

--- a/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
+++ b/libcalico-go/lib/backend/k8s/resources/workloadendpoint.go
@@ -128,6 +128,12 @@ func (c *WorkloadEndpointClient) calcCNIAnnotations(kvp *model.KVPair) map[strin
 		log.WithField("containerID", containerID).Debug("Container ID specified, including in patch")
 		annotations[conversion.AnnotationContainerID] = containerID
 	}
+
+	mac := wep.Spec.MAC
+	if mac != "" {
+		log.WithField("MAC", mac).Debug("MAC specified, including in patch")
+		annotations[conversion.AnnotationHwAddr] = mac
+	}
 	return annotations
 }
 


### PR DESCRIPTION
## Description

The current code attempts to assign the current MAC address to the `workloadEndpoint.spec.mac` field, but this operation is ineffective.

https://github.com/projectcalico/calico/blob/086c2754a422f0631622493a9ecf9a63aeb0c9c8/cni-plugin/pkg/k8s/k8s.go#L404-L410


**change**
This change ensures that the current MAC address is assigned to both the `workloadEndpoint.spec.mac` field and the `cni.projectcalico.org/hwAddr` annotation.  If the user hasn't specified the `cni.projectcalico.org/hwAddr` annotation,  calico CNI will still set the current MAC address in this annotation.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
