### PR TITLE
Pin python-dateutil to v2.8.2

### DIFF
--- a/node/calico_test/requirements.txt
+++ b/node/calico_test/requirements.txt
@@ -5,5 +5,6 @@ nose-parameterized==0.6.0
 nose-timer==0.7.1
 nose==1.3.7
 pytest
+python-dateutil==2.8.2
 pyyaml==5.3.1
 simplejson==3.13.2


### PR DESCRIPTION
## Description

This change pins python-dateutil package to v2.8.2. The latest release v2.9. 0 on Feb 29, 2024 breaks Node UT/FVs (probably due to python2 being dropped).

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
