### PR TITLE
Use semaphore self-hosted arm64 machine

### DIFF
--- a/.semaphore/push-images/alp.yml
+++ b/.semaphore/push-images/alp.yml
@@ -8,39 +8,48 @@ agent:
 execution_time_limit:
   minutes: 60
 
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Free up space on the build machine.
+      - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+
 blocks:
-  # Build and push images.
-  # We'll only do this on non-PR builds, where we have credentials to do so.
-  - name: "Publish ALP images"
+  - name: Publish ALP images
+    dependencies: []
     skip:
-      # Only run on branches, not PRs.
       when: "branch !~ '.+'"
     task:
-      prologue:
-        commands:
-        - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
-        - sudo systemctl stop docker
-        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-        - sudo systemctl start docker
-        # Free up space on the build machine.
-        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
-        # Semaphore is doing shallow clone on a commit without tags.
-        # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - retry git fetch --unshallow
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      secrets:
-      - name: quay-robot-calico+semaphoreci
-      - name: docker
       jobs:
-      - name: "ALP"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C pod2daemon image-all cd CONFIRM=true; fi
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C app-policy image-all cd CONFIRM=true; fi
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C app-policy cd CONFIRM=true; fi
+  - name: Publish ALP multi-arch manifests
+    dependencies:
+      - Publish ALP images
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch manifests
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C app-policy push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/apiserver.yml
+++ b/.semaphore/push-images/apiserver.yml
@@ -8,40 +8,48 @@ agent:
 execution_time_limit:
   minutes: 60
 
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Free up space on the build machine.
+      - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+
 blocks:
-  # Build and push images.
-  # We'll only do this on non-PR builds, where we have credentials to do so.
-  - name: "Publish apiserver images"
+  - name: Publish apiserver images
+    dependencies: []
     skip:
-      # Only run on branches, not PRs.
       when: "branch !~ '.+'"
     task:
-      prologue:
-        commands:
-        - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
-        - sudo systemctl stop docker
-        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-        - sudo systemctl start docker
-        # Free up space on the build machine.
-        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
-        # Semaphore is doing shallow clone on a commit without tags.
-        # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - retry git fetch --unshallow
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      secrets:
-      - name: quay-robot-calico+semaphoreci
-      - name: docker
       jobs:
-      # The apiserver build takes a long time due to some architectures, so we split it up.
-      # TODO: Add support for other architectures
-      - name: "Linux amd64"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make VALIDARCHES=amd64 -C apiserver image-all cd-common CONFIRM=true; fi
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C apiserver cd CONFIRM=true; fi
+  - name: Publish apiserver multi-arch manifests
+    dependencies:
+      - Publish apiserver images
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch manifests
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C apiserver push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/calicoctl.yml
+++ b/.semaphore/push-images/calicoctl.yml
@@ -2,44 +2,54 @@ version: v1.0
 name: Publish calicoctl images
 agent:
   machine:
-    type: e1-standard-4
+    type: e1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60
 
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Free up space on the build machine.
+      - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+
 blocks:
-  # Build and push images.
-  # We'll only do this on non-PR builds, where we have credentials to do so.
-  - name: "Publish calicoctl images"
+  - name: Publish calicoctl images
+    dependencies: []
     skip:
-      # Only run on branches, not PRs.
       when: "branch !~ '.+'"
     task:
-      prologue:
-        commands:
-        - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
-        - sudo systemctl stop docker
-        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-        - sudo systemctl start docker
-        # Free up space on the build machine.
-        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
-        # Semaphore is doing shallow clone on a commit without tags.
-        # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - retry git fetch --unshallow
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      secrets:
-      - name: quay-robot-calico+semaphoreci
-      - name: docker
       jobs:
-      - name: "calicoctl"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C calicoctl image-all cd CONFIRM=true; fi
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C calicoctl cd CONFIRM=true; fi
+  - name: Publish calicoctl multi-arch manifests
+    dependencies:
+      - Publish calicoctl images
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch manifests
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C calicoctl push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -8,44 +8,51 @@ agent:
 execution_time_limit:
   minutes: 60
 
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Free up space on the build machine.
+      - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+
 blocks:
-  # Build and push images.
-  # We'll only do this on non-PR builds, where we have credentials to do so.
-  - name: "Publish cni-plugin images"
+  - name: Publish cni-plugin images
+    dependencies: []
     skip:
-      # Only run on branches, not PRs.
       when: "branch !~ '.+'"
     task:
-      prologue:
-        commands:
-        - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
-        - sudo systemctl stop docker
-        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-        - sudo systemctl start docker
-        # Free up space on the build machine.
-        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
-        # Semaphore is doing shallow clone on a commit without tags.
-        # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - retry git fetch --unshallow
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      secrets:
-      - name: quay-robot-calico+semaphoreci
-      - name: docker
       jobs:
-      - name: "linux"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin image-all cd CONFIRM=true; fi
-      - name: "windows"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin release-windows CONFIRM=true; fi
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin cd CONFIRM=true; fi
+        - name: Windows
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin release-windows CONFIRM=true; fi
+  - name: Publish cni-plugin multi-arch manifests
+    dependencies:
+      - Publish cni-plugin images
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch manifests
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C cni-plugin push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/key-cert-provisioner.yml
+++ b/.semaphore/push-images/key-cert-provisioner.yml
@@ -8,38 +8,48 @@ agent:
 execution_time_limit:
   minutes: 60
 
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Free up space on the build machine.
+      - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+
 blocks:
-  # Build and push images.
-  # We'll only do this on non-PR builds, where we have credentials to do so.
-  - name: "Publish key-cert-provisioner images"
+  - name: Publish key-cert-provisioner images
+    dependencies: []
     skip:
-      # Only run on branches, not PRs.
       when: "branch !~ '.+'"
     task:
-      prologue:
-        commands:
-        - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
-        - sudo systemctl stop docker
-        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-        - sudo systemctl start docker
-        # Free up space on the build machine.
-        - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
-        # Semaphore is doing shallow clone on a commit without tags.
-        # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - retry git fetch --unshallow
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      secrets:
-      - name: quay-robot-calico+semaphoreci
-      - name: docker
       jobs:
-      - name: "key-cert-provisioner"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C key-cert-provisioner cd CONFIRM=true; fi
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C key-cert-provisioner cd CONFIRM=true; fi
+  - name: Publish key-cert-provisioner multi-arch manifests
+    dependencies:
+      - Publish key-cert-provisioner images
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch manifests
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C key-cert-provisioner push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/kube-controllers.yml
+++ b/.semaphore/push-images/kube-controllers.yml
@@ -8,38 +8,48 @@ agent:
 execution_time_limit:
   minutes: 60
 
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Free up space on the build machine.
+      - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+
 blocks:
-  # Build and push images.
-  # We'll only do this on non-PR builds, where we have credentials to do so.
-  - name: "Publish kube-controllers images"
+  - name: Publish kube-controllers images
+    dependencies: []
     skip:
-      # Only run on branches, not PRs.
       when: "branch !~ '.+'"
     task:
-      prologue:
-        commands:
-        - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
-        - sudo systemctl stop docker
-        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-        - sudo systemctl start docker
-        # Free up space on the build machine.
-        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
-        # Semaphore is doing shallow clone on a commit without tags.
-        # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - retry git fetch --unshallow
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      secrets:
-      - name: quay-robot-calico+semaphoreci
-      - name: docker
       jobs:
-      - name: "kube-controllers"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C kube-controllers image-all cd CONFIRM=true; fi
+        - name: "kube-controllers"
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C kube-controllers cd CONFIRM=true; fi
+  - name: Publish kube-controllers multi-arch manifests
+    dependencies:
+      - Publish kube-controllers images
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch manifests
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C kube-controllers push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -10,27 +10,27 @@ execution_time_limit:
 
 global_job_config:
   secrets:
-  - name: google-service-account-for-tigera-infra
-  - name: launchpad-secret-key
+    - name: google-service-account-for-tigera-infra
+    - name: launchpad-secret-key
   prologue:
     commands:
-    - checkout
-    # Semaphore is doing shallow clone on a commit without tags.
-    # unshallow it because we need a reliable git describe.
-    - retry git fetch --unshallow
-    - git config --global user.email marvin@tigera.io
-    - git config --global user.name Marvin
-    - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
-    - gcloud config set project tigera-wp-tcp-redirect
-    - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    - export SECRET_KEY=$HOME/secrets/marvin.txt
-    - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
-    - export HOST=ubuntu@binaries-projectcalico-org
-    - sudo apt-get update -y
-    - sudo apt-get install -y moreutils patchelf
+      - checkout
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it because we need a reliable git describe.
+      - retry git fetch --unshallow
+      - git config --global user.email marvin@tigera.io
+      - git config --global user.name Marvin
+      - export GOOGLE_APPLICATION_CREDENTIALS=$HOME/secrets/tigera-infra-access.json
+      - gcloud config set project tigera-wp-tcp-redirect
+      - gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+      - export SECRET_KEY=$HOME/secrets/marvin.txt
+      - export GCLOUD_ARGS='--zone us-east1-c --project tigera-wp-tcp-redirect'
+      - export HOST=ubuntu@binaries-projectcalico-org
+      - sudo apt-get update -y
+      - sudo apt-get install -y moreutils patchelf
 
 blocks:
-  - name: 'Publish openstack packages'
+  - name: "Publish openstack packages"
     skip:
       # Only run on branches, not PRs.
       #
@@ -44,6 +44,6 @@ blocks:
       when: "branch !~ '.+'"
     task:
       jobs:
-      - name: 'packages'
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release/packaging release-publish VERSION=$SEMAPHORE_GIT_BRANCH; fi
+        - name: "packages"
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C hack/release/packaging release-publish VERSION=$SEMAPHORE_GIT_BRANCH; fi

--- a/.semaphore/push-images/pod2daemon.yml
+++ b/.semaphore/push-images/pod2daemon.yml
@@ -1,8 +1,8 @@
 version: v1.0
-name: Publish node images
+name: Publish pod2daemon images
 agent:
   machine:
-    type: e1-standard-4
+    type: e1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:
@@ -34,7 +34,7 @@ global_job_config:
       - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
 
 blocks:
-  - name: "Publish node images"
+  - name: Publish pod2daemon images
     dependencies: []
     skip:
       when: "branch !~ '.+'"
@@ -42,30 +42,14 @@ blocks:
       jobs:
         - name: Linux multi-arch
           commands:
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node cd EXCLUDEARCH=arm64 CONFIRM=true; fi
-        - name: Windows
-          commands:
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node release-windows CONFIRM=true; fi
-  - name: Publish node images - native arm64 runner
-    dependencies: []
-    skip:
-      when: "branch !~ '.+'"
-    task:
-      agent:
-        machine:
-          type: s1-aws-arm64-2
-      jobs:
-        - name: Linux arm64
-          commands:
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; make -C node cd ARCHES=arm64 CONFIRM=true; fi
-  - name: Publish node multi-arch manifests
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C pod2daemon cd CONFIRM=true; fi
+  - name: Publish pod2daemon multi-arch manifests
     dependencies:
-      - Publish node images
-      - "Publish node images - native arm64 runner"
+      - Publish pod2daemon images
     skip:
       when: "branch !~ '.+'"
     task:
       jobs:
         - name: Linux multi-arch manifests
           commands:
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node push-manifests-with-tag CONFIRM=true; fi
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C pod2daemon push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/push-images/typha.yml
+++ b/.semaphore/push-images/typha.yml
@@ -2,44 +2,54 @@ version: v1.0
 name: Publish typha images
 agent:
   machine:
-    type: e1-standard-4
+    type: e1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:
   minutes: 60
 
+global_job_config:
+  env_vars:
+    - name: DEV_REGISTRIES
+      value: quay.io/calico docker.io/calico
+  secrets:
+    - name: docker
+    - name: quay-robot-calico+semaphoreci
+  prologue:
+    commands:
+      - checkout
+      # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
+      # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
+      # how much we churn docker containers during the build.  Disable it.
+      - sudo systemctl stop docker
+      - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
+      - sudo systemctl start docker
+      # Free up space on the build machine.
+      - sudo rm -rf ~/{.kerl,.kiex,.npm,.nvm,.phpbrew,.rbenv,.sbt} /opt/{apache-maven*,firefox*,scala} /usr/lib/jvm /usr/local/{aws2,golang,phantomjs*}
+      # Semaphore is doing shallow clone on a commit without tags.
+      # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
+      - retry git fetch --unshallow
+      - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+      - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+
 blocks:
-  # Build and push images.
-  # We'll only do this on non-PR builds, where we have credentials to do so.
-  - name: "Publish typha images"
+  - name: Publish typha images
+    dependencies: []
     skip:
-      # Only run on branches, not PRs.
       when: "branch !~ '.+'"
     task:
-      prologue:
-        commands:
-        - checkout
-        # Semaphore mounts a copy-on-write FS as /var/lib/docker in order to provide a pre-loaded cache of
-        # some images. However, the cache is not useful to us and the copy-on-write FS is a big problem given
-        # how much we churn docker containers during the build.  Disable it.
-        - sudo systemctl stop docker
-        - sudo umount /var/lib/docker && sudo killall qemu-nbd || true
-        - sudo systemctl start docker
-        # Free up space on the build machine.
-        - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl ~/.sbt ~/.npm /usr/lib/jvm /opt/firefox* /opt/apache-maven* /opt/scala /usr/local/golang
-        # Semaphore is doing shallow clone on a commit without tags.
-        # unshallow it for GIT_VERSION:=$(shell git describe --tags --dirty --always)
-        - retry git fetch --unshallow
-        - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
-        - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
-        - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
-      secrets:
-      - name: quay-robot-calico+semaphoreci
-      - name: docker
       jobs:
-      - name: "typha"
-        env_vars:
-        - name: DEV_REGISTRIES
-          value: quay.io/calico docker.io/calico
-        commands:
-        - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C typha image-all cd CONFIRM=true; fi
+        - name: Linux multi-arch
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C typha cd CONFIRM=true; fi
+  - name: Publish typha multi-arch manifests
+    dependencies:
+      - Publish typha images
+    skip:
+      when: "branch !~ '.+'"
+    task:
+      jobs:
+        - name: Linux multi-arch manifests
+          commands:
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C typha push-manifests-with-tag CONFIRM=true; fi

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -80,6 +80,10 @@ promotions:
     pipeline_file: push-images/kube-controllers.yml
     auto_promote:
       when: "branch =~ 'master|release-'"
+  - name: Push pod2daemon images
+    pipeline_file: push-images/pod2daemon.yml
+    auto_promote:
+      when: "branch =~ 'master|release-'"
   - name: Push typha images
     pipeline_file: push-images/typha.yml
     auto_promote:
@@ -335,16 +339,12 @@ blocks:
         commands:
           - ../.semaphore/run-and-monitor static-checks.log make static-checks
 
-- name: "Felix: multi-arch builds"
+- name: "Felix: multi-arch build"
   run:
     when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - "Felix: Build"
   task:
-    agent:
-      machine:
-        type: e1-standard-4
-        os_image: ubuntu2004
     prologue:
       commands:
         - cd felix
@@ -355,13 +355,31 @@ blocks:
         matrix:
           - env_var: ARCH
             values:
-              - arm64
               - ppc64le
               - s390x
         commands:
           # Only building the code, not the image here because the felix image is now only used for FV tests, which
           # only run on AMD64 at the moment.
           - ../.semaphore/run-and-monitor build-$ARCH.log make build ARCH=$ARCH
+
+- name: "Felix: Build - native arm64 runner"
+  run:
+    when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+  dependencies:
+    - "Felix: Build"
+  task:
+    agent:
+      machine:
+        type: s1-aws-arm64-2
+    prologue:
+      commands:
+        - cd felix
+        - cache restore go-pkg-cache
+        - cache restore go-mod-cache
+    jobs:
+      - name: Build binary
+        commands:
+          - ../.semaphore/run-and-monitor build-arm64.log make build ARCH=arm64
 
 - name: "Felix: Build Windows binaries"
   run:
@@ -493,7 +511,7 @@ blocks:
   run:
     when: "true or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
-    - "Felix: Build"
+    - Prerequisites
   task:
     prologue:
       commands:
@@ -573,7 +591,7 @@ blocks:
   run:
     when: "true or change_in(['/felix/', '/confd/', '/node/'])"
   dependencies:
-    - Prerequisites
+    - "Node: Build"
   task:
     agent:
       machine:
@@ -587,7 +605,6 @@ blocks:
         matrix:
           - env_var: ARCH
             values:
-              - arm64
               - ppc64le
               - s390x
         commands:
@@ -598,6 +615,23 @@ blocks:
       - name: "Build Windows image"
         commands:
           - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
+
+- name: "Node: Build - native arm64 runner"
+  run:
+    when: "true or change_in(['/felix/', '/confd/', '/node/'])"
+  dependencies:
+    - "Node: Build"
+  task:
+    agent:
+      machine:
+        type: s1-aws-arm64-2
+    prologue:
+      commands:
+        - cd node
+    jobs:
+      - name: Build image
+        commands:
+          - ../.semaphore/run-and-monitor build-arm64.log make image ARCH=arm64
 
 - name: "Node: kind-cluster tests"
   run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,6 +80,10 @@ promotions:
     pipeline_file: push-images/kube-controllers.yml
     auto_promote:
       when: "branch =~ 'master|release-'"
+  - name: Push pod2daemon images
+    pipeline_file: push-images/pod2daemon.yml
+    auto_promote:
+      when: "branch =~ 'master|release-'"
   - name: Push typha images
     pipeline_file: push-images/typha.yml
     auto_promote:
@@ -335,16 +339,12 @@ blocks:
         commands:
           - ../.semaphore/run-and-monitor static-checks.log make static-checks
 
-- name: "Felix: multi-arch builds"
+- name: "Felix: multi-arch build"
   run:
     when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - "Felix: Build"
   task:
-    agent:
-      machine:
-        type: e1-standard-4
-        os_image: ubuntu2004
     prologue:
       commands:
         - cd felix
@@ -355,13 +355,31 @@ blocks:
         matrix:
           - env_var: ARCH
             values:
-              - arm64
               - ppc64le
               - s390x
         commands:
           # Only building the code, not the image here because the felix image is now only used for FV tests, which
           # only run on AMD64 at the moment.
           - ../.semaphore/run-and-monitor build-$ARCH.log make build ARCH=$ARCH
+
+- name: "Felix: Build - native arm64 runner"
+  run:
+    when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+  dependencies:
+    - "Felix: Build"
+  task:
+    agent:
+      machine:
+        type: s1-aws-arm64-2
+    prologue:
+      commands:
+        - cd felix
+        - cache restore go-pkg-cache
+        - cache restore go-mod-cache
+    jobs:
+      - name: Build binary
+        commands:
+          - ../.semaphore/run-and-monitor build-arm64.log make build ARCH=arm64
 
 - name: "Felix: Build Windows binaries"
   run:
@@ -493,7 +511,7 @@ blocks:
   run:
     when: "false or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
-    - "Felix: Build"
+    - Prerequisites
   task:
     prologue:
       commands:
@@ -573,7 +591,7 @@ blocks:
   run:
     when: "false or change_in(['/felix/', '/confd/', '/node/'])"
   dependencies:
-    - Prerequisites
+    - "Node: Build"
   task:
     agent:
       machine:
@@ -587,7 +605,6 @@ blocks:
         matrix:
           - env_var: ARCH
             values:
-              - arm64
               - ppc64le
               - s390x
         commands:
@@ -598,6 +615,23 @@ blocks:
       - name: "Build Windows image"
         commands:
           - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
+
+- name: "Node: Build - native arm64 runner"
+  run:
+    when: "false or change_in(['/felix/', '/confd/', '/node/'])"
+  dependencies:
+    - "Node: Build"
+  task:
+    agent:
+      machine:
+        type: s1-aws-arm64-2
+    prologue:
+      commands:
+        - cd node
+    jobs:
+      - name: Build image
+        commands:
+          - ../.semaphore/run-and-monitor build-arm64.log make image ARCH=arm64
 
 - name: "Node: kind-cluster tests"
   run:

--- a/.semaphore/semaphore.yml.d/03-promotions.yml
+++ b/.semaphore/semaphore.yml.d/03-promotions.yml
@@ -37,6 +37,10 @@ promotions:
     pipeline_file: push-images/kube-controllers.yml
     auto_promote:
       when: "branch =~ 'master|release-'"
+  - name: Push pod2daemon images
+    pipeline_file: push-images/pod2daemon.yml
+    auto_promote:
+      when: "branch =~ 'master|release-'"
   - name: Push typha images
     pipeline_file: push-images/typha.yml
     auto_promote:

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -36,16 +36,12 @@
         commands:
           - ../.semaphore/run-and-monitor static-checks.log make static-checks
 
-- name: "Felix: multi-arch builds"
+- name: "Felix: multi-arch build"
   run:
     when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
     - "Felix: Build"
   task:
-    agent:
-      machine:
-        type: e1-standard-4
-        os_image: ubuntu2004
     prologue:
       commands:
         - cd felix
@@ -56,13 +52,31 @@
         matrix:
           - env_var: ARCH
             values:
-              - arm64
               - ppc64le
               - s390x
         commands:
           # Only building the code, not the image here because the felix image is now only used for FV tests, which
           # only run on AMD64 at the moment.
           - ../.semaphore/run-and-monitor build-$ARCH.log make build ARCH=$ARCH
+
+- name: "Felix: Build - native arm64 runner"
+  run:
+    when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
+  dependencies:
+    - "Felix: Build"
+  task:
+    agent:
+      machine:
+        type: s1-aws-arm64-2
+    prologue:
+      commands:
+        - cd felix
+        - cache restore go-pkg-cache
+        - cache restore go-mod-cache
+    jobs:
+      - name: Build binary
+        commands:
+          - ../.semaphore/run-and-monitor build-arm64.log make build ARCH=arm64
 
 - name: "Felix: Build Windows binaries"
   run:
@@ -194,7 +208,7 @@
   run:
     when: "${FORCE_RUN} or change_in(['/*', '/api/', '/libcalico-go/', '/typha/', '/felix/'], {exclude: ['/**/.gitignore', '/**/README.md', '/**/LICENSE']})"
   dependencies:
-    - "Felix: Build"
+    - Prerequisites
   task:
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -20,7 +20,7 @@
   run:
     when: "${FORCE_RUN} or change_in(['/felix/', '/confd/', '/node/'])"
   dependencies:
-    - Prerequisites
+    - "Node: Build"
   task:
     agent:
       machine:
@@ -34,7 +34,6 @@
         matrix:
           - env_var: ARCH
             values:
-              - arm64
               - ppc64le
               - s390x
         commands:
@@ -45,6 +44,23 @@
       - name: "Build Windows image"
         commands:
           - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
+
+- name: "Node: Build - native arm64 runner"
+  run:
+    when: "${FORCE_RUN} or change_in(['/felix/', '/confd/', '/node/'])"
+  dependencies:
+    - "Node: Build"
+  task:
+    agent:
+      machine:
+        type: s1-aws-arm64-2
+    prologue:
+      commands:
+        - cd node
+    jobs:
+      - name: Build image
+        commands:
+          - ../.semaphore/run-and-monitor build-arm64.log make image ARCH=arm64
 
 - name: "Node: kind-cluster tests"
   run:

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -89,11 +89,9 @@ CONTAINER_FIPS_CREATED=.apiserver.created-$(ARCH)-fips
 
 .PHONY: image $(API_SERVER_IMAGE)
 image: $(API_SERVER_IMAGE)
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 $(API_SERVER_IMAGE): $(CONTAINER_MARKER)
 $(CONTAINER_CREATED): Dockerfile $(BINDIR)/apiserver-$(ARCH)

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -134,11 +134,9 @@ proto/healthz.pb.go: proto/healthz.proto
 ###############################################################################
 .PHONY: image $(DIKASTES_IMAGE)
 image: $(DIKASTES_IMAGE)
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 $(DIKASTES_IMAGE): $(CONTAINER_MARKER)
 $(CONTAINER_CREATED): register Dockerfile $(BINDIR)/dikastes-$(ARCH) $(BINDIR)/healthz-$(ARCH)

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -121,11 +121,9 @@ image-windows: $(WINDOWS_IMAGE_REQS)
 # Building the image
 ###############################################################################
 image: $(DEPLOY_CONTAINER_MARKER)
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 # Builds the statically compiled binaries into a container.
 $(DEPLOY_CONTAINER_STATIC_MARKER): Dockerfile build fetch-cni-bins

--- a/felix/Makefile
+++ b/felix/Makefile
@@ -58,13 +58,6 @@ EXTRA_DOCKER_ARGS+=--init -v $(CURDIR)/../pod2daemon:/go/src/github.com/projectc
 ###############################################################################
 include ../lib.Makefile
 
-ifeq ($(ARCH),arm64)
-# Required for eBPF support in ARM64.
-# We need to force ARM64 build image to be used in a crosscompilation run.
-CALICO_BUILD:=$(GO_BUILD_IMAGE):$(GO_BUILD_VER)-$(ARCH)
-DOCKER_GO_BUILD:=$(DOCKER_RUN) $(CALICO_BUILD)
-endif
-
 FV_ETCDIMAGE?=$(ETCD_IMAGE)
 FV_TYPHAIMAGE?=felix-test/typha:latest-$(BUILDARCH)
 FV_K8SIMAGE=calico/go-build:$(GO_BUILD_VER)

--- a/key-cert-provisioner/Makefile
+++ b/key-cert-provisioner/Makefile
@@ -55,11 +55,9 @@ $(BINDIR)/test-signer-$(ARCH):
 # BUILD IMAGE
 ###############################################################################
 .PHONY: image-all
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 SIGNER_CREATED=.signer.created-$(ARCH)
 

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -82,11 +82,9 @@ $(BINDIR)/kubectl-$(ARCH):
 # Building the image
 ###############################################################################
 ## Builds the controller binary and docker image.
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 image: $(KUBE_CONTROLLER_CONTAINER_MARKER)
 
@@ -162,7 +160,7 @@ ci: clean mod-download image-all static-checks ut
 ###############################################################################
 .PHONY: cd
 ## Deploys images to registry
-cd: cd-common
+cd: image-all cd-common
 
 ###############################################################################
 # Release

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -861,11 +861,15 @@ sub-manifest-%:
 	$(DOCKER) manifest create $(call unescapefs,$*):$(IMAGETAG) $(addprefix --amend ,$(addprefix $(call unescapefs,$*):$(IMAGETAG)-,$(VALIDARCHES)))
 	$(DOCKER) manifest push --purge $(call unescapefs,$*):$(IMAGETAG)
 
+push-manifests-with-tag: var-require-one-of-CONFIRM-DRYRUN var-require-all-BRANCH_NAME
+	$(MAKE) push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(GIT_VERSION) EXCLUDEARCH="$(EXCLUDEARCH)"
+
 # cd-common tags and pushes images with the branch name and git version. This target uses PUSH_IMAGES, BUILD_IMAGE,
 # and BRANCH_NAME env variables to figure out what to tag and where to push it to.
 cd-common: var-require-one-of-CONFIRM-DRYRUN var-require-all-BRANCH_NAME
-	$(MAKE) retag-build-images-with-registries push-images-to-registries push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"
-	$(MAKE) retag-build-images-with-registries push-images-to-registries push-manifests IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(shell git describe --tags --dirty --long --always --abbrev=12) EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) retag-build-images-with-registries push-images-to-registries IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) retag-build-images-with-registries push-images-to-registries IMAGETAG=$(if $(IMAGETAG_PREFIX),$(IMAGETAG_PREFIX)-)$(shell git describe --tags --dirty --long --always --abbrev=12) EXCLUDEARCH="$(EXCLUDEARCH)"
 
 ###############################################################################
 # Release targets and helpers

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -16,22 +16,16 @@ ARG IPTABLES_VER=1.8.8-6
 ARG LIBNFTNL_VER=1.2.2-1
 ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
-ARG QEMU_IMAGE
 ARG BIRD_IMAGE=calico/bird:latest
 ARG UBI_IMAGE
 
 FROM calico/bpftool:v5.3-arm64 as bpftool
-FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 
 # Use this build stage to build iptables rpm and runit binaries.
 # We need to rebuild the iptables rpm because the prepackaged rpm does not have legacy iptables binaries.
 # We need to build runit because there aren't any rpms for it in CentOS or ubi repositories.
 FROM quay.io/centos/centos:stream8 as centos
-
-# Enable non-native builds of this image on an amd64 hosts.
-# This must be the first RUN command in this file!
-COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
 ARG IPTABLES_VER
 ARG LIBNFTNL_VER
@@ -85,13 +79,6 @@ RUN wget -P /tmp https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_V
     gunzip /tmp/runit_${RUNIT_VER}.orig.tar.gz && \
     tar -xpf /tmp/runit_${RUNIT_VER}.orig.tar -C /tmp && \
     cd /tmp/admin/runit-${RUNIT_VER}/ && \
-    # runit compilation trigger a false positive error halting the process.
-    sed -i "s/runit-init/\/tmp\/admin\/runit-2.1.2\/compile\/runit-init/" src/runit-init.dist && \
-    sed -i "s/runsv/\/tmp\/admin\/runit-2.1.2\/compile\/runsv/" src/runsv.dist && \
-    sed -i "s/runsvchdir/\/tmp\/admin\/runit-2.1.2\/compile\/runsvchdir/" src/runsvchdir.dist && \
-    sed -i "s/runsvdir/\/tmp\/admin\/runit-2.1.2\/compile\/runsvdir/" src/runsvdir.dist && \
-    sed -i "s/svlogd/\/tmp\/admin\/runit-2.1.2\/compile\/svlogd/" src/svlogd.dist && \
-    sed -i "s/utmpset/\/tmp\/admin\/runit-2.1.2\/compile\/utmpset/" src/utmpset.dist && \
     package/install
 
 FROM ${UBI_IMAGE} as ubi
@@ -101,10 +88,6 @@ ARG IPTABLES_VER
 ARG LIBNFTNL_VER
 ARG IPSET_VER
 ARG RUNIT_VER
-
-# Enable non-native builds of this image on an amd64 hosts.
-# This must be the first RUN command in this file!
-COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
 
 # Update base packages to pick up security updates.  Must do this before adding the centos repo.
 RUN microdnf upgrade
@@ -219,14 +202,8 @@ RUN chmod u+s /bin/mountns
 
 # Clean out as many files as we can from the filesystem.  We no longer need dnf or the platform python install
 # or any of its dependencies.
-COPY clean-up-filesystem.sh /
-
-# Allowing qemu binaries to persist.
-RUN sed -i 's#zmore#zmore\n\tqemu\n#m' clean-up-filesystem.sh
+COPY clean-up-filesystem.sh /clean-up-filesystem.sh
 RUN /clean-up-filesystem.sh
-
-# Delete qemu binaries
-RUN rm /usr/bin/qemu-*-static
 
 # Add in top-level license file
 COPY LICENSE /licenses/LICENSE

--- a/node/Makefile
+++ b/node/Makefile
@@ -246,11 +246,9 @@ endif
 # Building the image
 ###############################################################################
 ## Create the images for all supported ARCHes
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64 image-windows
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 image $(NODE_IMAGE): register $(NODE_CONTAINER_MARKER)
 $(NODE_CONTAINER_CREATED): $(REMOTE_DEPS) ./Dockerfile.$(ARCH) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) $(NODE_CONTAINER_FILES) $(TOOLS_MOUNTNS_BINARY)
@@ -437,7 +435,7 @@ st: st-checks $(REMOTE_DEPS) image dist/calicoctl busybox.tar calico-node.tar wo
 ci: static-checks ut image image-windows st
 
 ## Deploys images to registry
-cd: cd-common release-windows
+cd: image-all cd-common
 
 ###############################################################################
 # Release

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -137,11 +137,9 @@ REGISTRAR_CONTAINER_FIPS_CREATED=.csi-registrar.created-$(ARCH)-fips
 
 .PHONY: image calico/pod2daemon-flexvol
 image: $(FLEXVOL_IMAGE) $(CSI_IMAGE) $(REGISTRAR_IMAGE)
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 $(FLEXVOL_IMAGE): $(FLEXVOL_CONTAINER_MARKER)
 $(FLEXVOL_CONTAINER_CREATED): flexvol/docker-image/Dockerfile bin/flexvol-$(ARCH)

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -102,11 +102,9 @@ image: $(BUILD_IMAGES)
 
 # Build the image for the target architecture
 .PHONY: image-all
-image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
+image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
-	$(MAKE) image ARCH=$*
-sub-image-fips-%:
-	$(MAKE) image FIPS=true ARCH=$*
+	$(MAKE) image FIPS=$(FIPS) ARCH=$*
 
 # Build the calico/typha docker image, which contains only Typha.
 .PHONY: image $(TYPHA_IMAGE)
@@ -166,7 +164,7 @@ ifeq (,$(filter k8sfv-test, $(EXCEPT)))
 endif
 
 ## Deploys images to registry
-cd: cd-common
+cd: image-all cd-common
 
 fv: k8sfv-test
 


### PR DESCRIPTION
## Description

This change moves some time-consuming emulated arm64 component builds to native arm64 runner. It reduces build time by 5x-10x comparing to emulated builds.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
