### PR TITLE
Reduce number of docker exec calls when killing FV workloads.

### DIFF
--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -61,6 +61,7 @@ type Workload struct {
 	isRunning             bool
 	isSpoofing            bool
 	listenAnyIP           bool
+	pid                   string
 
 	cleanupLock sync.Mutex
 }
@@ -94,13 +95,8 @@ func (w *Workload) Stop() {
 		log.Info("Stop no-op because nil workload")
 	} else {
 		log.WithField("workload", w).Info("Stop")
-		output, err := w.C.ExecOutput("cat", fmt.Sprintf("/tmp/%v", w.Name))
-		Expect(err).NotTo(HaveOccurred(), "failed to run docker exec command to get workload pid")
-		pid := strings.TrimSpace(output)
-		w.C.Exec("kill", pid)
-		_ = w.C.ExecMayFail("ip", "link", "del", w.InterfaceName)
-		_ = w.C.ExecMayFail("ip", "netns", "del", w.NamespaceID())
-		_, err = w.runCmd.Process.Wait()
+		_ = w.C.ExecMayFail("sh", "-c", fmt.Sprintf("kill -9 %s & ip link del %s & ip netns del %s & wait", w.pid, w.InterfaceName, w.NamespaceID()))
+		_, err := w.runCmd.Process.Wait()
 		if err != nil {
 			log.WithField("workload", w).Error("failed to wait for process")
 		}
@@ -205,8 +201,7 @@ func (w *Workload) Start() error {
 		protoArg = "--protocol=" + w.Protocol
 	}
 
-	command := fmt.Sprintf("echo $$ > /tmp/%v; exec test-workload %v '%v' '%v' '%v'",
-		w.Name,
+	command := fmt.Sprintf("echo $$; exec test-workload %v '%v' '%v' '%v'",
 		protoArg,
 		w.InterfaceName,
 		w.IP,
@@ -253,12 +248,22 @@ func (w *Workload) Start() error {
 		}
 	}()
 
+	pid, err := stdoutReader.ReadString('\n')
+	if err != nil {
+		// (Only) if we fail here, wait for the stderr to be output before returning.
+		defer errDone.Wait()
+		if err != nil {
+			return fmt.Errorf("reading PID from stdout failed: %w", err)
+		}
+	}
+	w.pid = strings.TrimSpace(pid)
+
 	namespacePath, err := stdoutReader.ReadString('\n')
 	if err != nil {
 		// (Only) if we fail here, wait for the stderr to be output before returning.
 		defer errDone.Wait()
 		if err != nil {
-			return fmt.Errorf("Reading from stdout failed: %v", err)
+			return fmt.Errorf("reading from stdout failed: %w", err)
 		}
 	}
 

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -94,13 +94,29 @@ func (w *Workload) Stop() {
 	if w == nil {
 		log.Info("Stop no-op because nil workload")
 	} else {
-		log.WithField("workload", w).Info("Stop")
+		log.WithField("workload", w.Name).Info("Stop")
 		_ = w.C.ExecMayFail("sh", "-c", fmt.Sprintf("kill -9 %s & ip link del %s & ip netns del %s & wait", w.pid, w.InterfaceName, w.NamespaceID()))
-		_, err := w.runCmd.Process.Wait()
-		if err != nil {
-			log.WithField("workload", w).Error("failed to wait for process")
+		// Killing the process inside the container should cause our long-running
+		// docker exec command to exit.  Do the Wait on a background goroutine,
+		// so we can time it out, just in case.
+		waitDone := make(chan struct{})
+		go func() {
+			defer close(waitDone)
+			_, err := w.runCmd.Process.Wait()
+			if err != nil {
+				log.WithField("workload", w.Name).Error("Failed to wait for docker exec, attempting to kill it.")
+				_ = w.runCmd.Process.Kill()
+			}
+		}()
+
+		select {
+		case <-waitDone:
+			log.WithField("workload", w.Name).Info("Workload stopped")
+		case <-time.After(10 * time.Second):
+			log.WithField("workload", w.Name).Error("Workload docker exec failed to exit?  Killing it.")
+			_ = w.runCmd.Process.Kill()
 		}
-		log.WithField("workload", w).Info("Workload now stopped")
+
 		w.isRunning = false
 	}
 }
@@ -252,9 +268,7 @@ func (w *Workload) Start() error {
 	if err != nil {
 		// (Only) if we fail here, wait for the stderr to be output before returning.
 		defer errDone.Wait()
-		if err != nil {
-			return fmt.Errorf("reading PID from stdout failed: %w", err)
-		}
+		return fmt.Errorf("reading PID from stdout failed: %w", err)
 	}
 	w.pid = strings.TrimSpace(pid)
 
@@ -262,9 +276,7 @@ func (w *Workload) Start() error {
 	if err != nil {
 		// (Only) if we fail here, wait for the stderr to be output before returning.
 		defer errDone.Wait()
-		if err != nil {
-			return fmt.Errorf("reading from stdout failed: %w", err)
-		}
+		return fmt.Errorf("reading from stdout failed: %w", err)
 	}
 
 	w.namespacePath = strings.TrimSpace(namespacePath)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Felix FV infrastructure performance tweaks:

* When starting workload, output PID to stdout and read it immediately (saves `docker exec ... cat <pidfile>` later on).
* Combine workload teardown commands into one `sh -c "..."` invocation, saves a few more `docker exec` transactions, which cost ~100ms each.

Benchmarking locally, I see 1-200ms saving per teardown.  Seems to add up to ~1-2min across a run.  Smallish win for a small change.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
