### PR TITLE
EV-4698 Remove unnecessary FIPS code

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -9,25 +9,21 @@ ci: fv
 .PHONY: fv
 fv: setup-fv bin/fips-test-build
 	# Run a server using the FIPS strict mode settings and wait 1s to let it come up.
-	./bin/fips-test-build &
+	$(DOCKER_RUN) --name fips-test-build --rm $(CALICO_BUILD) ./bin/fips-test-build &
 	sleep 1
 	# The server should respond with the value for STRICT_FIPS.
-	curl -k  https://localhost:8083 | grep true
+	$(DOCKER_RUN) $(CALICO_BUILD) curl -k  https://localhost:8083 | grep true
 	# Run the nmap tool on the server to find out the tls versions and ciphers.
 	docker run --net=host --rm -it instrumentisto/nmap --script ssl-enum-ciphers -p 8083 127.0.0.1 > tmp/nmap.log
-	cp tmp/nmap.log tmp/nmap.log.orig
 	# remove times and dates from file
 	sed -i '1,4d;22d' tmp/nmap.log
-	$(MAKE) kill
+	docker rm -f fips-test-build
 	# If the ciphers are as expected, we get exit code 0.
 	diff fv/expected-nmap.log  tmp/nmap.log
 
 bin/fips-test-build:
 	$(call build_cgo_boring_binary, $(PACKAGE_NAME)/fv/main, $@)
 
-setup-fv: kill
+setup-fv:
 	mkdir -p bin tmp
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'openssl req -batch -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout tmp/tls.key -out tmp/tls.crt'
-
-kill:
-	pgrep fips-test-build | xargs kill || true

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -9,7 +9,7 @@ ci: fv
 .PHONY: fv
 fv: setup-fv bin/fips-test-build
 	# Run a server using the FIPS strict mode settings and wait 1s to let it come up.
-	$(DOCKER_RUN) --name fips-test-build --rm $(CALICO_BUILD) ./bin/fips-test-build &
+	$(DOCKER_RUN) --name fips-test-build --rm -d $(CALICO_BUILD) ./bin/fips-test-build
 	sleep 1
 	# The server should respond with the value for STRICT_FIPS.
 	$(DOCKER_RUN) $(CALICO_BUILD) curl -k  https://localhost:8083 | grep true

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -15,6 +15,7 @@ fv: setup-fv bin/fips-test-build
 	curl -k  https://localhost:8083 | grep true
 	# Run the nmap tool on the server to find out the tls versions and ciphers.
 	docker run --net=host --rm -it instrumentisto/nmap --script ssl-enum-ciphers -p 8083 127.0.0.1 > tmp/nmap.log
+	cp tmp/nmap.log tmp/nmap.log.orig
 	# remove times and dates from file
 	sed -i '1,4d;22d' tmp/nmap.log
 	$(MAKE) kill

--- a/crypto/fv/main/main.go
+++ b/crypto/fv/main/main.go
@@ -12,7 +12,7 @@ func main() {
 	server := http.Server{
 		Addr:      ":8083",
 		Handler:   fipsHandler{},
-		TLSConfig: tls.NewTLSConfig(false),
+		TLSConfig: tls.NewTLSConfig(),
 	}
 
 	err := server.ListenAndServeTLS("tmp/tls.crt", "tmp/tls.key")

--- a/crypto/pkg/tls/tls.go
+++ b/crypto/pkg/tls/tls.go
@@ -20,16 +20,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Ciphers supported by TLS 1.2 in fips mode
-var tls12CiphersFIPS = []uint16{
-	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-	tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-}
-
 // Ciphers supported by TLS 1.2
 var tls12Ciphers = []uint16{
 	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -53,30 +43,13 @@ var tls13Ciphers = []uint16{
 	tls.TLS_AES_128_GCM_SHA256,
 }
 
-// NewTLSConfig returns a tls.Config with the recommended default settings for Calico Enterprise components.
-// Read more recommendations here in Chapter 3:
-// https://www.gsa.gov/cdnstatic/SSL_TLS_Implementation_%5BCIO_IT_Security_14-69_Rev_6%5D_04-06-2021docx.pdf
-// When built with GOEXPERIMENT and tag boringcrypto, the TLS settings in the config will automatically
-// be overwritten and set to strict mode, due to the fipsonly import in fipstls.go.
-func NewTLSConfig(fipsMode bool) *tls.Config {
-	log.WithField("BuiltWithBoringCrypto", BuiltWithBoringCrypto).
-		WithField("fipsMode", fipsMode).
-		Debug("creating a TLS config")
-
-	cfg := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		MaxVersion: tls.VersionTLS13,
+// NewTLSConfig returns a tls.Config with the recommended default settings for Calico components. Based on build flags,
+// boringCrypto may be used and fips strict mode may be enforced, which can override the parameters defined in this func.
+func NewTLSConfig() *tls.Config {
+	log.WithField("BuiltWithBoringCrypto", BuiltWithBoringCrypto).Debug("creating a TLS config")
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS13,
+		CipherSuites: append(tls12Ciphers, tls13Ciphers...),
 	}
-
-	if fipsMode {
-		cfg.CurvePreferences = []tls.CurveID{tls.CurveP384, tls.CurveP256}
-		cfg.CipherSuites = tls12CiphersFIPS
-		// Our certificate for FIPS validation not mention validation for v1.3.
-		cfg.MaxVersion = tls.VersionTLS12
-		cfg.Renegotiation = tls.RenegotiateNever
-	} else {
-		cfg.CipherSuites = tls12Ciphers
-		cfg.CipherSuites = append(cfg.CipherSuites, tls13Ciphers...)
-	}
-	return cfg
 }

--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -61,9 +61,6 @@ var (
 	VERSION    string
 	version    bool
 	statusFile string
-
-	// fipsModeEnabled enables FIPS 140-2 validated crypto mode.
-	fipsModeEnabled bool
 )
 
 func init() {
@@ -83,7 +80,6 @@ func init() {
 	if err != nil {
 		log.WithError(err).Fatal("Failed to set klog logging configuration")
 	}
-	fipsModeEnabled = os.Getenv("FIPS_MODE_ENABLED") == "true"
 }
 
 func main() {
@@ -416,7 +412,7 @@ func newEtcdV3Client() (*clientv3.Client, error) {
 		return nil, err
 	}
 
-	baseTLSConfig := tls.NewTLSConfig(fipsModeEnabled)
+	baseTLSConfig := tls.NewTLSConfig()
 	tlsClient.MaxVersion = baseTLSConfig.MaxVersion
 	tlsClient.MinVersion = baseTLSConfig.MinVersion
 	tlsClient.CipherSuites = baseTLSConfig.CipherSuites

--- a/libcalico-go/lib/apiconfig/apiconfig.go
+++ b/libcalico-go/lib/apiconfig/apiconfig.go
@@ -62,9 +62,6 @@ type EtcdConfig struct {
 	EtcdKey    string `json:"etcdKey" ignored:"true"`
 	EtcdCert   string `json:"etcdCert" ignored:"true"`
 	EtcdCACert string `json:"etcdCACert" ignored:"true"`
-
-	// EtcdFIPSModeEnabled uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
-	EtcdFIPSModeEnabled bool `json:"etcdFIPSModeEnabled" envconfig:"ETCD_FIPS_MODE_ENABLED"`
 }
 
 type KubeConfig struct {

--- a/libcalico-go/lib/backend/etcdv3/etcdv3.go
+++ b/libcalico-go/lib/backend/etcdv3/etcdv3.go
@@ -114,7 +114,7 @@ func NewEtcdV3Client(config *apiconfig.EtcdConfig) (api.Client, error) {
 		return nil, fmt.Errorf("could not initialize etcdv3 client: %+v", err)
 	}
 
-	baseTLSConfig := calicotls.NewTLSConfig(config.EtcdFIPSModeEnabled)
+	baseTLSConfig := calicotls.NewTLSConfig()
 	tlsConfig.MaxVersion = baseTLSConfig.MaxVersion
 	tlsConfig.MinVersion = baseTLSConfig.MinVersion
 	tlsConfig.CipherSuites = baseTLSConfig.CipherSuites

--- a/typha/pkg/config/config_params.go
+++ b/typha/pkg/config/config_params.go
@@ -148,9 +148,6 @@ type Config struct {
 	K8sServiceName                        string        `config:"string;calico-typha"`
 	K8sPortName                           string        `config:"string;calico-typha"`
 
-	// FIPSModeEnabled Enables FIPS 140-2 verified crypto mode.
-	FIPSModeEnabled bool `config:"bool;false"`
-
 	// State tracking.
 
 	// nameToSource tracks where we loaded each config param from.

--- a/typha/pkg/syncclient/sync_client.go
+++ b/typha/pkg/syncclient/sync_client.go
@@ -66,9 +66,6 @@ type Options struct {
 	// DebugDiscardKVUpdates discards all KV updates from typha without decoding them.
 	// Useful for load testing Typha without having to run a "full" client.
 	DebugDiscardKVUpdates bool
-
-	// FIPSModeEnabled Enables FIPS 140-2 verified crypto mode.
-	FIPSModeEnabled bool
 }
 
 func (o *Options) readTimeout() time.Duration {
@@ -284,7 +281,7 @@ func (s *SyncerClient) connect(cxt context.Context, typhaAddr discovery.Typha) e
 			log.WithError(err).Error("Failed to load certificate and key")
 			return err
 		}
-		tlsConfig := calicotls.NewTLSConfig(s.options.FIPSModeEnabled)
+		tlsConfig := calicotls.NewTLSConfig()
 		tlsConfig.Certificates = []tls.Certificate{cert}
 		// Typha API is a private binary API so we can enforce a recent TLS variant without
 		// worrying about back-compatibility with old browsers (for example).

--- a/typha/pkg/syncclientutils/config.go
+++ b/typha/pkg/syncclientutils/config.go
@@ -44,9 +44,6 @@ type TyphaConfig struct {
 	CAFile   string
 	CN       string
 	URISAN   string
-
-	// FIPSModeEnabled Enables FIPS 140-2 verified crypto mode.
-	FIPSModeEnabled bool
 }
 
 // ReadTyphaConfig reads the TyphaConfig from environment variables.

--- a/typha/pkg/syncclientutils/config_test.go
+++ b/typha/pkg/syncclientutils/config_test.go
@@ -27,7 +27,6 @@ var _ = Describe("Test TyphaConfig", func() {
 
 	BeforeEach(func() {
 		os.Setenv("FELIX_TYPHACAFILE", "cafile")
-		os.Setenv("FELIX_TYPHAFIPSMODEENABLED", "true")
 		os.Setenv("FELIX_TYPHAREADTIMEOUT", "100")
 
 	})
@@ -35,7 +34,6 @@ var _ = Describe("Test TyphaConfig", func() {
 	It("should be able to read all types", func() {
 		typhaConfig := syncclientutils.ReadTyphaConfig([]string{"FELIX_"})
 		Expect(typhaConfig.CAFile).To(Equal("cafile"))
-		Expect(typhaConfig.FIPSModeEnabled).To(BeTrue())
 		Expect(typhaConfig.ReadTimeout.Seconds()).To(Equal(100.))
 	})
 })

--- a/typha/pkg/syncclientutils/startsyncerclient.go
+++ b/typha/pkg/syncclientutils/startsyncerclient.go
@@ -72,15 +72,14 @@ func MustStartSyncerClientIfTyphaConfigured(
 		myVersion, myHostname, myInfo,
 		dedupeBuf,
 		&syncclient.Options{
-			SyncerType:      syncerType,
-			ReadTimeout:     typhaConfig.ReadTimeout,
-			WriteTimeout:    typhaConfig.WriteTimeout,
-			KeyFile:         typhaConfig.KeyFile,
-			CertFile:        typhaConfig.CertFile,
-			CAFile:          typhaConfig.CAFile,
-			ServerCN:        typhaConfig.CN,
-			ServerURISAN:    typhaConfig.URISAN,
-			FIPSModeEnabled: typhaConfig.FIPSModeEnabled,
+			SyncerType:   syncerType,
+			ReadTimeout:  typhaConfig.ReadTimeout,
+			WriteTimeout: typhaConfig.WriteTimeout,
+			KeyFile:      typhaConfig.KeyFile,
+			CertFile:     typhaConfig.CertFile,
+			CAFile:       typhaConfig.CAFile,
+			ServerCN:     typhaConfig.CN,
+			ServerURISAN: typhaConfig.URISAN,
 		},
 	)
 	if err := typhaConnection.Start(context.Background()); err != nil {

--- a/typha/pkg/syncserver/sync_server.go
+++ b/typha/pkg/syncserver/sync_server.go
@@ -158,9 +158,6 @@ type Config struct {
 	// DebugLogWrites tells the server to wrap each connection with a Writer that
 	// logs every write.  Intended only for use in tests!
 	DebugLogWrites bool
-
-	// FIPSModeEnabled Enables FIPS 140-2 verified crypto mode.
-	FIPSModeEnabled bool
 }
 
 const (
@@ -343,10 +340,7 @@ func (s *Server) serve(cxt context.Context) {
 	)
 	if s.config.requiringTLS() {
 		pwd, _ := os.Getwd()
-		logCxt.WithFields(log.Fields{
-			"pwd":             pwd,
-			"fipsModeEnabled": s.config.FIPSModeEnabled,
-		}).Info("Opening TLS listen socket")
+		logCxt.WithField("pwd", pwd).Info("Opening TLS listen socket")
 		cert, tlsErr := tls.LoadX509KeyPair(s.config.CertFile, s.config.KeyFile)
 		if tlsErr != nil {
 			logCxt.WithFields(log.Fields{
@@ -354,7 +348,7 @@ func (s *Server) serve(cxt context.Context) {
 				"keyFile":  s.config.KeyFile,
 			}).WithError(tlsErr).Panic("Failed to load certificate and key")
 		}
-		tlsConfig := calicotls.NewTLSConfig(s.config.FIPSModeEnabled)
+		tlsConfig := calicotls.NewTLSConfig()
 		tlsConfig.Certificates = []tls.Certificate{cert}
 
 		// Arrange for server to verify the clients' certificates.


### PR DESCRIPTION
The FIPS_ENABLED flags precede building with fips_strict mode. With the introduction of that flag, there is no point any longer of passing a bool into the `NewTLSConfig()` func.

Also, did some cleanup of the Makefile for the crypto suite.
