### PR TITLE
Fix typo for Google Container Registry URL

### DIFF
--- a/process/testing/winfv/README.md
+++ b/process/testing/winfv/README.md
@@ -12,7 +12,7 @@ From setup-fv.sh
 - Setup VPC resources.
 - Create and bootstrap linux node (install docker) and windows node (setup etcd-endpoints, install pscp.exe and putty key to transfer files between windows and linux nodes).
 - Copy over run-fv.ps1 to linux node, add a line to copy back report from windows node to linux node.
-- Copy over docker credentials and log in to grc.io. Start etcd, kube-apiserver, kube-controller-manager on linux nodes.
+- Copy over docker credentials and log in to gcr.io. Start etcd, kube-apiserver, kube-controller-manager on linux nodes.
 - Setup wait-report.sh on linux node. 
 - Windows node wait until it found a file named `file-ready` on linux node.
 


### PR DESCRIPTION
## Description

This fix corrects a typo in testing instructions for logging into Google Container Registry. The documentation mis-specifies the registry URL gcr.io as grc.io, which is under 3rd-party control. Currently, following the testing instructions as specified can result in sharing credentials with the 3rd party.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
