### PR TITLE
[release-v3.27] Auto pick #8416: bump iptables version to v1.8.8

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -13,8 +13,8 @@
 # limitations under the License.
 ARG ARCH=x86_64
 ARG GIT_VERSION=unknown
-ARG IPTABLES_VER=1.8.4-17
-ARG LIBNFTNL_VER=1.1.5-4
+ARG IPTABLES_VER=1.8.8-6
+ARG LIBNFTNL_VER=1.2.2-1
 ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
 ARG BIRD_IMAGE=calico/bird:latest
@@ -33,11 +33,11 @@ ARG IPTABLES_VER
 ARG LIBNFTNL_VER
 ARG IPSET_VER
 ARG RUNIT_VER
-ARG CENTOS_MIRROR_BASE_URL=http://linuxsoft.cern.ch/centos-vault/8.4.2105
-ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/libnftnl-${LIBNFTNL_VER}.el8.src.rpm
-ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/iptables-${IPTABLES_VER}.el8.src.rpm
-ARG STREAM9_MIRROR_BASE_URL=https://iad.mirror.rackspace.com/centos-stream/9-stream
-ARG IPSET_SOURCERPM_URL=${STREAM9_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
+ARG CENTOS_MIRROR_BASE_URL=https://linuxsoft.cern.ch/cern/centos/s9
+ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/libnftnl-${LIBNFTNL_VER}.el9.src.rpm
+ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/iptables-${IPTABLES_VER}.el9.src.rpm
+ARG IPTABLES_LEGACY_SOURCERPM_URL=https://dl.fedoraproject.org/pub/epel/9/Everything/source/tree/Packages/i/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
+ARG IPSET_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.
 RUN dnf install -y 'dnf-command(config-manager)' && \
@@ -62,34 +62,13 @@ RUN rpm -i ${LIBNFTNL_SOURCERPM_URL} && \
     rpm -Uv /root/rpmbuild/RPMS/${ARCH}/libnftnl-devel-${LIBNFTNL_VER}.el8.${ARCH}.rpm && \
     # Install source RPM for iptables and install its build dependencies.
     rpm -i ${IPTABLES_SOURCERPM_URL} && \
-    yum-builddep -y --spec /root/rpmbuild/SPECS/iptables.spec
-
-# Patch the iptables build spec so that we keep the legacy iptables binaries.
-RUN sed -i '/drop all legacy tools/,/sbindir.*legacy/d' /root/rpmbuild/SPECS/iptables.spec
-
-# Patch the iptables build spec to drop the renaming of nft binaries. Instead of renaming binaries,
-# we will use alternatives to set the canonical iptables binaries.
-RUN sed -i '/rename nft versions to standard name/,/^done/d' /root/rpmbuild/SPECS/iptables.spec
-
-# Patch the iptables build spec so that legacy and nft iptables binaries are verified to be in the resulting rpm.
-RUN sed -i '/%files$/a \
-\%\{_sbindir\}\/xtables-legacy-multi \n\
-\%\{_sbindir\}\/ip6tables-legacy \n\
-\%\{_sbindir\}\/ip6tables-legacy-restore \n\
-\%\{_sbindir\}\/ip6tables-legacy-save \n\
-\%\{_sbindir\}\/iptables-legacy \n\
-\%\{_sbindir\}\/iptables-legacy-restore \n\
-\%\{_sbindir\}\/iptables-legacy-save \n\
-\%\{_sbindir\}\/ip6tables-nft\n\
-\%\{_sbindir\}\/ip6tables-nft-restore\n\
-\%\{_sbindir\}\/ip6tables-nft-save\n\
-\%\{_sbindir\}\/iptables-nft\n\
-\%\{_sbindir\}\/iptables-nft-restore\n\
-\%\{_sbindir\}\/iptables-nft-save\n\
-' /root/rpmbuild/SPECS/iptables.spec
-
-# Finally rebuild iptables.
-RUN rpmbuild -bb /root/rpmbuild/SPECS/iptables.spec
+    yum-builddep -y --spec /root/rpmbuild/SPECS/iptables.spec && \
+    rpmbuild -bb /root/rpmbuild/SPECS/iptables.spec && \
+    # iptables-legacy has been deprecated, but to keep the backwards compatibility
+    # we need install source RPM for iptables-legacy and install its build dependencies.
+    rpm -i ${IPTABLES_LEGACY_SOURCERPM_URL} && \
+    yum-builddep -y --spec /root/rpmbuild/SPECS/iptables-epel.spec && \
+    rpmbuild -bb /root/rpmbuild/SPECS/iptables-epel.spec 
 
 # Install source RPM for ipset and install its build dependencies.
 RUN rpm -i ${IPSET_SOURCERPM_URL} && \
@@ -163,9 +142,12 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     # Install iptables via rpms. The libs must be force installed because the iptables source RPM has the release
     # version '9.el8_0.1' while the existing iptables-libs (pulled in by the iputils package) has version '9.el8.1'.
     rpm --force -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.${ARCH}.rpm && \
+    rpm --force -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.${ARCH}.rpm && \
     # Install compatible libnftnl version with selected iptables version
     rpm --force -i /tmp/rpms/libnftnl-${LIBNFTNL_VER}.el8.${ARCH}.rpm && \
-    rpm -i /tmp/rpms/iptables-${IPTABLES_VER}.el8.${ARCH}.rpm && \
+    # Install both and select at runtime.
+    rpm -i /tmp/rpms/iptables-legacy-${IPTABLES_VER}.el8.2.${ARCH}.rpm && \
+    rpm -i /tmp/rpms/iptables-nft-${IPTABLES_VER}.el8.${ARCH}.rpm && \
     # Install ipset version
     rpm --force -i /tmp/rpms/ipset-libs-${IPSET_VER}.el8.x86_64.rpm && \
     rpm -i /tmp/rpms/ipset-${IPSET_VER}.el8.x86_64.rpm && \

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -13,8 +13,8 @@
 # limitations under the License.
 ARG ARCH=aarch64
 ARG GIT_VERSION=unknown
-ARG IPTABLES_VER=1.8.4-17
-ARG LIBNFTNL_VER=1.1.5-4
+ARG IPTABLES_VER=1.8.8-6
+ARG LIBNFTNL_VER=1.2.2-1
 ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
 ARG QEMU_IMAGE
@@ -37,11 +37,11 @@ ARG IPTABLES_VER
 ARG LIBNFTNL_VER
 ARG IPSET_VER
 ARG RUNIT_VER
-ARG CENTOS_MIRROR_BASE_URL=http://linuxsoft.cern.ch/centos-vault/8.4.2105
-ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/libnftnl-${LIBNFTNL_VER}.el8.src.rpm
-ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/Source/SPackages/iptables-${IPTABLES_VER}.el8.src.rpm
-ARG STREAM9_MIRROR_BASE_URL=https://iad.mirror.rackspace.com/centos-stream/9-stream
-ARG IPSET_SOURCERPM_URL=${STREAM9_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
+ARG CENTOS_MIRROR_BASE_URL=https://linuxsoft.cern.ch/cern/centos/s9
+ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/libnftnl-${LIBNFTNL_VER}.el9.src.rpm
+ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/iptables-${IPTABLES_VER}.el9.src.rpm
+ARG IPTABLES_LEGACY_SOURCERPM_URL=https://dl.fedoraproject.org/pub/epel/9/Everything/source/tree/Packages/i/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
+ARG IPSET_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.
 RUN dnf install -y 'dnf-command(config-manager)' && \
@@ -66,34 +66,13 @@ RUN rpm -i ${LIBNFTNL_SOURCERPM_URL} && \
     rpm -Uv /root/rpmbuild/RPMS/${ARCH}/libnftnl-devel-${LIBNFTNL_VER}.el8.${ARCH}.rpm && \
     # Install source RPM for iptables and install its build dependencies.
     rpm -i ${IPTABLES_SOURCERPM_URL} && \
-    yum-builddep -y --spec /root/rpmbuild/SPECS/iptables.spec
-
-# Patch the iptables build spec so that we keep the legacy iptables binaries.
-RUN sed -i '/drop all legacy tools/,/sbindir.*legacy/d' /root/rpmbuild/SPECS/iptables.spec
-
-# Patch the iptables build spec to drop the renaming of nft binaries. Instead of renaming binaries,
-# we will use alternatives to set the canonical iptables binaries.
-RUN sed -i '/rename nft versions to standard name/,/^done/d' /root/rpmbuild/SPECS/iptables.spec
-
-# Patch the iptables build spec so that legacy and nft iptables binaries are verified to be in the resulting rpm.
-RUN sed -i '/%files$/a \
-\%\{_sbindir\}\/xtables-legacy-multi \n\
-\%\{_sbindir\}\/ip6tables-legacy \n\
-\%\{_sbindir\}\/ip6tables-legacy-restore \n\
-\%\{_sbindir\}\/ip6tables-legacy-save \n\
-\%\{_sbindir\}\/iptables-legacy \n\
-\%\{_sbindir\}\/iptables-legacy-restore \n\
-\%\{_sbindir\}\/iptables-legacy-save \n\
-\%\{_sbindir\}\/ip6tables-nft\n\
-\%\{_sbindir\}\/ip6tables-nft-restore\n\
-\%\{_sbindir\}\/ip6tables-nft-save\n\
-\%\{_sbindir\}\/iptables-nft\n\
-\%\{_sbindir\}\/iptables-nft-restore\n\
-\%\{_sbindir\}\/iptables-nft-save\n\
-' /root/rpmbuild/SPECS/iptables.spec
-
-# Finally rebuild iptables.
-RUN rpmbuild -bb /root/rpmbuild/SPECS/iptables.spec
+    yum-builddep -y --spec /root/rpmbuild/SPECS/iptables.spec && \
+    rpmbuild -bb /root/rpmbuild/SPECS/iptables.spec && \
+    # iptables-legacy has been deprecated, but to keep the backwards compatibility
+    # we need install source RPM for iptables-legacy and install its build dependencies.
+    rpm -i ${IPTABLES_LEGACY_SOURCERPM_URL} && \
+    yum-builddep -y --spec /root/rpmbuild/SPECS/iptables-epel.spec && \
+    rpmbuild -bb /root/rpmbuild/SPECS/iptables-epel.spec 
 
 # Install source RPM for ipset and install its build dependencies.
 RUN rpm -i ${IPSET_SOURCERPM_URL} && \
@@ -183,9 +162,12 @@ RUN rm /etc/yum.repos.d/ubi.repo && \
     # Install iptables via rpms. The libs must be force installed because the iptables source RPM has the release
     # version '9.el8_0.1' while the existing iptables-libs (pulled in by the iputils package) has version '9.el8.1'.
     rpm --force -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.${ARCH}.rpm && \
+    rpm --force -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.${ARCH}.rpm && \
     # Install compatible libnftnl version with selected iptables version
     rpm --force -i /tmp/rpms/libnftnl-${LIBNFTNL_VER}.el8.${ARCH}.rpm && \
-    rpm -i /tmp/rpms/iptables-${IPTABLES_VER}.el8.${ARCH}.rpm && \
+    # Install both and select at runtime.
+    rpm -i /tmp/rpms/iptables-legacy-${IPTABLES_VER}.el8.2.${ARCH}.rpm && \
+    rpm -i /tmp/rpms/iptables-nft-${IPTABLES_VER}.el8.${ARCH}.rpm && \
     # Install ipset version
     rpm --force -i /tmp/rpms/ipset-libs-${IPSET_VER}.el8.${ARCH}.rpm && \
     rpm -i /tmp/rpms/ipset-${IPSET_VER}.el8.${ARCH}.rpm && \


### PR DESCRIPTION
Cherry pick of #8416 on release-v3.27.

#8416: bump iptables version to v1.8.8

# Original PR Body below

## Description

Currently, the iptables version of calico-node is 1.8.4, The `iptables-nft-save -t raw` are incompatible. This patch will bump iptables to 1.8.8, which can solve the incompatible issue.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/8403

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Bump iptables version of calico-node to 1.8.8
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.