### PR TITLE
feat: support kubernetes-services-endpoint

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -159,7 +159,7 @@ calicoctl:
 # Configuration for the Calico CSI plugin - setting to None will disable the plugin, default: /var/lib/kubelet
 kubeletVolumePluginPath: None   
 
-#for windows or eBFP support it is necessary to supply the api server
+# Optionally configure the host and port used to access the Kubernetes API server.
 kubernetesServiceEndpoint:
   host: "" #e.g. k8s.mycompany.com
   port: "6443"

--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -158,4 +158,9 @@ calicoctl:
 
 # Configuration for the Calico CSI plugin - setting to None will disable the plugin, default: /var/lib/kubelet
 kubeletVolumePluginPath: None   
+
+#for windows or eBFP support it is necessary to supply the api server
+kubernetesServiceEndpoint:
+  host: "" #e.g. k8s.mycompany.com
+  port: "6443"
 ```

--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -161,6 +161,6 @@ kubeletVolumePluginPath: None
 
 # Optionally configure the host and port used to access the Kubernetes API server.
 kubernetesServiceEndpoint:
-  host: "" #e.g. k8s.mycompany.com
+  host: ""
   port: "6443"
 ```

--- a/charts/tigera-operator/templates/tigera-operator/01-kubernetes-services-endpoint.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/01-kubernetes-services-endpoint.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.kubernetesServiceEndpoint.host -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubernetes-services-endpoint
+  namespace: {{.Release.Namespace}}
+data:
+  KUBERNETES_SERVICE_HOST: {{ .Values.kubernetesServiceEndpoint.host }}
+  KUBERNETES_SERVICE_PORT: {{ .Values.kubernetesServiceEndpoint.port }}
+{{- end }}

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -60,7 +60,7 @@ calicoctl:
 
 kubeletVolumePluginPath: /var/lib/kubelet
 
-#for windows or eBFP support it is necessary to supply the api server
+# Optionally configure the host and port used to access the Kubernetes API server.
 kubernetesServiceEndpoint:
   host: "" #e.g. k8s.mycompany.com
   port: "6443"

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -62,5 +62,5 @@ kubeletVolumePluginPath: /var/lib/kubelet
 
 # Optionally configure the host and port used to access the Kubernetes API server.
 kubernetesServiceEndpoint:
-  host: "" #e.g. k8s.mycompany.com
+  host: ""
   port: "6443"

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -59,3 +59,8 @@ calicoctl:
   tag: master
 
 kubeletVolumePluginPath: /var/lib/kubelet
+
+#for windows or eBFP support it is necessary to supply the api server
+kubernetesServiceEndpoint:
+  host: "" #e.g. k8s.mycompany.com
+  port: "6443"


### PR DESCRIPTION
## Description

support kubernetes-services-endpoint

## Related issues/PRs

fixes #7164

## Todos

- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
You can now specify kubernetesServiceEndpoint in the helm chart to support windows or eBFP.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
