### PR TITLE
Enable setting default felix configuration via helm installs

### DIFF
--- a/charts/tigera-operator/templates/crs/configmap-felixconfiguration-templates.yaml
+++ b/charts/tigera-operator/templates/crs/configmap-felixconfiguration-templates.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.defaultFelixConfiguration.enabled }}
+{{ $spec := omit .Values.defaultFelixConfiguration "enabled" }}
+kind: FelixConfiguration
+apiVersion: crd.projectcalico.org/v1
+metadata:
+  name: default
+spec:
+{{ $spec | toYaml | indent 2 }}
+{{ end }}

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -18,6 +18,9 @@ installation:
 apiServer:
   enabled: true
 
+defaultFelixConfiguration:
+  enabled: false
+
 certs:
   node:
     key:


### PR DESCRIPTION
What:
- Enable setting felix configuration for default reousrce via helm install.

How:
- defaultFelixConfiguration template is provided and it is added in the helm values.yaml. By default setting defaultFelixConfiguration is set to enabled: false and if user wants to set some values, they should set enabled: true first and then add the properties and values.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
