### PR TITLE
Optimise the log formatter

### DIFF
--- a/libcalico-go/lib/logutils/benchmarks_test.go
+++ b/libcalico-go/lib/logutils/benchmarks_test.go
@@ -27,8 +27,70 @@ func BenchmarkLogWithOurFormat(b *testing.B) {
 	logger.SetOutput(&NullWriter{})
 
 	b.ResetTimer()
+	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
 		logger.Info("Test log")
+	}
+}
+
+func BenchmarkLogWithOurFormatFixedFields(b *testing.B) {
+	logger := logrus.New()
+	logger.SetFormatter(&Formatter{})
+	logger.SetReportCaller(true)
+	logger.SetOutput(&NullWriter{})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	entry := logger.WithFields(logrus.Fields{
+		"a": "b",
+		"c": "d",
+		"e": "f",
+		"g": "h",
+	})
+
+	for i := 0; i < b.N; i++ {
+		entry.Info("Test log")
+	}
+}
+
+func BenchmarkLogWithFieldOurFormat(b *testing.B) {
+	logger := logrus.New()
+	logger.SetFormatter(&Formatter{})
+	logger.SetReportCaller(true)
+	logger.SetOutput(&NullWriter{})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	entry := logger.WithFields(logrus.Fields{
+		"a": "b",
+		"c": "d",
+		"e": "f",
+		"g": "h",
+	})
+
+	for i := 0; i < b.N; i++ {
+		entry.WithField("f", "g").Info("Test log")
+	}
+}
+
+func BenchmarkLogWithFieldsOurFormat(b *testing.B) {
+	logger := logrus.New()
+	logger.SetFormatter(&Formatter{})
+	logger.SetReportCaller(true)
+	logger.SetOutput(&NullWriter{})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		logger.WithFields(logrus.Fields{
+			"a": "b",
+			"c": "d",
+			"e": "f",
+			"g": "h",
+		}).Info("Test log")
 	}
 }


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Significantly improve the performance and allocation count of our log formatter:

- Remove allocations by using buffer more carefully.
- Use optimised time formatter.
- Pre-compute level+PID strings to avoid call to strings.ToUpper() etc.
- When sorting field keys, avoid allocation by declaring static-sized array.

Benchmarks:
```
Before:

goos: linux
goarch: amd64
pkg: github.com/projectcalico/calico/libcalico-go/lib/logutils
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkLogWithOurFormat-12               	  309297	      3945 ns/op	     874 B/op	      17 allocs/op
BenchmarkLogWithOurFormatFixedFields-12    	  258922	      4549 ns/op	    1242 B/op	      22 allocs/op
BenchmarkLogWithFieldOurFormat-12          	  202881	      5778 ns/op	    1723 B/op	      26 allocs/op
BenchmarkLogWithFieldsOurFormat-12         	  235368	      4985 ns/op	    1741 B/op	      26 allocs/op

After:

goos: linux
goarch: amd64
pkg: github.com/projectcalico/calico/libcalico-go/lib/logutils
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkLogWithOurFormat-12               	  429015	      2935 ns/op	     745 B/op	       7 allocs/op
BenchmarkLogWithOurFormatFixedFields-12    	  375942	      2896 ns/op	     985 B/op	       7 allocs/op
BenchmarkLogWithFieldOurFormat-12          	  310732	      3530 ns/op	    1434 B/op	      10 allocs/op
BenchmarkLogWithFieldsOurFormat-12         	  290439	      3830 ns/op	    1484 B/op	      11 allocs/op
```

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Log formatting performance has been improved, reducing the overhead of logging.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
