### PR TITLE
Add logging statement to indicate ss command usage

### DIFF
--- a/calicoctl/calicoctl/commands/node/diags.go
+++ b/calicoctl/calicoctl/commands/node/diags.go
@@ -129,7 +129,9 @@ func runDiags(logDir string) error {
 			content, err := exec.Command(parts[0], parts[1], parts[2]).CombinedOutput()
 			if err != nil {
 				fmt.Printf("Failed to run command: %s\nError: %s\n", strings.Join(parts, " "), string(content))
-			}
+			} else {
+                                fmt.Println("Dumping ss (\"netstat -a -n\" fails, used \"ss -a -n\" instead)")
+                        }
 
 			fp := filepath.Join(diagsTmpDir, parts[0])
 			if err := os.WriteFile(fp, content, 0666); err != nil {


### PR DESCRIPTION
## Description
Added a fmt.Println statement to log a message explaining that the   command "netstat -a -n" failed to run and that "ss -a -n" was used   instead. This change was made to provide better context to users   who might encounter the error message "Failed to run command: netstat -a -n".  
  
Users who encounter this error should not immediately consider installing netstat.

![image](https://github.com/projectcalico/calico/assets/112474703/1d8f0ddd-2c18-44ba-b8c6-b046572a51a2)

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
