### PR TITLE
handle proto.DataplaneInSync msg in status_reporter

### DIFF
--- a/felix/fv/status_report_test.go
+++ b/felix/fv/status_report_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build fvtests
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
+	"github.com/projectcalico/calico/felix/fv/connectivity"
+	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
+	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	bapi "github.com/projectcalico/calico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/calico/libcalico-go/lib/backend/model"
+
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+)
+
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ openstack status-reporting", []apiconfig.DatastoreType{apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
+	var (
+		infra  infrastructure.DatastoreInfra
+		tc     infrastructure.TopologyContainers
+		client client.Interface
+		_      = client
+		w      *workload.Workload
+		cc     *connectivity.Checker
+		_      = cc
+	)
+
+	BeforeEach(func() {
+		infra = getInfra()
+
+		topologyOptions := infrastructure.DefaultTopologyOptions()
+		topologyOptions.VXLANMode = api.VXLANModeAlways
+		topologyOptions.IPIPEnabled = false
+		topologyOptions.EnableIPv6 = false
+		topologyOptions.ExtraEnvVars["FELIX_ENDPOINTREPORTINGENABLED"] = "true"
+		topologyOptions.ExtraEnvVars["FELIX_OPENSTACKREGION"] = "r0"
+		topologyOptions.FelixDebugFilenameRegex = "status_reporter.go"
+
+		tc, client = infrastructure.StartNNodeTopology(1, topologyOptions, infra)
+
+		w = workload.Run(tc.Felixes[0], "wl", "default", "10.65.0.2", "8088", "tcp")
+		w.ConfigureInInfra(infra)
+	})
+
+	AfterEach(func() {
+		w.Stop()
+		tc.Stop()
+		if CurrentGinkgoTestDescription().Failed {
+			infra.DumpErrorData()
+		}
+		infra.Stop()
+	})
+
+	Describe("With status-reporting writing to etcd", func() {
+		getStatuses := func() []*model.KVPair {
+			wlListOpts := model.WorkloadEndpointStatusListOptions{
+				Hostname: tc.Felixes[0].Hostname,
+			}
+
+			By(fmt.Sprintf("listing workload endpoint statuses {%+v}", wlListOpts))
+
+			c := infra.GetCalicoClient()
+			backendClient := c.(interface{ Backend() bapi.Client }).Backend()
+			statuses, err := backendClient.List(context.Background(), wlListOpts, "")
+			Expect(err).NotTo(HaveOccurred(), "Couldn't list workload endpoint statuses")
+
+			return statuses.KVPairs
+		}
+
+		It("should write endpoint to etcd", func() {
+			Eventually(getStatuses, "10s").Should(HaveLen(1))
+			kvs := getStatuses()
+			wepStatusKey, ok := kvs[0].Key.(model.WorkloadEndpointStatusKey)
+			Expect(ok).To(BeTrue(), "Unexpected key type when listing workload endpoint statuses")
+			Expect(wepStatusKey.Hostname).To(Equal(tc.Felixes[0].Hostname))
+			Expect(wepStatusKey.OrchestratorID).To(Equal("felixfv"))
+			Expect(wepStatusKey.EndpointID).To(Equal(w.Name))
+			wepStatusValue, ok := kvs[0].Value.(*model.WorkloadEndpointStatus)
+			Expect(ok).To(BeTrue())
+			Expect(wepStatusValue.Status).To(Equal("up"))
+		})
+	})
+})

--- a/felix/statusrep/status_reporter_test.go
+++ b/felix/statusrep/status_reporter_test.go
@@ -128,7 +128,6 @@ var updatedHostEPKey = model.HostEndpointStatusKey{
 var _ = Describe("Status", func() {
 	var esr *EndpointStatusReporter
 	var epUpdates chan interface{}
-	var inSyncChan chan bool
 	var datastore *mockDatastore
 	var resyncTicker, rateLimitTicker *mockStoppable
 	var resyncTickerChan, rateLimitTickerChan chan time.Time
@@ -142,7 +141,6 @@ var _ = Describe("Status", func() {
 	JustBeforeEach(func() {
 		log.Info("JustBeforeEach called, creating EndpointStatusReporter")
 		epUpdates = make(chan interface{})
-		inSyncChan = make(chan bool)
 		datastore = newMockDatastore()
 		resyncTicker = &mockStoppable{}
 		rateLimitTicker = &mockStoppable{}
@@ -153,7 +151,6 @@ var _ = Describe("Status", func() {
 			hostname,
 			region,
 			epUpdates,
-			inSyncChan,
 			datastore,
 			resyncTicker,
 			resyncTickerChan,
@@ -174,7 +171,7 @@ var _ = Describe("Status", func() {
 	Describe("with empty datastore", func() {
 		Describe("after sending in-sync message", func() {
 			JustBeforeEach(func() {
-				inSyncChan <- true
+				epUpdates <- &proto.DataplaneInSync{}
 			})
 			It("Should start a resync", func() {
 				resyncTickerChan <- time.Now()
@@ -274,7 +271,7 @@ var _ = Describe("Status", func() {
 		})
 		Describe("after sending in-sync", func() {
 			JustBeforeEach(func() {
-				inSyncChan <- true
+				epUpdates <- &proto.DataplaneInSync{}
 			})
 			It("should only clean up local endpoints", func() {
 				// Kick off the resync.
@@ -293,14 +290,14 @@ var _ = Describe("Status", func() {
 				resyncTickerChan <- time.Now()
 				// Then send a no-op event (so that we block until
 				// the above event finishes).  No cleanup should happen yet.
-				inSyncChan <- true
+				epUpdates <- &proto.DataplaneInSync{}
 				Expect(datastore.numKVs()).To(Equal(4))
 				// Rate limit tick should trigger cleanup.
 				rateLimitTickerChan <- time.Now()
-				inSyncChan <- true
+				epUpdates <- &proto.DataplaneInSync{}
 				Expect(datastore.numKVs()).To(Equal(3))
 				rateLimitTickerChan <- time.Now()
-				inSyncChan <- true
+				epUpdates <- &proto.DataplaneInSync{}
 				Expect(datastore.numKVs()).To(Equal(2))
 			}, 1)
 
@@ -357,9 +354,9 @@ var _ = Describe("Status", func() {
 				It("should retry the deletes", func() {
 					// Kick off the first resync.
 					resyncTickerChan <- time.Now()
-					rateLimitTickerChan <- time.Now() // Triggers first delete.
-					rateLimitTickerChan <- time.Now() // Triggers second.
-					inSyncChan <- false               // Wait for next loop
+					rateLimitTickerChan <- time.Now()     // Triggers first delete.
+					rateLimitTickerChan <- time.Now()     // Triggers second.
+					epUpdates <- &proto.DataplaneInSync{} // Wait for next loop
 					Expect(datastore.numKVs()).To(Equal(4),
 						"datastore should still contain all original keys")
 					// Send in timer ticks to finish retries.
@@ -417,7 +414,7 @@ var _ = Describe("Status", func() {
 		})
 		Describe("after sending in-sync", func() {
 			JustBeforeEach(func() {
-				inSyncChan <- true
+				epUpdates <- &proto.DataplaneInSync{}
 			})
 			It("should only clean up local endpoints", func() {
 				// Kick off the resync.
@@ -448,18 +445,15 @@ var _ = Describe("Status", func() {
 var _ = Describe("Non-mocked EndpointStatusReporter", func() {
 	var esr *EndpointStatusReporter
 	var epUpdates chan interface{}
-	var inSyncChan chan bool
 	var datastore *mockDatastore
 
 	BeforeEach(func() {
 		epUpdates = make(chan interface{})
-		inSyncChan = make(chan bool)
 		datastore = newMockDatastore()
 		esr = NewEndpointStatusReporter(
 			hostname,
 			"",
 			epUpdates,
-			inSyncChan,
 			datastore,
 			10*time.Second,  // Rate limit.
 			100*time.Second, // Resync interval.


### PR DESCRIPTION
## Description

A panic is occurring on OpenStack Mainline ST due to an unhandled protobuf type recently added 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
