### PR TITLE
[release-v3.27] Auto pick #8679: Do wep rpf check for icmpv6 if src is not link local

### DIFF
--- a/felix/bpf-gpl/ip_addr.h
+++ b/felix/bpf-gpl/ip_addr.h
@@ -47,7 +47,7 @@ static CALI_BPF_INLINE int ipv6_addr_t_cmp(ipv6_addr_t *x, ipv6_addr_t *y)
 }
 
 #define ip_void(ip)	((ip).a == 0 && (ip).b == 0 && (ip).c == 0 && (ip).d == 0)
-#define ip_link_local(ip)	(bpf_htonl((ip).a) == 0xfe800000)
+#define ip_link_local(ip)	((bpf_htonl((ip).a) & (0xffc00000)) == 0xfe800000)
 #define VOID_IP		({ipv6_addr_t x = {}; x;})
 #define ip_set_void(ip)	do {	\
 	(ip).a = 0;		\

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -440,7 +440,7 @@ syn_force_policy:
 
 	if (CALI_F_FROM_WEP
 #ifdef IPVER6
-			&& ctx->state->ip_proto != IPPROTO_ICMPV6
+			&& !(ctx->state->ip_proto == IPPROTO_ICMPV6 && ip_link_local(ctx->state->ip_src))
 #endif
 		) {
 		struct cali_rt *r = cali_rt_lookup(&ctx->state->ip_src);


### PR DESCRIPTION
Cherry pick of #8679 on release-v3.27.

#8679: Do wep rpf check for icmpv6 if src is not link local

# Original PR Body below

## Description

This PR has changes for 
1. wep rpf check for icmpv6 packets if the src is not link local
2. snat the icmpv6 packets if destination is not in the ippool and src is not linklocal.

fixes https://github.com/projectcalico/calico/issues/8636

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fix natOutgoing SNAT for icmp6
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.