### PR TITLE
Fix bug where key usage was not consistent

### DIFF
--- a/key-cert-provisioner/pkg/k8s/certificate.go
+++ b/key-cert-provisioner/pkg/k8s/certificate.go
@@ -110,7 +110,7 @@ func SubmitCSR(ctx context.Context, config *cfg.Config, restClient *RestClient, 
 		Spec: certV1.CertificateSigningRequestSpec{
 			Request:    x509CSR.CSR,
 			SignerName: config.Signer,
-			Usages:     []certV1.KeyUsage{certV1.UsageServerAuth, certV1.UsageClientAuth, certV1.UsageDigitalSignature, certV1.UsageKeyAgreement},
+			Usages:     []certV1.KeyUsage{certV1.UsageServerAuth, certV1.UsageClientAuth, certV1.UsageDigitalSignature, certV1.UsageKeyAgreement, certV1.UsageKeyEncipherment},
 		},
 	}
 

--- a/key-cert-provisioner/pkg/k8s/certificate_test.go
+++ b/key-cert-provisioner/pkg/k8s/certificate_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Test Certificates", func() {
 			Expect(csr.Spec.Request).To(Equal(csrPem))
 			Expect(csr.Spec.SignerName).To(Equal(signer))
 			Expect(csr.Spec.Usages).To(ConsistOf(certV1.UsageServerAuth, certV1.UsageClientAuth,
-				certV1.UsageDigitalSignature, certV1.UsageKeyAgreement))
+				certV1.UsageDigitalSignature, certV1.UsageKeyAgreement, certV1.UsageKeyEncipherment))
 			Expect(csr.Spec.Usages).NotTo(ConsistOf(certV1beta1.UsageServerAuth, certV1beta1.UsageClientAuth,
 				certV1beta1.UsageDigitalSignature, certV1beta1.UsageKeyAgreement))
 		})

--- a/key-cert-provisioner/pkg/tls/tls.go
+++ b/key-cert-provisioner/pkg/tls/tls.go
@@ -65,7 +65,7 @@ func CreateX509CSR(config *cfg.Config) (*X509CSR, error) {
 		return nil, err
 	}
 
-	usageVal, err := marshalKeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature)
+	usageVal, err := marshalKeyUsage(x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement)
 	if err != nil {
 		return nil, err
 	}

--- a/key-cert-provisioner/test-signer/test-signer.go
+++ b/key-cert-provisioner/test-signer/test-signer.go
@@ -153,7 +153,7 @@ func main() {
 				NotBefore:             time.Now(),
 				NotAfter:              time.Now().Add(10e4 * time.Hour),
 				// see http://golang.org/pkg/crypto/x509/#KeyUsage
-				KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+				KeyUsage:       x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement,
 				ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 				DNSNames:       cr.DNSNames,
 				IPAddresses:    cr.IPAddresses,


### PR DESCRIPTION
Fix bug where key usage was not consistent between the x509 CSR and the k8s CSR. For now added both key usages in both places, even though we may strictly only need KeyAgreement with the current ciphers that we support.