### PR TITLE
[BPF] host can access self via a service without CTLB

### DIFF
--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -55,6 +55,12 @@ int calico_tc_main(struct __sk_buff *skb)
 	 */
 	skb->mark = SKB_MARK;
 #endif
+
+	if (CALI_F_LO && CALI_F_TO_HOST) {
+		/* Do nothing, it is a packet that just looped around. */
+		return TC_ACT_UNSPEC;
+	}
+
 	/* Optimisation: if another BPF program has already pre-approved the packet,
 	 * skip all processing. */
 	if (CALI_F_FROM_HOST && skb->mark == CALI_SKB_MARK_BYPASS) {
@@ -263,6 +269,16 @@ static CALI_BPF_INLINE void calico_tc_process_ct_lookup(struct cali_tc_ctx *ctx)
 		  skb_mark_equals(ctx->skb, CALI_SKB_MARK_BYPASS_MASK, CALI_SKB_MARK_SKIP_FIB)));
 
 	if (HAS_HOST_CONFLICT_PROG &&
+			/* Do not do conflict resolution for host-self loop. Unlike with
+			 * traffic to another backend, we are not able to tell traffic to
+			 * self via service from straight to self.
+			 */
+			!CALI_F_LO &&
+			/* Do conflict resolution on other device if it clashes with
+			 * traffic looped via the NAT_IF but it hasn't been seen yet and
+			 * is not looped via the NAT_IF, that is, it is from host, but not
+			 * to a service.
+			 */
 			(ctx->state->ct_result.flags & CALI_CT_FLAG_VIA_NAT_IF) &&
 			!(ctx->skb->mark & (CALI_SKB_MARK_FROM_NAT_IFACE_OUT | CALI_SKB_MARK_SEEN))) {
 		CALI_DEBUG("Host source SNAT conflict\n");


### PR DESCRIPTION
added test for this case

No host source conflict resolution on lo since we cannot tell traffic straight to self from traffic to self via a service. Host connecting to self and connecting to the same self port via a service should be rare, but if that is necessaty, than CTLB is the only option.

fixes https://github.com/projectcalico/calico/issues/8557
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: host can access self via a service without CTLB
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
