### PR TITLE
Automated cherry pick of #8909: Rebuild containernetworking binaries, so we don't need to

### DIFF
--- a/cni-plugin/.gitignore
+++ b/cni-plugin/.gitignore
@@ -18,3 +18,5 @@ report/*.xml
 crds.yaml
 Makefile.common*
 config/
+.containernetworking-plugins.*
+containernetworking-plugins/

--- a/cni-plugin/.gitignore
+++ b/cni-plugin/.gitignore
@@ -18,5 +18,5 @@ report/*.xml
 crds.yaml
 Makefile.common*
 config/
-.containernetworking-plugins.*
+.containernetworking-plugins*
 containernetworking-plugins/

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -25,9 +25,6 @@ WINFV_SRCFILES=$(shell find win_tests -name '*.go')
 # fail if unable to download
 CURL=curl -C - -sSf
 
-# The CNI plugin code that will be cloned and rebuilt with this repo's go-build image
-# whenever the cni-plugin image is created.
-CNI_VERSION=v1.1.1-calico+go-1.22.5
 CNI_ARTIFACTS_URL=https://github.com/projectcalico/containernetworking-plugins/releases/download
 FLANNEL_ARTIFACTS_URL=https://github.com/projectcalico/flannel-cni-plugin/releases/download
 FLANNEL_VERSION=v1.2.0-flannel2-go1.22.5

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -143,10 +143,15 @@ $(DEPLOY_CONTAINER_FIPS_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
 
+
+# These are the files that we need to copy from the containernetworking-plugins project to our image.
+CN_FILES :=  host-local portmap loopback tuning bandwidth
+
 CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins-$(CNI_VERSION).cloned
 
 $(CONTAINERNETWORKING_PLUGINS_CLONED):
 	rm -rf containernetworking-plugins .containernetworking-plugins-*.cloned
+	@$(foreach file,$(CN_FILES),find bin -name $(file) -type f -delete;)
 	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
 	touch $@
 
@@ -159,11 +164,7 @@ $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth 
 		/bin/sh -xe -c ' \
 			GOFLAGS='-buildvcs=false' CGO_ENABLED=0 GOARCH=$(ARCH) ./build_linux.sh $(CN_FLAGS)'
 	-mkdir -p $(BIN)
-	cp containernetworking-plugins/bin/host-local $(BIN)
-	cp containernetworking-plugins/bin/loopback $(BIN)
-	cp containernetworking-plugins/bin/portmap $(BIN)
-	cp containernetworking-plugins/bin/tuning $(BIN)
-	cp containernetworking-plugins/bin/bandwidth $(BIN)
+	@$(foreach file,$(CN_FILES),cp containernetworking-plugins/bin/$(file) $(BIN);)
 
 .PHONY: fetch-cni-bins fetch-win-cni-bins
 fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -57,9 +57,8 @@ clean: clean-windows
 	find . -name '.*.published*' -type f -delete
 	rm -rf $(BIN) bin $(DEPLOY_CONTAINER_MARKER) .go-pkg-cache pkg/install/install.test
 	rm -f *.created
-	rm -rf bin $(DEPLOY_CONTAINER_MARKER) pkg/install/install.test
-	rm -rf config/ dist/
-	-docker image rm -f $$(docker images $(CNI_PLUGIN_IMAGE) -a -q)
+	rm -rf config/
+	rm -rf dist/
 	rm -rf containernetworking-plugins .containernetworking-plugins-*
 
 clean-windows: clean-windows-builder

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -59,8 +59,10 @@ clean: clean-windows
 	find . -name '.*.published*' -type f -delete
 	rm -rf $(BIN) bin $(DEPLOY_CONTAINER_MARKER) .go-pkg-cache pkg/install/install.test
 	rm -f *.created
-	rm -rf config/
-	rm -rf dist/
+	rm -rf bin $(DEPLOY_CONTAINER_MARKER) pkg/install/install.test
+	rm -rf config/ dist/
+	-docker image rm -f $$(docker images $(CNI_PLUGIN_IMAGE) -a -q)
+	rm -rf containernetworking-plugins .containernetworking-plugins.created
 
 clean-windows: clean-windows-builder
 	rm -rf $(WINDOWS_BIN) $(WINDOWS_DIST)
@@ -140,13 +142,31 @@ $(DEPLOY_CONTAINER_FIPS_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
 
+CN_FLAGS=-ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"
+
+CONTAINERNETWORKING_PLUGINS_CREATED=.containernetworking-plugins-$(ARCH).created
+CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins.cloned
+
+$(CONTAINERNETWORKING_PLUGINS_CLONED):
+	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
+	touch $@
+
+$(CONTAINERNETWORKING_PLUGINS_CREATED): $(CONTAINERNETWORKING_PLUGINS_CLONED)
+	docker run \
+		-v $(CURDIR)/containernetworking-plugins:/go/src/github.com/containernetworking/plugins:z \
+		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/containernetworking/plugins --rm $(CALICO_BUILD) \
+		/bin/sh -xe -c ' \
+			GOFLAGS='-buildvcs=false' CGO_ENABLED=0 GOARCH=$(ARCH) ./build_linux.sh $(CN_FLAGS)'
+	mv containernetworking-plugins/bin containernetworking-plugins/bin-$(ARCH)
+	touch $@
+
 .PHONY: fetch-cni-bins fetch-win-cni-bins
-fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
+fetch-cni-bins: $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
 fetch-win-cni-bins: $(WINDOWS_BIN)/flannel.exe
 
-$(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth:
+$(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth: $(CONTAINERNETWORKING_PLUGINS_CREATED)
 	-mkdir -p $(BIN)
-	$(CURL) -L --retry 5 $(CNI_ARTIFACTS_URL)/$(CNI_VERSION)/cni-plugins-linux-$(subst v7,,$(ARCH))-$(CNI_VERSION).tgz | tar -xz -C $(BIN) ./loopback ./host-local ./portmap ./tuning ./bandwidth
+	cp containernetworking-plugins/bin-$(ARCH)/$(subst $(BIN)/,,$@) $@
 
 $(BIN)/flannel:
 	-mkdir -p $(BIN)
@@ -184,7 +204,7 @@ ut-datastore:
 	-v $(CERTS_PATH):/home/user/certs \
 	$(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 			cd  /go/src/$(PACKAGE_NAME) && \
-			ginkgo -cover -r -skipPackage pkg/install $(GINKGO_ARGS)'
+			ginkgo -cover -r -skipPackage pkg/install,containernetworking-plugins $(GINKGO_ARGS)'
 
 ut-etcd: run-k8s-controller-manager build $(BIN)/host-local
 	$(MAKE) ut-datastore DATASTORE_TYPE=etcdv3

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -167,7 +167,7 @@ $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth 
 	cp containernetworking-plugins/bin/bandwidth $(BIN)
 
 .PHONY: fetch-cni-bins fetch-win-cni-bins
-fetch-cni-bins: $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
+fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
 fetch-win-cni-bins: $(WINDOWS_BIN)/flannel.exe
 
 $(BIN)/flannel:

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -25,7 +25,8 @@ WINFV_SRCFILES=$(shell find win_tests -name '*.go')
 # fail if unable to download
 CURL=curl -C - -sSf
 
-# Use forked CNI plugin URL and corresponding tagged artifacts.
+# The CNI plugin code that will be cloned and rebuilt with this repo's go-build image
+# whenever the cni-plugin image is created.
 CNI_VERSION=v1.1.1-calico+go-1.22.5
 CNI_ARTIFACTS_URL=https://github.com/projectcalico/containernetworking-plugins/releases/download
 FLANNEL_ARTIFACTS_URL=https://github.com/projectcalico/flannel-cni-plugin/releases/download
@@ -62,7 +63,7 @@ clean: clean-windows
 	rm -rf bin $(DEPLOY_CONTAINER_MARKER) pkg/install/install.test
 	rm -rf config/ dist/
 	-docker image rm -f $$(docker images $(CNI_PLUGIN_IMAGE) -a -q)
-	rm -rf containernetworking-plugins .containernetworking-plugins.created
+	rm -rf containernetworking-plugins .containernetworking-plugins-*
 
 clean-windows: clean-windows-builder
 	rm -rf $(WINDOWS_BIN) $(WINDOWS_DIST)
@@ -144,29 +145,30 @@ $(DEPLOY_CONTAINER_FIPS_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
 
 CN_FLAGS=-ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"
 
-CONTAINERNETWORKING_PLUGINS_CREATED=.containernetworking-plugins-$(ARCH).created
-CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins.cloned
+CONTAINERNETWORKING_PLUGINS_CREATED=.containernetworking-plugins-$(CNI_VERSION)-$(ARCH).created
+CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins-$(CNI_VERSION).cloned
 
 $(CONTAINERNETWORKING_PLUGINS_CLONED):
+	rm -rf containernetworking-plugins .containernetworking-plugins-*.cloned
 	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
 	touch $@
 
-$(CONTAINERNETWORKING_PLUGINS_CREATED): $(CONTAINERNETWORKING_PLUGINS_CLONED)
+$(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth &: $(CONTAINERNETWORKING_PLUGINS_CLONED)
 	docker run \
 		-v $(CURDIR)/containernetworking-plugins:/go/src/github.com/containernetworking/plugins:z \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/containernetworking/plugins --rm $(CALICO_BUILD) \
 		/bin/sh -xe -c ' \
 			GOFLAGS='-buildvcs=false' CGO_ENABLED=0 GOARCH=$(ARCH) ./build_linux.sh $(CN_FLAGS)'
-	mv containernetworking-plugins/bin containernetworking-plugins/bin-$(ARCH)
-	touch $@
+	-mkdir -p $(BIN)
+	cp containernetworking-plugins/bin/host-local $(BIN)
+	cp containernetworking-plugins/bin/loopback $(BIN)
+	cp containernetworking-plugins/bin/portmap $(BIN)
+	cp containernetworking-plugins/bin/tuning $(BIN)
+	cp containernetworking-plugins/bin/bandwidth $(BIN)
 
 .PHONY: fetch-cni-bins fetch-win-cni-bins
 fetch-cni-bins: $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
 fetch-win-cni-bins: $(WINDOWS_BIN)/flannel.exe
-
-$(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth: $(CONTAINERNETWORKING_PLUGINS_CREATED)
-	-mkdir -p $(BIN)
-	cp containernetworking-plugins/bin-$(ARCH)/$(subst $(BIN)/,,$@) $@
 
 $(BIN)/flannel:
 	-mkdir -p $(BIN)

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -143,15 +143,14 @@ $(DEPLOY_CONTAINER_FIPS_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
 
-CN_FLAGS=-ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"
-
-CONTAINERNETWORKING_PLUGINS_CREATED=.containernetworking-plugins-$(CNI_VERSION)-$(ARCH).created
 CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins-$(CNI_VERSION).cloned
 
 $(CONTAINERNETWORKING_PLUGINS_CLONED):
 	rm -rf containernetworking-plugins .containernetworking-plugins-*.cloned
 	git clone --single-branch --branch $(CNI_VERSION) https://github.com/projectcalico/containernetworking-plugins.git
 	touch $@
+
+CN_FLAGS=-ldflags "-X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=$(GIT_VERSION)"
 
 $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth &: $(CONTAINERNETWORKING_PLUGINS_CLONED)
 	docker run \

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -158,7 +158,7 @@ $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth 
 		-v $(CURDIR)/containernetworking-plugins:/go/src/github.com/containernetworking/plugins:z \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/containernetworking/plugins --rm $(CALICO_BUILD) \
 		/bin/sh -xe -c ' \
-			GOFLAGS='-buildvcs=false' CGO_ENABLED=0 GOARCH=$(ARCH) ./build_linux.sh $(CN_FLAGS)'
+			GOFLAGS='-buildvcs=false' CGO_ENABLED=0 GOARCH=$(subst v7,,$(ARCH)) ./build_linux.sh $(CN_FLAGS)'
 	-mkdir -p $(BIN)
 	@$(foreach file,$(CN_FILES),cp containernetworking-plugins/bin/$(file) $(BIN);)
 

--- a/metadata.mk
+++ b/metadata.mk
@@ -48,5 +48,5 @@ WINDOWS_HPC_VERSION ?= v1.0.0
 WINDOWS_VERSIONS ?= 1809 ltsc2022
 
 # The CNI plugin code that will be cloned and rebuilt with this repo's go-build image
-# whenever the cni-plugin image is created.
-CNI_VERSION=v1.1.1-calico+go-1.22.5
+# whenever the cni-plugin image is created. v1.22.4+ are not compatible with go 1.21.
+CNI_VERSION=v1.1.1-calico+go-1.22.3

--- a/metadata.mk
+++ b/metadata.mk
@@ -49,4 +49,4 @@ WINDOWS_VERSIONS ?= 1809 ltsc2022
 
 # The CNI plugin code that will be cloned and rebuilt with this repo's go-build image
 # whenever the cni-plugin image is created.
-CNI_VERSION=v1.1.1-calico+go-1.22.3
+CNI_VERSION=v1.1.1-calico+go-1.22.5

--- a/metadata.mk
+++ b/metadata.mk
@@ -46,3 +46,7 @@ WINDOWS_DIST = dist/windows
 WINDOWS_HPC_VERSION ?= v1.0.0
 # The Windows versions used as base for Calico Windows images
 WINDOWS_VERSIONS ?= 1809 ltsc2022
+
+# The CNI plugin code that will be cloned and rebuilt with this repo's go-build image
+# whenever the cni-plugin image is created.
+CNI_VERSION=v1.1.1-calico+go-1.22.3


### PR DESCRIPTION
Cherry pick of #8909 on release-v3.27.

#8909: Rebuild containernetworking binaries, so we don't need to