### PR TITLE
[release-v3.28] Auto pick #9054: Build resource lists from registered resources

### DIFF
--- a/calicoctl/calicoctl/commands/apply.go
+++ b/calicoctl/calicoctl/commands/apply.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -63,21 +64,7 @@ Description:
 
   Valid resource types are:
 
-    * bgpConfiguration
-    * bgpPeer
-    * felixConfiguration
-    * globalNetworkPolicy
-    * globalNetworkSet
-    * hostEndpoint
-    * ipPool
-    * ipReservation
-    * kubeControllersConfiguration
-    * networkPolicy
-    * networkSet
-    * node
-    * profile
-    * workloadEndpoint
-
+<RESOURCE_LIST>
   When applying a resource:
   -  if the resource does not already exist (as determined by it's primary
      identifiers) then it is created
@@ -98,6 +85,14 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	name, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	// Replace <RESOURCE_LIST> with the list of resource types.
+	kinds := resourcemgr.ValidResources()
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", r)
+	}
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/apply.go
+++ b/calicoctl/calicoctl/commands/apply.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
-	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -87,12 +86,7 @@ Description:
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	// Replace <RESOURCE_LIST> with the list of resource types.
-	kinds := resourcemgr.ValidResources()
-	resourceList := ""
-	for _, r := range kinds {
-		resourceList += fmt.Sprintf("    - %s\n", r)
-	}
-	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", util.Resources(), 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/create.go
+++ b/calicoctl/calicoctl/commands/create.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -65,21 +66,7 @@ Description:
 
   Valid resource types are:
 
-    * bgpConfiguration
-    * bgpPeer
-    * felixConfiguration
-    * globalNetworkPolicy
-    * globalNetworkSet
-    * hostEndpoint
-    * ipPool
-    * ipReservation
-    * kubeControllersConfiguration
-    * networkPolicy
-    * networkSet
-    * node
-    * profile
-    * workloadEndpoint
-
+<RESOURCE_LIST>
   Attempting to create a resource that already exists is treated as a
   terminating error unless the --skip-exists flag is set.  If this flag is set,
   resources that already exist are skipped.
@@ -95,6 +82,14 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	name, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	// Replace <RESOURCE_LIST> with the list of resource types.
+	kinds := resourcemgr.ValidResources()
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", r)
+	}
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/create.go
+++ b/calicoctl/calicoctl/commands/create.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
-	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -84,12 +83,7 @@ Description:
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	// Replace <RESOURCE_LIST> with the list of resource types.
-	kinds := resourcemgr.ValidResources()
-	resourceList := ""
-	for _, r := range kinds {
-		resourceList += fmt.Sprintf("    - %s\n", r)
-	}
-	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", util.Resources(), 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/delete.go
+++ b/calicoctl/calicoctl/commands/delete.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
-	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -96,12 +95,7 @@ Description:
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	// Replace <RESOURCE_LIST> with the list of resource types.
-	kinds := resourcemgr.ValidResources()
-	resourceList := ""
-	for _, r := range kinds {
-		resourceList += fmt.Sprintf("    - %s\n", r)
-	}
-	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", util.Resources(), 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/delete.go
+++ b/calicoctl/calicoctl/commands/delete.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -71,21 +72,7 @@ Description:
 
   Valid resource types are:
 
-    * bgpConfiguration
-    * bgpPeer
-    * felixConfiguration
-    * globalNetworkPolicy
-    * globalNetworkSet
-    * hostEndpoint
-    * ipPool
-    * ipReservation
-    * kubeControllersConfiguration
-    * networkPolicy
-    * networkSet
-    * node
-    * profile
-    * workloadEndpoint
-
+<RESOURCE_LIST>
   The resource type is case-insensitive and may be pluralized.
 
   Attempting to delete a resource that does not exists is treated as a
@@ -107,6 +94,14 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	name, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	// Replace <RESOURCE_LIST> with the list of resource types.
+	kinds := resourcemgr.ValidResources()
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", r)
+	}
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/get.go
+++ b/calicoctl/calicoctl/commands/get.go
@@ -15,17 +15,18 @@
 package commands
 
 import (
-	"github.com/docopt/docopt-go"
-
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/docopt/docopt-go"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -74,21 +75,7 @@ Description:
 
   Valid resource types are:
 
-    * bgpConfiguration
-    * bgpPeer
-    * felixConfiguration
-    * globalNetworkPolicy
-    * globalNetworkSet
-    * hostEndpoint
-    * ipPool
-    * ipReservation
-    * kubeControllersConfiguration
-    * networkPolicy
-    * networkSet
-    * node
-    * profile
-    * workloadEndpoint
-
+<RESOURCE_LIST>
   The resource type is case-insensitive and may be pluralized.
 
   Attempting to get resources that do not exist will simply return no results.
@@ -126,6 +113,14 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	name, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	// Replace <RESOURCE_LIST> with the list of resource types.
+	kinds := resourcemgr.ValidResources()
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", r)
+	}
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
 
 	// -a option Backward compatibility
 	for k, v := range args {

--- a/calicoctl/calicoctl/commands/get.go
+++ b/calicoctl/calicoctl/commands/get.go
@@ -26,7 +26,6 @@ import (
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
-	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -115,12 +114,7 @@ Description:
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	// Replace <RESOURCE_LIST> with the list of resource types.
-	kinds := resourcemgr.ValidResources()
-	resourceList := ""
-	for _, r := range kinds {
-		resourceList += fmt.Sprintf("    - %s\n", r)
-	}
-	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", util.Resources(), 1)
 
 	// -a option Backward compatibility
 	for k, v := range args {

--- a/calicoctl/calicoctl/commands/label.go
+++ b/calicoctl/calicoctl/commands/label.go
@@ -87,12 +87,7 @@ Description:
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", binaryName)
 
 	// Replace <RESOURCE_LIST> with the list of resource types.
-	kinds := resourcemgr.ValidResources()
-	resourceList := ""
-	for _, r := range kinds {
-		resourceList += fmt.Sprintf("    - %s\n", r)
-	}
-	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", util.Resources(), 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/label.go
+++ b/calicoctl/calicoctl/commands/label.go
@@ -71,20 +71,7 @@ Description:
   The label command is used to add or update a label on a resource. Resource types
   that can be labeled are:
 
-    * bgpConfiguration
-    * bgpPeer
-    * felixConfiguration
-    * globalNetworkPolicy
-    * globalNetworkSet
-    * hostEndpoint
-    * ipPool
-    * ipReservation
-    * kubeControllersConfiguration
-    * networkPolicy
-    * node
-    * profile
-    * workloadEndpoint
-
+<RESOURCE_LIST>
   The resource type is case-insensitive and may be pluralized.
 
   Attempting to label resources that do not exist will get an error.
@@ -98,6 +85,14 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	binaryName, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", binaryName)
+
+	// Replace <RESOURCE_LIST> with the list of resource types.
+	kinds := resourcemgr.ValidResources()
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", r)
+	}
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/patch.go
+++ b/calicoctl/calicoctl/commands/patch.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -60,21 +61,7 @@ Description:
 
   Valid resource types are:
 
-    * bgpConfiguration
-    * bgpPeer
-    * felixConfiguration
-    * globalNetworkPolicy
-    * globalNetworkSet
-    * hostEndpoint
-    * ipPool
-    * ipReservation
-    * kubeControllersConfiguration
-    * networkPolicy
-    * networkSet
-    * node
-    * profile
-    * workloadEndpoint
-
+<RESOURCE_LIST>
   The resource type is case-insensitive and may be pluralized.
 
   Attempting to patch a resource that does not exists is treated as a
@@ -89,6 +76,14 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	name, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	// Replace <RESOURCE_LIST> with the list of resource types.
+	kinds := resourcemgr.ValidResources()
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", r)
+	}
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/patch.go
+++ b/calicoctl/calicoctl/commands/patch.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
-	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -78,12 +77,7 @@ Description:
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	// Replace <RESOURCE_LIST> with the list of resource types.
-	kinds := resourcemgr.ValidResources()
-	resourceList := ""
-	for _, r := range kinds {
-		resourceList += fmt.Sprintf("    - %s\n", r)
-	}
-	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", util.Resources(), 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/replace.go
+++ b/calicoctl/calicoctl/commands/replace.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -64,21 +65,7 @@ Description:
 
   Valid resource types are:
 
-    * bgpConfiguration
-    * bgpPeer
-    * felixConfiguration
-    * globalNetworkPolicy
-    * globalNetworkSet
-    * hostEndpoint
-    * ipPool
-    * ipReservation
-    * kubeControllersConfiguration
-    * networkPolicy
-    * networkSet
-    * node
-    * profile
-    * workloadEndpoint
-
+<RESOURCE_LIST>
   Attempting to replace a resource that does not exist is treated as a
   terminating error.
 
@@ -95,6 +82,14 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	name, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	// Replace <RESOURCE_LIST> with the list of resource types.
+	kinds := resourcemgr.ValidResources()
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", r)
+	}
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/commands/replace.go
+++ b/calicoctl/calicoctl/commands/replace.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/commands/constants"
-	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/calico/calicoctl/calicoctl/util"
 )
 
@@ -84,12 +83,7 @@ Description:
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	// Replace <RESOURCE_LIST> with the list of resource types.
-	kinds := resourcemgr.ValidResources()
-	resourceList := ""
-	for _, r := range kinds {
-		resourceList += fmt.Sprintf("    - %s\n", r)
-	}
-	doc = strings.Replace(doc, "<RESOURCE_LIST>", resourceList, 1)
+	doc = strings.Replace(doc, "<RESOURCE_LIST>", util.Resources(), 1)
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/calicoctl/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/calicoctl/resourcemgr/resourcemgr.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"sort"
 	"strings"
 	"time"
 
@@ -114,8 +113,8 @@ var (
 	allKinds  = []string{}
 )
 
+// ValidResources returns all registered resource kinds.
 func ValidResources() []string {
-	sort.Strings(allKinds)
 	return allKinds
 }
 

--- a/calicoctl/calicoctl/util/docstring.go
+++ b/calicoctl/calicoctl/util/docstring.go
@@ -1,9 +1,13 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+
+	"github.com/projectcalico/calico/calicoctl/calicoctl/resourcemgr"
 )
 
 func NameAndDescription() (string, string) {
@@ -17,4 +21,16 @@ func NameAndDescription() (string, string) {
 		desc = "calico kubectl plugin"
 	}
 	return name, desc
+}
+
+// Resources returns a string to insert into the docstring that lists the valid registered resources in use by
+// calicoctl, sorted alphabetically.
+func Resources() string {
+	kinds := resourcemgr.ValidResources()
+	sort.Strings(kinds)
+	resourceList := ""
+	for _, r := range kinds {
+		resourceList += fmt.Sprintf("    - %s\n", strings.ToLower(r))
+	}
+	return resourceList
 }


### PR DESCRIPTION
Cherry pick of #9054 on release-v3.28.

#9054: Build resource lists from registered resources

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fix calicoctl command descriptions to include the correct resource lists
based on the full set of registered resources.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix missing resources in calioctl command help text
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.