### PR TITLE
[release-v3.27] Auto pick #8523: Update syncer status from dataplane later

### DIFF
--- a/felix/bpf/proxy/syncer.go
+++ b/felix/bpf/proxy/syncer.go
@@ -256,10 +256,6 @@ func NewSyncer(family int, nodePortIPs []net.IP,
 		return nil, fmt.Errorf("unknwn family %d", family)
 	}
 
-	if err := s.loadOrigs(); err != nil {
-		return nil, err
-	}
-
 	return s, nil
 }
 
@@ -383,6 +379,11 @@ func (s *Syncer) startupBuildPrev(state DPSyncerState) error {
 }
 
 func (s *Syncer) startupSync(state DPSyncerState) error {
+	// Load current dataplane state.
+	if err := s.loadOrigs(); err != nil {
+		return err
+	}
+
 	// Try to build the previous maps based on the current state and what is in bpf maps.
 	// Once we have the previous map, we can apply the the current state as if we never
 	// restarted and apply only the diff using the regular code path.


### PR DESCRIPTION
Cherry pick of #8523 on release-v3.27.

#8523: Update syncer status from dataplane later

# Original PR Body below

When swapping a syncer in kube-proxy, defer loading state from dataplane until after the old syncer is done. Otherwise we may load state that is still being updated. This could lead to a discrepancy between the real state of the dataplane and what the caching maps thing the real state is.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.