### PR TITLE
Various cleanups

### DIFF
--- a/felix/dataplane/ipsets/ipsets_mgr.go
+++ b/felix/dataplane/ipsets/ipsets_mgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package ipsets
 
 import (
 	log "github.com/sirupsen/logrus"

--- a/felix/dataplane/ipsets/ipsets_mgr_test.go
+++ b/felix/dataplane/ipsets/ipsets_mgr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package ipsets
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/felix/dataplane/ipsets/mock_ipsets.go
+++ b/felix/dataplane/ipsets/mock_ipsets.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package ipsets
 
 import (
 	"net"
@@ -48,6 +48,7 @@ func (s *MockIPSets) AddOrReplaceIPSet(setMetadata ipsets.IPSetMetadata, newMemb
 	s.Members[setMetadata.SetID] = members
 	s.AddOrReplaceCalled = true
 }
+
 func (s *MockIPSets) AddMembers(setID string, newMembers []string) {
 	members := s.Members[setID]
 	for _, member := range newMembers {

--- a/felix/dataplane/linux/hostip_mgr.go
+++ b/felix/dataplane/linux/hostip_mgr.go
@@ -20,7 +20,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
@@ -32,15 +32,15 @@ type hostIPManager struct {
 	hostIfaceToAddrs map[string]set.Set[string]
 
 	hostIPSetID     string
-	ipsetsDataplane common.IPSetsDataplane
+	ipsetsDataplane dpsets.IPSetsDataplane
 	maxSize         int
 }
 
 func newHostIPManager(wlIfacesPrefixes []string,
 	ipSetID string,
-	ipsets common.IPSetsDataplane,
-	maxIPSetSize int) *hostIPManager {
-
+	ipsets dpsets.IPSetsDataplane,
+	maxIPSetSize int,
+) *hostIPManager {
 	return newHostIPManagerWithShims(
 		wlIfacesPrefixes,
 		ipSetID,
@@ -51,9 +51,9 @@ func newHostIPManager(wlIfacesPrefixes []string,
 
 func newHostIPManagerWithShims(wlIfacesPrefixes []string,
 	ipSetID string,
-	ipsets common.IPSetsDataplane,
-	maxIPSetSize int) *hostIPManager {
-
+	ipsets dpsets.IPSetsDataplane,
+	maxIPSetSize int,
+) *hostIPManager {
 	wlIfacesPattern := "^(" + strings.Join(wlIfacesPrefixes, "|") + ").*"
 	wlIfacesRegexp := regexp.MustCompile(wlIfacesPattern)
 

--- a/felix/dataplane/linux/hostip_mgr_test.go
+++ b/felix/dataplane/linux/hostip_mgr_test.go
@@ -18,18 +18,18 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
 var _ = Describe("Host ip manager", func() {
 	var (
 		hostIPMgr *hostIPManager
-		ipSets    *common.MockIPSets
+		ipSets    *dpsets.MockIPSets
 	)
 
 	BeforeEach(func() {
-		ipSets = common.NewMockIPSets()
+		ipSets = dpsets.NewMockIPSets()
 		hostIPMgr = newHostIPManager([]string{"cali"}, "this-host", ipSets, 1024)
 	})
 

--- a/felix/dataplane/linux/ipip_mgr.go
+++ b/felix/dataplane/linux/ipip_mgr.go
@@ -22,7 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/ethtool"
 	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/felix/proto"
@@ -35,7 +35,7 @@ import (
 //
 // ipipManager also takes care of the configuration of the IPIP tunnel device.
 type ipipManager struct {
-	ipsetsDataplane common.IPSetsDataplane
+	ipsetsDataplane dpsets.IPSetsDataplane
 
 	// activeHostnameToIP maps hostname to string IP address.  We don't bother to parse into
 	// net.IPs because we're going to pass them directly to the IPSet API.
@@ -53,7 +53,7 @@ type ipipManager struct {
 }
 
 func newIPIPManager(
-	ipsetsDataplane common.IPSetsDataplane,
+	ipsetsDataplane dpsets.IPSetsDataplane,
 	maxIPSetSize int,
 	externalNodeCidrs []string,
 ) *ipipManager {
@@ -61,7 +61,7 @@ func newIPIPManager(
 }
 
 func newIPIPManagerWithShim(
-	ipsetsDataplane common.IPSetsDataplane,
+	ipsetsDataplane dpsets.IPSetsDataplane,
 	maxIPSetSize int,
 	dataplane ipipDataplane,
 	externalNodeCIDRs []string,

--- a/felix/dataplane/linux/ipip_mgr_test.go
+++ b/felix/dataplane/linux/ipip_mgr_test.go
@@ -15,17 +15,17 @@
 package intdataplane
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"errors"
 	"fmt"
 	"net"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
@@ -38,7 +38,7 @@ var (
 var _ = Describe("IpipMgr (tunnel configuration)", func() {
 	var (
 		ipipMgr   *ipipManager
-		ipSets    *common.MockIPSets
+		ipSets    *dpsets.MockIPSets
 		dataplane *mockIPIPDataplane
 	)
 
@@ -53,7 +53,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 
 	BeforeEach(func() {
 		dataplane = &mockIPIPDataplane{}
-		ipSets = common.NewMockIPSets()
+		ipSets = dpsets.NewMockIPSets()
 		ipipMgr = newIPIPManagerWithShim(ipSets, 1024, dataplane, nil)
 	})
 
@@ -107,7 +107,6 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 				dataplane.ResetCalls()
 				err = ipipMgr.configureIPIPDevice(1500, ip2, false)
 				Expect(err).ToNot(HaveOccurred())
-
 			})
 			It("should avoid creating the interface", func() {
 				Expect(dataplane.RunCmdCalled).To(BeFalse())
@@ -206,7 +205,7 @@ var _ = Describe("IpipMgr (tunnel configuration)", func() {
 var _ = Describe("ipipManager IP set updates", func() {
 	var (
 		ipipMgr   *ipipManager
-		ipSets    *common.MockIPSets
+		ipSets    *dpsets.MockIPSets
 		dataplane *mockIPIPDataplane
 	)
 
@@ -216,7 +215,7 @@ var _ = Describe("ipipManager IP set updates", func() {
 
 	BeforeEach(func() {
 		dataplane = &mockIPIPDataplane{}
-		ipSets = common.NewMockIPSets()
+		ipSets = dpsets.NewMockIPSets()
 		ipipMgr = newIPIPManagerWithShim(ipSets, 1024, dataplane, []string{externalCIDR})
 	})
 

--- a/felix/dataplane/linux/masq_mgr.go
+++ b/felix/dataplane/linux/masq_mgr.go
@@ -19,7 +19,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/rules"
@@ -39,7 +39,7 @@ import (
 // pool is excluded.
 type masqManager struct {
 	ipVersion       uint8
-	ipsetsDataplane common.IPSetsDataplane
+	ipsetsDataplane dpsets.IPSetsDataplane
 	natTable        Table
 	activePools     map[string]*proto.IPAMPool
 	masqPools       set.Set[string]
@@ -50,7 +50,7 @@ type masqManager struct {
 }
 
 func newMasqManager(
-	ipsetsDataplane common.IPSetsDataplane,
+	ipsetsDataplane dpsets.IPSetsDataplane,
 	natTable Table,
 	ruleRenderer rules.RuleRenderer,
 	maxIPSetSize int,

--- a/felix/dataplane/linux/masq_mgr_test.go
+++ b/felix/dataplane/linux/masq_mgr_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/generictables"
 	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/felix/iptables"
@@ -31,12 +31,12 @@ var _ = Describe("Masquerade manager", func() {
 	var (
 		masqMgr      *masqManager
 		natTable     *mockTable
-		ipSets       *common.MockIPSets
+		ipSets       *dpsets.MockIPSets
 		ruleRenderer rules.RuleRenderer
 	)
 
 	BeforeEach(func() {
-		ipSets = common.NewMockIPSets()
+		ipSets = dpsets.NewMockIPSets()
 		natTable = newMockTable("nat")
 		ruleRenderer = rules.NewRenderer(rules.Config{
 			IPSetConfigV4: ipsets.NewIPVersionConfig(

--- a/felix/dataplane/linux/vxlan_mgr.go
+++ b/felix/dataplane/linux/vxlan_mgr.go
@@ -31,7 +31,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/environment"
 	"github.com/projectcalico/calico/felix/ethtool"
 	"github.com/projectcalico/calico/felix/ip"
@@ -91,7 +91,7 @@ type vxlanManager struct {
 
 	// Indicates if configuration has changed since the last apply.
 	routesDirty       bool
-	ipsetsDataplane   common.IPSetsDataplane
+	ipsetsDataplane   dpsets.IPSetsDataplane
 	ipSetMetadata     ipsets.IPSetMetadata
 	externalNodeCIDRs []string
 	vtepsDirty        bool
@@ -117,7 +117,7 @@ type VXLANFDB interface {
 }
 
 func newVXLANManager(
-	ipsetsDataplane common.IPSetsDataplane,
+	ipsetsDataplane dpsets.IPSetsDataplane,
 	rt routetable.RouteTableInterface,
 	fdb VXLANFDB,
 	deviceName string,
@@ -192,7 +192,7 @@ func newVXLANManager(
 }
 
 func newVXLANManagerWithShims(
-	ipsetsDataplane common.IPSetsDataplane,
+	ipsetsDataplane dpsets.IPSetsDataplane,
 	rt, brt routetable.RouteTableInterface,
 	fdb VXLANFDB,
 	deviceName string,

--- a/felix/dataplane/linux/vxlan_mgr_test.go
+++ b/felix/dataplane/linux/vxlan_mgr_test.go
@@ -21,7 +21,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/felix/routetable"
@@ -103,6 +103,7 @@ func (m *mockVXLANDataplane) LinkList() ([]netlink.Link, error) {
 func (m *mockVXLANDataplane) LinkAdd(netlink.Link) error {
 	return nil
 }
+
 func (m *mockVXLANDataplane) LinkDel(netlink.Link) error {
 	return nil
 }
@@ -141,7 +142,7 @@ var _ = Describe("VXLANManager", func() {
 		la := netlink.NewLinkAttrs()
 		la.Name = "eth0"
 		manager = newVXLANManagerWithShims(
-			common.NewMockIPSets(),
+			dpsets.NewMockIPSets(),
 			rt, brt,
 			fdb,
 			"vxlan.calico",
@@ -168,7 +169,7 @@ var _ = Describe("VXLANManager", func() {
 		)
 
 		managerV6 = newVXLANManagerWithShims(
-			common.NewMockIPSets(),
+			dpsets.NewMockIPSets(),
 			rt, brt,
 			fdb,
 			"vxlan-v6.calico",

--- a/felix/dataplane/linux/xdp_state.go
+++ b/felix/dataplane/linux/xdp_state.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/bpf"
 	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/ipsets"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/projectcalico/calico/libcalico-go/lib/set"
@@ -2176,7 +2177,7 @@ type ipsetsSource interface {
 }
 
 var (
-	_ ipsetsSource = &common.IPSetsManager{}
+	_ ipsetsSource = &dpsets.IPSetsManager{}
 	_ ipsetsSource = &nilIPSetsSource{}
 )
 

--- a/felix/dataplane/windows/win_dataplane.go
+++ b/felix/dataplane/windows/win_dataplane.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/projectcalico/calico/felix/dataplane/windows/hns"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/dataplane/windows/ipsets"
 	"github.com/projectcalico/calico/felix/dataplane/windows/policysets"
 	"github.com/projectcalico/calico/felix/jitter"
@@ -45,9 +45,7 @@ const (
 	reschedDelay = time.Duration(5) * time.Second
 )
 
-var (
-	processStartTime time.Time
-)
+var processStartTime time.Time
 
 func init() {
 	processStartTime = time.Now()
@@ -182,7 +180,7 @@ func NewWinDataplaneDriver(hns hns.API, config Config) *WindowsDataplane {
 	}
 	dp.policySets = policysets.NewPolicySets(hns, ipsc, policysets.FileReader(policysets.StaticFileName))
 
-	dp.RegisterManager(common.NewIPSetsManager("ipv4", ipSetsV4, config.MaxIPSetSize))
+	dp.RegisterManager(dpsets.NewIPSetsManager("ipv4", ipSetsV4, config.MaxIPSetSize))
 	dp.RegisterManager(newPolicyManager(dp.policySets))
 	dp.endpointMgr = newEndpointManager(hns, dp.policySets)
 	dp.RegisterManager(dp.endpointMgr)

--- a/felix/docker-image/Dockerfile
+++ b/felix/docker-image/Dockerfile
@@ -67,7 +67,7 @@ RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # Felix is built with RHEL/UBI and links against libpcap.so.1. We need this symbolic link
 # until Debian changes the soname from .0.8 to .1.
-RUN ln -s $(readlink /usr/lib/*-linux-gnu/libpcap.so.0.8) $(ldconfig -v 2>/dev/null | grep '^/lib/' | cut -f1 -d:)/libpcap.so.1
+RUN ln -s $(readlink /usr/lib/*-linux-gnu/libpcap.so.0.8) $(ldconfig -v 2>/dev/null | grep '^/lib/' | head -n 1 | cut -f1 -d:)/libpcap.so.1
 
 COPY felix.cfg /etc/calico/felix.cfg
 COPY calico-felix-wrapper /usr/bin

--- a/felix/docker-image/Dockerfile
+++ b/felix/docker-image/Dockerfile
@@ -67,7 +67,7 @@ RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # Felix is built with RHEL/UBI and links against libpcap.so.1. We need this symbolic link
 # until Debian changes the soname from .0.8 to .1.
-RUN ln -s $(readlink /usr/lib/*-linux-gnu/libpcap.so.0.8) /usr/lib/x86_64-linux-gnu/libpcap.so.1
+RUN ln -s $(readlink /usr/lib/*-linux-gnu/libpcap.so.0.8) lib$(ldconfig -v 2>/dev/null | grep -Po '/lib/(.*): ' | sed -e 's/: //')/libpcap.so.1
 
 COPY felix.cfg /etc/calico/felix.cfg
 COPY calico-felix-wrapper /usr/bin

--- a/felix/docker-image/Dockerfile
+++ b/felix/docker-image/Dockerfile
@@ -67,7 +67,7 @@ RUN update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 # Felix is built with RHEL/UBI and links against libpcap.so.1. We need this symbolic link
 # until Debian changes the soname from .0.8 to .1.
-RUN ln -s $(readlink /usr/lib/*-linux-gnu/libpcap.so.0.8) lib$(ldconfig -v 2>/dev/null | grep -Po '/lib/(.*): ' | sed -e 's/: //')/libpcap.so.1
+RUN ln -s $(readlink /usr/lib/*-linux-gnu/libpcap.so.0.8) $(ldconfig -v 2>/dev/null | grep '^/lib/' | cut -f1 -d:)/libpcap.so.1
 
 COPY felix.cfg /etc/calico/felix.cfg
 COPY calico-felix-wrapper /usr/bin

--- a/felix/iptables/match_builder.go
+++ b/felix/iptables/match_builder.go
@@ -32,7 +32,8 @@ var _ generictables.MatchCriteria = matchCriteria{}
 type matchCriteria []string
 
 func Match() generictables.MatchCriteria {
-	return new(matchCriteria)
+	var m matchCriteria
+	return m
 }
 
 func (m matchCriteria) Render() string {

--- a/felix/nftables/ipsets.go
+++ b/felix/nftables/ipsets.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/deltatracker"
 	"github.com/projectcalico/calico/felix/ip"
 	"github.com/projectcalico/calico/felix/ipsets"
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/knftables"
 )
 
-var _ common.IPSetsDataplane = &IPSets{}
+var _ dpsets.IPSetsDataplane = &IPSets{}
 
 var (
 	gaugeVecNumSets = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/felix/nftables/match_builder.go
+++ b/felix/nftables/match_builder.go
@@ -102,7 +102,8 @@ func (m nftMatch) transportProto() string {
 }
 
 func Match() generictables.MatchCriteria {
-	return new(nftMatch)
+	var m nftMatch
+	return m
 }
 
 func (m nftMatch) IPVersion(ipVersion uint8) generictables.MatchCriteria {

--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -29,7 +29,7 @@ import (
 
 	"sigs.k8s.io/knftables"
 
-	"github.com/projectcalico/calico/felix/dataplane/common"
+	dpsets "github.com/projectcalico/calico/felix/dataplane/ipsets"
 	"github.com/projectcalico/calico/felix/environment"
 	"github.com/projectcalico/calico/felix/generictables"
 	"github.com/projectcalico/calico/felix/ipsets"
@@ -128,7 +128,7 @@ func init() {
 // nftablesTable is an implementation of the generictables.Table interface that programs nftables. It represents a
 // single nftables table.
 type nftablesTable struct {
-	common.IPSetsDataplane
+	dpsets.IPSetsDataplane
 
 	name      string
 	ipVersion uint8


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- Felix docker-image uses architecture-agnostic `ln` command.
- Move ipsets to new package, out of `dataplane/common`
- Be consistent in use of pointer vs. non-pointer is match structures.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.