### PR TITLE
[release-v3.28] Auto pick #8666: include IP pool name in custom-resources.yaml

### DIFF
--- a/manifests/custom-resources.yaml
+++ b/manifests/custom-resources.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   # Configures Calico networking.
   calicoNetwork:
-    # Note: The ipPools section cannot be modified post-install.
     ipPools:
-    - blockSize: 26
+    - name: default-ipv4-pool
+      blockSize: 26
       cidr: 192.168.0.0/16
       encapsulation: VXLANCrossSubnet
       natOutgoing: Enabled

--- a/manifests/custom-resources.yaml
+++ b/manifests/custom-resources.yaml
@@ -8,7 +8,7 @@ spec:
   # Configures Calico networking.
   calicoNetwork:
     ipPools:
-    - name: default-ipv4-pool
+    - name: default-ipv4-ippool
       blockSize: 26
       cidr: 192.168.0.0/16
       encapsulation: VXLANCrossSubnet


### PR DESCRIPTION
Cherry pick of #8666 on release-v3.28.

#8666: include IP pool name in custom-resources.yaml

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

v3.28 introduces a new field. Include it set by default (1) for
backwards compatibility in terms of naming and (2) for self-documenting
configuration.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.