### PR TITLE
Use distinct UIDs for Profiles generated for Namespaces and ServiceAccounts

### DIFF
--- a/libcalico-go/lib/backend/k8s/conversion/conversion.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion.go
@@ -19,9 +19,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	discovery "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -36,9 +38,7 @@ import (
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
-var (
-	protoTCP = kapiv1.ProtocolTCP
-)
+var protoTCP = kapiv1.ProtocolTCP
 
 type selectorType int8
 
@@ -99,13 +99,22 @@ func (c converter) NamespaceToProfile(ns *kapiv1.Namespace) (*model.KVPair, erro
 	// based on name within the namespaceSelector.
 	labels[NamespaceLabelPrefix+NameLabel] = ns.Name
 
+	// We don't want to use the same UID for the Profile as the Namespace, as two
+	// objects should not have the same UID. This causes confusion in the Kubernetes garbage collection logic.
+	// We can still generate a new UID programmatically from the Namespace's UID, though. This ensures a deterministic
+	// yet unique UID.
+	uid, err := uuid.NewRandomFromReader(strings.NewReader(string(ns.UID)))
+	if err != nil {
+		return nil, err
+	}
+
 	// Create the profile object.
 	name := NamespaceProfileNamePrefix + ns.Name
 	profile := apiv3.NewProfile()
 	profile.ObjectMeta = metav1.ObjectMeta{
 		Name:              name,
 		CreationTimestamp: ns.CreationTimestamp,
-		UID:               ns.UID,
+		UID:               types.UID(uid.String()),
 	}
 	profile.Spec = apiv3.ProfileSpec{
 		Ingress:       []apiv3.Rule{{Action: apiv3.Allow}},
@@ -731,12 +740,21 @@ func (c converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KV
 	// based on name within the serviceAccountSelector.
 	labels[ServiceAccountLabelPrefix+NameLabel] = sa.Name
 
+	// We don't want to use the same UID for the Profile as the ServiceAccount, as two
+	// objects should not have the same UID. This causes confusion in the Kubernetes garbage collection logic.
+	// We can still generate a new UID programmatically from the ServiceAccount's UID, though. This ensures a deterministic
+	// yet unique UID.
+	uid, err := uuid.NewRandomFromReader(strings.NewReader(string(sa.UID)))
+	if err != nil {
+		return nil, err
+	}
+
 	name := serviceAccountNameToProfileName(sa.Name, sa.Namespace)
 	profile := apiv3.NewProfile()
 	profile.ObjectMeta = metav1.ObjectMeta{
 		Name:              name,
 		CreationTimestamp: sa.CreationTimestamp,
-		UID:               sa.UID,
+		UID:               types.UID(uid.String()),
 	}
 	profile.Spec.LabelsToApply = labels
 
@@ -754,7 +772,6 @@ func (c converter) ServiceAccountToProfile(sa *kapiv1.ServiceAccount) (*model.KV
 
 // ProfileNameToServiceAccount extracts the ServiceAccount name from the given Profile name.
 func (c converter) ProfileNameToServiceAccount(profileName string) (ns, sa string, err error) {
-
 	// Profile objects backed by ServiceAccounts have form "ksa.<namespace>.<sa_name>"
 	if !strings.HasPrefix(profileName, ServiceAccountProfileNamePrefix) {
 		// This is not backed by a Kubernetes ServiceAccount.

--- a/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
+++ b/libcalico-go/lib/backend/k8s/conversion/conversion_test.go
@@ -32,6 +32,7 @@ import (
 	kapiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -3130,6 +3131,7 @@ var _ = Describe("Test Namespace conversion", func() {
 					"roger": "rabbit",
 				},
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3162,6 +3164,7 @@ var _ = Describe("Test Namespace conversion", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "default",
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3192,6 +3195,7 @@ var _ = Describe("Test Namespace conversion", func() {
 				Annotations: map[string]string{
 					"net.beta.kubernetes.io/network-policy": "{\"ingress\": {\"isolation\": \"DefaultDeny\"}}",
 				},
+				UID: types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3217,6 +3221,7 @@ var _ = Describe("Test Namespace conversion", func() {
 				Annotations: map[string]string{
 					"net.beta.kubernetes.io/network-policy": "invalidJSON",
 				},
+				UID: types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3227,6 +3232,22 @@ var _ = Describe("Test Namespace conversion", func() {
 		})
 	})
 
+	It("should generate a deterministic UID for a Namespace Profile", func() {
+		ns := kapiv1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+			Spec: kapiv1.NamespaceSpec{},
+		}
+
+		p, err := c.NamespaceToProfile(&ns)
+		Expect(err).NotTo(HaveOccurred())
+		p2, err := c.NamespaceToProfile(&ns)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.UID).To(Equal(p2.UID))
+	})
+
 	It("should handle a valid but not DefaultDeny annotation", func() {
 		ns := kapiv1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -3234,6 +3255,7 @@ var _ = Describe("Test Namespace conversion", func() {
 				Annotations: map[string]string{
 					"net.beta.kubernetes.io/network-policy": "{}",
 				},
+				UID: types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 			Spec: kapiv1.NamespaceSpec{},
 		}
@@ -3272,6 +3294,7 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 					"roger": "rabbit",
 				},
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 		}
 
@@ -3294,12 +3317,28 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 		Expect(labels["pcsa.roger"]).To(Equal("rabbit"))
 	})
 
+	It("should generate a deterministic UID for a ServiceAccount Profile", func() {
+		sa := kapiv1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sa-test",
+				Namespace: "test",
+				UID:       types.UID("30316465-6365-4463-ad63-3564622d3638"),
+			},
+		}
+		p, err := c.ServiceAccountToProfile(&sa)
+		Expect(err).NotTo(HaveOccurred())
+		p2, err := c.ServiceAccountToProfile(&sa)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(p.UID).To(Equal(p2.UID))
+	})
+
 	It("should parse a ServiceAccount in Namespace to a Profile", func() {
 		sa := kapiv1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "sa-test",
 				Namespace:   "test",
 				Annotations: map[string]string{},
+				UID:         types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 		}
 
@@ -3314,6 +3353,7 @@ var _ = Describe("Test ServiceAccount conversion", func() {
 		sa := kapiv1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "sa-test",
+				UID:  types.UID("30316465-6365-4463-ad63-3564622d3638"),
 			},
 		}
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

As discussed in
https://github.com/projectcalico/calico/issues/5715#issuecomment-1414047534,
we currently have a problem with how we handle these automatically
generated Profile resources.

Namely, they are created with the same UID as the Namespace or
ServiceAccount from which they are generated. This was originally OK
since they never showed up in the API, but with the introduction of the
Calico API server they now appear in the Kubernetes API, thus confusing
things like Kubernetes cascading deletion via OwnerReferences.

This can cause confusing and subtle errors whereby deleting a parent
resource does not clean up the child resources in the cluster, and can
appear intermittently depending on event ordering and the garbage
collector's view of the world.

This PR attempts to generate a unique-but-still-deterministic UID for
use in this case, so that Profiles generated for Namespaces and
ServiceAccounts do not appear to be the same exact object as the
Namespace / ServiceAccount that it represents.

Note that the linked issue discusses two problems with our use of UID,
and that this PR only fixes the issue as it relates to these read-only
Profile objects. Another solution is required for CRDs that support
Write operations.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

https://github.com/projectcalico/calico/issues/5715

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix bug that inhibited garbage collection of Namespaces and ServiceAccounts with OwnerReferences.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.