### PR TITLE
CTLB changes - v46 program will handle both v4 and v6.

### DIFF
--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -24,6 +24,19 @@ static CALI_BPF_INLINE bool is_ipv4_as_ipv6(__u32 *addr) {
 	return addr[0] == 0 && addr[1] == 0 && addr[2] == bpf_htonl(0x0000ffff);
 }
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(max_entries, 3);
+	__uint(map_flags, 0);
+}cali_ctlb_progs SEC(".maps");
+
+enum cali_ctlb_prog_index {
+	PROG_INDEX_V6_CONNECT,
+	PROG_INDEX_V6_SENDMSG,
+	PROG_INDEX_V6_RECVMSG,
+};
 
 SEC("cgroup/connect6")
 int calico_connect_v46(struct bpf_sock_addr *ctx)

--- a/felix/bpf-gpl/connect_balancer_v46.c
+++ b/felix/bpf-gpl/connect_balancer_v46.c
@@ -20,6 +20,11 @@
 #include "sendrecv.h"
 #include "connect.h"
 
+static CALI_BPF_INLINE bool is_ipv4_as_ipv6(__u32 *addr) {
+	return addr[0] == 0 && addr[1] == 0 && addr[2] == bpf_htonl(0x0000ffff);
+}
+
+
 SEC("cgroup/connect6")
 int calico_connect_v46(struct bpf_sock_addr *ctx)
 {
@@ -33,13 +38,11 @@ int calico_connect_v46(struct bpf_sock_addr *ctx)
 			ctx->user_ip6[2],
 			ctx->user_ip6[3]);
 
-	/* check if it is a IPv4 mapped as IPv6 and if so, use the v4 table */
-	if (ctx->user_ip6[0] == 0 && ctx->user_ip6[1] == 0 &&
-			ctx->user_ip6[2] == bpf_htonl(0x0000ffff)) {
+	if (is_ipv4_as_ipv6(ctx->user_ip6)) {
 		goto v4;
 	}
 
-	CALI_DEBUG("connect_v46: not implemented for v6 yet\n");
+	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_CONNECT);
 	goto out;
 
 v4:
@@ -58,8 +61,37 @@ out:
 SEC("cgroup/sendmsg6")
 int calico_sendmsg_v46(struct bpf_sock_addr *ctx)
 {
-	CALI_DEBUG("sendmsg_v46\n");
+	if (CTLB_EXCLUDE_UDP) {
+		goto out;
+	}
 
+	__be32 ipv4;
+
+	CALI_DEBUG("sendmsg_v46 ip[0-1] %x%x\n",
+			ctx->user_ip6[0],
+			ctx->user_ip6[1]);
+	CALI_DEBUG("sendmsg_v46 ip[2-3] %x%x\n",
+			ctx->user_ip6[2],
+			ctx->user_ip6[3]);
+
+	if (is_ipv4_as_ipv6(ctx->user_ip6)) {
+		goto v4;
+	}
+
+	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_SENDMSG);
+	goto out;
+
+v4:
+	ipv4 = ctx->user_ip6[3];
+	CALI_DEBUG("sendmsg_v46 %x:%d\n", bpf_ntohl(ipv4), ctx_port_to_host(ctx->user_port));
+
+	if (ctx->type != SOCK_DGRAM) {
+		CALI_INFO("unexpected sock type %d\n", ctx->type);
+		goto out;
+	}
+	do_nat_common(ctx, IPPROTO_UDP, &ipv4, false);
+
+out:
 	return 1;
 }
 
@@ -79,13 +111,11 @@ int calico_recvmsg_v46(struct bpf_sock_addr *ctx)
 			ctx->user_ip6[2],
 			ctx->user_ip6[3]);
 
-	/* check if it is a IPv4 mapped as IPv6 and if so, use the v4 table */
-	if (ctx->user_ip6[0] == 0 && ctx->user_ip6[1] == 0 &&
-			ctx->user_ip6[2] == bpf_htonl(0x0000ffff)) {
+	if (is_ipv4_as_ipv6(ctx->user_ip6)) {
 		goto v4;
 	}
 
-	CALI_DEBUG("recvmsg_v46: not implemented for v6 yet\n");
+	bpf_tail_call(ctx, &cali_ctlb_progs, PROG_INDEX_V6_RECVMSG);
 	goto out;
 
 
@@ -125,3 +155,4 @@ v4:
 out:
 	return 1;
 }
+

--- a/felix/bpf-gpl/sendrecv.h
+++ b/felix/bpf-gpl/sendrecv.h
@@ -49,6 +49,14 @@ CALI_MAP_NAMED(cali_v4_ct_nats, cali_ct_nats ,,
 		struct ct_nats_key, struct sendrec_val,
 		10000, 0)
 
+CALI_MAP_V1(cali_ctlb_progs, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 3, 0)
+
+enum cali_ctlb_prog_index {
+	PROG_INDEX_V6_CONNECT,
+	PROG_INDEX_V6_SENDMSG,
+	PROG_INDEX_V6_RECVMSG,
+};
+
 static CALI_BPF_INLINE __u16 ctx_port_to_host(__u32 port)
 {
 	return bpf_ntohl(port) >> 16;

--- a/felix/bpf-gpl/sendrecv.h
+++ b/felix/bpf-gpl/sendrecv.h
@@ -49,14 +49,6 @@ CALI_MAP_NAMED(cali_v4_ct_nats, cali_ct_nats ,,
 		struct ct_nats_key, struct sendrec_val,
 		10000, 0)
 
-CALI_MAP_V1(cali_ctlb_progs, BPF_MAP_TYPE_PROG_ARRAY, __u32, __u32, 3, 0)
-
-enum cali_ctlb_prog_index {
-	PROG_INDEX_V6_CONNECT,
-	PROG_INDEX_V6_SENDMSG,
-	PROG_INDEX_V6_RECVMSG,
-};
-
 static CALI_BPF_INLINE __u16 ctx_port_to_host(__u32 port)
 {
 	return bpf_ntohl(port) >> 16;

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -43,9 +43,9 @@ type cgroupProgs struct {
 }
 
 const (
-	CTLBConnectV6 = iota
-	CTLBSendV6
-	CTLBRecvV6
+	ProgIndexCTLBV6 = iota
+	ProgIndexCTLBSendV6
+	ProgIndexCTLBRecvV6
 )
 
 var ProgramsMapParameters = maps.MapParameters{
@@ -171,21 +171,21 @@ func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Dur
 }
 
 func updateCTLBJumpMap(name string, obj *libbpf.Obj) error {
-	err := obj.UpdateJumpMap(name, "calico_connect_v6", CTLBConnectV6)
+	err := obj.UpdateJumpMap(name, "calico_connect_v6", ProgIndexCTLBV6)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to update %s map at index %d", name, CTLBConnectV6)
+		log.WithError(err).Errorf("Failed to update %s map at index %d", name, ProgIndexCTLBV6)
 		return err
 	}
 
-	err = obj.UpdateJumpMap(name, "calico_sendmsg_v6", CTLBSendV6)
+	err = obj.UpdateJumpMap(name, "calico_sendmsg_v6", ProgIndexCTLBSendV6)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to update %s map at index %d", name, CTLBSendV6)
+		log.WithError(err).Errorf("Failed to update %s map at index %d", name, ProgIndexCTLBSendV6)
 		return err
 	}
 
-	err = obj.UpdateJumpMap(name, "calico_recvmsg_v6", CTLBRecvV6)
+	err = obj.UpdateJumpMap(name, "calico_recvmsg_v6", ProgIndexCTLBRecvV6)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to update %s map at index %d", name, CTLBRecvV6)
+		log.WithError(err).Errorf("Failed to update %s map at index %d", name, ProgIndexCTLBRecvV6)
 		return err
 	}
 	return nil

--- a/felix/bpf/nat/connecttime.go
+++ b/felix/bpf/nat/connecttime.go
@@ -42,6 +42,24 @@ type cgroupProgs struct {
 	Name        string `json:"name"`
 }
 
+const (
+	CTLBConnectV6 = iota
+	CTLBSendV6
+	CTLBRecvV6
+)
+
+var ProgramsMapParameters = maps.MapParameters{
+	Type:       "prog_array",
+	KeySize:    4,
+	ValueSize:  4,
+	MaxEntries: 3,
+	Name:       "cali_ctlb_progs",
+}
+
+func NewProgramsMap() maps.Map {
+	return maps.NewPinnedMap(ProgramsMapParameters)
+}
+
 func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 	if os.Getenv("FELIX_DebugSkipCTLBCleanup") == "true" {
 		log.Info("FV special case: skipping CTLB cleanup")
@@ -86,25 +104,20 @@ func RemoveConnectTimeLoadBalancer(cgroupv2 string) error {
 	}
 
 	bpf.CleanUpCalicoPins("/sys/fs/bpf/calico_connect4")
+	ctlbProgsMap := NewProgramsMap()
+	os.Remove(ctlbProgsMap.Path())
 
 	return nil
 }
 
-func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
-
-	progPinDir := path.Join(bpfMount, "calico_connect4")
-	_ = os.RemoveAll(progPinDir)
-
+func loadProgram(logLevel, ipver string, udpNotSeen time.Duration, excludeUDP bool) (*libbpf.Obj, error) {
 	filename := path.Join(bpfdefs.ObjectDir, ProgFileName(logLevel, ipver))
-
-	progName := "calico_" + name + "_v" + ipver
 
 	log.WithField("filename", filename).Debug("Loading object file")
 	obj, err := libbpf.OpenObject(filename)
 	if err != nil {
-		return fmt.Errorf("failed to load program %s from %s: %w", progName, filename, err)
+		return nil, fmt.Errorf("failed to load %s: %w", filename, err)
 	}
-	defer obj.Close()
 
 	for m, err := obj.FirstMap(); m != nil && err == nil; m, err = m.NextMap() {
 		// In case of global variables, libbpf creates an internal map <prog_name>.rodata
@@ -116,7 +129,7 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSe
 				continue
 			}
 			if err := libbpf.CTLBSetGlobals(m, udpNotSeen, excludeUDP); err != nil {
-				return fmt.Errorf("error setting globals: %w", err)
+				return nil, fmt.Errorf("error setting globals: %w", err)
 			}
 			continue
 		}
@@ -124,18 +137,27 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSe
 		if size := maps.Size(mapName); size != 0 {
 			err := m.SetSize(size)
 			if err != nil {
-				return fmt.Errorf("error set map size %s: %w", m.Name(), err)
+				return nil, fmt.Errorf("error set map size %s: %w", m.Name(), err)
 			}
 		}
 		if err := m.SetPinPath(path.Join(bpfdefs.GlobalPinDir, mapName)); err != nil {
-			return fmt.Errorf("error pinning map %s: %w", mapName, err)
+			return nil, fmt.Errorf("error pinning map %s: %w", mapName, err)
 		}
-		log.WithFields(log.Fields{"program": progName, "map": mapName}).Debug("Pinned map")
+		log.WithFields(log.Fields{"obj": filename, "map": mapName}).Debug("Pinned map")
 	}
 
 	if err := obj.Load(); err != nil {
-		return fmt.Errorf("error loading program %s: %w", progName, err)
+		return nil, fmt.Errorf("error loading object %s: %w", filename, err)
 	}
+	return obj, nil
+}
+
+func attachProgram(name, ipver, bpfMount, cgroupPath string, udpNotSeen time.Duration, excludeUDP bool, obj *libbpf.Obj) error {
+
+	progPinDir := path.Join(bpfMount, "calico_connect4")
+	_ = os.RemoveAll(progPinDir)
+
+	progName := "calico_" + name + "_v" + ipver
 
 	// N.B. no need to remember the link since we are never going to detach
 	// these programs unless Felix restarts.
@@ -148,7 +170,28 @@ func installProgram(name, ipver, bpfMount, cgroupPath, logLevel string, udpNotSe
 	return nil
 }
 
-func InstallConnectTimeLoadBalancer(ipFamily int, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
+func updateCTLBJumpMap(name string, obj *libbpf.Obj) error {
+	err := obj.UpdateJumpMap(name, "calico_connect_v6", CTLBConnectV6)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to update %s map at index %d", name, CTLBConnectV6)
+		return err
+	}
+
+	err = obj.UpdateJumpMap(name, "calico_sendmsg_v6", CTLBSendV6)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to update %s map at index %d", name, CTLBSendV6)
+		return err
+	}
+
+	err = obj.UpdateJumpMap(name, "calico_recvmsg_v6", CTLBRecvV6)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to update %s map at index %d", name, CTLBRecvV6)
+		return err
+	}
+	return nil
+}
+
+func InstallConnectTimeLoadBalancer(ipv4Enabled, ipv6Enabled bool, cgroupv2 string, logLevel string, udpNotSeen time.Duration, excludeUDP bool) error {
 
 	bpfMount, err := utils.MaybeMountBPFfs()
 	if err != nil {
@@ -161,60 +204,93 @@ func InstallConnectTimeLoadBalancer(ipFamily int, cgroupv2 string, logLevel stri
 		return errors.Wrap(err, "failed to set-up cgroupv2")
 	}
 
-	switch ipFamily {
-	case 4:
-		err = installProgram("connect", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, excludeUDP)
+	ctlbProgsMap := NewProgramsMap()
+	var v4Obj, v46Obj, v6Obj *libbpf.Obj
+
+	// Load the v6 CTLB program.
+	if ipv6Enabled {
+		v6Obj, err = loadProgram(logLevel, "6", udpNotSeen, excludeUDP)
 		if err != nil {
 			return err
 		}
-
-		err = installProgram("connect", "46", bpfMount, cgroupPath, logLevel, udpNotSeen, excludeUDP)
-		if err != nil {
-			return err
-		}
-
-		if !excludeUDP {
-			err = installProgram("sendmsg", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
-			if err != nil {
-				return err
-			}
-
-			err = installProgram("recvmsg", "4", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
-			if err != nil {
-				return err
-			}
-
-			err = installProgram("sendmsg", "46", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
-			if err != nil {
-				return err
-			}
-
-			err = installProgram("recvmsg", "46", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
-			if err != nil {
-				return err
-			}
-		}
-	case 6:
-		err = installProgram("connect", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, excludeUDP)
-		if err != nil {
-			return err
-		}
-
-		if !excludeUDP {
-			err = installProgram("sendmsg", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
-			if err != nil {
-				return err
-			}
-
-			err = installProgram("recvmsg", "6", bpfMount, cgroupPath, logLevel, udpNotSeen, false)
-			if err != nil {
-				return err
-			}
-		}
-	default:
-		return fmt.Errorf("unrecognized ip family %d", ipFamily)
+		defer v6Obj.Close()
 	}
 
+	// Load and attach v4, v46 CTLB program.
+	if ipv4Enabled {
+		v4Obj, err = loadProgram(logLevel, "4", udpNotSeen, excludeUDP)
+		if err != nil {
+			return err
+		}
+		defer v4Obj.Close()
+
+		v46Obj, err = loadProgram(logLevel, "46", udpNotSeen, excludeUDP)
+		if err != nil {
+			return err
+		}
+		defer v46Obj.Close()
+		err = attachProgram("connect", "4", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v4Obj)
+		if err != nil {
+			return err
+		}
+		err = attachProgram("connect", "46", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v46Obj)
+		if err != nil {
+			return err
+		}
+
+		if !excludeUDP {
+			err = attachProgram("sendmsg", "4", bpfMount, cgroupPath, udpNotSeen, false, v4Obj)
+			if err != nil {
+				return err
+			}
+
+			err = attachProgram("recvmsg", "4", bpfMount, cgroupPath, udpNotSeen, false, v4Obj)
+			if err != nil {
+				return err
+			}
+
+			err = attachProgram("sendmsg", "46", bpfMount, cgroupPath, udpNotSeen, false, v46Obj)
+			if err != nil {
+				return err
+			}
+
+			err = attachProgram("recvmsg", "46", bpfMount, cgroupPath, udpNotSeen, false, v46Obj)
+			if err != nil {
+				return err
+			}
+		}
+		// If dual-stack, populate the jump maps with v6 ctlb programs.
+		if v6Obj != nil {
+			if err := ctlbProgsMap.EnsureExists(); err != nil {
+				log.WithError(err).Error("Failed to create CTLB programs maps")
+				return err
+			}
+			err = updateCTLBJumpMap(ctlbProgsMap.GetName(), v6Obj)
+			if err != nil {
+				return err
+			}
+		} else {
+			//delete the jump map
+			os.Remove(ctlbProgsMap.Path())
+		}
+		return nil
+	}
+	err = attachProgram("connect", "6", bpfMount, cgroupPath, udpNotSeen, excludeUDP, v6Obj)
+	if err != nil {
+		return err
+	}
+
+	if !excludeUDP {
+		err = attachProgram("sendmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj)
+		if err != nil {
+			return err
+		}
+
+		err = attachProgram("recvmsg", "6", bpfMount, cgroupPath, udpNotSeen, false, v6Obj)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -841,12 +841,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				}
 			}
 
-			ipFamily := 4
-			if config.BPFIpv6Enabled {
-				ipFamily = 6
-			}
 			// Activate the connect-time load balancer.
-			err = bpfnat.InstallConnectTimeLoadBalancer(ipFamily,
+			err = bpfnat.InstallConnectTimeLoadBalancer(true, config.BPFIpv6Enabled,
 				config.BPFCgroupV2, logLevel, config.BPFConntrackTimeouts.UDPLastSeen, excludeUDP)
 			if err != nil {
 				log.WithError(err).Panic("BPFConnTimeLBEnabled but failed to attach connect-time load balancer, bailing out.")


### PR DESCRIPTION
## Description

This PR addresses the below scenarios related to CTLB for dual stack.

 1. V6 programs are loaded into the jump map when in dual stack mode.
 2. v46 program handles both IPv4 masqueraded as ipv6 and real IPv6. when receiving an IPv6 packet, v46 program jumps to the v6 program.
 
Also the CTLB object files are loaded once.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
