### PR TITLE
[release-v3.28] Auto pick #8790: Variable source port for VXLAN NodePort tunnel

### DIFF
--- a/felix/bpf-gpl/nat4.h
+++ b/felix/bpf-gpl/nat4.h
@@ -19,7 +19,7 @@
 #define VXLAN_ENCAP_SIZE	(sizeof(struct ethhdr) + sizeof(struct iphdr) + \
 				sizeof(struct udphdr) + sizeof(struct vxlanhdr))
 
-static CALI_BPF_INLINE int vxlan_encap(struct cali_tc_ctx *ctx,  __be32 *ip_src, __be32 *ip_dst)
+static CALI_BPF_INLINE int vxlan_encap(struct cali_tc_ctx *ctx,  __be32 *ip_src, __be32 *ip_dst, __u16 src_port)
 {
 	int ret;
 	__wsum csum;
@@ -65,7 +65,8 @@ static CALI_BPF_INLINE int vxlan_encap(struct cali_tc_ctx *ctx,  __be32 *ip_src,
 	ip_hdr(ctx)->check = 0;
 	ip_hdr(ctx)->protocol = IPPROTO_UDP;
 
-	udp->source = udp->dest = bpf_htons(VXLAN_PORT);
+	udp->source = bpf_htons(src_port);
+	udp->dest = bpf_htons(VXLAN_PORT);
 	udp->len = bpf_htons(bpf_ntohs(ip_hdr(ctx)->tot_len) - sizeof(struct iphdr));
 
 	*((__u8*)&vxlan->flags) = 1 << 3; /* set the I flag to make the VNI valid */

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1085,7 +1085,7 @@ nat_encap:
 	}
 
 	/* Trivial hash to use multiple vxlan flows. Note that any value will do
-	 * as long as it is a constatnt for this direction of the flow. Does not
+	 * as long as it is a constant for this direction of the flow. Does not
 	 * even need to be the same for both directions.
 	 *
 	 * ICMP does not have ports, but there is little to no worries about a
@@ -1098,7 +1098,7 @@ nat_encap:
 		goto  deny;
 	}
 
-	STATE->sport = vxlan_src_port; 
+	STATE->sport = vxlan_src_port;
 	STATE->dport = VXLAN_PORT;
 	STATE->ip_proto = IPPROTO_UDP;
 

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1084,12 +1084,22 @@ nat_encap:
 		}
 	}
 
-	if (vxlan_encap(ctx, &STATE->ip_src, &STATE->ip_dst)) {
+	/* Trivial hash to use multiple vxlan flows. Note that any value will do
+	 * as long as it is a constatnt for this direction of the flow. Does not
+	 * even need to be the same for both directions.
+	 *
+	 * ICMP does not have ports, but there is little to no worries about a
+	 * possible out-of-order processing in relation to the related flow.
+	 */
+	__u16 vxlan_src_port = STATE->sport ^ STATE->dport;
+
+	if (vxlan_encap(ctx, &STATE->ip_src, &STATE->ip_dst, vxlan_src_port)) {
 		deny_reason(ctx, CALI_REASON_ENCAP_FAIL);
 		goto  deny;
 	}
 
-	STATE->sport = STATE->dport = VXLAN_PORT;
+	STATE->sport = vxlan_src_port; 
+	STATE->dport = VXLAN_PORT;
 	STATE->ip_proto = IPPROTO_UDP;
 
 	CALI_DEBUG("vxlan return %d ifindex_fwd %d\n",

--- a/felix/bpf-gpl/ut/ipv4_opts_test.c
+++ b/felix/bpf-gpl/ut/ipv4_opts_test.c
@@ -47,7 +47,7 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	__u32 a = 0x06060606;
 	__u32 b = 0x10101010;
 
-	if (vxlan_encap(ctx, &a, &b)) {
+	if (vxlan_encap(ctx, &a, &b, 0xdead)) {
 		CALI_DEBUG("vxlan: encap failed!\n");
 		deny_reason(ctx, CALI_REASON_ENCAP_FAIL);
 		goto  deny;

--- a/felix/bpf-gpl/ut/nat_encap_test.c
+++ b/felix/bpf-gpl/ut/nat_encap_test.c
@@ -35,5 +35,5 @@ static CALI_BPF_INLINE int calico_unittest_entry (struct __sk_buff *skb)
 	__u32 a = HOST_IP;
 	__u32 b = 0x02020202;
 
-	return vxlan_encap(ctx, &a, &b);
+	return vxlan_encap(ctx, &a, &b, 0xdead);
 }

--- a/felix/bpf/ut/nat_encap_test.go
+++ b/felix/bpf/ut/nat_encap_test.go
@@ -106,7 +106,6 @@ func checkVxlan(pktR gopacket.Packet) gopacket.Packet {
 	udpL := pktR.Layer(layers.LayerTypeUDP)
 	Expect(udpL).NotTo(BeNil())
 	udpR := udpL.(*layers.UDP)
-	Expect(udpR.SrcPort).To(Equal(layers.UDPPort(testVxlanPort)))
 	Expect(udpR.DstPort).To(Equal(layers.UDPPort(testVxlanPort)))
 	Expect(udpR.Checksum).To(Equal(uint16(0)))
 
@@ -175,7 +174,6 @@ func getVxlanVNI(pktR gopacket.Packet) uint32 {
 	udpL := pktR.Layer(layers.LayerTypeUDP)
 	Expect(udpL).NotTo(BeNil())
 	udpR := udpL.(*layers.UDP)
-	Expect(udpR.SrcPort).To(Equal(layers.UDPPort(testVxlanPort)))
 	Expect(udpR.DstPort).To(Equal(layers.UDPPort(testVxlanPort)))
 	Expect(udpR.Checksum).To(Equal(uint16(0)))
 


### PR DESCRIPTION
Cherry pick of #8790 on release-v3.28.

#8790: Variable source port for VXLAN NodePort tunnel

# Original PR Body below

To efficiently use bonded network cards or multiple CPUs on the receiving node, it is wrong to use a single VXLAN stream for forwarding services (node ports) from one node to a backend on another node. We need to preserve the notion of separate flows by varying the source port for each of the flowsi - as recommended by the RFC. We do so be XORing the source ports of the original stream to create the source port for the vxlan stream that carries it.

refs https://github.com/projectcalico/calico/issues/8620

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Forwarding services via vxlan tunnel uses different source ports for different flows to better utilize bonded devices and CPUs on the receiving side.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.