### PR TITLE
[release-v3.28] Add VALIDARCHES=arm64 when making cd-common on arm64 runner

### DIFF
--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -59,7 +59,7 @@ blocks:
           commands:
             # Don't call `make -C node cd ARCHES=arm64` here because node image-all also builds
             # FIPS images that will fail on native arm64 runners. They are built in the previous block.
-            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=arm64 CONFIRM=true; fi
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make -C node image cd-common ARCH=arm64 VALIDARCHES=arm64 CONFIRM=true; fi
   - name: Publish node multi-arch manifests
     dependencies:
       - Publish node images


### PR DESCRIPTION
## Description

`make image` nees `ARCH` to be set and `make cd-common` needs VALIDARCHES so add them both when publishing on native arm64 runner.

## Related issues/PRs

This change is missed from https://github.com/projectcalico/calico/pull/8810 when picking to the release v3.28 branch in https://github.com/projectcalico/calico/pull/8809.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
