### PR TITLE
Revert hcsshim version bump

### DIFF
--- a/felix/dataplane/windows/endpoint_mgr.go
+++ b/felix/dataplane/windows/endpoint_mgr.go
@@ -191,10 +191,7 @@ func (m *endpointManager) RefreshHnsEndpointCache(forceRefresh bool) error {
 		// Some CNI plugins do not clear endpoint properly when a pod has been torn down.
 		// In that case, it is possible Felix sees multiple endpoints with the same IP.
 		// We need to filter out inactive endpoints that do not attach to any container.
-		// An endpoint is considered to be active if its state is Attached or AttachedSharing.
-		// Note: Endpoint.State attribute is dependent on HNS v1 api. If hcsshim upgrades to HNS v2
-		// api this will break. We then need to Reach out to Microsoft to facilate the change via HNS.
-		if endpoint.State.String() != "Attached" && endpoint.State.String() != "AttachedSharing" {
+		if len(endpoint.SharedContainers) == 0 {
 			log.WithFields(log.Fields{
 				"id":   endpoint.Id,
 				"name": endpoint.Name,

--- a/felix/dataplane/windows/hns/hns_linux.go
+++ b/felix/dataplane/windows/hns/hns_linux.go
@@ -119,26 +119,6 @@ type Policy struct {
 
 // Types from hnsendpoint.go.
 
-// EndpointState represents the states of an HNS Endpoint lifecycle.
-type EndpointState uint16
-
-const (
-	Uninitialized   EndpointState = iota
-	Created         EndpointState = 1
-	Attached        EndpointState = 2
-	AttachedSharing EndpointState = 3
-	Detached        EndpointState = 4
-	Degraded        EndpointState = 5
-	Destroyed       EndpointState = 6
-)
-
-// EndpointState const
-// The lifecycle of an Endpoint goes through created, attached, AttachedSharing - endpoint is being shared with other containers,
-// detached, after being attached, degraded and finally destroyed.
-func (es EndpointState) String() string {
-	return [...]string{"Uninitialized", "Attached", "AttachedSharing", "Detached", "Degraded", "Destroyed"}[es]
-}
-
 // HNSEndpoint represents a network endpoint in HNS
 type HNSEndpoint struct {
 	Id                 string            `json:"ID,omitempty"`
@@ -161,9 +141,8 @@ type HNSEndpoint struct {
 	IsRemoteEndpoint   bool              `json:",omitempty"`
 	EnableLowMetric    bool              `json:",omitempty"`
 	//Namespace          *Namespace        `json:",omitempty"`
-	EncapOverhead    uint16        `json:",omitempty"`
-	SharedContainers []string      `json:",omitempty"`
-	State            EndpointState `json:",omitempty"`
+	EncapOverhead    uint16   `json:",omitempty"`
+	SharedContainers []string `json:",omitempty"`
 }
 
 // ApplyACLPolicy applies a set of ACL Policies on the Endpoint

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/BurntSushi/toml v1.3.2
-	github.com/Microsoft/hcsshim v0.11.6
+	github.com/Microsoft/hcsshim v0.11.4
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go-v2 v1.25.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.0
@@ -120,7 +120,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b // indirect
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,10 +83,10 @@ github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
-github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
-github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Microsoft/hcsshim v0.11.6 h1:qxVO1cqHMQFm11vXklhRIYu/qiukJCqccjQAOddolvk=
-github.com/Microsoft/hcsshim v0.11.6/go.mod h1:MV8xMfmECjl5HdO7U/3/hFVnkmSBjAjmA09d4bExKcU=
+github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
+github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
+github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
Revert hcsshim version bump from v0.11.6 back to v0.11.4, as this was breaking Windows policies.

(original PR https://github.com/projectcalico/calico/pull/8913)

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Revert hcsshim library version bump from v0.11.6 back to v0.11.4 to fix Windows policies.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
