### PR TITLE
[release-v3.27] Auto pick #8388: Add tests for DefaultEndpointToHostAction.

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1935,8 +1935,9 @@ func (m *bpfEndpointManager) wepApplyPolicy(ap *tc.AttachPoint,
 	}
 
 	// If workload egress and DefaultEndpointToHostAction is ACCEPT or DROP, suppress the normal
-	// host-* endpoint policy.
-	if polDirection == PolDirnEgress && m.epToHostAction != "RETURN" {
+	// host-* endpoint policy. If it does not exist, suppress it as well, not to
+	// create deny due to the fact that there are not profiles or tiers etc.
+	if polDirection == PolDirnEgress && (m.epToHostAction != "RETURN" || !m.wildcardExists) {
 		rules.SuppressNormalHostPolicy = true
 	}
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1934,10 +1934,16 @@ func (m *bpfEndpointManager) wepApplyPolicy(ap *tc.AttachPoint,
 		m.addHostPolicy(&rules, &m.wildcardHostEndpoint, polDirection.Inverse())
 	}
 
-	// If workload egress and DefaultEndpointToHostAction is ACCEPT or DROP, suppress the normal
-	// host-* endpoint policy. If it does not exist, suppress it as well, not to
-	// create deny due to the fact that there are not profiles or tiers etc.
-	if polDirection == PolDirnEgress && (m.epToHostAction != "RETURN" || !m.wildcardExists) {
+	// Intentionally leaving this code here until the *-hep takes precedence.
+	wildcardEPPolicyAppliesToWEPs := false
+	if wildcardEPPolicyAppliesToWEPs {
+		// If workload egress and DefaultEndpointToHostAction is ACCEPT or DROP, suppress the normal
+		// host-* endpoint policy. If it does not exist, suppress it as well, not to
+		// create deny due to the fact that there are not profiles or tiers etc.
+		if polDirection == PolDirnEgress && (m.epToHostAction != "RETURN" || !m.wildcardExists) {
+			rules.SuppressNormalHostPolicy = true
+		}
+	} else {
 		rules.SuppressNormalHostPolicy = true
 	}
 

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -519,7 +519,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				endpointToHostAction = "RETURN"
 			})
 
-			It("has host-* policy on workload egress but not ingress", func() {
+			It("has host-* policy suppressed on ingress and egress", func() {
 				var caliI, caliE *polprog.Rules
 
 				// Check workload ingress.
@@ -532,7 +532,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				Expect(caliE.ForHostInterface).To(BeFalse())
 				Expect(caliE.HostNormalTiers).To(HaveLen(1))
 				Expect(caliE.HostNormalTiers[0].Policies).To(HaveLen(1))
-				Expect(caliE.SuppressNormalHostPolicy).To(BeFalse())
+				Expect(caliE.SuppressNormalHostPolicy).To(BeTrue())
 			})
 		})
 	})

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1559,15 +1559,13 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 			})
 		}
 
-		// Accept any SEEN packets that go to the host. What remains here should be from
-		// host interfaces. This should accept packets in default-DROP iptable
-		// environments.  Such packets go through BPF on host iface but must go through
-		// the INPUT of iptables too. default-DROP would block IPIP/VXLAN/WG/etc. traffic
-		// without explicit ACCEPT.
-		inputRules = append(inputRules, iptables.Rule{
-			Match:  iptables.Match().MarkMatchesWithMask(tcdefs.MarkSeen, tcdefs.MarkSeenMask),
-			Action: iptables.AcceptAction{},
-		})
+		if rulesConfig.EndpointToHostAction != "ACCEPT" {
+			// We must accept WG traffic that goes towards the host. By this time, it is a
+			// SEEN traffic, so it was policed and accepted at a HEP. If the default INPUT
+			// chain policy was DROP, it would get dropped now, therefore an explicit accept
+			// is needed.
+			inputRules = append(inputRules, rules.FilterInputChainAllowWG(t.IPVersion, rulesConfig, iptables.AcceptAction{})...)
+		}
 
 		if t.IPVersion == 6 {
 			if !d.config.BPFIpv6Enabled {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -428,7 +428,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 				for i, felix := range tc.Felixes {
 					felix.Exec("conntrack", "-L")
-					felix.Exec("calico-bpf", "-6", "policy", "dump", "cali1ab524b60b9", "all", "--asm")
+					felix.Exec("calico-bpf", "policy", "dump", "cali8d1e69e5f89", "all", "--asm")
 					if testOpts.ipv6 {
 						felix.Exec("ip6tables-save", "-c")
 						felix.Exec("ip", "-6", "link")
@@ -623,6 +623,18 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 					cc.ExpectSome(w[1], w[0])
 					cc.ExpectNone(w[1], hostW)
 					cc.ExpectSome(hostW, w[0])
+					cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
+				})
+			})
+
+			Describe("with DefaultEndpointToHostAction=RETURN", func() {
+				BeforeEach(func() {
+					options.ExtraEnvVars["FELIX_DefaultEndpointToHostAction"] = "RETURN"
+					options.AutoHEPsEnabled = false
+				})
+				It("should allow traffic from workload to host", func() {
+					cc.Expect(Some, w[1], hostW)
+					cc.Expect(Some, hostW, w[0])
 					cc.CheckConnectivity(conntrackChecks(tc.Felixes)...)
 				})
 			})

--- a/felix/fv/ep_to_host_action_test.go
+++ b/felix/fv/ep_to_host_action_test.go
@@ -51,6 +51,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ endpoint-to-host-action tes
 		options := infrastructure.DefaultTopologyOptions()
 		options.IPIPEnabled = false
 		options.DelayFelixStart = true
+		options.FelixLogSeverity = "Debug"
 		tc, client = infrastructure.StartNNodeTopology(2, options, infra)
 
 		infra.AddDefaultAllow()
@@ -222,6 +223,10 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ endpoint-to-host-action tes
 		entry("DROP", "Return", "*-pre-dnat", api.Deny, connectivity.None),
 		entry("DROP", "Drop", "*-pre-dnat", api.Deny, connectivity.None),
 
+		entry("ACCEPT", "Accept", "*-pre-dnat", api.Deny, connectivity.None),
+		entry("ACCEPT", "Return", "*-pre-dnat", api.Deny, connectivity.None),
+		entry("ACCEPT", "Drop", "*-pre-dnat", api.Deny, connectivity.None),
+
 		// DefaultEndpointToHostAction overrides normal wildcard HEP policy (this
 		// surprised me, but I think it was a change made near the end of development to prevent
 		// a breaking change).
@@ -232,5 +237,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ endpoint-to-host-action tes
 		entry("DROP", "Accept", "*", api.Deny, connectivity.Some),
 		entry("DROP", "Return", "*", api.Deny, connectivity.None),
 		entry("DROP", "Drop", "*", api.Deny, connectivity.None),
+
+		entry("ACCEPT", "Accept", "*", api.Deny, connectivity.Some),
+		entry("ACCEPT", "Return", "*", api.Deny, connectivity.Some),
+		entry("ACCEPT", "Drop", "*", api.Deny, connectivity.None),
 	)
 })

--- a/felix/fv/ep_to_host_action_test.go
+++ b/felix/fv/ep_to_host_action_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/calico/felix/fv/connectivity"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/utils"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
+)
+
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ endpoint-to-host-action tests", []apiconfig.DatastoreType{apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+	var (
+		infra  infrastructure.DatastoreInfra
+		tc     infrastructure.TopologyContainers
+		client client.Interface
+		w      [2]*workload.Workload
+		hostW  [2]*workload.Workload
+
+		cc *connectivity.Checker
+	)
+
+	BeforeEach(func() {
+		infra = getInfra()
+		options := infrastructure.DefaultTopologyOptions()
+		options.IPIPEnabled = false
+		options.DelayFelixStart = true
+		tc, client = infrastructure.StartNNodeTopology(2, options, infra)
+
+		infra.AddDefaultAllow()
+
+		for ii := range w {
+			wIP := fmt.Sprintf("10.65.%d.2", ii)
+			wName := fmt.Sprintf("w%d", ii)
+			w[ii] = workload.Run(tc.Felixes[ii], wName, "default", wIP, "8055", "tcp")
+			w[ii].ConfigureInInfra(infra)
+
+			hostW[ii] = workload.Run(tc.Felixes[ii], fmt.Sprintf("host%d", ii), "", tc.Felixes[ii].IP, "8055", "tcp")
+		}
+
+		cc = &connectivity.Checker{}
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			for _, felix := range tc.Felixes {
+				felix.Exec("iptables-save", "-c")
+				felix.Exec("ipset", "list")
+				felix.Exec("ip", "r")
+				felix.Exec("ip", "a")
+			}
+		}
+
+		for _, wl := range w {
+			wl.Stop()
+		}
+		for _, wl := range hostW {
+			wl.Stop()
+		}
+		tc.Stop()
+
+		if CurrentGinkgoTestDescription().Failed {
+			infra.DumpErrorData()
+		}
+		infra.Stop()
+	})
+
+	entry := func(chainPolicy string, epToHostPol string, hep string, hepPolicy api.Action, expectedConn connectivity.Expected) table.TableEntry {
+		return table.Entry(
+			fmt.Sprintf("INPUT=%s, ep-to-host=%s, HEP=%s, HEP-pol=%s, expected connectivity=%v",
+				chainPolicy, epToHostPol, hep, hepPolicy, expectedConn),
+			chainPolicy, epToHostPol, hep, hepPolicy, expectedConn,
+		)
+	}
+
+	table.DescribeTable("endpoint to host tests",
+		func(chainPolicy string, epToHostPol string, hepIface string, hepPolicy api.Action, expectedConn connectivity.Expected) {
+			// Set the chain policy.
+			for _, f := range tc.Felixes {
+				// Need to make sure Felix's datastore connection is allowed to return.
+				f.Exec("iptables", "-A", "INPUT", "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT")
+				// Make sure there's no WEP-to-WEP connectivity before Felix comes up.
+				f.Exec("iptables", "-t", "filter", "-P", "FORWARD", "DROP")
+				f.Exec("iptables", "-t", "filter", "-P", "INPUT", chainPolicy)
+			}
+			// Set Felix policy.
+			By("Updating DefaultEndpointToHostAction")
+			utils.UpdateFelixConfig(client, func(configuration *api.FelixConfiguration) {
+				configuration.Spec.DefaultEndpointToHostAction = epToHostPol
+			})
+
+			switch hepIface {
+			case "none":
+			case "eth0", "*":
+				policy := api.NewGlobalNetworkPolicy()
+				policy.Name = "default-hep"
+				policy.Spec.Selector = "hep=='true'"
+				policy.Spec.Egress = []api.Rule{{Action: api.Allow}}
+				policy.Spec.Ingress = []api.Rule{
+					{
+						Action: hepPolicy,
+						Source: api.EntityRule{
+							Selector: "!has(hep)",
+						},
+					},
+				}
+				_, err := client.GlobalNetworkPolicies().Create(utils.Ctx, policy, utils.NoOptions)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, f := range tc.Felixes {
+					hep := api.NewHostEndpoint()
+					hep.Name = "hep-" + f.Name
+					hep.Labels = map[string]string{
+						"hep": "true",
+					}
+					hep.Spec.Node = f.Hostname
+					hep.Spec.ExpectedIPs = []string{f.IP}
+					hep.Spec.InterfaceName = hepIface
+					_, err := client.HostEndpoints().Create(context.TODO(), hep, options.SetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}
+			default:
+				Fail("Unknown hep type: " + hepIface)
+			}
+
+			// Check that we start with no WEP-to-WEP connectivity.  This ensures that, when
+			// we see WEP-to-WEP connectivity in the check below, we know that Felix has
+			// finished programming the dataplane.
+			cc.Expect(connectivity.None, w[0], w[1])
+			cc.CheckConnectivity()
+			cc.ResetExpectations()
+
+			// Trigger startup, Felix will apply the ep-to-host policy and the WEP-to-WEP
+			// allow profile in one transaction.
+			for _, f := range tc.Felixes {
+				f.TriggerDelayedStart()
+			}
+
+			// Now add the default allow profile, which should give us WEP-to-WEP connectivity.
+			// When we get WEp-to-WEP, we know that Felix has finished programming so the
+			// WEP-to-host test is valid.
+
+			By("Checking connectivity")
+			cc.Expect(expectedConn, w[0], hostW[0])
+			cc.Expect(expectedConn, w[1], hostW[1])
+			cc.Expect(connectivity.Some, w[0], w[1])
+			cc.CheckConnectivity()
+		},
+		entry("DROP", "Accept", "none", "", connectivity.Some),
+		entry("DROP", "Return", "none", "", connectivity.None),
+		entry("DROP", "Drop", "none", "", connectivity.None),
+
+		entry("ACCEPT", "Accept", "none", "", connectivity.Some),
+		entry("ACCEPT", "Return", "none", "", connectivity.Some),
+		entry("ACCEPT", "Drop", "none", "", connectivity.None),
+
+		// HEP on eth0 is irrelevant: an interface-specific HEP has no effect on workload traffic.
+		entry("ACCEPT", "Return", "eth0", api.Deny, connectivity.Some),
+		entry("DROP", "Return", "eth0", api.Deny, connectivity.None),
+
+		// Wildcard HEP overrides the ep-to-host policy.
+		entry("DROP", "Accept", "*", api.Allow, connectivity.Some),
+		entry("DROP", "Return", "*", api.Allow, connectivity.Some),
+		entry("DROP", "Drop", "*", api.Allow, connectivity.Some),
+		entry("DROP", "Accept", "*", api.Deny, connectivity.None),
+		entry("DROP", "Return", "*", api.Deny, connectivity.None),
+		entry("DROP", "Drop", "*", api.Deny, connectivity.None),
+	)
+})

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -907,6 +907,13 @@ func (kds *K8sDatastoreInfra) DumpErrorData() {
 			log.Info(spew.Sdump(hep))
 		}
 	}
+	fcs, err := kds.calicoClient.FelixConfigurations().List(context.Background(), options.ListOptions{})
+	if err == nil {
+		log.Info("DIAGS: Calico FelixConfigurations:")
+		for _, fc := range fcs.Items {
+			log.Info(spew.Sdump(fc))
+		}
+	}
 }
 
 func (kds *K8sDatastoreInfra) containerGetIPForURL(c *containers.Container) string {

--- a/felix/fv/wireguard-available
+++ b/felix/fv/wireguard-available
@@ -19,7 +19,7 @@
 # (non-zero) if not.
 
 mod_dir=/lib/modules/`uname -r`
-for f in `find $mod_dir -name wireguard.ko`; do
+for f in `find $mod_dir -name wireguard.ko*`; do
     echo Found Wireguard module object at $f
     exit 0
 done


### PR DESCRIPTION
Cherry pick of #8388 on release-v3.27.

#8388: Add tests for DefaultEndpointToHostAction.

# Original PR Body below

## Description

If there is no wildcard HEP, there is no policy that should be applied. But without skipping, empty list of profiles would create a default deny rule if none of the non-existent profiles matches. That is obviously always hit and traffic toward the host is dropped if defaultEndpointToHostAction is set to RETURN.

In fact, to be compatible with iptables behaviour, we should never apply normal *-hep policy, only the preDNAT one. This PR leaves the normal policy code there for enabling it in the future.


Also includes FV tests for defaultEndpointToHostAction by @fasaxc that codify behaviour and unify it across dataplanes.

Removed blanket ACCEPT in INPUT chain, only wg traffic is explicitly accepted now, the rest is dropped if INPUT policy is DROP and defaultEndpointToHostAction==RETURN.
## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/7252
## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: align defaultEndpointToHostAction with iptables - do not apply normal *-hep policy to wep
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.