### PR TITLE
[release-v3.27] Auto pick #8462: Add retry mechanism to Windows version

### DIFF
--- a/cni-plugin/pkg/install/install_windows.go
+++ b/cni-plugin/pkg/install/install_windows.go
@@ -154,11 +154,11 @@ func replacePlatformSpecificVars(c config, netconf string) string {
 	netconf = strings.Replace(netconf, "__IPAM_TYPE__", ipamType, -1)
 
 	// Get Windows version information via powershell to determine whether DSR is supported.
-	// Retry for 3 attempts in case any step fails.
+	// Retry for 10 attempts in case any step fails.
 	var stdout, stderr string
 	var err error
 	var winVerInt, buildNumInt, halVerInt int
-	for attempts := 3; attempts > 0; attempts-- {
+	for attempts := 10; attempts > 0; attempts-- {
 		stdout, stderr, err = winutils.Powershell("Get-ComputerInfo | select WindowsVersion, OsBuildNumber, OsHardwareAbstractionLayer")
 		logger := logrus.WithFields(logrus.Fields{"stderr": stderr, "stdout": stdout})
 		if err != nil {

--- a/cni-plugin/pkg/install/install_windows.go
+++ b/cni-plugin/pkg/install/install_windows.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -152,29 +153,62 @@ func replacePlatformSpecificVars(c config, netconf string) string {
 	}
 	netconf = strings.Replace(netconf, "__IPAM_TYPE__", ipamType, -1)
 
-	stdout, stderr, err := winutils.Powershell("Get-ComputerInfo | select WindowsVersion, OsBuildNumber, OsHardwareAbstractionLayer")
-	if err != nil {
-		logrus.Fatalf("Failed to interact with powershell\nerror: %s\nstderr: %s", err, stderr)
+	// Get Windows version information via powershell to determine whether DSR is supported.
+	// Retry for 3 attempts in case any step fails.
+	var stdout, stderr string
+	var err error
+	var winVerInt, buildNumInt, halVerInt int
+	for attempts := 3; attempts > 0; attempts-- {
+		stdout, stderr, err = winutils.Powershell("Get-ComputerInfo | select WindowsVersion, OsBuildNumber, OsHardwareAbstractionLayer")
+		logger := logrus.WithFields(logrus.Fields{"stderr": stderr, "stdout": stdout})
+		if err != nil {
+			logger.WithError(err).Warn("Failed to interact with powershell. May retry...")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		lines := strings.Split(stdout, "\r\n")
+		if len(lines) < 4 {
+			logger.WithError(err).Warn("Could not parse output from powershell command. May retry...")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		line := lines[3]
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			logger.WithError(err).WithField("line", line).Warn("Could not parse fields from powershell command output line. May retry...")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		winVer := fields[0]
+		winVerInt, err = strconv.Atoi(winVer)
+		if err != nil {
+			logger.WithError(err).WithField("winVer", winVer).Warn("Error converting winVer to int. May retry...")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		buildNum := fields[1]
+		buildNumInt, err = strconv.Atoi(buildNum)
+		if err != nil {
+			logger.WithError(err).WithField("buildNum", buildNum).Warn("Error converting buildNum to int. May retry...")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		hal := fields[2]
+		halVer := strings.Split(hal, ".")[3]
+		halVerInt, err = strconv.Atoi(halVer)
+		if err != nil {
+			logger.WithError(err).WithField("halVer", halVer).Warn("Error converting halVer to int. May retry...")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
 	}
-	line := strings.Split(stdout, "\r\n")[3]
-	fields := strings.Fields(line)
-	winVer := fields[0]
-	winVerInt, err := strconv.Atoi(winVer)
 	if err != nil {
-		logrus.Fatalf("Error converting winVer to int\nerror: %s", err)
+		logrus.WithError(err).Fatal("Failed to retrieve Windows version information to determine DSR support.")
 	}
-	buildNum := fields[1]
-	buildNumInt, err := strconv.Atoi(buildNum)
-	if err != nil {
-		logrus.Fatalf("Error converting buildNum to int\nerror: %s", err)
-	}
-	hal := fields[2]
-	halVer := strings.Split(hal, ".")[3]
-	halVerInt, err := strconv.Atoi(halVer)
-	if err != nil {
-		logrus.Fatalf("Error converting halVer to int\nerror: %s", err)
-	}
+
 	supportsDSR := (winVerInt == 1809 && buildNumInt >= 17763 && halVerInt >= 1432) || (winVerInt >= 1903 && buildNumInt >= 18317)
+	logrus.WithField("supportsDSR", supportsDSR).Info("Successfully determined whether DSR is supported.")
 	// Remove the quotes when replacing with boolean values (the quotes are in so that the template is valid JSON even before replacing)
 	if supportsDSR {
 		netconf = strings.Replace(netconf, `"__DSR_SUPPORT__"`, "true", -1)


### PR DESCRIPTION
Cherry pick of #8462 on release-v3.27.

#8462: Add retry mechanism to Windows version

# Original PR Body below


## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added retry mechanism to Windows version retrieval in install-cni to address possible panics when the OS is not ready.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.