### PR TITLE
[release-v3.28] Auto pick #8696: Add file number to cni-plugin installer log output

### DIFF
--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -103,7 +103,7 @@ func fileExists(file string) bool {
 }
 
 func mkdir(path string) {
-	if err := os.MkdirAll(path, 0777); err != nil {
+	if err := os.MkdirAll(path, 0o777); err != nil {
 		logrus.WithError(err).Fatalf("Failed to create directory %s", path)
 	}
 }
@@ -124,6 +124,9 @@ func Install(version string) error {
 
 	// Configure logging before anything else.
 	logrus.SetFormatter(&logutils.Formatter{Component: "cni-installer"})
+
+	// Install a hook that adds file/line no information.
+	logrus.AddHook(&logutils.ContextHook{})
 
 	// Clean up any existing binaries / config / assets.
 	if err := os.RemoveAll(winutils.GetHostPath("/host/etc/cni/net.d/calico-tls")); err != nil && !os.IsNotExist(err) {
@@ -386,7 +389,7 @@ func writeCNIConfig(c config) {
 	// Write out the file.
 	name := getEnv("CNI_CONF_NAME", "10-calico.conflist")
 	path := winutils.GetHostPath(fmt.Sprintf("/host/etc/cni/net.d/%s", name))
-	err = os.WriteFile(path, []byte(netconf), 0644)
+	err = os.WriteFile(path, []byte(netconf), 0o644)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -495,7 +498,7 @@ current-context: calico-context`
 		data = strings.Replace(data, "__TLS_CFG__", ca, -1)
 	}
 
-	if err := os.WriteFile(winutils.GetHostPath("/host/etc/cni/net.d/calico-kubeconfig"), []byte(data), 0600); err != nil {
+	if err := os.WriteFile(winutils.GetHostPath("/host/etc/cni/net.d/calico-kubeconfig"), []byte(data), 0o600); err != nil {
 		logrus.Fatal(err)
 	}
 }


### PR DESCRIPTION
Cherry pick of #8696 on release-v3.28.

#8696: Add file number to cni-plugin installer log output

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fixes that the cni installer emits logs like this one:

```
cni-installer/<nil> <nil>: Unable to create token for CNI kubeconfig error=Unauthorized
```

Instead, the <nil> <nil> will be populated with log context.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix missing log line numbers in cni-installer log output
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.