### PR TITLE
[release-v3.26] Manual pick #8827: Improve cni-plugin binary install verification

### DIFF
--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -182,6 +181,7 @@ func Install(version string) error {
 	// Place the new binaries if the directory is writeable.
 	dirs := []string{"/host/opt/cni/bin", "/host/secondary-bin-dir"}
 	binsWritten := false
+	calicoBinaryOK := false
 	for _, d := range dirs {
 		if err := fileutil.IsDirWriteable(d); err != nil {
 			logrus.Infof("%s is not writeable, skipping", d)
@@ -211,6 +211,15 @@ func Install(version string) error {
 				logrus.WithError(err).Errorf("Failed to install %s", target)
 				os.Exit(1)
 			}
+			// Verify if the binary was installed successfully, exit (to retry) otherwise
+			binaryOK, err := destinationUptoDate(source, target)
+			if err != nil || !binaryOK {
+				logrus.WithError(err).Errorf("Failed to verify installed binary %s", target)
+				os.Exit(1)
+			}
+			if binary.Name() == "calico" || binary.Name() == "calico.exe" {
+				calicoBinaryOK = true
+			}
 			logrus.Infof("Installed %s", target)
 		}
 
@@ -218,17 +227,7 @@ func Install(version string) error {
 		logrus.Infof("Wrote Calico CNI binaries to %s\n", d)
 		binsWritten = true
 
-		// Instead of executing 'calico -v', check if the calico binary was copied successfully
-		calicoBinaryName := "calico"
-		if runtime.GOOS == "windows" {
-			calicoBinaryName = "calico.exe"
-		}
-		calicoBinaryOK, err := destinationUptoDate("/opt/cni/bin/"+calicoBinaryName, d+"/"+calicoBinaryName)
-		if err != nil {
-			logrus.WithError(err).Warnf("Failed verifying installed binary, exiting")
-			return err
-		}
-		// Print version number if successful
+		// Print version number if it was successfully installed
 		if calicoBinaryOK {
 			logrus.Infof("CNI plugin version: %s", version)
 		}


### PR DESCRIPTION
Cherry pick of https://github.com/projectcalico/calico/pull/8827 on release-v3.26.

https://github.com/projectcalico/calico/pull/8827: Improve cni-plugin binary install verification

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Improve cni-plugin binary install verification.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
