### PR TITLE
[BPF] set MTU on bpfin/out.cali to match host

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -455,6 +455,7 @@ var _ = Describe("BPF Endpoint Manager", func() {
 			&environment.FakeFeatureDetector{},
 			nil,
 			environment.NewFeatureDetector(nil).GetFeatures(),
+			1250,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		bpfEpMgr.v4.hostIP = net.ParseIP("1.2.3.4")

--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -716,6 +716,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
 			featureDetector,
 			config.HealthAggregator,
 			dataplaneFeatures,
+			podMTU,
 		)
 
 		if err != nil {

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -5229,9 +5229,9 @@ func dumpIfStateMap(felix *infrastructure.Felix) ifstate.MapMem {
 	return m
 }
 
-func ensureAllNodesBPFProgramsAttached(felixes []*infrastructure.Felix) {
+func ensureAllNodesBPFProgramsAttached(felixes []*infrastructure.Felix, ifacesExtra ...string) {
 	for _, felix := range felixes {
-		ensureBPFProgramsAttachedOffset(2, felix)
+		ensureBPFProgramsAttachedOffset(2, felix, ifacesExtra...)
 	}
 }
 

--- a/felix/fv/mtu_test.go
+++ b/felix/fv/mtu_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
-var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs to IP sets", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
+var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ VXLAN topology before adding host IPs to IP sets", []apiconfig.DatastoreType{apiconfig.EtcdV3, apiconfig.Kubernetes}, func(getInfra infrastructure.InfraFactory) {
 	var (
 		infra  infrastructure.DatastoreInfra
 		tc     infrastructure.TopologyContainers
@@ -45,6 +45,17 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 				out, _ := felix.ExecOutput("cat", "/var/lib/calico/mtu")
 				return strings.TrimSpace(out)
 			}, "60s", "500ms").Should(Equal(fmt.Sprint(mtu)))
+		}
+		if BPFMode() {
+			felix := tc.Felixes[0]
+			EventuallyWithOffset(1, func() string {
+				out, _ := felix.ExecOutput("ip", "link", "show", "dev", "bpfin.cali")
+				return out
+			}, "5s", "500ms").Should(ContainSubstring(fmt.Sprintf("mtu %d", mtu)))
+			EventuallyWithOffset(1, func() string {
+				out, _ := felix.ExecOutput("ip", "link", "show", "dev", "bpfout.cali")
+				return out
+			}, "5s", "500ms").Should(ContainSubstring(fmt.Sprintf("mtu %d", mtu)))
 		}
 	}
 
@@ -59,6 +70,9 @@ var _ = infrastructure.DatastoreDescribe("VXLAN topology before adding host IPs 
 		if CurrentGinkgoTestDescription().Failed {
 			for _, felix := range tc.Felixes {
 				felix.Exec("ip", "link")
+				if BPFMode() {
+					felix.Exec("calico-bpf", "ifstate", "dump")
+				}
 			}
 			infra.DumpErrorData()
 		}


### PR DESCRIPTION
Set the MTU to match the smallest MTU of the host devices as per the current autodetection. That makes sure that if large MTU is used, the extra device does not create a bottleneck with a small MTU. Also when MTU changes, on host devices, it get adjusted automatically.  If an overlay is used, the special device MTU is adjusted to the size of the overlay.

Fixes https://github.com/projectcalico/calico/issues/8868

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
