### PR TITLE
Add UTs for all IP set types in nftables mode

### DIFF
--- a/felix/ipsets/ipset_defs.go
+++ b/felix/ipsets/ipset_defs.go
@@ -133,7 +133,7 @@ func (t IPSetType) IsMemberIPV6(member string) bool {
 
 		return cidr1
 	case IPSetTypeBitmapPort:
-		return strings.HasPrefix("v6,", member)
+		return strings.HasPrefix(member, "v6,")
 	}
 	log.WithField("type", string(t)).Panic("Unknown IPSetType")
 	return false

--- a/felix/nftables/ipsets.go
+++ b/felix/nftables/ipsets.go
@@ -569,7 +569,7 @@ func (s *IPSets) NFTablesSet(name string) *knftables.Set {
 		return nil
 	}
 
-	flags := make([]knftables.SetFlag, 0, 1)
+	var flags []knftables.SetFlag
 	switch metadata.Type {
 	case ipsets.IPSetTypeHashIPPort:
 		// IP and port sets don't support the interval flag.

--- a/felix/nftables/ipsets_test.go
+++ b/felix/nftables/ipsets_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/knftables"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/felix/ipsets"
@@ -201,18 +202,112 @@ var _ = Describe("IPSets with empty data plane", func() {
 			&knftables.Element{Set: "cali40unsupported-set", Key: []string{"10.0.0.1"}},
 		))
 	})
+})
 
-	It("should program a hash:net,net IP set", func() {
-		meta := ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashNetNet}
-		s.AddOrReplaceIPSet(meta, []string{"10.0.0.0/32,11.0.0.0/32"})
+var _ = DescribeTable("IPSets programming v4",
+	func(meta ipsets.IPSetMetadata, members []string, expected []*knftables.Element) {
+		f := NewFake(knftables.IPv4Family, "calico")
+		ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV4, "cali", nil, nil)
+		s := NewIPSets(ipv, f, logutils.NewSummarizer("test loop"))
+		s.AddOrReplaceIPSet(meta, members)
 		Expect(s.ApplyUpdates).NotTo(Panic())
+
+		// Read it back.
 		sets, err := f.List(context.Background(), "sets")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(sets).To(Equal([]string{"cali40test"}))
+		Expect(sets).To(Equal([]string{"cali40" + meta.SetID}))
 
-		members, err := f.ListElements(context.Background(), "set", "cali40test")
+		m, err := f.ListElements(context.Background(), "set", "cali40"+meta.SetID)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(members).To(HaveLen(1))
-		Expect(members[0].Key).To(Equal([]string{"10.0.0.0", "11.0.0.0"}))
-	})
-})
+		Expect(m).To(ContainElements(expected))
+
+		// Trigger a resync to make sure we can handle it.
+		s.QueueResync()
+		Expect(s.ApplyUpdates).NotTo(Panic())
+
+		// Read it back again.
+		m, err = f.ListElements(context.Background(), "set", "cali40"+meta.SetID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).To(ContainElements(expected))
+	},
+
+	Entry(
+		ipsets.IPSetTypeHashIP,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashIP}, []string{"10.0.0.1"},
+		[]*knftables.Element{{Set: "cali40test", Key: []string{"10.0.0.1"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeHashNet,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashNet}, []string{"10.0.0.0/24"},
+		[]*knftables.Element{{Set: "cali40test", Key: []string{"10.0.0.0/24"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeHashIPPort,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashIPPort}, []string{"1.2.3.4,tcp:81"},
+		[]*knftables.Element{{Set: "cali40test", Key: []string{"1.2.3.4", "tcp", "81"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeHashNetNet,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashNetNet}, []string{"10.0.0.0/32,10.0.0.0/32"},
+		[]*knftables.Element{{Set: "cali40test", Key: []string{"10.0.0.0", "10.0.0.0"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeBitmapPort,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeBitmapPort}, []string{"v4,80"},
+		[]*knftables.Element{{Set: "cali40test", Key: []string{"80"}}},
+	),
+)
+
+var _ = DescribeTable("IPSets programming v6",
+	func(meta ipsets.IPSetMetadata, members []string, expected []*knftables.Element) {
+		f := NewFake(knftables.IPv4Family, "calico")
+		ipv := ipsets.NewIPVersionConfig(ipsets.IPFamilyV6, "cali", nil, nil)
+		s := NewIPSets(ipv, f, logutils.NewSummarizer("test loop"))
+		s.AddOrReplaceIPSet(meta, members)
+		Expect(s.ApplyUpdates).NotTo(Panic())
+
+		// Read it back.
+		sets, err := f.List(context.Background(), "sets")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sets).To(Equal([]string{"cali60" + meta.SetID}))
+
+		m, err := f.ListElements(context.Background(), "set", "cali60"+meta.SetID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).To(ContainElements(expected))
+
+		// Trigger a resync to make sure we can handle it.
+		s.QueueResync()
+		Expect(s.ApplyUpdates).NotTo(Panic())
+
+		// Read it back again.
+		m, err = f.ListElements(context.Background(), "set", "cali60"+meta.SetID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).To(ContainElements(expected))
+	},
+
+	Entry(
+		ipsets.IPSetTypeHashIP,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashIP}, []string{"2001:db8::1"},
+		[]*knftables.Element{{Set: "cali60test", Key: []string{"2001:db8::1"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeHashNet,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashNet}, []string{"2001:db8::/64"},
+		[]*knftables.Element{{Set: "cali60test", Key: []string{"2001:db8::/64"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeHashIPPort,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashIPPort}, []string{"2001:db8::1,tcp:81"},
+		[]*knftables.Element{{Set: "cali60test", Key: []string{"2001:db8::1", "tcp", "81"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeHashNetNet,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeHashNetNet}, []string{"2001:db8::/128,2001:db8::/128"},
+		[]*knftables.Element{{Set: "cali60test", Key: []string{"2001:db8::", "2001:db8::"}}},
+	),
+	Entry(
+		ipsets.IPSetTypeBitmapPort,
+		ipsets.IPSetMetadata{SetID: "test", Type: ipsets.IPSetTypeBitmapPort}, []string{"v6,80"},
+		[]*knftables.Element{{Set: "cali60test", Key: []string{"80"}}},
+	),
+)


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add unit tests to exercise creation and resyncing logic for all IPSetType variants in nftables data plane.

This also caught a bug in the base IP set logic when determining whether a bitmap:port IP set is v6 or v4.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.