### PR TITLE
[release-v3.28] Auto pick #9084: Fix parsing host IP, attach BPF programs to all

### DIFF
--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -2198,6 +2198,10 @@ func (m *bpfEndpointManager) doApplyPolicy(ifaceName string) (bpfInterfaceState,
 			v4Readiness = ifaceNotReady
 			v6Readiness = ifaceNotReady
 		}
+		if _, err := m.dp.queryClassifier(ifindex, state.qdisc.handle, state.qdisc.prio, false); err != nil {
+			v4Readiness = ifaceNotReady
+			v6Readiness = ifaceNotReady
+		}
 	}
 
 	ap := m.calculateTCAttachPoint(ifaceName)

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -785,7 +785,6 @@ func (m *bpfEndpointManager) updateHostIP(ipAddr string, ipFamily int) {
 		// Should be safe without the lock since there shouldn't be any active background threads
 		// but taking it now makes us robust to refactoring.
 		m.ifacesLock.Lock()
-		defer m.ifacesLock.Unlock()
 		for ifaceName := range m.nameToIface {
 			m.withIface(ifaceName, func(iface *bpfInterface) (forceDirty bool) {
 				iface.dpState.v4Readiness = ifaceNotReady
@@ -793,6 +792,7 @@ func (m *bpfEndpointManager) updateHostIP(ipAddr string, ipFamily int) {
 				return true
 			})
 		}
+		m.ifacesLock.Unlock()
 		// We use host IP as the source when routing service for the ctlb workaround. We
 		// need to update those routes, so make them all dirty.
 		for svc := range m.services {

--- a/felix/dataplane/linux/bpf_ep_mgr.go
+++ b/felix/dataplane/linux/bpf_ep_mgr.go
@@ -771,7 +771,11 @@ func (m *bpfEndpointManager) withIface(ifaceName string, fn func(iface *bpfInter
 	m.dirtyIfaceNames.Add(ifaceName)
 }
 
-func (m *bpfEndpointManager) updateHostIP(ip net.IP, ipFamily int) {
+func (m *bpfEndpointManager) updateHostIP(ipAddr string, ipFamily int) {
+	ip, _, err := net.ParseCIDR(ipAddr)
+	if err != nil {
+		ip = net.ParseIP(ipAddr)
+	}
 	if ip != nil {
 		if ipFamily == 4 {
 			m.v4.hostIP = ip
@@ -781,11 +785,14 @@ func (m *bpfEndpointManager) updateHostIP(ip net.IP, ipFamily int) {
 		// Should be safe without the lock since there shouldn't be any active background threads
 		// but taking it now makes us robust to refactoring.
 		m.ifacesLock.Lock()
+		defer m.ifacesLock.Unlock()
 		for ifaceName := range m.nameToIface {
-			m.dirtyIfaceNames.Add(ifaceName)
+			m.withIface(ifaceName, func(iface *bpfInterface) (forceDirty bool) {
+				iface.dpState.v4Readiness = ifaceNotReady
+				iface.dpState.v6Readiness = ifaceNotReady
+				return true
+			})
 		}
-		m.ifacesLock.Unlock()
-
 		// We use host IP as the source when routing service for the ctlb workaround. We
 		// need to update those routes, so make them all dirty.
 		for svc := range m.services {
@@ -826,12 +833,12 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 	case *proto.HostMetadataUpdate:
 		if m.v4 != nil && msg.Hostname == m.hostname {
 			log.WithField("HostMetadataUpdate", msg).Infof("Host IP changed: %s", msg.Ipv4Addr)
-			m.updateHostIP(net.ParseIP(msg.Ipv4Addr), 4)
+			m.updateHostIP(msg.Ipv4Addr, 4)
 		}
 	case *proto.HostMetadataV6Update:
 		if m.v6 != nil && msg.Hostname == m.hostname {
 			log.WithField("HostMetadataV6Update", msg).Infof("Host IPv6 changed: %s", msg.Ipv6Addr)
-			m.updateHostIP(net.ParseIP(msg.Ipv6Addr), 6)
+			m.updateHostIP(msg.Ipv6Addr, 6)
 		}
 	case *proto.HostMetadataV4V6Update:
 		if msg.Hostname != m.hostname {
@@ -839,11 +846,11 @@ func (m *bpfEndpointManager) OnUpdate(msg interface{}) {
 		}
 		if m.v4 != nil {
 			log.WithField("HostMetadataV4V6Update", msg).Infof("Host IP changed: %s", msg.Ipv4Addr)
-			m.updateHostIP(net.ParseIP(msg.Ipv4Addr), 4)
+			m.updateHostIP(msg.Ipv4Addr, 4)
 		}
 		if m.v6 != nil {
 			log.WithField("HostMetadataV4V6Update", msg).Infof("Host IPv6 changed: %s", msg.Ipv6Addr)
-			m.updateHostIP(net.ParseIP(msg.Ipv6Addr), 6)
+			m.updateHostIP(msg.Ipv6Addr, 6)
 		}
 	case *proto.ServiceUpdate:
 		m.onServiceUpdate(msg)
@@ -2295,7 +2302,7 @@ func (m *bpfEndpointManager) ensureProgramAttached(ap attachPoint) (qDiscInfo, e
 	if err != nil {
 		return qdisc, err
 	}
-	if tcRes, ok := res.(*tc.AttachResult); ok {
+	if tcRes, ok := res.(tc.AttachResult); ok {
 		qdisc.valid = true
 		qdisc.prio = tcRes.Prio()
 		qdisc.handle = tcRes.Handle()

--- a/felix/dataplane/linux/bpf_ep_mgr_test.go
+++ b/felix/dataplane/linux/bpf_ep_mgr_test.go
@@ -65,6 +65,7 @@ type mockDataplane struct {
 	mutex       sync.Mutex
 	lastProgID  int
 	progs       map[string]int
+	numAttaches map[string]int
 	policy      map[string]polprog.Rules
 	routes      map[ip.CIDR]struct{}
 	netlinkShim netlinkshim.Interface
@@ -83,6 +84,7 @@ func newMockDataplane() *mockDataplane {
 	return &mockDataplane{
 		lastProgID:  5,
 		progs:       map[string]int{},
+		numAttaches: map[string]int{},
 		policy:      map[string]polprog.Rules{},
 		routes:      map[ip.CIDR]struct{}{},
 		netlinkShim: netlinkShim,
@@ -113,6 +115,8 @@ func (m *mockDataplane) loadDefaultPolicies() error {
 
 func (m *mockDataplane) ensureProgramAttached(ap attachPoint) (qDiscInfo, error) {
 	var qdisc qDiscInfo
+	key := ap.IfaceName() + ":" + ap.HookName().String()
+	m.numAttaches[key] = m.numAttaches[key] + 1
 	return qdisc, nil
 }
 
@@ -245,6 +249,12 @@ func (m *mockDataplane) programAttached(key string) bool {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	return m.progs[key] != 0
+}
+
+func (m *mockDataplane) numOfAttaches(key string) int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.numAttaches[key]
 }
 
 func (m *mockDataplane) setRoute(cidr ip.CIDR) {
@@ -545,6 +555,28 @@ var _ = Describe("BPF Endpoint Manager", func() {
 		}
 	}
 
+	genHostMetadataUpdate := func(ip string) func() {
+		return func() {
+			bpfEpMgr.OnUpdate(&proto.HostMetadataUpdate{
+				Hostname: "uthost",
+				Ipv4Addr: ip,
+			})
+			err := bpfEpMgr.CompleteDeferredWork()
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
+	genHostMetadataV6Update := func(ip string) func() {
+		return func() {
+			bpfEpMgr.OnUpdate(&proto.HostMetadataV6Update{
+				Hostname: "uthost",
+				Ipv6Addr: ip,
+			})
+			err := bpfEpMgr.CompleteDeferredWork()
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+
 	hostEp := proto.HostEndpoint{
 		Name: "uthost-eth0",
 		PreDnatTiers: []*proto.TierInfo{
@@ -644,6 +676,34 @@ var _ = Describe("BPF Endpoint Manager", func() {
 				Expect(caliE.HostNormalTiers[0].Policies).To(HaveLen(1))
 				Expect(caliE.SuppressNormalHostPolicy).To(BeTrue())
 			})
+		})
+	})
+
+	Context("with workload endpoints", func() {
+		JustBeforeEach(func() {
+			newBpfEpMgr(true)
+			genWLUpdate("cali12345")()
+			genIfaceUpdate("cali12345", ifacemonitor.StateUp, 15)()
+		})
+
+		It("must re-attach programs when hostIP changes", func() {
+			Expect(dp.programAttached("cali12345:ingress")).To(BeTrue())
+			Expect(dp.programAttached("cali12345:egress")).To(BeTrue())
+			Expect(dp.numOfAttaches("cali12345:ingress")).To(Equal(1))
+			Expect(dp.numOfAttaches("cali12345:egress")).To(Equal(1))
+			genHostMetadataUpdate("5.6.7.8/32")()
+			Expect(dp.numOfAttaches("cali12345:ingress")).To(Equal(2))
+			Expect(dp.numOfAttaches("cali12345:egress")).To(Equal(2))
+			genHostMetadataUpdate("1.2.3.4")()
+			Expect(dp.numOfAttaches("cali12345:ingress")).To(Equal(3))
+			Expect(dp.numOfAttaches("cali12345:egress")).To(Equal(3))
+
+			genHostMetadataV6Update("1::5/128")()
+			Expect(dp.numOfAttaches("cali12345:ingress")).To(Equal(4))
+			Expect(dp.numOfAttaches("cali12345:egress")).To(Equal(4))
+			genHostMetadataV6Update("1::4")()
+			Expect(dp.numOfAttaches("cali12345:ingress")).To(Equal(5))
+			Expect(dp.numOfAttaches("cali12345:egress")).To(Equal(5))
 		})
 	})
 


### PR DESCRIPTION
Cherry pick of #9084 on release-v3.28.

#9084: Fix parsing host IP, attach BPF programs to all

# Original PR Body below

## Description
This PR fixes 2 issues related to host IP change.
1. Fix parsing of host IP - hostIP updates can have addresses as ```ip``` or ```ip/mask```. Need to make sure either way the update is parsed correctly.
2. When there is a host IP, mark all interfaces ```not ready``` so that bpf programs can be re-attached with updated priority.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf - Fix parsing host IP update and re-attach program on all interfaces when there is a host IP update.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.