### PR TITLE
Update as the older format bpf_map-def was deprecated

### DIFF
--- a/felix/bpf-apache/sockops.c
+++ b/felix/bpf-apache/sockops.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/felix/bpf-apache/sockops.c
+++ b/felix/bpf-apache/sockops.c
@@ -15,13 +15,13 @@
 #include <linux/bpf.h>
 #include "sockops.h"
 
-struct bpf_map_def __attribute__((section("maps"))) calico_sk_endpoints = {
-	.type           = BPF_MAP_TYPE_LPM_TRIE,
-	.key_size       = sizeof(union ip4_bpf_lpm_trie_key),
-	.value_size     = sizeof(__u32),
-	.max_entries    = 65535,
-	.map_flags      = BPF_F_NO_PREALLOC,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_LPM_TRIE);
+    __uint(max_entries, 65535);
+    __type(key, union ip4_bpf_lpm_trie_key);
+    __type(value, __u32);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} calico_sk_endpoints __attribute__((section(".maps")));
 
 __attribute__((section("calico_sockops_func")))
 enum bpf_ret_code calico_sockops(struct bpf_sock_ops *skops)

--- a/felix/bpf-apache/sockops.c
+++ b/felix/bpf-apache/sockops.c
@@ -17,11 +17,11 @@
 
 struct {
     __uint(type, BPF_MAP_TYPE_LPM_TRIE);
-    __uint(max_entries, 65535);
     __type(key, union ip4_bpf_lpm_trie_key);
     __type(value, __u32);
+    __uint(max_entries, 65535);
     __uint(map_flags, BPF_F_NO_PREALLOC);
-} calico_sk_endpoints __attribute__((section(".maps")));
+} calico_sk_endpoints SEC(".maps");
 
 __attribute__((section("calico_sockops_func")))
 enum bpf_ret_code calico_sockops(struct bpf_sock_ops *skops)


### PR DESCRIPTION
## Description
bpf_map_def  map declaration was deprecated https://github.com/libbpf/libbpf/wiki/Libbpf%3A-the-road-to-v1.0#drop-support-for-legacy-bpf-map-declaration-syntax

was getting errors while building from the source for Wolfi
```
2024/04/04 18:21:20 INFO clang -Wno-error=unused-but-set-variable -m64 -D__x86_64__ -x c -D__KERNEL__ -D__ASM_SYSREG_H -Wunused -Wall -Werror -fno-stack-protector -O2 -target bpf -emit-llvm -g -I/usr/include/x86_64-pc-linux-gnu -c sockops.c -o sockops.ll
2024/04/04 18:21:20 WARN sockops.c:18:53: error: variable has incomplete type 'struct bpf_map_def'
2024/04/04 18:21:20 WARN struct bpf_map_def __attribute__((section("maps"))) calico_sk_endpoints = {
2024/04/04 18:21:20 WARN                                                     ^
2024/04/04 18:21:20 WARN sockops.c:18:8: note: forward declaration of 'struct bpf_map_def'
2024/04/04 18:21:20 WARN struct bpf_map_def __attribute__((section("maps"))) calico_sk_endpoints = {
2024/04/04 18:21:20 WARN        ^
2024/04/04 18:21:20 WARN 1 error generated.
```
