### PR TITLE
Windows: Support running on non-English system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,6 @@ require (
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.6.0
 	github.com/prometheus/common v0.47.0
-	github.com/rakelkar/gonetsh v0.3.2
 	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1
 	github.com/shirou/gopsutil v0.0.0-20190323131628-2cbc9195c892
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -101,7 +101,6 @@ github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
-github.com/antoninbas/go-powershell v0.1.0/go.mod h1:01pgKhz1CJxGnCWqXVDgvmp/QmHgWgEdxdYP+1azopE=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
@@ -661,8 +660,6 @@ github.com/prometheus/common v0.47.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5E
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/rakelkar/gonetsh v0.3.2 h1:ebvU73nAFQ4zUF28hATOprT1CIhZPrVE9Rs/xN6F6Q4=
-github.com/rakelkar/gonetsh v0.3.2/go.mod h1:MkEXf5yV9DRTy8TfpWdvMuCTkxajNE/0tn9pvZ6ikDw=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -698,7 +695,6 @@ github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
@@ -1342,7 +1338,6 @@ k8s.io/dynamic-resource-allocation v0.28.9 h1:u3upC0ah0eNrO1uh3yUL3VefvB1OUTNQLK
 k8s.io/dynamic-resource-allocation v0.28.9/go.mod h1:SIwpYxFh5gk7bW1dZ+GgnA6l4VmhrnUugePlLxYva+4=
 k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 h1:pWEwq4Asjm4vjW7vcsmijwBhOr1/shsbSYiWXmNGlks=
 k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
-k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.120.1 h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw=
@@ -1371,7 +1366,6 @@ k8s.io/pod-security-admission v0.29.7 h1:GeL63bPR29TTmc9T9RNDR86Xi0gg0+jcISf+O+o
 k8s.io/pod-security-admission v0.29.7/go.mod h1:2fZW4VgBjir4qas3JB13uZDpxvJM1n9zkKRfY6p89fI=
 k8s.io/sample-apiserver v0.29.7 h1:oSSPrnomVIzdGBTau6HHx/f//cVlhdbdt7tb8eqUj9I=
 k8s.io/sample-apiserver v0.29.7/go.mod h1:t5NfRN9VQiP3EkM6eHZs7ub6oyNCso1aPLgEu4dEiZs=
-k8s.io/utils v0.0.0-20200410111917-5770800c2500/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57 h1:gbqbevonBh57eILzModw6mrkbwM0gQBEuevE/AaBsHY=
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 modernc.org/mathutil v1.6.0 h1:fRe9+AmYlaej+64JsEEhoWuAYBkOtQiMEU7n/XgfYi4=


### PR DESCRIPTION
## Description

When Windows Server is in a non-English language, creating Pods fails, and Calico reports the following error:

```go
Waiting for interface matching management IP... error=no index found for interface
```

I tried to look for related issues, such as someone reporting the same problem on Calico [#5145](https://github.com/projectcalico/calico/issues/5145). The temporary solution is to modify the setting `region` of the Windows system to use [Unicode encoding](https://github.com/kubernetes-sigs/sig-windows-tools/issues/68#issuecomment-696139451), and then reboot.

This is clearly not a good solution. Calico should be able to run well on non-English Windows Servers.

Following the above error message, I looked into the source code and found that the problem is due to the `rakelkar/gonetsh` package. It get network interface information by invoking `PowerShell` to run the `netsh` command and then parsing its output. When Windows is in a non-English language, the `netsh` output contains non-English characters, causing `rakelkar/gonetsh` to fail in matching the output correctly, resulting in the "no index found for interface" error.

`rakelkar/gonetsh` is not actively maintained. Using the standard Go library `net` is sufficient to get the necessary network interface information on Windows. The `os` library is also sufficient to execute relevant `PowerShell` commands for network settings. Therefore, replacing `rakelkar/gonetsh` with implementations using standard Go libraries can effectively resolve the problem on non-English Windows servers and make future maintenance easier.

Incidentally, the Flannel project also used the `rakelkar/gonetsh` library to get Windows network interface information and encountered the [same problem](https://github.com/flannel-io/flannel/pull/1209) on non-English Windows Servers. Their solution was to [remove `rakelkar/gonetsh`](https://github.com/flannel-io/flannel/pull/1238). For Calico, isn't it urgent to make a similar change?

## Related issues/PRs



## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

```release-note
Replaced `rakelkar/gonetsh` library with standard Go lib utilities to add support for non-English language versions of Windows.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
