### PR TITLE
Mock netlink and test improvements

### DIFF
--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -102,8 +102,8 @@ func init() {
 	}
 	for i := 0; i < ourType.NumField(); i++ {
 		nlFieldType := nlType.Field(i).Type
-		outFieldType := ourType.Field(i).Type
-		if nlFieldType != outFieldType {
+		ourFieldType := ourType.Field(i).Type
+		if nlFieldType != ourFieldType {
 			panic(fmt.Sprintf("netlink.LinkNotFoundError structure appears to have changed (field type %v != %v)",
 				nlFieldType, ourType.Field(i).Type))
 		}
@@ -841,7 +841,7 @@ func (d *MockNetlinkDataplane) RouteReplace(route *netlink.Route) error {
 		return SimulatedError
 	}
 	key := KeyForRoute(route)
-	log.WithField("routeKey", key).Info("Mock dataplane: RouteUpdate called")
+	log.WithField("routeKey", key).Info("Mock dataplane: RouteReplace called")
 	d.AddedRouteKeys.Add(key)
 	d.ExistingTables.Add(route.Table)
 	if _, ok := d.RouteKeyToRoute[key]; ok {

--- a/felix/netlinkshim/mocknetlink/netlink.go
+++ b/felix/netlinkshim/mocknetlink/netlink.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unsafe"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -59,6 +60,7 @@ func New() *MockNetlinkDataplane {
 			},
 		},
 		SetStrictCheckErr: SimulatedError,
+		NeighsByFamily:    map[int]map[NeighKey]*netlink.Neigh{},
 
 		// Use a single global mutex.  This works around an issue in the wireguard tests, which use multiple
 		// mock dataplanes to hand to different parts of the code under test.  That led to concurrency bugs
@@ -76,10 +78,41 @@ var _ netlinkshim.Interface = (*MockNetlinkDataplane)(nil)
 var (
 	SimulatedError        = errors.New("dummy error")
 	NotFoundError         = errors.New("not found")
+	LinkNotFoundError     = netlink.LinkNotFoundError{}
 	FileDoesNotExistError = errors.New("file does not exist")
 	AlreadyExistsError    = errors.New("already exists")
 	NotSupportedError     = errors.New("operation not supported")
 )
+
+func init() {
+	// Ugh, the error field isn't exported and logging out the error
+	// panics if the error field isn't set.  Use an unsafe cast to
+	// set the value.
+
+	// Copy of the netlink.LinkNotFoundError struct.
+	type myLinkNotFoundError struct {
+		error
+	}
+
+	// First check that our struct matches the netlink one...
+	nlType := reflect.TypeOf(LinkNotFoundError)
+	ourType := reflect.TypeOf(myLinkNotFoundError{})
+	if nlType.NumField() != ourType.NumField() {
+		panic("netlink.LinkNotFoundError structure appears to have changed (different number of fields)")
+	}
+	for i := 0; i < ourType.NumField(); i++ {
+		nlFieldType := nlType.Field(i).Type
+		outFieldType := ourType.Field(i).Type
+		if nlFieldType != outFieldType {
+			panic(fmt.Sprintf("netlink.LinkNotFoundError structure appears to have changed (field type %v != %v)",
+				nlFieldType, ourType.Field(i).Type))
+		}
+	}
+
+	// All good, proceed with the sketchy cast...
+	var lnf = (*myLinkNotFoundError)((unsafe.Pointer)(&LinkNotFoundError))
+	lnf.error = NotFoundError
+}
 
 type FailFlags uint32
 
@@ -88,9 +121,12 @@ const (
 	FailNextLinkByName
 	FailNextLinkByNameNotFound
 	FailNextRouteList
+	FailNextRouteAddOrReplace
 	FailNextRouteAdd
+	FailNextRouteReplace
 	FailNextRouteDel
 	FailNextAddARP
+	FailNextNeighSet
 	FailNextNewNetlink
 	FailNextSetSocketTimeout
 	FailNextLinkAdd
@@ -143,6 +179,12 @@ func (f FailFlags) String() string {
 	}
 	if f&FailNextRouteAdd != 0 {
 		parts = append(parts, "FailNextRouteAdd")
+	}
+	if f&FailNextRouteAddOrReplace != 0 {
+		parts = append(parts, "FailNextRouteAddOrReplace")
+	}
+	if f&FailNextRouteReplace != 0 {
+		parts = append(parts, "FailNextRouteReplace")
 	}
 	if f&FailNextRouteDel != 0 {
 		parts = append(parts, "FailNextRouteDel")
@@ -230,6 +272,8 @@ type MockNetlinkDataplane struct {
 	DeletedRouteKeys set.Set[string]
 	UpdatedRouteKeys set.Set[string]
 
+	NeighsByFamily map[int]map[NeighKey]*netlink.Neigh
+
 	StrictEnabled               bool
 	NumNewNetlinkCalls          int
 	NetlinkOpen                 bool
@@ -258,6 +302,15 @@ type MockNetlinkDataplane struct {
 	mutex                   *sync.Mutex
 	deletedConntrackEntries set.Set[ip.Addr]
 	ConntrackSleep          time.Duration
+}
+
+type NeighKey struct {
+	MAC string
+	IP  ip.Addr
+}
+
+func (d *MockNetlinkDataplane) FeatureGate(name string) string {
+	return ""
 }
 
 func (d *MockNetlinkDataplane) RefreshFeatures() {
@@ -307,6 +360,12 @@ func (d *MockNetlinkDataplane) GetDeletedConntrackEntries() []net.IP {
 }
 
 func (d *MockNetlinkDataplane) AddIface(idx int, name string, up bool, running bool) *MockLink {
+	if idx == 0 {
+		panic("0 is not a valid ifindex")
+	}
+	if idx == 1 && name != "lo" {
+		panic("1 is always 'lo'")
+	}
 	t := "unknown"
 	if strings.Contains(name, "wireguard") {
 		t = "wireguard"
@@ -317,6 +376,11 @@ func (d *MockNetlinkDataplane) AddIface(idx int, name string, up bool, running b
 	link := &MockLink{
 		LinkAttrs: la,
 		LinkType:  t,
+	}
+	for otherName, link := range d.NameToLink {
+		if link.LinkAttrs.Index == idx {
+			Fail(fmt.Sprintf("ifindex %d already in use by %s, cannot add %s", idx, otherName, name))
+		}
 	}
 	d.NameToLink[name] = link
 	d.SetIface(name, up, running)
@@ -413,7 +477,7 @@ func (d *MockNetlinkDataplane) LinkByName(name string) (netlink.Link, error) {
 
 	Expect(d.NetlinkOpen).To(BeTrue())
 	if d.shouldFail(FailNextLinkByNameNotFound) {
-		return nil, NotFoundError
+		return nil, LinkNotFoundError
 	}
 	if d.shouldFail(FailNextLinkByName) {
 		return nil, SimulatedError
@@ -424,7 +488,7 @@ func (d *MockNetlinkDataplane) LinkByName(name string) (netlink.Link, error) {
 	if link, ok := d.NameToLink[name]; ok {
 		return link.copy(), nil
 	}
-	return nil, NotFoundError
+	return nil, LinkNotFoundError
 }
 
 func (d *MockNetlinkDataplane) LinkAdd(link netlink.Link) error {
@@ -467,7 +531,7 @@ func (d *MockNetlinkDataplane) LinkDel(link netlink.Link) error {
 	}
 
 	if _, ok := d.NameToLink[link.Attrs().Name]; !ok {
-		return NotFoundError
+		return LinkNotFoundError
 	}
 
 	delete(d.NameToLink, link.Attrs().Name)
@@ -489,7 +553,7 @@ func (d *MockNetlinkDataplane) LinkSetMTU(link netlink.Link, mtu int) error {
 		d.NameToLink[link.Attrs().Name] = link
 		return nil
 	}
-	return NotFoundError
+	return LinkNotFoundError
 }
 
 func (d *MockNetlinkDataplane) LinkSetUp(link netlink.Link) error {
@@ -509,7 +573,7 @@ func (d *MockNetlinkDataplane) LinkSetUp(link netlink.Link) error {
 		d.NameToLink[link.Attrs().Name] = link
 		return nil
 	}
-	return NotFoundError
+	return LinkNotFoundError
 }
 
 func (d *MockNetlinkDataplane) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
@@ -747,7 +811,7 @@ func (d *MockNetlinkDataplane) RouteAdd(route *netlink.Route) error {
 	defer GinkgoRecover()
 
 	Expect(d.NetlinkOpen).To(BeTrue())
-	if d.shouldFail(FailNextRouteAdd) {
+	if d.shouldFail(FailNextRouteAdd) || d.shouldFail(FailNextRouteAddOrReplace) {
 		return SimulatedError
 	}
 	key := KeyForRoute(route)
@@ -765,6 +829,33 @@ func (d *MockNetlinkDataplane) RouteAdd(route *netlink.Route) error {
 		d.RouteKeyToRoute[key] = r
 		return nil
 	}
+}
+
+func (d *MockNetlinkDataplane) RouteReplace(route *netlink.Route) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	defer GinkgoRecover()
+
+	Expect(d.NetlinkOpen).To(BeTrue())
+	if d.shouldFail(FailNextRouteReplace) || d.shouldFail(FailNextRouteAddOrReplace) {
+		return SimulatedError
+	}
+	key := KeyForRoute(route)
+	log.WithField("routeKey", key).Info("Mock dataplane: RouteUpdate called")
+	d.AddedRouteKeys.Add(key)
+	d.ExistingTables.Add(route.Table)
+	if _, ok := d.RouteKeyToRoute[key]; ok {
+		d.UpdatedRouteKeys.Add(key)
+	} else {
+		d.AddedRouteKeys.Add(key)
+	}
+	r := *route
+	if r.Table == 0 {
+		// Table 0 is "unspecified", which gets defaulted to the main table.
+		r.Table = unix.RT_TABLE_MAIN
+	}
+	d.RouteKeyToRoute[key] = r
+	return nil
 }
 
 func (d *MockNetlinkDataplane) RouteDel(route *netlink.Route) error {
@@ -789,7 +880,115 @@ func (d *MockNetlinkDataplane) RouteDel(route *netlink.Route) error {
 	}
 }
 
-// ----- Routetable specific ARP and Conntrack functions -----
+func (d *MockNetlinkDataplane) NeighAdd(neigh *netlink.Neigh) error {
+	family := neigh.Family
+	err := d.checkNeighFamily(family)
+	if err != nil {
+		return err
+	}
+
+	if d.NeighsByFamily[family] == nil {
+		d.NeighsByFamily[family] = map[NeighKey]*netlink.Neigh{}
+	}
+	if neigh.IP == nil {
+		return unix.EINVAL
+	}
+	if neigh.HardwareAddr == nil {
+		return unix.EINVAL
+	}
+	nk := NeighKey{
+		MAC: neigh.HardwareAddr.String(),
+		IP:  ip.FromNetIP(neigh.IP),
+	}
+
+	if _, ok := d.NeighsByFamily[family][nk]; ok {
+		return unix.EEXIST
+	}
+	d.NeighsByFamily[family][nk] = neigh
+	return nil
+}
+
+func (d *MockNetlinkDataplane) checkNeighFamily(family int) error {
+	switch family {
+	case unix.AF_INET, unix.AF_INET6, unix.AF_BRIDGE:
+	// Supported
+	default:
+		return fmt.Errorf("unsupported family, should be AF_INET/INET6/BRIDGE")
+	}
+	return nil
+}
+
+func (d *MockNetlinkDataplane) NeighList(linkIndex, family int) ([]netlink.Neigh, error) {
+	err := d.checkNeighFamily(family)
+	if err != nil {
+		return nil, err
+	}
+	var res []netlink.Neigh
+	for _, n := range d.NeighsByFamily[family] {
+		if linkIndex == 0 || n.LinkIndex == linkIndex {
+			res = append(res, *n)
+		}
+	}
+	return res, nil
+}
+
+func (d *MockNetlinkDataplane) NeighSet(neigh *netlink.Neigh) error {
+	family := neigh.Family
+	err := d.checkNeighFamily(family)
+	if err != nil {
+		return err
+	}
+	if d.shouldFail(FailNextNeighSet) {
+		return SimulatedError
+	}
+
+	if d.NeighsByFamily[family] == nil {
+		d.NeighsByFamily[family] = map[NeighKey]*netlink.Neigh{}
+	}
+	if neigh.IP == nil {
+		return unix.EINVAL
+	}
+	if neigh.HardwareAddr == nil {
+		return unix.EINVAL
+	}
+	nk := NeighKey{
+		MAC: neigh.HardwareAddr.String(),
+		IP:  ip.FromNetIP(neigh.IP),
+	}
+
+	d.NeighsByFamily[family][nk] = neigh
+	return nil
+}
+
+func (d *MockNetlinkDataplane) NeighDel(neigh *netlink.Neigh) error {
+	family := neigh.Family
+	err := d.checkNeighFamily(family)
+	if err != nil {
+		return err
+	}
+
+	if d.NeighsByFamily[family] == nil {
+		d.NeighsByFamily[family] = map[NeighKey]*netlink.Neigh{}
+	}
+	if neigh.IP == nil {
+		return unix.EINVAL
+	}
+	if neigh.HardwareAddr == nil {
+		return unix.EINVAL
+	}
+	nk := NeighKey{
+		MAC: neigh.HardwareAddr.String(),
+		IP:  ip.FromNetIP(neigh.IP),
+	}
+
+	if _, ok := d.NeighsByFamily[family][nk]; !ok {
+		return unix.ENOENT
+	}
+	delete(d.NeighsByFamily[family], nk)
+	return nil
+}
+
+// ----- Routetable specific Conntrack functions -----
 
 func (d *MockNetlinkDataplane) AddStaticArpEntry(cidr ip.CIDR, destMAC net.HardwareAddr, ifaceName string) error {
 	d.mutex.Lock()
@@ -805,6 +1004,23 @@ func (d *MockNetlinkDataplane) AddStaticArpEntry(cidr ip.CIDR, destMAC net.Hardw
 		"ifaceName": ifaceName,
 	}).Info("Mock dataplane: adding ARP entry")
 	d.addedArpEntries.Add(getArpKey(cidr, destMAC, ifaceName))
+
+	if d.NeighsByFamily[unix.AF_INET] == nil {
+		d.NeighsByFamily[unix.AF_INET] = map[NeighKey]*netlink.Neigh{}
+	}
+
+	linkIndex := d.NameToLink[ifaceName].LinkAttrs.Index
+	d.NeighsByFamily[unix.AF_INET][NeighKey{
+		MAC: destMAC.String(),
+		IP:  cidr.Addr(),
+	}] = &netlink.Neigh{
+		Family:       unix.AF_INET,
+		LinkIndex:    linkIndex,
+		State:        netlink.NUD_PERMANENT,
+		Type:         unix.RTN_UNICAST,
+		IP:           cidr.Addr().AsNetIP(),
+		HardwareAddr: destMAC,
+	}
 	return nil
 }
 
@@ -824,10 +1040,6 @@ func (d *MockNetlinkDataplane) RemoveConntrackFlows(ipVersion uint8, ipAddr net.
 	time.Sleep(d.ConntrackSleep)
 }
 
-func (d *MockNetlinkDataplane) NeighAdd(neigh *netlink.Neigh) error {
-	return nil
-}
-
 // ----- Internals -----
 
 func (d *MockNetlinkDataplane) shouldFail(flag FailFlags) bool {
@@ -839,6 +1051,13 @@ func (d *MockNetlinkDataplane) shouldFail(flag FailFlags) bool {
 		log.WithField("flag", flag).Warn("Mock dataplane: triggering failure")
 	}
 	return flagPresent
+}
+
+func (d *MockNetlinkDataplane) IfIndex(name string) int {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	return d.NameToLink[name].LinkAttrs.Index
 }
 
 func KeyForRoute(route *netlink.Route) string {

--- a/felix/netlinkshim/netlink.go
+++ b/felix/netlinkshim/netlink.go
@@ -32,6 +32,7 @@ type Interface interface {
 	LinkSetUp(link netlink.Link) error
 	RouteListFiltered(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error)
 	RouteAdd(route *netlink.Route) error
+	RouteReplace(route *netlink.Route) error
 	RouteDel(route *netlink.Route) error
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
@@ -41,6 +42,9 @@ type Interface interface {
 	RuleDel(rule *netlink.Rule) error
 	Delete()
 	NeighAdd(neigh *netlink.Neigh) error
+	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
+	NeighSet(a *netlink.Neigh) error
+	NeighDel(a *netlink.Neigh) error
 }
 
 func NewRealNetlink() (Interface, error) {

--- a/felix/routetable/route_table_test.go
+++ b/felix/routetable/route_table_test.go
@@ -169,13 +169,13 @@ var _ = Describe("RouteTable", func() {
 	})
 
 	Describe("with some interfaces", func() {
-		var cali1, cali3, eth0 *mocknetlink.MockLink
+		var cali1, cali2, cali3, eth0 *mocknetlink.MockLink
 		var gatewayRoute, cali1Route, cali1Route2, cali3Route netlink.Route
 		BeforeEach(func() {
-			eth0 = dataplane.AddIface(0, "eth0", true, true)
-			cali1 = dataplane.AddIface(1, "cali1", true, true)
-			dataplane.AddIface(2, "cali2", true, true)
-			cali3 = dataplane.AddIface(3, "cali3", true, true)
+			eth0 = dataplane.AddIface(2, "eth0", true, true)
+			cali1 = dataplane.AddIface(3, "cali1", true, true)
+			cali2 = dataplane.AddIface(4, "cali2", true, true)
+			cali3 = dataplane.AddIface(5, "cali3", true, true)
 			cali1Route = netlink.Route{
 				LinkIndex: cali1.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.1/32"),
@@ -245,7 +245,7 @@ var _ = Describe("RouteTable", func() {
 			))
 		})
 		It("Should clear out a source address when source address is not set", func() {
-			updateLink := dataplane.AddIface(5, "cali5", true, true)
+			updateLink := dataplane.AddIface(6, "cali5", true, true)
 			updateRoute := netlink.Route{
 				LinkIndex: updateLink.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.5/32"),
@@ -267,7 +267,6 @@ var _ = Describe("RouteTable", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dataplane.UpdatedRouteKeys).To(HaveKey(mocknetlink.KeyForRoute(&updateRoute)))
 			Expect(dataplane.RouteKeyToRoute[mocknetlink.KeyForRoute(&updateRoute)]).To(Equal(fixedRoute))
-
 		})
 		Describe("With a device route source address set", func() {
 			deviceRouteSource := "192.168.0.1"
@@ -323,7 +322,7 @@ var _ = Describe("RouteTable", func() {
 			})
 			It("Should not remove routes with a source address", func() {
 				// Route that should be left alone
-				noopLink := dataplane.AddIface(4, "cali4", true, true)
+				noopLink := dataplane.AddIface(6, "cali4", true, true)
 				noopRoute := netlink.Route{
 					LinkIndex: noopLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.4/32"),
@@ -346,7 +345,7 @@ var _ = Describe("RouteTable", func() {
 			})
 			It("Should update source addresses from nil to a given source", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.AddIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(6, "cali5", true, true)
 				updateRoute := netlink.Route{
 					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
@@ -372,7 +371,7 @@ var _ = Describe("RouteTable", func() {
 
 			It("Should update source addresses from an old source to a new one", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.AddIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(6, "cali5", true, true)
 				updateRoute := netlink.Route{
 					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
@@ -505,7 +504,7 @@ var _ = Describe("RouteTable", func() {
 			})
 			It("Should not remove routes with a protocol", func() {
 				// Route that should be left alone
-				noopLink := dataplane.AddIface(4, "cali4", true, true)
+				noopLink := dataplane.AddIface(6, "cali4", true, true)
 				noopRoute := netlink.Route{
 					LinkIndex: noopLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.4/32"),
@@ -526,7 +525,7 @@ var _ = Describe("RouteTable", func() {
 			})
 			It("Should update protocol from nil to a given protocol", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.AddIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(6, "cali5", true, true)
 				updateRoute := netlink.Route{
 					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
@@ -550,7 +549,7 @@ var _ = Describe("RouteTable", func() {
 
 			It("Should update protocol from an old protocol to a new one", func() {
 				// Route that needs to be updated
-				updateLink := dataplane.AddIface(5, "cali5", true, true)
+				updateLink := dataplane.AddIface(6, "cali5", true, true)
 				updateRoute := netlink.Route{
 					LinkIndex: updateLink.LinkAttrs.Index,
 					Dst:       mustParseCIDR("10.0.0.5/32"),
@@ -845,7 +844,7 @@ var _ = Describe("RouteTable", func() {
 				})
 				It("should keep correct route", func() {
 					Expect(dataplane.RouteKeyToRoute["254-10.0.0.1/32"]).To(Equal(netlink.Route{
-						LinkIndex: 1,
+						LinkIndex: cali1.LinkAttrs.Index,
 						Dst:       &ip1,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
@@ -857,7 +856,7 @@ var _ = Describe("RouteTable", func() {
 				It("should add new route", func() {
 					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-10.0.0.2/32"))
 					Expect(dataplane.RouteKeyToRoute["254-10.0.0.2/32"]).To(Equal(netlink.Route{
-						LinkIndex: 2,
+						LinkIndex: cali2.LinkAttrs.Index,
 						Dst:       &ip2,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
@@ -868,7 +867,7 @@ var _ = Describe("RouteTable", func() {
 				It("should update changed route", func() {
 					Expect(dataplane.RouteKeyToRoute).To(HaveKey("254-10.0.1.3/32"))
 					Expect(dataplane.RouteKeyToRoute["254-10.0.1.3/32"]).To(Equal(netlink.Route{
-						LinkIndex: 3,
+						LinkIndex: cali3.LinkAttrs.Index,
 						Dst:       &ip13,
 						Type:      syscall.RTN_UNICAST,
 						Protocol:  FelixRouteProtocol,
@@ -956,7 +955,7 @@ var _ = Describe("RouteTable", func() {
 		var cali1 *mocknetlink.MockLink
 		var cali1Route netlink.Route
 		BeforeEach(func() {
-			cali1 = dataplane.AddIface(1, "cali1", false, false)
+			cali1 = dataplane.AddIface(2, "cali1", false, false)
 			cali1Route = netlink.Route{
 				LinkIndex: cali1.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.1/32"),
@@ -1017,7 +1016,7 @@ var _ = Describe("RouteTable", func() {
 
 				// Set interface up
 				rt.OnIfaceStateChanged("cali1", ifacemonitor.StateUp)
-				cali1 = dataplane.AddIface(1, "cali1", true, true)
+				dataplane.SetIface("cali1", true, true)
 
 				// Now, the apply should work.
 				err = rt.Apply()
@@ -1086,8 +1085,8 @@ var _ = Describe("RouteTable (main table)", func() {
 		var cali1, eth0 *mocknetlink.MockLink
 		var gatewayRoute, cali1Route, cali1RouteTable100 netlink.Route
 		BeforeEach(func() {
-			eth0 = dataplane.AddIface(0, "eth0", true, true)
-			cali1 = dataplane.AddIface(1, "cali1", true, true)
+			eth0 = dataplane.AddIface(2, "eth0", true, true)
+			cali1 = dataplane.AddIface(3, "cali1", true, true)
 			cali1Route = netlink.Route{
 				LinkIndex: cali1.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.1/32"),
@@ -1189,8 +1188,8 @@ var _ = Describe("RouteTable (table 100)", func() {
 		var cali, eth0 *mocknetlink.MockLink
 		var gatewayRoute, caliRoute, caliRouteTable100, throwRoute, caliRouteTable100SameAsThrow netlink.Route
 		BeforeEach(func() {
-			eth0 = dataplane.AddIface(0, "eth0", true, true)
-			cali = dataplane.AddIface(1, "cali", true, true)
+			eth0 = dataplane.AddIface(2, "eth0", true, true)
+			cali = dataplane.AddIface(3, "cali", true, true)
 			caliRoute = netlink.Route{
 				LinkIndex: cali.LinkAttrs.Index,
 				Dst:       mustParseCIDR("10.0.0.1/32"),


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Add support for NeighXXX operations in mock netlink. These will replace the shell-out to 'arp' in a future update.
- Police interface index.  Prevents creating a cali interface that overlaps lo.
- Fix up tests accordingly.
- Fix duplicate wireguard test descriptions.
- Fix test leakage in wireguard tests.
- Return a real netlink.LinkNotFound error from the tests; requires an unsafe hack to populate the field.  Improve check in RouteTable to check for the error type as well as the message.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-9902

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
