### PR TITLE
fix windows kubelet-service.ps1

### DIFF
--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -30,15 +30,22 @@ Wait-ForCalicoInit
 
 Write-Host "Using configured nodename: $env:NODENAME DNS: $env:DNS_NAME_SERVERS"
 
-Write-Host "Auto-detecting node IP, looking for interface named like '$InterfaceName' ..."
-$na = Get-NetAdapter | ? Name -Like "$InterfaceName" | ? Status -EQ Up
-while ($na -EQ $null) {
-    Write-Host "Waiting for interface named like '$InterfaceName' ..."
-    Start-Sleep 3
+if ($NodeIp -EQ "")
+{
+    Write-Host "Auto-detecting node IP, looking for interface named like '$InterfaceName' ..."
     $na = Get-NetAdapter | ? Name -Like "$InterfaceName" | ? Status -EQ Up
+    while ($na -EQ $null) {
+        Write-Host "Waiting for interface named like '$InterfaceName' ..."
+        Start-Sleep 3
+        $na = Get-NetAdapter | ? Name -Like "$InterfaceName" | ? Status -EQ Up
+    }
+    $NodeIp = (Get-NetIPAddress -InterfaceAlias $na.ifAlias -AddressFamily IPv4).IPAddress
+    Write-Host "Detected node IP: $NodeIp."
 }
-$NodeIp = (Get-NetIPAddress -InterfaceAlias $na.ifAlias -AddressFamily IPv4).IPAddress
-Write-Host "Detected node IP: $NodeIp."
+else
+{
+    Write-Host "Specific node IP: $NodeIp."
+}
 
 $argList = @(`
     "--hostname-override=$env:NODENAME", `
@@ -58,6 +65,7 @@ $argList = @(`
 if (Get-IsContainerdRunning)
 {
     Write-Host "Detected containerd running, configuring kubelet for containerd"
+    $argList += "--container-runtime=remote"
     $argList += "--container-runtime-endpoint=npipe:////.//pipe//containerd-containerd"
 }
 else

--- a/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
+++ b/node/windows-packaging/CalicoWindows/kubernetes/kubelet-service.ps1
@@ -65,7 +65,6 @@ $argList = @(`
 if (Get-IsContainerdRunning)
 {
     Write-Host "Detected containerd running, configuring kubelet for containerd"
-    $argList += "--container-runtime=remote"
     $argList += "--container-runtime-endpoint=npipe:////.//pipe//containerd-containerd"
 }
 else


### PR DESCRIPTION
## Description

 If the parameter `--NodeIp` is provided, the discovery logic should be skipped.

## Related issues/PRs

fixes #5231 

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
