### PR TITLE
Address some bpf fv flakes

### DIFF
--- a/felix/bpf/bpf.go
+++ b/felix/bpf/bpf.go
@@ -384,7 +384,70 @@ type getnextEntry struct {
 type mapEntry struct {
 	Key   []string `json:"key"`
 	Value []string `json:"value"`
-	Err   string   `json:"error"`
+}
+
+func (me *mapEntry) UnmarshalJSON(data []byte) error {
+	type entry struct {
+		Key   []string `json:"key"`
+		Value any      `json:"value"`
+	}
+
+	if string(data) == "null" {
+		return nil
+	}
+
+	var e entry
+	err := json.Unmarshal(data, &e)
+	if err != nil {
+		// bad json
+		return err
+	}
+
+	v, ok := e.Value.([]any)
+	if !ok {
+		// the value is not what it should be, likely an error like the entry is
+		// now missing (race) so we just ignore it. It is still a valid json.
+		// Return an empty entry which we will filter out.
+		return nil
+	}
+
+	hexbytes := make([]string, len(v))
+	for i, x := range v {
+		hexbytes[i] = x.(string)
+	}
+
+	*me = mapEntry{
+		Key:   e.Key,
+		Value: hexbytes,
+	}
+
+	return nil
+}
+
+type hexMap []mapEntry
+
+func (hm *hexMap) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var m []mapEntry
+	err := json.Unmarshal(data, &m)
+	if err != nil {
+		return err
+	}
+
+	var res hexMap
+
+	for _, v := range m {
+		if len(v.Key) != 0 {
+			res = append(res, v)
+		}
+	}
+
+	*hm = res
+
+	return nil
 }
 
 type perCpuMapEntry []struct {
@@ -500,7 +563,7 @@ func (b *BPFLib) DumpFailsafeMap() ([]ProtoPort, error) {
 		return nil, fmt.Errorf("failed to dump map (%s): %s\n%s", mapPath, err, output)
 	}
 
-	l := []mapEntry{}
+	l := hexMap{}
 	err = json.Unmarshal(output, &l)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
@@ -587,9 +650,6 @@ func (b *BPFLib) LookupFailsafeMap(proto uint8, port uint16) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
 	}
-	if l.Err != "" {
-		return false, fmt.Errorf("%s", l.Err)
-	}
 
 	return true, err
 }
@@ -632,9 +692,6 @@ func (b *BPFLib) LookupCIDRMap(ifName string, family IPFamily, ip net.IP, mask i
 	err = json.Unmarshal(output, &l)
 	if err != nil {
 		return 0, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
-	}
-	if l.Err != "" {
-		return 0, fmt.Errorf("%s", l.Err)
 	}
 
 	val, err := hexToCIDRMapValue(l.Value)
@@ -705,7 +762,7 @@ func (b *BPFLib) DumpCIDRMap(ifName string, family IPFamily) (map[CIDRMapKey]uin
 		return nil, fmt.Errorf("failed to dump in map (%s): %s\n%s", mapName, err, output)
 	}
 
-	var al []mapEntry
+	var al hexMap
 	err = json.Unmarshal(output, &al)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
@@ -2020,7 +2077,7 @@ func (b *BPFLib) DumpSockmapEndpointsMap(family IPFamily) ([]CIDRMapKey, error) 
 		return nil, fmt.Errorf("failed to dump in map (%s): %s\n%s", sockmapEndpointsMapName, err, output)
 	}
 
-	var al []mapEntry
+	var al hexMap
 	err = json.Unmarshal(output, &al)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
@@ -2076,9 +2133,6 @@ func (b *BPFLib) LookupSockmapEndpointsMap(ip net.IP, mask int) (bool, error) {
 	err = json.Unmarshal(output, &l)
 	if err != nil {
 		return false, fmt.Errorf("cannot parse json output: %v\n%s", err, output)
-	}
-	if l.Err != "" {
-		return false, fmt.Errorf("%s", l.Err)
 	}
 
 	return true, err
@@ -2249,7 +2303,7 @@ func ListTcXDPAttachedProgs(dev ...string) (TcList, XDPList, error) {
 
 // IterMapCmdOutput iterates over the output of a command obtained by DumpMapCmd
 func IterMapCmdOutput(output []byte, f func(k, v []byte)) error {
-	var mp []mapEntry
+	var mp hexMap
 	err := json.Unmarshal(output, &mp)
 	if err != nil {
 		return fmt.Errorf("cannot parse json output: %w\n%s", err, output)

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1206,7 +1206,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				}
 
 				for _, f := range tc.Felixes {
-					Eventually(felixReady(f), "5s", "100ms").Should(BeGood())
+					Eventually(felixReady(f), "10s", "500ms").Should(BeGood())
 				}
 			}
 		}


### PR DESCRIPTION
## Description

    [BPF] ignore map entries that have non-existent values
    
    Fixes this flake in FVs:
    
    Unexpected error:
        <*fmt.wrapError | 0xc00274d380>:
        cannot parse json output: json: cannot unmarshal object into Go struct field mapEntry.value of type []string
        [{
                "key": ["0x01","0x00","0x00","0x00","0x00","0x00","0x00","0x00"
                ],
                "value": {
                    "error": "No such file or directory"
                }
            },{
                "key": ["0x02","0x00","0x00","0x00","0x00","0x00","0x00","0x00"
                ],
                "value": ["0x0a","0x41","0x00","0x02","0x77","0x1f","0x00","0x00"
                ]
            },{
                "key": ["0x00","0x00","0x00","0x00","0x00","0x00","0x00","0x00"
                ],
                "value": ["0xac","0x11","0x00","0x03","0x2b","0x19","0x00","0x00"
                ]
            }
        ]


    Increase fv timeout for felix to become healthy. Takes about 6s


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
