### PR TITLE
Add value sanity check and Len to DeltaTracker.

### DIFF
--- a/felix/deltatracker/delta_tracker.go
+++ b/felix/deltatracker/delta_tracker.go
@@ -43,6 +43,16 @@ import (
 // keys that are in the dataplane map but not in the desired map.  The
 // pending maps are exposed via the IterPendingUpdates and IterPendingDeletions
 // methods.
+//
+// It's not recommended to use mutable objects in a DeltaTracker.  Updating a
+// mutable object while it is in the DeltaTracker will corrupt its internal
+// state.  By design, the DeltaTracker aliases the Desired and Dataplane values
+// if they happen to be equal. So, to safely mutate a value, you must
+// take a copy, mutate the copy and then re-insert the value.  Note: it is not
+// safe to delete the object from one side of the tracker, mutate it and
+// re-insert it.  Deleting an object that is in-sync from the Dataplane side
+// moves the object from the inDataplaneAndDesired map to the desiredUpdates
+// map, keeping a reference.
 type DeltaTracker[K comparable, V any] struct {
 	// To reduce occupancy, we treat the set of KVs in the dataplane and in the
 	// desired state like a Venn diagram, and we only store each region once
@@ -78,6 +88,8 @@ type DeltaTracker[K comparable, V any] struct {
 	inDataplaneNotDesired map[K]V
 	desiredUpdates        map[K]V
 
+	desiredLen int
+
 	// valuesEqual is the comparison function for the value type, it defaults to
 	// reflect.DeepEqual.
 	valuesEqual func(a, b V) bool
@@ -98,6 +110,15 @@ func WithLogCtx[K comparable, V any](lc *logrus.Entry) Option[K, V] {
 }
 
 func New[K comparable, V any](opts ...Option[K, V]) *DeltaTracker[K, V] {
+	var valueZero V
+	valType := reflect.TypeOf(valueZero)
+	if valType != nil && valType.Kind() == reflect.Map {
+		// Storing a map as the value is particularly confusing.  Even if
+		// the caller does Desired().Delete(k) to remove the mapping, we may
+		// keep hold of the same map in the inDataplaneNotDesired map resulting
+		// in aliasing.
+		logrus.Panic("Map values should not be used in a DeltaTracker.")
+	}
 	cm := &DeltaTracker[K, V]{
 		inDataplaneAndDesired: make(map[K]V),
 		inDataplaneNotDesired: make(map[K]V),
@@ -131,18 +152,25 @@ func (c *DesiredView[K, V]) Set(k K, v V) {
 		// the "not desired" map to the "desired map".
 		c.inDataplaneAndDesired[k] = currentVal
 		delete(c.inDataplaneNotDesired, k)
+		c.desiredLen++
 	} else {
 		// Didn't find the key in the "not-desired" map, check the "desired" map.
 		currentVal, presentInDP = c.inDataplaneAndDesired[k]
 	}
 
 	// Check if we think we need to update the dataplane as a result.
-	if presentInDP && c.valuesEqual(currentVal, v) {
+	if !presentInDP {
+		if _, presentInDesired := c.desiredUpdates[k]; !presentInDesired {
+			// New key, increment our count.
+			c.desiredLen++
+		}
+	} else if c.valuesEqual(currentVal, v) {
 		// Dataplane already agrees with the new value so clear any pending update.
 		c.logCtx.Debug("Set: Key in dataplane already, ignoring.")
 		delete(c.desiredUpdates, k)
 		return
 	}
+
 	// Either key is not in the dataplane, or the value associated with it is not as desired.
 	// Queue up an update.
 	c.desiredUpdates[k] = v
@@ -161,15 +189,25 @@ func (c *DesiredView[K, V]) Get(k K) (V, bool) {
 // cache, it is added to the pending deletions set.  Removes the key from the pending updates set.
 func (c *DesiredView[K, V]) Delete(k K) {
 	if logrus.GetLevel() >= logrus.DebugLevel {
-		c.logCtx.WithFields(logrus.Fields{"k": k}).Debug("Delete")
+		c.logCtx.WithFields(logrus.Fields{"k": k}).Debug("Delete (desired)")
 	}
-	delete(c.desiredUpdates, k)
+	_, presentInDesired := c.desiredUpdates[k]
+	if presentInDesired {
+		// Key was present.
+		delete(c.desiredUpdates, k)
+	}
 
 	// Check if we need to update the dataplane.
-	if currentVal, ok := c.inDataplaneAndDesired[k]; ok {
+	currentVal, presentInDPDesired := c.inDataplaneAndDesired[k]
+	if presentInDPDesired {
 		// Value is in dataplane, move it to pending deletions.
 		c.inDataplaneNotDesired[k] = currentVal
 		delete(c.inDataplaneAndDesired, k)
+	}
+
+	if presentInDesired || presentInDPDesired {
+		// Key was present, decrement the count.
+		c.desiredLen--
 	}
 }
 
@@ -193,6 +231,10 @@ func (c *DesiredView[K, V]) Iter(f func(k K, v V)) {
 		}
 		f(k, v)
 	}
+}
+
+func (c *DesiredView[K, V]) Len() int {
+	return c.desiredLen
 }
 
 type DataplaneView[K comparable, V any] DeltaTracker[K, V]
@@ -388,6 +430,8 @@ func (c *PendingUpdatesView[K, V]) Iter(f func(k K, v V) IterAction) {
 		case IterActionUpdateDataplane:
 			delete(c.desiredUpdates, k)
 			c.inDataplaneAndDesired[k] = v
+		case IterActionNoOpStopIteration:
+			break
 		}
 	}
 }

--- a/felix/deltatracker/delta_tracker.go
+++ b/felix/deltatracker/delta_tracker.go
@@ -44,15 +44,13 @@ import (
 // pending maps are exposed via the IterPendingUpdates and IterPendingDeletions
 // methods.
 //
-// It's not recommended to use mutable objects in a DeltaTracker.  Updating a
-// mutable object while it is in the DeltaTracker will corrupt its internal
-// state.  By design, the DeltaTracker aliases the Desired and Dataplane values
-// if they happen to be equal. So, to safely mutate a value, you must
-// take a copy, mutate the copy and then re-insert the value.  Note: it is not
-// safe to delete the object from one side of the tracker, mutate it and
-// re-insert it.  Deleting an object that is in-sync from the Dataplane side
-// moves the object from the inDataplaneAndDesired map to the desiredUpdates
-// map, keeping a reference.
+// Note: it is not safe to mutate keys/values that are stored in a DeltaTracker
+// because it would corrupt the internal state. Surprisingly(!), it is also
+// unsafe to delete a key, modify the value and then re-insert the value!  This
+// is because (as an occupancy optimisation) the DeltaTracker aliases the
+// Desired and Dataplane values if they happen to be equal.  So, to safely
+// mutate a value, you must take a copy, mutate the copy and re-insert the
+// copy.
 type DeltaTracker[K comparable, V any] struct {
 	// To reduce occupancy, we treat the set of KVs in the dataplane and in the
 	// desired state like a Venn diagram, and we only store each region once


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add a Len method to the Desired() side of the DeltaTracker.

Panic if trying to use a map in the DeltaTracker.  Found this was particularly hard to get right in another PR.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

Enabling features for #8418

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
