### PR TITLE
add test for disable checksumoffload on IPIP device

### DIFF
--- a/felix/fv/ipip_test.go
+++ b/felix/fv/ipip_test.go
@@ -65,8 +65,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 		if BPFMode() && getDataStoreType(infra) == "etcdv3" {
 			Skip("Skipping BPF test for etcdv3 backend.")
 		}
-		tc, client = infrastructure.StartNNodeTopology(2, infrastructure.DefaultTopologyOptions(), infra)
-
+		tc, client = infrastructure.StartNNodeTopology(2, createDefaultTopologyOptionsWithChecksumOffload(true), infra)
 		// Install a default profile that allows all ingress and egress, in the absence of any Policy.
 		infra.AddDefaultAllow()
 
@@ -154,6 +153,16 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ IPIP topology before adding
 		cc.ExpectSome(tc.Felixes[0], hostW[1])
 		cc.ExpectSome(tc.Felixes[1], hostW[0])
 		cc.CheckConnectivity()
+	})
+
+	It("should disable checksum offload", func() {
+		Eventually(func() string {
+			out, err := tc.Felixes[0].ExecOutput("ethtool", "-k", "tunl0")
+			if err != nil {
+				return fmt.Sprintf("ERROR: %v", err)
+			}
+			return out
+		}, "10s", "100ms").Should(ContainSubstring("tx-checksumming: off"))
 	})
 
 	Context("with host protection policy in place", func() {
@@ -490,6 +499,15 @@ type createK8sServiceWithoutKubeProxyArgs struct {
 	tgtPort   int
 	chain     string
 	ipv6      bool
+}
+
+func createDefaultTopologyOptionsWithChecksumOffload(brokenXSum bool) infrastructure.TopologyOptions {
+	topologyOptions := infrastructure.DefaultTopologyOptions()
+	// We force the broken checksum handling on or off so that we're not dependent on kernel version
+	// for these tests.  Since we're testing in containers anyway, checksum offload can't really be
+	// tested but we can verify the state with ethtool.
+	topologyOptions.ExtraEnvVars["FELIX_FeatureDetectOverride"] = fmt.Sprintf("ChecksumOffloadBroken=%t", brokenXSum)
+	return topologyOptions
 }
 
 func createK8sServiceWithoutKubeProxy(args createK8sServiceWithoutKubeProxyArgs) {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

add test for disable checksumoffload on IPIP device

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

https://github.com/projectcalico/calico/pull/8031#pullrequestreview-1746597070

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
