### PR TITLE
[release-v3.27] Auto pick #8380: pods in nat-outgoing shoul dnot SNAT to local host

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -445,7 +445,12 @@ syn_force_policy:
 
 		// Check whether the workload needs outgoing NAT to this address.
 		if (r->flags & CALI_RT_NAT_OUT) {
-			if (!(cali_rt_lookup_flags(&ctx->state->post_nat_ip_dst) & CALI_RT_IN_POOL)) {
+			struct cali_rt *rt = cali_rt_lookup(&ctx->state->post_nat_ip_dst);
+			enum cali_rt_flags flags = CALI_RT_UNKNOWN;
+			if (rt) {
+				flags = rt->flags;
+			}
+			if (!(flags & CALI_RT_IN_POOL) && !cali_rt_flags_local_host(flags)) {
 				CALI_DEBUG("Source is in NAT-outgoing pool "
 					   "but dest is not, need to SNAT.\n");
 				ctx->state->flags |= CALI_ST_NAT_OUTGOING;

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -375,6 +375,8 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			if testOpts.dsr {
 				options.ExtraEnvVars["FELIX_BPFExternalServiceMode"] = "dsr"
 			}
+			// ACCEPT is what is set by our manifests and operator by default.
+			options.ExtraEnvVars["FELIX_DefaultEndpointToHostAction"] = "ACCEPT"
 			options.ExternalIPs = true
 			options.ExtraEnvVars["FELIX_BPFExtToServiceConnmark"] = "0x80"
 			if !testOpts.ipv6 {
@@ -1479,6 +1481,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					It("should handle NAT outgoing", func() {
 						By("SNATting outgoing traffic with the flag set")
 						cc.ExpectSNAT(w[0][0], felixIP(0), hostW[1])
+						cc.Expect(Some, w[0][0], hostW[0]) // no snat
 						cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
 
 						if testOpts.tunnel == "none" {

--- a/felix/fv/test-workload/test-workload.go
+++ b/felix/fv/test-workload/test-workload.go
@@ -75,7 +75,7 @@ func main() {
 	panicIfError(err)
 
 	listenAnyIP := false
-	if _, ok := arguments["--listen-any-ip"]; ok {
+	if arg, ok := arguments["--listen-any-ip"]; ok && arg.(bool) {
 		listenAnyIP = true
 	}
 


### PR DESCRIPTION
Cherry pick of #8380 on release-v3.27.

#8380: pods in nat-outgoing shoul dnot SNAT to local host

# Original PR Body below

When a pod is accessing a local host, it should not get SNATed as the host when it is in a nat-outgoing ippool. (a) it is unnecessary as the local node can be accessed and (b) there is no way to return the traffic as is it would return to the host itself.


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Fixes https://github.com/projectcalico/calico/issues/7252
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixed pods in nat-outgoing should not SNAT when accessing local host
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.