### PR TITLE
Prevent upgrade-ipam for host-local IPAM

### DIFF
--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: 0
       priorityClassName: system-node-critical
       initContainers:
-{{- if and (eq .Values.network "calico") (eq .Values.datastore "kubernetes") }}
+{{- if and (eq .Values.network "calico") (eq .Values.datastore "kubernetes") (eq .Values.ipam "calico-ipam") }}
         # This container performs upgrade from host-local IPAM to calico-ipam.
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.

--- a/charts/calico/templates/calico-node.yaml
+++ b/charts/calico/templates/calico-node.yaml
@@ -637,7 +637,7 @@ spec:
           secret:
             secretName: calico-etcd-secrets
             defaultMode: 0400
-{{- else if and (eq .Values.network "calico") (eq .Values.datastore "kubernetes") }}
+{{- else if and (eq .Values.network "calico") (eq .Values.datastore "kubernetes") (eq .Values.ipam "calico-ipam") }}
         # Mount in the directory for host-local IPAM allocations. This is
         # used when upgrading from host-local to calico-ipam, and can be removed
         # if not using the upgrade-ipam init container.


### PR DESCRIPTION
## Description

Otherwise, the init container upgrade-ipam would clear the state of the host-local plugin, potentially causing it to reassign IPs that are still in use.

Example:
```
 Warning  FailedCreatePodSandBox  102s  kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "ff47431fb9a1758c7a14688e6e6339de5bd475ade3e68f73139cc0a4565f31c9": plugin type="calico" failed (add): error adding host side routes for interface: calic2c3994f071, error: route (Ifindex: 44, Dst: 10.233.64.2/32, Scope: link) already exists for an interface other than 'calic2c3994f071': route (Ifindex: 25, Dst: 10.233.64.2/32, Scope: link, Iface: calib8e5d9c71dc)
```

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```