### PR TITLE
Fix felix/bpf-gpl amd64 build with newer glibc headers

### DIFF
--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -43,9 +43,9 @@ CFLAGS +=  \
 TRIPLET := $(shell gcc -dumpmachine)
 CFLAGS += -I/usr/include/$(TRIPLET)
 
-ifeq ($(ARCH),amd64)
-	CFLAGS += -D__TARGET_ARCH_x86
-else ifeq ($(ARCH),arm64)
+ifeq ($(findstring x86_64,$(TRIPLET)),x86_64)
+	CFLAGS += -D__TARGET_ARCH_x86 -D__x86_64__
+else ifeq ($(findstring aarch64,$(TRIPLET)),aarch64)
 	CFLAGS += -D__TARGET_ARCH_arm64
 endif
 CC := clang-16


### PR DESCRIPTION
## Description

This change fixes `felix/bpf-gpl` build for amd64 with newer glibc headers shipped in systems like Debian 11 (glibc v2.31) or RHEL 9 (glibc v2.34).

It doesn't seem to affect builds with current RHEL 8 (glibc v2.28) toolchain in `calico/go-build:v0.90`.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
