### PR TITLE
update flannel to v0.24.3

### DIFF
--- a/charts/calico/values.yaml
+++ b/charts/calico/values.yaml
@@ -14,7 +14,7 @@ kubeControllers:
   image: docker.io/calico/kube-controllers
 flannel:
   image: docker.io/flannel/flannel
-  tag: v0.21.3
+  tag: v0.24.3
 flannelMigration:
   image: docker.io/calico/flannel-migration
 dikastes:

--- a/manifests/canal-etcd.yaml
+++ b/manifests/canal-etcd.yaml
@@ -607,7 +607,7 @@ spec:
         # Runs the flannel daemon to enable vxlan networking between
         # container hosts.
         - name: flannel
-          image: docker.io/flannel/flannel:v0.21.3
+          image: docker.io/flannel/flannel:v0.24.3
           imagePullPolicy: IfNotPresent
           env:
             # The location of the etcd cluster.

--- a/manifests/canal.yaml
+++ b/manifests/canal.yaml
@@ -4983,7 +4983,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: docker.io/flannel/flannel:v0.21.3
+          image: docker.io/flannel/flannel:v0.24.3
           imagePullPolicy: IfNotPresent
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:


### PR DESCRIPTION
Updates flannel to v0.24.3 (replaces pr #8212 ) 

Tested with:

Talos v1.6.1
Kernel 6.1.69
Kubernetes v1.29.0

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update flannel version to v0.24.3.
```

