### PR TITLE
[v3.27] Ignore down interfaces when calculating host MTU

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -25,7 +25,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
@@ -33,6 +32,8 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"k8s.io/client-go/kubernetes"
+
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
@@ -1085,6 +1086,10 @@ func findHostMTU(matchRegex *regexp.Regexp) (int, error) {
 		fields := log.Fields{"mtu": l.Attrs().MTU, "name": l.Attrs().Name}
 		if matchRegex == nil || !matchRegex.MatchString(l.Attrs().Name) {
 			log.WithFields(fields).Debug("Skipping interface for MTU detection")
+			continue
+		}
+		if !ifacemonitor.LinkIsOperUp(l) {
+			log.WithFields(fields).Debug("Skipping down interface for MTU detection")
 			continue
 		}
 		log.WithFields(fields).Debug("Examining link for MTU calculation")

--- a/felix/fv/infrastructure/topology.go
+++ b/felix/fv/infrastructure/topology.go
@@ -83,6 +83,12 @@ func (c *TopologyContainers) Stop() {
 	}
 }
 
+func (c *TopologyContainers) TriggerDelayedStart() {
+	for _, f := range c.Felixes {
+		f.TriggerDelayedStart()
+	}
+}
+
 func DefaultTopologyOptions() TopologyOptions {
 	felixLogLevel := "Info"
 	if envLogLevel := os.Getenv("FV_FELIX_LOG_LEVEL"); envLogLevel != "" {

--- a/felix/fv/mtu_test.go
+++ b/felix/fv/mtu_test.go
@@ -39,9 +39,86 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 		client client.Interface
 	)
 
+	expectMTU := func(mtu int) {
+		for _, felix := range tc.Felixes {
+			EventuallyWithOffset(1, func() string {
+				out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
+				return strings.TrimSpace(out)
+			}, "60s", "500ms").Should(Equal(fmt.Sprint(mtu)))
+		}
+	}
+
+	vxlanOverhead := func(ipv6 bool) int {
+		if ipv6 {
+			return 70
+		}
+		return 50
+	}
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			for _, felix := range tc.Felixes {
+				felix.Exec("ip", "link")
+			}
+			infra.DumpErrorData()
+		}
+		tc.Stop()
+		infra.Stop()
+	})
+
 	for _, ipv6 := range []bool{true, false} {
 		enableIPv6 := ipv6
 		Describe(fmt.Sprintf("IPv6 enabled: %v", enableIPv6), func() {
+			Context("with default MTU interface pattern", func() {
+				BeforeEach(func() {
+					infra = getInfra()
+					topologyOptions := infrastructure.DefaultTopologyOptions()
+					topologyOptions.DelayFelixStart = true
+					topologyOptions.VXLANMode = api.VXLANModeAlways
+					topologyOptions.IPIPEnabled = false
+					topologyOptions.EnableIPv6 = enableIPv6
+
+					// Need n>1 or the infra won't set up IP pools!
+					tc, client = infrastructure.StartNNodeTopology(2, topologyOptions, infra)
+				})
+
+				It("should get the MTU from the main interface", func() {
+					// Set a distinctive MTU on the main interface.
+					for _, f := range tc.Felixes {
+						f.Exec("ip", "link", "set", "dev", "eth0", "mtu", "1312")
+					}
+					tc.TriggerDelayedStart()
+					expectMTU(1312 - vxlanOverhead(enableIPv6))
+				})
+
+				addDummyNIC := func(f *infrastructure.Felix, up bool) {
+					f.Exec("ip", "link", "add", "type", "dummy")
+					f.Exec("ip", "link", "set", "dev", "dummy0", "mtu", "1300")
+					f.Exec("ip", "link", "set", "name", "eth1", "dummy0")
+					if up {
+						f.Exec("ip", "link", "set", "dev", "eth1", "up")
+					}
+				}
+				It("should ignore a secondary interface that is down", func() {
+					// Set a distinctive MTU on the main interface.
+					for _, f := range tc.Felixes {
+						f.Exec("ip", "link", "set", "dev", "eth0", "mtu", "1312")
+						addDummyNIC(f, false)
+					}
+					tc.TriggerDelayedStart()
+					expectMTU(1312 - vxlanOverhead(enableIPv6))
+				})
+				It("should consider a secondary interface that is up", func() {
+					// Set a distinctive MTU on the main interface.
+					for _, f := range tc.Felixes {
+						f.Exec("ip", "link", "set", "dev", "eth0", "mtu", "1312")
+						addDummyNIC(f, true)
+					}
+					tc.TriggerDelayedStart()
+					expectMTU(1300 - vxlanOverhead(enableIPv6))
+				})
+			})
+
 			Context("with mismatched MTU interface pattern", func() {
 				BeforeEach(func() {
 					infra = getInfra()
@@ -71,39 +148,13 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 					}, "30s", "100ms").ShouldNot(HaveOccurred())
 				})
 
-				AfterEach(func() {
-					if CurrentGinkgoTestDescription().Failed {
-						for _, felix := range tc.Felixes {
-							felix.Exec("iptables-save", "-c")
-							felix.Exec("ipset", "list")
-							felix.Exec("ip", "r")
-							felix.Exec("ip", "a")
-						}
-					}
-
-					tc.Stop()
-
-					if CurrentGinkgoTestDescription().Failed {
-						infra.DumpErrorData()
-					}
-					infra.Stop()
-				})
-
 				It("should configure MTU correctly based on FelixConfiguration", func() {
 					// We should NOT detect the primary interface's MTU of 1500, and instead default
 					// to 1460 due to the mismatched regex. Since VXLAN is enabled, we expect 1460 minus
 					// the VXLAN overhead of 50 in case of IPv4 or 70 in case of IPv6 to show up in the MTU file.
-					vxlanDisabledMtu := "1460"
-					vxlanEnabledMtu := "1410"
-					if enableIPv6 {
-						vxlanEnabledMtu = "1390"
-					}
-					for _, felix := range tc.Felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
-							return out
-						}, "60s", "500ms").Should(ContainSubstring(vxlanEnabledMtu))
-					}
+					vxlanDisabledMtu := 1460
+					vxlanEnabledMtu := vxlanDisabledMtu - vxlanOverhead(enableIPv6)
+					expectMTU(vxlanEnabledMtu)
 
 					// Disable VXLAN. We should expect the MTU to change, but still based on the default 1460.
 					// Create a default FelixConfiguration
@@ -123,29 +174,16 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 					}
 
 					// It should now have an MTU of 1460 since there is no encap.
-					for _, felix := range tc.Felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
-							return out
-						}, "60s", "500ms").Should(ContainSubstring(vxlanDisabledMtu))
-					}
+					expectMTU(vxlanDisabledMtu)
 				})
 
 				It("should configure MTU correctly based on IP pools", func() {
 					// We should NOT detect the primary interface's MTU of 1500, and instead default
 					// to 1460 due to the mismatched regex. Since VXLAN is enabled, we expect 1460
 					// minus the VXLAN overhead of 50 in case of IPv4 or 70 in case of IPv6 to show up in the MTU file.
-					vxlanDisabledMtu := "1460"
-					vxlanEnabledMtu := "1410"
-					if enableIPv6 {
-						vxlanEnabledMtu = "1390"
-					}
-					for _, felix := range tc.Felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
-							return out
-						}, "60s", "500ms").Should(ContainSubstring(vxlanEnabledMtu))
-					}
+					vxlanDisabledMtu := 1460
+					vxlanEnabledMtu := vxlanDisabledMtu - vxlanOverhead(enableIPv6)
+					expectMTU(vxlanEnabledMtu)
 
 					// Unset VXLAN on FelixConfiguration. We should expect the MTU not to change, since the VXLAN encap is set in the default IPPool.
 					fc := api.NewFelixConfiguration()
@@ -155,12 +193,8 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 					Expect(err).NotTo(HaveOccurred())
 
 					// It should still have an MTU of 1410 (or 1390 for IPv6) since the VXLAN encap is set in the default IPPool.
-					for _, felix := range tc.Felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
-							return out
-						}, "60s", "500ms").Should(ContainSubstring(vxlanEnabledMtu))
-					}
+
+					expectMTU(vxlanEnabledMtu)
 
 					// Set VXLANModeNever on the default IP pool(s)
 					pool, err := client.IPPools().Get(context.Background(), infrastructure.DefaultIPPoolName, options.GetOptions{})
@@ -177,12 +211,7 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 					}
 
 					// It should now have an MTU of 1460 since there is no encap.
-					for _, felix := range tc.Felixes {
-						Eventually(func() string {
-							out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
-							return out
-						}, "60s", "500ms").Should(ContainSubstring(vxlanDisabledMtu))
-					}
+					expectMTU(vxlanDisabledMtu)
 				})
 			})
 		})

--- a/felix/ifacemonitor/iface_monitor.go
+++ b/felix/ifacemonitor/iface_monitor.go
@@ -285,7 +285,7 @@ func (m *InterfaceMonitor) storeAndNotifyLink(ifaceExists bool, link netlink.Lin
 	m.storeAndNotifyLinkInner(ifaceExists, newName, link)
 }
 
-func linkIsOperUp(link netlink.Link) bool {
+func LinkIsOperUp(link netlink.Link) bool {
 	// We need the operstate of the interface; this is carried in the IFF_RUNNING flag.  The
 	// IFF_UP flag contains the admin state, which doesn't tell us whether we can program routes
 	// etc.
@@ -315,7 +315,7 @@ func (m *InterfaceMonitor) storeAndNotifyLinkInner(ifaceExists bool, ifaceName s
 	}
 	newState := StateNotPresent
 	if ifaceExists {
-		if linkIsOperUp(link) {
+		if LinkIsOperUp(link) {
 			newState = StateUp
 		} else {
 			newState = StateDown

--- a/felix/ifacemonitor/update_filter.go
+++ b/felix/ifacemonitor/update_filter.go
@@ -86,7 +86,7 @@ mainLoop:
 				return
 			}
 			idx := int(linkUpd.Index)
-			linkIsUp := linkUpd.Header.Type == syscall.RTM_NEWLINK && linkIsOperUp(linkUpd.Link)
+			linkIsUp := linkUpd.Header.Type == syscall.RTM_NEWLINK && LinkIsOperUp(linkUpd.Link)
 			var delay time.Duration
 			if linkIsUp {
 				if len(updatesByIfaceIdx[idx]) == 0 {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
--
Pick https://github.com/projectcalico/calico/pull/8496
CORE-10150

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Host MTU auto-detection now ignores interfaces that are down.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
