### PR TITLE
Allow IPv6 packets to v4 programs if v6 programs are not loaded

### DIFF
--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -44,7 +44,6 @@ struct cali_tc_preamble_globals {
 };
 
 enum cali_globals_flags {
-	CALI_GLOBALS_RESERVED0			= 0x00000001,
 	CALI_GLOBALS_RESERVED1			= 0x00000002,
 	CALI_GLOBALS_RESERVED2			= 0x00000004,
 	CALI_GLOBALS_RESERVED3			= 0x00000008,

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -44,8 +44,7 @@ struct cali_tc_preamble_globals {
 };
 
 enum cali_globals_flags {
-	/* CALI_GLOBALS_IPV6_ENABLED is set when IPv6 is enabled by Felix */
-	CALI_GLOBALS_IPV6_ENABLED		= 0x00000001,
+	CALI_GLOBALS_RESERVED0			= 0x00000001,
 	CALI_GLOBALS_RESERVED1			= 0x00000002,
 	CALI_GLOBALS_RESERVED2			= 0x00000004,
 	CALI_GLOBALS_RESERVED3			= 0x00000008,

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -35,12 +35,7 @@ static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 		CALI_DEBUG("ARP: allowing packet\n");
 		goto allow_no_fib;
 	case ETH_P_IPV6:
-		// If IPv6 is supported and enabled, handle the packet
-		if (GLOBAL_FLAGS & CALI_GLOBALS_IPV6_ENABLED) {
-			CALI_DEBUG("IPv6 packet, continue with parsing it.\n");
-			goto ipv6_packet;
-		}
-		// otherwise, drop if the packet is from workload
+		// Drop if the packet is from workload
 		if (CALI_F_WEP) {
 			CALI_DEBUG("IPv6 from workload: drop\n");
 			goto deny;
@@ -79,10 +74,6 @@ static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 	}
 
 	return PARSING_OK;
-
-ipv6_packet:
-	// Parse IPv6 header, and perform necessary checks here
-	return PARSING_OK_V6;
 
 allow_no_fib:
 	return PARSING_ALLOW_WITHOUT_ENFORCING_POLICY;

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -35,9 +35,9 @@ static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 		CALI_DEBUG("ARP: allowing packet\n");
 		goto allow_no_fib;
 	case ETH_P_IPV6:
-		// Drop if the packet is from workload
+		// Drop if the packet is to/from workload
 		if (CALI_F_WEP) {
-			CALI_DEBUG("IPv6 from workload: drop\n");
+			CALI_DEBUG("IPv6 to/from workload: drop\n");
 			goto deny;
 		} else { // or allow, it the packet is on host interface
 			CALI_DEBUG("IPv6 on host interface: allow\n");

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -33,7 +33,12 @@ int  cali_tc_preamble(struct __sk_buff *skb)
 	__u16 protocol = bpf_ntohs(skb->protocol);
 	/* Set the globals for the rest of the prog chain. */
 	if (protocol == ETH_P_IPV6) {
-		globals->data = __globals.v6;
+		if ((__globals.v6.jumps[PROG_INDEX_MAIN] != (__u32)-1) ||
+				(__globals.v6.jumps[PROG_INDEX_MAIN_DEBUG] != (__u32)-1)) {
+			globals->data = __globals.v6;
+		} else {
+			globals->data = __globals.v4;
+		}
 	} else {
 		globals->data = __globals.v4;
 	}

--- a/felix/bpf-gpl/tc_preamble.c
+++ b/felix/bpf-gpl/tc_preamble.c
@@ -32,13 +32,8 @@ int  cali_tc_preamble(struct __sk_buff *skb)
 
 	__u16 protocol = bpf_ntohs(skb->protocol);
 	/* Set the globals for the rest of the prog chain. */
-	if (protocol == ETH_P_IPV6) {
-		if ((__globals.v6.jumps[PROG_INDEX_MAIN] != (__u32)-1) ||
-				(__globals.v6.jumps[PROG_INDEX_MAIN_DEBUG] != (__u32)-1)) {
-			globals->data = __globals.v6;
-		} else {
-			globals->data = __globals.v4;
-		}
+	if (protocol == ETH_P_IPV6 && (__globals.v6.jumps[PROG_INDEX_MAIN] != (__u32)-1)) {
+		globals->data = __globals.v6;
 	} else {
 		globals->data = __globals.v4;
 	}

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -377,7 +377,6 @@ func (o *Obj) AttachCGroup(cgroup, progName string) (*Link, error) {
 
 const (
 	// Set when IPv6 is enabled to configure bpf dataplane accordingly
-	GlobalsIPv6Enabled      uint32 = C.CALI_GLOBALS_IPV6_ENABLED
 	GlobalsRPFOptionEnabled uint32 = C.CALI_GLOBALS_RPF_OPTION_ENABLED
 	GlobalsRPFOptionStrict  uint32 = C.CALI_GLOBALS_RPF_OPTION_STRICT
 	GlobalsNoDSRCidrs       uint32 = C.CALI_GLOBALS_NO_DSR_CIDRS

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -58,7 +58,6 @@ type AttachPoint struct {
 	ExtToServiceConnmark uint32
 	PSNATStart           uint16
 	PSNATEnd             uint16
-	IPv6Enabled          bool
 	RPFEnforceOption     uint8
 	NATin                uint32
 	NATout               uint32
@@ -403,10 +402,6 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 
 	if globalData.VxlanPort == 0 {
 		globalData.VxlanPort = 4789
-	}
-
-	if ap.IPv6Enabled {
-		globalData.Flags |= libbpf.GlobalsIPv6Enabled
 	}
 
 	if ap.DSROptoutCIDRs {

--- a/felix/bpf/ut/bpf_prog_test.go
+++ b/felix/bpf/ut/bpf_prog_test.go
@@ -735,7 +735,7 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					VxlanPort:    testVxlanPort,
 					PSNatStart:   uint16(topts.psnaStart),
 					PSNatLen:     uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:        libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
+					Flags:        libbpf.GlobalsNoDSRCidrs,
 					LogFilterJmp: 0xffffffff,
 				}
 
@@ -760,7 +760,7 @@ func objLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHostC
 					VxlanPort:    testVxlanPort,
 					PSNatStart:   uint16(topts.psnaStart),
 					PSNatLen:     uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:        libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
+					Flags:        libbpf.GlobalsNoDSRCidrs,
 					LogFilterJmp: 0xffffffff,
 				}
 
@@ -873,7 +873,7 @@ func objUTLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHos
 					VxlanPort:  testVxlanPort,
 					PSNatStart: uint16(topts.psnaStart),
 					PSNatLen:   uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:      libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
+					Flags:      libbpf.GlobalsNoDSRCidrs,
 				}
 
 				copy(globals.HostTunnelIPv6[:], node1tunIPV6.To16())
@@ -889,7 +889,7 @@ func objUTLoad(fname, bpfFsDir, ipFamily string, topts testOpts, polProg, hasHos
 					VxlanPort:  testVxlanPort,
 					PSNatStart: uint16(topts.psnaStart),
 					PSNatLen:   uint16(topts.psnatEnd-topts.psnaStart) + 1,
-					Flags:      libbpf.GlobalsIPv6Enabled | libbpf.GlobalsNoDSRCidrs,
+					Flags:      libbpf.GlobalsNoDSRCidrs,
 				}
 				copy(globals.HostTunnelIPv4[0:4], node1tunIP.To4())
 				copy(globals.HostIPv4[0:4], hostIP.To4())

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2150,7 +2150,6 @@ func mergeAttachPoints(ap4, ap6 attachPoint) attachPoint {
 				aptcV4.HostTunnelIPv6 = aptcV6.HostTunnelIPv6
 				aptcV4.HookLayoutV6 = aptcV6.HookLayoutV6
 				aptcV4.PolicyIdxV6 = aptcV6.PolicyIdxV6
-				aptcV4.IPv6Enabled = true
 				return aptcV4
 			}
 		}
@@ -2643,7 +2642,6 @@ func (d *bpfEndpointManagerDataplane) configureTCAttachPoint(policyDirection Pol
 	}
 
 	ap.ToOrFrom = toOrFrom
-	ap.IPv6Enabled = (d.ipFamily == proto.IPVersion_IPV6)
 	return ap
 }
 

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2150,6 +2150,7 @@ func mergeAttachPoints(ap4, ap6 attachPoint) attachPoint {
 				aptcV4.HostTunnelIPv6 = aptcV6.HostTunnelIPv6
 				aptcV4.HookLayoutV6 = aptcV6.HookLayoutV6
 				aptcV4.PolicyIdxV6 = aptcV6.PolicyIdxV6
+				aptcV4.IPv6Enabled = true
 				return aptcV4
 			}
 		}

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -350,7 +350,8 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 
 					// Since we allow the IPv6 packets through IPv4 programs, a stale neighbor entry might get created
 					// when trying to reach w[0][0] from workloads in felix-1. This will impact subsequent
-					// tests. Hence cleaning up the neighbor entry.
+					// tests. This does not seem to be a problem with ubuntu 22+ but is on ubuntu 20.
+					// Hence cleaning up the neighbor entry.
 					tc.Felixes[0].Exec("ip", "-6", "neigh", "del", w[0][0].IP6, "dev", w[0][0].InterfaceName)
 
 					// Add the node IPv6 address

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -285,6 +285,7 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 					tc.TriggerDelayedStart()
 
 					ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready)
+					ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
 					cc.ExpectSome(w[0][1], w[0][0])
 					cc.ExpectSome(w[1][0], w[0][0])
 					cc.ExpectSome(w[1][1], w[0][0])


### PR DESCRIPTION
## Description

The changes in this PR lets the IPv6 packet to the IPv4 bpf programs in case the ipv6 dataplane is not ready.  This is important to allow IPv6 packets through host endpoints so that we don't lock out ourselves. 

IPv6 packets from workloads will be dropped by the IPv4 main program.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
