### PR TITLE
update how to build calico-kube-controllers

### DIFF
--- a/kube-controllers/README.md
+++ b/kube-controllers/README.md
@@ -26,8 +26,8 @@ If you'd like to run the build and tests locally outside of a container, you'll 
 
 Contributions to this code are welcome!  The code in this repository can be built and tested using the Makefile.
 
-- `make docker-image` will produce a docker image containing the artifacts suitable for deploying to kubernetes.
-- `make binary` will build just the controller binary so it can be run locally.
+- `make image` will produce a docker image containing the artifacts suitable for deploying to kubernetes.
+- `make build` will build just the controller binary so it can be run locally.
 
 For more information, see `make help`.
 


### PR DESCRIPTION
## Description

updated how to build calico-kube-controllers

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
