### PR TITLE
Run calico/apiserver as non-root by default

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -21,6 +21,8 @@ LABEL version=${GIT_VERSION}
 
 COPY --from=source / /
 
+USER 10001:10001
+
 WORKDIR /code
 
 ENTRYPOINT ["/code/apiserver"]


### PR DESCRIPTION
## Description

This changeset sets non-root and non-group for calico/apiserver.

## Related issues/PRs

* Partially pick https://github.com/projectcalico/calico/pull/8570/files#diff-4515d3c3a9b9a975c020db3c1b5d9f05e9be98d45cf4fda9b6ffad4922d8414eR13 back to the main branch.
* Related to https://github.com/tigera/operator/pull/2906.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
