### PR TITLE
Automated cherry pick of #8900: Update clang as latest go-build has clang-17

### DIFF
--- a/felix/bpf-apache/Makefile
+++ b/felix/bpf-apache/Makefile
@@ -32,7 +32,7 @@ CFLAGS +=  \
 TRIPLET := $(shell gcc -dumpmachine)
 CFLAGS += -I/usr/include/$(TRIPLET)
 
-CC := clang-16
+CC := clang-17
 LD := llc
 
 C_FILES:=filter.c redir.c sockops.c

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -48,7 +48,7 @@ ifeq ($(findstring x86_64,$(TRIPLET)),x86_64)
 else ifeq ($(findstring aarch64,$(TRIPLET)),aarch64)
 	CFLAGS += -D__TARGET_ARCH_arm64
 endif
-CC := clang-16
+CC := clang-17
 LD := llc
 
 UT_C_FILES:=$(shell find ut -name '*.c')


### PR DESCRIPTION
Cherry pick of #8900 on release-v3.28.

#8900: Update clang as latest go-build has clang-17