### PR TITLE
Add 'release notes exist' validation to release process [cp #8786][v3.26]

### DIFF
--- a/hack/release/pkg/builder/builder.go
+++ b/hack/release/pkg/builder/builder.go
@@ -142,6 +142,11 @@ func (r *ReleaseBuilder) BuildRelease() error {
 		return err
 	}
 
+	err = r.assertReleaseNotesPresent(ver)
+	if err != nil {
+		return err
+	}
+
 	// Assert that manifests are using the correct version.
 	err = r.assertManifestVersions(ver)
 	if err != nil {
@@ -544,6 +549,25 @@ func (r *ReleaseBuilder) publishContainerImages(ver string) error {
 			logrus.Info(out)
 			break
 		}
+	}
+	return nil
+}
+
+func (r *ReleaseBuilder) assertReleaseNotesPresent(ver string) error {
+	// Validate that the release notes for this version are present,
+	// fail if not.
+
+	releaseNotesPath := fmt.Sprintf("release-notes/%s-release-notes.md", ver)
+	releaseNotesStat, err := os.Stat(releaseNotesPath)
+
+	// If we got an error, handle that?
+	if err != nil {
+		return fmt.Errorf("release notes file is invalid: %s", err.Error())
+	}
+	if releaseNotesStat.Size() == 0 {
+		return fmt.Errorf("release notes file is invalid: file is 0 bytes")
+	} else if releaseNotesStat.IsDir() {
+		return fmt.Errorf("release notes file is invalid: %s is a directory", releaseNotesPath)
 	}
 	return nil
 }


### PR DESCRIPTION
Performs some validations on the release notes file before starting a release.

Cherry-pick of #8786. See that PR for examples.