### PR TITLE
[release-v3.27] Auto pick #8447: Improvements to cni-plugin binaries

### DIFF
--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -75,34 +75,40 @@ ifeq ($(ARCH),amd64)
 WINDOWS_BIN=bin/windows
 build: $(WINDOWS_BIN)/install.exe $(WINDOWS_BIN)/calico.exe $(WINDOWS_BIN)/calico-ipam.exe
 endif
-# If ARCH is arm based, find the requested version/variant
-ifeq ($(word 1,$(subst v, ,$(ARCH))),arm)
-ARM_VERSION := $(word 2,$(subst v, ,$(ARCH)))
-endif
-# Define go architecture flags to support arm variants
-GOARCH_FLAGS :=-e GOARCH=$(ARCH)
-ifdef ARM_VERSION
-GOARCH_FLAGS :=-e GOARCH=arm -e GOARM=$(ARM_VERSION)
-endif
 
 build-all: $(addprefix sub-build-,$(VALIDARCHES))
 sub-build-%:
 	$(MAKE) build ARCH=$*
 
-## Build the Calico network plugin and ipam plugins
+## Build the Calico installation binary for the network and ipam plugins
 $(BIN)/install binary: $(SRC_FILES)
 ifeq ($(FIPS),true)
+	$(call build_cgo_boring_binary, $(PACKAGE_NAME)/cmd/install, $@)
+else
+	$(call build_binary, $(PACKAGE_NAME)/cmd/install, $@)
+endif
+
+## Build the Calico network and ipam plugins
+$(BIN)/calico: $(SRC_FILES)
+ifeq ($(FIPS), true)
 	$(call build_cgo_boring_binary, $(PACKAGE_NAME)/cmd/calico, $@)
 else
 	$(call build_binary, $(PACKAGE_NAME)/cmd/calico, $@)
 endif
 
-## Build the Calico network plugin and ipam plugins for Windows
+$(BIN)/calico-ipam: $(BIN)/calico
+	cp "$<" "$@"
+
+## Build the Calico network and ipam plugins for Windows
 $(WINDOWS_BIN)/install.exe: $(SRC_FILES)
+	mkdir -p $(WINDOWS_BIN)
+	$(call build_windows_binary, $(PACKAGE_NAME)/cmd/install, $@)
+
+$(WINDOWS_BIN)/calico.exe: $(SRC_FILES)
 	mkdir -p $(WINDOWS_BIN)
 	$(call build_windows_binary, $(PACKAGE_NAME)/cmd/calico, $@)
 
-$(WINDOWS_BIN)/calico-ipam.exe $(WINDOWS_BIN)/calico.exe: $(WINDOWS_BIN)/install.exe
+$(WINDOWS_BIN)/calico-ipam.exe: $(WINDOWS_BIN)/calico.exe
 	cp "$<" "$@"
 
 # NOTE: WINDOWS_IMAGE_REQS must be defined with the requirements to build the windows
@@ -159,9 +165,6 @@ $(WINDOWS_BIN)/flannel.exe:
 ut: run-k8s-controller-manager $(BIN)/install $(BIN)/host-local $(BIN)/calico-ipam $(BIN)/calico
 	$(MAKE) ut-datastore DATASTORE_TYPE=etcdv3
 	$(MAKE) ut-datastore DATASTORE_TYPE=kubernetes
-
-$(BIN)/calico-ipam $(BIN)/calico: $(BIN)/install
-	cp "$<" "$@"
 
 ut-datastore:
 	# The tests need to run as root

--- a/cni-plugin/cmd/install/install.go
+++ b/cni-plugin/cmd/install/install.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018,2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2023 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,25 +15,17 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
+	"github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/cni-plugin/pkg/ipamplugin"
-	"github.com/projectcalico/calico/cni-plugin/pkg/plugin"
+	"github.com/projectcalico/calico/cni-plugin/pkg/install"
 )
 
 // VERSION is filled out during the build process (using git describe output)
 var VERSION string
 
 func main() {
-	// Use the name of the binary to determine which routine to run.
-	_, filename := filepath.Split(os.Args[0])
-	switch filename {
-	case "calico", "calico.exe":
-		plugin.Main(VERSION)
-	case "calico-ipam", "calico-ipam.exe":
-		ipamplugin.Main(VERSION)
-	default:
-		panic("Unknown binary name: " + filename)
+	err := install.Install()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error installing CNI plugin")
 	}
 }


### PR DESCRIPTION
Cherry pick of #8447 on release-v3.27.

#8447: Improvements to cni-plugin binaries

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.