### PR TITLE
[v3.26] [CORE-10548] Revert windows endpoint mgr logic change

### DIFF
--- a/felix/dataplane/windows/endpoint_mgr.go
+++ b/felix/dataplane/windows/endpoint_mgr.go
@@ -188,14 +188,20 @@ func (m *endpointManager) RefreshHnsEndpointCache(forceRefresh bool) error {
 			continue
 		}
 
-		// An endpoint is considered to be active if its state is Attached or AttachedSharing.
-		// Note: Endpoint.State attribute is dependent on HNS v1 api. If hcsshim upgrades to HNS v2
-		// api this will break. We then need to Reach out to Microsoft to facilate the change via HNS.
-		if endpoint.State.String() != "Attached" && endpoint.State.String() != "AttachedSharing" {
+		// Some CNI plugins do not clear endpoint properly when a pod has been torn down.
+		// In that case, it is possible Felix sees multiple endpoints with the same IP.
+		// We need to filter out inactive endpoints that do not attach to any container.
+		if len(endpoint.SharedContainers) == 0 {
 			log.WithFields(log.Fields{
 				"id":   endpoint.Id,
 				"name": endpoint.Name,
 			}).Warn("This is a stale endpoint with no container attached")
+			log.WithFields(log.Fields{
+				"id":               endpoint.Id,
+				"name":             endpoint.Name,
+				"state":            endpoint.State.String(),
+				"sharedcontainers": endpoint.SharedContainers,
+			}).Debug("Stale endpoint debug information")
 			continue
 		}
 		ip := endpoint.IPAddress.String() + ipv4AddrSuffix


### PR DESCRIPTION
Revert windows endpoint mgr logic change from https://github.com/projectcalico/calico/pull/9027 which was breaking windows policies and add extra debug logging.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
