### PR TITLE
Let jitter.Ticker.Stop() interrupt the next tick.

### DIFF
--- a/felix/jitter/jittered_ticker_test.go
+++ b/felix/jitter/jittered_ticker_test.go
@@ -28,8 +28,7 @@ var _ = Describe("Real 20ms + 10ms Ticker", func() {
 	var startTime time.Time
 	BeforeEach(func() {
 		startTime = time.Now()
-		ticker = NewTicker(20*time.Millisecond,
-			10*time.Millisecond)
+		ticker = NewTicker(20*time.Millisecond, 10*time.Millisecond)
 	})
 	AfterEach(func() {
 		ticker.Stop()
@@ -62,6 +61,15 @@ var _ = Describe("Real 20ms + 10ms Ticker", func() {
 		Expect(foundLT5).To(BeTrue())
 		Expect(foundGT5).To(BeTrue())
 	}, 1)
+})
+
+var _ = Describe("Ticker.Stop()", func() {
+	It("should interrupt the current tick", func() {
+		ticker := NewTicker(5*time.Second, 10*time.Millisecond)
+		startTime := time.Now()
+		ticker.Stop()
+		Expect(time.Since(startTime)).To(BeNumerically("<", 100*time.Millisecond))
+	})
 })
 
 var _ = Describe("Delay calculation", func() {


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
- Speeds up some tests that stut down tickers.
- Rename stuttered JitterTicker interface.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->
Upstreamed from https://github.com/tigera/calico-private/pull/7855

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that shutting down a ticker waited a whole tick.  (Mainly impacts tests.)
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
