### PR TITLE
Fix bug where key usage was not consistently set with the chosen priv…

### DIFF
--- a/key-cert-provisioner/pkg/cfg/config_suite_test.go
+++ b/key-cert-provisioner/pkg/cfg/config_suite_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cfg
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTLS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/key-cert-provisioner/pkg/cfg/config_test.go
+++ b/key-cert-provisioner/pkg/cfg/config_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfg_test
+
+import (
+	"crypto/x509"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	certv1 "k8s.io/api/certificates/v1"
+
+	"github.com/projectcalico/calico/key-cert-provisioner/pkg/cfg"
+)
+
+var _ = DescribeTable("Test configuration related to private key algorithm",
+	func(privateKeyAlgorithm,
+		expectedKeyAlgorithm string,
+		expectedX509Usage x509.KeyUsage,
+		expectedCertv1Usage []certv1.KeyUsage) {
+		keyAlg, x509Usage, certv1Usage := cfg.GetPrivateKeyInfo(privateKeyAlgorithm)
+		Expect(keyAlg).To(Equal(expectedKeyAlgorithm))
+		Expect(x509Usage).To(Equal(expectedX509Usage))
+		Expect(certv1Usage).To(Equal(expectedCertv1Usage))
+	},
+	Entry("Algorithm: RSAWithSize2048", "RSAWithSize2048", "RSAWithSize2048",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyEncipherment}),
+
+	Entry("Algorithm: RSAWithSize4096", "RSAWithSize4096", "RSAWithSize4096",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyEncipherment}),
+
+	Entry("Algorithm: RSAWithSize8192", "RSAWithSize8192", "RSAWithSize8192",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyEncipherment}),
+
+	Entry("Algorithm: ECDSAWithCurve256", "ECDSAWithCurve256", "ECDSAWithCurve256",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageKeyAgreement,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyAgreement}),
+
+	Entry("Algorithm: ECDSAWithCurve384", "ECDSAWithCurve384", "ECDSAWithCurve384",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageKeyAgreement,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyAgreement}),
+
+	Entry("Algorithm: ECDSAWithCurve521", "ECDSAWithCurve521", "ECDSAWithCurve521",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageKeyAgreement,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyAgreement}),
+
+	Entry("Empty string should default to RSAWithSize2048", "", "RSAWithSize2048",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyEncipherment}),
+
+	Entry("Weird value should default to RSAWithSize2048", "weird value", "RSAWithSize2048",
+		x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature,
+		[]certv1.KeyUsage{certv1.UsageServerAuth, certv1.UsageClientAuth, certv1.UsageDigitalSignature, certv1.UsageKeyEncipherment}),
+)

--- a/key-cert-provisioner/pkg/k8s/certificate.go
+++ b/key-cert-provisioner/pkg/k8s/certificate.go
@@ -110,7 +110,7 @@ func SubmitCSR(ctx context.Context, config *cfg.Config, restClient *RestClient, 
 		Spec: certV1.CertificateSigningRequestSpec{
 			Request:    x509CSR.CSR,
 			SignerName: config.Signer,
-			Usages:     []certV1.KeyUsage{certV1.UsageServerAuth, certV1.UsageClientAuth, certV1.UsageDigitalSignature, certV1.UsageKeyAgreement},
+			Usages:     config.Certv1Usage,
 		},
 	}
 

--- a/key-cert-provisioner/pkg/k8s/certificate_test.go
+++ b/key-cert-provisioner/pkg/k8s/certificate_test.go
@@ -54,6 +54,8 @@ var _ = Describe("Test Certificates", func() {
 		config = &cfg.Config{
 			Signer:  signer,
 			CSRName: csrName,
+			Certv1Usage: []certV1.KeyUsage{certV1.UsageServerAuth, certV1.UsageClientAuth,
+				certV1.UsageDigitalSignature, certV1.UsageKeyAgreement},
 		}
 		tlsCsr = &tls.X509CSR{
 			CSR: csrPem,

--- a/key-cert-provisioner/pkg/tls/tls.go
+++ b/key-cert-provisioner/pkg/tls/tls.go
@@ -65,7 +65,7 @@ func CreateX509CSR(config *cfg.Config) (*X509CSR, error) {
 		return nil, err
 	}
 
-	usageVal, err := marshalKeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature)
+	usageVal, err := marshalKeyUsage(config.X509KeyUsage)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func CreateX509CSR(config *cfg.Config) (*X509CSR, error) {
 				Value:    basicVal,
 				Critical: true,
 			},
-			// KeyUsage will be set to KeyEncipherment and DigitalSignature.
+			// KeyUsage will be based on the type of private key algorithm.
 			usageVal,
 			{
 				// ExtKeyUsage will be set to ServerAuth and ClientAuth.
@@ -132,22 +132,22 @@ type basicConstraints struct {
 // Default: 2048 bit.
 func GeneratePrivateKey(algorithm string) (interface{}, []byte, error) {
 	switch algorithm {
-	case "RSAWithSize2048":
+	case cfg.RSAWithSize2048:
 		return genRSA(2048)
 
-	case "RSAWithSize4096":
+	case cfg.RSAWithSize4096:
 		return genRSA(4096)
 
-	case "RSAWithSize8192":
+	case cfg.RSAWithSize8192:
 		return genRSA(8192)
 
-	case "ECDSAWithCurve256":
+	case cfg.ECDSAWithCurve256:
 		return genECDSA(elliptic.P256())
 
-	case "ECDSAWithCurve384":
+	case cfg.ECDSAWithCurve384:
 		return genECDSA(elliptic.P384())
 
-	case "ECDSAWithCurve521":
+	case cfg.ECDSAWithCurve521:
 		return genECDSA(elliptic.P521())
 
 	default:


### PR DESCRIPTION
Fix bug where key usage was not consistently set with the chosen private key algorithm.

One issue that the key usage is dependent on the private key algorithm: 
- RSA needs keyencipherment
- ECDSA needs keyagreement

The other issue is that the key usage in the certificates.k8s.io request did not match with the x509 request. Depending on how the signer is implemented, this could potentially cause either a rejection of the CSR or potentially the wrong key usage.