### PR TITLE
[release-v3.28] Auto pick #8803: Interface autodetection - ebpf

### DIFF
--- a/felix/bpf/ifstate/map.go
+++ b/felix/bpf/ifstate/map.go
@@ -42,13 +42,27 @@ const (
 	FlgWEP       = uint32(0x1)
 	FlgIPv4Ready = uint32(0x2)
 	FlgIPv6Ready = uint32(0x4)
-	FlgMax       = uint32(0x7)
+	FlgHEP       = uint32(0x8)
+	FlgBond      = uint32(0x10)
+	FlgBondSlave = uint32(0x20)
+	FlgVxlan     = uint32(0x40)
+	FlgIPIP      = uint32(0x80)
+	FlgWireguard = uint32(0x100)
+	FlgL3        = uint32(0x200)
+	FlgMax       = uint32(0x3ff)
 )
 
 var flagsToStr = map[uint32]string{
 	FlgWEP:       "workload",
 	FlgIPv4Ready: "v4Ready",
 	FlgIPv6Ready: "v6Ready",
+	FlgHEP:       "host",
+	FlgBond:      "bond",
+	FlgBondSlave: "bondslave",
+	FlgVxlan:     "vxlan",
+	FlgIPIP:      "ipip",
+	FlgWireguard: "wg",
+	FlgL3:        "l3",
 }
 
 var MapParams = maps.MapParameters{

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -140,7 +140,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 		}
 
 		hostep1State = ifstateMap[ifstate.NewKey(uint32(host1.Attrs().Index))]
-		Expect(hostep1State.Flags()).To(Equal(ifstate.FlgIPv4Ready))
+		Expect(hostep1State.Flags()).To(Equal(ifstate.FlgIPv4Ready | ifstate.FlgHEP))
 
 		if ipv6Enabled {
 			// IPv6 address update
@@ -216,7 +216,7 @@ func runAttachTest(t *testing.T, ipv6Enabled bool) {
 			Expect(hostep1State.IngressPolicyV6()).NotTo(Equal(-1))
 			Expect(hostep1State.EgressPolicyV6()).NotTo(Equal(-1))
 			Expect(hostep1State.XDPPolicyV6()).NotTo(Equal(-1))
-			Expect(hostep1State.Flags()).To(Equal(ifstate.FlgIPv4Ready | ifstate.FlgIPv6Ready))
+			Expect(hostep1State.Flags()).To(Equal(ifstate.FlgIPv4Ready | ifstate.FlgIPv6Ready | ifstate.FlgHEP))
 			Expect(ifstateMap).To(HaveKey(ifstate.NewKey(uint32(workload0.Attrs().Index))))
 			workloadep0State := ifstateMap[ifstate.NewKey(uint32(workload0.Attrs().Index))]
 			Expect(workloadep0State.Flags()).To(Equal(ifstate.FlgWEP | ifstate.FlgIPv4Ready | ifstate.FlgIPv6Ready))

--- a/felix/config/config_params.go
+++ b/felix/config/config_params.go
@@ -179,7 +179,7 @@ type Config struct {
 	BPFLogLevel                        string            `config:"oneof(off,info,debug);off;non-zero"`
 	BPFLogFilters                      map[string]string `config:"keyvaluelist;;"`
 	BPFCTLBLogFilter                   string            `config:"oneof(all);;"`
-	BPFDataIfacePattern                *regexp.Regexp    `config:"regexp;^((en|wl|ww|sl|ib)[Popsx].*|(eth|wlan|wwan).*|tunl0$|vxlan.calico$|vxlan-v6.calico$|wireguard.cali$|wg-v6.cali$)"`
+	BPFDataIfacePattern                *regexp.Regexp    `config:"regexp;^((en|wl|ww|sl|ib)[Popsx].*|(eth|wlan|wwan|bond).*|tunl0$|vxlan.calico$|vxlan-v6.calico$|wireguard.cali$|wg-v6.cali$)"`
 	BPFL3IfacePattern                  *regexp.Regexp    `config:"regexp;"`
 	BPFConnectTimeLoadBalancingEnabled bool              `config:"bool;;"`
 	BPFConnectTimeLoadBalancing        string            `config:"oneof(TCP,Enabled,Disabled);TCP;non-zero"`

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -716,6 +716,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			dp.loopSummarizer,
 			featureDetector,
 			config.HealthAggregator,
+			dataplaneFeatures,
 		)
 
 		if err != nil {
@@ -723,8 +724,6 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 		}
 
 		dp.RegisterManager(bpfEndpointManager)
-
-		bpfEndpointManager.Features = dataplaneFeatures
 
 		// HostNetworkedNAT is Enabled and CTLB enabled.
 		// HostNetworkedNAT is Disabled and CTLB is either disabled/TCP.

--- a/felix/fv/bpf_attach_test.go
+++ b/felix/fv/bpf_attach_test.go
@@ -17,11 +17,14 @@
 package fv_test
 
 import (
+	"encoding/json"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/projectcalico/calico/felix/bpf/ifstate"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 )
@@ -41,7 +44,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 
 	BeforeEach(func() {
 		infra = getInfra()
-		// opts := infrastructure.DefaultTopologyOptions()
 		opts := infrastructure.TopologyOptions{
 			FelixLogSeverity: "debug",
 			DelayFelixStart:  true,
@@ -91,5 +93,73 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf reattach object",
 			out, _ := felix.ExecOutput("bpftool", "-jp", "net")
 			return out
 		}, "15s", "1s").ShouldNot(ContainSubstring("eth0"))
+	})
+
+	It("should attach programs to the bond interfaces", func() {
+		By("Starting Felix")
+		felix.TriggerDelayedStart()
+		By("Check that dummy interfaces has a program")
+		tc.Felixes[0].Exec("ip", "link", "add", "eth10", "type", "dummy")
+		tc.Felixes[0].Exec("ip", "link", "add", "eth20", "type", "dummy")
+
+		getBPFNet := func() []string {
+			out, _ := felix.ExecOutput("bpftool", "-jp", "net")
+			devs := []string{}
+			var output []struct {
+				Tc []struct {
+					Devname string `json:"devname"`
+				} `json:"tc"`
+			}
+			err := json.Unmarshal([]byte(out), &output)
+			if err == nil {
+				for _, tc := range output[0].Tc {
+					devs = append(devs, tc.Devname)
+				}
+			}
+			return devs
+		}
+
+		// Bring up the interfaces
+		tc.Felixes[0].Exec("ifconfig", "eth10", "up")
+		tc.Felixes[0].Exec("ifconfig", "eth20", "up")
+
+		Eventually(getBPFNet, "15s", "1s").Should(ContainElements("eth10", "eth20"))
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP, "eth20": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
+
+		By("Creating a bond interface and eth10, eth20 to the bond")
+		tc.Felixes[0].Exec("ip", "link", "add", "bond0", "type", "bond", "mode", "802.3ad")
+		tc.Felixes[0].Exec("ifconfig", "eth10", "down")
+		tc.Felixes[0].Exec("ifconfig", "eth20", "down")
+		tc.Felixes[0].Exec("ip", "link", "set", "eth10", "master", "bond0")
+		tc.Felixes[0].Exec("ip", "link", "set", "eth20", "master", "bond0")
+		tc.Felixes[0].Exec("ifconfig", "bond0", "up")
+		time.Sleep(0 * time.Second)
+		Eventually(getBPFNet, "15s", "1s").Should(ContainElement("bond0"))
+		Eventually(getBPFNet, "15s", "1s").ShouldNot(ContainElements("eth10", "eth20"))
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgBond})
+
+		By("Removing eth10 from bond")
+		tc.Felixes[0].Exec("ip", "link", "set", "eth10", "nomaster")
+		tc.Felixes[0].Exec("ifconfig", "eth10", "up")
+		Eventually(getBPFNet, "15s", "1s").ShouldNot(ContainElement("eth20"))
+		Eventually(getBPFNet, "15s", "1s").Should(ContainElements("bond0", "eth10"))
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"bond0": ifstate.FlgIPv4Ready | ifstate.FlgBond, "eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
+
+		By("Removing eth20 from bond")
+		tc.Felixes[0].Exec("ip", "link", "set", "eth20", "nomaster")
+		tc.Felixes[0].Exec("ifconfig", "eth20", "up")
+		Eventually(getBPFNet, "15s", "1s").Should(ContainElements("bond0", "eth10", "eth20"))
+		ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgHEP, map[string]uint32{"eth10": ifstate.FlgIPv4Ready | ifstate.FlgHEP, "eth20": ifstate.FlgIPv4Ready | ifstate.FlgHEP})
+
+		By("Creating a bond interface which does match BPFDataIfacePattern")
+		tc.Felixes[0].Exec("ip", "link", "add", "foo0", "type", "bond", "mode", "802.3ad")
+		tc.Felixes[0].Exec("ifconfig", "eth10", "down")
+		tc.Felixes[0].Exec("ifconfig", "eth20", "down")
+
+		tc.Felixes[0].Exec("ip", "link", "set", "eth10", "master", "foo0")
+		tc.Felixes[0].Exec("ip", "link", "set", "eth20", "master", "foo0")
+		tc.Felixes[0].Exec("ifconfig", "foo0", "up")
+		Eventually(getBPFNet, "15s", "1s").Should(ContainElements("eth10", "eth20"))
+
 	})
 })

--- a/felix/fv/bpf_dual_stack_test.go
+++ b/felix/fv/bpf_dual_stack_test.go
@@ -264,8 +264,8 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 		if !ipv6Dataplane {
 			JustBeforeEach(func() {
 				tc.TriggerDelayedStart()
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready, nil)
 			})
 			It("should drop ipv6 packets at workload interface and allow ipv6 packets at host interface when in IPv4 only mode", func() {
 				// IPv4 connectivity must work.
@@ -356,8 +356,8 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 
 				tc.TriggerDelayedStart()
 
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
 				cc.ExpectSome(w[0][1], w[0][0])
 				cc.ExpectSome(w[1][0], w[0][0])
 				cc.ExpectSome(w[1][1], w[0][0])
@@ -389,7 +389,7 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 				_, err = k8sClient.CoreV1().Nodes().UpdateStatus(context.Background(), node, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
 				cc.ExpectSome(w[0][1], w[0][0])
 				cc.ExpectSome(w[1][0], w[0][0])
 				cc.ExpectSome(w[1][1], w[0][0])
@@ -404,8 +404,8 @@ func describeBPFDualStackTests(ctlbEnabled, ipv6Dataplane bool) bool {
 				tc.TriggerDelayedStart()
 				externalClient := infrastructure.RunExtClient("ext-client")
 				_ = externalClient
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
 
 				tcpdump := externalClient.AttachTCPDump("any")
 				tcpdump.SetLogEnabled(true)
@@ -532,10 +532,17 @@ func removeIPv6Address(k8sClient *kubernetes.Clientset, felix *infrastructure.Fe
 	felix.Exec("ip", "-6", "addr", "del", felix.Container.IPv6+"/64", "dev", "eth0")
 }
 
-func ensureRightIFStateFlags(felix *infrastructure.Felix, ready uint32) {
+func ensureRightIFStateFlags(felix *infrastructure.Felix, ready uint32, additionalInterfaces map[string]uint32) {
 	expectedIfacesToFlags := map[string]uint32{
-		"eth0": ready,
+		"eth0": ifstate.FlgHEP | ready,
 	}
+
+	if additionalInterfaces != nil {
+		for k, v := range additionalInterfaces {
+			expectedIfacesToFlags[k] = v
+		}
+	}
+
 	for _, w := range felix.Workloads {
 		if w.Runs() {
 			if iface := w.GetInterfaceName(); iface != "" {

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -189,8 +189,8 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 				Expect(err).NotTo(HaveOccurred())
 			}
 			if BPFMode() {
-				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
-				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready)
+				ensureRightIFStateFlags(tc.Felixes[0], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
+				ensureRightIFStateFlags(tc.Felixes[1], ifstate.FlgIPv4Ready|ifstate.FlgIPv6Ready, nil)
 			}
 		})
 


### PR DESCRIPTION
Cherry pick of #8803 on release-v3.28.

#8803: Interface autodetection - ebpf

# Original PR Body below

## Description

This PR adds the following
1. bond* added to the default value of dataIfacePattern Regex.
2. Handle dynamic addition of interfaces to the bond.
3. IFstate map changes to add more info about the type of each interface.

This PR does not handle attaching xdp programs to the bond slaves. Will be done subsequently.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf:  If a bond master device is part of the bpfDataIfacePattern regexp, calico attaches to it and not to the slaves
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.