### PR TITLE
[release-v3.27] Add missing libresolv.so in node-driver-registrar

### DIFF
--- a/pod2daemon/node-driver-registrar-docker/Dockerfile.amd64
+++ b/pod2daemon/node-driver-registrar-docker/Dockerfile.amd64
@@ -23,8 +23,9 @@ ARG GIT_VERSION=unknown
 # If *.so files are missing, you will see an error saying that your entrypoint cannot be found.
 # The necessary files can be found using the ldd command on the binary.
 COPY --from=ubi /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
 COPY --from=ubi /lib64/libc.so.6 /lib64/libc.so.6
+COPY --from=ubi /lib64/libpthread.so.0 /lib64/libpthread.so.0
+COPY --from=ubi /lib64/libresolv.so.2 /lib64/libresolv.so.2
 
 ARG BIN_DIR
 ADD ${BIN_DIR}/node-driver-registrar-amd64 /usr/local/bin/node-driver-registrar


### PR DESCRIPTION
## Description

Copy libresolv.so from UBI to node-driver-registrar image.

## Related issues/PRs

Fixes https://github.com/projectcalico/calico/issues/8515.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
