### PR TITLE
Remove ApplyOnForward for network policy resource

### DIFF
--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ func convertNetworkPolicyV2ToV1Value(val interface{}) (interface{}, error) {
 		OutboundRules:    RulesAPIV2ToBackend(spec.Egress, v3res.Namespace),
 		Selector:         selector,
 		Types:            policyTypesAPIV2ToBackend(spec.Types),
-		ApplyOnForward:   true,
+		ApplyOnForward:   false,
 		PerformanceHints: v3res.Spec.PerformanceHints,
 	}
 

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/networkpolicyprocessor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ var _ = Describe("Test the NetworkPolicy update processor", func() {
 				Value: &model.Policy{
 					Namespace:      ns1,
 					Selector:       "projectcalico.org/namespace == 'namespace1'",
-					ApplyOnForward: true,
+					ApplyOnForward: false,
 				},
 				Revision: testRev,
 			}))
@@ -193,7 +193,7 @@ var (
 				Order:          &testDefaultPolicyOrder,
 				Selector:       "(projectcalico.org/orchestrator == 'k8s') && projectcalico.org/namespace == 'default'",
 				Types:          []string{"egress"},
-				ApplyOnForward: true,
+				ApplyOnForward: false,
 				OutboundRules: []model.Rule{
 					{
 						Action:      "allow",
@@ -238,7 +238,7 @@ var expected2 = []*model.KVPair{
 			Order:          &testDefaultPolicyOrder,
 			Selector:       "(projectcalico.org/orchestrator == 'k8s') && projectcalico.org/namespace == 'default'",
 			Types:          []string{"ingress"},
-			ApplyOnForward: true,
+			ApplyOnForward: false,
 			InboundRules: []model.Rule{
 				{
 					Action:                       "allow",

--- a/libcalico-go/lib/backend/syncersv1/updateprocessors/shared_test.go
+++ b/libcalico-go/lib/backend/syncersv1/updateprocessors/shared_test.go
@@ -208,7 +208,7 @@ func fullNPv1(namespace string) (p model.Policy) {
 		Order:          &testPolicyOrder101,
 		InboundRules:   []model.Rule{ir},
 		OutboundRules:  []model.Rule{or},
-		ApplyOnForward: true,
+		ApplyOnForward: false,
 		Types:          []string{"ingress", "egress"},
 	}
 }


### PR DESCRIPTION
## Description
`ApplyOnForward` is only valid for [GlobalNetworkPolicy](https://docs.tigera.io/calico/latest/reference/resources/globalnetworkpolicy) and is not valid in [NetworkPolicy](https://docs.tigera.io/calico/latest/reference/resources/networkpolicy) resource. This PR sets it to `False` by default for `NetworkPolicy`.

Similar to this PR for EE: https://github.com/tigera/libcalico-go-private/pull/623

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
