### PR TITLE
[BPF] proxy - syncer must not count not-ready endpoints

### DIFF
--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -761,11 +761,11 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 			if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
 				return 0, 0, err
 			}
+			cnt++
+			local++
 		}
 
 		cpEps = append(cpEps, ep)
-		cnt++
-		local++
 	}
 
 	for _, ep := range eps {
@@ -778,10 +778,10 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 			if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
 				return 0, 0, err
 			}
+			cnt++
 		}
 
 		cpEps = append(cpEps, ep)
-		cnt++
 	}
 
 	flags := uint32(0)


### PR DESCRIPTION
We include terminating eps in the eps list so that we can prevent conntrack clean up, but they are not written into the backend map and so they should not be reflected in the backends count.

Test that Terminating is propagated through proxy frontend. Test in FV that proxy removes the terminating backend from the NAT table.

refs https://github.com/projectcalico/calico/issues/8423

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
