### PR TITLE
[release-v3.28] Auto pick #8712: wg6 traffic is allowed even if blocked by policy

### DIFF
--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -418,6 +418,7 @@ func TcSetGlobals(
 		(*C.char)(unsafe.Pointer(&globalData.HostTunnelIPv6[0])),
 		C.uint(globalData.Flags),
 		C.ushort(globalData.WgPort),
+		C.ushort(globalData.Wg6Port),
 		C.uint(globalData.NatIn),
 		C.uint(globalData.NatOut),
 		C.uint(globalData.LogFilterJmp),

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -152,6 +152,7 @@ void bpf_tc_set_globals(struct bpf_map *map,
 			char* host_tunnel_ip6,
 			uint flags,
 			ushort wg_port,
+			ushort wg6_port,
 			uint natin,
 			uint natout,
 			uint log_filter_jmp,
@@ -194,6 +195,8 @@ void bpf_tc_set_globals(struct bpf_map *map,
 	for (i = 0; i < sizeof(v6.jumps)/sizeof(uint); i++) {
 		v6.jumps[i] = jumps6[i];
 	}
+
+	v6.wg_port = wg6_port;
 
 	data.v4 = v4;
 	data.v6 = v6;

--- a/felix/bpf/libbpf/libbpf_common.go
+++ b/felix/bpf/libbpf/libbpf_common.go
@@ -26,6 +26,7 @@ type TcGlobalData struct {
 	HostTunnelIPv4 [16]byte
 	Flags          uint32
 	WgPort         uint16
+	Wg6Port        uint16
 	NatIn          uint32
 	NatOut         uint32
 	LogFilterJmp   uint32

--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -55,6 +55,7 @@ type AttachPoint struct {
 	TunnelMTU            uint16
 	VXLANPort            uint16
 	WgPort               uint16
+	Wg6Port              uint16
 	ExtToServiceConnmark uint32
 	PSNATStart           uint16
 	PSNATEnd             uint16
@@ -389,6 +390,7 @@ func (ap *AttachPoint) ConfigureProgram(m *libbpf.Map) error {
 		PSNatStart:   ap.PSNATStart,
 		PSNatLen:     ap.PSNATEnd,
 		WgPort:       ap.WgPort,
+		Wg6Port:      ap.Wg6Port,
 		NatIn:        ap.NATin,
 		NatOut:       ap.NATout,
 		LogFilterJmp: uint32(ap.LogFilterIdx),

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -279,6 +279,7 @@ type bpfEndpointManager struct {
 	vxlanMTU                int
 	vxlanPort               uint16
 	wgPort                  uint16
+	wg6Port                 uint16
 	dsrEnabled              bool
 	dsrOptoutCidrs          bool
 	bpfExtToServiceConnmark int
@@ -465,6 +466,7 @@ func newBPFEndpointManager(
 		vxlanMTU:                config.VXLANMTU,
 		vxlanPort:               uint16(config.VXLANPort),
 		wgPort:                  uint16(config.Wireguard.ListeningPort),
+		wg6Port:                 uint16(config.Wireguard.ListeningPortV6),
 		dsrEnabled:              config.BPFNodePortDSREnabled,
 		dsrOptoutCidrs:          len(config.BPFDSROptoutCIDRs) > 0,
 		bpfExtToServiceConnmark: config.BPFExtToServiceConnmark,
@@ -2657,6 +2659,7 @@ func (m *bpfEndpointManager) calculateTCAttachPoint(ifaceName string) *tc.Attach
 	ap.Type = endpointType
 	if ap.Type != tcdefs.EpTypeWorkload {
 		ap.WgPort = m.wgPort
+		ap.Wg6Port = m.wg6Port
 		ap.NATin = uint32(m.natInIdx)
 		ap.NATout = uint32(m.natOutIdx)
 	} else {

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1520,7 +1520,7 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 				// only go to the host. Make sure that they are not forwarded.
 				fwdRules = append(fwdRules, rules.ICMPv6Filter(d.ruleRenderer.IptablesFilterDenyAction())...)
 			}
-		} else if (t.IPVersion == 6) == (d.config.BPFIpv6Enabled) /* XXX remove condition for dual stack */ {
+		} else {
 			// Let the BPF programs know if Linux conntrack knows about the flow.
 			fwdRules = append(fwdRules, bpfMarkPreestablishedFlowsRules()...)
 			// The packet may be about to go to a local workload.  However, the local workload may not have a BPF

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -193,6 +193,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 
 				if CurrentGinkgoTestDescription().Failed {
 					for _, felix := range topologyContainers.Felixes {
+						felix.Exec("ip", "link")
 						felix.Exec("ip", "addr")
 						felix.Exec("ip", "rule", "list")
 						felix.Exec("ip", "route", "show", "table", "all")

--- a/felix/fv/wireguard_test.go
+++ b/felix/fv/wireguard_test.go
@@ -356,13 +356,13 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 							Eventually(func() string {
 								out, _ := felix.ExecOutput("ip", "-d", "link", "show", ifaceName)
 								return out
-							}, "10s", "100ms").Should(ContainSubstring(fmt.Sprintf("mtu %d", mtu)))
+							}, "30s", "330ms").Should(ContainSubstring(fmt.Sprintf("mtu %d", mtu)))
 						}
 						if wireguardEnabledV6 {
 							Eventually(func() string {
 								out, _ := felix.ExecOutput("ip", "-d", "link", "show", ifaceNameV6)
 								return out
-							}, "10s", "100ms").Should(ContainSubstring(fmt.Sprintf("mtu %d", mtuV6)))
+							}, "30s", "330ms").Should(ContainSubstring(fmt.Sprintf("mtu %d", mtuV6)))
 						}
 					}
 
@@ -373,24 +373,24 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ WireGuard-Supported", []api
 								out, err := felix.ExecOutput("wg", "show", ifaceName)
 								Expect(err).NotTo(HaveOccurred())
 								return out
-							}, "10s", "100ms").Should(ContainSubstring(fmt.Sprintf("listening port: %d", port)))
+							}, "30s", "330ms").Should(ContainSubstring(fmt.Sprintf("listening port: %d", port)))
 							Eventually(func() string {
 								out, err := felix.ExecOutput("ip", "rule", "show", "pref", fmt.Sprintf("%d", rule))
 								Expect(err).NotTo(HaveOccurred())
 								return out
-							}, "10s", "100ms").ShouldNot(BeEmpty())
+							}, "30s", "330ms").ShouldNot(BeEmpty())
 						}
 						if wireguardEnabledV6 {
 							Eventually(func() string {
 								out, err := felix.ExecOutput("wg", "show", ifaceNameV6)
 								Expect(err).NotTo(HaveOccurred())
 								return out
-							}, "10s", "100ms").Should(ContainSubstring(fmt.Sprintf("listening port: %d", portV6)))
+							}, "30s", "330ms").Should(ContainSubstring(fmt.Sprintf("listening port: %d", portV6)))
 							Eventually(func() string {
 								out, err := felix.ExecOutput("ip", "-6", "rule", "show", "pref", fmt.Sprintf("%d", rule))
 								Expect(err).NotTo(HaveOccurred())
 								return out
-							}, "10s", "100ms").ShouldNot(BeEmpty())
+							}, "30s", "330ms").ShouldNot(BeEmpty())
 						}
 					}
 				})


### PR DESCRIPTION
Cherry pick of #8712 on release-v3.28.

#8712: wg6 traffic is allowed even if blocked by policy

# Original PR Body below

This fixes a misconfiguration as wg6 may/likely have different listening port than wg. So the right config value needs to be set.

Also all v4 iptables rules are now rendered in dual stack mode.

wg6 fv tests are enabled.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note



<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: wg6 traffic is allowed even if blocked by policy
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.