### PR TITLE
Allow user-defined rules in nftables mode

### DIFF
--- a/felix/nftables/table.go
+++ b/felix/nftables/table.go
@@ -138,7 +138,7 @@ func init() {
 
 	appendBaseChains = map[string]knftables.Chain{}
 	for _, chain := range insertBaseChains {
-		// Insert the append chains slightly after the inert chains, allowing for intermediate rules.
+		// Hook the append chains slightly after the insert chains, allowing for intermediate rules.
 		prio := appendPriorities[*chain.Priority]
 		appendBaseChains[chain.Name] = knftables.Chain{
 			Name:     chain.Name + "-append",


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

To simulate the behavior provided in iptables mode, this PR enables user-defined rules to be inserted between Calico's "insert" and "append" rules.

For example, to deny traffic that Calico would have otherwise allowed.

It does so by splitting our nftables hooks into two parts: an insert chain, and an append chain with a slightly higher priority.

Users can then define their own table, hooked between the two chains, to define their own rules.

Note that with this PR, Calico "drop" rules still take priority regardless of any user intevention. Additional changes would be needed to enable this, as nftables drop rules override any previous or subsequent allow actions in other tables.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.