### PR TITLE
Better logging to aid in addressing calico_cni_k8s_test flakes

### DIFF
--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -70,12 +70,14 @@ func ensureNamespace(clientset *kubernetes.Clientset, name string) {
 }
 
 func ensurePodCreated(clientset *kubernetes.Clientset, namespace string, pod *v1.Pod) *v1.Pod {
+	By(fmt.Sprintf("Creating pod '%s'", pod.Name))
 	pod, err := clientset.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	// Immediately try to get the pod, and retry until we do. This prevents race
 	// conditions where the API Server has accepted the create, but isn't ready
 	// to find the pod on a get. These races can cause the tests to be flaky.
+	By(fmt.Sprintf("Ensuring pod '%s' is in the datastore", pod.Name))
 	EventuallyWithOffset(1, func() error {
 		_, err := clientset.CoreV1().Pods(namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 		return err
@@ -530,7 +532,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
+			  "log_level":"debug"
 			}`
 
 			It("should create pods with the right MTU", func() {
@@ -589,7 +591,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
+			  "log_level":"debug"
 			}`
 
 			It("creates pods with the new mtu", func() {
@@ -667,7 +669,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -708,7 +710,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -754,7 +756,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -814,7 +816,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("10.123.0.0/16 via 169.254.1.1 dev eth0"),
@@ -874,7 +876,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -1949,7 +1951,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                           "kubeconfig": "/home/user/certs/kubeconfig"
 					 },
 					"policy": {"type": "k8s"},
-					"log_level":"info"
+					"log_level":"debug"
 				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 
 			assignIP := net.IPv4(20, 0, 0, 111).To4()
@@ -2082,7 +2084,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                           "kubeconfig": "/home/user/certs/kubeconfig"
 					 },
 					"policy": {"type": "k8s"},
-					"log_level":"info"
+					"log_level":"debug"
 				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 
 			// Now create a K8s pod (without any pod IP annotations).
@@ -2597,7 +2599,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
            			  "nodename_file_optional": true,
-				  "log_level": "info",
+				  "log_level": "debug",
 			 	  "ipam": {
 				    "type": "calico-ipam"
 				  },
@@ -3080,7 +3082,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
            			  "nodename_file_optional": true,
-				  "log_level": "info",
+				  "log_level": "debug",
 				  "readiness_gates": "http://localhost:9099/invalid_x12vx",
 			 	  "ipam": {
 				    "type": "calico-ipam"
@@ -3141,7 +3143,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
            			  "nodename_file_optional": true,
-				  "log_level": "info",
+				  "log_level": "debug",
 				  "readiness_gates": ["%s"],
 			 	  "ipam": {
 				    "type": "calico-ipam"
@@ -3207,7 +3209,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
+			  "log_level":"debug"
 			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")
@@ -3243,7 +3245,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
+			  "log_level":"debug"
 			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")

--- a/libcalico-go/lib/clientv3/client.go
+++ b/libcalico-go/lib/clientv3/client.go
@@ -191,7 +191,7 @@ func (p poolAccessor) GetEnabledPools(ipVersion int) ([]v3.IPPool, error) {
 		} else if err != nil {
 			log.Warnf("Failed to parse the IPPool: %s. Ignoring that IPPool", pool.Spec.CIDR)
 		} else {
-			log.Debugf("Ignoring IPPool: %s. IP version is different.", pool.Spec.CIDR)
+			log.Debugf("Ignoring IPPool: %s. Wanted IP-version %d, pool is: %d.", pool.Spec.CIDR, ipVersion, cidr.Version())
 		}
 		return false
 	})
@@ -202,7 +202,7 @@ func (p poolAccessor) getPools(filter func(pool *v3.IPPool) bool) ([]v3.IPPool, 
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("Got list of all IPPools: %v", pools)
+	log.Debugf("Got list of all IPPools: %+v", pools)
 	var filtered []v3.IPPool
 	for _, pool := range pools.Items {
 		if filter(&pool) {
@@ -316,7 +316,7 @@ func (c client) ensureClusterInformation(ctx context.Context, calicoVersion, clu
 			clusterInfo.Spec.DatastoreReady = &datastoreReady
 			updateNeeded = true
 		} else {
-			log.WithField("DatastoreReady", clusterInfo.Spec.DatastoreReady).Debug("DatastoreReady value already set")
+			log.WithField("DatastoreReady", *clusterInfo.Spec.DatastoreReady).Debug("DatastoreReady value already set")
 		}
 
 		if clusterType != "" {


### PR DESCRIPTION
## Description

Does not fix, but hopefully aids in diagnosing CORE-10163.

## Related issues/PRs

CORE-10163.


## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
