### PR TITLE
CNI wait file waits for status up

### DIFF
--- a/felix/fv/pod_setup_wait_test.go
+++ b/felix/fv/pod_setup_wait_test.go
@@ -131,6 +131,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Pod setup status wait", []a
 			By("creating a workload before Felix starts")
 			wl := workload.New(tc.Felixes[0], "workload-endpoint-status-tests-0", "default", "10.65.0.10", "8080", "tcp")
 			wl.ConfigureInInfra(infra)
+			err := wl.Start()
+			Expect(err).NotTo(HaveOccurred(), "Couldn't start a test workload")
 
 			By("determining the filename Felix will look for")
 			wKey, err := names.V3WorkloadEndpointToWorkloadEndpointKey(wl.WorkloadEndpoint)

--- a/felix/statusrep/status_file_reporter_test.go
+++ b/felix/statusrep/status_file_reporter_test.go
@@ -12,17 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package statusrep_test
+package statusrep
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/proto"
-	"github.com/projectcalico/calico/felix/statusrep"
+	"github.com/projectcalico/calico/libcalico-go/lib/names"
 )
 
 type mockBackoff struct {
@@ -39,7 +42,43 @@ func (b *mockBackoff) Step() time.Duration {
 	return b.StepDuration
 }
 
+type mockFilesys struct {
+	createCB  func(string)
+	removeCB  func(string)
+	mkdirCB   func(name string)
+	readdirCB func(name string)
+}
+
+func (f *mockFilesys) Create(name string) (*os.File, error) {
+	if f.createCB != nil {
+		f.createCB(name)
+	}
+	return os.Create(name)
+}
+
+func (f *mockFilesys) Remove(name string) error {
+	if f.removeCB != nil {
+		f.removeCB(name)
+	}
+	return os.Remove(name)
+}
+
+func (f *mockFilesys) Mkdir(name string, perm os.FileMode) error {
+	if f.mkdirCB != nil {
+		f.mkdirCB(name)
+	}
+	return os.Mkdir(name, perm)
+}
+
+func (f *mockFilesys) ReadDir(name string) ([]os.DirEntry, error) {
+	if f.readdirCB != nil {
+		f.readdirCB(name)
+	}
+	return os.ReadDir(name)
+}
+
 var _ = Describe("Endpoint Policy Status Reports [file-reporting]", func() {
+	logrus.SetLevel(logrus.DebugLevel)
 	var endpointUpdatesC chan interface{}
 	var ctx context.Context
 	var cancel context.CancelFunc
@@ -56,18 +95,24 @@ var _ = Describe("Endpoint Policy Status Reports [file-reporting]", func() {
 	})
 
 	It("should create a new directory and retry if it fails", func() {
-		var fileReporter *statusrep.EndpointStatusFileReporter
+		var fileReporter *EndpointStatusFileReporter
 
 		backoffCalledC := make(chan struct{})
-		newMockBackoff := func() statusrep.Backoff {
+		newMockBackoff := func() Backoff {
 			return &mockBackoff{
 				C:            backoffCalledC,
-				StepDuration: 1 * time.Nanosecond,
+				StepDuration: 1 * time.Second,
 			}
+		}
+		readdirC := make(chan string, 100)
+		mockfs := mockFilesys{
+			readdirCB: func(name string) {
+				readdirC <- name
+			},
 		}
 
 		// Use a path we think the reporter cannot write to.
-		fileReporter = statusrep.NewEndpointStatusFileReporter(endpointUpdatesC, "/root/", statusrep.WithNewBackoffFunc(newMockBackoff))
+		fileReporter = NewEndpointStatusFileReporter(endpointUpdatesC, "/root/", WithNewBackoffFunc(newMockBackoff), WithFilesys(&mockfs))
 
 		By("Starting a fileReporter which cannot create the necessary directory")
 
@@ -79,6 +124,54 @@ var _ = Describe("Endpoint Policy Status Reports [file-reporting]", func() {
 		}()
 
 		Eventually(endpointUpdatesC, "10s").Should(BeSent(&proto.DataplaneInSync{}))
+
+		Eventually(readdirC, "10s").Should(Receive(Equal("/root/endpoint-status")), "Expected reporter to try reading a forbidden directory")
 		Eventually(backoffCalledC, "10s").Should(BeClosed(), "Backoff wasn't called by the reporter (is the file-reporting unexpectedly succeeding?).")
+	})
+
+	It("should only add a desired file to the delta-tracker when update has status up", func() {
+		fileCreatedC := make(chan string, 100)
+		mockfs := mockFilesys{
+			createCB: func(name string) {
+				fileCreatedC <- name
+			},
+		}
+		reporter := NewEndpointStatusFileReporter(endpointUpdatesC, "/tmp", WithHostname("host"), WithFilesys(&mockfs))
+
+		go func() {
+			defer close(doneC)
+			reporter.SyncForever(ctx)
+		}()
+
+		By("Sending a status-down update to the reporter")
+
+		wepID := &proto.WorkloadEndpointID{
+			OrchestratorId: "abc",
+			WorkloadId:     "default/pod1",
+			EndpointId:     "eth0",
+		}
+		key := names.WorkloadEndpointIDToWorkloadEndpointKey(wepID, "host")
+		mapKey := names.WorkloadEndpointKeyToStatusFilename(key)
+		filename := filepath.Join("/tmp/endpoint-status", mapKey)
+
+		Eventually(endpointUpdatesC, "10s").Should(BeSent(&proto.WorkloadEndpointStatusUpdate{
+			Id: wepID,
+			Status: &proto.EndpointStatus{
+				Status: "down",
+			},
+		}))
+		Eventually(endpointUpdatesC, "10s").Should(BeSent(&proto.DataplaneInSync{}))
+
+		Consistently(fileCreatedC, "3s").ShouldNot(Receive(), "Tracker wrote a file for an endpoint before status was up")
+
+		By("Sending a status-up update to the reporter")
+		Eventually(endpointUpdatesC, "10s").Should(BeSent(&proto.WorkloadEndpointStatusUpdate{
+			Id: wepID,
+			Status: &proto.EndpointStatus{
+				Status: "up",
+			},
+		}))
+
+		Eventually(fileCreatedC, "10s").Should(Receive(Equal(filename)), "Tracker did not add desired file for endpoint with status up")
 	})
 })


### PR DESCRIPTION
## Description

Bugfix: status_file_reporter currently writes files too early. It should wait for a WorkloadEndpointStatusUpdate to have status "up"


## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
