### PR TITLE
add global +x permissions to endpoint-status dir

### DIFF
--- a/felix/statusrep/status_file_reporter.go
+++ b/felix/statusrep/status_file_reporter.go
@@ -331,7 +331,7 @@ func ensureStatusDir(prefix string) (entries []fs.DirEntry, err error) {
 	entries, err = os.ReadDir(filename)
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		// Discard ErrNotExist and return the result of attempting to create it.
-		return entries, os.Mkdir(filename, fs.FileMode(0644))
+		return entries, os.Mkdir(filename, fs.FileMode(0655))
 	}
 
 	return entries, err


### PR DESCRIPTION
## Description

Currently the endpoint-status directory is created with perms: `rwx-r__-r__`
This leads to strange `ls -l` output when inspecting the files as non-root:

```
ubuntu:~$ ls -l /var/run/calico/endpoint-status/
ls: cannot access '/var/run/calico/endpoint-status/k8s calico-system%2Fcalico-kube-controllers-9c65d96ff-54vg8 eth0': Permission denied
ls: cannot access '/var/run/calico/endpoint-status/k8s kube-system%2Fcoredns-5dd5756b68-rlt8h eth0': Permission denied
ls: cannot access '/var/run/calico/endpoint-status/k8s kube-system%2Fcoredns-5dd5756b68-mxwjn eth0': Permission denied
ls: cannot access '/var/run/calico/endpoint-status/k8s calico-system%2Fcsi-node-driver-2bx8l eth0': Permission denied
total 0
-????????? ? ? ? ?            ? 'k8s calico-system%2Fcalico-kube-controllers-9c65d96ff-54vg8 eth0'
-????????? ? ? ? ?            ? 'k8s calico-system%2Fcsi-node-driver-2bx8l eth0'
-????????? ? ? ? ?            ? 'k8s kube-system%2Fcoredns-5dd5756b68-mxwjn eth0'
-????????? ? ? ? ?            ? 'k8s kube-system%2Fcoredns-5dd5756b68-rlt8h eth0'

```

Permitting execution of the parent directory fixes this issue.

Release note not required as patch can be released at the same time as the feature in question.
