### PR TITLE
Revert "Disable VXLAN checksum offload by default."

### DIFF
--- a/felix/environment/feature_detect_linux.go
+++ b/felix/environment/feature_detect_linux.go
@@ -50,6 +50,8 @@ var (
 	v3Dot10Dot0 = MustParseVersion("3.10.0")
 	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
 	v3Dot14Dot0 = MustParseVersion("3.14.0")
+	// v5Dot7Dot0 contains a fix for checksum offloading.
+	v5Dot7Dot0 = MustParseVersion("5.7.0")
 	// v5Dot14Dot0 is the fist kernel version that IPIP tunnels acts like other L3
 	// devices where bpf programs only see inner IP header. In RHEL based distros,
 	// kernel 4.18.0 (v4Dot18Dot0_330) is the first one with this behavior.
@@ -130,7 +132,7 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 		SNATFullyRandom:          iptV.Compare(v1Dot6Dot0) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		MASQFullyRandom:          iptV.Compare(v1Dot6Dot2) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		RestoreSupportsLock:      iptV.Compare(v1Dot6Dot2) >= 0,
-		ChecksumOffloadBroken:    true, // Was supposed to be fixed in v5.7 but still seems to be broken.
+		ChecksumOffloadBroken:    kerV.Compare(v5Dot7Dot0) <= 0,
 		IPIPDeviceIsL3:           d.ipipDeviceIsL3(),
 		KernelSideRouteFiltering: netlinkSupportsStrict,
 	}

--- a/felix/environment/feature_detect_test.go
+++ b/felix/environment/feature_detect_test.go
@@ -147,6 +147,16 @@ func TestFeatureDetection(t *testing.T) {
 				ChecksumOffloadBroken: true,
 			},
 		},
+		{
+			"iptables v1.8.4",
+			"Linux version 5.8.0",
+			Features{
+				RestoreSupportsLock:   true,
+				SNATFullyRandom:       true,
+				MASQFullyRandom:       true,
+				ChecksumOffloadBroken: false,
+			},
+		},
 	} {
 		tst := tst
 		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
@@ -507,32 +517,28 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.10.0 - ubuntu",
 			Features{
-				IPIPDeviceIsL3:        false,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: false,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.14.0 - something else",
 			Features{
-				IPIPDeviceIsL3:        true,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.15.0",
 			Features{
-				IPIPDeviceIsL3:        true,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.10.0 - Default",
 			Features{
-				IPIPDeviceIsL3:        true,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "true",
@@ -541,8 +547,7 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.14.0",
 			Features{
-				IPIPDeviceIsL3:        false,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: false,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",
@@ -551,8 +556,7 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.16.0 - Ubuntu",
 			Features{
-				IPIPDeviceIsL3:        false,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: false,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",


### PR DESCRIPTION
The issue should be fixed in recent kernel and we did not manage to reproduce it. If the issue still persists, it is easier to disable it for the user who hits the issue then to reenable it on a live cluster where this is not a problem.

This reverts commit 53f3e1b62f9475ad8a5509923c1bcf98aa1a1bd1.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Important note: Re-enable VXLAN checksum offload for kernels > 5.7 (takes effect when nodes are restarted).  The offload was disabled in the past due to kernel bugs but has substantial performance impact.  We've been unable to find an environment where this needs to be disabled, so are re-enabling the offload with the intent of proving it works or finding a setup where it doesn't.

If you encounter problems after upgrading and restarting nodes, please let us know and set "ChecksumOffloadBroken=true" in the FelixConfiguration's featureDetectOverride field to restore the previous behavior.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
