### PR TITLE
[release-v3.27] Auto pick #8990: Rebuild flannel-cni-plugin binaries on demand

### DIFF
--- a/cni-plugin/.gitignore
+++ b/cni-plugin/.gitignore
@@ -20,3 +20,5 @@ Makefile.common*
 config/
 .containernetworking-plugins*
 containernetworking-plugins/
+.flannel-cni-plugin*
+flannel-cni-plugin/

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -27,7 +27,6 @@ CURL=curl -C - -sSf
 
 CNI_ARTIFACTS_URL=https://github.com/projectcalico/containernetworking-plugins/releases/download
 FLANNEL_ARTIFACTS_URL=https://github.com/projectcalico/flannel-cni-plugin/releases/download
-FLANNEL_VERSION=v1.2.0-flannel2-go1.22.5
 
 # By default set the CNI_SPEC_VERSION to 0.3.1 for tests.
 CNI_SPEC_VERSION?=0.3.1
@@ -60,6 +59,7 @@ clean: clean-windows
 	rm -rf config/
 	rm -rf dist/
 	rm -rf containernetworking-plugins .containernetworking-plugins-*
+	rm -rf flannel-cni-plugin .flannel-cni-plugin-*
 
 clean-windows: clean-windows-builder
 	rm -rf $(WINDOWS_BIN) $(WINDOWS_DIST)
@@ -114,7 +114,7 @@ $(WINDOWS_BIN)/calico-ipam.exe: $(WINDOWS_BIN)/calico.exe
 # image. These must be added as reqs to 'image-windows' (originally defined in
 # lib.Makefile) on the specific package Makefile otherwise they are not correctly
 # recognized.
-WINDOWS_IMAGE_REQS := Dockerfile-windows build fetch-win-cni-bins
+WINDOWS_IMAGE_REQS := Dockerfile-windows build build-win-cni-bins
 image-windows: $(WINDOWS_IMAGE_REQS)
 
 ###############################################################################
@@ -128,20 +128,19 @@ sub-image-fips-%:
 	$(MAKE) image FIPS=true ARCH=$*
 
 # Builds the statically compiled binaries into a container.
-$(DEPLOY_CONTAINER_STATIC_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
+$(DEPLOY_CONTAINER_STATIC_MARKER): Dockerfile.$(ARCH) build build-cni-bins
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BIN) -t $(CNI_PLUGIN_IMAGE):latest-$(ARCH) -f Dockerfile.$(ARCH) . --load
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest
 	touch $@
 
 # Builds the FIPS binaries into a container.
-$(DEPLOY_CONTAINER_FIPS_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
+$(DEPLOY_CONTAINER_FIPS_MARKER): Dockerfile.$(ARCH) build build-cni-bins
 	$(DOCKER_BUILD) --build-arg BIN_DIR=$(BIN) -t $(CNI_PLUGIN_IMAGE):latest-fips-$(ARCH) -f Dockerfile.$(ARCH) . --load
 	$(MAKE) retag-build-images-with-registries VALIDARCHES=$(ARCH) IMAGETAG=latest-fips LATEST_IMAGE_TAG=latest-fips
 	touch $@
 
-
 # These are the files that we need to copy from the containernetworking-plugins project to our image.
-CN_FILES :=  host-local portmap loopback tuning bandwidth
+CN_FILES := host-local portmap loopback tuning bandwidth
 
 CONTAINERNETWORKING_PLUGINS_CLONED=.containernetworking-plugins-$(CNI_VERSION).cloned
 
@@ -162,19 +161,35 @@ $(BIN)/host-local $(BIN)/loopback $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth 
 	-mkdir -p $(BIN)
 	@$(foreach file,$(CN_FILES),cp containernetworking-plugins/bin/$(file) $(BIN);)
 
-.PHONY: fetch-cni-bins fetch-win-cni-bins
-fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
-fetch-win-cni-bins: $(WINDOWS_BIN)/flannel.exe
+FLANNEL_CNI_PLUGIN_CLONED=.flannel-cni-plugin-$(FLANNEL_VERSION).cloned
 
-$(BIN)/flannel:
+$(FLANNEL_CNI_PLUGIN_CLONED):
+	rm -rf flannel-cni-plugin .flannel-cni-plugin-*.cloned
+	-rm -rf $(BIN)/flannel $(WINDOWS_BIN)/flannel.exe
+	git clone --single-branch --branch $(FLANNEL_VERSION) https://github.com/projectcalico/flannel-cni-plugin.git
+	touch $@
+
+$(BIN)/flannel: $(FLANNEL_CNI_PLUGIN_CLONED)
+	docker run \
+		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
+		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
+		/bin/sh -xe -c ' \
+			ARCH=$(ARCH) VERSION=$(FLANNEL_VERSION) make build_linux'
 	-mkdir -p $(BIN)
-	$(CURL) -L --retry 5 $(FLANNEL_ARTIFACTS_URL)/$(FLANNEL_VERSION)/cni-plugin-flannel-linux-$(subst v7,,$(ARCH))-$(FLANNEL_VERSION).tgz | tar -xz -C $(BIN) flannel-$(subst v7,,$(ARCH))
-	mv $(BIN)/flannel-$(subst v7,,$(ARCH)) $@
+	cp flannel-cni-plugin/dist/flannel-$(ARCH) $(BIN)/flannel
 
-$(WINDOWS_BIN)/flannel.exe:
+$(WINDOWS_BIN)/flannel.exe: $(FLANNEL_CNI_PLUGIN_CLONED)
+	docker run \
+		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
+		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
+		/bin/sh -xe -c ' \
+			ARCH=$(ARCH) VERSION=$(FLANNEL_VERSION) make build_windows'
 	-mkdir -p $(WINDOWS_BIN)
-	$(CURL) -L --retry 5 $(FLANNEL_ARTIFACTS_URL)/$(FLANNEL_VERSION)/cni-plugin-flannel-windows-amd64-$(FLANNEL_VERSION).tgz | tar -xz -C $(WINDOWS_BIN) flannel-amd64.exe
-	mv $(WINDOWS_BIN)/flannel-amd64.exe $@
+	cp flannel-cni-plugin/dist/flannel-$(ARCH).exe $(WINDOWS_BIN)/flannel.exe
+
+.PHONY: build-cni-bins build-win-cni-bins
+build-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
+build-win-cni-bins: $(WINDOWS_BIN)/flannel.exe
 
 ###############################################################################
 # Unit Tests
@@ -202,7 +217,7 @@ ut-datastore:
 	-v $(CERTS_PATH):/home/user/certs \
 	$(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 			cd  /go/src/$(PACKAGE_NAME) && \
-			ginkgo -cover -r -skipPackage pkg/install,containernetworking-plugins $(GINKGO_ARGS)'
+			ginkgo -cover -r -skipPackage pkg/install,containernetworking-plugins,flannel-cni-plugin $(GINKGO_ARGS)'
 
 ut-etcd: run-k8s-controller-manager build $(BIN)/host-local
 	$(MAKE) ut-datastore DATASTORE_TYPE=etcdv3

--- a/cni-plugin/Makefile
+++ b/cni-plugin/Makefile
@@ -174,18 +174,18 @@ $(BIN)/flannel: $(FLANNEL_CNI_PLUGIN_CLONED)
 		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
 		/bin/sh -xe -c ' \
-			ARCH=$(ARCH) VERSION=$(FLANNEL_VERSION) make build_linux'
+			ARCH=$(subst v7,,$(ARCH)) VERSION=$(FLANNEL_VERSION) make build_linux'
 	-mkdir -p $(BIN)
-	cp flannel-cni-plugin/dist/flannel-$(ARCH) $(BIN)/flannel
+	cp flannel-cni-plugin/dist/flannel-$(subst v7,,$(ARCH)) $(BIN)/flannel
 
 $(WINDOWS_BIN)/flannel.exe: $(FLANNEL_CNI_PLUGIN_CLONED)
 	docker run \
 		-v $(CURDIR)/flannel-cni-plugin:/go/src/github.com/flannel-io/cni-plugin:z \
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) -w /go/src/github.com/flannel-io/cni-plugin --rm $(CALICO_BUILD) \
 		/bin/sh -xe -c ' \
-			ARCH=$(ARCH) VERSION=$(FLANNEL_VERSION) make build_windows'
+			ARCH=$(subst v7,,$(ARCH)) VERSION=$(FLANNEL_VERSION) make build_windows'
 	-mkdir -p $(WINDOWS_BIN)
-	cp flannel-cni-plugin/dist/flannel-$(ARCH).exe $(WINDOWS_BIN)/flannel.exe
+	cp flannel-cni-plugin/dist/flannel-$(subst v7,,$(ARCH)).exe $(WINDOWS_BIN)/flannel.exe
 
 .PHONY: build-cni-bins build-win-cni-bins
 build-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth

--- a/libcalico-go/lib/ipam/ipam_test.go
+++ b/libcalico-go/lib/ipam/ipam_test.go
@@ -238,7 +238,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 3))
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 26", func(b Benchmarker) {
@@ -255,7 +255,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 3))
 		}, 100)
 
 		Measure("It should be able to allocate a single address quickly - blocksize 20", func(b Benchmarker) {
@@ -272,7 +272,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(1))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 3))
 		}, 100)
 
 		Measure("It should be able to allocate a lot of addresses quickly", func(b Benchmarker) {
@@ -289,7 +289,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(v4ia.IPs)).To(Equal(64))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 3))
 		}, 20)
 
 		Measure("It should be able to allocate and release addresses quickly", func(b Benchmarker) {
@@ -313,7 +313,7 @@ var _ = testutils.E2eDatastoreDescribe("IPAM tests", testutils.DatastoreAll, fun
 				Expect(len(out)).To(Equal(0))
 			})
 
-			Expect(runtime.Seconds()).Should(BeNumerically("<", 1))
+			Expect(runtime.Seconds()).Should(BeNumerically("<", 3))
 		}, 20)
 	})
 

--- a/metadata.mk
+++ b/metadata.mk
@@ -50,3 +50,4 @@ WINDOWS_VERSIONS ?= 1809 ltsc2022
 # The CNI plugin code that will be cloned and rebuilt with this repo's go-build image
 # whenever the cni-plugin image is created. v1.22.4+ are not compatible with go 1.21.
 CNI_VERSION=v1.1.1-calico+go-1.22.3
+FLANNEL_VERSION=v1.2.0-flannel2-go1.22.2


### PR DESCRIPTION
Cherry pick of #8990 on release-v3.27.

#8990: Rebuild flannel-cni-plugin binaries on demand

# Original PR Body below

Do the same for flannel-cni-plugin as https://github.com/projectcalico/calico/pull/8909 did for containernetworking-plugins, i.e. clone the repo and build using the go-build image from the calico monorepo on-demand.

This is done to remove the tedious step of creating new releases and updating the Makefile with the new version on the flannel-cni-plugin repo.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.