### PR TITLE
Teardown apiserver in FV before running dual stack tests

### DIFF
--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -78,7 +78,7 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 		}
 
 		BeforeEach(func() {
-			iOpts := []infrastructure.CreateOption{infrastructure.K8sWithIPv6(),
+			iOpts := []infrastructure.CreateOption{infrastructure.K8sWithDualStack(),
 				infrastructure.K8sWithAPIServerBindAddress("::"),
 				infrastructure.K8sWithServiceClusterIPRange("dead:beef::abcd:0:0:0/112,10.101.0.0/16")}
 			infra = getInfra(iOpts...)

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -51,13 +51,17 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 
 	BeforeEach(func() {
 		var err error
-		iOpts := []infrastructure.CreateOption{infrastructure.K8sWithIPv6(),
-			infrastructure.K8sWithAPIServerBindAddress("::"),
-			infrastructure.K8sWithServiceClusterIPRange("dead:beef::abcd:0:0:0/112,10.101.0.0/16")}
+		iOpts := []infrastructure.CreateOption{}
+		if BPFMode() {
+			iOpts = append(iOpts,
+				infrastructure.K8sWithDualStack(),
+				infrastructure.K8sWithAPIServerBindAddress("::"),
+				infrastructure.K8sWithServiceClusterIPRange("dead:beef::abcd:0:0:0/112,10.101.0.0/16"))
+		}
 		infra = getInfra(iOpts...)
 		options := infrastructure.DefaultTopologyOptions()
-		options.EnableIPv6 = true
 		if BPFMode() {
+			options.EnableIPv6 = true
 			options.ExtraEnvVars["FELIX_BPFLogLevel"] = "debug"
 			options.IPIPEnabled = false
 		}

--- a/felix/fv/infrastructure/infra_k8s.go
+++ b/felix/fv/infrastructure/infra_k8s.go
@@ -73,6 +73,7 @@ type K8sDatastoreInfra struct {
 	runningTest string
 
 	ipv6                  bool
+	dualStack             bool
 	serviceClusterIPRange string
 	apiServerBindIP       string
 	ipMask                string
@@ -168,7 +169,7 @@ func GetK8sDatastoreInfra(index K8sInfraIndex, opts ...CreateOption) (*K8sDatast
 			ginkgo.Fail(fmt.Sprintf("Previous test didn't clean up the infra: %s", K8sInfra[index].runningTest))
 		}
 
-		resetAll := temp.ipv6 != kds.ipv6
+		resetAll := temp.ipv6 != kds.ipv6 || temp.dualStack != kds.dualStack
 
 		if !resetAll {
 			kds.EnsureReady()
@@ -1165,6 +1166,16 @@ func K8sWithIPv6() CreateOption {
 	return func(ds DatastoreInfra) {
 		if kds, ok := ds.(*K8sDatastoreInfra); ok {
 			kds.ipv6 = true
+			kds.ipMask = "/128"
+		}
+	}
+}
+
+func K8sWithDualStack() CreateOption {
+	return func(ds DatastoreInfra) {
+		if kds, ok := ds.(*K8sDatastoreInfra); ok {
+			kds.ipv6 = true
+			kds.dualStack = true
 			kds.ipMask = "/128"
 		}
 	}


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/tigera/calico-private/pull/7323

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
