### PR TITLE
Cleanup bpfin/out.cali when BPF is turned off

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -4176,3 +4176,19 @@ func (pa *jumpMapAlloc) checkFreeLockHeld(idx int) {
 		}).Panic("jumpMapAlloc: Free set and free stack got out of sync")
 	}
 }
+
+func removeBPFSpecialDevices() {
+	bpfin, err := netlink.LinkByName(bpfInDev)
+	if err != nil {
+		if errors.Is(err, netlink.LinkNotFoundError{}) {
+			return
+		}
+		log.WithError(err).Warnf("Failed to make sure that %s/%s device is (not) present.", bpfInDev, bpfOutDev)
+		return
+	}
+
+	err = netlink.LinkDel(bpfin)
+	if err != nil {
+		log.WithError(err).Warnf("Failed to remove %s/%s device.", bpfInDev, bpfOutDev)
+	}
+}

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -633,6 +633,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			log.WithError(err).Info("Failed to remove BPF connect-time load balancer, ignoring.")
 		}
 		tc.CleanUpProgramsAndPins()
+		removeBPFSpecialDevices()
 	} else {
 		// In BPF mode we still use iptables for raw egress policy.
 		dp.RegisterManager(newRawEgressPolicyManager(rawTableV4, ruleRenderer, 4, ipSetsV4.SetFilter))

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -1090,7 +1090,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				It("should cleanup after we disable eBPF", func() {
 					By("Waiting for dp to get setup up")
 
-					ensureAllNodesBPFProgramsAttached(tc.Felixes)
+					ensureBPFProgramsAttached(tc.Felixes[0], "bpfout.cali")
 
 					By("Changing env and restarting felix")
 
@@ -1112,6 +1112,11 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 						out, _ := tc.Felixes[0].ExecOutput("bpftool", "-jp", "map", "show")
 						return out
 					}, "15s", "1s").ShouldNot(Or(ContainSubstring("cali_"), ContainSubstring("xdp_cali_")))
+
+					out, _ := tc.Felixes[0].ExecCombinedOutput("ip", "link", "show", "dev", "bpfin.cali")
+					Expect(out).To(Equal("Device \"bpfin.cali\" does not exist.\n"))
+					out, _ = tc.Felixes[0].ExecCombinedOutput("ip", "link", "show", "dev", "bpfout.cali")
+					Expect(out).To(Equal("Device \"bpfout.cali\" does not exist.\n"))
 				})
 			}
 		})


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: cleanup BPF special devices when BPF is turned off
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
