### PR TITLE
[BPF] use a label to clean up conntrack to terminating udp backends

### DIFF
--- a/felix/bpf/proxy/proxy.go
+++ b/felix/bpf/proxy/proxy.go
@@ -173,7 +173,7 @@ func New(k8s kubernetes.Interface, dp DPSyncer, hostname string, opts ...Option)
 		p.recorder,
 		nil,
 	)
-	p.svcChanges = k8sp.NewServiceChangeTracker(nil, ipVersion, p.recorder, nil)
+	p.svcChanges = k8sp.NewServiceChangeTracker(makeServiceInfo, ipVersion, p.recorder, nil)
 
 	noProxyName, err := labels.NewRequirement(apis.LabelServiceProxyName, selection.DoesNotExist, nil)
 	if err != nil {
@@ -361,4 +361,40 @@ func (is *initState) setEpsSynced() {
 type loggerRecorder struct{}
 
 func (r *loggerRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+}
+
+const (
+	ReapTerminatingUDPAnnotation   = "projectcalico.org/udpConntrackCleanup"
+	ReapTerminatingUDPImmediatelly = "terminatingImmediately"
+)
+
+type ServiceAnnotations interface {
+	ReapTerminatingUDP() bool
+}
+
+type servicePortAnnotations struct {
+	reapTerminatingUDP bool
+}
+
+func (s *servicePortAnnotations) ReapTerminatingUDP() bool {
+	return s.reapTerminatingUDP
+}
+
+type servicePort struct {
+	k8sp.ServicePort
+	servicePortAnnotations
+}
+
+func makeServiceInfo(_ *v1.ServicePort, s *v1.Service, baseSvc *k8sp.BaseServicePortInfo) k8sp.ServicePort {
+	svc := &servicePort{
+		ServicePort: baseSvc,
+	}
+
+	if baseSvc.Protocol() == v1.ProtocolUDP {
+		if v, ok := s.ObjectMeta.Annotations[ReapTerminatingUDPAnnotation]; ok && v == ReapTerminatingUDPImmediatelly {
+			svc.reapTerminatingUDP = true
+		}
+	}
+
+	return svc
 }


### PR DESCRIPTION
When a backend pod of a service is in terminating state, we keep existing connections as that pod is likely in a terminating grace period. However, a pod may get stuck in terminating state. New connections are not directed to that pod and if there is no connectivity to the pod TCP will fail eventually and new connections will select another backend. However UDP follows the established conntrack. So labeling a service with

projectcalico.org/udpConntrackCleanup = terminatingImmediately

would ensure that we clean up conntrack entries towards this backend once it becomes terminating. This make the dataplane pick another backend once there is a conntrack miss, which unblocks the client.

Fixes https://github.com/projectcalico/calico/issues/8423

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
