### PR TITLE
Move Felix log level setting earlier

### DIFF
--- a/felix/daemon/daemon.go
+++ b/felix/daemon/daemon.go
@@ -346,6 +346,14 @@ configRetry:
 		break configRetry
 	}
 
+	// If we get here, we've loaded the configuration successfully.
+	// Update log levels before we do anything else.
+	logutils.ConfigureLogging(configParams)
+	// Since we may have enabled more logging, log with the build context
+	// again.
+	buildInfoLogCxt.WithField("config", configParams).Info(
+		"Successfully loaded configuration.")
+
 	if numClientsCreated > 2 {
 		// We don't have a way to close datastore connection so, if we reconnected after
 		// a failure to load config, restart felix to avoid leaking connections.
@@ -370,14 +378,6 @@ configRetry:
 
 	// Enable or disable the health HTTP server according to coalesced config.
 	healthAggregator.ServeHTTP(configParams.HealthEnabled, configParams.HealthHost, configParams.HealthPort)
-
-	// If we get here, we've loaded the configuration successfully.
-	// Update log levels before we do anything else.
-	logutils.ConfigureLogging(configParams)
-	// Since we may have enabled more logging, log with the build context
-	// again.
-	buildInfoLogCxt.WithField("config", configParams).Info(
-		"Successfully loaded configuration.")
 
 	// Configure Windows firewall rules if appropriate
 	winutils.MaybeConfigureWindowsFirewallRules(configParams.WindowsManageFirewallRules, configParams.PrometheusMetricsEnabled, configParams.PrometheusMetricsPort)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Noticed that we weren't getting logs from doGoRuntimeSetup (#8904) and the health aggregator set-up.  I think the logging set-up had just drifted down the list over time as more initialisation logic was added.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix: move log initialisation earlier in start-up sequence to avoid missing some logs.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
