### PR TITLE
Revert "[release-v3.28] Auto pick #8746: Revert "Disable VXLAN checksum offload by default.""

### DIFF
--- a/felix/environment/feature_detect_linux.go
+++ b/felix/environment/feature_detect_linux.go
@@ -50,8 +50,6 @@ var (
 	v3Dot10Dot0 = MustParseVersion("3.10.0")
 	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
 	v3Dot14Dot0 = MustParseVersion("3.14.0")
-	// v5Dot7Dot0 contains a fix for checksum offloading.
-	v5Dot7Dot0 = MustParseVersion("5.7.0")
 	// v5Dot14Dot0 is the fist kernel version that IPIP tunnels acts like other L3
 	// devices where bpf programs only see inner IP header. In RHEL based distros,
 	// kernel 4.18.0 (v4Dot18Dot0_330) is the first one with this behavior.
@@ -132,7 +130,7 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 		SNATFullyRandom:          iptV.Compare(v1Dot6Dot0) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		MASQFullyRandom:          iptV.Compare(v1Dot6Dot2) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		RestoreSupportsLock:      iptV.Compare(v1Dot6Dot2) >= 0,
-		ChecksumOffloadBroken:    kerV.Compare(v5Dot7Dot0) <= 0,
+		ChecksumOffloadBroken:    true, // Was supposed to be fixed in v5.7 but still seems to be broken.
 		IPIPDeviceIsL3:           d.ipipDeviceIsL3(),
 		KernelSideRouteFiltering: netlinkSupportsStrict,
 	}

--- a/felix/environment/feature_detect_test.go
+++ b/felix/environment/feature_detect_test.go
@@ -147,16 +147,6 @@ func TestFeatureDetection(t *testing.T) {
 				ChecksumOffloadBroken: true,
 			},
 		},
-		{
-			"iptables v1.8.4",
-			"Linux version 5.8.0",
-			Features{
-				RestoreSupportsLock:   true,
-				SNATFullyRandom:       true,
-				MASQFullyRandom:       true,
-				ChecksumOffloadBroken: false,
-			},
-		},
 	} {
 		tst := tst
 		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
@@ -517,28 +507,32 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.10.0 - ubuntu",
 			Features{
-				IPIPDeviceIsL3: false,
+				IPIPDeviceIsL3:        false,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.14.0 - something else",
 			Features{
-				IPIPDeviceIsL3: true,
+				IPIPDeviceIsL3:        true,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.15.0",
 			Features{
-				IPIPDeviceIsL3: true,
+				IPIPDeviceIsL3:        true,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.10.0 - Default",
 			Features{
-				IPIPDeviceIsL3: true,
+				IPIPDeviceIsL3:        true,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "true",
@@ -547,7 +541,8 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.14.0",
 			Features{
-				IPIPDeviceIsL3: false,
+				IPIPDeviceIsL3:        false,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",
@@ -556,7 +551,8 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.16.0 - Ubuntu",
 			Features{
-				IPIPDeviceIsL3: false,
+				IPIPDeviceIsL3:        false,
+				ChecksumOffloadBroken: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",


### PR DESCRIPTION
Reverts projectcalico/calico#8774