### PR TITLE
eBPF: Update map definitions in programs used by iptables

### DIFF
--- a/felix/bpf-apache/Makefile
+++ b/felix/bpf-apache/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+# Copyright (c) 2020-2024 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/felix/bpf-apache/Makefile
+++ b/felix/bpf-apache/Makefile
@@ -25,7 +25,8 @@ CFLAGS +=  \
 	-fno-stack-protector \
 	-O2 \
 	-target bpf \
-	-emit-llvm
+	-emit-llvm \
+	-g
 
 # Workaround for Ubuntu placing "asm/types.h" in /usr/include/x86_64-linux-gnu
 TRIPLET := $(shell gcc -dumpmachine)

--- a/felix/bpf-apache/bpf.h
+++ b/felix/bpf-apache/bpf.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/bpf-apache/bpf.h
+++ b/felix/bpf-apache/bpf.h
@@ -16,17 +16,19 @@
 #define __CALI_BPF_H__
 
 #include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
 #include <stddef.h>
 #include <linux/ip.h>
 
 /* Kernel/libbpf bpf_helpers.h also contain this struct 'bpf_map_def' */
-struct bpf_map_def {
+/*struct bpf_map_def {
         unsigned int type;
         unsigned int key_size;
         unsigned int value_size;
         unsigned int max_entries;
         unsigned int map_flags;
-};
+};*/
 
 #define CALI_BPF_INLINE inline __attribute__((always_inline))
 
@@ -53,16 +55,8 @@ struct bpf_map_def {
  * BPF helper function stubs
  */
 
-#define MAKEFUNC(ret_type,fname,...) \
-	static ret_type (*bpf_ ## fname)(__VA_ARGS__) = (void*) BPF_FUNC_ ## fname;
-
 #define BPF_REDIR_EGRESS 0
 #define BPF_REDIR_INGRESS 1
-MAKEFUNC(int, msg_redirect_hash,
-	struct sk_msg_md*, struct bpf_map_def*, void*, __u64)
-MAKEFUNC(int, sock_hash_update,
-	struct bpf_sock_ops*, struct bpf_map_def*, void*, __u64)
-MAKEFUNC(void*, map_lookup_elem, void*, const void*)
 
 /*
  * Data types, structs, and unions

--- a/felix/bpf-apache/bpf.h
+++ b/felix/bpf-apache/bpf.h
@@ -21,15 +21,6 @@
 #include <stddef.h>
 #include <linux/ip.h>
 
-/* Kernel/libbpf bpf_helpers.h also contain this struct 'bpf_map_def' */
-/*struct bpf_map_def {
-        unsigned int type;
-        unsigned int key_size;
-        unsigned int value_size;
-        unsigned int max_entries;
-        unsigned int map_flags;
-};*/
-
 #define CALI_BPF_INLINE inline __attribute__((always_inline))
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/felix/bpf-apache/filter.c
+++ b/felix/bpf-apache/filter.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/bpf-apache/filter.c
+++ b/felix/bpf-apache/filter.c
@@ -53,7 +53,7 @@ CALI_BPF_INLINE static int extract_ports(__u32 len, struct iphdr * h,
 }
 
 
-__attribute__((section("prefilter_func")))
+SEC("xdp")
 enum xdp_action prefilter(struct xdp_md* xdp)
 {
 	struct ethhdr * ehdr;

--- a/felix/bpf-apache/filter.h
+++ b/felix/bpf-apache/filter.h
@@ -25,7 +25,7 @@ struct {
     __type(value, __u32);
     __uint(max_entries, 10240);
     __uint(map_flags, BPF_F_NO_PREALLOC);
-} calico_prefilter_v4 SEC(".map");
+} calico_prefilter_v4 SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -33,4 +33,4 @@ struct {
     __type(value, __u32);
     __uint(max_entries, 65535);
     __uint(map_flags, BPF_F_NO_PREALLOC);
-} calico_failsafe_ports SEC(".map");
+} calico_failsafe_ports SEC(".maps");

--- a/felix/bpf-apache/filter.h
+++ b/felix/bpf-apache/filter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <linux/bpf.h>
 #include "bpf.h"
 
 struct protoport {
@@ -20,18 +19,18 @@ struct protoport {
 	__u16 port;
 };
 
-struct bpf_map_def __attribute__((section("maps"))) calico_prefilter_v4 = {
-	.type           = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size       = sizeof(union ip4_bpf_lpm_trie_key),
-	.value_size     = sizeof(__u32),
-	.max_entries    = 10240,
-	.map_flags      = BPF_F_NO_PREALLOC,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_LPM_TRIE);
+    __type(key, union ip4_bpf_lpm_trie_key);
+    __type(value, __u32);
+    __uint(max_entries, 10240);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} calico_prefilter_v4 SEC(".map");
 
-struct bpf_map_def __attribute__((section("maps"))) calico_failsafe_ports = {
-	.type           = BPF_MAP_TYPE_HASH,
-	.key_size       = sizeof(struct protoport),
-	.value_size     = 1,
-	.max_entries    = 65535,
-	.map_flags      = BPF_F_NO_PREALLOC,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, struct protoport);
+    __type(value, __u32);
+    __uint(max_entries, 65535);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} calico_failsafe_ports SEC(".map");

--- a/felix/bpf-apache/sockops.h
+++ b/felix/bpf-apache/sockops.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ struct sock_key {
 	__u32 envoy_side;
 };
 
-struct bpf_map_def __attribute__((section("maps"))) calico_sock_map = {
-	.type           = BPF_MAP_TYPE_SOCKHASH,
-	.key_size       = sizeof(struct sock_key),
-	.value_size     = sizeof(__u32),
-	.max_entries    = 65535,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_SOCKHASH);
+    __type(key, struct sock_key);
+    __type(value, __u32);
+    __uint(max_entries, 65535);
+} calico_sock_map SEC(".map");

--- a/felix/bpf-apache/sockops.h
+++ b/felix/bpf-apache/sockops.h
@@ -28,4 +28,4 @@ struct {
     __type(key, struct sock_key);
     __type(value, __u32);
     __uint(max_entries, 65535);
-} calico_sock_map SEC(".map");
+} calico_sock_map SEC(".maps");


### PR DESCRIPTION
## Description
Update map definition in the bpf programs under `bpf-apache` to make `libbpf v1.0+`  (or any tools using it) load them without any error. Loading current bpf programs with `libbpf v1.0+` leads to the following error:
```
libbpf: elf: legacy map definitions in 'maps' section are not supported by libbpf v1.0+
Error: failed to open object file
```

This error does not happen in k8s clusters since we bundle the necessary tools like `bpftool` with `calico-node` image.  The customer hit this issue in an openstack cluster. 

Tested with kernel 6.5 and libbpf 1.2, and `ip` tool can successfully load the program.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Update map definitions in programs used in iptables mode to let libbpf v1.0+ load them successfully.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
