### PR TITLE
Fix crypto UT after upgrading to golang v1.21.6

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -16,7 +16,7 @@ fv: setup-fv bin/fips-test-build
 	# Run the nmap tool on the server to find out the tls versions and ciphers.
 	docker run --net=host --rm -it instrumentisto/nmap --script ssl-enum-ciphers -p 8083 127.0.0.1 > tmp/nmap.log
 	# remove times and dates from file
-	sed -i '1,4d;19d' tmp/nmap.log
+	sed -i '1,4d;22d' tmp/nmap.log
 	$(MAKE) kill
 	# If the ciphers are as expected, we get exit code 0.
 	diff fv/expected-nmap.log  tmp/nmap.log

--- a/crypto/fv/expected-nmap.log
+++ b/crypto/fv/expected-nmap.log
@@ -5,10 +5,13 @@ PORT     STATE SERVICE
 |     ciphers: 
 |       TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
 |       TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
-|       TLS_RSA_WITH_AES_128_GCM_SHA256 (rsa 2048) - A
-|       TLS_RSA_WITH_AES_256_GCM_SHA384 (rsa 2048) - A
 |     compressors: 
 |       NULL
+|     cipher preference: server
+|   TLSv1.3: 
+|     ciphers: 
+|       TLS_AKE_WITH_AES_128_GCM_SHA256 (secp256r1) - A
+|       TLS_AKE_WITH_AES_256_GCM_SHA384 (secp256r1) - A
 |     cipher preference: server
 |_  least strength: A
 


### PR DESCRIPTION
## Description

Fix crypto UT after upgradeing to golang v1.21.6 due to the changes in BoringCrypto fips-20220613 and TLS v1.3 [1].

[1] https://github.com/golang/go/issues/64719

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
