### PR TITLE
felix: ensure vxlan udp flows are not tracked in conntrack

### DIFF
--- a/felix/generictables/match_builder.go
+++ b/felix/generictables/match_builder.go
@@ -56,6 +56,7 @@ type MatchCriteria interface {
 	IPSetNames() (ipSetNames []string)
 	SourcePorts(ports ...uint16) MatchCriteria
 	NotSourcePorts(ports ...uint16) MatchCriteria
+	DestPort(port uint16) MatchCriteria
 	DestPorts(ports ...uint16) MatchCriteria
 	NotDestPorts(ports ...uint16) MatchCriteria
 	SourcePortRanges(ports []*proto.PortRange) MatchCriteria

--- a/felix/iptables/match_builder.go
+++ b/felix/iptables/match_builder.go
@@ -234,6 +234,10 @@ func (m matchCriteria) NotSourcePorts(ports ...uint16) generictables.MatchCriter
 	return append(m, fmt.Sprintf("-m multiport ! --source-ports %s", portsString))
 }
 
+func (m matchCriteria) DestPort(port uint16) generictables.MatchCriteria {
+	return append(m, fmt.Sprintf("--dport %v", port))
+}
+
 func (m matchCriteria) DestPorts(ports ...uint16) generictables.MatchCriteria {
 	portsString := PortsToMultiport(ports)
 	return append(m, fmt.Sprintf("-m multiport --destination-ports %s", portsString))

--- a/felix/nftables/match_builder.go
+++ b/felix/nftables/match_builder.go
@@ -391,6 +391,11 @@ func (m nftMatch) NotSourcePorts(ports ...uint16) generictables.MatchCriteria {
 	return m
 }
 
+func (m nftMatch) DestPort(port uint16) generictables.MatchCriteria {
+	m.clauses = append(m.clauses, fmt.Sprintf("%s dport %v", m.transportProto(), port))
+	return m
+}
+
 func (m nftMatch) DestPorts(ports ...uint16) generictables.MatchCriteria {
 	m.clauses = append(m.clauses, fmt.Sprintf("%s dport %s", m.transportProto(), PortsToMultiport(ports)))
 	return m


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

felix: ensure vxlan udp flows are not tracked in conntrack

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes https://github.com/projectcalico/calico/issues/8934

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

fixes https://github.com/projectcalico/calico/issues/8934

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Felix now arranges for VXLAN packets to skip netfilter conntrack. VXLAN uses pseudo random source ports so the "flows" are unidirectional and not meaningful to conntrack.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
