### PR TITLE
Bump kindest/node image to k8s v1.27 release train

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -599,10 +599,10 @@ blocks:
               - s390x
         commands:
           - ../.semaphore/run-and-monitor image-$ARCH.log make image ARCH=$ARCH
-      - name: "Build Windows archive"
+      - name: Build Windows archive
         commands:
           - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
-      - name: "Build Windows image"
+      - name: Build Windows image
         commands:
           - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -599,10 +599,10 @@ blocks:
               - s390x
         commands:
           - ../.semaphore/run-and-monitor image-$ARCH.log make image ARCH=$ARCH
-      - name: "Build Windows archive"
+      - name: Build Windows archive
         commands:
           - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
-      - name: "Build Windows image"
+      - name: Build Windows image
         commands:
           - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
 

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -38,10 +38,10 @@
               - s390x
         commands:
           - ../.semaphore/run-and-monitor image-$ARCH.log make image ARCH=$ARCH
-      - name: "Build Windows archive"
+      - name: Build Windows archive
         commands:
           - ../.semaphore/run-and-monitor build-windows-archive.log make build-windows-archive
-      - name: "Build Windows image"
+      - name: Build Windows image
         commands:
           - ../.semaphore/run-and-monitor build-windows-image.log make image-windows
 

--- a/metadata.mk
+++ b/metadata.mk
@@ -11,13 +11,11 @@ ACK_GINKGO=ACK_GINKGO_DEPRECATIONS=1.16.5
 K8S_VERSION=v1.27.11
 
 # Version of various tools used in the build and tests.
-KIND_VERSION=v0.14.0
-HELM_VERSION=v3.11.3
 COREDNS_VERSION=1.5.2
 ETCD_VERSION=v3.5.6
-# FIXME upgrading to kindest/node newer than v1.24.7 causes Node/kind-cluster and sig-network conformance
-# tests to timeout or fail.
-KINDEST_NODE_VERSION=v1.24.7
+HELM_VERSION=v3.11.3
+KINDEST_NODE_VERSION=v1.27.11
+KIND_VERSION=v0.22.0
 PROTOC_VER=v0.1
 UBI_VERSION=8.9
 

--- a/node/tests/k8st/deploy_resources_on_kind_cluster.sh
+++ b/node/tests/k8st/deploy_resources_on_kind_cluster.sh
@@ -7,10 +7,10 @@ ARCH=${ARCH:-amd64}
 # kubectl binary.
 : ${kubectl:=../hack/test/kind/kubectl}
 
-function checkModule(){
+function checkModule() {
   MODULE="$1"
   echo "Checking kernel module $MODULE ..."
-  if lsmod | grep "$MODULE" &> /dev/null ; then
+  if lsmod | grep "$MODULE" &>/dev/null; then
     return 0
   else
     return 1
@@ -34,7 +34,7 @@ EOF
 EOF
 
   # And add all the IPV6 env vars
-  sed -i '/# Enable IPIP/r /dev/stdin' "${yaml}" << EOF
+  sed -i '/# Enable IPIP/r /dev/stdin' "${yaml}" <<EOF
             - name: IP6
               value: "autodetect"
             - name: CALICO_IPV6POOL_CIDR
@@ -72,9 +72,9 @@ echo
 
 echo "Wait for Calico to be ready..."
 while ! time ${kubectl} wait pod -l k8s-app=calico-node --for=condition=Ready -n kube-system --timeout=300s; do
-    # This happens when no matching resources exist yet,
-    # i.e. immediately after application of the Calico YAML.
-    sleep 5
+  # This happens when no matching resources exist yet,
+  # i.e. immediately after application of the Calico YAML.
+  sleep 5
 done
 time ${kubectl} wait pod -l k8s-app=calico-kube-controllers --for=condition=Ready -n kube-system --timeout=300s
 time ${kubectl} wait pod -l k8s-app=kube-dns --for=condition=Ready -n kube-system --timeout=300s
@@ -92,10 +92,10 @@ ${kubectl} apply -f tests/k8st/infra/test-webserver.yaml
 
 echo "Wait for client and webserver pods to be ready..."
 while ! time ${kubectl} wait pod -l pod-name=client --for=condition=Ready --timeout=300s; do
-    sleep 5
+  sleep 5
 done
 while ! time ${kubectl} wait pod -l app=webserver --for=condition=Ready --timeout=300s; do
-    sleep 5
+  sleep 5
 done
 echo "client and webserver pods are running."
 echo
@@ -108,7 +108,7 @@ rm $TEST_DIR/infra/apiserver.yaml.tmp
 openssl req -x509 -nodes -newkey rsa:4096 -keyout apiserver.key -out apiserver.crt -days 365 -subj "/" -addext "subjectAltName = DNS:calico-api.calico-apiserver.svc"
 ${kubectl} create secret -n calico-apiserver generic calico-apiserver-certs --from-file=apiserver.key --from-file=apiserver.crt
 ${kubectl} patch apiservice v3.projectcalico.org -p \
-    "{\"spec\": {\"caBundle\": \"$(${kubectl} get secret -n calico-apiserver calico-apiserver-certs -o go-template='{{ index .data "apiserver.crt" }}')\"}}"
+  "{\"spec\": {\"caBundle\": \"$(${kubectl} get secret -n calico-apiserver calico-apiserver-certs -o go-template='{{ index .data "apiserver.crt" }}')\"}}"
 time ${kubectl} wait pod -l k8s-app=calico-apiserver --for=condition=Ready -n calico-apiserver --timeout=30s
 echo "Calico apiserver is running."
 


### PR DESCRIPTION
## Description

This changeset bumps kindest/node to the latest k8s v1.27 release train for calico/node STs. It prepares for next k8s dependency update to v1.28+ releases.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
