### PR TITLE
Stop calicoctl node run from executing the token watcher.

### DIFF
--- a/calicoctl/calicoctl/commands/node/run.go
+++ b/calicoctl/calicoctl/commands/node/run.go
@@ -108,14 +108,14 @@ Options:
                            > interface=<IFACE NAME REGEX LIST>
                              Use the first valid IP address found on interfaces
                              named as per the first matching supplied interface
-			     name regex. Regexes are separated by commas
-			     (e.g. eth.*,enp0s.*).
-			   > skip-interface=<IFACE NAME REGEX LIST>
-			     Use the first valid IP address on the first
-			     enumerated interface (same logic as first-found
-			     above) that does NOT match with any of the
-			     specified interface name regexes. Regexes are
-			     separated by commas (e.g. eth.*,enp0s.*).
+                             name regex. Regexes are separated by commas
+                             (e.g. eth.*,enp0s.*).
+                           > skip-interface=<IFACE NAME REGEX LIST>
+                             Use the first valid IP address on the first
+                             enumerated interface (same logic as first-found
+                             above) that does NOT match with any of the
+                             specified interface name regexes. Regexes are
+                             separated by commas (e.g. eth.*,enp0s.*).
                            [default: first-found]
      --ip6-autodetection-method=<IP6_AUTODETECTION_METHOD>
                            Specify the autodetection method for detecting the
@@ -145,7 +145,7 @@ Options:
                            Path to the file containing Felix
                            configuration in YAML or JSON format.
      --allow-version-mismatch
-	                       Allow client and cluster versions mismatch.
+                           Allow client and cluster versions mismatch.
 
 Description:
   This command is used to start a calico/node container instance which provides
@@ -238,6 +238,8 @@ Description:
 	envs := map[string]string{
 		"NODENAME":                  name,
 		"CALICO_NETWORKING_BACKEND": backend,
+		// Disable CNI management, it is only supported inside k8s.
+		"CALICO_MANAGE_CNI": "false",
 	}
 
 	if nopools {

--- a/node/tests/st/utils/docker_host.py
+++ b/node/tests/st/utils/docker_host.py
@@ -354,7 +354,7 @@ class DockerHost(object):
             if FELIX_LOGLEVEL != "":
                 felix_logsetting = " -e FELIX_LOGSEVERITYSCREEN=" + FELIX_LOGLEVEL
 
-            # Construct the calicoctl command that we want, including the
+            # Construct the docker command that we want, including the
             # CALICO_IPV4POOL_CIDR setting.
             modified_cmd = (
                 prefix +


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
It is only supported when run as a Pod.  It makes a lot of log spam when run outside of k8s (as the node ST tests do).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
calicoctl node run no longer executes the Kubernetes token watcher, which can only run inside a Kubernetes pod.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
