### PR TITLE
[v3.28] Avoid failure to add interface when XFRM is not supported 

### DIFF
--- a/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
+++ b/cni-plugin/pkg/dataplane/linux/dataplane_linux.go
@@ -67,7 +67,7 @@ func (d *linuxDataplane) DoNetworking(
 
 	d.logger.Infof("Setting the host side veth name to %s", hostVethName)
 
-	hostNlHandle, err := netlink.NewHandle()
+	hostNlHandle, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create host netlink handle: %v", err)
 	}

--- a/cni-plugin/tests/calico_cni_test.go
+++ b/cni-plugin/tests/calico_cni_test.go
@@ -847,7 +847,7 @@ var _ = Describe("CalicoCni", func() {
 				containerID, result, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, "", testutils.TEST_DEFAULT_NS, "", "meep1337")
 				Expect(err).ShouldNot(HaveOccurred())
 
-				hostNlHandle, err := netlink.NewHandle()
+				hostNlHandle, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
 				Expect(err).ShouldNot(HaveOccurred())
 				defer hostNlHandle.Close()
 

--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -126,7 +126,7 @@ func newVXLANManager(
 	ipVersion uint8,
 	featureDetector environment.FeatureDetectorIface,
 ) *vxlanManager {
-	nlHandle, _ := netlink.NewHandle()
+	nlHandle, _ := netlink.NewHandle(syscall.NETLINK_ROUTE)
 
 	blackHoleProto := defaultVXLANProto
 	if dpConfig.DeviceRouteProtocol != syscall.RTPROT_BOOT {

--- a/felix/k8sfv/pod.go
+++ b/felix/k8sfv/pod.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -66,7 +67,7 @@ func createPod(clientset *kubernetes.Clientset, d deployment, nsName string, spe
 	// the link but then LinkByName wouldn't find it.  It's not clear why doing that helps but it
 	// may be that the kernel enforces consistency when you re-use the same socket, or, it may be
 	// that load causes the issue and we put less load on the kernel.
-	handle, err := netlink.NewHandle()
+	handle, err := netlink.NewHandle(syscall.NETLINK_ROUTE)
 	panicIfError(err)
 	defer handle.Close()
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Avoid failing to create interface when XFRM is not supported by the kernel

By default, netlink.NewHandle() will return a handle with all netlink families supported by the library (currently, ROUTE, XFRM, NETFILTER). This causes calico to error out on kernels that don't support XFRM.

This fix limits the handle to the ROUTE netlink family only.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Pick of #8710

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix errors when running on a kernel that doesn't support the XFRM netlink family.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
