### PR TITLE
Release IPAM blocks if they have been empty for a certain time

### DIFF
--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -472,11 +472,18 @@ func (c *ipamController) onBlockUpdated(kvp model.KVPair) {
 		log.WithFields(alloc.fields()).Debug("New IP allocation")
 	}
 
-	// If the block is empty, mark it as such. We'll check if it needs to be
-	// cleaned up in the sync loop.
+	// Check if the block is empty and schedule it for GC if needed.
+	// Skip blocks without an affinity, since these will be cleaned up when their last address is freed and
+	// thus we don't need to do any explicit GC.
 	delete(c.emptyBlocks, blockCIDR)
 	if n != "" && numAllocationsInBlock == 0 {
+		// The block is empty and affine to a node - add it to the emptyBlocks map. We'll check these blocks
+		// later to see if they can be cleaned up.
 		c.emptyBlocks[blockCIDR] = n
+	} else if n != "" {
+		// The block is assigned to a node and not empty - mark it as in-use, clearing any previous empty
+		// status if it had been marked empty before.
+		c.blockReleaseTracker.markInUse(blockCIDR)
 	}
 
 	// Remove any previously assigned allocations that have since been released.

--- a/kube-controllers/pkg/controllers/node/ipam.go
+++ b/kube-controllers/pkg/controllers/node/ipam.go
@@ -628,37 +628,18 @@ func (c *ipamController) updateMetrics() {
 
 // checkEmptyBlocks looks at known empty blocks, and releases their affinity
 // if appropriate. A block is a candidate for having its affinity released if:
+//
 // - The block is empty.
 // - The block's node has at least one other affine block.
-// - The other blocks on the node are not at capacity.
 // - The node is not currently undergoing a migration from Flannel
+//
+// A block will only be released if it has been in this state for longer than the configured
+// grace period, which defaults to 15m.
 func (c *ipamController) checkEmptyBlocks() error {
 	for blockCIDR, node := range c.emptyBlocks {
 		logc := log.WithFields(log.Fields{"blockCIDR": blockCIDR, "node": node})
 		nodeBlocks := c.blocksByNode[node]
 		if len(nodeBlocks) <= 1 {
-			continue
-		}
-
-		// The node has more than one block. Check that the other blocks allocated to this node
-		// are not at capacity. We only release blocks when there's room in the other affine blocks,
-		// otherwise the next IP allocation will just assign a new block to this node anyway.
-		numAddressesAvailableOnNode := 0
-		for b := range nodeBlocks {
-			if b == blockCIDR {
-				// Skip the known empty block.
-				continue
-			}
-
-			// Sum the number of unallocated addresses across the other blocks.
-			kvp := c.allBlocks[b]
-			numAddressesAvailableOnNode += len(kvp.Value.(*model.AllocationBlock).Unallocated)
-		}
-
-		// Make sure there are some addresses available before releasing.
-		if numAddressesAvailableOnNode < 3 {
-			logc.Debug("Block is still needed, skip release")
-			c.blockReleaseTracker.markInUse(blockCIDR)
 			continue
 		}
 

--- a/kube-controllers/pkg/controllers/node/ipam_test.go
+++ b/kube-controllers/pkg/controllers/node/ipam_test.go
@@ -1447,4 +1447,83 @@ var _ = Describe("IPAM controller UTs", func() {
 		Eventually(numBlocks, 1*time.Second, 100*time.Millisecond).Should(Equal(1))
 		Consistently(numBlocks, assertionTimeout, 100*time.Millisecond).Should(Equal(1))
 	})
+
+	// This test verifies that the GC cleans up blocks even if the total number of free addresses on the node
+	// is small.
+	// Reference: https://github.com/projectcalico/calico/issues/7987
+	It("should clean up small IPAM blocks", func() {
+		// Create Calico and k8s nodes for the test.
+		n := libapiv3.Node{}
+		n.Name = "cnode"
+		n.Spec.OrchRefs = []libapiv3.OrchRef{{NodeName: "kname", Orchestrator: apiv3.OrchestratorKubernetes}}
+		_, err := cli.Nodes().Create(context.TODO(), &n, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		kn := v1.Node{}
+		kn.Name = "kname"
+		_, err = cs.CoreV1().Nodes().Create(context.TODO(), &kn, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		var node *v1.Node
+		Eventually(nodes).WithTimeout(time.Second).Should(Receive(&node))
+
+		// Start the controller.
+		c.Start(stopChan)
+
+		// Add small, empty blocks to the node.
+		// Use a block size of 31, resulting in 2 allocations per block.
+		for i := 0; i < 5; i++ {
+			unallocated := make([]int, 64)
+			for i := 0; i < len(unallocated); i++ {
+				unallocated[i] = i
+			}
+			cidr := net.MustParseCIDR(fmt.Sprintf("10.0.%d.0/31", i))
+			aff := "host:cnode"
+			key := model.BlockKey{CIDR: cidr}
+			b := model.AllocationBlock{
+				CIDR:        cidr,
+				Affinity:    &aff,
+				Allocations: make([]*int, 64),
+				Unallocated: unallocated,
+				Attributes:  []model.AllocationAttribute{},
+			}
+			kvp := model.KVPair{
+				Key:   key,
+				Value: &b,
+			}
+			update := bapi.Update{KVPair: kvp, UpdateType: bapi.UpdateTypeKVNew}
+			c.onUpdate(update)
+		}
+
+		// Wait for controller state to update with all blocks.
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			return len(c.allBlocks) == 5
+		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		// The controller should recognize them all as empty.
+		Eventually(func() bool {
+			done := c.pause()
+			defer done()
+			return len(c.emptyBlocks) == 5
+		}, 1*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		// Mark the syncer as InSync so that the GC will be enabled.
+		c.onStatusUpdate(bapi.InSync)
+
+		// 4 out of the 5 empty blocks should be released, but not all.
+		numBlocks := func() int {
+			done := c.pause()
+			defer done()
+			return len(c.blocksByNode["cnode"])
+		}
+		Eventually(numBlocks, assertionTimeout, 100*time.Millisecond).Should(Equal(1))
+		Consistently(numBlocks, assertionTimeout, 100*time.Millisecond).Should(Equal(1))
+		numBlocks = func() int {
+			done := c.pause()
+			defer done()
+			return len(c.emptyBlocks)
+		}
+		Eventually(numBlocks, 1*time.Second, 100*time.Millisecond).Should(Equal(1))
+		Consistently(numBlocks, assertionTimeout, 100*time.Millisecond).Should(Equal(1))
+	})
 })


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Remove the check for total free addresses on a node, and instead just
rely on the time-based heuristic for whether an IPAM block is OK to
delete.

By default, blocks will now be deleted if they are consistently empty
for 15m or more (the default leak grace period). But this can be
configured using KubeControllersConfiguration. 

The previous check was meant to ensure we didn't allocate and delete
blocks rapidly, but the time-based grace period should do that just as
well.


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/7987

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve IPAM block garbage collection behavior for IP pools with small blocks.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.