### PR TITLE
Wrap errors in FVs to give better diags on failure.

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -4188,7 +4188,8 @@ func (pa *jumpMapAlloc) checkFreeLockHeld(idx int) {
 func removeBPFSpecialDevices() {
 	bpfin, err := netlink.LinkByName(bpfInDev)
 	if err != nil {
-		if errors.Is(err, netlink.LinkNotFoundError{}) {
+		var lnf netlink.LinkNotFoundError
+		if errors.As(err, &lnf) {
 			return
 		}
 		log.WithError(err).Warnf("Failed to make sure that %s/%s device is (not) present.", bpfInDev, bpfOutDev)

--- a/felix/fv/utils/utils.go
+++ b/felix/fv/utils/utils.go
@@ -139,6 +139,9 @@ func GetCommandOutput(command string, args ...string) (string, error) {
 	cmd := Command(command, args...)
 	log.Infof("Running '%s %s'", cmd.Path, strings.Join(cmd.Args, " "))
 	output, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("command failed %q: %w", cmd, err)
+	}
 	return string(output), err
 }
 
@@ -150,7 +153,6 @@ func RunCommand(command string, args ...string) error {
 
 func Command(name string, args ...string) *exec.Cmd {
 	log.Debugf("Creating Command [%s].", formatCommand(name, args))
-
 	return exec.Command(name, args...)
 }
 

--- a/felix/fv/workload/workload.go
+++ b/felix/fv/workload/workload.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	api "github.com/projectcalico/calico/libcalico-go/lib/apis/v3"
@@ -501,8 +502,9 @@ func (w *Workload) LatencyTo(ip, port string) (time.Duration, string) {
 	}
 	out, err := w.ExecOutput("hping3", "-p", port, "-c", "20", "--fast", "-S", "-n", ip)
 	stderr := ""
-	if err, ok := err.(*exec.ExitError); ok {
-		stderr = string(err.Stderr)
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr = string(exitErr.Stderr)
 	}
 	Expect(err).NotTo(HaveOccurred(), stderr)
 
@@ -537,8 +539,9 @@ func (w *Workload) SendPacketsTo(ip string, count int, size int) (error, string)
 	s := fmt.Sprintf("%d", size)
 	_, err := w.ExecOutput("ping", "-c", c, "-W", "1", "-s", s, ip)
 	stderr := ""
-	if err, ok := err.(*exec.ExitError); ok {
-		stderr = string(err.Stderr)
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr = string(exitErr.Stderr)
 	}
 	return err, stderr
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
When the FVs fail, often the error will be an `ExecError` from a command.  Unhelpfully, the default string representation of that error is just a dump of internal state; missing useful clues such as the command that was run. Update the places where we run commands to wrap the errors or other wise dump more useful information.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
