### PR TITLE
fix(vxlan):detect vtep mac addr change

### DIFF
--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -863,7 +863,7 @@ func vxlanLinksIncompat(l1, l2 netlink.Link) string {
 	if v1.GBP != v2.GBP {
 		return fmt.Sprintf("gbp: %v vs %v", v1.GBP, v2.GBP)
 	}
-	
+
 	if len(v1.Attrs().HardwareAddr) > 0 && len(v2.Attrs().HardwareAddr) > 0 && !bytes.Equal(v1.Attrs().HardwareAddr, v2.Attrs().HardwareAddr) {
 		return fmt.Sprintf("vtep mac addr: %v vs %v", v1.Attrs().HardwareAddr, v2.Attrs().HardwareAddr)
 	}

--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -15,6 +15,7 @@
 package intdataplane
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -861,6 +862,10 @@ func vxlanLinksIncompat(l1, l2 netlink.Link) string {
 
 	if v1.GBP != v2.GBP {
 		return fmt.Sprintf("gbp: %v vs %v", v1.GBP, v2.GBP)
+	}
+	
+	if len(v1.Attrs().HardwareAddr) > 0 && len(v2.Attrs().HardwareAddr) > 0 && !bytes.Equal(v1.Attrs().HardwareAddr, v2.Attrs().HardwareAddr) {
+		return fmt.Sprintf("vtep mac addr: %v vs %v", v1.Attrs().HardwareAddr, v2.Attrs().HardwareAddr)
 	}
 
 	return ""


### PR DESCRIPTION
There are roughly two cases when our vtep(vxlan.calico) mac address gets messed up: 

1. Someone or some third-party component may modify the mac address of vtep on a node 
2. When a  node left the cluster and didn't get properly cleaned, the old mac address may stuck, and then the node rejoin the cluster and the vtep gets a new mac address assigned(but not executed). 

In both case, calico-node wouldn't be able to pull up new vtep and network on the node would be broken(eg. any request from workload on this node to other workload inside the cluster won't succeed). So we need to detect mac address changes and retry pulling up vtep to make sure network not broken.

```release-note
Calico now reconciles its VXLAN tunnel interface MAC address if it changes.
```