### PR TITLE
BPF -  Fix route add/delete 

### DIFF
--- a/felix/routetable/route_table.go
+++ b/felix/routetable/route_table.go
@@ -845,7 +845,11 @@ func (r *RouteTable) fullResyncRoutesForLink(logCxt *log.Entry, ifaceName string
 			routeProblems = append(routeProblems, "unexpected route")
 		}
 		if dest != ipV6LinkLocalCIDR {
-			if !r.deviceRouteSourceAddress.Equal(route.Src) {
+			expectedSrc := r.deviceRouteSourceAddress
+			if expectedTargetFound && expectedTarget.Src != nil {
+				expectedSrc = expectedTarget.Src.AsNetIP()
+			}
+			if !expectedSrc.Equal(route.Src) {
 				routeProblems = append(routeProblems, "incorrect source address")
 			}
 			if r.deviceRouteProtocol != route.Protocol {


### PR DESCRIPTION
In BPF dataplane, we add routes to UDP services, so that host networked processes 
can reach them. This route is added/deleted in a loop forever because the routetable does not have a deviceRouteSrcAddress configured.

This PR fixes the issue by checking the source of the expected target against the route's source.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed continuous addition/deletion of service routes in eBPF mode.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
