### PR TITLE
[BPF] dual stack for v6 only

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -1574,7 +1574,7 @@ func (m *bpfEndpointManager) CompleteDeferredWork() error {
 		m.reportHealth(true, "")
 	} else {
 		m.dirtyIfaceNames.Iter(func(iface string) error {
-			m.updateRateLimitedLog.WithField("name", iface).Debug("Interface remains dirty.")
+			m.updateRateLimitedLog.WithField("name", iface).Info("Interface remains dirty.")
 			return nil
 		})
 		m.reportHealth(false, "Failed to configure some interfaces.")
@@ -1738,6 +1738,11 @@ func (m *bpfEndpointManager) applyProgramsToDirtyDataInterfaces() {
 		if !m.isDataIface(iface) && !m.isL3Iface(iface) {
 			log.WithField("iface", iface).Debug(
 				"Ignoring interface that doesn't match the host data/l3 interface regex")
+			if !m.isWorkloadIface(iface) {
+				log.WithField("iface", iface).Debug(
+					"Removing interface that doesn't match the host data/l3 interface and is not workload interface")
+				return set.RemoveItem
+			}
 			return nil
 		}
 


### PR DESCRIPTION
## Description

    [BPF] When IPv6 is enabled, either v4 or v6 connectivity is enough
    
    If IPv6 is enabled (which enables dual stack), it is ok, if only ipv6
    addresses are avilable. Felix reports ready and connectivity exists.
    When IPv4 are assigned later, IPv4 connectivity will work. The same hold
    in reverse order.
    
    worded differently, Felix reports ready if the path for whatever ip
    version of its host IPs is ready. If there is a vX host IP and version
    X path is not loaded, Felix is not ready as there is an error.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
