### PR TITLE
bump GO_BUILD_VER from v0.88 to v0.89 to move go from 1.21.9 to 1.21.…

### DIFF
--- a/felix/bpf-apache/Makefile
+++ b/felix/bpf-apache/Makefile
@@ -19,9 +19,6 @@ CFLAGS +=  \
 	-x c \
 	-D__KERNEL__ \
 	-D__ASM_SYSREG_H \
-	-Wno-unused-value \
-	-Wno-pointer-sign \
-	-Wno-compare-distinct-pointer-types \
 	-Wunused \
 	-Wall \
 	-Werror \
@@ -35,8 +32,8 @@ CFLAGS +=  \
 TRIPLET := $(shell gcc -dumpmachine)
 CFLAGS += -I/usr/include/$(TRIPLET)
 
-CC := clang-12
-LD := llc-12
+CC := clang-15
+LD := llc-15
 
 C_FILES:=filter.c redir.c sockops.c
 OBJS:=$(addprefix bin/,$(C_FILES:.c=.o))

--- a/felix/bpf-apache/redir.c
+++ b/felix/bpf-apache/redir.c
@@ -21,7 +21,6 @@ enum sk_action calico_sk_msg(struct sk_msg_md *msg)
 {
 	struct sock_key key = {};
 	__u32 sip, sport, dip, dport;
-	int err;
 
 	dip = msg->remote_ip4;
 	sip = msg->local_ip4;
@@ -52,7 +51,7 @@ enum sk_action calico_sk_msg(struct sk_msg_md *msg)
 		key.envoy_side = 1;
 	}
 
-	err = bpf_msg_redirect_hash(msg, &calico_sock_map, &key, BPF_REDIR_INGRESS);
+	bpf_msg_redirect_hash(msg, &calico_sock_map, &key, BPF_REDIR_INGRESS);
 
 	// If the packet couldn't be redirected, pass it to the rest of the
 	// stack.

--- a/felix/bpf-apache/sockops.c
+++ b/felix/bpf-apache/sockops.c
@@ -29,7 +29,6 @@ enum bpf_ret_code calico_sockops(struct bpf_sock_ops *skops)
 	struct sock_key key = {};
 	union ip4_bpf_lpm_trie_key sip, dip;
 	__u32 sport, dport;
-	int err;
 
 	switch (skops->op) {
 		case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
@@ -80,7 +79,7 @@ enum bpf_ret_code calico_sockops(struct bpf_sock_ops *skops)
 		key.envoy_side = 0;
 	}
 
-	err = bpf_sock_hash_update(skops, &calico_sock_map, &key, BPF_ANY);
+	bpf_sock_hash_update(skops, &calico_sock_map, &key, BPF_ANY);
 
 	return BPF_OK;
 }

--- a/felix/bpf-gpl/Makefile
+++ b/felix/bpf-gpl/Makefile
@@ -43,8 +43,8 @@ CFLAGS +=  \
 TRIPLET := $(shell gcc -dumpmachine)
 CFLAGS += -I/usr/include/$(TRIPLET)
 
-CC := clang-12
-LD := llc-12
+CC := clang-15
+LD := llc-15
 
 UT_C_FILES:=$(shell find ut -name '*.c')
 UT_OBJS:=$(UT_C_FILES:.c=.o) $(shell ./list-ut-objs)

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -1383,6 +1383,7 @@ int calico_tc_skb_send_icmp_replies(struct __sk_buff *skb)
 	ctx.state->sport = ctx.state->dport = 0;
 	return forward_or_drop(&ctx);
 deny:
+	(void)fib_flags;
 	return TC_ACT_SHOT;
 }
 

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -625,9 +625,6 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	struct cali_tc_state *state = ctx->state;
 	int rc = TC_ACT_UNSPEC;
 	bool fib = true;
-	//this is suppressing a variable set and never used clang warning. Maybe dangerous? 
-	//Is actually used at fwd_fib_set(&fwd, fib) but maybe new clang realizes thats unreachable.
-	CALI_DEBUG("fib=%t", fib);
 	struct ct_create_ctx ct_ctx_nat = {};
 	int ct_rc = ct_result_rc(state->ct_result.rc);
 	bool ct_related = ct_result_is_related(state->ct_result.rc);
@@ -1330,6 +1327,7 @@ encap_allow:
 	}
 
 deny:
+	(void)fib; //this is suppressing a variable set and never used clang warning.
 	{
 		struct fwd fwd = {
 			.res = TC_ACT_SHOT,

--- a/felix/bpf-gpl/tc.c
+++ b/felix/bpf-gpl/tc.c
@@ -625,6 +625,9 @@ static CALI_BPF_INLINE struct fwd calico_tc_skb_accepted(struct cali_tc_ctx *ctx
 	struct cali_tc_state *state = ctx->state;
 	int rc = TC_ACT_UNSPEC;
 	bool fib = true;
+	//this is suppressing a variable set and never used clang warning. Maybe dangerous? 
+	//Is actually used at fwd_fib_set(&fwd, fib) but maybe new clang realizes thats unreachable.
+	CALI_DEBUG("fib=%t", fib);
 	struct ct_create_ctx ct_ctx_nat = {};
 	int ct_rc = ct_result_rc(state->ct_result.rc);
 	bool ct_related = ct_result_is_related(state->ct_result.rc);

--- a/metadata.mk
+++ b/metadata.mk
@@ -3,7 +3,7 @@
 #################################################################################################
 
 # The version of github.com/projectcalico/go-build to use.
-GO_BUILD_VER = v0.88
+GO_BUILD_VER = v0.89
 
 # Version of Kubernetes to use for tests, bitnami/kubectl, and kubectl binary release.
 K8S_VERSION=v1.26.8

--- a/metadata.mk
+++ b/metadata.mk
@@ -15,7 +15,7 @@ ETCD_VERSION=v3.5.1
 # tests to timeout or fail.
 KINDEST_NODE_VERSION=v1.24.7
 PROTOC_VER=v0.1
-UBI_VERSION=8.9
+UBI_VERSION=8.10
 
 # Configuration for Semaphore integration.
 ORGANIZATION = projectcalico


### PR DESCRIPTION
…11 to fix cve https://avd.aquasec.com/nvd/cve-2024-24790

## Description
Trivy detects a cve.

trivy i --severity=HIGH,CRITICAL  docker.io/calico/typha:v3.26.4
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.4            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of         │
│         │                │          │        │                   │                 │ CONTINUATION frames causes DoS                             │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘

```

## Related issues/PRs

fixes #8974

another CVE PR is https://github.com/projectcalico/calico/pull/8975


## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
