### PR TITLE
[release-v3.27] Auto pick #8585: Fix windows cni-plugin tests

### DIFF
--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -638,17 +638,7 @@ blocks:
       value: master_ssh_key
     - name: WIN_PPK_KEY
       value: win_ppk_key
-    - name: K8S_VERSION
-      value: 1.22.6
     jobs:
-    - name: Docker - Windows FV
-      execution_time_limit:
-        minutes: 60
-      commands:
-      - ../.semaphore/run-and-monitor win-fv-docker.log ./.semaphore/run-win-fv.sh
-      env_vars:
-      - name: CONTAINER_RUNTIME
-        value: docker
     - name: Containerd - Windows FV
       execution_time_limit:
         minutes: 60
@@ -658,7 +648,7 @@ blocks:
       - name: CONTAINER_RUNTIME
         value: containerd
       - name: CONTAINERD_VERSION
-        value: 1.4.12
+        value: 1.6.22
 
 - name: "cni-plugin"
   run:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -641,7 +641,7 @@ blocks:
     jobs:
     - name: Containerd - Windows FV
       execution_time_limit:
-        minutes: 60
+        minutes: 120
       commands:
       - ../.semaphore/run-and-monitor win-fv-containerd.log ./.semaphore/run-win-fv.sh
       env_vars:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -638,17 +638,7 @@ blocks:
       value: master_ssh_key
     - name: WIN_PPK_KEY
       value: win_ppk_key
-    - name: K8S_VERSION
-      value: 1.22.6
     jobs:
-    - name: Docker - Windows FV
-      execution_time_limit:
-        minutes: 60
-      commands:
-      - ../.semaphore/run-and-monitor win-fv-docker.log ./.semaphore/run-win-fv.sh
-      env_vars:
-      - name: CONTAINER_RUNTIME
-        value: docker
     - name: Containerd - Windows FV
       execution_time_limit:
         minutes: 60
@@ -658,7 +648,7 @@ blocks:
       - name: CONTAINER_RUNTIME
         value: containerd
       - name: CONTAINERD_VERSION
-        value: 1.4.12
+        value: 1.6.22
 
 - name: "cni-plugin"
   run:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -641,7 +641,7 @@ blocks:
     jobs:
     - name: Containerd - Windows FV
       execution_time_limit:
-        minutes: 60
+        minutes: 120
       commands:
       - ../.semaphore/run-and-monitor win-fv-containerd.log ./.semaphore/run-win-fv.sh
       env_vars:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -639,7 +639,7 @@ blocks:
     jobs:
     - name: Containerd - Windows FV
       execution_time_limit:
-        minutes: 60
+        minutes: 120
       commands:
       - ../.semaphore/run-and-monitor win-fv-containerd.log ./.semaphore/run-win-fv.sh
       env_vars:

--- a/.semaphore/semaphore.yml.tpl
+++ b/.semaphore/semaphore.yml.tpl
@@ -636,17 +636,7 @@ blocks:
       value: master_ssh_key
     - name: WIN_PPK_KEY
       value: win_ppk_key
-    - name: K8S_VERSION
-      value: 1.22.6
     jobs:
-    - name: Docker - Windows FV
-      execution_time_limit:
-        minutes: 60
-      commands:
-      - ../.semaphore/run-and-monitor win-fv-docker.log ./.semaphore/run-win-fv.sh
-      env_vars:
-      - name: CONTAINER_RUNTIME
-        value: docker
     - name: Containerd - Windows FV
       execution_time_limit:
         minutes: 60
@@ -656,7 +646,7 @@ blocks:
       - name: CONTAINER_RUNTIME
         value: containerd
       - name: CONTAINERD_VERSION
-        value: 1.4.12
+        value: 1.6.22
 
 - name: "cni-plugin"
   run:

--- a/cni-plugin/.semaphore/run-win-fv.sh
+++ b/cni-plugin/.semaphore/run-win-fv.sh
@@ -18,10 +18,10 @@ puttygen ${MASTER_CONNECT_KEY} -O private -o ${WIN_PPK_KEY}
 chmod 600 $WIN_PPK_KEY
 aws ec2 import-key-pair --key-name ${KEYPAIR_NAME} --public-key-material file://${MASTER_CONNECT_KEY_PUB}
 
-# Set up the cluster. Set FV timeout to 40 minutes.
+# Set up the cluster. Set FV timeout to 60 minutes.
 NAME_PREFIX="$CLUSTER_NAME" KUBE_VERSION="$K8S_VERSION" WINDOWS_KEYPAIR_NAME="$KEYPAIR_NAME" \
 WINDOWS_PEM_FILE="$MASTER_CONNECT_KEY" WINDOWS_PPK_FILE="$WIN_PPK_KEY" WINDOWS_OS="Windows1809container" \
-CONTAINER_RUNTIME="$CONTAINER_RUNTIME" FV_TIMEOUT=2400 ./setup-fv.sh -q | tee fv.log
+CONTAINER_RUNTIME="$CONTAINER_RUNTIME" FV_TIMEOUT=3600 ./setup-fv.sh -q | tee fv.log
 
 # Run FV
 MASTER_IP=$(grep ubuntu@ fv.log | cut -d '@' -f2)

--- a/process/testing/winfv/create_kubeadm_cluster.sh
+++ b/process/testing/winfv/create_kubeadm_cluster.sh
@@ -25,7 +25,9 @@ sudo apt-get update -y
 KUBE_REPO_VERSION=$(echo ${KUBE_VERSION} | cut -d '.' -f 1,2)
 # Download the k8s repo signing key
 sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v{KUBE_REPO_VERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 755 /etc/apt/keyrings
+curl -fsSL --retry 5 "https://pkgs.k8s.io/core:/stable:/v${KUBE_REPO_VERSION}/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 # Add the Kubernetes apt repository
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${KUBE_REPO_VERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 

--- a/process/testing/winfv/create_kubeadm_cluster.sh
+++ b/process/testing/winfv/create_kubeadm_cluster.sh
@@ -21,12 +21,15 @@ sudo systemctl restart docker
 sudo usermod -aG docker ubuntu
 
 sudo apt-get update -y
-# Download the Google Cloud public signing key
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
-# Add the Kubernetes apt repository
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
-K8S_PKG_VERSION=${KUBE_VERSION}-00
+KUBE_REPO_VERSION=$(echo ${KUBE_VERSION} | cut -d '.' -f 1,2)
+# Download the k8s repo signing key
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v{KUBE_REPO_VERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+# Add the Kubernetes apt repository
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${KUBE_REPO_VERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+K8S_PKG_VERSION=${KUBE_VERSION}-1.1
 sudo apt-get update && sudo apt-get install -y kubelet=${K8S_PKG_VERSION} kubeadm=${K8S_PKG_VERSION} kubectl=${K8S_PKG_VERSION}
 sudo swapoff -a
 

--- a/process/testing/winfv/setup-fv.sh
+++ b/process/testing/winfv/setup-fv.sh
@@ -17,7 +17,7 @@
 NAME_PREFIX="${NAME_PREFIX:=${USER}-win-fv}"
 
 # Kubernetes version
-KUBE_VERSION="${KUBE_VERSION:=1.20.1}"
+KUBE_VERSION="${KUBE_VERSION:=1.28.7}"
 
 # AWS keypair name for nodes
 WINDOWS_KEYPAIR_NAME="${WINDOWS_KEYPAIR_NAME:=AWS-key-pair}"
@@ -324,7 +324,7 @@ function show_all_instances() {
 }
 
 function wait_for_docker_installed() {
-  echo "Waiting for docker been installed on linux node"
+  echo "Waiting for docker to have been installed on linux node"
   for i in `seq 1 30`; do
     sleep 2
     ${MASTER_CONNECT_COMMAND} docker images

--- a/process/testing/winfv/setup-fv.sh
+++ b/process/testing/winfv/setup-fv.sh
@@ -16,8 +16,17 @@
 # Prefix for cluster name
 NAME_PREFIX="${NAME_PREFIX:=${USER}-win-fv}"
 
+# Get K8S_VERSION variable from metadata.mk, default to a value if it cannot be found
+SCRIPT_CURRENT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+METADATAMK=${SCRIPT_CURRENT_DIR}/../../../metadata.mk
+if [ -f ${METADATAMK} ]; then
+    K8S_VERSION=$(grep K8S_VERSION ${METADATAMK} | cut -d "=" -f 2)
+else
+    K8S_VERSION=v1.27.11
+fi
+
 # Kubernetes version
-KUBE_VERSION="${KUBE_VERSION:=1.28.7}"
+KUBE_VERSION="${KUBE_VERSION:=${K8S_VERSION#v}}"
 
 # AWS keypair name for nodes
 WINDOWS_KEYPAIR_NAME="${WINDOWS_KEYPAIR_NAME:=AWS-key-pair}"
@@ -45,7 +54,7 @@ WINDOWS_OS="${WINDOWS_OS:=Windows2022container}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:=docker}"
 
 # Specify containerd version to use.
-CONTAINERD_VERSION="${CONTAINERD_VERSION:=1.4.4}"
+CONTAINERD_VERSION="${CONTAINERD_VERSION:=1.6.22}"
 
 #specify description of AMI,this would be a filter to search AMI.
 #we can create a Json file for description and use it. TODO????

--- a/process/testing/winfv/setup-fv.sh
+++ b/process/testing/winfv/setup-fv.sh
@@ -346,6 +346,20 @@ function wait_for_docker_installed() {
   return 1
 }
 
+function wait_for_containerd_installed() {
+  echo "Waiting for containerd to have been installed on linux node"
+  for i in `seq 1 30`; do
+    sleep 2
+    ${MASTER_CONNECT_COMMAND} crictl images
+
+    if [ $? -eq 0 ]; then
+      echo "containerd installed. Ready to setup linux node for FV"
+      return 0
+    fi
+  done
+  return 1
+}
+
 function master_scp() {
   local file=$1
   scp -i ${WINDOWS_PEM_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $file ubuntu@${LINUX_EIP}:/home/ubuntu
@@ -404,6 +418,7 @@ function setup_kubeadm_cluster(){
 }
 function setup_fv() {
   wait_for_docker_installed
+  wait_for_containerd_installed
 
   setup_linux
   setup_kubeadm_cluster


### PR DESCRIPTION
Cherry pick of #8585 on release-v3.27.

#8585: Fix windows cni-plugin tests

# Original PR Body below

Replace broken apt repos with new ones per https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/

Bump k8s version to 1.28.7

Remove docker runs as it is deprecated on k8s v1.24+

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.