### PR TITLE
[release-v3.28] Auto pick #8749: clean up stale ICMPv6 conntrack entries

### DIFF
--- a/felix/bpf/conntrack/cleanup.go
+++ b/felix/bpf/conntrack/cleanup.go
@@ -175,7 +175,7 @@ func (t *Timeouts) EntryExpired(nowNanos int64, proto uint8, entry ValueInterfac
 			}
 		}
 		return "", false
-	case ProtoICMP:
+	case ProtoICMP, ProtoICMP6:
 		if age > t.ICMPLastSeen {
 			return "no traffic on ICMP flow for too long", true
 		}

--- a/felix/bpf/conntrack/map.go
+++ b/felix/bpf/conntrack/map.go
@@ -136,9 +136,10 @@ func MapV2() maps.Map {
 }
 
 const (
-	ProtoICMP = 1
-	ProtoTCP  = 6
-	ProtoUDP  = 17
+	ProtoICMP  = 1
+	ProtoTCP   = 6
+	ProtoUDP   = 17
+	ProtoICMP6 = 58
 )
 
 func KeyFromBytes(k []byte) KeyInterface {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -448,7 +448,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						felix.Exec("calico-bpf", "-6", "routes", "dump")
 						felix.Exec("calico-bpf", "-6", "nat", "dump")
 						felix.Exec("calico-bpf", "-6", "nat", "aff")
-						felix.Exec("calico-bpf", "-6", "conntrack", "dump")
+						felix.Exec("calico-bpf", "-6", "conntrack", "dump", "--raw")
 						felix.Exec("calico-bpf", "-6", "arp", "dump")
 					} else {
 						felix.Exec("iptables-save", "-c")
@@ -462,7 +462,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						felix.Exec("calico-bpf", "routes", "dump")
 						felix.Exec("calico-bpf", "nat", "dump")
 						felix.Exec("calico-bpf", "nat", "aff")
-						felix.Exec("calico-bpf", "conntrack", "dump")
+						felix.Exec("calico-bpf", "conntrack", "dump", "--raw")
 						felix.Exec("calico-bpf", "arp", "dump")
 					}
 					felix.Exec("calico-bpf", "counters", "dump")
@@ -2389,9 +2389,9 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						)
 
 						if testOpts.ipv6 {
-							ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "-6", "dump")
+							ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "-6", "dump", "--raw")
 						} else {
-							ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "dump")
+							ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "dump", "--raw")
 						}
 						Expect(err).NotTo(HaveOccurred())
 						re := regexp.MustCompile(`LastSeen:\s*(\d+)`)
@@ -2412,9 +2412,9 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						// entries.
 						numWl0ConntrackEntries := func() int {
 							if testOpts.ipv6 {
-								ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "-6", "dump")
+								ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "-6", "dump", "--raw")
 							} else {
-								ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "dump")
+								ctDump, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "dump", "--raw")
 							}
 							Expect(err).NotTo(HaveOccurred())
 							return strings.Count(ctDump, w[0][0].IP)


### PR DESCRIPTION
Cherry pick of #8749 on release-v3.28.

#8749: clean up stale ICMPv6 conntrack entries

# Original PR Body below

## Description

    calico-bpf conntrack dump has less verbose output
    
    Not to bother user with too much information, the output shows where a
    connection goes from and too. If there is a service invoplved in the
    middle, it shows that too. You can get the orifginal output using the
    --raw  option.
    
    UDP 172.18.0.1:35199 -> 239.255.255.250:1900  Age: 56.28257308s Active ago 53.279924595s
    TCP 172.18.0.9:57736 -> 172.18.0.7:30333 -> 10.65.0.2:8055  Age: 2.535576963s Active ago 493.47131ms SYN-SENT
    UDP 172.18.0.1:5353 -> 224.0.0.251:5353  Age: 57.284951727s Active ago 50.27747628s
    UDP 172.18.0.1:37213 -> 239.255.255.250:1900  Age: 59.283295671s Active ago 57.282576585s
    TCP 172.18.0.1:52424 -> 172.18.0.7:9099  Age: 58.300322297s Active ago 12.945516929s ESTABLISHED

    TCP 172.18.0.9:57162 -> 172.18.0.6:30333 -> 10.65.0.2:8055 external client, service forwarded to/from 172.18.0.6  Age: 6.107113931s Active ago 988.204797ms SYN-SENT

    [BPF] clean up stale ICMPv6 conntrack entries



<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: clean up stale icmp6 conntrack entries
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.