### PR TITLE
[release-v3.27] Auto pick #8085: Allow custom cgroup2 path

### DIFF
--- a/felix/bpf/bpfdefs/defs.go
+++ b/felix/bpf/bpfdefs/defs.go
@@ -14,10 +14,20 @@
 
 package bpfdefs
 
+import "os"
+
 const (
-	DefaultBPFfsPath = "/sys/fs/bpf"
-	CgroupV2Path     = "/run/calico/cgroup"
+	DefaultBPFfsPath    = "/sys/fs/bpf"
+	DefaultCgroupV2Path = "/run/calico/cgroup"
 
 	GlobalPinDir = DefaultBPFfsPath + "/tc/globals/"
 	ObjectDir    = "/usr/lib/calico/bpf"
 )
+
+func GetCgroupV2Path() string {
+	cgroupV2CustomPath := os.Getenv("CALICO_CGROUP_PATH")
+	if cgroupV2CustomPath == "" {
+		return DefaultCgroupV2Path
+	}
+	return cgroupV2CustomPath
+}

--- a/felix/bpf/utils/utils.go
+++ b/felix/bpf/utils/utils.go
@@ -74,27 +74,28 @@ func MaybeMountBPFfs() (string, error) {
 
 func MaybeMountCgroupV2() (string, error) {
 	var err error
-	if err := os.MkdirAll(bpfdefs.CgroupV2Path, 0700); err != nil {
+	cgroupV2Path := bpfdefs.GetCgroupV2Path()
+	if err := os.MkdirAll(cgroupV2Path, 0700); err != nil {
 		return "", err
 	}
 
-	mnt, err := isMount(bpfdefs.CgroupV2Path)
+	mnt, err := isMount(cgroupV2Path)
 	if err != nil {
-		return "", fmt.Errorf("error checking if %s is a mount: %v", bpfdefs.CgroupV2Path, err)
+		return "", fmt.Errorf("error checking if %s is a mount: %v", cgroupV2Path, err)
 	}
 
-	fsCgroup, err := isCgroupV2(bpfdefs.CgroupV2Path)
+	fsCgroup, err := isCgroupV2(cgroupV2Path)
 	if err != nil {
-		return "", fmt.Errorf("error checking if %s is CgroupV2: %v", bpfdefs.CgroupV2Path, err)
+		return "", fmt.Errorf("error checking if %s is CgroupV2: %v", cgroupV2Path, err)
 	}
 
 	if !mnt {
-		err = mountCgroupV2(bpfdefs.CgroupV2Path)
+		err = mountCgroupV2(cgroupV2Path)
 	} else if !fsCgroup {
-		err = fmt.Errorf("something that's not cgroup v2 is already mounted in %s", bpfdefs.CgroupV2Path)
+		err = fmt.Errorf("something that's not cgroup v2 is already mounted in %s", cgroupV2Path)
 	}
 
-	return bpfdefs.CgroupV2Path, err
+	return cgroupV2Path, err
 }
 
 func mountCgroupV2(path string) error {


### PR DESCRIPTION
Cherry pick of #8085 on release-v3.27.

#8085: Allow custom cgroup2 path

# Original PR Body below

## Description
Currently, the mount-bpffs init container tries to create the folder /run/calico/cgroup for mounting the cgroupv2 fs

This causes issues on distros like Talos Linux as described in the issue https://github.com/projectcalico/calico/issues/7892

This can be a configurable path instead

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
https://github.com/projectcalico/calico/issues/7892

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: alternative cgroup2 mount path can be specified by setting CALICO_CGROUP_PATH evn var for node.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.