### PR TITLE
[release-v3.28] Auto pick #8760: Do not panic if host route does not have DstNodeIP

### DIFF
--- a/felix/dataplane/linux/bpf_route_mgr.go
+++ b/felix/dataplane/linux/bpf_route_mgr.go
@@ -366,8 +366,12 @@ func (m *bpfRouteManager) calculateRoute(cidr ip.CIDR) routes.ValueInterface {
 	case proto.RouteType_REMOTE_HOST:
 		flags |= routes.FlagsRemoteHost
 		if cgRoute.DstNodeIp == "" {
-			log.WithField("node", cgRoute.DstNodeName).Panic(
-				"Remote host route is missing node's IP but its CIDR should equal its IP.")
+			// This may legally happen in dual-stack installation when IPv6 is enabled,
+			// but autodetection for IPv4 (or vice versa) is not enabled and a node has
+			// that IP version regardless. Technically we know the node's IP, but we are
+			// told not to care. No reason to panic.
+			log.WithField("node", cgRoute.DstNodeName).Debug(
+				"Excluding remote host route. It is missing node's IP.")
 			return nil
 		}
 		nodeIP := net.ParseIP(cgRoute.DstNodeIp)


### PR DESCRIPTION
Cherry pick of #8760 on release-v3.28.

#8760: Do not panic if host route does not have DstNodeIP

# Original PR Body below

This can happen when a node has both v4/6 IPs but we care about one of them only.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.