### PR TITLE
BPF: report non-ready when failing to program BPF programs

### DIFF
--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -384,9 +384,6 @@ configRetry:
 	// Set any watchdog timeout overrides before we initialise components.
 	health.SetGlobalTimeoutOverrides(configParams.HealthTimeoutOverrides)
 
-	// We're now both live and ready.
-	healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
-
 	// Enable or disable the health HTTP server according to coalesced config.
 	healthAggregator.ServeHTTP(configParams.HealthEnabled, configParams.HealthHost, configParams.HealthPort)
 
@@ -435,6 +432,11 @@ configRetry:
 		configChangedRestartCallback,
 		fatalErrorCallback,
 		k8sClientSet)
+
+	// Defer reporting ready until we've started the dataplane driver.  This
+	// ensures that our overall readiness waits for the dataplane driver to
+	// report ready on its health report.
+	healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
 
 	// Initialise the glue logic that connects the calculation graph to/from the dataplane driver.
 	log.Info("Connect to the dataplane driver.")

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/projectcalico/calico/felix/ethtool"
+	"github.com/projectcalico/calico/libcalico-go/lib/health"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -86,6 +87,8 @@ import (
 const (
 	bpfInDev  = "bpfin.cali"
 	bpfOutDev = "bpfout.cali"
+
+	bpfEPManagerHealthName = "BPFEndpointManager"
 )
 
 var (
@@ -161,7 +164,8 @@ type bpfDataplane interface {
 }
 
 type hasLoadPolicyProgram interface {
-	loadPolicyProgram(progName string,
+	loadPolicyProgram(
+		progName string,
 		ipFamily proto.IPVersion,
 		rules polprog.Rules,
 		staticProgsMap maps.Map,
@@ -353,6 +357,8 @@ type bpfEndpointManager struct {
 
 	v4 *bpfEndpointManagerDataplane
 	v6 *bpfEndpointManagerDataplane
+
+	healthAggregator *health.HealthAggregator
 }
 
 type bpfEndpointManagerDataplane struct {
@@ -382,7 +388,11 @@ type ManagerWithHEPUpdate interface {
 	OnHEPUpdate(hostIfaceToEpMap map[string]proto.HostEndpoint)
 }
 
-func NewTestEpMgr(config *Config, bpfmaps *bpfmap.Maps, workloadIfaceRegex *regexp.Regexp) (ManagerWithHEPUpdate, error) {
+func NewTestEpMgr(
+	config *Config,
+	bpfmaps *bpfmap.Maps,
+	workloadIfaceRegex *regexp.Regexp,
+) (ManagerWithHEPUpdate, error) {
 	return newBPFEndpointManager(nil, config, bpfmaps, true, workloadIfaceRegex, idalloc.New(),
 		rules.NewRenderer(rules.Config{
 			BPFEnabled:                  true,
@@ -406,6 +416,7 @@ func NewTestEpMgr(config *Config, bpfmaps *bpfmap.Maps, workloadIfaceRegex *rege
 		nil,
 		logutils.NewSummarizer("test"),
 		new(environment.FakeFeatureDetector),
+		nil,
 	)
 }
 
@@ -422,6 +433,7 @@ func newBPFEndpointManager(
 	livenessCallback func(),
 	opReporter logutils.OpRecorder,
 	featureDetector environment.FeatureDetectorIface,
+	healthAggregator *health.HealthAggregator,
 ) (*bpfEndpointManager, error) {
 	if livenessCallback == nil {
 		livenessCallback = func() {}
@@ -479,6 +491,19 @@ func newBPFEndpointManager(
 		bpfPolicyDebugEnabled:  config.BPFPolicyDebugEnabled,
 		polNameToMatchIDs:      map[string]set.Set[polprog.RuleMatchID]{},
 		dirtyRules:             set.New[polprog.RuleMatchID](),
+
+		healthAggregator: healthAggregator,
+	}
+
+	if healthAggregator != nil {
+		healthAggregator.RegisterReporter(bpfEPManagerHealthName, &health.HealthReport{
+			Ready: true,
+			Live:  false,
+		}, 0)
+		healthAggregator.Report(bpfEPManagerHealthName, &health.HealthReport{
+			Ready:  false,
+			Detail: "Not yet synced.",
+		})
 	}
 
 	// Calculate allowed XDP attachment modes.  Note, in BPF mode untracked ingress policy is
@@ -1466,6 +1491,7 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 
 	if err := m.ifStateMap.ApplyAllChanges(); err != nil {
 		log.WithError(err).Warn("Failed to write updates to ifstate BPF map.")
+		m.reportHealth(false, "Failed to update interface state map.")
 		return err
 	}
 
@@ -1497,6 +1523,7 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 		if m.removeOldJumps {
 			oldBase := path.Join(bpfdefs.GlobalPinDir, "old_jumps")
 			if err := os.RemoveAll(oldBase); err != nil && os.IsNotExist(err) {
+				m.reportHealth(false, "Failed to clean up old jump maps.")
 				return fmt.Errorf("failed to remove %s: %w", oldBase, err)
 			}
 			m.removeOldJumps = false
@@ -1505,9 +1532,22 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 			legacy.CleanUpMaps()
 			m.legacyCleanUp = false
 		}
+		m.reportHealth(true, "")
+	} else {
+		m.reportHealth(false, "Failed to configure some interfaces.")
 	}
 
 	return nil
+}
+
+func (m *bpfEndpointManager) reportHealth(ready bool, detail string) {
+	if m.healthAggregator == nil {
+		return
+	}
+	m.healthAggregator.Report(bpfEPManagerHealthName, &health.HealthReport{
+		Ready:  ready,
+		Detail: detail,
+	})
 }
 
 func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface string) (bpfInterfaceState, error) {

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -394,6 +394,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			nil,
 			logutils.NewSummarizer("test"),
 			&environment.FakeFeatureDetector{},
+			nil,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		bpfEpMgr.Features = environment.NewFeatureDetector(nil).GetFeatures()

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -27,8 +27,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	"github.com/projectcalico/api/pkg/lib/numorstring"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
@@ -36,6 +34,9 @@ import (
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"k8s.io/client-go/kubernetes"
+
+	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	"github.com/projectcalico/api/pkg/lib/numorstring"
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/bpf/bpfmap"
@@ -705,6 +706,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			dp.reportHealth,
 			dp.loopSummarizer,
 			featureDetector,
+			config.HealthAggregator,
 		)
 
 		if err != nil {

--- a/felix/fv/health_test.go
+++ b/felix/fv/health_test.go
@@ -40,7 +40,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -48,6 +47,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/libcalico-go/lib/net"
 
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
@@ -60,29 +61,37 @@ import (
 var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 
 	var k8sInfra *infrastructure.K8sDatastoreInfra
+	var felix *infrastructure.Felix
+
+	felixReady := func() int {
+		return healthStatus(felix.IP, "9099", "readiness")
+	}
+
+	felixLiveness := func() int {
+		return healthStatus(felix.IP, "9099", "liveness")
+	}
 
 	BeforeEach(func() {
 		var err error
 		k8sInfra, err = infrastructure.GetK8sDatastoreInfra(infrastructure.K8SInfraLocalCluster)
 		Expect(err).NotTo(HaveOccurred())
-	})
 
-	JustBeforeEach(func() {
-		// Felix can now flap ready/non-ready while loading its config.  Delay until that
-		// is done.
-		time.Sleep(1 * time.Second)
+		// Avoid cross-talk between tests.
+		felix = nil
 	})
 
 	AfterEach(func() {
+		felix.Stop()
 		k8sInfra.Stop()
 	})
-
-	var felix *infrastructure.Felix
-	var felixReady, felixLiveness func() int
 
 	// describeCommonFelixTests creates specs for Felix tests that are common between the
 	// two scenarios below (with and without Typha).
 	describeCommonFelixTests := func() {
+		BeforeEach(func() {
+			waitForMainLoop(felix)
+		})
+
 		Describe("with normal Felix startup", func() {
 
 			It("should become ready and stay ready", func() {
@@ -105,10 +114,6 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 
 			pod.ConfigureInInfra(k8sInfra)
 		}
-
-		AfterEach(func() {
-			felix.Stop()
-		})
 
 		Describe("after removing iptables-restore", func() {
 			BeforeEach(func() {
@@ -178,8 +183,8 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 				utils.Config.TyphaImage,
 				"calico-typha")...)
 		Expect(typhaContainer).NotTo(BeNil())
-		typhaReady = getHealthStatus(typhaContainer.IP, "9098", "readiness")
-		typhaLiveness = getHealthStatus(typhaContainer.IP, "9098", "liveness")
+		typhaReady = healthStatusFn(typhaContainer.IP, "9098", "readiness")
+		typhaLiveness = healthStatusFn(typhaContainer.IP, "9098", "liveness")
 	}
 
 	type felixParams struct {
@@ -200,12 +205,17 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 		}
 		felix = infrastructure.RunFelix(
 			k8sInfra, 0, infrastructure.TopologyOptions{
-				EnableIPv6:   false,
-				ExtraEnvVars: envVars,
+				EnableIPv6:      false,
+				ExtraEnvVars:    envVars,
+				DelayFelixStart: true,
 			},
 		)
-		felixReady = getHealthStatus(felix.IP, "9099", "readiness")
-		felixLiveness = getHealthStatus(felix.IP, "9099", "liveness")
+		if BPFMode() {
+			// In BPF mode, felix needs the Node to be configured.
+			ipPoolCIDR := net.MustParseCIDR("10.70.0.0/24")
+			k8sInfra.AddNode(felix, &ipPoolCIDR.IPNet, nil, 0, true)
+		}
+		felix.TriggerDelayedStart()
 	}
 
 	Describe("healthHost not 'all interfaces'", func() {
@@ -228,19 +238,11 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 			startFelix("", k8sInfra.GetDockerArgs, felixParams{dataplaneTimeout: "20", healthHost: "localhost"})
 			Eventually(checkHealthInternally, "10s", "100ms").ShouldNot(HaveOccurred())
 		})
-
-		AfterEach(func() {
-			felix.Stop()
-		})
 	})
 
 	Describe("with Felix running (no Typha)", func() {
 		BeforeEach(func() {
 			startFelix("", k8sInfra.GetDockerArgs, felixParams{dataplaneTimeout: "20", healthHost: "0.0.0.0"})
-		})
-
-		AfterEach(func() {
-			felix.Stop()
 		})
 
 		describeCommonFelixTests()
@@ -249,10 +251,7 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 	Describe("with Felix (no Typha) and Felix calc graph set to hang (10s calc graph timeout)", func() {
 		BeforeEach(func() {
 			startFelix("", k8sInfra.GetDockerArgs, felixParams{calcGraphTimeout: "10s", calcGraphHangTime: "5", healthHost: "0.0.0.0"})
-		})
-
-		AfterEach(func() {
-			felix.Stop()
+			waitForMainLoop(felix)
 		})
 
 		It("should report live initially, then become non-live", func() {
@@ -265,10 +264,7 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 	Describe("with Felix (no Typha) and Felix dataplane set to hang (default 90s timeout)", func() {
 		BeforeEach(func() {
 			startFelix("", k8sInfra.GetDockerArgs, felixParams{dataplaneHangTime: "5", healthHost: "0.0.0.0"})
-		})
-
-		AfterEach(func() {
-			felix.Stop()
+			waitForMainLoop(felix)
 		})
 
 		It("should report live initially, then become non-live", func() {
@@ -282,10 +278,7 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 	Describe("with Felix (no Typha) and Felix dataplane set to hang (20s timeout)", func() {
 		BeforeEach(func() {
 			startFelix("", k8sInfra.GetDockerArgs, felixParams{dataplaneTimeout: "20", dataplaneHangTime: "5", healthHost: "0.0.0.0"})
-		})
-
-		AfterEach(func() {
-			felix.Stop()
+			waitForMainLoop(felix)
 		})
 
 		It("should report live initially, then become non-live", func() {
@@ -302,7 +295,6 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 		})
 
 		AfterEach(func() {
-			felix.Stop()
 			typhaContainer.Stop()
 		})
 
@@ -329,7 +321,6 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 		})
 
 		AfterEach(func() {
-			felix.Stop()
 			typhaContainer.Stop()
 		})
 
@@ -348,10 +339,6 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 	Describe("with typha connected to bad API endpoint", func() {
 		BeforeEach(func() {
 			startTypha(k8sInfra.GetBadEndpointDockerArgs)
-		})
-
-		AfterEach(func() {
-			typhaContainer.Stop()
 		})
 
 		It("typha should not report ready", func() {
@@ -402,10 +389,6 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 			}
 		})
 
-		AfterEach(func() {
-			felix.Stop()
-		})
-
 		It("felix should report ready", func() {
 			Eventually(felixReady, "5s", "100ms").Should(BeGood())
 			Consistently(felixReady, "10s", "1s").Should(BeGood())
@@ -423,7 +406,6 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 			startFelix(typhaContainer.IP+":5474", k8sInfra.GetDockerArgs, felixParams{dataplaneTimeout: "20", healthHost: "0.0.0.0"})
 		})
 		AfterEach(func() {
-			felix.Stop()
 			typhaContainer.Stop()
 		})
 		It("should become unready, then die", func() {
@@ -436,22 +418,36 @@ var _ = Describe("_HEALTH_ _BPF-SAFE_ health tests", func() {
 
 const statusErr = -1
 
-func getHealthStatus(ip, port, endpoint string) func() int {
+func healthStatusFn(ip, port, endpoint string) func() int {
 	return func() int {
-		resp, err := http.Get("http://" + ip + ":" + port + "/" + endpoint)
-		if err != nil {
-			log.WithError(err).WithField("resp", resp).Warn("HTTP GET failed")
-			return statusErr
-		}
-		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
-		log.WithField("resp", resp).Infof("Health response:\n%v\n", string(body))
-		return resp.StatusCode
+		return healthStatus(ip, port, endpoint)
 	}
 }
 
-func BeErr() types.GomegaMatcher {
-	return BeNumerically("==", statusErr)
+func healthStatus(ip, port, endpoint string) int {
+	resp, err := http.Get("http://" + ip + ":" + port + "/" + endpoint)
+	if err != nil {
+		log.WithError(err).WithField("resp", resp).Warn("HTTP GET failed")
+		return statusErr
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	log.WithField("resp", resp).Infof("Health response %v:\n%v\n", resp.StatusCode, string(body))
+	return resp.StatusCode
+}
+
+func waitForMainLoop(felix *infrastructure.Felix) {
+	Eventually(func() string {
+		resp, err := http.Get("http://" + felix.IP + ":9099/readiness")
+		if err != nil {
+			log.WithError(err).WithField("resp", resp).Warn("HTTP GET failed")
+			return "<error>"
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		return string(body)
+	}, "10s").Should(ContainSubstring("InternalDataplaneMainLoop"))
+	By("Felix main loop started, InternalDataplaneMainLoop shown in health.")
 }
 
 func BeBad() types.GomegaMatcher {

--- a/felix/fv/health_test.go
+++ b/felix/fv/health_test.go
@@ -437,7 +437,7 @@ func healthStatus(ip, port, endpoint string) int {
 }
 
 func waitForMainLoop(felix *infrastructure.Felix) {
-	Eventually(func() string {
+	EventuallyWithOffset(1, func() string {
 		resp, err := http.Get("http://" + felix.IP + ":9099/readiness")
 		if err != nil {
 			log.WithError(err).WithField("resp", resp).Warn("HTTP GET failed")

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -236,6 +236,9 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 }
 
 func (f *Felix) Stop() {
+	if f == nil {
+		return
+	}
 	if CreateCgroupV2 {
 		_ = f.ExecMayFail("rmdir", path.Join("/run/calico/cgroup/", f.Name))
 	}

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -694,7 +694,7 @@ func (kds *K8sDatastoreInfra) AddNode(felix *Felix, v4CIDR *net.IPNet, v6CIDR *n
 			}},
 		},
 	}
-	if len(felix.IPv6) > 0 {
+	if len(felix.IPv6) > 0 && v6CIDR != nil {
 		nodeIn.ObjectMeta.Annotations["projectcalico.org/IPv6Address"] = fmt.Sprintf("%s/%s", felix.IPv6, felix.IPv6Prefix)
 		nodeIn.Spec.PodCIDRs = append(nodeIn.Spec.PodCIDRs, fmt.Sprintf("%x%x:%x%x:%x%x:%x%x:%x%x:%x%x:%d:0/96", v6CIDR.IP[0], v6CIDR.IP[1], v6CIDR.IP[2], v6CIDR.IP[3], v6CIDR.IP[4], v6CIDR.IP[5], v6CIDR.IP[6], v6CIDR.IP[7], v6CIDR.IP[8], v6CIDR.IP[9], v6CIDR.IP[10], v6CIDR.IP[11], idx))
 		nodeIn.Status.Addresses = append(nodeIn.Status.Addresses, v1.NodeAddress{


### PR DESCRIPTION
## Description

Found that the health tests were flaking in BPF mode due because:

- BPF mode was reporting ready even though it was failing to program BPF programs.
- That confused the health tests.  They saw felix ready and did things such as removing the iptables binary to cause felix to fail.  Felix didn't fail in the expected way because it wasn't getting past the BPF programming stage.
- The health tests were generally getting confused by Felix being ready at start of day and then adding additional non-ready health reporters. 

Fix these by:

- Adding health reporting to the BPF endpoint manager so that it reports non-ready if it fails to program BPF programs (e.g. due to lack of host IP).
- Adding a Node in the health tests.
- Waiting for the internal dataplane health report to show up before checking health.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-10174

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Felix could briefly report "ready" in the middle of initialisation, before going "non-ready" again until the dataplane was in-sync.  In eBPF mode, Felix will now report non-Ready if it fails to program some BPF programs.  Previously, this would only be reported through logging.  
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
