### PR TITLE
Add support for XDP v6

### DIFF
--- a/felix/.semaphore/create-test-vm
+++ b/felix/.semaphore/create-test-vm
@@ -28,7 +28,7 @@ function create-vm() {
   gcloud --quiet compute instances create "${vm_name}" \
            --zone=${zone} \
            --machine-type=n1-standard-4 \
-           --image=ubuntu-2004-focal-v20230302 \
+           --image=ubuntu-2204-jammy-v20240228 \
            --image-project=ubuntu-os-cloud \
            --boot-disk-size=20GB \
            --boot-disk-type=pd-standard && \
@@ -39,9 +39,9 @@ function create-vm() {
   done  && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt install apt-transport-https ca-certificates curl software-properties-common && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg" && \
-  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable' | sudo tee /etc/apt/sources.list.d/docker.list" && \
+  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu jammy stable' | sudo tee /etc/apt/sources.list.d/docker.list" && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt update -y && \
-  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt install -y --no-install-recommends git docker-ce=5:20.10.9~3-0~ubuntu-focal docker-ce-cli=5:20.10.9~3-0~ubuntu-focal containerd.io make iproute2 wireguard && \
+  gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo apt install -y --no-install-recommends git docker-ce=5:20.10.14~3-0~ubuntu-jammy docker-ce-cli=5:20.10.14~3-0~ubuntu-jammy containerd.io make iproute2 wireguard && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo usermod -a -G docker ubuntu && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- sudo modprobe ipip && \
   gcloud --quiet compute ssh --zone=${zone} "ubuntu@${vm_name}" -- 'if [ -s /etc/docker/daemon.json ] ; then cat /etc/docker/daemon.json | sed "\$d" | sed "\$s/\$/,/" > /tmp/daemon.json ; else echo -en {\\n > /tmp/daemon.json ; fi' && \

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -110,6 +110,8 @@ test%_v6.ll: tc.c tc.d calculate-flags
 	$(COMPILE)
 xdp%.ll: xdp.c xdp.d calculate-flags
 	$(COMPILE)
+xdp%_v6.ll: xdp.c xdp.d calculate-flags
+	$(COMPILE)
 test_xdp%.ll: xdp.c xdp.d calculate-flags
 	$(COMPILE)
 

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -114,6 +114,8 @@ xdp%_v6.ll: xdp.c xdp.d calculate-flags
 	$(COMPILE)
 test_xdp%.ll: xdp.c xdp.d calculate-flags
 	$(COMPILE)
+test_xdp%_v6.ll: xdp.c xdp.d calculate-flags
+	$(COMPILE)
 
 LINK=$(LD) -march=bpf -filetype=obj -o $@ $<
 bin/tc_preamble.o: tc_preamble.ll | bin

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -251,7 +251,7 @@ static CALI_BPF_INLINE void ip_dec_ttl(struct iphdr *ip)
 
 #if CALI_F_XDP
 
-extern const volatile struct cali_xdp_globals __globals;
+extern const volatile struct cali_xdp_preamble_globals __globals;
 #define CALI_CONFIGURABLE(name) 1 /* any value will do, it is not configured */
 #define CALI_CONFIGURABLE_IP(name) 1
 

--- a/felix/bpf-gpl/globals.h
+++ b/felix/bpf-gpl/globals.h
@@ -64,4 +64,9 @@ struct cali_xdp_globals {
 	__u32 jumps[16];
 };
 
+struct cali_xdp_preamble_globals {
+	struct cali_xdp_globals v4;
+	struct cali_xdp_globals v6;
+};
+
 #endif /* __CALI_GLOBALS_H__ */

--- a/felix/bpf-gpl/list-objs
+++ b/felix/bpf-gpl/list-objs
@@ -27,6 +27,8 @@ for log_level in debug info no_log; do
   echo "bin/connect_time_${log_level}_v46_co-re.o"
   echo "bin/connect_time_${log_level}_v6_co-re.o"
   echo "bin/xdp_${log_level}.o"
+  echo "bin/xdp_${log_level}_v6.o"
+  echo "bin/xdp_${log_level}_co-re_v6.o"
 
   for core_support in co-re legacy; do
     for host_drop in "" "host_drop_"; do

--- a/felix/bpf-gpl/list-objs
+++ b/felix/bpf-gpl/list-objs
@@ -27,7 +27,6 @@ for log_level in debug info no_log; do
   echo "bin/connect_time_${log_level}_v46_co-re.o"
   echo "bin/connect_time_${log_level}_v6_co-re.o"
   echo "bin/xdp_${log_level}.o"
-  echo "bin/xdp_${log_level}_v6.o"
   echo "bin/xdp_${log_level}_co-re_v6.o"
 
   for core_support in co-re legacy; do

--- a/felix/bpf-gpl/list-ut-objs
+++ b/felix/bpf-gpl/list-ut-objs
@@ -39,3 +39,4 @@ done
 echo "bin/test_from_hep_fib_no_log_skb0x0.o"
 echo "bin/test_from_wep_fib_no_log.o"
 echo "bin/test_xdp_debug.o"
+echo "bin/test_xdp_debug_co-re_v6.o"

--- a/felix/bpf-gpl/metadata.h
+++ b/felix/bpf-gpl/metadata.h
@@ -22,7 +22,6 @@ enum cali_metadata_flags {
 // Set metadata to be received by TC programs
 static CALI_BPF_INLINE int xdp2tc_set_metadata(struct cali_tc_ctx *ctx, __u32 flags)
 {
-#ifndef IPVER6
 		/* XXX */
 #ifndef UNITTEST
 		struct cali_metadata *metadata;
@@ -52,11 +51,16 @@ static CALI_BPF_INLINE int xdp2tc_set_metadata(struct cali_tc_ctx *ctx, __u32 fl
 		goto error;
 	}
 
+#ifdef IPVER6
+	CALI_DEBUG("IP6 FLOW LBL: %d\n", ip_hdr(ctx)->flow_lbl[2]);
+	ip_hdr(ctx)->flow_lbl[2] |= CALI_META_ACCEPTED_BY_XDP;
+	CALI_DEBUG("Set IP6 FLOW LBL: %d\n", ip_hdr(ctx)->flow_lbl[2]);
+#else
 	CALI_DEBUG("IP TOS: %d\n", ip_hdr(ctx)->tos);
 	ip_hdr(ctx)->tos |= CALI_META_ACCEPTED_BY_XDP;
 	CALI_DEBUG("Set IP TOS: %d\n", ip_hdr(ctx)->tos);
-	goto metadata_ok;
 #endif
+	goto metadata_ok;
 #endif
 
 error:
@@ -69,8 +73,6 @@ metadata_ok:
 
 // Fetch metadata set by XDP program. If not set or on error return 0.
 static CALI_BPF_INLINE __u32 xdp2tc_get_metadata(struct __sk_buff *skb) {
-#ifndef IPVER6
-		/* XXX */
 	struct cali_metadata *metadata;
 #ifndef UNITTEST
 	metadata = (void *)(unsigned long)skb->data_meta;
@@ -93,12 +95,19 @@ static CALI_BPF_INLINE __u32 xdp2tc_get_metadata(struct __sk_buff *skb) {
 		goto no_metadata;
 	}
 
-	CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "IP TOS: %d\n", ip_hdr(&ctx)->tos);
 	struct cali_metadata unittest_metadata = {};
+#ifdef IPVER6
+	CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "IP6 Flow label: %d\n", ip_hdr(&ctx)->flow_lbl[2]);
+	unittest_metadata.flags = ip_hdr(&ctx)->flow_lbl[2];
+	ip_hdr(&ctx)->flow_lbl[2] &= (~CALI_META_ACCEPTED_BY_XDP);
+	CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "Set IP6 Flow label: %d\n", ip_hdr(&ctx)->flow_lbl[2]);
+#else
+	CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "IP TOS: %d\n", ip_hdr(&ctx)->tos);
 	unittest_metadata.flags = ip_hdr(&ctx)->tos;
-	metadata = &unittest_metadata;
 	ip_hdr(&ctx)->tos &= (~CALI_META_ACCEPTED_BY_XDP);
 	CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "Set IP TOS: %d\n", ip_hdr(&ctx)->tos);
+#endif
+	metadata = &unittest_metadata;
 	goto metadata_ok;
 #endif /* UNITTEST */
 
@@ -107,9 +116,6 @@ no_metadata:
 
 metadata_ok:
 	return metadata->flags;
-#else
-	return 0;
-#endif
 }
 
 #endif /* CALI_F_XDP */

--- a/felix/bpf-gpl/metadata.h
+++ b/felix/bpf-gpl/metadata.h
@@ -22,7 +22,6 @@ enum cali_metadata_flags {
 // Set metadata to be received by TC programs
 static CALI_BPF_INLINE int xdp2tc_set_metadata(struct cali_tc_ctx *ctx, __u32 flags)
 {
-		/* XXX */
 #ifndef UNITTEST
 		struct cali_metadata *metadata;
 		// Reserve space in-front of xdp_md.meta for metadata.

--- a/felix/bpf-gpl/parsing6.h
+++ b/felix/bpf-gpl/parsing6.h
@@ -18,16 +18,16 @@ static CALI_BPF_INLINE int parse_packet_ip_v6(struct cali_tc_ctx *ctx) {
 	 * an initial decision based on Ethernet protocol before parsing packet
 	 * for more headers.
 	 */
-	if (CALI_F_XDP) {
-		if (skb_refresh_validate_ptrs(ctx, UDP_SIZE)) {
-			deny_reason(ctx, CALI_REASON_SHORT);
-			CALI_DEBUG("Too short\n");
-			goto deny;
-		}
-		protocol = bpf_ntohs(eth_hdr(ctx)->h_proto);
-	} else {
-		protocol = bpf_ntohs(ctx->skb->protocol);
+#if CALI_F_XDP
+	if (skb_refresh_validate_ptrs(ctx, UDP_SIZE)) {
+		deny_reason(ctx, CALI_REASON_SHORT);
+		CALI_DEBUG("Too short\n");
+		goto deny;
 	}
+	protocol = bpf_ntohs(eth_hdr(ctx)->h_proto);
+#else
+	protocol = bpf_ntohs(ctx->skb->protocol);
+#endif
 
 	switch (protocol) {
 	case ETH_P_IPV6:

--- a/felix/bpf-gpl/types.h
+++ b/felix/bpf-gpl/types.h
@@ -100,13 +100,13 @@ struct cali_tc_state {
 	/* Record of the rule IDs of the rules that were hit. */
 	__u64 rule_ids[MAX_RULE_IDS];
 
+	__u64 flags;
 	/* Result of the conntrack lookup. */
 	struct calico_ct_result ct_result; /* 28 bytes */
 
 	/* Result of the NAT calculation.  Zeroed if there is no DNAT. */
 	struct calico_nat_dest nat_dest; /* 8 bytes */
 	__u64 prog_start_time;
-	__u64 flags;
 #ifndef IPVER6
 	__u8 __pad_ipv4[48];
 #endif

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -46,6 +46,9 @@ int calico_xdp_main(struct xdp_md *xdp)
 		.ipheader_len = IP_SIZE,
 	};
 	struct cali_tc_ctx *ctx = &_ctx;
+#ifdef IPVER6
+CALI_DEBUG("Received ipv6 pkt\n");
+#endif
 
 	if (!ctx->xdp_globals) {
 		CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "State map globals lookup failed: DROP\n");
@@ -203,12 +206,12 @@ int calico_xdp_drop(struct xdp_md *xdp)
 	counter_inc(ctx, CALI_REASON_DROPPED_BY_POLICY);
 
 	CALI_DEBUG("proto=%d\n", ctx->state->ip_proto);
-	CALI_DEBUG("src=%x dst=%x\n", bpf_ntohl(ctx->state->ip_src),
-			bpf_ntohl(ctx->state->ip_dst));
-	CALI_DEBUG("pre_nat=%x:%d\n", bpf_ntohl(ctx->state->pre_nat_ip_dst),
+	CALI_DEBUG("src=%x dst=%x\n", debug_ip(ctx->state->ip_src),
+			debug_ip(ctx->state->ip_dst));
+	CALI_DEBUG("pre_nat=%x:%d\n", debug_ip(ctx->state->pre_nat_ip_dst),
 			ctx->state->pre_nat_dport);
-	CALI_DEBUG("post_nat=%x:%d\n", bpf_ntohl(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
-	CALI_DEBUG("tun_ip=%x\n", ctx->state->tun_ip);
+	CALI_DEBUG("post_nat=%x:%d\n", debug_ip(ctx->state->post_nat_ip_dst), ctx->state->post_nat_dport);
+	CALI_DEBUG("tun_ip=%x\n", debug_ip(ctx->state->tun_ip));
 	CALI_DEBUG("pol_rc=%d\n", ctx->state->pol_rc);
 	CALI_DEBUG("sport=%d\n", ctx->state->sport);
 	CALI_DEBUG("flags=0x%x\n", ctx->state->flags);

--- a/felix/bpf-gpl/xdp.c
+++ b/felix/bpf-gpl/xdp.c
@@ -46,9 +46,6 @@ int calico_xdp_main(struct xdp_md *xdp)
 		.ipheader_len = IP_SIZE,
 	};
 	struct cali_tc_ctx *ctx = &_ctx;
-#ifdef IPVER6
-CALI_DEBUG("Received ipv6 pkt\n");
-#endif
 
 	if (!ctx->xdp_globals) {
 		CALI_LOG_IF(CALI_LOG_LEVEL_DEBUG, "State map globals lookup failed: DROP\n");

--- a/felix/bpf-gpl/xdp_preamble.c
+++ b/felix/bpf-gpl/xdp_preamble.c
@@ -5,34 +5,58 @@
 // stdbool.h has no deps so it's OK to include; stdint.h pulls in parts
 // of the std lib that aren't compatible with BPF.
 #include <stdbool.h>
+#include <linux/if_ether.h>
 
+#include "skb.h"
 #include "bpf.h"
 #include "types.h"
 #include "globals.h"
 #include "jump.h"
 #include "log.h"
 
-const volatile struct cali_xdp_globals __globals;
+const volatile struct cali_xdp_preamble_globals __globals;
+
+static CALI_BPF_INLINE __u16 parse_eth_hdr(struct xdp_md *xdp) {
+	void *data_end = (void *)(long)xdp->data_end;
+	struct ethhdr *eth = (void *)(long)xdp->data;
+	__u64 offset = sizeof(*eth);
+	if ((void *)eth + offset > data_end) {
+		return 0xffff;
+	}
+	return bpf_ntohs(eth->h_proto);
+}	
 
 SEC("xdp")
-int  cali_xdp_preamble(struct __sk_buff *skb)
+int  cali_xdp_preamble(struct xdp_md *xdp)
 {
 	struct cali_xdp_globals *globals = state_get_globals_xdp();
 
 	if (!globals) {
-		return TC_ACT_SHOT;
+		return XDP_DROP;
+	}
+	__u16 protocol = parse_eth_hdr(xdp);
+	if (protocol == 0xffff) {
+		return XDP_DROP;
 	}
 
-	/* Set the globals for the rest of the prog chain. */
-	*globals = __globals;
+	switch (protocol) {
+		case ETH_P_IPV6:
+			*globals = __globals.v6;
+			break;
+		case ETH_P_IP:
+			*globals = __globals.v4;
+			break;
+		default:
+			return XDP_PASS;
+	}
 
 #if EMIT_LOGS
 	CALI_LOG("xdp_preamble iface %s\n", globals->iface_name);
 #endif
 
 	/* Jump to the start of the prog chain. */
-	bpf_tail_call(skb, &cali_jump_map, globals->jumps[PROG_INDEX_MAIN]);
+	bpf_tail_call(xdp, &cali_jump_map, ((volatile __u32*)(globals->jumps))[PROG_INDEX_MAIN]);
 	CALI_LOG("xdp_preamble iface %s failed to call main %d\n", globals->iface_name, globals->jumps[PROG_INDEX_MAIN]);
 	/* Drop the packet in the unexpected case of not being able to make the jump. */
-	return TC_ACT_SHOT;
+	return XDP_DROP;
 }

--- a/felix/bpf-gpl/xdp_preamble.c
+++ b/felix/bpf-gpl/xdp_preamble.c
@@ -40,15 +40,12 @@ int  cali_xdp_preamble(struct xdp_md *xdp)
 		return XDP_DROP;
 	}
 
-	switch (protocol) {
-		case ETH_P_IPV6:
-			*globals = __globals.v6;
-			break;
-		case ETH_P_IP:
-			*globals = __globals.v4;
-			break;
-		default:
-			return XDP_PASS;
+	if (protocol == ETH_P_IPV6 && (__globals.v6.jumps[PROG_INDEX_MAIN] != (__u32)-1)) {
+		*globals = __globals.v6;
+	} else if (protocol == ETH_P_IP && (__globals.v4.jumps[PROG_INDEX_MAIN] != (__u32)-1)) {
+		*globals = __globals.v4;
+	} else {
+		return XDP_PASS;
 	}
 
 #if EMIT_LOGS

--- a/felix/bpf-gpl/xdp_preamble.c
+++ b/felix/bpf-gpl/xdp_preamble.c
@@ -16,12 +16,13 @@
 
 const volatile struct cali_xdp_preamble_globals __globals;
 
-static CALI_BPF_INLINE __u16 parse_eth_hdr(struct xdp_md *xdp) {
+static CALI_BPF_INLINE __u16 parse_eth_hdr(struct xdp_md *xdp)
+{
 	void *data_end = (void *)(long)xdp->data_end;
 	struct ethhdr *eth = (void *)(long)xdp->data;
 	__u64 offset = sizeof(*eth);
 	if ((void *)eth + offset > data_end) {
-		return 0xffff;
+		bpf_exit(XDP_DROP);
 	}
 	return bpf_ntohs(eth->h_proto);
 }	

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -162,15 +162,28 @@ func initObjectFiles() {
 		}
 	}
 
-	for _, logLevel := range []string{"off", "info", "debug"} {
-		l := strings.ToLower(logLevel)
-		if l == "off" {
-			l = "no_log"
+	for _, family := range []int{4, 6} {
+		for _, logLevel := range []string{"off", "info", "debug"} {
+			l := strings.ToLower(logLevel)
+			if l == "off" {
+				l = "no_log"
+			}
+			filename := "xdp_" + l + ".o"
+			if family == 6 {
+				filename = "xdp_" + l
+				if bpfutils.SupportsBTF() {
+					filename = filename + "_co-re_v6.o"
+				} else {
+					filename = filename + "_v6.o"
+				}
+			}
+
+			objectFiles[AttachType{
+				Family:   family,
+				Hook:     XDP,
+				LogLevel: logLevel,
+			}] = filename
 		}
-		objectFiles[AttachType{
-			Hook:     XDP,
-			LogLevel: logLevel,
-		}] = "xdp_" + l + ".o"
 	}
 }
 

--- a/felix/bpf/hook/load.go
+++ b/felix/bpf/hook/load.go
@@ -170,12 +170,7 @@ func initObjectFiles() {
 			}
 			filename := "xdp_" + l + ".o"
 			if family == 6 {
-				filename = "xdp_" + l
-				if bpfutils.SupportsBTF() {
-					filename = filename + "_co-re_v6.o"
-				} else {
-					filename = filename + "_v6.o"
-				}
+				filename = "xdp_" + l + "_co-re_v6.o"
 			}
 
 			objectFiles[AttachType{

--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -444,14 +444,19 @@ func XDPSetGlobals(
 	defer C.free(unsafe.Pointer(cName))
 
 	cJumps := make([]C.uint, len(globalData.Jumps))
+	cJumpsV6 := make([]C.uint, len(globalData.Jumps))
 
 	for i, v := range globalData.Jumps {
 		cJumps[i] = C.uint(v)
 	}
 
+	for i, v := range globalData.JumpsV6 {
+		cJumpsV6[i] = C.uint(v)
+	}
 	_, err := C.bpf_xdp_set_globals(m.bpfMap,
 		cName,
 		&cJumps[0],
+		&cJumpsV6[0],
 	)
 
 	return err

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -295,18 +295,23 @@ void bpf_ctlb_set_globals(struct bpf_map *map, uint udp_not_seen_timeo, bool exc
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));
 }
 
-void bpf_xdp_set_globals(struct bpf_map *map, char *iface_name, uint *jumps)
+void bpf_xdp_set_globals(struct bpf_map *map, char *iface_name, uint *jumps, uint *jumpsV6)
 {
-	struct cali_xdp_globals data = {
+	struct cali_xdp_preamble_globals data = {
 	};
 
-	strncpy(data.iface_name, iface_name, sizeof(data.iface_name));
-	data.iface_name[sizeof(data.iface_name)-1] = '\0';
+	strncpy(data.v4.iface_name, iface_name, sizeof(data.v4.iface_name));
+	data.v4.iface_name[sizeof(data.v4.iface_name)-1] = '\0';
+	data.v6 = data.v4;
 	
 	int i;
 
-	for (i = 0; i < sizeof(data.jumps)/sizeof(__u32); i++) {
-		data.jumps[i] = jumps[i];
+	for (i = 0; i < sizeof(data.v4.jumps)/sizeof(__u32); i++) {
+		data.v4.jumps[i] = jumps[i];
+	}
+
+	for (i = 0; i < sizeof(data.v6.jumps)/sizeof(__u32); i++) {
+		data.v6.jumps[i] = jumpsV6[i];
 	}
 
 	set_errno(bpf_map__set_initial_value(map, (void*)(&data), sizeof(data)));

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -40,4 +40,5 @@ type TcGlobalData struct {
 type XDPGlobalData struct {
 	IfaceName string
 	Jumps     [16]uint32
+	JumpsV6   [16]uint32
 }

--- a/felix/bpf/polprog/pol_prog_builder.go
+++ b/felix/bpf/polprog/pol_prog_builder.go
@@ -142,7 +142,7 @@ var (
 	stateOffRulesHit = FieldOffset{Offset: stateEventHdrSize + 100, Field: "state->rules_hit"}
 	stateOffRuleIDs  = FieldOffset{Offset: stateEventHdrSize + 104, Field: "state->rule_ids"}
 
-	stateOffFlags = FieldOffset{Offset: stateEventHdrSize + 408, Field: "state->flags"}
+	stateOffFlags = FieldOffset{Offset: stateEventHdrSize + 360, Field: "state->flags"}
 
 	skbCb0 = FieldOffset{Offset: 12*4 + 0*4, Field: "skb->cb[0]"}
 	skbCb1 = FieldOffset{Offset: 12*4 + 1*4, Field: "skb->cb[1]"}

--- a/felix/bpf/state/map.go
+++ b/felix/bpf/state/map.go
@@ -104,6 +104,7 @@ type State struct {
 	IPSize              uint16
 	RulesHit            uint32
 	RuleIDs             [MaxRuleIDs]uint64
+	Flags               uint64
 	ConntrackRCFlags    uint32
 	_                   uint32
 	ConntrackNATIPPort  uint64
@@ -113,7 +114,6 @@ type State struct {
 	_                   uint32
 	NATData             uint64
 	ProgStartTime       uint64
-	Flags               uint64
 	_                   [48]byte // ipv6 padding
 }
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -245,10 +245,14 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		Expect(hasXDP).To(BeTrue())
 
 		xdppm := jumpMapDump(commonMaps.XDPJumpMap)
-		Expect(xdppm).To(HaveLen(1))
+		xdpMapLen := 1
+		if ipv6Enabled {
+			xdpMapLen = 2
+		}
+		Expect(xdppm).To(HaveLen(xdpMapLen))
 		Expect(xdppm).To(HaveKey(hostep1State.XDPPolicyV4()))
 		if ipv6Enabled {
-			Expect(xdppm).NotTo(HaveKey(hostep1State.XDPPolicyV6()))
+			Expect(xdppm).To(HaveKey(hostep1State.XDPPolicyV6()))
 		}
 	})
 

--- a/felix/bpf/ut/xdp_test.go
+++ b/felix/bpf/ut/xdp_test.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	TOS_BYTE   = 15
+	FLOW_BYTE  = 17
 	TOS_NOTSET = 0
 	TOS_SET    = 128
 )
@@ -69,16 +70,16 @@ var oneXDPRule = polprog.Rules{
 			Name: "Allow some",
 			Rules: []polprog.Rule{{
 				Rule: &proto.Rule{
-					SrcNet: []string{"9.8.2.1/32"},
-					DstNet: []string{"1.2.8.9/32"},
+					SrcNet: []string{"9.8.2.1/32", "6::6/128"},
+					DstNet: []string{"1.2.8.9/32", "3::3/128"},
 					Action: "Deny",
 				}}, {
 				Rule: &proto.Rule{
-					DstNet: []string{"1.2.0.0/16"},
+					DstNet: []string{"1.2.0.0/16", "1::2/64"},
 					Action: "Allow",
 				}}, {
 				Rule: &proto.Rule{
-					SrcNet: []string{"9.8.7.0/24"},
+					SrcNet: []string{"9.8.7.0/24", "5::8/64"},
 					Action: "Deny",
 				}},
 			}}},
@@ -89,6 +90,15 @@ type xdpTest struct {
 	Description string
 	Rules       *polprog.Rules
 	IPv4Header  *layers.IPv4
+	NextHeader  gopacket.Layer
+	Drop        bool
+	Metadata    bool
+}
+
+type xdpTestV6 struct {
+	Description string
+	Rules       *polprog.Rules
+	IPv6Header  *layers.IPv6
 	NextHeader  gopacket.Layer
 	Drop        bool
 	Metadata    bool
@@ -261,5 +271,147 @@ func TestXDPPrograms(t *testing.T) {
 			}
 			Expect(res.dataOut).To(Equal(pktBytes))
 		}, withXDP())
+	}
+}
+
+var xdpV6TestCases = []xdpTestV6{
+	{
+		Description: "2 - Packets not matched, must pass without metadata",
+		Rules:       nil,
+		IPv6Header:  ipv6Default,
+		Drop:        false,
+		Metadata:    false,
+	},
+	{
+		Description: "3 - Deny all rule, packet must drop",
+		Rules:       &denyAllRulesXDP,
+		IPv6Header:  ipv6Default,
+		Drop:        true,
+		Metadata:    false,
+	},
+	{
+		Description: "4 - Allow all rule, packet must pass with metadata",
+		Rules:       &allowAllRulesXDP,
+		IPv6Header:  ipv6Default,
+		Drop:        false,
+		Metadata:    true,
+	},
+	{
+		Description: "5 - Match with failsafe, must pass without metadata",
+		Rules:       nil,
+		IPv6Header: &layers.IPv6{
+			Version:  6,
+			HopLimit: 64,
+			SrcIP:    net.IP([]byte{0x04, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}),
+			DstIP:    net.IP([]byte{0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+		},
+		NextHeader: &layers.UDP{
+			DstPort: 53,
+			SrcPort: 54321,
+		},
+		Drop:     false,
+		Metadata: false,
+	},
+	{
+		Description: "6 - Match against a deny policy, must drop",
+		Rules:       &oneXDPRule,
+		IPv6Header: &layers.IPv6{
+			Version:  6,
+			HopLimit: 64,
+			SrcIP:    net.IP([]byte{0x00, 06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6}),
+			DstIP:    net.IP([]byte{0x00, 03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}),
+		},
+		NextHeader: &layers.TCP{
+			DstPort: 80,
+			SrcPort: 55555,
+		},
+		Drop:     true,
+		Metadata: false,
+	},
+	{
+		Description: "7 - Match against a deny policy, must drop",
+		Rules:       &oneXDPRule,
+		IPv6Header: &layers.IPv6{
+			Version:  6,
+			HopLimit: 64,
+			SrcIP:    net.IP([]byte{0x00, 05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6}),
+			DstIP:    net.IP([]byte{0x00, 03, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}),
+		},
+		NextHeader: &layers.TCP{
+			DstPort: 80,
+			SrcPort: 55555,
+		},
+		Drop:     true,
+		Metadata: false,
+	},
+	{
+		Description: "8 - Match against an allow policy, must pass with metadata",
+		Rules:       &oneXDPRule,
+		IPv6Header: &layers.IPv6{
+			Version:  6,
+			HopLimit: 64,
+			SrcIP:    net.IP([]byte{0x00, 02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}),
+			DstIP:    net.IP([]byte{0x00, 01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}),
+		},
+		NextHeader: &layers.TCP{
+			DstPort: 80,
+			SrcPort: 55555,
+		},
+		Drop:     false,
+		Metadata: true,
+	},
+	{
+		Description: "9 - Unmatched packet against failsafe and a policy",
+		Rules:       &oneXDPRule,
+		IPv6Header: &layers.IPv6{
+			Version:  6,
+			HopLimit: 64,
+			SrcIP:    net.IP([]byte{0x00, 0x08, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}),
+			DstIP:    net.IP([]byte{0x00, 07, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7}),
+		},
+		NextHeader: &layers.UDP{
+			DstPort: 8080,
+			SrcPort: 54321,
+		},
+		Drop:     false,
+		Metadata: false,
+	},
+}
+
+func TestXDPV6Programs(t *testing.T) {
+	RegisterTestingT(t)
+
+	defer resetBPFMaps()
+	err := fsafeMapV6.Update(
+		failsafes.MakeKeyV6(17, 53, false, "4::4", 16).ToSlice(),
+		failsafes.ValueV6(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer func() { bpfIfaceName = "" }()
+
+	for i, tc := range xdpV6TestCases {
+		bpfIfaceName = fmt.Sprintf("XDPV6-%d", i)
+		runBpfTest(t, "xdp_calico_entrypoint", tc.Rules, func(bpfrun bpfProgRunFn) {
+			_, _, _, _, pktBytes, err := testPacketV6(nil, tc.IPv6Header, tc.NextHeader, nil)
+			Expect(err).NotTo(HaveOccurred())
+			res, err := bpfrun(pktBytes)
+			Expect(err).NotTo(HaveOccurred())
+			result := "XDP_PASS"
+			if tc.Drop {
+				result = "XDP_DROP"
+			}
+			pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+			fmt.Printf("pktR = %+v\n", pktR)
+			Expect(res.RetvalStrXDP()).To(Equal(result), fmt.Sprintf("expected the program to return %s", result))
+			Expect(res.dataOut).To(HaveLen(len(pktBytes)))
+			if tc.Metadata {
+				Expect(res.dataOut[FLOW_BYTE]).To(Equal(uint8(TOS_SET)))
+				res.dataOut[FLOW_BYTE] = TOS_NOTSET
+			} else {
+				Expect(res.dataOut[FLOW_BYTE]).To(Equal(uint8(TOS_NOTSET)))
+			}
+			Expect(res.dataOut).To(Equal(pktBytes))
+		}, withXDP(), withIPv6())
 	}
 }

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2366,15 +2366,16 @@ func (d *bpfEndpointManagerDataplane) applyPolicyToDataIface(
 	ep *proto.HostEndpoint,
 	state *bpfInterfaceState,
 	ap *tc.AttachPoint,
-	xdpAP *xdp.AttachPoint,
+	apxdp *xdp.AttachPoint,
 ) (*tc.AttachPoint, *tc.AttachPoint, *xdp.AttachPoint, error) {
 
 	ingressAttachPoint := *ap
 	egressAttachPoint := *ap
-	xdpAttachPoint := *xdpAP
+	xdpAttachPoint := *apxdp
 
 	var parallelWG sync.WaitGroup
 	var ingressAP, egressAP *tc.AttachPoint
+	var xdpAP *xdp.AttachPoint
 	var ingressErr, egressErr, xdpErr error
 
 	parallelWG.Add(2)
@@ -2490,7 +2491,7 @@ func (d *bpfEndpointManagerDataplane) attachXDPProgram(ap *xdp.AttachPoint, ep *
 		}
 		ap.Log().Infof("Rules: %v", rules)
 		err = m.updatePolicyProgramFn(rules, "xdp", ap, d.ipFamily)
-		ap.Log().WithError(err).Infof("Applied untracked policy hep=%v", ep.Name)
+		ap.Log().WithError(err).Debugf("Applied untracked policy hep=%v", ep.Name)
 		return ap, err
 	}
 	return ap, nil

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1599,6 +1599,7 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface string) (bpfInterfac
 	if err := m.dataIfaceStateFillJumps(ifaceName, &state); err != nil {
 		return state, err
 	}
+
 	_, err = m.dp.ensureQdisc(iface)
 	if err != nil {
 		return state, err
@@ -1651,18 +1652,16 @@ func (m *bpfEndpointManager) doApplyPolicyToDataIface(iface string) (bpfInterfac
 	}()
 
 	// Attach xdp program.
-	if m.v4 != nil {
-		parallelWG.Add(1)
-		go func() {
-			defer parallelWG.Done()
-			xdpAP := mergeAttachPoints(xdpAP4, xdpAP6)
-			if hepPtr != nil && len(hepPtr.UntrackedTiers) == 1 && xdpAP != nil {
-				_, xdpErr = m.dp.ensureProgramAttached(xdpAP4)
-			} else {
-				xdpErr = m.dp.ensureNoProgram(xdpAP)
-			}
-		}()
-	}
+	parallelWG.Add(1)
+	go func() {
+		defer parallelWG.Done()
+		xdpAP := mergeAttachPoints(xdpAP4, xdpAP6)
+		if hepPtr != nil && len(hepPtr.UntrackedTiers) == 1 && xdpAP != nil {
+			_, xdpErr = m.dp.ensureProgramAttached(xdpAP)
+		} else {
+			xdpErr = m.dp.ensureNoProgram(xdpAP)
+		}
+	}()
 
 	// Attach egress program.
 	egressAP := mergeAttachPoints(egressAP4, egressAP6)
@@ -2163,6 +2162,10 @@ func mergeAttachPoints(ap4, ap6 attachPoint) attachPoint {
 			return apxdpV4
 		} else if apxdpV6 != nil && apxdpV4 == nil {
 			return apxdpV6
+		} else if apxdpV6 != nil && apxdpV4 != nil {
+			apxdpV4.PolicyIdxV6 = apxdpV6.PolicyIdxV6
+			apxdpV4.HookLayoutV6 = apxdpV6.HookLayoutV6
+			return apxdpV4
 		}
 	}
 	return nil
@@ -2368,6 +2371,7 @@ func (d *bpfEndpointManagerDataplane) applyPolicyToDataIface(
 
 	ingressAttachPoint := *ap
 	egressAttachPoint := *ap
+	xdpAttachPoint := *xdpAP
 
 	var parallelWG sync.WaitGroup
 	var ingressAP, egressAP *tc.AttachPoint
@@ -2381,12 +2385,7 @@ func (d *bpfEndpointManagerDataplane) applyPolicyToDataIface(
 
 	go func() {
 		defer parallelWG.Done()
-		// XDP IPv6 is not supported yet.
-		if d.ipFamily == proto.IPVersion_IPV4 {
-			xdpErr = d.attachXDPProgram(xdpAP, ep, state)
-		} else {
-			xdpAP = nil
-		}
+		xdpAP, xdpErr = d.attachXDPProgram(&xdpAttachPoint, ep, state)
 	}()
 
 	egressAP, egressErr = d.attachDataIfaceProgram(ifaceName, ep, PolDirnEgress, state, &egressAttachPoint)
@@ -2469,7 +2468,7 @@ func (d *bpfEndpointManagerDataplane) attachDataIfaceProgram(
 	return ap, nil
 }
 
-func (d *bpfEndpointManagerDataplane) attachXDPProgram(ap *xdp.AttachPoint, ep *proto.HostEndpoint, state *bpfInterfaceState) error {
+func (d *bpfEndpointManagerDataplane) attachXDPProgram(ap *xdp.AttachPoint, ep *proto.HostEndpoint, state *bpfInterfaceState) (*xdp.AttachPoint, error) {
 	if d.ipFamily == proto.IPVersion_IPV6 {
 		ap.PolicyIdxV6 = state.v6.policyIdx[hook.XDP]
 	} else {
@@ -2480,21 +2479,21 @@ func (d *bpfEndpointManagerDataplane) attachXDPProgram(ap *xdp.AttachPoint, ep *
 	if ep != nil && len(ep.UntrackedTiers) == 1 {
 		err := m.dp.ensureProgramLoaded(ap, d.ipFamily)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		ap.Log().Debugf("Building program for untracked policy hep=%v", ep.Name)
+		ap.Log().Infof("Building program for untracked policy hep=%v, family=%v", ep.Name, d.ipFamily)
 		rules := polprog.Rules{
 			ForHostInterface: true,
 			HostNormalTiers:  m.extractTiers(ep.UntrackedTiers[0], PolDirnIngress, false),
 			ForXDP:           true,
 		}
-		ap.Log().Debugf("Rules: %v", rules)
+		ap.Log().Infof("Rules: %v", rules)
 		err = m.updatePolicyProgramFn(rules, "xdp", ap, d.ipFamily)
-		ap.Log().WithError(err).Debugf("Applied untracked policy hep=%v", ep.Name)
-		return err
+		ap.Log().WithError(err).Infof("Applied untracked policy hep=%v", ep.Name)
+		return ap, err
 	}
-	return nil
+	return ap, nil
 }
 
 // PolDirection is the Calico datamodel direction of policy.  On a host endpoint, ingress is towards the host.
@@ -3215,9 +3214,16 @@ func (m *bpfEndpointManager) ensureProgramLoaded(ap attachPoint, ipFamily proto.
 			LogLevel: apxdp.LogLevel,
 		}
 
+		at.Family = int(ipFamily)
 		pm := m.commonMaps.XDPProgramsMap.(*hook.ProgramsMap)
-		if apxdp.HookLayout, err = pm.LoadObj(at); err != nil {
-			return fmt.Errorf("loading generic xdp hook program: %w", err)
+		if ipFamily == proto.IPVersion_IPV6 {
+			if apxdp.HookLayoutV6, err = pm.LoadObj(at); err != nil {
+				return fmt.Errorf("loading generic xdp hook program: %w", err)
+			}
+		} else {
+			if apxdp.HookLayoutV4, err = pm.LoadObj(at); err != nil {
+				return fmt.Errorf("loading generic xdp hook program: %w", err)
+			}
 		}
 	} else {
 		return fmt.Errorf("unknown attach type")

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -112,7 +112,7 @@ func (m *mockDataplane) ensureProgramLoaded(ap attachPoint, ipFamily proto.IPVer
 	//var res tc.AttachResult // we don't care about the values
 
 	if apxdp, ok := ap.(*xdp.AttachPoint); ok {
-		apxdp.HookLayout = hook.Layout{
+		apxdp.HookLayoutV4 = hook.Layout{
 			hook.SubProgXDPAllowed: 123,
 			hook.SubProgXDPDrop:    456,
 		}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -923,6 +923,8 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 				ipSetsV6,
 				config.MaxIPSetSize))
 			dp.RegisterManager(newPolicyManager(rawTableV6, mangleTableV6, filterTableV6, ruleRenderer, 6))
+		} else {
+			dp.RegisterManager(newRawEgressPolicyManager(rawTableV6, ruleRenderer, 6, ipSetsV6.SetFilter))
 		}
 
 		dp.RegisterManager(newEndpointManager(
@@ -1573,11 +1575,9 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 		t.InsertOrAppendRules("PREROUTING", []iptables.Rule{{
 			Action: iptables.JumpAction{Target: rules.ChainRawPrerouting},
 		}})
-		if t.IPVersion == 4 {
-			t.InsertOrAppendRules("OUTPUT", []iptables.Rule{{
-				Action: iptables.JumpAction{Target: rules.ChainRawOutput},
-			}})
-		}
+		t.InsertOrAppendRules("OUTPUT", []iptables.Rule{{
+			Action: iptables.JumpAction{Target: rules.ChainRawOutput},
+		}})
 	}
 
 	if d.config.BPFExtToServiceConnmark != 0 {

--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -277,7 +277,7 @@ func (c *Checker) ExpectedConnectivityPretty() []string {
 			}
 		}
 		if exp.ipVersion == 6 {
-			result[i] += fmt.Sprintf(" (with IPv6)")
+			result[i] += " (with IPv6)"
 		}
 		if exp.ExpectedPacketLoss.Duration > 0 {
 			if exp.ExpectedPacketLoss.MaxNumber >= 0 {

--- a/felix/fv/connectivity/conncheck.go
+++ b/felix/fv/connectivity/conncheck.go
@@ -276,6 +276,9 @@ func (c *Checker) ExpectedConnectivityPretty() []string {
 				result[i] += fmt.Sprintf(" (client MTU %d -> %d)", exp.clientMTUStart, exp.clientMTUEnd)
 			}
 		}
+		if exp.ipVersion == 6 {
+			result[i] += fmt.Sprintf(" (with IPv6)")
+		}
 		if exp.ExpectedPacketLoss.Duration > 0 {
 			if exp.ExpectedPacketLoss.MaxNumber >= 0 {
 				result[i] += fmt.Sprintf(" (maxLoss: %d packets)", exp.ExpectedPacketLoss.MaxNumber)

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/projectcalico/calico/felix/fv/connectivity"
+	. "github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -29,6 +29,7 @@ import (
 
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/workload"
@@ -44,17 +45,24 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 		tc             infrastructure.TopologyContainers
 		hostW          [2]*workload.Workload
 		client         client.Interface
-		cc             *connectivity.Checker
+		cc             *Checker
 		externalClient *containers.Container
 	)
 
 	BeforeEach(func() {
 		var err error
-		infra = getInfra()
-
+		iOpts := []infrastructure.CreateOption{infrastructure.K8sWithIPv6(),
+			infrastructure.K8sWithAPIServerBindAddress("::"),
+			infrastructure.K8sWithServiceClusterIPRange("dead:beef::abcd:0:0:0/112,10.101.0.0/16")}
+		infra = getInfra(iOpts...)
 		options := infrastructure.DefaultTopologyOptions()
+		options.EnableIPv6 = true
+		if BPFMode() {
+			options.ExtraEnvVars["FELIX_BPFLogLevel"] = "debug"
+			options.IPIPEnabled = false
+		}
 		tc, client = infrastructure.StartNNodeTopology(2, options, infra)
-		cc = &connectivity.Checker{}
+		cc = &Checker{}
 
 		// Start a host networked workload on each host for connectivity checks.
 		for ii := range tc.Felixes {
@@ -71,7 +79,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 				"default",
 				tc.Felixes[ii].IP, // Same IP as felix means "run in the host's namespace"
 				portsToOpen,
-				"tcp")
+				"tcp", workload.WithIPv6Address(tc.Felixes[ii].IPv6))
 		}
 
 		// We will use this container to model an external client trying to connect into
@@ -85,8 +93,11 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 		if CurrentGinkgoTestDescription().Failed {
 			for _, felix := range tc.Felixes {
 				felix.Exec("iptables-save", "-c")
+				felix.Exec("ip6tables-save", "-c")
 				felix.Exec("ip", "r")
 				felix.Exec("calico-bpf", "policy", "dump", "eth0", "all", "--asm")
+				felix.Exec("calico-bpf", "-6", "policy", "dump", "eth0", "all", "--asm")
+				felix.Exec("calico-bpf", "counters", "dump")
 			}
 		}
 	})
@@ -100,6 +111,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 	expectFullConnectivity := func() {
 		cc.ResetExpectations()
 		cc.ExpectSome(tc.Felixes[0], hostW[1].Port(8055))
+		cc.ExpectSome(tc.Felixes[0], hostW[1].Port(8055))
 		cc.ExpectSome(tc.Felixes[1], hostW[0].Port(8055))
 		cc.ExpectSome(tc.Felixes[0], hostW[1].Port(2379))
 		cc.ExpectSome(tc.Felixes[1], hostW[0].Port(2379))
@@ -107,6 +119,17 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 		cc.ExpectSome(tc.Felixes[1], hostW[0].Port(22))
 		cc.ExpectSome(externalClient, hostW[1].Port(22))
 		cc.ExpectSome(externalClient, hostW[0].Port(22))
+
+		if BPFMode() {
+			cc.Expect(Some, tc.Felixes[0], hostW[1].Port(8055), ExpectWithIPVersion(6))
+			cc.Expect(Some, tc.Felixes[1], hostW[0].Port(8055), ExpectWithIPVersion(6))
+			cc.Expect(Some, tc.Felixes[0], hostW[1].Port(2379), ExpectWithIPVersion(6))
+			cc.Expect(Some, tc.Felixes[1], hostW[0].Port(2379), ExpectWithIPVersion(6))
+			cc.Expect(Some, tc.Felixes[0], hostW[1].Port(22), ExpectWithIPVersion(6))
+			cc.Expect(Some, tc.Felixes[1], hostW[0].Port(22), ExpectWithIPVersion(6))
+			cc.Expect(Some, externalClient, hostW[1].Port(22), ExpectWithIPVersion(6))
+			cc.Expect(Some, externalClient, hostW[0].Port(22), ExpectWithIPVersion(6))
+		}
 		cc.CheckConnectivityOffset(1)
 	}
 
@@ -125,7 +148,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			err := infra.AddAllowToDatastore("host-endpoint=='true'")
 			Expect(err).NotTo(HaveOccurred())
 
-			ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel = context.WithTimeout(context.Background(), 50*time.Second)
 
 			for _, f := range tc.Felixes {
 				hep := api.NewHostEndpoint()
@@ -135,9 +158,14 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 					"host-endpoint": "true",
 				}
 				hep.Spec.Node = f.Hostname
-				hep.Spec.ExpectedIPs = []string{f.IP}
+				hep.Spec.InterfaceName = "eth0"
+				hep.Spec.ExpectedIPs = []string{f.IP, f.IPv6}
 				_, err := client.HostEndpoints().Create(ctx, hep, options.SetOptions{})
 				Expect(err).NotTo(HaveOccurred())
+			}
+			if BPFMode() {
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
 			}
 		})
 
@@ -161,8 +189,21 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			// But external client should still be able to access it...
 			cc.ExpectSome(externalClient, hostW[1].Port(22))
 			cc.ExpectSome(externalClient, hostW[0].Port(22))
-			cc.CheckConnectivity()
 
+			if BPFMode() {
+				cc.Expect(None, tc.Felixes[0], hostW[1].Port(8055), ExpectWithIPVersion(6))
+				cc.Expect(None, tc.Felixes[1], hostW[0].Port(8055), ExpectWithIPVersion(6))
+				cc.Expect(Some, tc.Felixes[0], hostW[1].Port(2379), ExpectWithIPVersion(6))
+				cc.Expect(Some, tc.Felixes[1], hostW[0].Port(2379), ExpectWithIPVersion(6))
+				// Port 22 is inbound-only so it'll be blocked by the (lack of egress policy).
+				cc.Expect(None, tc.Felixes[0], hostW[1].Port(22), ExpectWithIPVersion(6))
+				cc.Expect(None, tc.Felixes[1], hostW[0].Port(22), ExpectWithIPVersion(6))
+				// But external client should still be able to access it...
+				cc.Expect(Some, externalClient, hostW[1].Port(22), ExpectWithIPVersion(6))
+				cc.Expect(Some, externalClient, hostW[0].Port(22), ExpectWithIPVersion(6))
+			}
+
+			cc.CheckConnectivity()
 			host0Selector := fmt.Sprintf("name == 'eth0-%s'", tc.Felixes[0].Name)
 			host1Selector := fmt.Sprintf("name == 'eth0-%s'", tc.Felixes[1].Name)
 
@@ -221,10 +262,9 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			Expect(err).NotTo(HaveOccurred())
 
 			expectFullConnectivity()
-
 			if BPFMode() {
 				By("Having a Linux IP set for the egress policy")
-				Expect(tc.Felixes[0].IPSetNames()).To(ConsistOf(utils.IPSetNameForSelector(4, host1Selector)))
+				Expect(tc.Felixes[0].IPSetNames()).To(ContainElements(utils.IPSetNameForSelector(4, host1Selector), utils.IPSetNameForSelector(6, host1Selector)))
 			}
 
 			By("Having only failsafe connectivity after replacing host-0's egress rules with Deny")
@@ -250,6 +290,17 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			cc.ExpectSome(tc.Felixes[1], hostW[0].Port(22))  // Still open due to failsafe.
 			cc.ExpectSome(externalClient, hostW[1].Port(22)) // Allowed by failsafe
 			cc.ExpectSome(externalClient, hostW[0].Port(22)) // Allowed by failsafe
+
+			if BPFMode() {
+				cc.Expect(None, tc.Felixes[0], hostW[1].Port(8055), ExpectWithIPVersion(6))
+				cc.Expect(None, tc.Felixes[1], hostW[0].Port(8055), ExpectWithIPVersion(6))
+				cc.Expect(Some, tc.Felixes[0], hostW[1].Port(2379), ExpectWithIPVersion(6))
+				cc.Expect(Some, tc.Felixes[1], hostW[0].Port(2379), ExpectWithIPVersion(6))
+				cc.Expect(None, tc.Felixes[0], hostW[1].Port(22), ExpectWithIPVersion(6))  // Now blocked (lack of egress).
+				cc.Expect(Some, tc.Felixes[1], hostW[0].Port(22), ExpectWithIPVersion(6))  // Still open due to failsafe.
+				cc.Expect(Some, externalClient, hostW[1].Port(22), ExpectWithIPVersion(6)) // Allowed by failsafe
+				cc.Expect(Some, externalClient, hostW[0].Port(22), ExpectWithIPVersion(6)) // Allowed by failsafe
+			}
 			cc.CheckConnectivity()
 
 			By("Having full connectivity after putting them back")
@@ -287,6 +338,17 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			cc.ExpectSome(tc.Felixes[1], hostW[0].Port(22))  // Allowed by failsafe
 			cc.ExpectSome(externalClient, hostW[1].Port(22)) // Allowed by failsafe
 			cc.ExpectSome(externalClient, hostW[0].Port(22)) // Allowed by failsafe
+
+			if BPFMode() {
+				cc.Expect(None, tc.Felixes[0], hostW[1].Port(8055), ExpectWithIPVersion(6))
+				cc.Expect(None, tc.Felixes[1], hostW[0].Port(8055), ExpectWithIPVersion(6))
+				cc.Expect(Some, tc.Felixes[0], hostW[1].Port(2379), ExpectWithIPVersion(6))
+				cc.Expect(Some, tc.Felixes[1], hostW[0].Port(2379), ExpectWithIPVersion(6))
+				cc.Expect(None, tc.Felixes[0], hostW[1].Port(22), ExpectWithIPVersion(6))  // Response traffic blocked by policy
+				cc.Expect(Some, tc.Felixes[1], hostW[0].Port(22), ExpectWithIPVersion(6))  // Allowed by failsafe
+				cc.Expect(Some, externalClient, hostW[1].Port(22), ExpectWithIPVersion(6)) // Allowed by failsafe
+				cc.Expect(Some, externalClient, hostW[0].Port(22), ExpectWithIPVersion(6)) // Allowed by failsafe
+			}
 			cc.CheckConnectivity()
 		})
 	})

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -828,6 +828,7 @@ func (p *Port) ToMatcher(explicitPort ...uint16) *connectivity.Matcher {
 		IP:         p.Workload.IP,
 		Port:       fmt.Sprint(p.Port),
 		TargetName: fmt.Sprintf("%s on port %d", p.Workload.Name, p.Port),
+		IP6:        p.Workload.IP6,
 	}
 }
 

--- a/felix/rules/static.go
+++ b/felix/rules/static.go
@@ -1247,10 +1247,8 @@ func (r *DefaultRuleRenderer) StaticBPFModeRawChains(ipVersion uint8,
 		r.WireguardIncomingMarkChain(),
 	}
 
-	if ipVersion == 4 {
-		chains = append(chains,
-			r.StaticRawOutputChain(tcdefs.MarkSeenBypass))
-	}
+	chains = append(chains,
+		r.StaticRawOutputChain(tcdefs.MarkSeenBypass))
 
 	return chains
 }


### PR DESCRIPTION
## Description

This PR has the following changes
1. Fix IPV6 hostendpoints
2. Support XDP V6 and v6 donottrack policy


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: XDP v6 requires Linux kernel 5.18+ (Ubuntu >=22.04)
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
