### PR TITLE
Make tc preamble program dispatch both IPv4/IPv6 packets.

### DIFF
--- a/felix/Makefile
+++ b/felix/Makefile
@@ -195,7 +195,7 @@ protobuf proto/felixbackend.pb.go: proto/felixbackend.proto
 
 # We pre-build lots of different variants of the TC programs, defer to the script.
 BPF_GPL_O_FILES:=$(addprefix bpf-gpl/,$(shell bpf-gpl/list-objs))
-BPF_GPL_O_FILES+=bpf-gpl/bin/tc_preamble.o bpf-gpl/bin/tc_preamble_v6.o \
+BPF_GPL_O_FILES+=bpf-gpl/bin/tc_preamble.o \
 		 bpf-gpl/bin/xdp_preamble.o bpf-gpl/bin/policy_default.o
 
 # There's a one-to-one mapping from UT C files to objects and the same for the apache programs..

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -53,7 +53,6 @@ UT_OBJS+=ut/ip_parse_test_v6.o
 
 OBJS:=$(shell ./list-objs)
 OBJS+=bin/tc_preamble.o
-OBJS+=bin/tc_preamble_v6.o
 OBJS+=bin/xdp_preamble.o
 OBJS+=bin/policy_default.o
 C_FILES:=tc_preamble.c tc.c connect_balancer.c connect_balancer_v46.c connect_balancer_v6.c xdp_preamble.c xdp.c policy_default.c
@@ -85,9 +84,6 @@ ut/icmp6_port_unreachable.ll: CFLAGS += -DIPVER6
 tc_preamble.ll: tc_preamble.c tc_preamble.d
 	$(CC) $(CFLAGS) -c $< -o $@
 
-tc_preamble_v6.ll: tc_preamble.c tc_preamble.d
-	$(CC) $(CFLAGS) -DIPVER6 -c $< -o $@
-
 xdp_preamble.ll: xdp_preamble.c xdp_preamble.d
 	$(CC) $(CFLAGS) -DCALI_COMPILE_FLAGS=64 -c $< -o $@
 
@@ -115,8 +111,6 @@ test_xdp%.ll: xdp.c xdp.d calculate-flags
 
 LINK=$(LD) -march=bpf -filetype=obj -o $@ $<
 bin/tc_preamble.o: tc_preamble.ll | bin
-	$(LINK)
-bin/tc_preamble_v6.o: tc_preamble_v6.ll | bin
 	$(LINK)
 bin/xdp_preamble.o: xdp_preamble.ll | bin
 	$(LINK)

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -253,27 +253,33 @@ static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)
 
 extern const volatile struct cali_xdp_globals __globals;
 #define CALI_CONFIGURABLE(name) 1 /* any value will do, it is not configured */
+#define CALI_CONFIGURABLE_IP(name) 1
 
 #elif (!CALI_F_CGROUP) || defined(UNITTEST)
 
-extern const volatile struct cali_tc_globals __globals;
-#define CALI_CONFIGURABLE(name) ctx->globals->name
-
+extern const volatile struct cali_globals __globals;
+#define CALI_CONFIGURABLE(name) ctx->globals->data.name
+#ifdef IPVER6
+#define CALI_CONFIGURABLE_IP(name) CALI_CONFIGURABLE(name)
+#else
+#define CALI_CONFIGURABLE_IP(name) ctx->globals->data.name.a
+#endif
 #else
 
 #define CALI_CONFIGURABLE(name) 1 /* any value will do, it is not configured */
+#define CALI_CONFIGURABLE_IP(name) 1
 
 #endif /* loader */
 
-#define HOST_IP		CALI_CONFIGURABLE(host_ip)
+#define HOST_IP		CALI_CONFIGURABLE_IP(host_ip)
 #define TUNNEL_MTU 	CALI_CONFIGURABLE(tunnel_mtu)
 #define VXLAN_PORT 	CALI_CONFIGURABLE(vxlan_port)
-#define INTF_IP		CALI_CONFIGURABLE(intf_ip)
+#define INTF_IP		CALI_CONFIGURABLE_IP(intf_ip)
 #define EXT_TO_SVC_MARK	CALI_CONFIGURABLE(ext_to_svc_mark)
 #define PSNAT_START	CALI_CONFIGURABLE(psnat_start)
 #define PSNAT_LEN	CALI_CONFIGURABLE(psnat_len)
 #define GLOBAL_FLAGS 	CALI_CONFIGURABLE(flags)
-#define HOST_TUNNEL_IP	CALI_CONFIGURABLE(host_tunnel_ip)
+#define HOST_TUNNEL_IP	CALI_CONFIGURABLE_IP(host_tunnel_ip)
 #define WG_PORT		CALI_CONFIGURABLE(wg_port)
 #define NATIN_IFACE	CALI_CONFIGURABLE(natin_idx)
 

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -257,7 +257,7 @@ extern const volatile struct cali_xdp_globals __globals;
 
 #elif (!CALI_F_CGROUP) || defined(UNITTEST)
 
-extern const volatile struct cali_globals __globals;
+extern const volatile struct cali_tc_preamble_globals __globals;
 #define CALI_CONFIGURABLE(name) ctx->globals->data.name
 #ifdef IPVER6
 #define CALI_CONFIGURABLE_IP(name) CALI_CONFIGURABLE(name)

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -7,7 +7,7 @@
 
 #include "ip_addr.h"
 
-#define DECLARE_TC_GLOBALS(name, ip_t)	\
+#define DECLARE_TC_GLOBAL_DATA(name, ip_t)	\
 struct name {				\
 	ip_t host_ip;			\
 	__be16 tunnel_mtu;		\
@@ -25,19 +25,23 @@ struct name {				\
 	__u8 iface_name[16];		\
 	__u32 log_filter_jmp;		\
 	__u32 jumps[40];		\
+}
+
+DECLARE_TC_GLOBAL_DATA(cali_tc_global_data, ipv6_addr_t);
+struct cali_tc_globals {
+	struct cali_tc_global_data data;
+
 	/* Needs to be 32bit aligned as it is followed by scratch area for 				\
 	 * building headers. We reuse the same slot in state map to save 				\
 	 * ourselves a lookup. 										\
 	 */												\
 	__u32 __scratch[]; /* N.B. this provides pointer to the location but does not add to the size */ \
-}
+};
 
-DECLARE_TC_GLOBALS(cali_tc_globals, ipv46_addr_t);
-/* cali_tc_globals_v6 is for userspace as cali_tc_globals are used for ipv4 in
- * userspace, but it has the exact same layout as cali_tc_globals in eBPF when
- * compiled for ipv6.
- */
-DECLARE_TC_GLOBALS(cali_tc_globals_v6, ipv6_addr_t);
+struct cali_globals {
+	struct cali_tc_global_data v4;
+	struct cali_tc_global_data v6;
+};
 
 enum cali_globals_flags {
 	/* CALI_GLOBALS_IPV6_ENABLED is set when IPv6 is enabled by Felix */

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -38,7 +38,7 @@ struct cali_tc_globals {
 	__u32 __scratch[]; /* N.B. this provides pointer to the location but does not add to the size */ \
 };
 
-struct cali_globals {
+struct cali_tc_preamble_globals {
 	struct cali_tc_global_data v4;
 	struct cali_tc_global_data v6;
 };

--- a/felix/bpf-gpl/jump.h
+++ b/felix/bpf-gpl/jump.h
@@ -50,8 +50,8 @@ CALI_MAP_V1(cali_jump_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 200, 0)
 CALI_MAP_V1(cali_jump_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 200, 0)
 
 #define __CALI_JUMP_TO(ctx, index) do {	\
-	CALI_DEBUG("jump to idx %d prog at %d\n", index, (ctx)->globals->jumps[PROG_PATH(index)]);	\
-	bpf_tail_call((ctx)->skb, &cali_jump_map, (ctx)->globals->jumps[PROG_PATH(index)]);	\
+	CALI_DEBUG("jump to idx %d prog at %d\n", index, (ctx)->globals->data.jumps[PROG_PATH(index)]);	\
+	bpf_tail_call((ctx)->skb, &cali_jump_map, (ctx)->globals->data.jumps[PROG_PATH(index)]);	\
 } while (0)
 
 #define CALI_JUMP_TO(ctx, index) __CALI_JUMP_TO(ctx, index)
@@ -97,12 +97,12 @@ CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 2400, 0)
 CALI_MAP_V1(cali_jump_prog_map, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 240000, 0)
 
 #define __CALI_JUMP_TO_POLICY(ctx, allow, deny, pol) do {	\
-	(ctx)->skb->cb[0] = (ctx)->globals->jumps[PROG_PATH(allow)];			\
-	(ctx)->skb->cb[1] = (ctx)->globals->jumps[PROG_PATH(deny)];				\
-	CALI_DEBUG("policy allow prog at %d\n", (ctx)->globals->jumps[PROG_PATH(allow)]);	\
-	CALI_DEBUG("policy deny prog at %d\n", (ctx)->globals->jumps[PROG_PATH(deny)]);	\
-	CALI_DEBUG("jump to policy prog at %d\n", (ctx)->globals->jumps[pol]);		\
-	bpf_tail_call((ctx)->skb, &cali_jump_prog_map, (ctx)->globals->jumps[pol]);	\
+	(ctx)->skb->cb[0] = (ctx)->globals->data.jumps[PROG_PATH(allow)];			\
+	(ctx)->skb->cb[1] = (ctx)->globals->data.jumps[PROG_PATH(deny)];				\
+	CALI_DEBUG("policy allow prog at %d\n", (ctx)->globals->data.jumps[PROG_PATH(allow)]);	\
+	CALI_DEBUG("policy deny prog at %d\n", (ctx)->globals->data.jumps[PROG_PATH(deny)]);	\
+	CALI_DEBUG("jump to policy prog at %d\n", (ctx)->globals->data.jumps[pol]);		\
+	bpf_tail_call((ctx)->skb, &cali_jump_prog_map, (ctx)->globals->data.jumps[pol]);	\
 } while (0)
 
 #define CALI_JUMP_TO_POLICY(ctx) \

--- a/felix/bpf-gpl/log.h
+++ b/felix/bpf-gpl/log.h
@@ -28,7 +28,7 @@
 } while (0)
 
 #if !(CALI_F_XDP) && !(CALI_F_CGROUP)
-#define CALI_IFACE_LOG(fmt, ...) CALI_LOG("%s" fmt, ctx->globals->iface_name, ## __VA_ARGS__)
+#define CALI_IFACE_LOG(fmt, ...) CALI_LOG("%s" fmt, ctx->globals->data.iface_name, ## __VA_ARGS__)
 #elif CALI_F_XDP
 #define CALI_IFACE_LOG(fmt, ...) CALI_LOG("%s" fmt, ctx->xdp_globals->iface_name, ## __VA_ARGS__)
 #else

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -13,7 +13,7 @@
 #include "jump.h"
 #include "log.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 #define JUMP_IDX(idx) (idx)
 #define JUMP_IDX_DEBUG(idx) (idx ## _DEBUG)

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -5,6 +5,7 @@
 // stdbool.h has no deps so it's OK to include; stdint.h pulls in parts
 // of the std lib that aren't compatible with BPF.
 #include <stdbool.h>
+#include <linux/if_ether.h>
 
 #include "bpf.h"
 #include "types.h"
@@ -12,19 +13,13 @@
 #include "jump.h"
 #include "log.h"
 
-const volatile struct cali_tc_globals __globals;
-
-#ifdef IPVER6
-#define IPV " v6"
-#else
-#define IPV " v4"
-#endif
+const volatile struct cali_globals __globals;
 
 #define JUMP_IDX(idx) (idx)
 #define JUMP_IDX_DEBUG(idx) (idx ## _DEBUG)
 
-#define JUMP(idx) globals->jumps[JUMP_IDX(idx)]
-#define JUMP_DEBUG(idx) globals->jumps[JUMP_IDX_DEBUG(idx)]
+#define JUMP(idx) globals->data.jumps[JUMP_IDX(idx)]
+#define JUMP_DEBUG(idx) globals->data.jumps[JUMP_IDX_DEBUG(idx)]
 
 SEC("tc")
 int  cali_tc_preamble(struct __sk_buff *skb)
@@ -35,43 +30,48 @@ int  cali_tc_preamble(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
+	__u16 protocol = bpf_ntohs(skb->protocol);
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	if (protocol == ETH_P_IPV6) {
+		globals->data = __globals.v6;
+	} else {
+		globals->data = __globals.v4;
+	}
 
 #if EMIT_LOGS
-	CALI_LOG("tc_preamble" IPV " iface %s\n", globals->iface_name);
+	CALI_LOG("tc_preamble iface %s\n", globals->data.iface_name);
 #endif
 
 	/* If we have log filter installed, tell the filter where to jump next
 	 * and jump to the filter.
 	 */
-	if (globals->log_filter_jmp != (__u32)-1) {
+	if (globals->data.log_filter_jmp != (__u32)-1) {
 		skb->cb[0] = JUMP(PROG_INDEX_MAIN);
 		skb->cb[1] = JUMP_DEBUG(PROG_INDEX_MAIN);
-		bpf_tail_call(skb, &cali_jump_prog_map, globals->log_filter_jmp);
-		CALI_LOG("tc_preamble" IPV " iface %s failed to call log filter %d\n",
-				globals->iface_name, globals->log_filter_jmp);
+		bpf_tail_call(skb, &cali_jump_prog_map, globals->data.log_filter_jmp);
+		CALI_LOG("tc_preamble iface %s failed to call log filter %d\n",
+				globals->data.iface_name, globals->data.log_filter_jmp);
 		/* try to jump to the regular path */
 	}
 
 	/* Jump to the start of the prog chain. */
 #if EMIT_LOGS
-	CALI_LOG("tc_preamble" IPV " iface %s jump to %d\n",
-			globals->iface_name, JUMP(PROG_INDEX_MAIN));
+	CALI_LOG("tc_preamble iface %s jump to %d\n",
+			globals->data.iface_name, JUMP(PROG_INDEX_MAIN));
 #endif
 	bpf_tail_call(skb, &cali_jump_map, JUMP(PROG_INDEX_MAIN));
-	CALI_LOG("tc_preamble" IPV " iface %s failed to call main %d\n",
-			globals->iface_name, JUMP(PROG_INDEX_MAIN));
+	CALI_LOG("tc_preamble iface %s failed to call main %d\n",
+			globals->data.iface_name, JUMP(PROG_INDEX_MAIN));
 
 	/* Try debug path in the unexpected case of not being able to make the jump. */
-	CALI_LOG("tc_preamble" IPV " iface %s jump to %d\n",
-			globals->iface_name, JUMP_DEBUG(PROG_INDEX_MAIN));
+	CALI_LOG("tc_preamble iface %s jump to %d\n",
+			globals->data.iface_name, JUMP_DEBUG(PROG_INDEX_MAIN));
 	bpf_tail_call(skb, &cali_jump_map, JUMP_DEBUG(PROG_INDEX_MAIN));
-	CALI_LOG("tc_preamble" IPV " iface %s failed to call debug main %d\n",
-			globals->iface_name, JUMP_DEBUG(PROG_INDEX_MAIN));
+	CALI_LOG("tc_preamble iface %s failed to call debug main %d\n",
+			globals->data.iface_name, JUMP_DEBUG(PROG_INDEX_MAIN));
 
 	/* Drop the packet in the unexpected case of not being able to make the jump. */
-	CALI_LOG("tc_preamble" IPV " iface %s failed to call main %d\n", globals->iface_name, JUMP(PROG_INDEX_MAIN));
+	CALI_LOG("tc_preamble iface %s failed to call main %d\n", globals->data.iface_name, JUMP(PROG_INDEX_MAIN));
 
 	return TC_ACT_SHOT;
 }

--- a/felix/bpf-gpl/ut/icmp6_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp6_port_unreachable.c
@@ -8,7 +8,7 @@
 #include "icmp.h"
 #include "parsing.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/icmp6_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp6_port_unreachable.c
@@ -8,7 +8,7 @@
 #include "icmp.h"
 #include "parsing.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {
@@ -19,7 +19,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	}
 
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	globals->data = __globals.v6;
 	DECLARE_TC_CTX(_ctx,
 		.skb = skb,
 		.ipheader_len = IP_SIZE,

--- a/felix/bpf-gpl/ut/icmp_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp_port_unreachable.c
@@ -7,7 +7,7 @@
 #include "nat.h"
 #include "icmp.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {
@@ -18,7 +18,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	}
 
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	globals->data = __globals.v4;
 	DECLARE_TC_CTX(_ctx,
 		.skb = skb,
 		.ipheader_len = IP_SIZE,

--- a/felix/bpf-gpl/ut/icmp_port_unreachable.c
+++ b/felix/bpf-gpl/ut/icmp_port_unreachable.c
@@ -7,7 +7,7 @@
 #include "nat.h"
 #include "icmp.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/icmp_too_big.c
+++ b/felix/bpf-gpl/ut/icmp_too_big.c
@@ -9,7 +9,7 @@
 #include "parsing.h"
 #include "jump.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/icmp_too_big.c
+++ b/felix/bpf-gpl/ut/icmp_too_big.c
@@ -9,7 +9,7 @@
 #include "parsing.h"
 #include "jump.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {
@@ -20,7 +20,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	}
 
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	globals->data = __globals.v4;
 	DECLARE_TC_CTX(_ctx,
 		.skb = skb,
 		.ipheader_len = IP_SIZE,

--- a/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
+++ b/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
@@ -7,7 +7,7 @@
 #include "nat.h"
 #include "icmp.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {
@@ -18,7 +18,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	}
 
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	globals->data = __globals.v4;
 	DECLARE_TC_CTX(_ctx,
 		.skb = skb,
 		.ipheader_len = IP_SIZE,

--- a/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
+++ b/felix/bpf-gpl/ut/icmp_ttl_exceeded.c
@@ -7,7 +7,7 @@
 #include "nat.h"
 #include "icmp.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/ip_dec_ttl.c
+++ b/felix/bpf-gpl/ut/ip_dec_ttl.c
@@ -6,7 +6,7 @@
 #include "bpf.h"
 #include "skb.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/ip_dec_ttl.c
+++ b/felix/bpf-gpl/ut/ip_dec_ttl.c
@@ -6,7 +6,7 @@
 #include "bpf.h"
 #include "skb.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/ip_parse_test.c
+++ b/felix/bpf-gpl/ut/ip_parse_test.c
@@ -7,7 +7,7 @@
 #include "jump.h"
 #include "nat.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {
@@ -18,7 +18,11 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	}
 
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+#ifdef IPVER6
+	globals->data = __globals.v6;
+#else
+	globals->data = __globals.v4;
+#endif
 	DECLARE_TC_CTX(_ctx,
 		.skb = skb,
 		.ipheader_len = IP_SIZE,

--- a/felix/bpf-gpl/ut/ip_parse_test.c
+++ b/felix/bpf-gpl/ut/ip_parse_test.c
@@ -7,7 +7,7 @@
 #include "jump.h"
 #include "nat.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/ipv4_opts_test.c
+++ b/felix/bpf-gpl/ut/ipv4_opts_test.c
@@ -7,7 +7,7 @@
 #include "jump.h"
 #include "nat.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/ipv4_opts_test.c
+++ b/felix/bpf-gpl/ut/ipv4_opts_test.c
@@ -7,7 +7,7 @@
 #include "jump.h"
 #include "nat.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {
@@ -18,7 +18,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	}
 
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	globals->data = __globals.v4;
 	DECLARE_TC_CTX(_ctx,
 		.skb = skb,
 		.ipheader_len = IP_SIZE,

--- a/felix/bpf-gpl/ut/nat_encap_test.c
+++ b/felix/bpf-gpl/ut/nat_encap_test.c
@@ -6,7 +6,7 @@
 #include "bpf.h"
 #include "nat.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {
@@ -17,7 +17,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	}
 
 	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	globals->data = __globals.v4;
 	DECLARE_TC_CTX(_ctx,
 		.skb = skb,
 		.fwd = {

--- a/felix/bpf-gpl/ut/nat_encap_test.c
+++ b/felix/bpf-gpl/ut/nat_encap_test.c
@@ -6,7 +6,7 @@
 #include "bpf.h"
 #include "nat.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 {

--- a/felix/bpf-gpl/ut/ut.h
+++ b/felix/bpf-gpl/ut/ut.h
@@ -25,7 +25,7 @@
 #include "counters.h"
 #include "jump.h"
 
-const volatile struct cali_tc_globals __globals;
+const volatile struct cali_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb);
 

--- a/felix/bpf-gpl/ut/ut.h
+++ b/felix/bpf-gpl/ut/ut.h
@@ -25,7 +25,7 @@
 #include "counters.h"
 #include "jump.h"
 
-const volatile struct cali_globals __globals;
+const volatile struct cali_tc_preamble_globals __globals;
 
 static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb);
 

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -398,57 +398,32 @@ func TcSetGlobals(
 		cJumps[i] = C.uint(v)
 	}
 
-	_, err := C.bpf_tc_set_globals(m.bpfMap,
-		cName,
-		C.uint(globalData.HostIP),
-		C.uint(globalData.IntfIP),
-		C.uint(globalData.ExtToSvcMark),
-		C.ushort(globalData.Tmtu),
-		C.ushort(globalData.VxlanPort),
-		C.ushort(globalData.PSNatStart),
-		C.ushort(globalData.PSNatLen),
-		C.uint(globalData.HostTunnelIP),
-		C.uint(globalData.Flags),
-		C.ushort(globalData.WgPort),
-		C.uint(globalData.NatIn),
-		C.uint(globalData.NatOut),
-		C.uint(globalData.LogFilterJmp),
-		&cJumps[0], // it is safe because we hold the reference here until we return.
-	)
+	cJumpsV6 := make([]C.uint, len(globalData.JumpsV6))
 
-	return err
-}
-
-func TcSetGlobals6(
-	m *Map,
-	globalData *TcGlobalData6,
-) error {
-
-	cName := C.CString(globalData.IfaceName)
-	defer C.free(unsafe.Pointer(cName))
-
-	cJumps := make([]C.uint, len(globalData.Jumps))
-
-	for i, v := range globalData.Jumps {
-		cJumps[i] = C.uint(v)
+	for i, v := range globalData.JumpsV6 {
+		cJumpsV6[i] = C.uint(v)
 	}
 
-	_, err := C.bpf_tc_set_globals_v6(m.bpfMap,
+	_, err := C.bpf_tc_set_globals(m.bpfMap,
 		cName,
 		(*C.char)(unsafe.Pointer(&globalData.HostIP[0])),
 		(*C.char)(unsafe.Pointer(&globalData.IntfIP[0])),
+		(*C.char)(unsafe.Pointer(&globalData.HostIPv6[0])),
+		(*C.char)(unsafe.Pointer(&globalData.IntfIPv6[0])),
 		C.uint(globalData.ExtToSvcMark),
 		C.ushort(globalData.Tmtu),
 		C.ushort(globalData.VxlanPort),
 		C.ushort(globalData.PSNatStart),
 		C.ushort(globalData.PSNatLen),
 		(*C.char)(unsafe.Pointer(&globalData.HostTunnelIP[0])),
+		(*C.char)(unsafe.Pointer(&globalData.HostTunnelIPv6[0])),
 		C.uint(globalData.Flags),
 		C.ushort(globalData.WgPort),
 		C.uint(globalData.NatIn),
 		C.uint(globalData.NatOut),
 		C.uint(globalData.LogFilterJmp),
 		&cJumps[0], // it is safe because we hold the reference here until we return.
+		&cJumpsV6[0],
 	)
 
 	return err

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -139,67 +139,26 @@ int bpf_link_destroy(struct bpf_link *link) {
 
 void bpf_tc_set_globals(struct bpf_map *map,
 			char *iface_name,
-			uint host_ip,
-			uint intf_ip,
+			char* host_ip,
+			char* intf_ip,
+			char* host_ip6,
+			char* intf_ip6,
 			uint ext_to_svc_mark,
 			ushort tmtu,
 			ushort vxlanPort,
 			ushort psnat_start,
 			ushort psnat_len,
-			uint host_tunnel_ip,
+			char* host_tunnel_ip,
+			char* host_tunnel_ip6,
 			uint flags,
 			ushort wg_port,
 			uint natin,
 			uint natout,
 			uint log_filter_jmp,
-			uint *jumps)
+			uint *jumps,
+			uint *jumps6)
 {
-	struct cali_tc_globals data = {
-		.host_ip = host_ip,
-		.tunnel_mtu = tmtu,
-		.vxlan_port = vxlanPort,
-		.intf_ip = intf_ip,
-		.ext_to_svc_mark = ext_to_svc_mark,
-		.psnat_start = psnat_start,
-		.psnat_len = psnat_len,
-		.host_tunnel_ip = host_tunnel_ip,
-		.flags = flags,
-		.wg_port = wg_port,
-		.natin_idx = natin,
-		.natout_idx = natout,
-		.log_filter_jmp = log_filter_jmp,
-	};
-
-	strncpy(data.iface_name, iface_name, sizeof(data.iface_name));
-	data.iface_name[sizeof(data.iface_name)-1] = '\0';
-
-	int i;
-
-	for (i = 0; i < sizeof(data.jumps)/sizeof(uint); i++) {
-		data.jumps[i] = jumps[i];
-	}
-
-	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
-}
-
-void bpf_tc_set_globals_v6(struct bpf_map *map,
-			   char *iface_name,
-			   char* host_ip,
-			   char* intf_ip,
-			   uint ext_to_svc_mark,
-			   ushort tmtu,
-			   ushort vxlanPort,
-			   ushort psnat_start,
-			   ushort psnat_len,
-			   char* host_tunnel_ip,
-			   uint flags,
-			   ushort wg_port,
-			   uint natin,
-			   uint natout,
-			   uint log_filter_jmp,
-			   uint *jumps)
-{
-	struct cali_tc_globals_v6 data = {
+	struct cali_tc_global_data v4 = {
 		.tunnel_mtu = tmtu,
 		.vxlan_port = vxlanPort,
 		.ext_to_svc_mark = ext_to_svc_mark,
@@ -212,19 +171,32 @@ void bpf_tc_set_globals_v6(struct bpf_map *map,
 		.log_filter_jmp = log_filter_jmp,
 	};
 
-	memcpy(&data.host_ip, host_ip, 16);
-	memcpy(&data.intf_ip, intf_ip, 16);
-	memcpy(&data.host_tunnel_ip, host_tunnel_ip, 16);
+	strncpy(v4.iface_name, iface_name, sizeof(v4.iface_name));
+	v4.iface_name[sizeof(v4.iface_name)-1] = '\0';
 
-	strncpy(data.iface_name, iface_name, sizeof(data.iface_name));
-	data.iface_name[sizeof(data.iface_name)-1] = '\0';
+	struct cali_tc_global_data v6 = v4;
+	struct cali_globals data;
+
+	memcpy(&v4.host_ip, host_ip, 16);
+	memcpy(&v4.intf_ip, intf_ip, 16);
+	memcpy(&v4.host_tunnel_ip, host_tunnel_ip, 16);
+
+	memcpy(&v6.host_ip, host_ip6, 16);
+	memcpy(&v6.intf_ip, intf_ip6, 16);
+	memcpy(&v6.host_tunnel_ip, host_tunnel_ip6, 16);
 
 	int i;
 
-	for (i = 0; i < sizeof(data.jumps)/sizeof(uint); i++) {
-		data.jumps[i] = jumps[i];
+	for (i = 0; i < sizeof(v4.jumps)/sizeof(uint); i++) {
+		v4.jumps[i] = jumps[i];
 	}
 
+	for (i = 0; i < sizeof(v6.jumps)/sizeof(uint); i++) {
+		v6.jumps[i] = jumps6[i];
+	}
+
+	data.v4 = v4;
+	data.v6 = v6;
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
 }
 

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -175,7 +175,7 @@ void bpf_tc_set_globals(struct bpf_map *map,
 	v4.iface_name[sizeof(v4.iface_name)-1] = '\0';
 
 	struct cali_tc_global_data v6 = v4;
-	struct cali_globals data;
+	struct cali_tc_preamble_globals data;
 
 	memcpy(&v4.host_ip, host_ip, 16);
 	memcpy(&v4.intf_ip, intf_ip, 16);

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -16,24 +16,6 @@ package libbpf
 
 type TcGlobalData struct {
 	IfaceName    string
-	HostIP       uint32
-	IntfIP       uint32
-	ExtToSvcMark uint32
-	Tmtu         uint16
-	VxlanPort    uint16
-	PSNatStart   uint16
-	PSNatLen     uint16
-	HostTunnelIP uint32
-	Flags        uint32
-	WgPort       uint16
-	NatIn        uint32
-	NatOut       uint32
-	LogFilterJmp uint32
-	Jumps        [40]uint32
-}
-
-type TcGlobalData6 struct {
-	IfaceName    string
 	HostIP       [16]byte
 	IntfIP       [16]byte
 	ExtToSvcMark uint32
@@ -48,6 +30,11 @@ type TcGlobalData6 struct {
 	NatOut       uint32
 	LogFilterJmp uint32
 	Jumps        [40]uint32
+
+	HostIPv6       [16]byte
+	IntfIPv6       [16]byte
+	HostTunnelIPv6 [16]byte
+	JumpsV6        [40]uint32
 }
 
 type XDPGlobalData struct {

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -142,10 +142,6 @@ func TcSetGlobals(_ *Map, globalData *TcGlobalData) error {
 	panic("LIBBPF syscall stub")
 }
 
-func TcSetGlobals6(_ *Map, globalData *TcGlobalData6) error {
-	panic("LIBBPF syscall stub")
-}
-
 func CTLBSetGlobals(_ *Map, _ time.Duration, _ bool) error {
 	panic("LIBBPF syscall stub")
 }

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -15,7 +15,6 @@
 package tc
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -74,7 +73,7 @@ func (ap *AttachPoint) Log() *log.Entry {
 	})
 }
 
-func (ap *AttachPoint) loadObject(ipVer int, file string) (*libbpf.Obj, error) {
+func (ap *AttachPoint) loadObject(file string) (*libbpf.Obj, error) {
 	obj, err := libbpf.OpenObject(file)
 	if err != nil {
 		return nil, err
@@ -89,14 +88,9 @@ func (ap *AttachPoint) loadObject(ipVer int, file string) (*libbpf.Obj, error) {
 			if strings.HasPrefix(mapName, ".rodata") {
 				continue
 			}
-			if ipVer == 4 {
-				if err := ap.ConfigureProgram(m); err != nil {
-					return nil, fmt.Errorf("failed to configure %s: %w", file, err)
-				}
-			} else {
-				if err := ap.ConfigureProgramV6(m); err != nil {
-					return nil, fmt.Errorf("failed to configure %s: %w", file, err)
-				}
+
+			if err := ap.ConfigureProgram(m); err != nil {
+				return nil, fmt.Errorf("failed to configure %s: %w", file, err)
 			}
 			continue
 		}
@@ -140,16 +134,8 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 	// By now the attach type specific generic set of programs is loaded and we
 	// only need to load and configure the preamble that will pass the
 	// configuration further to the selected set of programs.
-	var binaryToLoad string
-	var ipFamily int
-	if ap.IPv6Enabled {
-		binaryToLoad = path.Join(bpfdefs.ObjectDir, "tc_preamble_v6.o")
-		ipFamily = 6
-	} else {
-		binaryToLoad = path.Join(bpfdefs.ObjectDir, "tc_preamble.o")
-		ipFamily = 4
-	}
 
+	binaryToLoad := path.Join(bpfdefs.ObjectDir, "tc_preamble.o")
 	var res AttachResult
 
 	/* XXX we should remember the tag of the program and skip the rest if the tag is
@@ -159,10 +145,10 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 		return nil, err
 	}
 
-	obj, err := ap.loadObject(ipFamily, binaryToLoad)
+	obj, err := ap.loadObject(binaryToLoad)
 	if err != nil {
 		logCxt.Warn("Failed to load program")
-		return nil, fmt.Errorf("object v%d: %w", ipFamily, err)
+		return nil, fmt.Errorf("object %w", err)
 	}
 	defer obj.Close()
 
@@ -405,18 +391,19 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 
 		LogFilterJmp: uint32(ap.LogFilterIdx),
 	}
-	var err error
-	globalData.HostIP, err = convertIPToUint32(ap.HostIP)
-	if err != nil {
-		return err
+	if ap.HostIP.To4() != nil {
+		copy(globalData.HostIP[0:4], ap.HostIP.To4())
+	} else {
+		copy(globalData.HostIPv6[:], ap.HostIP.To16())
 	}
 	if globalData.VxlanPort == 0 {
 		globalData.VxlanPort = 4789
 	}
 
-	globalData.IntfIP, err = convertIPToUint32(ap.IntfIP)
-	if err != nil {
-		return err
+	if ap.IntfIP.To4() != nil {
+		copy(globalData.IntfIP[0:4], ap.IntfIP.To4())
+	} else {
+		copy(globalData.IntfIPv6[:], ap.IntfIP.To16())
 	}
 
 	if ap.DSROptoutCIDRs {
@@ -438,80 +425,34 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 	globalData.HostTunnelIP = globalData.HostIP
 
 	if ap.HostTunnelIP != nil {
-		globalData.HostTunnelIP, err = convertIPToUint32(ap.HostTunnelIP)
-		if err != nil {
-			return err
+		if ap.HostTunnelIP.To4() != nil {
+			copy(globalData.HostTunnelIP[0:4], ap.HostTunnelIP.To4())
+		} else {
+			copy(globalData.HostTunnelIPv6[:], ap.HostTunnelIP.To16())
 		}
 	}
 
 	for i := 0; i < len(globalData.Jumps); i++ {
-		globalData.Jumps[i] = 0xffffffff /* uint32(-1) */
+		globalData.Jumps[i] = 0xffffffff   /* uint32(-1) */
+		globalData.JumpsV6[i] = 0xffffffff /* uint32(-1) */
 	}
 
 	if ap.HookLayout != nil {
 		log.WithField("HookLayout", ap.HookLayout).Debugf("ConfigureProgram")
-		for p, i := range ap.HookLayout {
-			globalData.Jumps[p] = uint32(i)
+		if ap.IPv6Enabled {
+			for p, i := range ap.HookLayout {
+				globalData.JumpsV6[p] = uint32(i)
+			}
+			globalData.JumpsV6[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdx)
+		} else {
+			for p, i := range ap.HookLayout {
+				globalData.Jumps[p] = uint32(i)
+			}
+			globalData.Jumps[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdx)
 		}
-		globalData.Jumps[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdx)
 	}
 
 	return ConfigureProgram(m, ap.Iface, &globalData)
-}
-
-func (ap *AttachPoint) ConfigureProgramV6(m *libbpf.Map) error {
-	globalData := libbpf.TcGlobalData6{
-		ExtToSvcMark: ap.ExtToServiceConnmark,
-		VxlanPort:    ap.VXLANPort,
-		Tmtu:         ap.TunnelMTU,
-		PSNatStart:   ap.PSNATStart,
-		PSNatLen:     ap.PSNATEnd,
-		WgPort:       ap.WgPort,
-		NatIn:        ap.NATin,
-		NatOut:       ap.NATout,
-
-		LogFilterJmp: uint32(ap.LogFilterIdx),
-	}
-
-	copy(globalData.HostIP[:], ap.HostIP.To16())
-
-	if globalData.VxlanPort == 0 {
-		globalData.VxlanPort = 4789
-	}
-
-	copy(globalData.IntfIP[:], ap.IntfIP.To16())
-
-	if ap.DSROptoutCIDRs {
-		globalData.Flags |= libbpf.GlobalsNoDSRCidrs
-	}
-
-	switch ap.RPFEnforceOption {
-	case tcdefs.RPFEnforceOptionStrict:
-		globalData.Flags |= libbpf.GlobalsRPFOptionEnabled
-		globalData.Flags |= libbpf.GlobalsRPFOptionStrict
-	case tcdefs.RPFEnforceOptionLoose:
-		globalData.Flags |= libbpf.GlobalsRPFOptionEnabled
-	}
-
-	copy(globalData.HostTunnelIP[:], globalData.HostIP[:])
-
-	if ap.HostTunnelIP != nil {
-		copy(globalData.HostTunnelIP[:], ap.HostTunnelIP.To16())
-	}
-
-	for i := 0; i < len(globalData.Jumps); i++ {
-		globalData.Jumps[i] = 0xffffffff /* uint32(-1) */
-	}
-
-	if ap.HookLayout != nil {
-		log.WithField("HookLayout", ap.HookLayout).Debugf("ConfigureProgram")
-		for p, i := range ap.HookLayout {
-			globalData.Jumps[p] = uint32(i)
-		}
-		globalData.Jumps[tcdefs.ProgIndexPolicy] = uint32(ap.PolicyIdx)
-	}
-
-	return ConfigureProgramV6(m, ap.Iface, &globalData)
 }
 
 func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalData) error {
@@ -520,20 +461,4 @@ func ConfigureProgram(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalDa
 	globalData.IfaceName = string(in)
 
 	return libbpf.TcSetGlobals(m, globalData)
-}
-
-func ConfigureProgramV6(m *libbpf.Map, iface string, globalData *libbpf.TcGlobalData6) error {
-	in := []byte("---------------")
-	copy(in, iface)
-	globalData.IfaceName = string(in)
-
-	return libbpf.TcSetGlobals6(m, globalData)
-}
-
-func convertIPToUint32(ip net.IP) (uint32, error) {
-	ipv4 := ip.To4()
-	if ipv4 == nil {
-		return 0, fmt.Errorf("ip addr nil")
-	}
-	return binary.LittleEndian.Uint32([]byte(ipv4)), nil
 }

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -368,10 +368,6 @@ func setupAndRun(logger testLogger, loglevel, section string, rules *polprog.Rul
 		o, err := objLoad("../../bpf-gpl/bin/xdp_preamble.o", bpfFsDir, "preamble", topts, false, false)
 		Expect(err).NotTo(HaveOccurred())
 		defer o.Close()
-	} else if topts.ipv6 {
-		o, err := objLoad("../../bpf-gpl/bin/tc_preamble_v6.o", bpfFsDir, "preamble", topts, false, false)
-		Expect(err).NotTo(HaveOccurred())
-		defer o.Close()
 	} else {
 		o, err := objLoad("../../bpf-gpl/bin/tc_preamble.o", bpfFsDir, "preamble", topts, false, false)
 		Expect(err).NotTo(HaveOccurred())
@@ -734,7 +730,7 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 				}
 			} else if topts.ipv6 {
 				ifaceLog := topts.progLog + "-" + bpfIfaceName
-				globals := libbpf.TcGlobalData6{
+				globals := libbpf.TcGlobalData{
 					Tmtu:         natTunnelMTU,
 					VxlanPort:    testVxlanPort,
 					PSNatStart:   uint16(topts.psnaStart),
@@ -743,33 +739,35 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					LogFilterJmp: 0xffffffff,
 				}
 
-				copy(globals.HostTunnelIP[:], node1tunIPV6.To16())
-				copy(globals.HostIP[:], hostIP.To16())
-				copy(globals.IntfIP[:], intfIPV6.To16())
+				copy(globals.HostTunnelIPv6[:], node1tunIPV6.To16())
+				copy(globals.HostIPv6[:], hostIP.To16())
+				copy(globals.IntfIPv6[:], intfIPV6.To16())
 
 				for i := 0; i < tcdefs.ProgIndexEnd; i++ {
-					globals.Jumps[i] = uint32(i)
+					globals.JumpsV6[i] = uint32(i)
 				}
 
 				log.WithField("globals", globals).Debugf("configure program")
 
-				if err := tc.ConfigureProgramV6(m, ifaceLog, &globals); err != nil {
+				if err := tc.ConfigureProgram(m, ifaceLog, &globals); err != nil {
 					return nil, fmt.Errorf("failed to configure tc program: %w", err)
 				}
 				log.WithField("program", fname).Debugf("Configured BPF program iface \"%s\"", ifaceLog)
 			} else {
 				ifaceLog := topts.progLog + "-" + bpfIfaceName
 				globals := libbpf.TcGlobalData{
-					HostIP:       ipToU32(hostIP),
-					IntfIP:       ipToU32(intfIP),
 					Tmtu:         natTunnelMTU,
 					VxlanPort:    testVxlanPort,
 					PSNatStart:   uint16(topts.psnaStart),
 					PSNatLen:     uint16(topts.psnatEnd-topts.psnaStart) + 1,
 					Flags:        libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
-					HostTunnelIP: ipToU32(node1tunIP),
 					LogFilterJmp: 0xffffffff,
 				}
+
+				copy(globals.HostIP[0:4], hostIP)
+				copy(globals.IntfIP[0:4], intfIP)
+				copy(globals.HostTunnelIP[0:4], node1tunIP.To4())
+				fmt.Println("Sridhar1 ", globals.HostIP, globals.IntfIP, globals.HostTunnelIP)
 
 				for i := 0; i < tcdefs.ProgIndexEnd; i++ {
 					globals.Jumps[i] = uint32(i)
@@ -871,7 +869,7 @@ func objUTLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHos
 		if m.IsMapInternal() {
 			ifaceLog := topts.progLog + "-" + bpfIfaceName
 			if topts.ipv6 {
-				globals := libbpf.TcGlobalData6{
+				globals := libbpf.TcGlobalData{
 					Tmtu:       natTunnelMTU,
 					VxlanPort:  testVxlanPort,
 					PSNatStart: uint16(topts.psnaStart),
@@ -879,24 +877,25 @@ func objUTLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHos
 					Flags:      libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
 				}
 
-				copy(globals.HostTunnelIP[:], node1tunIPV6.To16())
-				copy(globals.HostIP[:], hostIP.To16())
-				copy(globals.IntfIP[:], intfIPV6.To16())
+				copy(globals.HostTunnelIPv6[:], node1tunIPV6.To16())
+				copy(globals.HostIPv6[:], hostIP.To16())
+				copy(globals.IntfIPv6[:], intfIPV6.To16())
 
-				if err := tc.ConfigureProgramV6(m, ifaceLog, &globals); err != nil {
+				if err := tc.ConfigureProgram(m, ifaceLog, &globals); err != nil {
 					return nil, fmt.Errorf("failed to configure v6 tc program: %w", err)
 				}
 			} else {
 				globals := libbpf.TcGlobalData{
-					HostIP:       ipToU32(hostIP),
-					IntfIP:       ipToU32(intfIP),
-					Tmtu:         natTunnelMTU,
-					VxlanPort:    testVxlanPort,
-					PSNatStart:   uint16(topts.psnaStart),
-					PSNatLen:     uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:        libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
-					HostTunnelIP: ipToU32(node1tunIP),
+					Tmtu:       natTunnelMTU,
+					VxlanPort:  testVxlanPort,
+					PSNatStart: uint16(topts.psnaStart),
+					PSNatLen:   uint16(topts.psnatEnd-topts.psnaStart) + 1,
+					Flags:      libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
 				}
+				copy(globals.HostTunnelIP[0:4], node1tunIP.To4())
+				copy(globals.HostIP[0:4], hostIP.To4())
+				copy(globals.IntfIP[0:4], intfIP.To4())
+
 				if err := tc.ConfigureProgram(m, ifaceLog, &globals); err != nil {
 					return nil, fmt.Errorf("failed to configure tc program: %w", err)
 				}


### PR DESCRIPTION
## Description

This PR has the changes to run a single BPF preamble program which dispatches both IPv4 and IPv6 packets based on skb->protocol. 

1. Removed building tc_preamble_v6.o. Changed the preamble program to handle both v4 and v6 packets.
2. Changed the global variable to have 2 members, one for v4 and one for v6.
3. Userspace changed to program the global vars.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
