### PR TITLE
[release-v3.27] Fix libpcap patchelf for calico-felix

### DIFF
--- a/hack/release/packaging/utils/create-update-packages.sh
+++ b/hack/release/packaging/utils/create-update-packages.sh
@@ -208,13 +208,13 @@ function do_felix {
     rm -f Makefile
     # Override dpkg's default file exclusions, otherwise our binaries won't get included (and some
     # generated files will).
-    # Build rpm first and then deb because we need to patchelf bin/calico-felix for Debian.
+    # Build deb first and then rpm because we need to patchelf bin/calico-felix for RHEL.
     PKG_NAME=felix \
 	    NAME=Felix \
 	    RPM_TAR_ARGS='--exclude=bin/calico-felix-* --exclude=.gitignore --exclude=*.d --exclude=*.ll --exclude=.go-pkg-cache --exclude=vendor --exclude=report' \
 	    DPKG_EXCL="-I'bin/calico-felix-*' -I.git -I.gitignore -I'*.d' -I'*.ll' -I.go-pkg-cache -I.git -Ivendor -Ireport" \
 	    DEB_EPOCH=2: \
-	    ${rootdir}/hack/release/packaging/utils/make-packages.sh rpm deb
+	    ${rootdir}/hack/release/packaging/utils/make-packages.sh deb rpm
     git checkout Makefile
 
 

--- a/hack/release/packaging/utils/make-packages.sh
+++ b/hack/release/packaging/utils/make-packages.sh
@@ -42,13 +42,6 @@ for package_type in "$@"; do
     case ${package_type} in
 
 	deb )
-	    if [ "${PKG_NAME}" = felix ]; then
-	        # Felix is built with RHEL/UBI and links against libpcap.so.1. We need this patchelf
-	        # until Debian changes the soname from .0.8 to .1.
-	        # FIXME remove the following patchelf command once Debian dependency is updated.
-	        patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 bin/calico-felix
-	    fi
-
 	    # The Debian version that we are about to generate.
 	    debver=${FORCE_VERSION_DEB:-`git_version_to_deb ${version}`}
 	    debver=`strip_v ${debver}`
@@ -87,6 +80,13 @@ EOF
 	    ;;
 
 	rpm )
+	    if [ "${PKG_NAME}" = felix ]; then
+	        # Felix is built with Debian based toolchain and links against libpcap.so.0.8.
+			# We need this patchelf for felix to run on RHEL distros. This is not needed
+			# with our RHEL based toolchain.
+	        patchelf --replace-needed libpcap.so.0.8 libpcap.so.1 bin/calico-felix
+	    fi
+
 	    rpm_spec=rpm/${PKG_NAME}.spec
 	    if [ -f ${rpm_spec}.in ]; then
 		debver=${FORCE_VERSION_RPM:-`git_version_to_rpm ${version}`}


### PR DESCRIPTION
## Description

For Calico v3.27, we build felix with Debian-based toolchain which links against libpcap.so.0.8. It will fail on RHEL rpm install because RHEL ships with libpcap.so.1. This change patchelf calico-felix to run on RHEL distros. This is not required for Calico v3.28+ because we switched our building base to RHEL/UBI.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
