### PR TITLE
[release-v3.27] Only patchelf felix for Debian packages

### DIFF
--- a/hack/release/packaging/docker-build-images/install-centos-build-deps
+++ b/hack/release/packaging/docker-build-images/install-centos-build-deps
@@ -2,18 +2,23 @@
 set -x
 set -e
 
+sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+
 yum install -y epel-release
-yum install -y rpm-build \
-               make \
-               git \
-               gcc \
-               python-setuptools \
-               python-pbr \
-               python2-devel \
-               python-urllib3 \
-               python3-setuptools \
-               python3-pbr \
-               python3-devel \
-               python3-urllib3 \
-               dbus-devel \
-               libidn-devel
+yum install -y \
+    dbus-devel \
+    gcc \
+    git \
+    libidn-devel \
+    make \
+    python-pbr \
+    python-setuptools \
+    python-urllib3 \
+    python2-devel \
+    python3-devel \
+    python3-pbr \
+    python3-setuptools \
+    python3-urllib3 \
+    rpm-build

--- a/hack/release/packaging/docker-build-images/install-ubuntu-build-deps
+++ b/hack/release/packaging/docker-build-images/install-ubuntu-build-deps
@@ -2,27 +2,30 @@
 
 # shellcheck disable=SC1091
 
-set -x      # Print commands as they're run
-set -e      # Exit immediately if a command returns non-zero
+set -x # Print commands as they're run
+set -e # Exit immediately if a command returns non-zero
 
 apt-get -q update
-DEBIAN_FRONTEND=noninteractive \
-apt-get install -y -q build-essential  \
-                   devscripts \
-                   debhelper \
-                   dh-python \
-                   python-all \
-                   python-setuptools \
-                   python3-all \
-                   python3-setuptools \
-                   libyajl2 \
-                   libdatrie1 \
-                   git \
-                   libnetfilter-conntrack-dev \
-                   libidn11-dev \
-                   libdbus-1-dev \
-                   libgmp-dev \
-                   nettle-dev \
-                   m4 \
-                   texinfo
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
+    build-essential \
+    debhelper \
+    devscripts \
+    dh-python \
+    git \
+    libdatrie1 \
+    libdbus-1-dev \
+    libgmp-dev \
+    libidn11-dev \
+    libnetfilter-conntrack-dev \
+    libpcap-dev \
+    libyajl2 \
+    m4 \
+    nettle-dev \
+    python-all \
+    python-setuptools \
+    python3-all \
+    python3-setuptools \
+    texinfo
+
 apt-get clean -y

--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -208,12 +208,13 @@ function do_felix {
     rm -f Makefile
     # Override dpkg's default file exclusions, otherwise our binaries won't get included (and some
     # generated files will).
+    # Build rpm first and then deb because we need to patchelf bin/calico-felix for Debian.
     PKG_NAME=felix \
 	    NAME=Felix \
 	    RPM_TAR_ARGS='--exclude=bin/calico-felix-* --exclude=.gitignore --exclude=*.d --exclude=*.ll --exclude=.go-pkg-cache --exclude=vendor --exclude=report' \
 	    DPKG_EXCL="-I'bin/calico-felix-*' -I.git -I.gitignore -I'*.d' -I'*.ll' -I.go-pkg-cache -I.git -Ivendor -Ireport" \
 	    DEB_EPOCH=2: \
-	    ${rootdir}/hack/release/packaging/utils/make-packages.sh deb rpm
+	    ${rootdir}/hack/release/packaging/utils/make-packages.sh rpm deb
     git checkout Makefile
 
 

--- a/hack/release/packaging/utils/make-packages.sh
+++ b/hack/release/packaging/utils/make-packages.sh
@@ -42,6 +42,13 @@ for package_type in "$@"; do
     case ${package_type} in
 
 	deb )
+	    if [ "${PKG_NAME}" = felix ]; then
+	        # Felix is built with RHEL/UBI and links against libpcap.so.1. We need this patchelf
+	        # until Debian changes the soname from .0.8 to .1.
+	        # FIXME remove the following patchelf command once Debian dependency is updated.
+	        patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 bin/calico-felix
+	    fi
+
 	    # The Debian version that we are about to generate.
 	    debver=${FORCE_VERSION_DEB:-`git_version_to_deb ${version}`}
 	    debver=`strip_v ${debver}`


### PR DESCRIPTION
## Description

This change patches calico-felix binary for Debian package only. We don't need to patch binary for RHEL rpm packages.

## Related issues/PRs

Pick https://github.com/projectcalico/calico/pull/8968 into release v3.27 branch.

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
