### PR TITLE
Run 2 copies of BPF DP components, one for v4 and one for v6

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -271,7 +271,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		endpointToHostAction string
 		dataIfacePattern     string
 		workloadIfaceRegex   string
-		ipSetIDAllocator     *idalloc.IDAllocator
+		ipSetIDAllocatorV4   *idalloc.IDAllocator
+		ipSetIDAllocatorV6   *idalloc.IDAllocator
 		vxlanMTU             int
 		nodePortDSR          bool
 		maps                 *bpfmap.Maps
@@ -291,7 +292,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		endpointToHostAction = "DROP"
 		dataIfacePattern = "^eth0"
 		workloadIfaceRegex = "cali"
-		ipSetIDAllocator = idalloc.New()
+		ipSetIDAllocatorV4 = idalloc.New()
+		ipSetIDAllocatorV6 = idalloc.New()
 		vxlanMTU = 0
 		nodePortDSR = true
 
@@ -378,7 +380,8 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			maps,
 			fibLookupEnabled,
 			regexp.MustCompile(workloadIfaceRegex),
-			ipSetIDAllocator,
+			ipSetIDAllocatorV4,
+			ipSetIDAllocatorV6,
 			ruleRenderer,
 			filterTableV4,
 			nil,

--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -95,11 +95,11 @@ type bpfRouteManager struct {
 
 	opReporter logutils.OpRecorder
 
-	wgEnabled   bool
-	ipv6Enabled bool
+	wgEnabled bool
+	ipFamily  proto.IPVersion
 }
 
-func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps,
+func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps, ipFamily proto.IPVersion,
 	opReporter logutils.OpRecorder) *bpfRouteManager {
 
 	// Record the external node CIDRs and pre-mark them as dirty.  These can only change with a config update,
@@ -116,11 +116,17 @@ func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps,
 			log.WithError(err).WithField("cidr", cidr).Error(
 				"Failed to parse external node CIDR (which should have been validated already).")
 		}
-		if !config.BPFIpv6Enabled {
+
+		if ipFamily == proto.IPVersion_IPV4 {
 			if _, ok := cidr.(ip.V4CIDR); !ok {
 				continue
 			}
+		} else {
+			if _, ok := cidr.(ip.V6CIDR); !ok {
+				continue
+			}
 		}
+
 		extCIDRs.Add(cidr)
 		log.WithField("cidr", cidr).Debugf("newBPFRouteManager 1")
 		dirtyCIDRs.Add(cidr)
@@ -137,8 +143,13 @@ func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps,
 			log.WithError(err).WithField("cidr", cidr).Error(
 				"Failed to parse DSR optout CIDR (which should have been validated already).")
 		}
-		if !config.BPFIpv6Enabled {
+
+		if ipFamily == proto.IPVersion_IPV4 {
 			if _, ok := cidr.(ip.V4CIDR); !ok {
+				continue
+			}
+		} else {
+			if _, ok := cidr.(ip.V6CIDR); !ok {
 				continue
 			}
 		}
@@ -169,11 +180,11 @@ func newBPFRouteManager(config *Config, maps *bpfmap.IPMaps,
 
 		opReporter: opReporter,
 
-		wgEnabled:   config.Wireguard.Enabled || config.Wireguard.EnabledV6,
-		ipv6Enabled: config.BPFIpv6Enabled,
+		wgEnabled: config.Wireguard.Enabled || config.Wireguard.EnabledV6,
+		ipFamily:  ipFamily,
 	}
 
-	if m.ipv6Enabled {
+	if ipFamily == proto.IPVersion_IPV6 {
 		m.bpfOps.NewKey = routes.NewKeyV6Intf
 		m.bpfOps.NewValue = routes.NewValueV6Intf
 		m.bpfOps.NewValueWithNextHop = routes.NewValueV6IntfWithNextHop
@@ -247,12 +258,12 @@ func (m *bpfRouteManager) CompleteDeferredWork() error {
 func (m *bpfRouteManager) recalculateRoutesForDirtyCIDRs() {
 	m.dirtyCIDRs.Iter(func(cidr ip.CIDR) error {
 		// Ignore IPv4 routes if IPv6 is enabled and vice-versa.
-		if m.ipv6Enabled {
-			if _, ok := cidr.(ip.V4CIDR); ok {
+		if m.ipFamily == proto.IPVersion_IPV4 {
+			if _, ok := cidr.(ip.V4CIDR); !ok {
 				return set.RemoveItem
 			}
 		} else {
-			if _, ok := cidr.(ip.V6CIDR); ok {
+			if _, ok := cidr.(ip.V6CIDR); !ok {
 				return set.RemoveItem
 			}
 		}
@@ -520,8 +531,12 @@ func (m *bpfRouteManager) onIfaceAddrsUpdate(update *ifaceAddrsUpdate) {
 		newCIDRs = set.New[ip.CIDR]()
 		update.Addrs.Iter(func(cidrStr string) error {
 			cidr := ip.MustParseCIDROrIP(cidrStr)
-			if !m.ipv6Enabled {
+			if m.ipFamily == proto.IPVersion_IPV4 {
 				if _, ok := cidr.(ip.V4CIDR); !ok {
+					return nil
+				}
+			} else {
+				if _, ok := cidr.(ip.V6CIDR); !ok {
 					return nil
 				}
 			}
@@ -588,8 +603,12 @@ func (m *bpfRouteManager) onHostIPsChange(newIPs []net.IP) {
 
 func (m *bpfRouteManager) onRouteUpdate(update *proto.RouteUpdate) {
 	cidr := ip.MustParseCIDROrIP(update.Dst)
-	if !m.ipv6Enabled {
+	if m.ipFamily == proto.IPVersion_IPV4 {
 		if _, ok := cidr.(ip.V4CIDR); !ok {
+			return
+		}
+	} else {
+		if _, ok := cidr.(ip.V6CIDR); !ok {
 			return
 		}
 	}
@@ -610,12 +629,15 @@ func (m *bpfRouteManager) onRouteUpdate(update *proto.RouteUpdate) {
 
 func (m *bpfRouteManager) onRouteRemove(update *proto.RouteRemove) {
 	cidr := ip.MustParseCIDROrIP(update.Dst)
-	if !m.ipv6Enabled {
+	if m.ipFamily == proto.IPVersion_IPV4 {
 		if _, ok := cidr.(ip.V4CIDR); !ok {
 			return
 		}
+	} else {
+		if _, ok := cidr.(ip.V6CIDR); !ok {
+			return
+		}
 	}
-
 	if _, ok := m.cidrToRoute[cidr]; ok {
 		// Check the entry is in the cache before removing and flagging as dirty.
 		delete(m.cidrToRoute, cidr)
@@ -679,7 +701,7 @@ func (m *bpfRouteManager) getWorkloadCIDRs(wep *proto.WorkloadEndpoint) (cidrs [
 	if wep == nil {
 		return
 	}
-	if m.ipv6Enabled {
+	if m.ipFamily == proto.IPVersion_IPV6 {
 		for _, addr := range wep.Ipv6Nets {
 			cidrs = append(cidrs, ip.MustParseCIDROrIP(addr))
 		}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -669,13 +669,15 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		// Register map managers first since they create the maps that will be used by the endpoint manager.
 		// Important that we create the maps before we load a BPF program with TC since we make sure the map
 		// metadata name is set whereas TC doesn't set that field.
-		ipSetIDAllocator := idalloc.New()
+		var ipSetIDAllocatorV4, ipSetIDAllocatorV6 *idalloc.IDAllocator
+		ipSetIDAllocatorV4 = idalloc.New()
 
 		// Start IPv4 BPF dataplane components
-		startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocator, config, ipsetsManager, dp)
+		startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocatorV4, config, ipsetsManager, dp)
 		if config.BPFIpv6Enabled {
 			// Start IPv6 BPF dataplane components
-			startBPFDataplaneComponents(proto.IPVersion_IPV6, bpfMaps.V6, ipSetIDAllocator, config, ipsetsManagerV6, dp)
+			ipSetIDAllocatorV6 = idalloc.New()
+			startBPFDataplaneComponents(proto.IPVersion_IPV6, bpfMaps.V6, ipSetIDAllocatorV6, config, ipsetsManagerV6, dp)
 		}
 
 		filterTbl := filterTableV4
@@ -700,7 +702,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			bpfMaps,
 			fibLookupEnabled,
 			workloadIfaceRegex,
-			ipSetIDAllocator,
+			ipSetIDAllocatorV4,
+			ipSetIDAllocatorV6,
 			ruleRenderer,
 			filterTbl,
 			dp.reportHealth,

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -671,10 +671,11 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		// metadata name is set whereas TC doesn't set that field.
 		ipSetIDAllocator := idalloc.New()
 
+		// Start IPv4 BPF dataplane components
+		startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocator, config, ipsetsManager, dp)
 		if config.BPFIpv6Enabled {
+			// Start IPv6 BPF dataplane components
 			startBPFDataplaneComponents(proto.IPVersion_IPV6, bpfMaps.V6, ipSetIDAllocator, config, ipsetsManagerV6, dp)
-		} else {
-			startBPFDataplaneComponents(proto.IPVersion_IPV4, bpfMaps.V4, ipSetIDAllocator, config, ipsetsManager, dp)
 		}
 
 		filterTbl := filterTableV4
@@ -2339,7 +2340,7 @@ func startBPFDataplaneComponents(ipFamily proto.IPVersion,
 	)
 	dp.RegisterManager(failsafeMgr)
 
-	bpfRTMgr := newBPFRouteManager(&config, bpfmaps, dp.loopSummarizer)
+	bpfRTMgr := newBPFRouteManager(&config, bpfmaps, ipFamily, dp.loopSummarizer)
 	dp.RegisterManager(bpfRTMgr)
 
 	conntrackScanner := bpfconntrack.NewScanner(bpfmaps.CtMap, ctKey, ctVal,


### PR DESCRIPTION
## Description

Run 2 copies of the below BPF dataplane components, one for IPv4 and one for IPv6
1. BPF kube-proxy
2. BPF route manager
3. Failsafe manager


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
