### PR TITLE
[release-v3.28] Auto pick #8798: Fix flake CORE-10163: controller-manager GC races with

### DIFF
--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -48,9 +48,10 @@ import (
 
 var counterByPrefix map[string]int
 
-// podName generates a new pod name for the given prefix. We use an incrementing counter
-// to ensure that a unique name is generated each time the function is called.
-func podName(prefix string) string {
+// pefixName generates a new unique name with the given prefix.
+// We use an incrementing counter to ensure that a unique name
+// is generated each time the function is called.
+func prefixName(prefix string) string {
 	if counterByPrefix == nil {
 		counterByPrefix = make(map[string]int)
 	}
@@ -160,7 +161,6 @@ func getKubernetesClient() *kubernetes.Clientset {
 }
 
 var _ = Describe("Kubernetes CNI tests", func() {
-	hostname, _ := names.Hostname()
 	ctx := context.Background()
 	calicoClient, err := client.NewFromEnv()
 	Expect(err).NotTo(HaveOccurred())
@@ -168,50 +168,53 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 	// Name of the pod used within each test. A new name is generated
 	// in BeforeEach to ensure a unique pod name per-test.
-	var name string
+	var testPodName, testNodeName string
+	hostname, err := names.Hostname()
+	Expect(err).NotTo(HaveOccurred(), "Test could not find hostname for test machine")
 
 	BeforeEach(func() {
 		testutils.WipeDatastore()
 
-		// Create the node for these tests. The IPAM code requires a corresponding Calico node to exist.
-		nodeName, err := names.Hostname()
-		Expect(err).NotTo(HaveOccurred())
-		err = testutils.AddNode(calicoClient, k8sClient, nodeName)
-		Expect(err).NotTo(HaveOccurred())
+		// Generate a name to use for the test's pod and node.
+		testPodName = prefixName("test-pod")
+		testNodeName = prefixName(hostname)
 
-		// Generate a name to use for the test's pod.
-		name = podName("test-pod")
+		// Create the node for these tests. The IPAM code requires a corresponding Calico node to exist.
+		err = testutils.AddNode(calicoClient, k8sClient, testNodeName)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		// Delete the node.
-		name, err := names.Hostname()
-		Expect(err).NotTo(HaveOccurred())
-		err = testutils.DeleteNode(calicoClient, k8sClient, name)
+		err = testutils.DeleteNode(calicoClient, k8sClient, testNodeName)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	cniVersion := os.Getenv("CNI_SPEC_VERSION")
 	Expect(cniVersion).NotTo(BeEmpty())
 	Context("using host-local IPAM", func() {
-		netconf := fmt.Sprintf(`
-			{
-			  "cniVersion": "%s",
-			  "name": "net1",
-			  "type": "calico",
-			  "etcd_endpoints": "http://%s:2379",
-			  "datastore_type": "%s",
-			  "ipam": {
-			    "type": "host-local",
-			    "subnet": "10.0.0.0/8"
-			  },
-			  "kubernetes": {
-			    "kubeconfig": "/home/user/certs/kubeconfig"
-			  },
-			  "policy": {"type": "k8s"},
-			  "nodename_file_optional": true,
-			  "log_level":"debug"
-			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+		var netconf string
+		BeforeEach(func() {
+			netconf = fmt.Sprintf(`
+				{
+				  "cniVersion": "%s",
+				  "name": "net1",
+				  "type": "calico",
+				  "etcd_endpoints": "http://%s:2379",
+				  "datastore_type": "%s",
+				  "ipam": {
+					"type": "host-local",
+					"subnet": "10.0.0.0/8"
+				  },
+				  "kubernetes": {
+					"kubeconfig": "/home/user/certs/kubeconfig"
+				  },
+				  "policy": {"type": "k8s"},
+				  "nodename_file_optional": true,
+				  "log_level":"debug",
+				  "nodename": "%s"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
+		})
 
 		It("successfully networks the namespace", func() {
 			clientset := getKubernetesClient()
@@ -220,18 +223,18 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			// Create a K8s pod w/o any special params
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: name},
+				ObjectMeta: metav1.ObjectMeta{Name: testPodName},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
-			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
-			containerID, result, contVeth, contAddresses, contRoutes, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, result, contVeth, contAddresses, contRoutes, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			mac := contVeth.Attrs().HardwareAddr
@@ -245,17 +248,17 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// TODO Make sure the profile doesn't exist
 
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 
 			wrkload, err := ids.CalculateWorkloadEndpointName(false)
 			Expect(err).NotTo(HaveOccurred())
 
-			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, name)
+			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, testPodName)
 
 			// The endpoint is created
 			endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -277,13 +280,13 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}))
 
 			Expect(endpoints.Items[0].Spec).Should(Equal(libapi.WorkloadEndpointSpec{
-				Pod:                name,
+				Pod:                testPodName,
 				InterfaceName:      interfaceName,
 				IPNetworks:         []string{result.IPs[0].Address.String()},
 				ServiceAccountName: "default",
 				MAC:                mac.String(),
 				Profiles:           []string{"kns.test", "ksa.test.default"},
-				Node:               hostname,
+				Node:               testNodeName,
 				Endpoint:           "eth0",
 				Workload:           "",
 				ContainerID:        containerID,
@@ -347,7 +350,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				})))
 
 			// Delete container
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			if os.Getenv("DATASTORE_TYPE") != "kubernetes" {
@@ -378,22 +381,22 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 				// Create a K8s pod w/o any special params
 				ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Name: name},
+					ObjectMeta: metav1.ObjectMeta{Name: testPodName},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name:  fmt.Sprintf("container-%s", name),
+							Name:  fmt.Sprintf("container-%s", testPodName),
 							Image: "ignore",
 							Ports: []v1.ContainerPort{{
 								Name:          "anamedport",
 								ContainerPort: 555,
 							}},
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
-				defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+				defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
-				containerID, result, contVeth, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+				containerID, result, contVeth, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				mac := contVeth.Attrs().HardwareAddr
@@ -406,15 +409,15 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				// TODO Make sure the profile doesn't exist
 
 				ids := names.WorkloadEndpointIdentifiers{
-					Node:         hostname,
+					Node:         testNodeName,
 					Orchestrator: api.OrchestratorKubernetes,
 					Endpoint:     "eth0",
-					Pod:          name,
+					Pod:          testPodName,
 					ContainerID:  containerID,
 				}
 
 				wrkload, err := ids.CalculateWorkloadEndpointName(false)
-				interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, name)
+				interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, testPodName)
 				Expect(err).NotTo(HaveOccurred())
 
 				// The endpoint is created
@@ -436,12 +439,12 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					"projectcalico.org/serviceaccount": "default",
 				}))
 				Expect(endpoints.Items[0].Spec).Should(Equal(libapi.WorkloadEndpointSpec{
-					Pod:                name,
+					Pod:                testPodName,
 					InterfaceName:      interfaceName,
 					IPNetworks:         []string{result.IPs[0].Address.String()},
 					MAC:                mac.String(),
 					Profiles:           []string{"kns.test", "ksa.test.default"},
-					Node:               hostname,
+					Node:               testNodeName,
 					ServiceAccountName: "default",
 					Endpoint:           "eth0",
 					Workload:           "",
@@ -459,7 +462,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Delete container
-				_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+				_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				if os.Getenv("DATASTORE_TYPE") != "kubernetes" {
@@ -491,24 +494,24 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 				// Create a K8s pod w/o any special params
 				ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Name: name},
+					ObjectMeta: metav1.ObjectMeta{Name: testPodName},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name:  name,
+							Name:  testPodName,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
-				defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+				defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
-				if err := testutils.CreateHostVeth("", name, testutils.K8S_TEST_NS, hostname); err != nil {
+				if err := testutils.CreateHostVeth("", testPodName, testutils.K8S_TEST_NS, testNodeName); err != nil {
 					panic(err)
 				}
-				_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+				_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+				_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
@@ -530,7 +533,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
+			  "log_level":"debug",
+			  "nodename": "%s"
 			}`
 
 			It("should create pods with the right MTU", func() {
@@ -546,7 +550,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 				// Create a K8s pod/container
 				name1 := fmt.Sprintf("mtutest%d", rand.Uint32())
-				mtuNetconf1 := fmt.Sprintf(mtuNetconfTemplate, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+				mtuNetconf1 := fmt.Sprintf(mtuNetconfTemplate, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
 
 				ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
@@ -555,7 +559,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 							Name:  name1,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 				defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name1)
@@ -589,7 +593,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
+			  "log_level":"debug",
+			  "nodename": "%s"
 			}`
 
 			It("creates pods with the new mtu", func() {
@@ -597,7 +602,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 				// Create a K8s pod/container with non-default MTU
 				name1 := fmt.Sprintf("mtutest%d", rand.Uint32())
-				mtuNetconf1 := fmt.Sprintf(mtuNetconfTemplate, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), 3000)
+				mtuNetconf1 := fmt.Sprintf(mtuNetconfTemplate, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), 3000, testNodeName)
 
 				ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: name1},
@@ -606,7 +611,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 							Name:  name1,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 				defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name1)
@@ -617,7 +622,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 				// Create another K8s pod/container with a different non-default MTU
 				name2 := fmt.Sprintf("mtutest2%d", rand.Uint32())
-				mtuNetconf2 := fmt.Sprintf(mtuNetconfTemplate, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), 4000)
+				mtuNetconf2 := fmt.Sprintf(mtuNetconfTemplate, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), 4000, testNodeName)
 
 				ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Name: name2},
@@ -626,7 +631,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 							Name:  name2,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 				defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name2)
@@ -647,6 +652,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			description, cniVersion, config, unexpectedRoute string
 			expectedV4Routes, expectedV6Routes               []string
 			numIPv4IPs, numIPv6IPs                           int
+			nodename                                         string
 		}{
 			{
 				description: "old-style inline subnet",
@@ -667,7 +673,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug",
+					  "nodename": "%s"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -676,6 +683,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: regexp.QuoteMeta("10."),
 				numIPv4IPs:      1,
 				numIPv6IPs:      0,
+				nodename:        prefixName(hostname),
 			},
 			{
 				// This scenario tests IPv4+IPv6 without specifying any routes.
@@ -708,7 +716,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug",
+					  "nodename": "%s"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -722,6 +731,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: regexp.QuoteMeta("10."),
 				numIPv4IPs:      1,
 				numIPv6IPs:      1,
+				nodename:        prefixName(hostname),
 			},
 			{
 				// This scenario tests IPv4+IPv6 without specifying any routes.
@@ -754,7 +764,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug",
+					  "nodename": "%s"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -768,6 +779,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: regexp.QuoteMeta("10."),
 				numIPv4IPs:      1,
 				numIPv6IPs:      1,
+				nodename:        prefixName(hostname),
 			},
 			{
 				// In this scenario, we use a lot more of the host-local IPAM plugin.  Namely:
@@ -814,7 +826,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug",
+					  "nodename": "%s"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("10.123.0.0/16 via 169.254.1.1 dev eth0"),
@@ -829,6 +842,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: "default",
 				numIPv4IPs:      2,
 				numIPv6IPs:      1,
+				nodename:        prefixName(hostname),
 			},
 			{
 				// In this scenario, we use a lot more of the host-local IPAM plugin.  Namely:
@@ -874,7 +888,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                            "kubeconfig": "/home/user/certs/kubeconfig"
 					  },
 					  "policy": {"type": "k8s"},
-					  "log_level":"info"
+					  "log_level":"debug",
+					  "nodename": "%s"
 					}`,
 				expectedV4Routes: []string{
 					regexp.QuoteMeta("default via 169.254.1.1 dev eth0"),
@@ -889,6 +904,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				},
 				numIPv4IPs: 2,
 				numIPv6IPs: 1,
+				nodename:   prefixName(hostname),
 			},
 		}
 
@@ -901,48 +917,48 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 			Context("Using host-local IPAM with one PodCIDR ("+c.description+"): request an IP then release it, and then request it again", func() {
 				It("should successfully assign IP both times and successfully release it in the middle", func() {
-					netconfHostLocalIPAM := fmt.Sprintf(c.config, c.cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+					netconfHostLocalIPAM := fmt.Sprintf(c.config, c.cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), c.nodename)
 
 					clientset := getKubernetesClient()
 
 					ensureNamespace(clientset, testutils.K8S_TEST_NS)
 
-					ensureNodeDeleted(clientset, hostname)
+					ensureNodeDeleted(clientset, c.nodename)
 
 					// Create a K8s Node object with PodCIDR and name equal to hostname.
 					_, err = clientset.CoreV1().Nodes().Create(context.Background(), &v1.Node{
-						ObjectMeta: metav1.ObjectMeta{Name: hostname},
+						ObjectMeta: metav1.ObjectMeta{Name: c.nodename},
 						Spec: v1.NodeSpec{
 							PodCIDR: "10.0.0.0/24",
 						},
 					}, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					defer ensureNodeDeleted(clientset, hostname)
+					defer ensureNodeDeleted(clientset, c.nodename)
 
 					By("Creating a pod with a specific IP address")
 					ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
-						ObjectMeta: metav1.ObjectMeta{Name: name},
+						ObjectMeta: metav1.ObjectMeta{Name: testPodName},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
-								Name:  name,
+								Name:  testPodName,
 								Image: "ignore",
 							}},
-							NodeName: hostname,
+							NodeName: c.nodename,
 						},
 					})
-					defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+					defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 					requestedIP := "10.0.0.42"
 					expectedIP := net.IPv4(10, 0, 0, 42).To4()
 
-					_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconfHostLocalIPAM, name, testutils.K8S_TEST_NS, requestedIP)
+					_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconfHostLocalIPAM, testPodName, testutils.K8S_TEST_NS, requestedIP)
 					Expect(err).NotTo(HaveOccurred())
 
 					podIP := contAddresses[0].IP
 					Expect(podIP).Should(Equal(expectedIP))
 
 					By("Deleting the pod we created earlier")
-					_, err = testutils.DeleteContainer(netconfHostLocalIPAM, contNs.Path(), name, testutils.K8S_TEST_NS)
+					_, err = testutils.DeleteContainer(netconfHostLocalIPAM, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("Creating a second pod with the same IP address as the first pod")
@@ -954,7 +970,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 								Name:  fmt.Sprintf("container-%s", name2),
 								Image: "ignore",
 							}},
-							NodeName: hostname,
+							NodeName: c.nodename,
 						},
 					})
 					defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name2)
@@ -1012,48 +1028,48 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			c := c // Make sure we get a fresh variable on each loop.
 			Context("Using host-local IPAM with two PodCIDRs ("+c.description+"): request an IP then release it, and then request it again", func() {
 				It("should successfully assign IP both times and successfully release it in the middle", func() {
-					netconfHostLocalIPAM := fmt.Sprintf(c.config, c.cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+					netconfHostLocalIPAM := fmt.Sprintf(c.config, c.cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), c.nodename)
 
 					clientset := getKubernetesClient()
 
 					ensureNamespace(clientset, testutils.K8S_TEST_NS)
 
-					ensureNodeDeleted(clientset, hostname)
+					ensureNodeDeleted(clientset, c.nodename)
 
 					// Create a K8s Node object with PodCIDR and name equal to hostname.
 					_, err = clientset.CoreV1().Nodes().Create(context.Background(), &v1.Node{
-						ObjectMeta: metav1.ObjectMeta{Name: hostname},
+						ObjectMeta: metav1.ObjectMeta{Name: c.nodename},
 						Spec: v1.NodeSpec{
 							PodCIDRs: []string{"10.10.0.0/24", "dead:beef::/96"},
 						},
 					}, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					defer ensureNodeDeleted(clientset, hostname)
+					defer ensureNodeDeleted(clientset, c.nodename)
 
 					By("Creating a pod with a specific IP address")
 					ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
-						ObjectMeta: metav1.ObjectMeta{Name: name},
+						ObjectMeta: metav1.ObjectMeta{Name: testPodName},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
-								Name:  name,
+								Name:  testPodName,
 								Image: "ignore",
 							}},
-							NodeName: hostname,
+							NodeName: c.nodename,
 						},
 					})
-					defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+					defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 					requestedIP := "10.10.0.42"
 					expectedIP := net.IPv4(10, 10, 0, 42).To4()
 
-					_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconfHostLocalIPAM, name, testutils.K8S_TEST_NS, requestedIP)
+					_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconfHostLocalIPAM, testPodName, testutils.K8S_TEST_NS, requestedIP)
 					Expect(err).NotTo(HaveOccurred())
 
 					podIP := contAddresses[0].IP
 					Expect(podIP).Should(Equal(expectedIP))
 
 					By("Deleting the pod we created earlier")
-					_, err = testutils.DeleteContainer(netconfHostLocalIPAM, contNs.Path(), name, testutils.K8S_TEST_NS)
+					_, err = testutils.DeleteContainer(netconfHostLocalIPAM, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					By("Creating a second pod with the same IP address as the first pod")
@@ -1065,7 +1081,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 								Name:  fmt.Sprintf("container-%s", name2),
 								Image: "ignore",
 							}},
-							NodeName: hostname,
+							NodeName: c.nodename,
 						},
 					})
 					defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name2)
@@ -1140,7 +1156,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			ncb, err := json.Marshal(nc)
@@ -1162,7 +1179,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testNS, name)
+			ensurePodDeleted(clientset, testNS, testPodName)
 
 			// Delete the IP Pools.
 			testutils.MustDeleteIPPool(calicoClient, pool1)
@@ -1185,26 +1202,26 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod.
 			ensurePodCreated(clientset, testNS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        name,
+					Name:        testPodName,
 					Annotations: map[string]string{},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
-			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, name, testNS, "")
+			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testNS, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			podIP := contAddresses[0].IP
 			Expect(pool1CIDR.Contains(podIP)).To(BeTrue())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testNS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testNS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -1224,24 +1241,24 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod.
 			ensurePodCreated(clientset, testNS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        name,
+					Name:        testPodName,
 					Annotations: map[string]string{},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
 			// Expect an error when invoking the CNI plugin.
-			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testNS, "")
+			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testNS, "")
 			Expect(err).To(HaveOccurred())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testNS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testNS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -1261,15 +1278,15 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod.
 			ensurePodCreated(clientset, testNS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        name,
+					Name:        testPodName,
 					Annotations: map[string]string{},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
@@ -1282,6 +1299,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					HandleID:    &handle,
 					IPv4Pools:   []cnet.IPNet{{IPNet: *pool1CIDR}},
 					IntendedUse: api.IPPoolAllowedUseWorkload,
+					Hostname:    testNodeName,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1289,11 +1307,11 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(len(v4ia.IPs)).To(Equal(numAddrsInPool))
 
 			// Expect an error when invoking the CNI plugin.
-			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testNS, "")
+			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testNS, "")
 			Expect(err).To(HaveOccurred())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testNS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testNS)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Release all the IPs assigned above.
@@ -1317,15 +1335,15 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod.
 			ensurePodCreated(clientset, testNS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        name,
+					Name:        testPodName,
 					Annotations: map[string]string{},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
@@ -1338,6 +1356,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					HandleID:    &handle,
 					IPv4Pools:   []cnet.IPNet{{IPNet: *pool1CIDR}},
 					IntendedUse: api.IPPoolAllowedUseWorkload,
+					Hostname:    testNodeName,
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -1345,7 +1364,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(len(v4ia.IPs)).To(Equal(numAddrsInPool))
 
 			// Invoke the CNI plugin.
-			_, r, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testNS, "")
+			_, r, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testNS, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect the assigned IP address in the second IP pool.
@@ -1353,7 +1372,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(pool2CIDR.Contains(r.IPs[0].Address.IP)).To(BeTrue(), "IP assigned from wrong pool")
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testNS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testNS)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Release all the IPs assigned above.
@@ -1381,7 +1400,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			ncb, err := json.Marshal(nc)
@@ -1399,7 +1419,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testNS, name)
+			ensurePodDeleted(clientset, testNS, testPodName)
 
 			// Delete the IP Pool.
 			testutils.MustDeleteIPPool(calicoClient, pool1)
@@ -1421,29 +1441,29 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod passing in an IP pool.
 			ensurePodCreated(clientset, testNS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/ipv4pools": "[\"50.70.0.0/16\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
 			// Run the CNI plugin.
-			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, name, testNS, "")
+			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testNS, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			podIP := contAddresses[0].IP
 			Expect(ipPoolCIDR.Contains(podIP)).To(BeTrue())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testNS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testNS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -1467,7 +1487,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			ncb, err := json.Marshal(nc)
@@ -1491,7 +1512,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 			// Delete the IP Pools.
 			testutils.MustDeleteIPPool(calicoClient, pool1)
@@ -1502,28 +1523,28 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Create a K8s pod passing in an IP pool.
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/ipv4pools": "[\"172.16.0.0/16\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
-			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			podIP := contAddresses[0].IP
 			Expect(pool1CIDR.Contains(podIP)).To(BeTrue())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -1531,28 +1552,28 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Create a K8s pod passing in an IP pool.
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/ipv4pools": fmt.Sprintf("[\"%s\"]", pool2Name),
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
-			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			podIP := contAddresses[0].IP
 			Expect(pool2CIDR.Contains(podIP)).To(BeTrue())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -1571,7 +1592,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			netconf.IPAM.Type = "calico-ipam"
 
@@ -1588,24 +1610,24 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			ensureNamespace(clientset, testutils.K8S_TEST_NS)
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/allowedSourcePrefixes": "[\"8.8.8.8/32\",\"1.1.1.0/24\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 		})
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 			// Delete IPPools.
 			ipPool := "172.16.0.0/16"
@@ -1618,7 +1640,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Invoke the CNI plugin
-			_, _, _, _, _, contNs, err := testutils.CreateContainer(string(confBytes), name, testutils.K8S_TEST_NS, "")
+			_, _, _, _, _, contNs, err := testutils.CreateContainer(string(confBytes), testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Assert that the endpoint is created
@@ -1630,7 +1652,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(endpoints.Items[0].Spec.AllowSpoofedSourcePrefixes).To(ConsistOf([]string{"1.1.1.0/24", "8.8.8.8/32"}))
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(string(confBytes), contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(string(confBytes), contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -1649,8 +1671,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
 				FeatureControl:       types.FeatureControl{FloatingIPs: true},
+				Nodename:             testNodeName,
 			}
 			netconf.IPAM.Type = "calico-ipam"
 
@@ -1668,24 +1691,24 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			ensureNamespace(clientset, testutils.K8S_TEST_NS)
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/floatingIPs": "[\"1.1.1.1\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 		})
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 			// Delete IPPools.
 			for _, ipPool := range []string{"172.16.0.0/16", "1.1.1.0/24"} {
@@ -1699,7 +1722,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Invoke the CNI plugin
-			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(string(confBytes), name, testutils.K8S_TEST_NS, "")
+			_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(string(confBytes), testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Assert that the endpoint is created
@@ -1713,7 +1736,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(endpoints.Items[0].Spec.IPNATs).Should(Equal([]libapi.IPNAT{{InternalIP: podIP.String(), ExternalIP: "1.1.1.1"}}))
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(string(confBytes), contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(string(confBytes), contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -1724,7 +1747,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Invoke the CNI plugin, expect it to fail.
-			_, _, _, _, _, contNs, err := testutils.CreateContainer(string(confBytes), name, testutils.K8S_TEST_NS, "")
+			_, _, _, _, _, contNs, err := testutils.CreateContainer(string(confBytes), testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).To(HaveOccurred())
 
 			if os.Getenv("DATASTORE_TYPE") != "kubernetes" {
@@ -1735,7 +1758,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(string(confBytes), contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(string(confBytes), contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -1759,8 +1782,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
 				FeatureControl:       types.FeatureControl{IPAddrsNoIpam: true},
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			Expect(nc.CNIVersion).NotTo(BeEmpty())
@@ -1771,7 +1795,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 		})
 
 		It("should successfully assigns the annotated IP address", func() {
@@ -1780,21 +1804,21 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod passing in an IP address.
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/ipAddrsNoIpam": "[\"10.0.0.1\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
-			containerID, _, contVeth, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, _, contVeth, contAddresses, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).NotTo(HaveOccurred())
 			mac := contVeth.Attrs().HardwareAddr
 
@@ -1802,17 +1826,17 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(podIP).Should(Equal(assignIP))
 
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 
 			wrkload, err := ids.CalculateWorkloadEndpointName(false)
 			Expect(err).NotTo(HaveOccurred())
 
-			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, name)
+			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, testPodName)
 
 			// The endpoint is created
 			endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -1834,13 +1858,13 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}))
 
 			Expect(endpoints.Items[0].Spec).Should(Equal(libapi.WorkloadEndpointSpec{
-				Pod:                name,
+				Pod:                testPodName,
 				InterfaceName:      interfaceName,
 				IPNetworks:         []string{assignIP.String() + "/32"},
 				ServiceAccountName: "default",
 				MAC:                mac.String(),
 				Profiles:           []string{"kns.test", "ksa.test.default"},
-				Node:               hostname,
+				Node:               testNodeName,
 				Endpoint:           "eth0",
 				Workload:           "",
 				ContainerID:        containerID,
@@ -1852,7 +1876,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -1868,24 +1892,24 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod passing in an IP address.
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/ipAddrsNoIpam": "[\"10.0.0.1\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
-			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).To(HaveOccurred())
 
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -1893,21 +1917,21 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod passing in more than one IPv4 address.
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/ipAddrsNoIpam": "[\"10.0.0.1\", \"10.0.0.2\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
-			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			_, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).To(HaveOccurred())
 
 			if os.Getenv("DATASTORE_TYPE") != "kubernetes" {
@@ -1918,7 +1942,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -1949,8 +1973,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                           "kubeconfig": "/home/user/certs/kubeconfig"
 					 },
 					"policy": {"type": "k8s"},
-					"log_level":"info"
-				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+					"log_level":"debug",
+					"nodename": "%s"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
 
 			assignIP := net.IPv4(20, 0, 0, 111).To4()
 
@@ -1963,22 +1988,22 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			// Now create a K8s pod passing in an IP address.
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/ipAddrs": "[\"20.0.0.111\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
-			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
-			containerID, _, contVeth, contAddresses, _, netNS, err := testutils.CreateContainer(netconfCalicoIPAM, name, testutils.K8S_TEST_NS, "")
+			containerID, _, contVeth, contAddresses, _, netNS, err := testutils.CreateContainer(netconfCalicoIPAM, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).NotTo(HaveOccurred())
 			mac := contVeth.Attrs().HardwareAddr
 
@@ -1986,17 +2011,17 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(podIP).Should(Equal(assignIP))
 
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 
 			wrkload, err := ids.CalculateWorkloadEndpointName(false)
 			Expect(err).NotTo(HaveOccurred())
 
-			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, name)
+			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, testPodName)
 
 			// Make sure WorkloadEndpoint is created and has the requested IP in the datastore.
 			endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -2018,13 +2043,13 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}))
 
 			Expect(endpoints.Items[0].Spec).Should(Equal(libapi.WorkloadEndpointSpec{
-				Pod:                name,
+				Pod:                testPodName,
 				InterfaceName:      interfaceName,
 				IPNetworks:         []string{assignIP.String() + "/32"},
 				ServiceAccountName: "default",
 				MAC:                mac.String(),
 				Profiles:           []string{"kns.test", "ksa.test.default"},
-				Node:               hostname,
+				Node:               testNodeName,
 				Endpoint:           "eth0",
 				Workload:           "",
 				ContainerID:        containerID,
@@ -2032,14 +2057,14 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}))
 
 			// Check the pod's IP annotations.
-			checkPodIPAnnotations(clientset, testutils.K8S_TEST_NS, name, "20.0.0.111/32", "20.0.0.111/32")
+			checkPodIPAnnotations(clientset, testutils.K8S_TEST_NS, testPodName, "20.0.0.111/32", "20.0.0.111/32")
 
 			// Assert sysctl values are set for what we would expect for an endpoint.
 			err = checkInterfaceConfig(interfaceName, "4")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconfCalicoIPAM, netNS.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconfCalicoIPAM, netNS.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -2082,28 +2107,29 @@ var _ = Describe("Kubernetes CNI tests", func() {
                                           "kubeconfig": "/home/user/certs/kubeconfig"
 					 },
 					"policy": {"type": "k8s"},
-					"log_level":"info"
-				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+					"log_level":"debug",
+					"nodename": "%s"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
 
 			// Now create a K8s pod (without any pod IP annotations).
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: testPodName,
 					Annotations: map[string]string{
 						"cni.projectcalico.org/floatingIPs": "[\"1.1.1.1\", \"2001:647f::21\"]",
 					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
-			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
-			containerID, _, contVeth, contAddresses, _, netNS, err := testutils.CreateContainer(netconfCalicoIPAM, name, testutils.K8S_TEST_NS, "")
+			containerID, _, contVeth, contAddresses, _, netNS, err := testutils.CreateContainer(netconfCalicoIPAM, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).NotTo(HaveOccurred())
 			mac := contVeth.Attrs().HardwareAddr
 
@@ -2114,17 +2140,17 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(podIPv6.To16()).NotTo(BeNil())
 
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 
 			wrkload, err := ids.CalculateWorkloadEndpointName(false)
 			Expect(err).NotTo(HaveOccurred())
 
-			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, name)
+			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, testPodName)
 
 			// Make sure WorkloadEndpoint is created and has the requested IP in the datastore.
 			endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -2146,13 +2172,13 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}))
 
 			Expect(endpoints.Items[0].Spec).Should(Equal(libapi.WorkloadEndpointSpec{
-				Pod:                name,
+				Pod:                testPodName,
 				InterfaceName:      interfaceName,
 				ServiceAccountName: "default",
 				IPNetworks:         []string{podIPv4.String() + "/32", podIPv6.String() + "/128"},
 				MAC:                mac.String(),
 				Profiles:           []string{"kns.test", "ksa.test.default"},
-				Node:               hostname,
+				Node:               testNodeName,
 				Endpoint:           "eth0",
 				Workload:           "",
 				IPNATs: []libapi.IPNAT{
@@ -2170,10 +2196,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}))
 
 			// Check the pod's IP annotations.
-			checkPodIPAnnotations(clientset, testutils.K8S_TEST_NS, name, podIPv4.String()+"/32", podIPv4.String()+"/32,"+podIPv6.String()+"/128")
+			checkPodIPAnnotations(clientset, testutils.K8S_TEST_NS, testPodName, podIPv4.String()+"/32", podIPv4.String()+"/32,"+podIPv6.String()+"/128")
 
 			// Delete the container.
-			_, err = testutils.DeleteContainer(netconfCalicoIPAM, netNS.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconfCalicoIPAM, netNS.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -2202,7 +2228,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			ncb, err := json.Marshal(nc)
@@ -2219,21 +2246,21 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: name,
+						Name: testPodName,
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name:  name,
+							Name:  testPodName,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 		})
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 			// Delete IP pools.
 			testutils.MustDeleteIPPool(calicoClient, ipPool)
@@ -2247,7 +2274,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 		// - CNI DEL for containerIDX (Spurious delete for old container ID)
 		It("Use different container IDs to ADD and DEL the container", func() {
 			// ADD the container with passing a container ID "X".
-			_, _, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, name, testutils.K8S_TEST_NS, "", cniContainerIDX)
+			_, _, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, testPodName, testutils.K8S_TEST_NS, "", cniContainerIDX)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Assert that the endpoint is created in the backend datastore with ContainerID "X".
@@ -2255,10 +2282,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(endpoints.Items).Should(HaveLen(1))
 			idsX := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  cniContainerIDX,
 			}
 			wrkloadX, err := idsX.CalculateWorkloadEndpointName(false)
@@ -2276,7 +2303,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Delete the container with container ID "X".
-			exitCode, err := testutils.DeleteContainerWithId(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, cniContainerIDX)
+			exitCode, err := testutils.DeleteContainerWithId(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, cniContainerIDX)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(exitCode).Should(Equal(0))
 
@@ -2288,7 +2315,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// ADD a new container with passing a container ID "Y".
-			_, _, _, _, _, contNs, err = testutils.CreateContainerWithId(netconf, name, testutils.K8S_TEST_NS, "", cniContainerIDY)
+			_, _, _, _, _, contNs, err = testutils.CreateContainerWithId(netconf, testPodName, testutils.K8S_TEST_NS, "", cniContainerIDY)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Assert that the endpoint is created in the backend datastore with ContainerID "Y".
@@ -2296,10 +2323,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(endpoints.Items).Should(HaveLen(1))
 			idsY := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  cniContainerIDY,
 			}
 			wrkloadY, err := idsY.CalculateWorkloadEndpointName(false)
@@ -2317,7 +2344,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Delete the container with container ID "X" again.
-			exitCode, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, cniContainerIDX)
+			exitCode, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, cniContainerIDX)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(exitCode).Should(Equal(0))
 
@@ -2337,7 +2364,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Finally, delete the container with container ID "Y".
-			exitCode, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, cniContainerIDY)
+			exitCode, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, cniContainerIDY)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(exitCode).Should(Equal(0))
 		})
@@ -2349,7 +2376,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 		// - CNI DEL using containerIDY (should actually delete the container)
 		It("should handle deletes for stale container IDs", func() {
 			// ADD the container with passing a CNI_CONTAINERID of "X".
-			_, _, _, _, _, _, err := testutils.CreateContainerWithId(netconf, name, testutils.K8S_TEST_NS, "", cniContainerIDX)
+			_, _, _, _, _, _, err := testutils.CreateContainerWithId(netconf, testPodName, testutils.K8S_TEST_NS, "", cniContainerIDX)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Assert that the endpoint is created in the backend datastore with ContainerID "X".
@@ -2357,10 +2384,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(endpoints.Items).Should(HaveLen(1))
 			idsX := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  cniContainerIDX,
 			}
 			wrkloadX, err := idsX.CalculateWorkloadEndpointName(false)
@@ -2377,7 +2404,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// ADD the container with passing a CNI_CONTAINERID of "Y"
-			_, _, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, name, testutils.K8S_TEST_NS, "", cniContainerIDY)
+			_, _, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, testPodName, testutils.K8S_TEST_NS, "", cniContainerIDY)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Assert that the endpoint is created in the backend datastore with ContainerID "Y".
@@ -2385,10 +2412,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(endpoints.Items).Should(HaveLen(1))
 			idsY := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  cniContainerIDY,
 			}
 			wrkloadY, err := idsY.CalculateWorkloadEndpointName(false)
@@ -2405,7 +2432,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Delete the container with the CNI_CONTAINERID "X".
-			exitCode, err := testutils.DeleteContainerWithId(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, cniContainerIDX)
+			exitCode, err := testutils.DeleteContainerWithId(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, cniContainerIDX)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(exitCode).Should(Equal(0))
 
@@ -2425,7 +2452,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			}
 
 			// Delete the container with the CNI_CONTAINERID "Y".
-			exitCode, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, cniContainerIDY)
+			exitCode, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, cniContainerIDY)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(exitCode).Should(Equal(0))
 
@@ -2472,7 +2499,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			ncb, err := json.Marshal(nc)
@@ -2484,19 +2512,19 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: name,
+						Name: testPodName,
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name:  name,
+							Name:  testPodName,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 
 			// Run the CNI plugin.
-			containerID, result, _, _, _, contNs, err = testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, result, _, _, _, contNs, err = testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// The endpoint is created in etcd
@@ -2504,10 +2532,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(endpoints.Items).Should(HaveLen(1))
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 			workloadName, err = ids.CalculateWorkloadEndpointName(false)
@@ -2528,15 +2556,15 @@ var _ = Describe("Kubernetes CNI tests", func() {
 		})
 
 		AfterEach(func() {
-			_, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, containerID)
+			_, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, containerID)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 		})
 
 		It("a second ADD for the same container should work, assigning a new IP", func() {
 			// Try to create the same pod with a different container (so CNI receives the ADD for the same endpoint again)
-			resultSecondAdd, _, _, _, err := testutils.RunCNIPluginWithId(netconf, name, testutils.K8S_TEST_NS, "", "new-container-id", "eth0", contNs)
+			resultSecondAdd, _, _, _, err := testutils.RunCNIPluginWithId(netconf, testPodName, testutils.K8S_TEST_NS, "", "new-container-id", "eth0", contNs)
 			Expect(err).NotTo(HaveOccurred())
 
 			// The IP addresses shouldn't be the same, since we'll reassign one.
@@ -2574,7 +2602,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			It("a second ADD should fail, but not clean up the original IPAM allocation", func() {
 				// Try to create the same container (so CNI receives the ADD for the same endpoint again)
 				// Use a different container ID but the same Pod Name/Namespace
-				_, _, _, _, err := testutils.RunCNIPluginWithId(netconf, name, testutils.K8S_TEST_NS, "", "new-container-id", "eth0", contNs)
+				_, _, _, _, err := testutils.RunCNIPluginWithId(netconf, testPodName, testutils.K8S_TEST_NS, "", "new-container-id", "eth0", contNs)
 				Expect(err).Should(HaveOccurred())
 
 				// IPAM reservation should still be in place.
@@ -2589,7 +2617,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 	})
 
 	Context("Create a container then send another ADD for the same container but with a different interface", func() {
-		netconf := fmt.Sprintf(`
+		var netconf string
+		BeforeEach(func() {
+			netconf = fmt.Sprintf(`
 				{
 				  "cniVersion": "%s",
 				  "name": "net10",
@@ -2604,9 +2634,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				  "kubernetes": {
 				    "kubeconfig": "/home/user/certs/kubeconfig"
 				  },
-				  "policy": {"type": "k8s"}
-				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
-
+				  "policy": {"type": "k8s"},
+				  "nodename": "%s"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
+		})
 		It("should successfully execute both ADDs but for second ADD will return the same result as the first time but it won't network the container", func() {
 			// Create a new ipPool.
 			testutils.MustCreateNewIPPool(calicoClient, "10.0.0.0/24", false, false, true)
@@ -2615,32 +2646,32 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			// Create two k8s pods - for this test we want to ensure that the names for the pods
 			// look alike to make sure we handle pods with very similar names.
-			name2 := fmt.Sprintf("%s-1", name)
+			name2 := fmt.Sprintf("%s-1", testPodName)
 
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: name,
+						Name: testPodName,
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name:  name,
+							Name:  testPodName,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 
 			// Create the container, which will call CNI and by default it will create the container with interface name 'eth0'.
-			containerID, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			// Make sure the pod gets cleaned up, whether we fail or not.
 			expectedIfaceName := "eth0"
 			defer func() {
-				_, err := testutils.DeleteContainerWithIdAndIfaceName(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, containerID, expectedIfaceName)
+				_, err := testutils.DeleteContainerWithIdAndIfaceName(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, containerID, expectedIfaceName)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+				ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 			}()
 
 			// The endpoint is created in etcd
@@ -2649,10 +2680,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(endpoints.Items).Should(HaveLen(1))
 
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 
@@ -2673,7 +2704,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			// Try to create the same container but with a different endpoint (container interface name 'eth1'),
 			// so CNI receives the ADD for the same containerID but different endpoint.
-			_, _, _, _, err = testutils.RunCNIPluginWithId(netconf, name, testutils.K8S_TEST_NS, "", containerID, "eth1", contNs)
+			_, _, _, _, err = testutils.RunCNIPluginWithId(netconf, testPodName, testutils.K8S_TEST_NS, "", containerID, "eth1", contNs)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// If the above command succeeds, the CNI plugin will have renamed the container side of the
@@ -2712,7 +2743,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 							Name:  name2,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 
@@ -2747,7 +2778,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			// Construct the workloadendpoint name for the second pod.
 			ids2 := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
 				Pod:          name2,
@@ -2795,7 +2826,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			ncb, err := json.Marshal(nc)
@@ -2811,7 +2843,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 			testutils.MustDeleteIPPool(calicoClient, pool)
 		})
@@ -2842,10 +2874,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			// Create a K8s pod with the service account
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: name},
+				ObjectMeta: metav1.ObjectMeta{Name: testPodName},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  fmt.Sprintf("container-%s", name),
+						Name:  fmt.Sprintf("container-%s", testPodName),
 						Image: "ignore",
 						Ports: []v1.ContainerPort{{
 							Name:          "anamedport",
@@ -2853,10 +2885,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 						}},
 					}},
 					ServiceAccountName: saName,
-					NodeName:           hostname,
+					NodeName:           testNodeName,
 				},
 			})
-			containerID, result, contVeth, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, result, contVeth, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			mac := contVeth.Attrs().HardwareAddr
@@ -2864,15 +2896,15 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(len(result.IPs)).Should(Equal(1))
 
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 
 			wrkload, err := ids.CalculateWorkloadEndpointName(false)
-			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, name)
+			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, testPodName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// The endpoint is created
@@ -2894,12 +2926,12 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				"projectcalico.org/orchestrator":   api.OrchestratorKubernetes,
 			}))
 			Expect(endpoints.Items[0].Spec).Should(Equal(libapi.WorkloadEndpointSpec{
-				Pod:                name,
+				Pod:                testPodName,
 				InterfaceName:      interfaceName,
 				IPNetworks:         []string{result.IPs[0].Address.String()},
 				MAC:                mac.String(),
 				Profiles:           []string{"kns.test", "ksa.test." + saName},
-				Node:               hostname,
+				Node:               testNodeName,
 				Endpoint:           "eth0",
 				ServiceAccountName: saName,
 				Workload:           "",
@@ -2916,7 +2948,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			err = checkInterfaceConfig(interfaceName, "4")
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			if os.Getenv("DATASTORE_TYPE") != "kubernetes" {
@@ -2959,7 +2991,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Kubernetes:           types.Kubernetes{Kubeconfig: "/home/user/certs/kubeconfig"},
 				Policy:               types.Policy{PolicyType: "k8s"},
 				NodenameFileOptional: true,
-				LogLevel:             "info",
+				LogLevel:             "debug",
+				Nodename:             testNodeName,
 			}
 			nc.IPAM.Type = "calico-ipam"
 			ncb, err := json.Marshal(nc)
@@ -2975,7 +3008,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 		AfterEach(func() {
 			// Delete pod
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 
 			testutils.MustDeleteIPPool(calicoClient, pool)
 		})
@@ -2988,30 +3021,30 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			generateName := "test-gen-name"
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS, &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:         name,
+					Name:         testPodName,
 					GenerateName: generateName,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  fmt.Sprintf("container-%s", name),
+						Name:  fmt.Sprintf("container-%s", testPodName),
 						Image: "ignore",
 						Ports: []v1.ContainerPort{{
 							Name:          "anamedport",
 							ContainerPort: 555,
 						}},
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 
-			containerID, result, contVeth, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, result, contVeth, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			ids := names.WorkloadEndpointIdentifiers{
-				Node:         hostname,
+				Node:         testNodeName,
 				Orchestrator: api.OrchestratorKubernetes,
 				Endpoint:     "eth0",
-				Pod:          name,
+				Pod:          testPodName,
 				ContainerID:  containerID,
 			}
 
@@ -3019,7 +3052,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			mac := contVeth.Attrs().HardwareAddr
-			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, name)
+			interfaceName := k8sconversion.NewConverter().VethNameForWorkload(testutils.K8S_TEST_NS, testPodName)
 
 			// The endpoint is created
 			endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -3044,13 +3077,13 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			// Let's just check that the Spec is good too.
 			Expect(endpoints.Items[0].Spec).Should(Equal(libapi.WorkloadEndpointSpec{
-				Pod:                name,
+				Pod:                testPodName,
 				InterfaceName:      interfaceName,
 				ServiceAccountName: "default",
 				IPNetworks:         []string{result.IPs[0].Address.String()},
 				MAC:                mac.String(),
 				Profiles:           []string{"kns.test", "ksa.test.default"},
-				Node:               hostname,
+				Node:               testNodeName,
 				Endpoint:           "eth0",
 				Workload:           "",
 				ContainerID:        containerID,
@@ -3066,13 +3099,15 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			err = checkInterfaceConfig(interfaceName, "4")
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+			_, err = testutils.DeleteContainer(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
 	Context("using bogus readiness_gates", func() {
-		netconf := fmt.Sprintf(`
+		var netconf string
+		BeforeEach(func() {
+			netconf = fmt.Sprintf(`
 				{
 				  "cniVersion": "%s",
 				  "name": "net10",
@@ -3088,9 +3123,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				  "kubernetes": {
 				    "kubeconfig": "/home/user/certs/kubeconfig"
 				  },
-				  "policy": {"type": "k8s"}
-				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
-
+				  "policy": {"type": "k8s"},
+				  "nodename": "%s"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
+		})
 		It("should fail container creation", func() {
 			// Create a new ipPool.
 			testutils.MustCreateNewIPPool(calicoClient, "10.0.0.0/24", false, false, true)
@@ -3101,25 +3137,25 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: name,
+						Name: testPodName,
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name:  name,
+							Name:  testPodName,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 
 			// Create the container, which will call CNI and by default it will create the container with interface name 'eth0'.
-			containerID, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).Should(HaveOccurred())
 			// Make sure the pod gets cleaned up, whether we fail or not.
 			expectedIfaceName := "eth0"
-			_, err = testutils.DeleteContainerWithIdAndIfaceName(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, containerID, expectedIfaceName)
+			_, err = testutils.DeleteContainerWithIdAndIfaceName(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, containerID, expectedIfaceName)
 			Expect(err).ShouldNot(HaveOccurred())
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 		})
 	})
 
@@ -3149,8 +3185,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				  "kubernetes": {
 				    "kubeconfig": "/home/user/certs/kubeconfig"
 				  },
-				  "policy": {"type": "k8s"}
-				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testEndpoint)
+				  "policy": {"type": "k8s"},
+				  "nodename": "%s"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testEndpoint, testNodeName)
 		})
 
 		AfterEach(func() {
@@ -3167,25 +3204,25 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			ensurePodCreated(clientset, testutils.K8S_TEST_NS,
 				&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: name,
+						Name: testPodName,
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name:  name,
+							Name:  testPodName,
 							Image: "ignore",
 						}},
-						NodeName: hostname,
+						NodeName: testNodeName,
 					},
 				})
 
 			// Create the container, which will call CNI and by default it will create the container with interface name 'eth0'.
-			containerID, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+			containerID, _, _, _, _, contNs, err := testutils.CreateContainer(netconf, testPodName, testutils.K8S_TEST_NS, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			// Make sure the pod gets cleaned up, whether we fail or not.
 			expectedIfaceName := "eth0"
-			_, err = testutils.DeleteContainerWithIdAndIfaceName(netconf, contNs.Path(), name, testutils.K8S_TEST_NS, containerID, expectedIfaceName)
+			_, err = testutils.DeleteContainerWithIdAndIfaceName(netconf, contNs.Path(), testPodName, testutils.K8S_TEST_NS, containerID, expectedIfaceName)
 			Expect(err).ShouldNot(HaveOccurred())
-			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
+			ensurePodDeleted(clientset, testutils.K8S_TEST_NS, testPodName)
 		})
 	})
 
@@ -3207,8 +3244,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
-			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+			  "log_level":"debug",
+			  "nodename": "%s"
+			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")
 			stdin, err := c.StdinPipe()
@@ -3243,8 +3281,9 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			  },
 			  "policy": {"type": "k8s"},
 			  "nodename_file_optional": true,
-			  "log_level":"info"
-			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+			  "log_level":"debug",
+			  "nodename": "%s"
+			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
 			pluginPath := fmt.Sprintf("%s/%s", os.Getenv("BIN"), os.Getenv("PLUGIN"))
 			c := exec.Command(pluginPath, "-t")
 			stdin, err := c.StdinPipe()
@@ -3262,46 +3301,29 @@ var _ = Describe("Kubernetes CNI tests", func() {
 	})
 
 	Describe("using hwAddr annotations to assign a fixed MAC address to a container veth", func() {
-
-		calicoClient, err := client.NewFromEnv()
-		Expect(err).NotTo(HaveOccurred())
-		k8sClient := getKubernetesClient()
-		netconf := fmt.Sprintf(`
-			{
-			  "cniVersion": "%s",
-			  "name": "net1",
-			  "type": "calico",
-			  "etcd_endpoints": "http://%s:2379",
-			  "datastore_type": "%s",
-			  "ipam": {
-			    "type": "host-local",
-			    "subnet": "10.0.0.0/8"
-			  },
-			  "kubernetes": {
-			    "kubeconfig": "/home/user/certs/kubeconfig"
-			  },
-			  "policy": {"type": "k8s"},
-			  "nodename_file_optional": true,
-			  "log_level":"debug"
-			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+		var netconf string
 		var name string
-
 		BeforeEach(func() {
-			testutils.WipeDatastore()
-			nodeName, err := names.Hostname()
-			Expect(err).NotTo(HaveOccurred())
-			err = testutils.AddNode(calicoClient, k8sClient, nodeName)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Generate a name to use for the test's pod.
-			name = podName("test-pod")
-		})
-
-		AfterEach(func() {
-			name, err := names.Hostname()
-			Expect(err).NotTo(HaveOccurred())
-			err = testutils.DeleteNode(calicoClient, k8sClient, name)
-			Expect(err).NotTo(HaveOccurred())
+			netconf = fmt.Sprintf(`
+				{
+				  "cniVersion": "%s",
+				  "name": "net1",
+				  "type": "calico",
+				  "etcd_endpoints": "http://%s:2379",
+				  "datastore_type": "%s",
+				  "ipam": {
+					"type": "host-local",
+					"subnet": "10.0.0.0/8"
+				  },
+				  "kubernetes": {
+					"kubeconfig": "/home/user/certs/kubeconfig"
+				  },
+				  "policy": {"type": "k8s"},
+				  "nodename_file_optional": true,
+				  "log_level":"debug",
+				  "nodename": "%s"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
+			name = prefixName("test-pod")
 		})
 
 		It("annotation containing a valid MAC address", func() {
@@ -3321,7 +3343,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 						Name:  name,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)
@@ -3349,10 +3371,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:  name,
+						Name:  testPodName,
 						Image: "ignore",
 					}},
-					NodeName: hostname,
+					NodeName: testNodeName,
 				},
 			})
 			defer ensurePodDeleted(clientset, testutils.K8S_TEST_NS, name)

--- a/cni-plugin/tests/calico_cni_k8s_test.go
+++ b/cni-plugin/tests/calico_cni_k8s_test.go
@@ -51,7 +51,7 @@ var counterByPrefix map[string]int
 // pefixName generates a new unique name with the given prefix.
 // We use an incrementing counter to ensure that a unique name
 // is generated each time the function is called.
-func prefixName(prefix string) string {
+func generateName(prefix string) string {
 	if counterByPrefix == nil {
 		counterByPrefix = make(map[string]int)
 	}
@@ -176,8 +176,8 @@ var _ = Describe("Kubernetes CNI tests", func() {
 		testutils.WipeDatastore()
 
 		// Generate a name to use for the test's pod and node.
-		testPodName = prefixName("test-pod")
-		testNodeName = prefixName(hostname)
+		testPodName = generateName("test-pod")
+		testNodeName = generateName(hostname)
 
 		// Create the node for these tests. The IPAM code requires a corresponding Calico node to exist.
 		err = testutils.AddNode(calicoClient, k8sClient, testNodeName)
@@ -683,7 +683,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: regexp.QuoteMeta("10."),
 				numIPv4IPs:      1,
 				numIPv6IPs:      0,
-				nodename:        prefixName(hostname),
+				nodename:        generateName(hostname),
 			},
 			{
 				// This scenario tests IPv4+IPv6 without specifying any routes.
@@ -731,7 +731,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: regexp.QuoteMeta("10."),
 				numIPv4IPs:      1,
 				numIPv6IPs:      1,
-				nodename:        prefixName(hostname),
+				nodename:        generateName(hostname),
 			},
 			{
 				// This scenario tests IPv4+IPv6 without specifying any routes.
@@ -779,7 +779,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: regexp.QuoteMeta("10."),
 				numIPv4IPs:      1,
 				numIPv6IPs:      1,
-				nodename:        prefixName(hostname),
+				nodename:        generateName(hostname),
 			},
 			{
 				// In this scenario, we use a lot more of the host-local IPAM plugin.  Namely:
@@ -842,7 +842,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				unexpectedRoute: "default",
 				numIPv4IPs:      2,
 				numIPv6IPs:      1,
-				nodename:        prefixName(hostname),
+				nodename:        generateName(hostname),
 			},
 			{
 				// In this scenario, we use a lot more of the host-local IPAM plugin.  Namely:
@@ -904,7 +904,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				},
 				numIPv4IPs: 2,
 				numIPv6IPs: 1,
-				nodename:   prefixName(hostname),
+				nodename:   generateName(hostname),
 			},
 		}
 
@@ -3323,7 +3323,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				  "log_level":"debug",
 				  "nodename": "%s"
 				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"), testNodeName)
-			name = prefixName("test-pod")
+			name = generateName("test-pod")
 		})
 
 		It("annotation containing a valid MAC address", func() {


### PR DESCRIPTION
Cherry pick of #8798 on release-v3.28.

#8798: Fix flake CORE-10163: controller-manager GC races with

# Original PR Body below

## Description

Avoids race by uniquely naming a new node for each test.

Enable debug logging for all CNI configs.

Also removes duplicated setup in some tests

CORE-10163

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.