### PR TITLE
[release-v3.28] Add qemu emulated arm64 node image build

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -75,11 +75,9 @@ RUN rpm -i ${IPSET_SOURCERPM_URL} && \
 
 # runit is not available in ubi or CentOS repos so build it.
 # get it from the debian repos as the official website doesn't support https
-RUN wget -P /tmp https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz && \
-    gunzip /tmp/runit_${RUNIT_VER}.orig.tar.gz && \
-    tar -xpf /tmp/runit_${RUNIT_VER}.orig.tar -C /tmp && \
-    cd /tmp/admin/runit-${RUNIT_VER}/ && \
-    package/install
+RUN curl -sfL https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz | tar xz -C /root && \
+    cd /root/admin/runit-${RUNIT_VER} && \
+    package/compile
 
 FROM ${UBI_IMAGE} as ubi
 
@@ -93,7 +91,7 @@ ARG RUNIT_VER
 RUN microdnf upgrade
 
 # Copy in runit binaries
-COPY --from=centos  /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
+COPY --from=centos  /root/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
 
 # Copy in our rpms
 COPY --from=centos  /root/rpmbuild/RPMS/x86_64/* /tmp/rpms/

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -81,11 +81,9 @@ RUN rpm -i ${IPSET_SOURCERPM_URL} && \
 
 # runit is not available in ubi or CentOS repos so build it.
 # get it from the debian repos as the official website doesn't support https
-RUN wget -P /tmp https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz && \
-    gunzip /tmp/runit_${RUNIT_VER}.orig.tar.gz && \
-    tar -xpf /tmp/runit_${RUNIT_VER}.orig.tar -C /tmp && \
-    cd /tmp/admin/runit-${RUNIT_VER}/ && \
-    package/install
+RUN curl -sfL https://ftp.debian.org/debian/pool/main/r/runit/runit_${RUNIT_VER}.orig.tar.gz | tar xz -C /root && \
+    cd /root/admin/runit-${RUNIT_VER} && \
+    package/compile
 
 FROM ${UBI_IMAGE} as ubi
 
@@ -103,7 +101,7 @@ COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN microdnf upgrade
 
 # Copy in runit binaries
-COPY --from=centos  /tmp/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
+COPY --from=centos  /root/admin/runit-${RUNIT_VER}/command/* /usr/local/bin/
 
 # Copy in our rpms
 COPY --from=centos  /root/rpmbuild/RPMS/aarch64/* /tmp/rpms/

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -17,15 +17,21 @@ ARG LIBNFTNL_VER=1.2.2-1
 ARG IPSET_VER=7.11-6
 ARG RUNIT_VER=2.1.2
 ARG BIRD_IMAGE=calico/bird:latest
+ARG QEMU_IMAGE
 ARG UBI_IMAGE
 
 FROM calico/bpftool:v5.3-arm64 as bpftool
+FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 
 # Use this build stage to build iptables rpm and runit binaries.
 # We need to rebuild the iptables rpm because the prepackaged rpm does not have legacy iptables binaries.
 # We need to build runit because there aren't any rpms for it in CentOS or ubi repositories.
 FROM quay.io/centos/centos:stream8 as centos
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
 ARG IPTABLES_VER
 ARG LIBNFTNL_VER
@@ -88,6 +94,10 @@ ARG IPTABLES_VER
 ARG LIBNFTNL_VER
 ARG IPSET_VER
 ARG RUNIT_VER
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
 # Update base packages to pick up security updates.  Must do this before adding the centos repo.
 RUN microdnf upgrade
@@ -203,7 +213,12 @@ RUN chmod u+s /bin/mountns
 # Clean out as many files as we can from the filesystem.  We no longer need dnf or the platform python install
 # or any of its dependencies.
 COPY clean-up-filesystem.sh /clean-up-filesystem.sh
+# Allowing qemu binaries to persist.
+RUN sed -i 's#zmore#zmore\n\tqemu\n#m' /clean-up-filesystem.sh
 RUN /clean-up-filesystem.sh
+
+# Delete qemu binaries
+RUN rm /usr/bin/qemu-aarch64-static
 
 # Add in top-level license file
 COPY LICENSE /licenses/LICENSE

--- a/node/Dockerfile.ppc64le
+++ b/node/Dockerfile.ppc64le
@@ -42,9 +42,7 @@ LABEL version=${GIT_VERSION}
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
-# we only need this for the intermediate "base" image, so we can run all the apk and other commands
-# when running on a kernel >= 4.8, this will become less relevant
-COPY --from=qemu /usr/bin/qemu-${ARCH}-static /usr/bin/
+COPY --from=qemu /usr/bin/qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 
 # Install remaining runtime deps required for felix from the global repository
 RUN apk add --no-cache bash ip6tables ipset iputils iproute2 conntrack-tools runit file ca-certificates
@@ -69,6 +67,6 @@ RUN chmod u+s /bin/mountns
 
 COPY --from=bpftool /bpftool /bin
 
-RUN rm /usr/bin/qemu-${ARCH}-static
+RUN rm /usr/bin/qemu-ppc64le-static
 
 CMD ["start_runit"]

--- a/node/Dockerfile.s390x
+++ b/node/Dockerfile.s390x
@@ -39,7 +39,7 @@ LABEL version=${GIT_VERSION}
 
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
-COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/qemu-s390x-static
 
 # Install remaining runtime deps required for felix from the global repository
 RUN apk add --no-cache bash ip6tables ipset iputils iproute2 conntrack-tools runit file ca-certificates
@@ -66,5 +66,7 @@ COPY --from=bpftool /bpftool /bin
 
 # Add in top-level license file
 COPY LICENSE /licenses
+
+RUN rm /usr/bin/qemu-s390x-static
 
 CMD ["start_runit"]


### PR DESCRIPTION
## Description

Qemu emulated arm64 node image build was remove in [1] in favor of the native builds. However, our release process isn't update to date with native runners. This changeset adds qemu back to arm64 node image build and updates qemu static binary copy and clean up for ppc64le and s390x.

[1] https://github.com/projectcalico/calico/pull/8558/files#diff-c6e82bd404a904c10b9a0756d78d913a8a5e2ff833fefd384c80af1d7c93c3bb

## Related issues/PRs

Pick https://github.com/projectcalico/calico/pull/8806 into release-v3.28 branch.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
