### PR TITLE
Upgrade bpftool to v7.4

### DIFF
--- a/felix/docker-image/Dockerfile
+++ b/felix/docker-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ ARG QEMU_IMAGE
 
 FROM ${QEMU_IMAGE} as qemu
 
-FROM calico/bpftool:v5.3-${TARGETARCH} as bpftool
+FROM calico/bpftool:v7.4.0 as bpftool
 
 FROM debian:11-slim as source
 

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ ARG RUNIT_VER=2.1.2
 ARG BIRD_IMAGE=calico/bird:latest
 ARG UBI_IMAGE
 
-FROM calico/bpftool:v5.3-amd64 as bpftool
+FROM calico/bpftool:v7.4.0 as bpftool
 FROM ${BIRD_IMAGE} as bird
 
 # Use this build stage to build iptables rpm and runit binaries.

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2024 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ ARG BIRD_IMAGE=calico/bird:latest
 ARG QEMU_IMAGE
 ARG UBI_IMAGE
 
-FROM calico/bpftool:v5.3-arm64 as bpftool
+FROM calico/bpftool:v7.4.0 as bpftool
 FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 

--- a/node/Dockerfile.ppc64le
+++ b/node/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2016,2021 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2016,2021-2024 Tigera, Inc. All rights reserved.
 # Copyright IBM Corp. 2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,7 @@ ARG BIRD_IMAGE=calico/bird:latest
 FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 
-FROM calico/bpftool:v5.3-ppc64le as bpftool
+FROM calico/bpftool:v7.4.0 as bpftool
 
 FROM ppc64le/alpine:3.18
 

--- a/node/Dockerfile.s390x
+++ b/node/Dockerfile.s390x
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2016,2024 Tigera, Inc. All rights reserved.
 # Copyright IBM Corp. 2017
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,7 @@ ARG BIRD_IMAGE
 FROM ${QEMU_IMAGE} as qemu
 FROM ${BIRD_IMAGE} as bird
 
-FROM calico/bpftool:v5.3-s390x as bpftool
+FROM calico/bpftool:v7.4.0 as bpftool
 
 FROM s390x/alpine:3.18 as base
 


### PR DESCRIPTION
## Description
Update `bpftool` from `v5.3` to `v7.4` to fix this GH issue: https://github.com/projectcalico/calico/issues/8856

PR to update Calico `bpftool` image: https://github.com/projectcalico/bpftool/pull/8

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
