### PR TITLE
CNI file permissions based on CIS Benchmarks

### DIFF
--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -303,6 +304,12 @@ func isValidJSON(s string) error {
 	return json.Unmarshal([]byte(s), &js)
 }
 
+// Convert permission string to fileMode for testing purposes
+func stringToFileMode(permString string) (os.FileMode, error) {
+        perm, err := strconv.ParseUint(permString, 8, 32)
+        return os.FileMode(perm), err
+}
+
 func writeCNIConfig(c config) {
 	netconf := defaultNetConf()
 
@@ -379,9 +386,17 @@ func writeCNIConfig(c config) {
 	}
 
 	// Write out the file.
+	// File permission: default (0600) and testing (0644)
+	permString := getEnv("TEST_FILE_PERMISSION", "0600")
+	logrus.Infof("CNI config file permission is set to %s\n", permString)
+	perm, err := stringToFileMode(permString)
+        if err != nil {
+                logrus.Fatal(err)
+        }
+
 	name := getEnv("CNI_CONF_NAME", "10-calico.conflist")
 	path := winutils.GetHostPath(fmt.Sprintf("/host/etc/cni/net.d/%s", name))
-	err = os.WriteFile(path, []byte(netconf), 0o600)
+	err = os.WriteFile(path, []byte(netconf), perm)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -381,7 +381,7 @@ func writeCNIConfig(c config) {
 	// Write out the file.
 	name := getEnv("CNI_CONF_NAME", "10-calico.conflist")
 	path := winutils.GetHostPath(fmt.Sprintf("/host/etc/cni/net.d/%s", name))
-	err = os.WriteFile(path, []byte(netconf), 0o644)
+	err = os.WriteFile(path, []byte(netconf), 0o600)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/cni-plugin/pkg/install/install.go
+++ b/cni-plugin/pkg/install/install.go
@@ -306,8 +306,8 @@ func isValidJSON(s string) error {
 
 // Convert permission string to fileMode for testing purposes
 func stringToFileMode(permString string) (os.FileMode, error) {
-        perm, err := strconv.ParseUint(permString, 8, 32)
-        return os.FileMode(perm), err
+	perm, err := strconv.ParseUint(permString, 8, 32)
+	return os.FileMode(perm), err
 }
 
 func writeCNIConfig(c config) {
@@ -390,9 +390,9 @@ func writeCNIConfig(c config) {
 	permString := getEnv("TEST_FILE_PERMISSION", "0600")
 	logrus.Infof("CNI config file permission is set to %s\n", permString)
 	perm, err := stringToFileMode(permString)
-        if err != nil {
-                logrus.Fatal(err)
-        }
+	if err != nil {
+		logrus.Fatal(err)
+	}
 
 	name := getEnv("CNI_CONF_NAME", "10-calico.conflist")
 	path := winutils.GetHostPath(fmt.Sprintf("/host/etc/cni/net.d/%s", name))

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -89,6 +89,7 @@ func runCniContainer(tempDir string, binFolderWriteable bool, extraArgs ...strin
 		"-e", "KUBERNETES_SERVICE_PORT=6443",
 		"-e", "KUBERNETES_NODE_NAME=my-node",
 		"-e", "KUBECONFIG=/home/user/certs/kubeconfig",
+		"-e", "TEST_FILE_PERMISSION=0644",
 		"-v", tempDir + "/bin:" + binFolder,
 		"-v", tempDir + "/net.d:/host/etc/cni/net.d",
 		"-v", tempDir + "/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount",
@@ -267,7 +268,7 @@ PuB/TL+u2y+iQUyXxLy3
 		})
 
 		It("Should parse and output a templated config", func() {
-			err := runCniContainer(tempDir, true, "-u", "0")
+			err := runCniContainer(tempDir, true)
 			Expect(err).NotTo(HaveOccurred())
 			expectFileContents(tempDir+"/net.d/10-calico.conflist", expectedDefaultConfig)
 		})
@@ -299,13 +300,13 @@ PuB/TL+u2y+iQUyXxLy3
 	})
 
 	It("should support CNI_CONF_NAME", func() {
-		err := runCniContainer(tempDir, true, "-u", "0", "-e", "CNI_CONF_NAME=20-calico.conflist")
+		err := runCniContainer(tempDir, true, "-e", "CNI_CONF_NAME=20-calico.conflist")
 		Expect(err).NotTo(HaveOccurred())
 		expectFileContents(tempDir+"/net.d/20-calico.conflist", expectedDefaultConfig)
 	})
 
 	It("should support a custom CNI_NETWORK_CONFIG", func() {
-		err := runCniContainer(tempDir, true, "-u", "0", "-e", "CNI_NETWORK_CONFIG={}")
+		err := runCniContainer(tempDir, true, "-e", "CNI_NETWORK_CONFIG={}")
 		Expect(err).NotTo(HaveOccurred())
 		actual, err := os.ReadFile(tempDir + "/net.d/10-calico.conflist")
 		Expect(err).NotTo(HaveOccurred())
@@ -325,7 +326,6 @@ PuB/TL+u2y+iQUyXxLy3
 		Expect(err).NotTo(HaveOccurred())
 		err = runCniContainer(
 			tempDir, true,
-			"-u", "0",
 			"-e", "CNI_NETWORK_CONFIG='oops, I used the CNI_NETWORK_CONFIG'",
 			"-e", "CNI_NETWORK_CONFIG_FILE=/host/etc/cni/net.d/alternate-config",
 		)
@@ -377,7 +377,7 @@ PuB/TL+u2y+iQUyXxLy3
 		It("Should copy a non-hidden file", func() {
 			err = os.WriteFile(tempDir+"/certs/etcd-cert", []byte("doesn't matter"), 0644)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to write file: %v", err))
-			err = runCniContainer(tempDir, true, "-u", "0", "-v", tempDir+"/certs:/calico-secrets", "-e", "CNI_NETWORK_CONFIG={\"etcd_cert\": \"__ETCD_CERT_FILE__\"}")
+			err = runCniContainer(tempDir, true, "-v", tempDir+"/certs:/calico-secrets", "-e", "CNI_NETWORK_CONFIG={\"etcd_cert\": \"__ETCD_CERT_FILE__\"}")
 			Expect(err).NotTo(HaveOccurred())
 			file, err := os.Open(tempDir + "/net.d/calico-tls/etcd-cert")
 			Expect(err).NotTo(HaveOccurred())

--- a/cni-plugin/pkg/install/install_test.go
+++ b/cni-plugin/pkg/install/install_test.go
@@ -267,7 +267,7 @@ PuB/TL+u2y+iQUyXxLy3
 		})
 
 		It("Should parse and output a templated config", func() {
-			err := runCniContainer(tempDir, true)
+			err := runCniContainer(tempDir, true, "-u", "0")
 			Expect(err).NotTo(HaveOccurred())
 			expectFileContents(tempDir+"/net.d/10-calico.conflist", expectedDefaultConfig)
 		})
@@ -299,13 +299,13 @@ PuB/TL+u2y+iQUyXxLy3
 	})
 
 	It("should support CNI_CONF_NAME", func() {
-		err := runCniContainer(tempDir, true, "-e", "CNI_CONF_NAME=20-calico.conflist")
+		err := runCniContainer(tempDir, true, "-u", "0", "-e", "CNI_CONF_NAME=20-calico.conflist")
 		Expect(err).NotTo(HaveOccurred())
 		expectFileContents(tempDir+"/net.d/20-calico.conflist", expectedDefaultConfig)
 	})
 
 	It("should support a custom CNI_NETWORK_CONFIG", func() {
-		err := runCniContainer(tempDir, true, "-e", "CNI_NETWORK_CONFIG={}")
+		err := runCniContainer(tempDir, true, "-u", "0", "-e", "CNI_NETWORK_CONFIG={}")
 		Expect(err).NotTo(HaveOccurred())
 		actual, err := os.ReadFile(tempDir + "/net.d/10-calico.conflist")
 		Expect(err).NotTo(HaveOccurred())
@@ -325,6 +325,7 @@ PuB/TL+u2y+iQUyXxLy3
 		Expect(err).NotTo(HaveOccurred())
 		err = runCniContainer(
 			tempDir, true,
+			"-u", "0",
 			"-e", "CNI_NETWORK_CONFIG='oops, I used the CNI_NETWORK_CONFIG'",
 			"-e", "CNI_NETWORK_CONFIG_FILE=/host/etc/cni/net.d/alternate-config",
 		)
@@ -376,7 +377,7 @@ PuB/TL+u2y+iQUyXxLy3
 		It("Should copy a non-hidden file", func() {
 			err = os.WriteFile(tempDir+"/certs/etcd-cert", []byte("doesn't matter"), 0644)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to write file: %v", err))
-			err = runCniContainer(tempDir, true, "-v", tempDir+"/certs:/calico-secrets", "-e", "CNI_NETWORK_CONFIG={\"etcd_cert\": \"__ETCD_CERT_FILE__\"}")
+			err = runCniContainer(tempDir, true, "-u", "0", "-v", tempDir+"/certs:/calico-secrets", "-e", "CNI_NETWORK_CONFIG={\"etcd_cert\": \"__ETCD_CERT_FILE__\"}")
 			Expect(err).NotTo(HaveOccurred())
 			file, err := os.Open(tempDir + "/net.d/calico-tls/etcd-cert")
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
CNI-related CIS Benchmarks include:

1.1.9	Ensure that the Container Network Interface file
        permissions are set to 600 or more restrictive.

Tests:
- Running "make test" in 'cni-plugin' directory successfully
- Delpoying Calico-node and Calico-Kube-controllers pods successfully
- Ensure /etc/cni/net.d/10-calico.conflist file permissions is set to 600
- Ensure Calico plugin is listed under '/opt/cni/bin/'

## Related issues/PRs

https://github.com/projectcalico/calico/issues/7461

## Todos

- [ x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Adjust CNI config file permissions to satisfy CIS benchmark expectations.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
