### PR TITLE
[v3.28] Fix broken pipe error when listing temp IP sets

### DIFF
--- a/felix/ipsets/ipsets.go
+++ b/felix/ipsets/ipsets.go
@@ -648,6 +648,12 @@ func (s *IPSets) runIPSetList(arg string, parsingFunc func(*bufio.Scanner) error
 	// Use a scanner to chunk the input into lines.
 	scanner := bufio.NewScanner(out)
 	parsingErr := parsingFunc(scanner)
+	if parsingErr == nil {
+		// In case the parsingFunc stopped early, drain stdout fully.
+		for scanner.Scan() {
+		}
+		parsingErr = scanner.Err()
+	}
 	closeErr := out.Close()
 	err = cmd.Wait()
 	logCxt := s.logCxt.WithField("stderr", stderr.String())
@@ -811,6 +817,13 @@ func (s *IPSets) writeUpdates(setName string, w io.Writer) (err error) {
 	// If the metadata needs to change then we have to write to a temporary IP
 	// set and swap it into place.
 	needTempIPSet := dpExists && dpMeta != desiredMeta
+	if needTempIPSet {
+		log.WithFields(log.Fields{
+			"desired":   desiredMeta,
+			"dataplane": dpMeta,
+			"setName":   setName,
+		}).Info("IP set metadata change, need to use a temporary IP set.")
+	}
 	// If the IP set doesn't exist yet, we need to create it.
 	needCreate := !dpExists
 


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fix that resync of temporary IP sets would fail with a broken pipe error from ipset.  This was because we failed to drain stdout in that case.

Fix that the mock dataplane didn't return an error in this case, resulting in the existing tests missing the problem.  After fixing the tests, they fail as they always should have done then the fix makes them pass again.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CI-1580
CORE-10564
Backport of https://github.com/projectcalico/calico/pull/9077

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Felix would panic when trying to resync a temporary IP set.  Temporary IP sets are created in certain scenarios after previous failures.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
