### PR TITLE
Increase ipset creation / deletion test timeouts to allow for slow CI

### DIFF
--- a/felix/fv/ipsets_test.go
+++ b/felix/fv/ipsets_test.go
@@ -123,17 +123,16 @@ var _ = Context("_IPSets_ Tests for IPset rendering", func() {
 		timeToRecreateAll := time.Since(startTime)
 		By(fmt.Sprint("All IP sets programmed after ", timeToRecreateAll))
 
-		// nftables mode is a bit slower here, so use a longer timeout
-		// until we can optimize nftables set programming.
-		timeout := 30 * time.Second
+		// This should take 10-30s, but leave some headroom for inconsistent CI performance
+		timeout := 90 * time.Second
 		if NFTMode() {
-			timeout = 90 * time.Second
+			// nftables mode is a bit slower here, so use a longer timeout
+			// until we can optimize nftables set programming.
+			timeout = 120 * time.Second
 		}
 		Expect(timeToCreateAll).To(BeNumerically("<", timeout),
 			"Creating IP sets succeeded but slower than expected")
 
-		// Before we rate limited deletions, this would take 80s+.  Now it takes
-		// 10s so 20s should give some headroom.
 		Expect(timeToRecreateAll).To(BeNumerically("<", timeout),
 			"Recreating IP sets succeeded but slower than expected")
 	})


### PR DESCRIPTION
The first of these tests failed here: https://github.com/projectcalico/calico/pull/8957

CI machines don't provide good or consistent performance, so I don't believe the FVs are an appropriate place for tightly bounded performance tests.