### PR TITLE
Set log level based on klog level

### DIFF
--- a/apiserver/cmd/apiserver/apiserver.go
+++ b/apiserver/cmd/apiserver/apiserver.go
@@ -58,5 +58,4 @@ func main() {
 
 	code := cli.Run(cmd)
 	os.Exit(code)
-
 }

--- a/apiserver/cmd/apiserver/server/options.go
+++ b/apiserver/cmd/apiserver/server/options.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -38,7 +37,6 @@ import (
 	"github.com/projectcalico/api/pkg/openapi"
 
 	"github.com/projectcalico/calico/apiserver/pkg/apiserver"
-	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
 )
 
 // CalicoServerOptions contains the aggregation of configuration structs for
@@ -62,6 +60,7 @@ type CalicoServerOptions struct {
 
 func (s *CalicoServerOptions) addFlags(flags *pflag.FlagSet) {
 	s.RecommendedOptions.AddFlags(flags)
+
 	flags.BoolVar(&s.EnableAdmissionController, "enable-admission-controller-support", s.EnableAdmissionController,
 		"If true, admission controller hooks will be enabled.")
 	flags.BoolVar(&s.PrintSwagger, "print-swagger", false,
@@ -179,14 +178,6 @@ func (o *CalicoServerOptions) Config() (*apiserver.Config, error) {
 	serverConfig.EnableContentionProfiling = false
 	serverConfig.EnableMetrics = false
 	serverConfig.EnableProfiling = false
-
-	// Extra extra config from environments.
-	//TODO(rlb): Need to unify our logging libraries
-	logrusLevel := logrus.InfoLevel
-	if env := os.Getenv("LOG_LEVEL"); env != "" {
-		logrusLevel = logutils.SafeParseLogLevel(env)
-	}
-	logrus.SetLevel(logrusLevel)
 
 	minResourceRefreshInterval := 5 * time.Second
 	if env := os.Getenv("MIN_RESOURCE_REFRESH_INTERVAL"); env != "" {

--- a/apiserver/cmd/apiserver/server/server.go
+++ b/apiserver/cmd/apiserver/server/server.go
@@ -21,10 +21,13 @@ package server
 import (
 	"flag"
 	"io"
+	"os"
 
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 
 	"github.com/projectcalico/calico/apiserver/pkg/apiserver"
+	"github.com/projectcalico/calico/libcalico-go/lib/logutils"
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/kubernetes/pkg/util/interrupt"
 
@@ -35,6 +38,20 @@ import (
 )
 
 const defaultEtcdPathPrefix = ""
+
+func logrusLevel() logrus.Level {
+	if env := os.Getenv("LOG_LEVEL"); env != "" {
+		return logutils.SafeParseLogLevel(env)
+	}
+
+	if klog.V(2).Enabled() {
+		return logrus.DebugLevel
+	}
+	if klog.V(1).Enabled() {
+		return logrus.InfoLevel
+	}
+	return logrus.ErrorLevel
+}
 
 // NewCommandStartMaster provides a CLI handler for 'start master' command
 func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, error) {
@@ -60,6 +77,8 @@ func NewCommandStartCalicoServer(out io.Writer) (*cobra.Command, error) {
 	opts.addFlags(flags)
 
 	cmd.Run = func(c *cobra.Command, args []string) {
+		logrus.SetLevel(logrusLevel())
+
 		h := interrupt.New(nil, func() {
 			close(stopCh)
 		})

--- a/apiserver/pkg/storage/calico/resource.go
+++ b/apiserver/pkg/storage/calico/resource.go
@@ -120,7 +120,7 @@ func validationError(err error, qualifiedKind schema.GroupKind, name string) *aa
 // in seconds (0 means forever). If no error is returned and out is not nil, out will be
 // set to the read value from database.
 func (rs *resourceStore) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
-	klog.Infof("Create called with key: %v for resource %v\n", key, rs.resourceName)
+	klog.V(1).Infof("Create called with key: %v for resource %v\n", key, rs.resourceName)
 	lcObj := rs.converter.convertToLibcalico(obj)
 
 	opts := options.SetOptions{TTL: time.Duration(ttl) * time.Second}
@@ -143,8 +143,9 @@ func (rs *resourceStore) Create(ctx context.Context, key string, obj, out runtim
 // If key didn't exist, it will return NotFound storage error.
 func (rs *resourceStore) Delete(ctx context.Context, key string, out runtime.Object,
 	preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc,
-	cachedExistingObject runtime.Object) error {
-	klog.Infof("Delete called with key: %v for resource %v\n", key, rs.resourceName)
+	cachedExistingObject runtime.Object,
+) error {
+	klog.V(1).Infof("Delete called with key: %v for resource %v\n", key, rs.resourceName)
 
 	ns, name, err := NamespaceAndNameFromKey(key, rs.isNamespaced)
 	if err != nil {
@@ -203,7 +204,7 @@ func checkPreconditions(key string, preconditions *storage.Preconditions, out ru
 // If resource version is "0", this interface will get current object at given key
 // and send it in an "ADDED" event, before watch starts.
 func (rs *resourceStore) Watch(ctx context.Context, key string, opts storage.ListOptions) (k8swatch.Interface, error) {
-	klog.Infof("Watch called with key: %v on resource %v\n", key, rs.resourceName)
+	klog.V(1).Infof("Watch called with key: %v on resource %v\n", key, rs.resourceName)
 	ns, name, err := NamespaceAndNameFromKey(key, rs.isNamespaced)
 	if err != nil {
 		return nil, err
@@ -219,7 +220,7 @@ func (rs *resourceStore) Watch(ctx context.Context, key string, opts storage.Lis
 // If resource version is "0", this interface will list current objects directory defined by key
 // and send them in "ADDED" events, before watch starts.
 func (rs *resourceStore) WatchList(ctx context.Context, key string, opts storage.ListOptions) (k8swatch.Interface, error) {
-	klog.Infof("WatchList called with key: %v on resource %v\n", key, rs.resourceName)
+	klog.V(1).Infof("WatchList called with key: %v on resource %v\n", key, rs.resourceName)
 	ns, name, err := NamespaceAndNameFromKey(key, rs.isNamespaced)
 	if err != nil {
 		return nil, err
@@ -233,8 +234,9 @@ func (rs *resourceStore) WatchList(ctx context.Context, key string, opts storage
 // The returned contents may be delayed, but it is guaranteed that they will
 // be have at least 'resourceVersion'.
 func (rs *resourceStore) Get(ctx context.Context, key string, optsK8s storage.GetOptions,
-	out runtime.Object) error {
-	klog.Infof("Get called with key: %v on resource %v\n", key, rs.resourceName)
+	out runtime.Object,
+) error {
+	klog.V(1).Infof("Get called with key: %v on resource %v\n", key, rs.resourceName)
 	ns, name, err := NamespaceAndNameFromKey(key, rs.isNamespaced)
 	if err != nil {
 		return err
@@ -259,7 +261,7 @@ func (rs *resourceStore) Get(ctx context.Context, key string, optsK8s storage.Ge
 // The returned contents may be delayed, but it is guaranteed that they will
 // match 'opts.ResourceVersion' according 'opts.ResourceVersionMatch'.
 func (rs *resourceStore) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	klog.Infof("GetList called with key: %v on resource %v\n", key, rs.resourceName)
+	klog.V(1).Infof("GetList called with key: %v on resource %v\n", key, rs.resourceName)
 	return rs.List(ctx, key, opts, listObj)
 }
 
@@ -268,7 +270,7 @@ func (rs *resourceStore) GetList(ctx context.Context, key string, opts storage.L
 // The returned contents may be delayed, but it is guaranteed that they will
 // be have at least 'resourceVersion'.
 func (rs *resourceStore) List(ctx context.Context, key string, optsK8s storage.ListOptions, listObj runtime.Object) error {
-	klog.Infof("List called with key: %v on resource %v\n", key, rs.resourceName)
+	klog.V(1).Infof("List called with key: %v on resource %v\n", key, rs.resourceName)
 	ns, name, err := NamespaceAndNameFromKey(key, rs.isNamespaced)
 	if err != nil {
 		return err
@@ -364,7 +366,8 @@ func decode(
 //	})
 func (rs *resourceStore) GuaranteedUpdate(
 	ctx context.Context, key string, out runtime.Object, ignoreNotFound bool,
-	preconditions *storage.Preconditions, userUpdate storage.UpdateFunc, cachedExistingObject runtime.Object) error {
+	preconditions *storage.Preconditions, userUpdate storage.UpdateFunc, cachedExistingObject runtime.Object,
+) error {
 	klog.V(6).Infof("GuaranteedUpdate called with key: %v on resource %v\n", key, rs.resourceName)
 	// If a cachedExistingObject was passed, use that as the initial object, otherwise use Get() to retrieve it
 	var initObj runtime.Object


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Set the logrus level based on the klog level in the apiserver. This
allows for unified configuration of log level. Also defaults the logrus
output to ERROR level.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
apiserver defaults logrus level based on `-v` argument
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.