### PR TITLE
Delete old map if they are of the same version but different sizes.

### DIFF
--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -632,7 +632,13 @@ func (b *PinnedMap) EnsureExists() error {
 		if b.KeySize != mapInfo.KeySize || b.ValueSize != mapInfo.ValueSize {
 			b.MapFD().Close()
 			os.Remove(b.Path())
-			log.Warn("Map with same name but different parameters exists. Deleting it")
+			log.WithFields(log.Fields{
+				"name":          b.Name,
+				"Old KeySize":   mapInfo.KeySize,
+				"New KeySize":   b.KeySize,
+				"Old ValueSize": mapInfo.ValueSize,
+				"New ValueSize": b.ValueSize,
+			}).Warn("Map with same name but different parameters exists. Deleting it")
 		} else {
 			if b.MaxEntries == mapInfo.MaxEntries {
 				return nil

--- a/felix/bpf/maps/maps.go
+++ b/felix/bpf/maps/maps.go
@@ -629,26 +629,32 @@ func (b *PinnedMap) EnsureExists() error {
 			return fmt.Errorf("error getting map info of the pinned map %w", err)
 		}
 
-		if b.MaxEntries == mapInfo.MaxEntries {
-			return nil
-		}
-		log.WithField("name", b.Name).Debugf("Size changed %d -> %d", mapInfo.MaxEntries, b.MaxEntries)
+		if b.KeySize != mapInfo.KeySize || b.ValueSize != mapInfo.ValueSize {
+			b.MapFD().Close()
+			os.Remove(b.Path())
+			log.Warn("Map with same name but different parameters exists. Deleting it")
+		} else {
+			if b.MaxEntries == mapInfo.MaxEntries {
+				return nil
+			}
+			log.WithField("name", b.Name).Debugf("Size changed %d -> %d", mapInfo.MaxEntries, b.MaxEntries)
 
-		// store the old fd
-		b.oldfd = b.MapFD()
-		b.oldSize = mapInfo.MaxEntries
+			// store the old fd
+			b.oldfd = b.MapFD()
+			b.oldSize = mapInfo.MaxEntries
 
-		err = b.repinAt(int(b.MapFD()), b.Path(), oldMapPath)
-		if err != nil {
-			return fmt.Errorf("error migrating the old map %w", err)
-		}
-		copyData = true
-		// Do not close the oldfd if the map is updated by the BPF programs.
-		if !b.UpdatedByBPF {
-			defer func() {
-				b.oldfd.Close()
-				b.oldfd = 0
-			}()
+			err = b.repinAt(int(b.MapFD()), b.Path(), oldMapPath)
+			if err != nil {
+				return fmt.Errorf("error migrating the old map %w", err)
+			}
+			copyData = true
+			// Do not close the oldfd if the map is updated by the BPF programs.
+			if !b.UpdatedByBPF {
+				defer func() {
+					b.oldfd.Close()
+					b.oldfd = 0
+				}()
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

when upgrading, delete the old map if its of the same version but has different key/value size. 

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix map creation during upgrade.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
