### PR TITLE
[release-v3.28] Auto pick #8740: Don't store Labels directly on v1 backing CRDs

### DIFF
--- a/libcalico-go/lib/backend/k8s/resources/resources.go
+++ b/libcalico-go/lib/backend/k8s/resources/resources.go
@@ -139,8 +139,6 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	romCopy.Name = ""
 	romCopy.Namespace = ""
 	romCopy.ResourceVersion = ""
-	romCopy.Labels = nil
-	romCopy.Annotations = nil
 	romCopy.UID = ""
 
 	// Any projectcalico.org/v3 owners need to be translated to their equivalent crd.projectcalico.org/v1 representations.
@@ -167,20 +165,19 @@ func ConvertCalicoResourceToK8sResource(resIn Resource) (Resource, error) {
 	if err != nil {
 		return nil, err
 	}
-	annotations := rom.GetAnnotations()
-	if len(annotations) == 0 {
-		annotations = make(map[string]string)
-	}
+
+	annotations := make(map[string]string)
 	annotations[metadataAnnotation] = string(metadataBytes)
 
 	// Make sure to clear out all of the Calico Metadata out of the ObjectMeta except for
-	// Name, Namespace, ResourceVersion, Labels, and Annotations. Annotations is already
-	// copied so it can be set separately.
+	// Name, Namespace, ResourceVersion, UID, and Annotations (built above).
 	meta := &metav1.ObjectMeta{}
 	meta.Name = rom.GetName()
 	meta.Namespace = rom.GetNamespace()
 	meta.ResourceVersion = rom.GetResourceVersion()
-	meta.Labels = rom.GetLabels()
+
+	// Explicitly nil out the labels on the underlying object so that they are not duplicated.
+	meta.Labels = nil
 
 	if rom.GetUID() != "" {
 		uid, err := conversion.ConvertUID(rom.GetUID())
@@ -254,14 +251,24 @@ func ConvertK8sResourceToCalicoResource(res Resource) error {
 		annotations = nil
 	}
 
+	// Start with the original labels and annotations from the v1 object, and merge in the values from the metadata
+	// annotation. This logic helps maintain labels and annotations on upgrade from older versions, where they were stored
+	// directly in the metadata of the v1 CRD.
+	labels := rom.GetLabels()
+	for k, v := range meta.GetLabels() {
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[k] = v
+	}
+
 	// Manually write in the data not stored in the annotations: Name, Namespace, ResourceVersion,
-	// Labels, and Annotations so that they do not get overwritten.
+	// so that they do not get overwritten.
 	meta.Name = rom.GetName()
 	meta.Namespace = rom.GetNamespace()
 	meta.ResourceVersion = rom.GetResourceVersion()
-	meta.Labels = rom.GetLabels()
-	meta.Annotations = annotations
 	meta.UID = rom.GetUID()
+	meta.Labels = labels
 
 	// If no creation timestamp was stored in the metadata annotation, use the one from the CR.
 	// The timestamp is normally set in the clientv3 code. However, for objects that bypass


### PR DESCRIPTION
Cherry pick of #8740 on release-v3.28.

#8740: Don't store Labels directly on v1 backing CRDs

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This change stops storing projectcalico.org/v3 Labels directly in the
metadata of the underlying crd.projectcalico.org/v1 backing CRDs. 

This is specifically to fix an interaction with ArgoCI where a label
that is used to track which resources are owned by Argo shows up on both
the v1 and v3 objects with different UIDs, causing Argo to continuously
believe that it is out of sync.

Instead, we store the v3 Labels within a special Calico annotation which
will be populate in the v3 resource at read time.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.