### PR TITLE
Execute MASQ rules after kube-proxy to avoid conflict - reenable vxlan csum offload

### DIFF
--- a/felix/environment/feature_detect_linux.go
+++ b/felix/environment/feature_detect_linux.go
@@ -50,6 +50,8 @@ var (
 	v3Dot10Dot0 = MustParseVersion("3.10.0")
 	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
 	v3Dot14Dot0 = MustParseVersion("3.14.0")
+	// v5Dot7Dot0 contains a fix for checksum offloading.
+	v5Dot7Dot0 = MustParseVersion("5.7.0")
 	// v5Dot14Dot0 is the fist kernel version that IPIP tunnels acts like other L3
 	// devices where bpf programs only see inner IP header. In RHEL based distros,
 	// kernel 4.18.0 (v4Dot18Dot0_330) is the first one with this behavior.
@@ -130,7 +132,7 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
 		SNATFullyRandom:          iptV.Compare(v1Dot6Dot0) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		MASQFullyRandom:          iptV.Compare(v1Dot6Dot2) >= 0 && kerV.Compare(v3Dot14Dot0) >= 0,
 		RestoreSupportsLock:      iptV.Compare(v1Dot6Dot2) >= 0,
-		ChecksumOffloadBroken:    true, // Was supposed to be fixed in v5.7 but still seems to be broken.
+		ChecksumOffloadBroken:    kerV.Compare(v5Dot7Dot0) <= 0,
 		IPIPDeviceIsL3:           d.ipipDeviceIsL3(),
 		KernelSideRouteFiltering: netlinkSupportsStrict,
 	}

--- a/felix/environment/feature_detect_test.go
+++ b/felix/environment/feature_detect_test.go
@@ -147,6 +147,16 @@ func TestFeatureDetection(t *testing.T) {
 				ChecksumOffloadBroken: true,
 			},
 		},
+		{
+			"iptables v1.8.4",
+			"Linux version 5.8.0",
+			Features{
+				RestoreSupportsLock:   true,
+				SNATFullyRandom:       true,
+				MASQFullyRandom:       true,
+				ChecksumOffloadBroken: false,
+			},
+		},
 	} {
 		tst := tst
 		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
@@ -507,32 +517,28 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.10.0 - ubuntu",
 			Features{
-				IPIPDeviceIsL3:        false,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: false,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.14.0 - something else",
 			Features{
-				IPIPDeviceIsL3:        true,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.15.0",
 			Features{
-				IPIPDeviceIsL3:        true,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: true,
 			},
 			map[string]string{},
 		},
 		{
 			"Linux version 5.10.0 - Default",
 			Features{
-				IPIPDeviceIsL3:        true,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: true,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "true",
@@ -541,8 +547,7 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.14.0",
 			Features{
-				IPIPDeviceIsL3:        false,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: false,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",
@@ -551,8 +556,7 @@ func TestBPFFeatureDetection(t *testing.T) {
 		{
 			"Linux version 5.16.0 - Ubuntu",
 			Features{
-				IPIPDeviceIsL3:        false,
-				ChecksumOffloadBroken: true,
+				IPIPDeviceIsL3: false,
 			},
 			map[string]string{
 				"IPIPDeviceIsL3": "false",


### PR DESCRIPTION
## Description

    Calico needs to do MASQ for several reasons and kube-proxy does it when
    it forwards nodeports to another node. Calico conflicts with this MASQ
    in case it routes traffic to the destionation via tunnel. This may
    result in a conflict which triggers wrongly calculated checksums in case
    tx csum offloading is enabled on the tunnel device, which lead to
    disabling offloading on the tunnel and thus to significant performance
    hit.
    
    Do MASQ after kube-proxy means that if kube-proxy already did it,
    calico's is not executed - it would be a duplicate anyway. Other MASQ
    and SNAT cases in the calico chain are othogonal to the kube-proxy
    usecase and thus execute as kube-proxy does not do MASQ in that case.
    
    Note that unlik ein other chains where calico may do policy and thus
    needs to go first, calico does not execute any policy in POSTROUTING
    nat.

fixes https://github.com/projectcalico/calico/issues/8860

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
