### PR TITLE
Build fips images when make image-all

### DIFF
--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -57,7 +57,9 @@ blocks:
       jobs:
         - name: Linux arm64
           commands:
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node cd ARCHES=arm64 CONFIRM=true; fi
+            # Don't call `make -C node cd ARCHES=arm64` here because node image-all also builds
+            # FIPS images that will fail on native arm64 runners. They are built in the previous block.
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=arm64 CONFIRM=true; fi
   - name: Publish node multi-arch manifests
     dependencies:
       - Publish node images

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -59,7 +59,7 @@ blocks:
           commands:
             # Don't call `make -C node cd ARCHES=arm64` here because node image-all also builds
             # FIPS images that will fail on native arm64 runners. They are built in the previous block.
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=arm64 CONFIRM=true; fi
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=arm64 VALIDARCHES=arm64 CONFIRM=true; fi
   - name: Publish node multi-arch manifests
     dependencies:
       - Publish node images

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -89,9 +89,11 @@ CONTAINER_FIPS_CREATED=.apiserver.created-$(ARCH)-fips
 
 .PHONY: image $(API_SERVER_IMAGE)
 image: $(API_SERVER_IMAGE)
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 $(API_SERVER_IMAGE): $(CONTAINER_MARKER)
 $(CONTAINER_CREATED): Dockerfile $(BINDIR)/apiserver-$(ARCH)

--- a/app-policy/Makefile
+++ b/app-policy/Makefile
@@ -134,9 +134,11 @@ proto/healthz.pb.go: proto/healthz.proto
 ###############################################################################
 .PHONY: image $(DIKASTES_IMAGE)
 image: $(DIKASTES_IMAGE)
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 $(DIKASTES_IMAGE): $(CONTAINER_MARKER)
 $(CONTAINER_CREATED): register Dockerfile $(BINDIR)/dikastes-$(ARCH) $(BINDIR)/healthz-$(ARCH)

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -122,9 +122,11 @@ image-windows: $(WINDOWS_IMAGE_REQS)
 # Building the image
 ###############################################################################
 image: $(DEPLOY_CONTAINER_MARKER)
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 # Builds the statically compiled binaries into a container.
 $(DEPLOY_CONTAINER_STATIC_MARKER): Dockerfile build fetch-cni-bins

--- a/key-cert-provisioner/Makefile
+++ b/key-cert-provisioner/Makefile
@@ -55,9 +55,11 @@ $(BINDIR)/test-signer-$(ARCH):
 # BUILD IMAGE
 ###############################################################################
 .PHONY: image-all
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 SIGNER_CREATED=.signer.created-$(ARCH)
 

--- a/kube-controllers/Makefile
+++ b/kube-controllers/Makefile
@@ -82,9 +82,11 @@ $(BINDIR)/kubectl-$(ARCH):
 # Building the image
 ###############################################################################
 ## Builds the controller binary and docker image.
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 image: $(KUBE_CONTROLLER_CONTAINER_MARKER)
 

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -34,7 +34,7 @@ ARG RUNIT_VER
 ARG CENTOS_MIRROR_BASE_URL=https://linuxsoft.cern.ch/cern/centos/s9
 ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/libnftnl-${LIBNFTNL_VER}.el9.src.rpm
 ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/iptables-${IPTABLES_VER}.el9.src.rpm
-ARG IPTABLES_LEGACY_SOURCERPM_URL=https://dl.fedoraproject.org/pub/epel/9/Everything/source/tree/Packages/i/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
+ARG IPTABLES_LEGACY_SOURCERPM_URL=https://yum.oracle.com/repo/OracleLinux/OL9/developer/EPEL/x86_64/getPackageSource/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
 ARG IPSET_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.
@@ -66,7 +66,7 @@ RUN rpm -i ${LIBNFTNL_SOURCERPM_URL} && \
     # we need install source RPM for iptables-legacy and install its build dependencies.
     rpm -i ${IPTABLES_LEGACY_SOURCERPM_URL} && \
     yum-builddep -y --spec /root/rpmbuild/SPECS/iptables-epel.spec && \
-    rpmbuild -bb /root/rpmbuild/SPECS/iptables-epel.spec 
+    rpmbuild -bb /root/rpmbuild/SPECS/iptables-epel.spec
 
 # Install source RPM for ipset and install its build dependencies.
 RUN rpm -i ${IPSET_SOURCERPM_URL} && \

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -40,7 +40,7 @@ ARG RUNIT_VER
 ARG CENTOS_MIRROR_BASE_URL=https://linuxsoft.cern.ch/cern/centos/s9
 ARG LIBNFTNL_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/libnftnl-${LIBNFTNL_VER}.el9.src.rpm
 ARG IPTABLES_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/iptables-${IPTABLES_VER}.el9.src.rpm
-ARG IPTABLES_LEGACY_SOURCERPM_URL=https://dl.fedoraproject.org/pub/epel/9/Everything/source/tree/Packages/i/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
+ARG IPTABLES_LEGACY_SOURCERPM_URL=https://yum.oracle.com/repo/OracleLinux/OL9/developer/EPEL/x86_64/getPackageSource/iptables-epel-${IPTABLES_VER}.el9.2.src.rpm
 ARG IPSET_SOURCERPM_URL=${CENTOS_MIRROR_BASE_URL}/BaseOS/source/tree/Packages/ipset-${IPSET_VER}.el9.src.rpm
 
 # Install build dependencies and security updates.
@@ -72,7 +72,7 @@ RUN rpm -i ${LIBNFTNL_SOURCERPM_URL} && \
     # we need install source RPM for iptables-legacy and install its build dependencies.
     rpm -i ${IPTABLES_LEGACY_SOURCERPM_URL} && \
     yum-builddep -y --spec /root/rpmbuild/SPECS/iptables-epel.spec && \
-    rpmbuild -bb /root/rpmbuild/SPECS/iptables-epel.spec 
+    rpmbuild -bb /root/rpmbuild/SPECS/iptables-epel.spec
 
 # Install source RPM for ipset and install its build dependencies.
 RUN rpm -i ${IPSET_SOURCERPM_URL} && \

--- a/node/Makefile
+++ b/node/Makefile
@@ -252,9 +252,11 @@ endif
 # Building the image
 ###############################################################################
 ## Create the images for all supported ARCHes
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 image $(NODE_IMAGE): register $(NODE_CONTAINER_MARKER)
 $(NODE_CONTAINER_CREATED): $(REMOTE_DEPS) ./Dockerfile.$(ARCH) $(NODE_CONTAINER_BINARY) $(INCLUDED_SOURCE) $(NODE_CONTAINER_FILES) $(TOOLS_MOUNTNS_BINARY)

--- a/pod2daemon/Makefile
+++ b/pod2daemon/Makefile
@@ -139,9 +139,11 @@ REGISTRAR_CONTAINER_FIPS_CREATED=.csi-registrar.created-$(ARCH)-fips
 
 .PHONY: image calico/pod2daemon-flexvol
 image: $(FLEXVOL_IMAGE) $(CSI_IMAGE) $(REGISTRAR_IMAGE)
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 $(FLEXVOL_IMAGE): $(FLEXVOL_CONTAINER_MARKER)
 $(FLEXVOL_CONTAINER_CREATED): flexvol/docker-image/Dockerfile bin/flexvol-$(ARCH)

--- a/typha/Makefile
+++ b/typha/Makefile
@@ -102,9 +102,11 @@ image: $(BUILD_IMAGES)
 
 # Build the image for the target architecture
 .PHONY: image-all
-image-all: $(addprefix sub-image-,$(VALIDARCHES))
+image-all: $(addprefix sub-image-,$(VALIDARCHES)) sub-image-fips-amd64
 sub-image-%:
-	$(MAKE) image FIPS=$(FIPS) ARCH=$*
+	$(MAKE) image ARCH=$*
+sub-image-fips-%:
+	$(MAKE) image FIPS=true ARCH=$*
 
 # Build the calico/typha docker image, which contains only Typha.
 .PHONY: image $(TYPHA_IMAGE)


### PR DESCRIPTION
## Description

FIPS images were shelved in [a previous PR](https://github.com/projectcalico/calico/pull/8558/files#diff-be78189bce6991a6c4862a573fc8041d0c9c83946410423e689e7161bff6fd0aL92) due to the [TLS v1.3 requirement](https://csrc.nist.gov/news/2019/nist-publishes-sp-800-52-revision-2) by Jan 1 2024. However, our coming release still expecting them so add them back when making all images.

## Related issues/PRs

Related to https://github.com/projectcalico/calico/pull/8558/files#diff-be78189bce6991a6c4862a573fc8041d0c9c83946410423e689e7161bff6fd0aL92.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
