### PR TITLE
calico-kube-controllers fix concurrent map writes issue

### DIFF
--- a/kube-controllers/cmd/kube-controllers/main.go
+++ b/kube-controllers/cmd/kube-controllers/main.go
@@ -129,6 +129,7 @@ func main() {
 	s := status.New(statusFile)
 
 	log.Info("Ensuring Calico datastore is initialized")
+	log.Info("Mutex testing draft")
 	s.SetReady("Startup", false, "initialized to false")
 	initCtx, cancelInit := context.WithTimeout(ctx, 60*time.Second)
 	// Loop until context expires or calicoClient is initialized.

--- a/kube-controllers/pkg/cache/cache.go
+++ b/kube-controllers/pkg/cache/cache.go
@@ -241,6 +241,10 @@ func (c *calicoCache) reconcile(reconcilerPeriod string) {
 }
 
 func (c *calicoCache) performDatastoreSync() error {
+	// lock the cache
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
 	// Get all the objects we care about from the datastore using ListFunc.
 	objMap, err := c.ListFunc()
 	if err != nil {

--- a/kube-controllers/pkg/cache/cache.go
+++ b/kube-controllers/pkg/cache/cache.go
@@ -126,7 +126,9 @@ func (c *calicoCache) Set(key string, newObj interface{}) {
 	if reflect.TypeOf(newObj) != c.ObjectType {
 		c.log.Fatalf("Wrong object type received to store in cache. Expected: %s, Found: %s", c.ObjectType, reflect.TypeOf(newObj))
 	}
-
+	// lock the cache
+	c.mut.Lock()
+	defer c.mut.Unlock()
 	// Check if the object exists in the cache already.  If it does and hasn't changed,
 	// then we don't need to send an update on the queue.
 	if existingObj, found := c.threadSafeCache.Get(key); found {

--- a/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
+++ b/libcalico-go/lib/backend/k8s/conversion/workload_endpoint_default.go
@@ -36,9 +36,9 @@ import (
 	cnet "github.com/projectcalico/calico/libcalico-go/lib/net"
 )
 
-type defaultWorkloadEndpointConverter struct {
-	mut *sync.Mutex
-}
+var defaultWorkloadEndpointMutex sync.Mutex
+
+type defaultWorkloadEndpointConverter struct{}
 
 // VethNameForWorkload returns a deterministic veth name
 // for the given Kubernetes workload (WEP) name and namespace.
@@ -61,8 +61,9 @@ func (wc defaultWorkloadEndpointConverter) VethNameForWorkload(namespace, podnam
 }
 
 func (wc defaultWorkloadEndpointConverter) PodToWorkloadEndpoints(pod *kapiv1.Pod) ([]*model.KVPair, error) {
-	wc.mut.Lock()
-	defer wc.mut.Unlock()
+
+	defaultWorkloadEndpointMutex.Lock()
+	defer defaultWorkloadEndpointMutex.Unlock()
 	wep, err := wc.podToDefaultWorkloadEndpoint(pod)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
Add mutex lock to the Set function to prevent a race condition that causes the process to panic with fatal error: concurrent map read and map write
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
fixes [8705](https://github.com/projectcalico/calico/issues/8705)
<!-- If appropriate, include a link to the issue this fixes.
If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
