### PR TITLE
Try to get the newest node configuration every poll interval when monitoring IP Address subnets

### DIFF
--- a/node/pkg/lifecycle/startup/startup.go
+++ b/node/pkg/lifecycle/startup/startup.go
@@ -349,6 +349,18 @@ func MonitorIPAddressSubnets() {
 	for {
 		<-time.After(pollInterval)
 		log.Debugf("Checking node IP address every %v", pollInterval)
+
+		// Every polling interval, try to get the k8s Node and use the latest K8s node IP to configure.
+		if clientset != nil {
+			curK8sNode, err := clientset.CoreV1().Nodes().Get(ctx, k8sNodeName, metav1.GetOptions{})
+			if err == nil {
+				k8sNode = curK8sNode
+			}
+		}
+
+		// Every polling interval, try to get new node configuration.
+		node = getNode(ctx, cli, nodeName)
+
 		updated := configureAndCheckIPAddressSubnets(ctx, cli, node, k8sNode)
 		if updated {
 			// Apply the updated node resource.


### PR DESCRIPTION
## Description

Try to get the newest node configuration every poll interval when monitoring IP Address subnets.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs
https://github.com/projectcalico/calico/issues/8700

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Tests

1. Current k8s node and IP.
```
NAME                                STATUS   ROLES    AGE   VERSION    INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                           KERNEL-VERSION                 CONTAINER-RUNTIME
hw-sks-test-logging-logging-m9c27   Ready    <none>   44h   v1.25.15   10.255.2.134   <none>        Rocky Linux 8.8 (Green Obsidian)   4.18.0-477.27.1.el8_8.x86_64   containerd://1.6.22
```
2. Modify the IP of k8s node by configuring static IP.
```
hw-sks-test-logging-logging-m9c27   Ready      <none>   44h   v1.25.15   10.255.2.135   <none>        Rocky Linux 8.8 (Green Obsidian)   4.18.0-477.27.1.el8_8.x86_64   containerd://1.6.22
```
3. `monitor-addresses` log show ip changed and updated
```
2024-04-18 15:32:05.741 [INFO][76] monitor-addresses/autodetection_methods.go 229: Including CIDR information from host interface. CIDR="10.255.2.135/16"
2024-04-18 15:32:05.742 [INFO][76] monitor-addresses/startup.go 579: Node IPv4 changed, will check for conflicts
2024-04-18 15:32:05.767 [WARNING][76] monitor-addresses/startup.go 1004: IPv4 address has changed. This could happen if there are multiple nodes with the same name. node="hw-sks-test-logging-logging-m9c27" original="10.255.2.134" updated="10.255.2.135"
2024-04-18 15:32:05.808 [INFO][76] monitor-addresses/startup.go 372: Updated node IP addresses
2024-04-18 15:33:05.864 [INFO][76] monitor-addresses/autodetection_methods.go 229: Including CIDR information from host interface. CIDR="10.255.2.135/16"
```

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Calico would ignore changes to Kubernetes Node InternalIP when using InternalIP node address autodetection.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
