### PR TITLE
Use KUBECONFIG env variable to build cluster config

### DIFF
--- a/apiserver/cmd/apiserver/server/watch.go
+++ b/apiserver/cmd/apiserver/server/watch.go
@@ -30,12 +30,6 @@ func WatchExtensionAuth(stopChan chan struct{}) (bool, error) {
 	// set up k8s client
 	// attempt 1: KUBECONFIG env var
 	cfgFile := os.Getenv("KUBECONFIG")
-	// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-	// be trusted in this case
-	// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-	if winutils.InHostProcessContainer() {
-		cfgFile = ""
-	}
 	cfg, err := winutils.BuildConfigFromFlags("", cfgFile)
 	if err != nil {
 		// attempt 2: in cluster config

--- a/cni-plugin/pkg/k8s/k8s.go
+++ b/cni-plugin/pkg/k8s/k8s.go
@@ -36,7 +36,6 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	libapi "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
@@ -901,18 +900,9 @@ func NewK8sClient(conf types.NetConf, logger *logrus.Entry) (*kubernetes.Clients
 	}
 
 	// Use the kubernetes client code to load the kubeconfig file and combine it with the overrides.
-	var config *rest.Config
-	var err error
-	if winutils.InHostProcessContainer() {
-		// ClientConfig() calls InClusterConfig() at some point, which doesn't work
-		// on Windows HPC. Use winutils.GetInClusterConfig() instead in this case.
-		// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-		config, err = winutils.GetInClusterConfig()
-	} else {
-		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
-			configOverrides).ClientConfig()
-	}
+	config, err := winutils.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		configOverrides)
 	if err != nil {
 		return nil, err
 	}

--- a/confd/pkg/backends/calico/routes.go
+++ b/confd/pkg/backends/calico/routes.go
@@ -72,12 +72,6 @@ func NewRouteGenerator(c *client) (rg *routeGenerator, err error) {
 	// set up k8s client
 	// attempt 1: KUBECONFIG env var
 	cfgFile := os.Getenv("KUBECONFIG")
-	// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-	// be trusted in this case
-	// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-	if winutils.InHostProcessContainer() {
-		cfgFile = ""
-	}
 	cfg, err := winutils.BuildConfigFromFlags("", cfgFile)
 	if err != nil {
 		log.WithError(err).Info("KUBECONFIG environment variable not found, attempting in-cluster")

--- a/confd/pkg/backends/calico/secret_watcher.go
+++ b/confd/pkg/backends/calico/secret_watcher.go
@@ -63,12 +63,6 @@ func NewSecretWatcher(c *client) (*secretWatcher, error) {
 	// set up k8s client
 	// attempt 1: KUBECONFIG env var
 	cfgFile := os.Getenv("KUBECONFIG")
-	// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-	// be trusted in this case
-	// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-	if winutils.InHostProcessContainer() {
-		cfgFile = ""
-	}
 	cfg, err := winutils.BuildConfigFromFlags("", cfgFile)
 	if err != nil {
 		log.WithError(err).Info("KUBECONFIG environment variable not found, attempting in-cluster")

--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -308,7 +308,7 @@ configRetry:
 		} else {
 			// Not using KDD, fall back on trying to get a Kubernetes client from the environment.
 			log.Info("Not using Kubernetes datastore driver, trying to get a Kubernetes client...")
-			k8sconf, err := winutils.GetInClusterConfig()
+			k8sconf, err := winutils.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 			if err != nil {
 				log.WithError(err).Info("Kubernetes in-cluster config not available. " +
 					"Assuming we're not in a Kubernetes deployment.")

--- a/libcalico-go/lib/backend/k8s/k8s.go
+++ b/libcalico-go/lib/backend/k8s/k8s.go
@@ -336,14 +336,9 @@ func CreateKubernetesClientset(ca *apiconfig.CalicoAPIConfigSpec) (*rest.Config,
 			return nil, nil, resources.K8sErrorToCalico(err, nil)
 		}
 		config, err = clientConfig.ClientConfig()
-	} else if winutils.InHostProcessContainer() {
-		// ClientConfig() calls InClusterConfig() at some point, which doesn't work
-		// on Windows HPC. Use winutils.GetInClusterConfig() instead in this case.
-		// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-		config, err = winutils.GetInClusterConfig()
 	} else {
-		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&loadingRules, configOverrides).ClientConfig()
+		config, err = winutils.NewNonInteractiveDeferredLoadingClientConfig(
+			&loadingRules, configOverrides)
 	}
 	if err != nil {
 		return nil, nil, resources.K8sErrorToCalico(err, nil)

--- a/libcalico-go/lib/upgrade/migrator/clients/v1/k8s/k8s.go
+++ b/libcalico-go/lib/upgrade/migrator/clients/v1/k8s/k8s.go
@@ -81,17 +81,8 @@ func NewKubeClient(kc *capi.KubeConfig) (*KubeClient, error) {
 
 	// A kubeconfig file was provided.  Use it to load a config, passing through
 	// any overrides.
-	var config *rest.Config
-	var err error
-	if winutils.InHostProcessContainer() {
-		// ClientConfig() calls InClusterConfig() at some point, which doesn't work
-		// on Windows HPC. Use winutils.GetInClusterConfig() instead in this case.
-		// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-		config, err = winutils.GetInClusterConfig()
-	} else {
-		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&loadingRules, configOverrides).ClientConfig()
-	}
+	config, err := winutils.NewNonInteractiveDeferredLoadingClientConfig(
+		&loadingRules, configOverrides)
 	if err != nil {
 		return nil, resources.K8sErrorToCalico(err, nil)
 	}

--- a/node/pkg/cni/token_watch.go
+++ b/node/pkg/cni/token_watch.go
@@ -63,12 +63,6 @@ func NamespaceOfUsedServiceAccount() string {
 
 func BuildClientSet() (*kubernetes.Clientset, error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
-	// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-	// be trusted in this case
-	// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-	if winutils.InHostProcessContainer() {
-		kubeconfig = ""
-	}
 	cfg, err := winutils.BuildConfigFromFlags("", kubeconfig)
 	logrus.WithFields(logrus.Fields{"KUBECONFIG": kubeconfig, "cfg": cfg}).Debug("running cni.BuildClientSet")
 	if err != nil {
@@ -231,12 +225,6 @@ func Run() {
 	for tu := range tokenChan {
 		logrus.Info("Update of CNI kubeconfig triggered based on elapsed time.")
 		kubeconfig := os.Getenv("KUBECONFIG")
-		// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-		// be trusted in this case
-		// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-		if winutils.InHostProcessContainer() {
-			kubeconfig = ""
-		}
 		cfg, err := winutils.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
 			logrus.WithError(err).Error("Error generating kube config.")

--- a/node/pkg/lifecycle/shutdown/shutdown.go
+++ b/node/pkg/lifecycle/shutdown/shutdown.go
@@ -43,14 +43,7 @@ func Run() {
 	var clientset *kubernetes.Clientset
 
 	// If running under kubernetes with secrets to call k8s API
-	kubeconfig := os.Getenv("KUBECONFIG")
-	// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-	// be trusted in this case
-	// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-	if winutils.InHostProcessContainer() {
-		kubeconfig = ""
-	}
-	if config, err := winutils.BuildConfigFromFlags("", kubeconfig); err == nil {
+	if config, err := winutils.BuildConfigFromFlags("", os.Getenv("KUBECONFIG")); err == nil {
 		// default timeout is 30 seconds, which isn't appropriate for this kind of
 		// shutdown action because network services, like kube-proxy might not be
 		// running and we don't want to block the full 30 seconds if they are just

--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -130,14 +130,7 @@ func Run() {
 	}
 
 	// If running under kubernetes with secrets to call k8s API
-	kubeconfig := os.Getenv("KUBECONFIG")
-	// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-	// be trusted in this case
-	// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-	if winutils.InHostProcessContainer() {
-		kubeconfig = ""
-	}
-	if config, err := winutils.BuildConfigFromFlags("", kubeconfig); err == nil {
+	if config, err := winutils.BuildConfigFromFlags("", os.Getenv("KUBECONFIG")); err == nil {
 		// default timeout is 30 seconds, which isn't appropriate for this kind of
 		// startup action because network services, like kube-proxy might not be
 		// running and we don't want to block the full 30 seconds if they are just
@@ -337,14 +330,7 @@ func MonitorIPAddressSubnets() {
 	if nodeRef := os.Getenv("CALICO_K8S_NODE_REF"); nodeRef != "" {
 		k8sNodeName = nodeRef
 	}
-	kubeconfig := os.Getenv("KUBECONFIG")
-	// Host env vars may override the container on Windows HPC, so $env:KUBECONFIG cannot
-	// be trusted in this case
-	// FIXME: this will no longer be needed when containerd v1.6 is EOL'd
-	if winutils.InHostProcessContainer() {
-		kubeconfig = ""
-	}
-	if config, err = winutils.BuildConfigFromFlags("", kubeconfig); err == nil {
+	if config, err = winutils.BuildConfigFromFlags("", os.Getenv("KUBECONFIG")); err == nil {
 		// Create the k8s clientset.
 		clientset, err = kubernetes.NewForConfig(config)
 		if err != nil {

--- a/typha/pkg/discovery/discovery.go
+++ b/typha/pkg/discovery/discovery.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -177,7 +178,7 @@ func (d *Discoverer) discoverTyphaAddrs() ([]Typha, error) {
 	if d.k8sClient == nil && d.inCluster {
 		// Client didn't provide a kube client but we're allowed to create one.
 		logrus.Info("Creating Kubernetes client for Typha discovery...")
-		k8sConf, err := winutils.GetInClusterConfig()
+		k8sConf, err := winutils.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 		if err != nil {
 			logrus.WithError(err).Error("Unable to create in-cluster Kubernetes config.")
 			return nil, err

--- a/typha/pkg/k8s/lookup.go
+++ b/typha/pkg/k8s/lookup.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"context"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ type RealK8sAPI struct {
 func (r *RealK8sAPI) clientSet() (*kubernetes.Clientset, error) {
 	if r.cachedClientSet == nil {
 		// TODO Typha: support Typha lookup without using rest.InClusterConfig().
-		k8sconf, err := winutils.GetInClusterConfig()
+		k8sconf, err := winutils.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 		if err != nil {
 			log.WithError(err).Error("Unable to create Kubernetes config.")
 			return nil, err


### PR DESCRIPTION
## Description

This refactors kubeconfig creation logic to use `KUBECONFIG` env variable if available

We use incluster config in several places instead of the passed env variable.

Also, move `InHostProcessContainer` function call to inside the `winutils` package to simplify the logic.



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
N/A
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
