### PR TITLE
[release-v3.27] Auto pick #8438: proxy - syncer must not count not-ready endpoints

### DIFF
--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -757,11 +757,11 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 			if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
 				return 0, 0, err
 			}
+			cnt++
+			local++
 		}
 
 		cpEps = append(cpEps, ep)
-		cnt++
-		local++
 	}
 
 	for _, ep := range eps {
@@ -774,10 +774,10 @@ func (s *Syncer) updateService(skey svcKey, sinfo k8sp.ServicePort, id uint32, e
 			if err := s.writeSvcBackend(id, uint32(cnt), ep); err != nil {
 				return 0, 0, err
 			}
+			cnt++
 		}
 
 		cpEps = append(cpEps, ep)
-		cnt++
 	}
 
 	flags := uint32(0)

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -936,6 +937,137 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						}
 						return out
 					}).Should(ContainSubstring("kernel.unprivileged_bpf_disabled = 1"))
+				})
+
+				It("should remove terminating workload from the NAT backends", func() {
+					By("Creating a fake service with fake endpoint")
+
+					clusterIP := "10.101.0.254"
+					svcIP1 := "192.168.12.1"
+					svcIP2 := "192.168.12.2"
+					svcIP3 := "192.168.12.3"
+					addrType := discovery.AddressTypeIPv4
+					family := 4
+					if testOpts.ipv6 {
+						clusterIP = "dead:beef::abcd:0:0:254"
+						svcIP1 = "dead:beef::192:168:12:1"
+						svcIP2 = "dead:beef::192:168:12:2"
+						svcIP3 = "dead:beef::192:168:12:3"
+						addrType = discovery.AddressTypeIPv6
+						family = 6
+					}
+
+					fakeSvc := &v1.Service{
+						TypeMeta:   typeMetaV1("Service"),
+						ObjectMeta: objectMetaV1("fake-service"),
+						Spec: v1.ServiceSpec{
+							ClusterIP: clusterIP,
+							Type:      "ClusterIP",
+							Ports: []v1.ServicePort{
+								{
+									Protocol: v1.ProtocolTCP,
+									Port:     int32(11666),
+								},
+							},
+						},
+					}
+
+					k8sClient := infra.(*infrastructure.K8sDatastoreInfra).K8sClient
+					_, err := k8sClient.CoreV1().Services("default").Create(context.Background(), fakeSvc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					portName := ""
+					portProto := v1.ProtocolTCP
+					portPort := int32(11166)
+					falsePtr := new(bool)
+					*falsePtr = false
+					truePtr := new(bool)
+					*truePtr = true
+
+					fakeEps := &discovery.EndpointSlice{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "EndpointSlice",
+							APIVersion: "discovery.k8s.io/v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake-service-eps",
+							Namespace: "default",
+							Labels: map[string]string{
+								"kubernetes.io/service-name": "fake-service",
+							},
+						},
+						AddressType: addrType,
+						Endpoints: []discovery.Endpoint{
+							{
+								Addresses: []string{svcIP1},
+								Conditions: discovery.EndpointConditions{
+									Ready:       truePtr,
+									Terminating: falsePtr,
+								},
+							},
+							{
+								Addresses: []string{svcIP2},
+								Conditions: discovery.EndpointConditions{
+									Ready:       truePtr,
+									Terminating: falsePtr,
+								},
+							},
+							{
+								Addresses: []string{svcIP3},
+								Conditions: discovery.EndpointConditions{
+									Ready:       truePtr,
+									Terminating: falsePtr,
+								},
+							},
+						},
+						Ports: []discovery.EndpointPort{{
+							Name:     &portName,
+							Protocol: &portProto,
+							Port:     &portPort,
+						}},
+					}
+
+					_, err = k8sClient.DiscoveryV1().EndpointSlices("default").
+						Create(context.Background(), fakeEps, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					var natK nat.FrontendKeyInterface
+					if testOpts.ipv6 {
+						natK = nat.NewNATKeyV6(net.ParseIP(clusterIP), 11666, 6)
+					} else {
+						natK = nat.NewNATKey(net.ParseIP(clusterIP), 11666, 6)
+					}
+
+					Eventually(func(g Gomega) {
+						natmap, natbe := dumpNATMapsAny(family, tc.Felixes[0])
+						g.Expect(natmap).To(HaveKey(natK))
+						g.Expect(natmap[natK].Count()).To(Equal(uint32(3)))
+						svc := natmap[natK]
+						bckID := svc.ID()
+						g.Expect(natbe).To(HaveKey(nat.NewNATBackendKey(bckID, 0)))
+						g.Expect(natbe).To(HaveKey(nat.NewNATBackendKey(bckID, 1)))
+						g.Expect(natbe).To(HaveKey(nat.NewNATBackendKey(bckID, 2)))
+						g.Expect(natbe).NotTo(HaveKey(nat.NewNATBackendKey(bckID, 3)))
+					}, "5s").Should(Succeed(), "service or backedns didn't show up")
+
+					fakeEps.Endpoints[1].Conditions.Ready = falsePtr
+					fakeEps.Endpoints[1].Conditions.Terminating = truePtr
+
+					_, err = k8sClient.DiscoveryV1().EndpointSlices("default").
+						Update(context.Background(), fakeEps, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(func(g Gomega) {
+						natmap, natbe := dumpNATMapsAny(family, tc.Felixes[0])
+						g.Expect(natmap).To(HaveKey(natK))
+						g.Expect(natmap[natK].Count()).To(Equal(uint32(2)))
+						svc := natmap[natK]
+						bckID := svc.ID()
+						g.Expect(natbe).To(HaveKey(nat.NewNATBackendKey(bckID, 0)))
+						g.Expect(natbe).To(HaveKey(nat.NewNATBackendKey(bckID, 1)))
+						g.Expect(natbe).NotTo(HaveKey(nat.NewNATBackendKey(bckID, 2)))
+					}, "5s").Should(Succeed(), "NAT did not get updated properly")
+
 				})
 			}
 		})


### PR DESCRIPTION
Cherry pick of #8438 on release-v3.27.

#8438: proxy - syncer must not count not-ready endpoints

# Original PR Body below

We include terminating eps in the eps list so that we can prevent conntrack clean up, but they are not written into the backend map and so they should not be reflected in the backends count.

Test that Terminating is propagated through proxy frontend. Test in FV that proxy removes the terminating backend from the NAT table.

refs https://github.com/projectcalico/calico/issues/8423

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixes possible holes in the list NAT backends if there is a terminating pod.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.