### PR TITLE
Fix windows cni-plugin fv to use correct apiserver port number

### DIFF
--- a/process/testing/winfv-cni-plugin/aso/config-minikube
+++ b/process/testing/winfv-cni-plugin/aso/config-minikube
@@ -2,7 +2,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority: c:\k\minikube\ca.crt
-    server: https://{{.Env.LINUX_PIP}}:32769
+    server: https://{{.Env.LINUX_PIP}}:{{.Env.APISERVER_PORT}}
   name: minikube
 contexts:
 - context:

--- a/process/testing/winfv-cni-plugin/aso/create-minikube-cluster.sh
+++ b/process/testing/winfv-cni-plugin/aso/create-minikube-cluster.sh
@@ -20,9 +20,13 @@ set -x
 
 LINUX_PIP=$1
 
-curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+curl -LO https://github.com/kubernetes/minikube/releases/download/v1.33.0/minikube-linux-amd64
 sudo install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
 
 minikube start  --listen-address=0.0.0.0 --apiserver-ips=$LINUX_PIP
 
-docker port minikube | grep 8443
+PORT_INFO=$(docker port minikube | grep 8443)
+
+port=$(echo $PORT_INFO | grep -oE '[0-9]{5}' | tail -1)
+echo "apiserver listening at port $port"
+echo $port > $HOME/port_info

--- a/process/testing/winfv-cni-plugin/aso/run-fv-cni-plugin.ps1
+++ b/process/testing/winfv-cni-plugin/aso/run-fv-cni-plugin.ps1
@@ -1,11 +1,12 @@
 Param(
   [parameter(Mandatory = $true)] $Backend,
-  [parameter(Mandatory = $false)] $LinuxPIP="{{.Env.LINUX_PIP}}"
+  [parameter(Mandatory = $false)] $LinuxPIP="{{.Env.LINUX_PIP}}",
+  [parameter(Mandatory = $false)] $LinuxAPIServerPort="{{.Env.APISERVER_PORT}}"
 )
 
 #Setting up Environment Variable
 Set-Item -Path env:KUBECONFIG -Value "C:\\k\\config"
-Set-Item -Path env:KUBERNETES_MASTER -Value "https://${LinuxPIP}:32769"
+Set-Item -Path env:KUBERNETES_MASTER -Value "https://${LinuxPIP}:${LinuxAPIServerPort}"
 Set-Item -Path env:ETCD_ENDPOINTS -Value "http://${LinuxPIP}:2389"
 Set-Item -Path env:BIN -Value "C:\\k"
 Set-Item -Path env:PLUGIN -Value "calico"

--- a/process/testing/winfv-cni-plugin/aso/setup-fv.sh
+++ b/process/testing/winfv-cni-plugin/aso/setup-fv.sh
@@ -29,6 +29,9 @@ function setup_minikube_cluster() {
   ${MASTER_CONNECT_COMMAND} sudo chmod +x /home/winfv/create-minikube-cluster.sh
   ${MASTER_CONNECT_COMMAND} bash /home/winfv/create-minikube-cluster.sh ${LINUX_PIP}
 
+  APISERVER_PORT=$(${MASTER_CONNECT_COMMAND} cat /home/winfv/port_info)
+  export APISERVER_PORT
+
     #create etcd manually with http protocol
   LOCAL_IP_ENV=${LINUX_PIP}
   ETCD_CONTAINER=quay.io/coreos/etcd:v3.4.6


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
