### PR TITLE
[BPF] fix forwarding and NATing of ICMP related messages

### DIFF
--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -190,14 +190,18 @@ enum calico_skb_mark {
 	CALI_SKB_MARK_CT_ESTABLISHED         = 0x08000000,
 	CALI_SKB_MARK_CT_ESTABLISHED_MASK    = 0x08000000,
 
-       /* CALI_SKB_MARK_TO_NAT_IFACE_OUT signals to routing that this packet should to
-        * to the bpfnatout interface.
-        */
-       CALI_SKB_MARK_TO_NAT_IFACE_OUT        = 0x41000000,
-       /* CALI_SKB_MARK_FROM_NAT_IFACE_OUT signals to the next hop that the packet passed
-	* through bpfnatout so that it can set its conntrack correctly.
-	*/
-       CALI_SKB_MARK_FROM_NAT_IFACE_OUT      = 0x81000000,
+	/* CALI_SKB_MARK_RELATED_RESOLVED mean it is related traffic, we already
+	 * know that and we have resolved NAT etc.
+	 */
+	CALI_SKB_MARK_RELATED_RESOLVED        = 0x11000000,
+	/* CALI_SKB_MARK_TO_NAT_IFACE_OUT signals to routing that this packet should to
+	 * to the bpfnatout interface.
+	 */
+	CALI_SKB_MARK_TO_NAT_IFACE_OUT        = 0x41000000,
+	/* CALI_SKB_MARK_FROM_NAT_IFACE_OUT signals to the next hop that the packet passed
+	 * through bpfnatout so that it can set its conntrack correctly.
+	 */
+	CALI_SKB_MARK_FROM_NAT_IFACE_OUT      = 0x81000000,
 
 };
 

--- a/felix/bpf-gpl/bpf.h
+++ b/felix/bpf-gpl/bpf.h
@@ -190,10 +190,11 @@ enum calico_skb_mark {
 	CALI_SKB_MARK_CT_ESTABLISHED         = 0x08000000,
 	CALI_SKB_MARK_CT_ESTABLISHED_MASK    = 0x08000000,
 
+	CALI_SKB_MARK_RESERVED                = 0x11000000,
 	/* CALI_SKB_MARK_RELATED_RESOLVED mean it is related traffic, we already
 	 * know that and we have resolved NAT etc.
 	 */
-	CALI_SKB_MARK_RELATED_RESOLVED        = 0x11000000,
+	CALI_SKB_MARK_RELATED_RESOLVED        = 0x21000000,
 	/* CALI_SKB_MARK_TO_NAT_IFACE_OUT signals to routing that this packet should to
 	 * to the bpfnatout interface.
 	 */

--- a/felix/bpf-gpl/conntrack_types.h
+++ b/felix/bpf-gpl/conntrack_types.h
@@ -204,10 +204,11 @@ enum calico_ct_result_type {
 #define CT_RES_SYN		0x1000
 #define CT_RES_CONFIRMED	0x2000
 
-#define ct_result_rc(rc)		((rc) & 0xff)
-#define ct_result_flags(rc)		((rc) & ~0xff)
-#define ct_result_set_rc(val, rc)	((val) = ct_result_flags(val) | (rc))
-#define ct_result_set_flag(val, flags)	((val) |= (flags))
+#define ct_result_rc(rc)			((rc) & 0xff)
+#define ct_result_flags(rc)			((rc) & ~0xff)
+#define ct_result_set_rc(val, rc)		((val) = ct_result_flags(val) | (rc))
+#define ct_result_set_flag(val, flags)		((val) |= (flags))
+#define ct_result_clear_flag(val, flags)	((val) &= ~(flags))
 
 #define ct_result_is_related(rc)	((rc) & CT_RES_RELATED)
 #define ct_result_rpf_failed(rc)	((rc) & CT_RES_RPF_FAILED)

--- a/felix/bpf-gpl/nat.h
+++ b/felix/bpf-gpl/nat.h
@@ -119,6 +119,11 @@ static CALI_BPF_INLINE int skb_nat_l4_csum(struct cali_tc_ctx *ctx, size_t off,
 
 	/* If the IPs have changed we must replace it as part of the pseudo header that is
 	 * used to calculate L4 csum.
+	 *
+	 * If we are fixing inner ICMP payload, we do not change L4 csum for the payload
+	 * (no need for that, it is just a fraction of the packet), but the L4 here is the
+	 * ICMP itself since its payload has changed. ICMPv4 does not include the pseudo
+	 * header in the csum and v6 had it already fixed when we modified the outer IP.
 	 */
 	if (csum_update) {
 		ret = bpf_l4_csum_replace(skb, off, 0, csum, flags | (inner_icmp ? 0 : BPF_F_PSEUDO_HDR));

--- a/felix/bpf-gpl/parsing4.h
+++ b/felix/bpf-gpl/parsing4.h
@@ -64,7 +64,7 @@ static CALI_BPF_INLINE int parse_packet_ip_v4(struct cali_tc_ctx *ctx)
 	}
 #endif
 
-	CALI_DEBUG("IP id=%d\n",bpf_ntohs(ip_hdr(ctx)->id));
+	CALI_DEBUG("IP id=%d len=%d\n",bpf_ntohs(ip_hdr(ctx)->id), bpf_htons(ip_hdr(ctx)->tot_len));
 	CALI_DEBUG("IP s=%x d=%x\n", bpf_ntohl(ip_hdr(ctx)->saddr), bpf_ntohl(ip_hdr(ctx)->daddr));
 	// Drop malformed IP packets
 	if (ip_hdr(ctx)->ihl < 5) {

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1502,7 +1502,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 					CALI_DEBUG("ICMP related: outer IP SNAT to %x\n",
 							debug_ip(state->ct_result.nat_ip));
 				}
-			} if (ct_rc == CALI_CT_ESTABLISHED_DNAT) {
+			} else if (ct_rc == CALI_CT_ESTABLISHED_DNAT) {
 				outer_ip_nat = true;
 				addr = &STATE->ip_dst;
 				ip_hdr_set_ip(ctx, daddr, state->ct_result.nat_ip);

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1437,7 +1437,7 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 
 	// Set the dport to 0, to make sure conntrack entries for icmp is proper as we use
 	// dport to hold icmp type and code
-	if (state->ip_proto == IPPROTO_ICMP_46) {
+	if (state->ip_proto == IPPROTO_ICMP_46 && !ct_related) {
 		state->dport = 0;
 		state->post_nat_dport = 0;
 	}
@@ -1476,34 +1476,49 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	l3_csum_off = skb_iphdr_offset(ctx) + offsetof(struct iphdr, check);
 #endif
 
-	if (ct_related) {
+	if (ct_related && skb_mark_equals(ctx->skb, CALI_SKB_MARK_RELATED_RESOLVED, CALI_SKB_MARK_RELATED_RESOLVED)) {
+		ct_rc = CALI_CT_ESTABLISHED;
+	} else if (ct_related &&
+			/* I CALI_CT_FLAG_NP_FWD is set, we need to forward the related response
+			 * to the node that has the backend and will deal with the rest.
+			 */
+			!(CALI_F_FROM_HEP && ctx->state->ct_result.flags & CALI_CT_FLAG_NP_FWD)) {
 		if (ctx->state->ip_proto == IPPROTO_ICMP_46) {
-			bool outer_ip_snat;
+			bool outer_ip_nat = false;
+			ipv46_addr_t *addr;
 
-			/* if we do SNAT ... */
-			outer_ip_snat = ct_rc == CALI_CT_ESTABLISHED_SNAT;
-			/* ... there is a return path to the tunnel ... */
-			outer_ip_snat = outer_ip_snat && !ip_void(state->ct_result.tun_ip);
-			/* ... and should do encap and it is not DSR or it is leaving host
-			 * and either DSR from WEP or originated at host ... */
-			outer_ip_snat = outer_ip_snat &&
-				((dnat_return_should_encap() && !CALI_F_DSR) ||
-				 (CALI_F_TO_HEP &&
-				  ((CALI_F_DSR && skb_seen(ctx->skb)) || !skb_seen(ctx->skb))));
+			if (ct_rc == CALI_CT_ESTABLISHED_SNAT) {
+				/* ... there is a return path to the tunnel ... */
+				outer_ip_nat = !ip_void(state->ct_result.tun_ip);
+				/* ... and should do encap and it is not DSR or it is leaving host
+				 * and either DSR from WEP or originated at host ... */
+				outer_ip_nat = outer_ip_nat &&
+					((dnat_return_should_encap() && !CALI_F_DSR) ||
+					 (CALI_F_TO_HEP &&
+					  ((CALI_F_DSR && skb_seen(ctx->skb)) || !skb_seen(ctx->skb))));
+				if (outer_ip_nat) {
+					addr = &STATE->ip_src;
+					ip_hdr_set_ip(ctx, saddr, state->ct_result.nat_ip);
+					CALI_DEBUG("ICMP related: outer IP SNAT to %x\n",
+							debug_ip(state->ct_result.nat_ip));
+				}
+			} if (ct_rc == CALI_CT_ESTABLISHED_DNAT) {
+				outer_ip_nat = true;
+				addr = &STATE->ip_dst;
+				ip_hdr_set_ip(ctx, daddr, state->ct_result.nat_ip);
+				CALI_DEBUG("ICMP related: outer IP DNAT to %x\n",
+						debug_ip(state->ct_result.nat_ip));
+			}
 
 			/* ... then fix the outer header IP first */
-			if (outer_ip_snat) {
-				ip_hdr_set_ip(ctx, saddr, state->ct_result.nat_ip);
+			if (outer_ip_nat) {
 #ifdef IPVER6
 				/* ... icmp6 checksum now includes pseudo header, fix it! */
 				l4_csum_off = skb_l4hdr_offset(ctx) + offsetof(struct icmp6hdr, icmp6_cksum);
 
 				__wsum csum = 0;
-				csum = bpf_csum_diff((__u32*)&STATE->ip_src, sizeof(ipv6_addr_t),
+				csum = bpf_csum_diff((__u32*)addr, sizeof(ipv6_addr_t),
 						     (__u32*)&STATE->ct_result.nat_ip, sizeof(ipv6_addr_t),
-						     csum);
-				csum = bpf_csum_diff((__u32*)&STATE->ip_dst, sizeof(ipv6_addr_t),
-						     (__u32*)&STATE->ct_result.nat_sip, sizeof(ipv6_addr_t),
 						     csum);
 				int res = bpf_l4_csum_replace(ctx->skb, l4_csum_off, 0, csum,  BPF_F_PSEUDO_HDR);
 				if (res) {
@@ -1512,14 +1527,12 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 				}
 #else
 				int res = bpf_l3_csum_replace(ctx->skb, l3_csum_off,
-						state->ip_src, state->ct_result.nat_ip, 4);
+						*addr, state->ct_result.nat_ip, 4);
 				if (res) {
 					deny_reason(ctx, CALI_REASON_CSUM_FAIL);
 					goto deny;
 				}
 #endif
-				CALI_DEBUG("ICMP related: outer IP SNAT to %x\n",
-						debug_ip(state->ct_result.nat_ip));
 			}
 
 			/* Related ICMP traffic must be an error response so it should include inner IP
@@ -1699,6 +1712,10 @@ int calico_tc_skb_icmp_inner_nat(struct __sk_buff *skb)
 				if (CALI_F_DSR) {
 					/* SNAT will be done after routing, when leaving HEP */
 					CALI_DEBUG("DSR enabled, skipping SNAT + encap\n");
+					/* Don't treat it as related anymore as we defer
+					 * that. This will not set CALI_SKB_MARK_RELATED_RESOLVED
+					 */
+					ct_result_clear_flag(STATE->ct_result.rc, CT_RES_RELATED);
 					goto allow;
 				}
 			}
@@ -1932,9 +1949,9 @@ allow:
 	ctx->state->flags |= CALI_ST_SKIP_POLICY;
 	CALI_JUMP_TO(ctx, PROG_INDEX_ALLOWED);
 	/* should not reach here */
-	CALI_DEBUG("Failed to jump to allow program.");
+	CALI_DEBUG("Failed to jump to allow program.\n");
 
 deny:
-	CALI_DEBUG("DENY due to policy");
+	CALI_DEBUG("DENY due to policy\n");
 	return TC_ACT_SHOT;
 }

--- a/felix/bpf/ut/icmp_related_test.go
+++ b/felix/bpf/ut/icmp_related_test.go
@@ -67,6 +67,7 @@ func TestICMPRelatedPlain(t *testing.T) {
 	defer func() { bpfIfaceName = "" }()
 
 	defer resetBPFMaps()
+	hostIP = node1ip
 
 	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
@@ -125,6 +126,7 @@ func TestICMPRelatedNATPodPod(t *testing.T) {
 	RegisterTestingT(t)
 
 	defer resetBPFMaps()
+	hostIP = node1ip
 
 	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
@@ -195,6 +197,7 @@ func TestICMPRelatedFromHost(t *testing.T) {
 	RegisterTestingT(t)
 
 	defer resetBPFMaps()
+	hostIP = node1ip
 
 	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
@@ -230,6 +233,7 @@ func TestICMPRelatedFromHostBeforeNAT(t *testing.T) {
 	RegisterTestingT(t)
 
 	defer resetBPFMaps()
+	hostIP = node1ip
 
 	_, ipv4, l4, _, pktBytes, err := testPacketUDPDefault()
 	Expect(err).NotTo(HaveOccurred())
@@ -297,8 +301,10 @@ func TestICMPRelatedFromHostBeforeNAT(t *testing.T) {
 }
 
 func makeICMPError(ipInner *layers.IPv4, l4 gopacket.SerializableLayer, icmpType, icmpCode uint8) []byte {
-	hostIP = node1ip
+	return makeICMPErrorFrom(node1ip, ipInner, l4, icmpType, icmpCode)
+}
 
+func makeICMPErrorFrom(from net.IP, ipInner *layers.IPv4, l4 gopacket.SerializableLayer, icmpType, icmpCode uint8) []byte {
 	payloadBuf := gopacket.NewSerializeBuffer()
 	err := gopacket.SerializeLayers(payloadBuf, gopacket.SerializeOptions{}, ipInner, l4)
 	Expect(err).NotTo(HaveOccurred())
@@ -317,7 +323,7 @@ func makeICMPError(ipInner *layers.IPv4, l4 gopacket.SerializableLayer, icmpType
 		IHL:      5,
 		TTL:      64,
 		Flags:    layers.IPv4DontFragment,
-		SrcIP:    hostIP,
+		SrcIP:    from,
 		DstIP:    ipInner.SrcIP,
 		Protocol: layers.IPProtocolICMPv4,
 		Length:   uint16(20 + 8 + len(payload)),

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -812,7 +812,7 @@ func TestNATNodePort(t *testing.T) {
 	var icmpEncaped []byte
 
 	skbMark = 0
-	// ICMP to big response from internet towards the backend on node1 from some middle box
+	// ICMP too big response from internet towards the backend on node1 from some middle box
 	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 		pktR := gopacket.NewPacket(icmpMTUTooBig, layers.LayerTypeEthernet, gopacket.Default)
 		fmt.Printf("pktR = %+v\n", pktR)

--- a/felix/bpf/ut/nat_test.go
+++ b/felix/bpf/ut/nat_test.go
@@ -678,6 +678,7 @@ func TestNATNodePort(t *testing.T) {
 	})
 
 	dumpCTMap(ctMap)
+	host2CT := saveCTMap(ctMap)
 	resetCTMap(ctMap)
 	restoreCTMap(ctMap, fromHostCT)
 	dumpCTMap(ctMap)
@@ -735,6 +736,8 @@ func TestNATNodePort(t *testing.T) {
 		Expect(res.Retval).To(Equal(resTC_ACT_SHOT))
 	})
 
+	var icmpMTUTooBig []byte
+
 	skbMark = saveMark
 	// Response leaving to original source
 	runBpfTest(t, "calico_to_host_ep", nil, func(bpfrun bpfProgRunFn) {
@@ -763,6 +766,17 @@ func TestNATNodePort(t *testing.T) {
 		// Approved for both sides due to forwarding through the tunnel
 		Expect(ctr.Data().A2B.Approved).To(BeTrue())
 		Expect(ctr.Data().B2A.Approved).To(BeTrue())
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		Expect(ipv4L).NotTo(BeNil())
+		ipv4R := ipv4L.(*layers.IPv4)
+
+		udpL := pktR.Layer(layers.LayerTypeUDP)
+		Expect(udpL).NotTo(BeNil())
+		udpR := udpL.(*layers.UDP)
+
+		icmpMTUTooBig = makeICMPErrorFrom(net.ParseIP("69.69.69.69"), ipv4R, udpR,
+			layers.ICMPv4TypeDestinationUnreachable, layers.ICMPv4CodeFragmentationNeeded)
 	})
 
 	dumpCTMap(ctMap)
@@ -795,8 +809,50 @@ func TestNATNodePort(t *testing.T) {
 		checkVxlanEncap(pktR, false, ipv4, udp, payload)
 	})
 
+	var icmpEncaped []byte
+
 	skbMark = 0
-	// Another pkt iwith a different source port arriving at node 1
+	// ICMP to big response from internet towards the backend on node1 from some middle box
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		pktR := gopacket.NewPacket(icmpMTUTooBig, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		payloadL := pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+
+		pktR = gopacket.NewPacket(payloadL.Payload(), layers.LayerTypeIPv4, gopacket.Default)
+		fmt.Printf("ICMP = %+v\n", pktR)
+
+		res, err := bpfrun(icmpMTUTooBig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR = gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+		payloadL = pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+		vxlanL := gopacket.NewPacket(payloadL.Payload(), layers.LayerTypeVXLAN, gopacket.Default)
+		Expect(vxlanL).NotTo(BeNil())
+		fmt.Printf("vxlanL = %+v\n", vxlanL)
+
+		ethL := vxlanL.Layer(layers.LayerTypeEthernet)
+		Expect(ethL).NotTo(BeNil())
+
+		pktR = gopacket.NewPacket(ethL.LayerPayload(), layers.LayerTypeIPv4, gopacket.Default)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal("69.69.69.69"))
+		Expect(ipv4R.DstIP.String()).To(Equal(node1ip.String()))
+
+		icmpL := pktR.Layer(layers.LayerTypeICMPv4)
+		Expect(icmpL).NotTo(BeNil())
+
+		icmpEncaped = res.dataOut
+	})
+
+	skbMark = 0
+	// Another pkt with a different source port arriving at node 1
 	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
 
 		// Change the source port
@@ -829,6 +885,124 @@ func TestNATNodePort(t *testing.T) {
 	 * TEST that unknown VNI is passed through
 	 */
 	testUnrelatedVXLAN(4, t, node2ip, vni)
+
+	hostIP = node2ip
+
+	// change the routing - it is a local workload now!
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2wCIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalWorkload|routes.FlagInIPAMPool).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// we must know that the encaped packet src ip if from a known host
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node1CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsRemoteHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	err = rtMap.Update(
+		routes.NewKey(ip.CIDRFromIPNet(&node2CIDR).(ip.V4CIDR)).AsBytes(),
+		routes.NewValue(routes.FlagsLocalHost).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	dumpRTMap(rtMap)
+
+	restoreCTMap(ctMap, host2CT)
+	dumpCTMap(ctMap)
+
+	// now we are at the node with local workload
+	err = natMap.Update(
+		nat.NewNATKey(ipv4.DstIP, uint16(udp.DstPort), uint8(ipv4.Protocol)).AsBytes(),
+		nat.NewNATValue(0 /* id */, 1 /* count */, 1 /* local */, 0).AsBytes(),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// ICMP arriving at node 2
+	bpfIfaceName = "NP-2"
+
+	skbMark = 0
+	runBpfTest(t, "calico_from_host_ep", nil, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(icmpEncaped)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal("69.69.69.69"))
+		Expect(ipv4R.DstIP.String()).To(Equal(natIP.String()))
+
+		ethL := pktR.Layer(layers.LayerTypeEthernet)
+		Expect(ethL).NotTo(BeNil())
+		ethR := ethL.(*layers.Ethernet)
+
+		icmpL := pktR.Layer(layers.LayerTypeICMPv4)
+		Expect(icmpL).NotTo(BeNil())
+		icmpR := icmpL.(*layers.ICMPv4)
+
+		payloadL := pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+
+		pkt := gopacket.NewSerializeBuffer()
+		err = gopacket.SerializeLayers(pkt, gopacket.SerializeOptions{ComputeChecksums: true},
+			ethR, ipv4R, icmpR, gopacket.Payload(payloadL.Payload()))
+		Expect(err).NotTo(HaveOccurred())
+		pktBytes := pkt.Bytes()
+
+		Expect(res.dataOut).To(Equal(pktBytes))
+
+		pktR = gopacket.NewPacket(payloadL.Payload(), layers.LayerTypeIPv4, gopacket.Default)
+		fmt.Printf("ICMP = %+v\n", pktR)
+
+		ipv4L = pktR.Layer(layers.LayerTypeIPv4)
+		ipv4R = ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(natIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(srcIP.String()))
+
+		udpL := pktR.Layer(layers.LayerTypeUDP)
+		Expect(udpL).NotTo(BeNil())
+		udpR := udpL.(*layers.UDP)
+		Expect(udpR.SrcPort).To(Equal(layers.UDPPort(natPort)))
+		Expect(udpR.DstPort).To(Equal(layers.UDPPort(udpDefault.SrcPort)))
+
+		recvPkt = res.dataOut
+	})
+
+	// Arriving at workload at node 2
+	runBpfTest(t, "calico_to_workload_ep", rulesDefaultAllow, func(bpfrun bpfProgRunFn) {
+		res, err := bpfrun(recvPkt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Retval).To(Equal(resTC_ACT_UNSPEC))
+
+		pktR := gopacket.NewPacket(res.dataOut, layers.LayerTypeEthernet, gopacket.Default)
+		fmt.Printf("pktR = %+v\n", pktR)
+
+		ipv4L := pktR.Layer(layers.LayerTypeIPv4)
+		ipv4R := ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal("69.69.69.69"))
+		Expect(ipv4R.DstIP.String()).To(Equal(natIP.String()))
+
+		payloadL := pktR.ApplicationLayer()
+		Expect(payloadL).NotTo(BeNil())
+
+		pktR = gopacket.NewPacket(payloadL.Payload(), layers.LayerTypeIPv4, gopacket.Default)
+		fmt.Printf("ICMP = %+v\n", pktR)
+
+		ipv4L = pktR.Layer(layers.LayerTypeIPv4)
+		ipv4R = ipv4L.(*layers.IPv4)
+		Expect(ipv4R.SrcIP.String()).To(Equal(natIP.String()))
+		Expect(ipv4R.DstIP.String()).To(Equal(srcIP.String()))
+
+		udpL := pktR.Layer(layers.LayerTypeUDP)
+		Expect(udpL).NotTo(BeNil())
+		udpR := udpL.(*layers.UDP)
+		Expect(udpR.SrcPort).To(Equal(layers.UDPPort(natPort)))
+		Expect(udpR.DstPort).To(Equal(layers.UDPPort(udpDefault.SrcPort)))
+	})
 
 	// TEST host-networked backend
 	{

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -4040,13 +4040,13 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								tcpdump.Start("-vvv", "icmp", "or", "icmp6")
 								defer tcpdump.Stop()
 
-								ipRouteFlushlushCache := []string{"ip", "route", "flush", "cache"}
+								ipRouteFlushCache := []string{"ip", "route", "flush", "cache"}
 								if testOpts.ipv6 {
-									ipRouteFlushlushCache = []string{"ip", "-6", "route", "flush", "cache"}
+									ipRouteFlushCache = []string{"ip", "-6", "route", "flush", "cache"}
 								}
 
 								By("Trying directly to pod")
-								w[0][0].Exec(ipRouteFlushlushCache...)
+								w[0][0].Exec(ipRouteFlushCache...)
 								cc.Expect(Some, remoteWL, w[0][0], ExpectWithPorts(8055), ExpectWithRecvLen(1350))
 								cc.CheckConnectivity()
 								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
@@ -4054,7 +4054,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								By("Trying directly to node with pod")
 								cc.ResetExpectations()
 								tcpdump.ResetCount("mtu-1300")
-								w[0][0].Exec(ipRouteFlushlushCache...)
+								w[0][0].Exec(ipRouteFlushCache...)
 								cc.Expect(Some, remoteWL, TargetIP(felixIP(0)), ExpectWithPorts(npPort), ExpectWithRecvLen(1350))
 								cc.CheckConnectivity()
 								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
@@ -4062,7 +4062,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 								By("Trying to node without pod")
 								cc.ResetExpectations()
 								tcpdump.ResetCount("mtu-1300")
-								w[0][0].Exec(ipRouteFlushlushCache...)
+								w[0][0].Exec(ipRouteFlushCache...)
 								cc.Expect(Some, remoteWL, TargetIP(felixIP(1)), ExpectWithPorts(npPort), ExpectWithRecvLen(1350))
 								cc.CheckConnectivity()
 								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1194,7 +1194,11 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 			// We will use this container to model an external client trying to connect into
 			// workloads on a host.  Create a route in the container for the workload CIDR.
 			// TODO: Copied from another test
-			externalClient = infrastructure.RunExtClient("ext-client")
+			externalClient = infrastructure.RunExtClientWithOpts("ext-client",
+				infrastructure.ExtClientOpts{
+					IPv6Enabled: testOpts.ipv6,
+				},
+			)
 			_ = externalClient
 
 			err := infra.AddDefaultDeny()
@@ -3965,6 +3969,106 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 
 				Context("with test-service being a nodeport @ "+strconv.Itoa(int(npPort)), func() {
 					nodePortsTest(false, false)
+
+					if !testOpts.connTimeEnabled && testOpts.tunnel == "none" &&
+						testOpts.protocol == "tcp" && !testOpts.dsr {
+						Context("with small MTU between remote client and cluster", func() {
+							var remoteWL *workload.Workload
+
+							BeforeEach(func() {
+								remoteWL = &workload.Workload{
+									C:             externalClient,
+									Name:          "remoteWL",
+									InterfaceName: "ethwl",
+									Protocol:      testOpts.protocol,
+									MTU:           1500,
+								}
+
+								remoteWLIP := "192.168.15.15"
+								remoteWL.IP = remoteWLIP
+								if testOpts.ipv6 {
+									remoteWLIP = "dead:beef:1515::1515"
+									remoteWL.IP6 = remoteWLIP
+								}
+
+								err := remoteWL.Start()
+								Expect(err).NotTo(HaveOccurred())
+
+								if testOpts.ipv6 {
+									externalClient.Exec("ip", "-6", "route", "add", remoteWLIP, "dev",
+										remoteWL.InterfaceName, "scope", "link")
+									externalClient.Exec("ip", "-6", "route", "add", w[0][0].IP, "via", tc.Felixes[0].IPv6, "dev", "eth0")
+									externalClient.Exec("ip", "addr", "add", "169.254.169.254", "dev", remoteWL.InterfaceName)
+									// Need to change the MTU on the host side of the veth. If
+									// we change it on the eth0 of the docker iface, not ICMP
+									// is generated.
+									externalClient.Exec("ip", "link", "set", "ethwl", "mtu", "1300")
+									for _, f := range tc.Felixes {
+										f.Exec("ip", "-6", "route", "add", remoteWLIP,
+											"via", externalClient.IPv6, "dev", "eth0")
+									}
+								} else {
+									externalClient.Exec("ip", "route", "add", remoteWLIP, "dev",
+										remoteWL.InterfaceName, "scope", "link")
+									externalClient.Exec("ip", "route", "add", w[0][0].IP, "via", tc.Felixes[0].IP, "dev", "eth0")
+									externalClient.Exec("ip", "addr", "add", "169.254.169.254", "dev", remoteWL.InterfaceName)
+									// Need to change the MTU on the host side of the veth. If
+									// we change it on the eth0 of the docker iface, not ICMP
+									// is generated.
+									externalClient.Exec("ip", "link", "set", "ethwl", "mtu", "1300")
+									for _, f := range tc.Felixes {
+										f.Exec("ip", "route", "add", remoteWLIP,
+											"via", externalClient.IP, "dev", "eth0")
+									}
+								}
+
+								pol.Spec.Ingress = []api.Rule{
+									{
+										Action: "Allow",
+										Source: api.EntityRule{
+											Nets: []string{remoteWLIP + "/" + ipMask()},
+										},
+									},
+								}
+								pol = updatePolicy(pol)
+							})
+
+							It("should have connectivity to service backend", func() {
+								tcpdump := tc.Felixes[0].AttachTCPDump(w[0][0].InterfaceName)
+								tcpdump.SetLogEnabled(true)
+								tcpdump.AddMatcher("mtu-1300", regexp.MustCompile("mtu 1300"))
+								tcpdump.Start("-vvv", "icmp", "or", "icmp6")
+								defer tcpdump.Stop()
+
+								ipRouteFlushlushCache := []string{"ip", "route", "flush", "cache"}
+								if testOpts.ipv6 {
+									ipRouteFlushlushCache = []string{"ip", "-6", "route", "flush", "cache"}
+								}
+
+								By("Trying directly to pod")
+								w[0][0].Exec(ipRouteFlushlushCache...)
+								cc.Expect(Some, remoteWL, w[0][0], ExpectWithPorts(8055), ExpectWithRecvLen(1350))
+								cc.CheckConnectivity()
+								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
+
+								By("Trying directly to node with pod")
+								cc.ResetExpectations()
+								tcpdump.ResetCount("mtu-1300")
+								w[0][0].Exec(ipRouteFlushlushCache...)
+								cc.Expect(Some, remoteWL, TargetIP(felixIP(0)), ExpectWithPorts(npPort), ExpectWithRecvLen(1350))
+								cc.CheckConnectivity()
+								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
+
+								By("Trying to node without pod")
+								cc.ResetExpectations()
+								tcpdump.ResetCount("mtu-1300")
+								w[0][0].Exec(ipRouteFlushlushCache...)
+								cc.Expect(Some, remoteWL, TargetIP(felixIP(1)), ExpectWithPorts(npPort), ExpectWithRecvLen(1350))
+								cc.CheckConnectivity()
+								Eventually(tcpdump.MatchCountFn("mtu-1300"), "5s", "330ms").Should(BeNumerically("==", 1))
+							})
+						})
+					}
 				})
 
 				// FIXME connect time shares the same NAT table and it is a lottery which one it gets


### PR DESCRIPTION
When a service (nodeport) is accessed from outside the cluster and traffic from backend generates ICMP error outside the cluster, we need to deliver the ICMP error (e.g. MTU too big) back to the backend workload so that it can adjust. These packets were not sent back into the vxlan tunnel neither we did DNAT on them if they were.

fixes https://github.com/projectcalico/calico/issues/8854

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: fixed forwarding, NATing and checksuming of related ICMP traffic (icmp errors)
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
