### PR TITLE
[BPF] send RST to midflow TCP packets from unknown streams

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -1453,8 +1453,15 @@ func (d *InternalDataplane) setUpIptablesBPF() {
 				Action:  iptables.AcceptAction{},
 			},
 			iptables.Rule{
+				Match: iptables.Match().
+					MarkMatchesWithMask(tcdefs.MarkSeenFallThrough, tcdefs.MarkSeenFallThroughMask).
+					Protocol("tcp"),
+				Comment: []string{"REJECT/rst packets from unknown TCP flows."},
+				Action:  iptables.RejectAction{With: "tcp-reset"},
+			},
+			iptables.Rule{
 				Match:   iptables.Match().MarkMatchesWithMask(tcdefs.MarkSeenFallThrough, tcdefs.MarkSeenFallThroughMask),
-				Comment: []string{fmt.Sprintf("%s packets from unknown flows.", d.ruleRenderer.IptablesFilterDenyAction())},
+				Comment: []string{fmt.Sprintf("%s packets from unknown non-TCP flows.", d.ruleRenderer.IptablesFilterDenyAction())},
 				Action:  d.ruleRenderer.IptablesFilterDenyAction(),
 			},
 		)

--- a/felix/fv/spoof_test.go
+++ b/felix/fv/spoof_test.go
@@ -123,15 +123,14 @@ var _ = Describe("Spoof tests", func() {
 	})
 
 	Context("IPv6", func() {
-		if BPFMode() && !BPFIPv6Support() {
-			return
-		}
-
 		BeforeEach(func() {
 			var err error
 			infra, err = infrastructure.GetEtcdDatastoreInfra()
 			Expect(err).NotTo(HaveOccurred())
 			opts := infrastructure.DefaultTopologyOptions()
+			opts.EnableIPv6 = true
+			opts.IPIPEnabled = false
+			opts.ExtraEnvVars["FELIX_IPV6SUPPORT"] = "true"
 
 			// The IPv4 tests had each workload running on an individual
 			// felix, but our current topology setup tooling doesn't yet

--- a/felix/fv/spoof_test.go
+++ b/felix/fv/spoof_test.go
@@ -18,11 +18,15 @@ package fv_test
 
 import (
 	"fmt"
+	"regexp"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+
 	"github.com/projectcalico/calico/felix/fv/connectivity"
+	"github.com/projectcalico/calico/felix/fv/containers"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
 	"github.com/projectcalico/calico/felix/fv/workload"
 )
@@ -89,6 +93,36 @@ var _ = Describe("Spoof tests", func() {
 			cc.ExpectSome(w[1], spoofed)
 			cc.CheckConnectivity()
 		})
+
+		Context("with external client", func() {
+			var (
+				externalClient *containers.Container
+			)
+			BeforeEach(func() {
+				externalClient = infrastructure.RunExtClient("ext-client")
+				err := externalClient.CopyFileIntoContainer("../bin/pktgen", "pktgen")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			AfterEach(func() {
+				externalClient.Stop()
+			})
+
+			It("should send RST for a stray TCP packet", func() {
+				tcpdump := tc.Felixes[0].AttachTCPDump("eth0")
+				tcpdump.SetLogEnabled(true)
+				pattern := fmt.Sprintf(`IP %s\.1234 > %s\.3434: Flags \[R\], seq 123`, tc.Felixes[0].IP, externalClient.IP)
+				tcpdump.AddMatcher("RST", regexp.MustCompile(pattern))
+				tcpdump.Start("tcp", "port", "1234")
+				defer tcpdump.Stop()
+
+				err := externalClient.ExecMayFail("pktgen", externalClient.IP, tc.Felixes[0].IP, "tcp",
+					"--port-src", "3434", "--port-dst", "1234", "--tcp-ack", "--tcp-ack-no=123", "--tcp-seq-no=111")
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(tcpdump.MatchCountFn("RST"), "5s", "200ms").Should(
+					BeNumerically("==", 1),
+					"We should see RST to a packet from an unknown flow")
+			})
+		})
 	}
 
 	Context("_BPF-SAFE_ IPv4", func() {
@@ -97,6 +131,8 @@ var _ = Describe("Spoof tests", func() {
 			infra, err = infrastructure.GetEtcdDatastoreInfra()
 			Expect(err).NotTo(HaveOccurred())
 			opts := infrastructure.DefaultTopologyOptions()
+			opts.ExtraEnvVars["FELIX_BPFConnectTimeLoadBalancing"] = string(api.BPFConnectTimeLBDisabled)
+			opts.ExtraEnvVars["FELIX_BPFHostNetworkedNATWithoutCTLB"] = string(api.BPFHostNetworkedNATEnabled)
 			tc, _ = infrastructure.StartNNodeTopology(3, opts, infra)
 			// Install a default profile allowing all ingress and egress,
 			// in the absence of policy.
@@ -130,6 +166,8 @@ var _ = Describe("Spoof tests", func() {
 			opts := infrastructure.DefaultTopologyOptions()
 			opts.EnableIPv6 = true
 			opts.IPIPEnabled = false
+			opts.ExtraEnvVars["FELIX_BPFConnectTimeLoadBalancing"] = string(api.BPFConnectTimeLBDisabled)
+			opts.ExtraEnvVars["FELIX_BPFHostNetworkedNATWithoutCTLB"] = string(api.BPFHostNetworkedNATEnabled)
 			opts.ExtraEnvVars["FELIX_IPV6SUPPORT"] = "true"
 
 			// The IPv4 tests had each workload running on an individual

--- a/felix/iptables/actions.go
+++ b/felix/iptables/actions.go
@@ -93,9 +93,13 @@ func (g DropAction) String() string {
 
 type RejectAction struct {
 	TypeReject struct{}
+	With       string
 }
 
 func (g RejectAction) ToFragment(features *environment.Features) string {
+	if g.With != "" {
+		return fmt.Sprintf("--jump REJECT --reject-with %s", g.With)
+	}
 	return "--jump REJECT"
 }
 


### PR DESCRIPTION
## Description

    For a smooth switch from iptables to ebpf mode, we do not want to
    interrupt existing connections. If we see midflow packets, we pass them
    to the host stack. If the stack can verify that they belong to an
    existing conntrack, we let them through and we learn the conntrack.
    
    We drop the rest. However, there are some situations when we can see a
    stray TCP packet during ebpf mode, for instance when a pod dies and ECMP
    kicks in and sends a packet to a different host.
    
    If such a packet gets dropped, the end of the connections remains stuck.
    This change sends an RST to such a stream instead of just dropping the
    packets so that the end host can break the connection.
    
Fixes https://github.com/projectcalico/calico/issues/8882


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: don't drop, but reject unknown midflow tcp packets with rst 
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
