### PR TITLE
update e1 generation runners to f1 generation runners

### DIFF
--- a/.semaphore/cleanup.yml
+++ b/.semaphore/cleanup.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Felix
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/license-scanning/fossa-scan.yml
+++ b/.semaphore/license-scanning/fossa-scan.yml
@@ -3,7 +3,7 @@ name: Run Fossa Scan
 
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/alp.yml
+++ b/.semaphore/push-images/alp.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish ALP images
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/apiserver.yml
+++ b/.semaphore/push-images/apiserver.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish apiserver images
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/calicoctl.yml
+++ b/.semaphore/push-images/calicoctl.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish calicoctl images
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/cni-plugin.yml
+++ b/.semaphore/push-images/cni-plugin.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish cni-plugin images
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/key-cert-provisioner.yml
+++ b/.semaphore/push-images/key-cert-provisioner.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish key-cert-provisioner images
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/kube-controllers.yml
+++ b/.semaphore/push-images/kube-controllers.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish kube-controllers images
 agent:
   machine:
-    type: e1-standard-4
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/node.yml
+++ b/.semaphore/push-images/node.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish node images
 agent:
   machine:
-    type: e1-standard-4
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/packaging.yaml
+++ b/.semaphore/push-images/packaging.yaml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish openstack packages
 agent:
   machine:
-    type: e1-standard-4
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/pod2daemon.yml
+++ b/.semaphore/push-images/pod2daemon.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish pod2daemon images
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/push-images/typha.yml
+++ b/.semaphore/push-images/typha.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish typha images
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/release/release.yml
+++ b/.semaphore/release/release.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Publish official release
 agent:
   machine:
-    type: e1-standard-8
+    type: f1-standard-4
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/.semaphore/semaphore-scheduled-builds.yml
+++ b/.semaphore/semaphore-scheduled-builds.yml
@@ -6,7 +6,7 @@ execution_time_limit:
   hours: 4
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 auto_cancel:
   running:
@@ -116,7 +116,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -270,7 +270,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-8
+        type: f1-standard-4
         os_image: ubuntu2004
     jobs:
       - name: sig-network conformance
@@ -287,7 +287,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -525,7 +525,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -555,7 +555,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-8
+        type: f1-standard-4
         os_image: ubuntu2004
     prologue:
       commands:
@@ -573,7 +573,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -664,7 +664,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -697,7 +697,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-2
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -714,7 +714,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,7 +6,7 @@ execution_time_limit:
   hours: 4
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 auto_cancel:
   running:
@@ -116,7 +116,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -270,7 +270,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-8
+        type: f1-standard-4
         os_image: ubuntu2004
     jobs:
       - name: sig-network conformance
@@ -287,7 +287,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -525,7 +525,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -555,7 +555,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-8
+        type: f1-standard-4
         os_image: ubuntu2004
     prologue:
       commands:
@@ -573,7 +573,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -664,7 +664,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -697,7 +697,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-2
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:
@@ -714,7 +714,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/01-preamble.yml
+++ b/.semaphore/semaphore.yml.d/01-preamble.yml
@@ -4,7 +4,7 @@ execution_time_limit:
   hours: 4
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 auto_cancel:
   running:

--- a/.semaphore/semaphore.yml.d/blocks/20-apiserver.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-apiserver.yml
@@ -8,7 +8,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-e2e.yml
@@ -6,7 +6,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-8
+        type: f1-standard-4
         os_image: ubuntu2004
     jobs:
       - name: sig-network conformance

--- a/.semaphore/semaphore.yml.d/blocks/20-felix.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-felix.yml
@@ -6,7 +6,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-kube-controllers.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-kube-controllers.yml
@@ -6,7 +6,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-node.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-node.yml
@@ -6,7 +6,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-8
+        type: f1-standard-4
         os_image: ubuntu2004
     prologue:
       commands:
@@ -24,7 +24,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/blocks/20-typha.yml
+++ b/.semaphore/semaphore.yml.d/blocks/20-typha.yml
@@ -6,7 +6,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/blocks/30-key-cert-provisioner.yml
+++ b/.semaphore/semaphore.yml.d/blocks/30-key-cert-provisioner.yml
@@ -6,7 +6,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-2
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
+++ b/.semaphore/semaphore.yml.d/blocks/40-openstack.yml
@@ -6,7 +6,7 @@
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     prologue:
       commands:

--- a/api/.semaphore/semaphore.yml
+++ b/api/.semaphore/semaphore.yml
@@ -5,7 +5,7 @@ execution_time_limit:
 
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 auto_cancel:

--- a/cni-plugin/.semaphore/cleanup.yml
+++ b/cni-plugin/.semaphore/cleanup.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: CNIPlugin
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/cni-plugin/.semaphore/semaphore.yml
+++ b/cni-plugin/.semaphore/semaphore.yml
@@ -6,7 +6,7 @@ execution_time_limit:
 
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 auto_cancel:

--- a/cni-plugin/.semaphore/update_pins.yml
+++ b/cni-plugin/.semaphore/update_pins.yml
@@ -6,7 +6,7 @@ execution_time_limit:
 
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 global_job_config:

--- a/felix/.semaphore/cleanup.yml
+++ b/felix/.semaphore/cleanup.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Felix
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 execution_time_limit:

--- a/felix/.semaphore/semaphore.yml
+++ b/felix/.semaphore/semaphore.yml
@@ -6,7 +6,7 @@ execution_time_limit:
 
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 auto_cancel:
@@ -44,7 +44,7 @@ blocks:
   task:
     agent:
       machine:
-        type: e1-standard-4
+        type: f1-standard-2
         os_image: ubuntu2004
     jobs:
     - name: Build and run UT, k8sfv
@@ -199,13 +199,13 @@ blocks:
         - ./.semaphore/clean-up-vms ${VM_PREFIX}
     secrets:
     - name: google-service-account-for-gce
-- name: Static checks on e1-standard-8
+- name: Static checks on f1-standard-4
   dependencies: []
   task:
     agent:
       machine:
         # Linters use a lot of RAM so use a bigger machine type.
-        type: e1-standard-8
+        type: f1-standard-4
         os_image: ubuntu2004
     prologue:
       commands:

--- a/felix/.semaphore/update_pins.yml
+++ b/felix/.semaphore/update_pins.yml
@@ -6,7 +6,7 @@ execution_time_limit:
 
 agent:
   machine:
-    type: e1-standard-2
+    type: f1-standard-2
     os_image: ubuntu2004
 
 global_job_config:


### PR DESCRIPTION
## Description
Update Semaphore machines from `e1` generation to `f1` generation runners.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
