### PR TITLE
Support IPV6 failsafes  - ebpf

### DIFF
--- a/felix/bpf-gpl/failsafe.h
+++ b/felix/bpf-gpl/failsafe.h
@@ -40,7 +40,6 @@ CALI_MAP_NAMED(cali_v4_fsafes, cali_fsafes, 2,
 #define FSAFE_PREFIX_LEN_IN_BITS (FSAFE_PREFIX_LEN * 8)
 
 static CALI_BPF_INLINE bool is_failsafe_in(__u8 ip_proto, __u16 dport, ipv46_addr_t ip) {
-#ifndef IPVER6
 	struct failsafe_key key = {
 		.prefixlen = FSAFE_PREFIX_LEN_IN_BITS,
 		.ip_proto = ip_proto,
@@ -51,14 +50,10 @@ static CALI_BPF_INLINE bool is_failsafe_in(__u8 ip_proto, __u16 dport, ipv46_add
 	if (cali_fsafes_lookup_elem(&key)) {
 		return true;
 	}
-#else
-	/* XXX not implemented yet*/
-#endif
 	return false;
 }
 
 static CALI_BPF_INLINE bool is_failsafe_out(__u8 ip_proto, __u16 dport, ipv46_addr_t ip) {
-#ifndef IPVER6
 	struct failsafe_key key = {
 		.prefixlen = FSAFE_PREFIX_LEN_IN_BITS,
 		.ip_proto = ip_proto,
@@ -69,9 +64,6 @@ static CALI_BPF_INLINE bool is_failsafe_out(__u8 ip_proto, __u16 dport, ipv46_ad
 	if (cali_fsafes_lookup_elem(&key)) {
 		return true;
 	}
-#else
-	/* XXX not implemented yet*/
-#endif
 	return false;
 }
 

--- a/felix/bpf/failsafes/failsafes.go
+++ b/felix/bpf/failsafes/failsafes.go
@@ -121,38 +121,14 @@ func (m *Manager) ResyncFailsafes() error {
 			return
 		}
 
-		mask, bits := ipnet.Mask.Size()
+		mask, _ := ipnet.Mask.Size()
 		maskedIPStr := ""
 		if m.ipFamily == proto.IPVersion_IPV4 {
 			ipv4 := ip.To4()
-			if ipv4 == nil || len(ipv4) != 4 {
-				// If ipv4 is nil, then the IP is not an IPv4 address. Only IPv4 addresses are supported in failsafes.
-				log.Errorf("Invalid IPv4 address configured in the failsafe ports: %s", cidr)
-				syncFailed = true
-				return
-			}
-
-			if bits != 32 {
-				log.Errorf("CIDR mask size not valid for IPv4 addresses: %d", bits)
-				syncFailed = true
-				return
-			}
-
 			// Mask the IP
 			maskedIPStr = ipv4.Mask(ipnet.Mask).String()
 		} else {
 			ipv6 := ip.To16()
-			if ipv6 == nil || len(ipv6) != 16 {
-				log.Errorf("Invalid IPv6 address configured in the failsafe ports: %s", cidr)
-				syncFailed = true
-				return
-			}
-
-			if bits != 128 {
-				log.Errorf("CIDR mask size not valid for IPv6 addresses: %d", bits)
-				syncFailed = true
-				return
-			}
 			maskedIPStr = ipv6.Mask(ipnet.Mask).String()
 		}
 

--- a/felix/bpf/failsafes/failsafes.go
+++ b/felix/bpf/failsafes/failsafes.go
@@ -28,6 +28,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/felix/logutils"
+	"github.com/projectcalico/calico/felix/proto"
 )
 
 type Manager struct {
@@ -43,6 +44,7 @@ type Manager struct {
 	opReporter   logutils.OpRecorder
 	keyFromSlice func([]byte) KeyInterface
 	makeKey      func(ipProto uint8, port uint16, outbound bool, ip string, mask int) KeyInterface
+	ipFamily     proto.IPVersion
 }
 
 func (m *Manager) OnUpdate(_ interface{}) {
@@ -52,6 +54,7 @@ func NewManager(
 	failsafesMap maps.Map,
 	failsafesIn, failsafesOut []config.ProtoPort,
 	opReporter logutils.OpRecorder,
+	ipFamily proto.IPVersion,
 	keyFromSlice func([]byte) KeyInterface,
 	makeKey func(ipProto uint8, port uint16, outbound bool, ip string, mask int) KeyInterface,
 ) *Manager {
@@ -62,6 +65,7 @@ func NewManager(
 		opReporter:   opReporter,
 		keyFromSlice: keyFromSlice,
 		makeKey:      makeKey,
+		ipFamily:     ipFamily,
 	}
 }
 
@@ -102,6 +106,9 @@ func (m *Manager) ResyncFailsafes() error {
 		cidr := p.Net
 		if p.Net == "" {
 			cidr = "0.0.0.0/0"
+			if m.ipFamily == proto.IPVersion_IPV6 {
+				cidr = "0::0/0"
+			}
 		}
 		ip, ipnet, err := cnet.ParseCIDROrIP(cidr)
 		if err != nil {
@@ -110,25 +117,46 @@ func (m *Manager) ResyncFailsafes() error {
 			return
 		}
 
-		ipv4 := ip.To4()
-		if ipv4 == nil || len(ipv4) != 4 {
-			// If ipv4 is nil, then the IP is not an IPv4 address. Only IPv4 addresses are supported in failsafes.
-			log.Errorf("Invalid IPv4 address configured in the failsafe ports: %s", cidr)
-			syncFailed = true
+		if ipnet.Version() != int(m.ipFamily) {
 			return
 		}
 
 		mask, bits := ipnet.Mask.Size()
-		if bits != 32 {
-			log.Errorf("CIDR mask size not valid for IPv4 addresses: %d", bits)
-			syncFailed = true
-			return
+		maskedIPStr := ""
+		if m.ipFamily == proto.IPVersion_IPV4 {
+			ipv4 := ip.To4()
+			if ipv4 == nil || len(ipv4) != 4 {
+				// If ipv4 is nil, then the IP is not an IPv4 address. Only IPv4 addresses are supported in failsafes.
+				log.Errorf("Invalid IPv4 address configured in the failsafe ports: %s", cidr)
+				syncFailed = true
+				return
+			}
+
+			if bits != 32 {
+				log.Errorf("CIDR mask size not valid for IPv4 addresses: %d", bits)
+				syncFailed = true
+				return
+			}
+
+			// Mask the IP
+			maskedIPStr = ipv4.Mask(ipnet.Mask).String()
+		} else {
+			ipv6 := ip.To16()
+			if ipv6 == nil || len(ipv6) != 16 {
+				log.Errorf("Invalid IPv6 address configured in the failsafe ports: %s", cidr)
+				syncFailed = true
+				return
+			}
+
+			if bits != 128 {
+				log.Errorf("CIDR mask size not valid for IPv6 addresses: %d", bits)
+				syncFailed = true
+				return
+			}
+			maskedIPStr = ipv6.Mask(ipnet.Mask).String()
 		}
 
-		// Mask the IP
-		maskedIP := ipv4.Mask(ipnet.Mask)
-
-		k := m.makeKey(ipProto, p.Port, outbound, maskedIP.String(), mask)
+		k := m.makeKey(ipProto, p.Port, outbound, maskedIPStr, mask)
 		unknownKeys.Discard(k)
 		err = m.failsafesMap.Update(k.ToSlice(), Value())
 		if err != nil {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2365,6 +2365,7 @@ func startBPFDataplaneComponents(ipFamily proto.IPVersion,
 		config.RulesConfig.FailsafeInboundHostPorts,
 		config.RulesConfig.FailsafeOutboundHostPorts,
 		dp.loopSummarizer,
+		ipFamily,
 		failSafesKeyFromSlice,
 		failSafesKey,
 	)


### PR DESCRIPTION
## Description

This PR has the changes for 
1. Adding failsafes entry to the IPv6 failsafe map.
2. BPF changes to enable failsafe check for IPv6.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
