### PR TITLE
[CORE-10546] Change rpm install order to fix 'undefined symbol: xtables_strdup'

### DIFF
--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -119,26 +119,27 @@ RUN microdnf install \
     # Needed for runit startup script
     which \
     # Needed for the cleanup script
-    findutils \
-    # nftables
-    nftables
+    findutils
 
 # Since the ubi repos do not contain all the packages we need (they're missing conntrack-tools),
 # we're using AlmaLinux repos for missing packages.
 COPY almalinux.repo /etc/yum.repos.d/almalinux.repo
 
 RUN microdnf --enablerepo=baseos install \
-    iproute-tc \
     # Needed for conntrack
     libnetfilter_cthelper libnetfilter_cttimeout libnetfilter_queue \
     conntrack-tools
 
-# Install iptables via rpms. The libs must be force installed because the iptables source RPM has the release
-# version '1.8.8-6.el8' conflicts with iptables-libs (pulled in by the iputils package) '1.8.5-11.el8_9'.
-RUN rpm --force -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.x86_64.rpm && \
-    rpm --force -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.x86_64.rpm && \
-    # Install compatible libnftnl version with selected iptables version
-    rpm -i /tmp/rpms/iptables-legacy-${IPTABLES_VER}.el8.2.x86_64.rpm && \
+# Install iptables-libs via rpm. The libs must installed before installing iproute-tc and nftables via 'microdnf install'
+# otherwise they will pull an outdated version of iptables-libs (1.8.5-11.el8_9) as a dependency.
+RUN rpm -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.x86_64.rpm && \
+    rpm -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.x86_64.rpm
+
+# iproute-tc and nftables depend on iptables-libs and should be installed after it.
+RUN microdnf --enablerepo=baseos install iproute-tc nftables
+
+# Install iptables via rpm. Install compatible libnftnl version with the selected iptables version
+RUN rpm -i /tmp/rpms/iptables-legacy-${IPTABLES_VER}.el8.2.x86_64.rpm && \
     rpm -i /tmp/rpms/iptables-nft-${IPTABLES_VER}.el8.x86_64.rpm && \
     # Install ipset version
     rpm --force -i /tmp/rpms/ipset-libs-${IPSET_VER}.el8.x86_64.rpm && \

--- a/node/Dockerfile.amd64
+++ b/node/Dockerfile.amd64
@@ -131,7 +131,7 @@ RUN microdnf --enablerepo=baseos install \
     conntrack-tools
 
 # Install iptables-libs via rpm. The libs must installed before installing iproute-tc and nftables via 'microdnf install'
-# otherwise they will pull an outdated version of iptables-libs (1.8.5-11.el8_9) as a dependency.
+# otherwise they will pull a different version of iptables-libs as a dependency.
 RUN rpm -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.x86_64.rpm && \
     rpm -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.x86_64.rpm
 

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -129,27 +129,27 @@ RUN microdnf install \
     # Needed for runit startup script
     which \
     # Needed for the cleanup script
-    findutils \
-    # nftables
-    nftables
-
+    findutils
 
 # Since the ubi repos do not contain all the packages we need (they're missing conntrack-tools),
 # we're using AlmaLinux repos for missing packages.
 COPY almalinux.repo /etc/yum.repos.d/almalinux.repo
 
 RUN microdnf --enablerepo=baseos install \
-    iproute-tc \
     # Needed for conntrack
     libnetfilter_cthelper libnetfilter_cttimeout libnetfilter_queue \
     conntrack-tools
 
-# Install iptables via rpms. The libs must be force installed because the iptables source RPM has the release
-# version '1.8.8-6.el8' conflicts with iptables-libs (pulled in by the iputils package) '1.8.5-11.el8_9'.
-RUN rpm --force -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.aarch64.rpm && \
-    rpm --force -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.aarch64.rpm && \
-    # Install compatible libnftnl version with selected iptables version
-    rpm --force -i /tmp/rpms/libnftnl-${LIBNFTNL_VER}.el8.aarch64.rpm && \
+# Install iptables-libs via rpm. The libs must installed before installing iproute-tc and nftables via 'microdnf install'
+# otherwise they will pull an outdated version of iptables-libs (1.8.5-11.el8_9) as a dependency.
+RUN rpm -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.aarch64.rpm && \
+    rpm -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.aarch64.rpm
+
+# iproute-tc and nftables depend on iptables-libs and should be installed after it.
+RUN microdnf --enablerepo=baseos install iproute-tc nftables
+
+# Install iptables via rpm. Install compatible libnftnl version with the selected iptables version
+RUN rpm --force -i /tmp/rpms/libnftnl-${LIBNFTNL_VER}.el8.aarch64.rpm && \
     # Install both and select at runtime.
     rpm -i /tmp/rpms/iptables-legacy-${IPTABLES_VER}.el8.2.aarch64.rpm && \
     rpm -i /tmp/rpms/iptables-nft-${IPTABLES_VER}.el8.aarch64.rpm && \

--- a/node/Dockerfile.arm64
+++ b/node/Dockerfile.arm64
@@ -141,7 +141,7 @@ RUN microdnf --enablerepo=baseos install \
     conntrack-tools
 
 # Install iptables-libs via rpm. The libs must installed before installing iproute-tc and nftables via 'microdnf install'
-# otherwise they will pull an outdated version of iptables-libs (1.8.5-11.el8_9) as a dependency.
+# otherwise they will pull a different version of iptables-libs as a dependency.
 RUN rpm -i /tmp/rpms/iptables-libs-${IPTABLES_VER}.el8.aarch64.rpm && \
     rpm -i /tmp/rpms/iptables-legacy-libs-${IPTABLES_VER}.el8.2.aarch64.rpm
 


### PR DESCRIPTION
`microdnf install iproute-tc nftables` would install `iptables-libs` 1.8.5-11.el8_9 as a dependency, and it provides `/lib64/libxtables.so.12.3.0`. When using that `.so` file with `LD_PRELOAD`, we can consistently reproduce the issue:

```
# LD_PRELOAD=/lib64/libxtables.so.12.3.0 iptables-legacy-save
iptables-legacy-save: symbol lookup error: iptables-legacy-save: undefined symbol: xtables_strdup
```

The problem was, during our build process, we build iptables (and iptables-libs) v1.8.8 and install with `rpm --force`, but that doesn´t remove the outdated v1.8.5. By moving things around in the Dockerfiles and installing iptables-libs 1.8.8 before iproute-tc and nftables, the problematic 1.8.5 package is no longer installed and thus the correct `.so` file should be used (`libxtables.so.12.6.0` at the time of writing this).

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

fixes https://github.com/projectcalico/calico/issues/8831 (tentatively, pending user confirmation)
<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix 'undefined symbol: xtables_strdup' error when running 'iptables-legacy-save' in the calico-node image.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
