### PR TITLE
Granting read access to secrets for calico-node

### DIFF
--- a/manifests/calico.yaml
+++ b/manifests/calico.yaml
@@ -4541,6 +4541,7 @@ rules:
     resources:
       - endpoints
       - services
+      - secrets
     verbs:
       # Used to discover service IPs for advertisement.
       - watch


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

[bug fix]

When establishing a BGP connection using a password, the password is stored within a Kubernetes Secret. The calico-node container requires read access to this Secret in order to retrieve the necessary password. Otherwise, you will encounter the following error message。

```
W0307 10:53:55.859473      89 reflector.go:533] pkg/mod/k8s.io/client-go@v0.27.8/tools/cache/reflector.go:231: failed to list *v1.Secret: secrets "bgp-password" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E0307 10:53:55.859497      89 reflector.go:148] pkg/mod/k8s.io/client-go@v0.27.8/tools/cache/reflector.go:231: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets "bgp-password" is forbidden: User "system:serviceaccount:kube-system:calico-node" cannot list resource "secrets" in API group "" in the namespace "kube-system"
```

