### PR TITLE
Ability to specify additional labels in helm chart

### DIFF
--- a/charts/tigera-operator/templates/_helpers.tpl
+++ b/charts/tigera-operator/templates/_helpers.tpl
@@ -18,3 +18,13 @@ by combining installation.imagePullSecrets with toplevel imagePullSecrets.
 {{- end -}}
 {{ $secrets | toYaml }}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "tigera-operator.labels" -}}
+k8s-app: tigera-operator
+{{- with .context.Values.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/tigera-operator/templates/tigera-operator/00-uninstall.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/00-uninstall.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     k8s-app: tigera-operator-uninstall
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
   annotations:
     # Mark this Job as a pre-deletion hook. This will only be executed as part
     # of helm uninstall, in order to ensure the Installation is cleaned up prior to

--- a/charts/tigera-operator/templates/tigera-operator/01-imagepullsecret.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/01-imagepullsecret.yaml
@@ -9,6 +9,8 @@ kind: Secret
 metadata:
   name: {{ $key }}
   namespace: {{ $ns }}
+  labels:
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
 data:
   .dockerconfigjson: {{ $value | b64enc }}
 type: kubernetes.io/dockerconfigjson

--- a/charts/tigera-operator/templates/tigera-operator/02-configmap-calico-resources.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-configmap-calico-resources.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: calico-resources
   namespace: {{.Release.Namespace}}
+  labels:
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
 data:
   # To create Calico resources before Calico components are started add
   # an entry here and the contents of the resource under the entry.

--- a/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-role-tigera-operator.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: tigera-operator
+  labels:
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-rolebinding-tigera-operator.yaml
@@ -2,6 +2,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tigera-operator
+  labels:
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: tigera-operator

--- a/charts/tigera-operator/templates/tigera-operator/02-serviceaccount-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-serviceaccount-tigera-operator.yaml
@@ -3,4 +3,6 @@ kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: {{.Release.Namespace}}
+  labels:
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
 imagePullSecrets: {{- include "tigera-operator.imagePullSecrets" . | nindent 2 }}

--- a/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
+++ b/charts/tigera-operator/templates/tigera-operator/02-tigera-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tigera-operator
   namespace: {{.Release.Namespace}}
   labels:
-    k8s-app: tigera-operator
+    {{- include "tigera-operator.labels" (dict "context" .) | nindent 4 }}
 spec:
   replicas: 1
   selector:

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -35,7 +35,7 @@ certs:
 # Resource requests and limits for the tigera/operator pod.
 resources: {}
 
-# Common labels for the all resources
+# Common labels for the all resources created by this chart
 additionalLabels: {}
 
 # Tolerations for the tigera/operator pod.

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -35,6 +35,9 @@ certs:
 # Resource requests and limits for the tigera/operator pod.
 resources: {}
 
+# Common labels for the all resources
+additionalLabels: {}
+
 # Tolerations for the tigera/operator pod.
 tolerations:
 - effect: NoExecute

--- a/charts/tigera-operator/values.yaml
+++ b/charts/tigera-operator/values.yaml
@@ -35,7 +35,7 @@ certs:
 # Resource requests and limits for the tigera/operator pod.
 resources: {}
 
-# Common labels for the all resources created by this chart
+# Common labels for all resources created by this chart
 additionalLabels: {}
 
 # Tolerations for the tigera/operator pod.

--- a/manifests/ocp/02-configmap-calico-resources.yaml
+++ b/manifests/ocp/02-configmap-calico-resources.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: calico-resources
   namespace: tigera-operator
+  labels:
+    k8s-app: tigera-operator
 data:
   # To create Calico resources before Calico components are started add
   # an entry here and the contents of the resource under the entry.

--- a/manifests/ocp/02-role-tigera-operator.yaml
+++ b/manifests/ocp/02-role-tigera-operator.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: tigera-operator
+  labels:
+    k8s-app: tigera-operator
 rules:
   - apiGroups:
       - ""

--- a/manifests/ocp/02-rolebinding-tigera-operator.yaml
+++ b/manifests/ocp/02-rolebinding-tigera-operator.yaml
@@ -2,6 +2,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tigera-operator
+  labels:
+    k8s-app: tigera-operator
 subjects:
 - kind: ServiceAccount
   name: tigera-operator

--- a/manifests/ocp/02-serviceaccount-tigera-operator.yaml
+++ b/manifests/ocp/02-serviceaccount-tigera-operator.yaml
@@ -3,5 +3,7 @@ kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: tigera-operator
+  labels:
+    k8s-app: tigera-operator
 imagePullSecrets:
   []

--- a/manifests/tigera-operator.yaml
+++ b/manifests/tigera-operator.yaml
@@ -25128,6 +25128,8 @@ kind: ServiceAccount
 metadata:
   name: tigera-operator
   namespace: tigera-operator
+  labels:
+    k8s-app: tigera-operator
 imagePullSecrets:
   []
 ---
@@ -25137,6 +25139,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: tigera-operator
+  labels:
+    k8s-app: tigera-operator
 rules:
   - apiGroups:
       - ""
@@ -25403,6 +25407,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tigera-operator
+  labels:
+    k8s-app: tigera-operator
 subjects:
 - kind: ServiceAccount
   name: tigera-operator


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Picking up https://github.com/projectcalico/calico/pull/8437 and running manifest generation.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
New helm values.yaml field - additionalLabels - allows configuring labels on resources created by the chart. @TheCubicleJockey
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.