### PR TITLE
[master] Auto pick #9088: Use the same priority when re-attaching preamble program

### DIFF
--- a/felix/bpf/libbpf/libbpf.go
+++ b/felix/bpf/libbpf/libbpf.go
@@ -167,7 +167,7 @@ func DetachClassifier(ifindex, handle, pref int, ingress bool) error {
 }
 
 // AttachClassifier return the program id and pref and handle of the qdisc
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int) (int, int, int, error) {
 	cSecName := C.CString(secName)
 	cIfName := C.CString(ifName)
 	defer C.free(unsafe.Pointer(cSecName))
@@ -177,7 +177,7 @@ func (o *Obj) AttachClassifier(secName, ifName string, ingress bool) (int, int, 
 		return -1, -1, -1, err
 	}
 
-	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress))
+	ret, err := C.bpf_tc_program_attach(o.obj, cSecName, C.int(ifIndex), C.bool(ingress), C.int(prio))
 	if err != nil {
 		return -1, -1, -1, fmt.Errorf("error attaching tc program %w", err)
 	}

--- a/felix/bpf/libbpf/libbpf_api.h
+++ b/felix/bpf/libbpf/libbpf_api.h
@@ -50,12 +50,12 @@ int bpf_program_fd(struct bpf_object *obj, char *secname)
 	return fd;
 }
 
-struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress)
+struct bpf_tc_opts bpf_tc_program_attach(struct bpf_object *obj, char *secName, int ifIndex, bool ingress, int prio)
 {
 	DECLARE_LIBBPF_OPTS(bpf_tc_hook, hook,
 			.attach_point = ingress ? BPF_TC_INGRESS : BPF_TC_EGRESS,
 			);
-	DECLARE_LIBBPF_OPTS(bpf_tc_opts, attach);
+	DECLARE_LIBBPF_OPTS(bpf_tc_opts, attach, .priority=prio,);
 
 	attach.prog_fd = bpf_program__fd(bpf_object__find_program_by_name(obj, secName));
 	if (attach.prog_fd < 0) {

--- a/felix/bpf/libbpf/libbpf_stub.go
+++ b/felix/bpf/libbpf/libbpf_stub.go
@@ -74,7 +74,7 @@ func DetachClassifier(ifindex, handle, pref int, ingress bool) error {
 	panic("LIBBPF syscall stub")
 }
 
-func (o *Obj) AttachClassifier(secName, ifName string, ingress bool) (int, int, int, error) {
+func (o *Obj) AttachClassifier(secName, ifName string, ingress bool, prio int) (int, int, int, error) {
 	panic("LIBBPF syscall stub")
 }
 

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -677,6 +677,141 @@ func TestAttach(t *testing.T) {
 	runAttachTest(t, true)
 }
 
+// This test simulates workload updates like changing labels, annotations.
+// Expectation is that multiple workload updates should still result in
+// preamble program not getting re-attached.
+func TestAttachWithMultipleWorkloadUpdate(t *testing.T) {
+	RegisterTestingT(t)
+
+	bpfmaps, err := bpfmap.CreateBPFMaps(false)
+	Expect(err).NotTo(HaveOccurred())
+
+	commonMaps := bpfmaps.CommonMaps
+	programs := commonMaps.ProgramsMap.(*hook.ProgramsMap)
+	loglevel := "off"
+
+	bpfEpMgr, err := linux.NewTestEpMgr(
+		&linux.Config{
+			Hostname:              "uthost",
+			BPFLogLevel:           loglevel,
+			BPFDataIfacePattern:   regexp.MustCompile("^hostep[12]"),
+			VXLANMTU:              1000,
+			VXLANPort:             1234,
+			BPFNodePortDSREnabled: false,
+			RulesConfig: rules.Config{
+				EndpointToHostAction: "RETURN",
+			},
+			BPFExtToServiceConnmark: 0,
+			FeatureGates: map[string]string{
+				"BPFConnectTimeLoadBalancingWorkaround": "enabled",
+			},
+			BPFPolicyDebugEnabled: true,
+		},
+		bpfmaps,
+		regexp.MustCompile("^workloadep[123]"),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	workload1 := createVethName("workloadep1")
+	defer deleteLink(workload1)
+
+	bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{Hostname: "uthost", Ipv4Addr: "1.2.3.4"})
+	bpfEpMgr.OnUpdate(linux.NewIfaceStateUpdate("workloadep1", ifacemonitor.StateUp, workload1.Attrs().Index))
+	bpfEpMgr.OnUpdate(linux.NewIfaceAddrsUpdate("workloadep1", "1.6.6.6"))
+	bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
+		Id: &proto.WorkloadEndpointID{
+			OrchestratorId: "k8s",
+			WorkloadId:     "workloadep1",
+			EndpointId:     "workloadep1",
+		},
+		Endpoint: &proto.WorkloadEndpoint{Name: "workloadep1"},
+	})
+	err = bpfEpMgr.CompleteDeferredWork()
+	Expect(err).NotTo(HaveOccurred())
+
+	valid, firstPrio, firstHandle := bpfEpMgr.GetIfaceQDiscInfo("workloadep1")
+	Expect(valid).To(BeTrue())
+	Expect(firstPrio).To(BeNumerically(">", 0))
+	Expect(firstHandle).To(BeNumerically(">", 0))
+
+	at := programs.Programs()
+	Expect(at).To(HaveKey(hook.AttachType{
+		Hook:       hook.Ingress,
+		Family:     4,
+		Type:       tcdefs.EpTypeWorkload,
+		LogLevel:   loglevel,
+		FIB:        true,
+		ToHostDrop: false,
+		DSR:        false}))
+	Expect(at).To(HaveKey(hook.AttachType{
+		Hook:       hook.Egress,
+		Family:     4,
+		Type:       tcdefs.EpTypeWorkload,
+		LogLevel:   loglevel,
+		FIB:        true,
+		ToHostDrop: false,
+		DSR:        false}))
+
+	for i := 0; i < 20; i++ {
+		bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
+			Id: &proto.WorkloadEndpointID{
+				OrchestratorId: "k8s",
+				WorkloadId:     "workloadep1",
+				EndpointId:     "workloadep1",
+			},
+			Endpoint: &proto.WorkloadEndpoint{Name: "workloadep1"},
+		})
+		err = bpfEpMgr.CompleteDeferredWork()
+		Expect(err).NotTo(HaveOccurred())
+		valid, prio, handle := bpfEpMgr.GetIfaceQDiscInfo("workloadep1")
+		Expect(valid).To(BeTrue())
+		Expect(prio).To(Equal(firstPrio))
+		Expect(handle).To(Equal(firstHandle))
+	}
+
+}
+
+// This test verifies that we use the same tc priority and but toggle between
+// handles when repeatedly attaching the preamble program.
+func TestRepeatedAttach(t *testing.T) {
+	RegisterTestingT(t)
+
+	iface, veth := createVeth()
+	defer func() {
+		deleteLink(veth)
+	}()
+
+	ap := &tc.AttachPoint{
+		AttachPoint: bpf.AttachPoint{
+			Iface: iface,
+			Hook:  hook.Ingress,
+		},
+		HostIPv4: net.IPv4(8, 8, 8, 8),
+		IntfIPv4: net.IPv4(7, 7, 7, 7),
+	}
+
+	_, err := tc.EnsureQdisc(iface)
+	Expect(err).NotTo(HaveOccurred(), "failed to create qdisc")
+	res, err := ap.AttachProgram()
+	Expect(err).NotTo(HaveOccurred(), "failed to attach preamble")
+	tcRes, ok := res.(tc.AttachResult)
+	Expect(ok).To(BeTrue())
+	prio := tcRes.Prio()
+	handle := tcRes.Handle()
+	for i := 0; i < 20; i++ {
+		res, err = ap.AttachProgram()
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to attach preamble : %d", i))
+		tcRes, ok = res.(tc.AttachResult)
+		Expect(ok).To(BeTrue())
+		Expect(tcRes.Prio()).To(Equal(prio))
+		if i%2 == 0 {
+			Expect(tcRes.Handle()).To(Equal(handle + 1))
+		} else {
+			Expect(tcRes.Handle()).To(Equal(handle))
+		}
+	}
+}
+
 func ifstateMapDump(m maps.Map) ifstate.MapMem {
 	ifstateMap := make(ifstate.MapMem)
 	ifstateMapIter := ifstate.MapMemIter(ifstateMap)

--- a/felix/bpf/ut/attach_test.go
+++ b/felix/bpf/ut/attach_test.go
@@ -752,7 +752,10 @@ func TestAttachWithMultipleWorkloadUpdate(t *testing.T) {
 		ToHostDrop: false,
 		DSR:        false}))
 
-	for i := 0; i < 20; i++ {
+	// The expectation is that, WorkloadEndpointUpdates must not
+	// result in re-attaching the program. Hence the priority, handle of
+	// the tc filters must be the same.
+	for i := 0; i < 2; i++ {
 		bpfEpMgr.OnUpdate(&proto.WorkloadEndpointUpdate{
 			Id: &proto.WorkloadEndpointID{
 				OrchestratorId: "k8s",
@@ -771,7 +774,7 @@ func TestAttachWithMultipleWorkloadUpdate(t *testing.T) {
 
 }
 
-// This test verifies that we use the same tc priority and but toggle between
+// This test verifies that we use the same tc priority but toggle between
 // handles when repeatedly attaching the preamble program.
 func TestRepeatedAttach(t *testing.T) {
 	RegisterTestingT(t)
@@ -798,7 +801,7 @@ func TestRepeatedAttach(t *testing.T) {
 	Expect(ok).To(BeTrue())
 	prio := tcRes.Prio()
 	handle := tcRes.Handle()
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 3; i++ {
 		res, err = ap.AttachProgram()
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to attach preamble : %d", i))
 		tcRes, ok = res.(tc.AttachResult)

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -404,6 +404,7 @@ type bpfAllowChainRenderer interface {
 type ManagerWithHEPUpdate interface {
 	Manager
 	OnHEPUpdate(hostIfaceToEpMap map[string]proto.HostEndpoint)
+	GetIfaceQDiscInfo(ifaceName string) (bool, int, int)
 }
 
 func NewTestEpMgr(
@@ -766,6 +767,11 @@ func (m *bpfEndpointManager) withIface(ifaceName string, fn func(iface *bpfInter
 
 	logCtx.Debug("Marking iface dirty.")
 	m.dirtyIfaceNames.Add(ifaceName)
+}
+
+func (m *bpfEndpointManager) GetIfaceQDiscInfo(ifaceName string) (bool, int, int) {
+	qdisc := m.nameToIface[ifaceName].dpState.qdisc
+	return qdisc.valid, qdisc.prio, qdisc.handle
 }
 
 func (m *bpfEndpointManager) updateHostIP(ip net.IP, ipFamily int) {
@@ -2243,7 +2249,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 		return state, fmt.Errorf("ingress qdisc info (%v) does not equal egress qdisc info (%v)",
 			ingressQdisc, egressQdisc)
 	}
-	state.qdisc = ingressQdisc
+
+	if attachPreamble {
+		state.qdisc = ingressQdisc
+	}
 
 	if err4 != nil && err6 != nil {
 		// This covers the case when we don't have hostIP on both paths.
@@ -2290,7 +2299,7 @@ func (m *bpfEndpointManager) ensureProgramAttached(ap attachPoint) (qDiscInfo, e
 	if err != nil {
 		return qdisc, err
 	}
-	if tcRes, ok := res.(*tc.AttachResult); ok {
+	if tcRes, ok := res.(tc.AttachResult); ok {
 		qdisc.valid = true
 		qdisc.prio = tcRes.Prio()
 		qdisc.handle = tcRes.Handle()
@@ -2384,7 +2393,6 @@ func (d *bpfEndpointManagerDataplane) wepApplyPolicyToDirection(readiness ifaceR
 	endpoint *proto.WorkloadEndpoint, polDirection PolDirection, ap *tc.AttachPoint,
 ) (*tc.AttachPoint, error) {
 	var policyIdx, filterIdx int
-
 	if d.hostIP == nil {
 		// Do not bother and wait
 		return nil, fmt.Errorf("unknown host IP")

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2192,6 +2192,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 			v4Readiness = ifaceNotReady
 			v6Readiness = ifaceNotReady
 		}
+		if _, err := m.dp.queryClassifier(ifindex, state.qdisc.handle, state.qdisc.prio, false); err != nil {
+			v4Readiness = ifaceNotReady
+			v6Readiness = ifaceNotReady
+		}
 	}
 
 	ap := m.calculateTCAttachPoint(ifaceName)


### PR DESCRIPTION
Cherry pick of #9088 on master.

#9088: Use the same priority when re-attaching preamble program

# Original PR Body below

Cherry pick of #9074 on release-v3.28.

#9074: Use the same priority when re-attaching preamble program

# Original PR Body below

## Description

This PR fixes the following issues
1. When the preamble program is attached repeatedly to an interface, we end up using a lot of tc priority and run into a kernel error. Fix - For the first program, use the kernel allocated priority. For subsequent attaches, we use the priority allocated by the kernel. When doing this, we attach to the same priority but the handle keeps toggling between 0x1 and 0x2.
2. When there is a workload update such as update to the labels, annotations, preamble programs are re-attached. Fix - When we first attach to an interface, we store the qdisc info. For subsequent workload updates, we use the stored qdisc info to decide whether to re-attach. This fix makes sure we don't overwrite the qdisc with invalid info.

fixes https://github.com/projectcalico/calico/issues/8897

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Fixed frequently attaching BPF programs when pods annotations/labels change and eventually failing due ro running out of  tc priority.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.