### PR TITLE
Fix: Add dnsSearch: [] to kind configs to prevent host search paths from breaking nc lookups

### DIFF
--- a/hack/test/kind/kind-single.config
+++ b/hack/test/kind/kind-single.config
@@ -6,6 +6,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
   podSubnet: "192.168.0.0/16"
+  dnsSearch: []
 nodes:
 # For libcalico-go tests, we only need a control plane node.
 - role: control-plane

--- a/hack/test/kind/kind.config
+++ b/hack/test/kind/kind.config
@@ -5,6 +5,7 @@ networking:
   disableDefaultCNI: true
   podSubnet: "192.168.0.0/16,fd00:10:244::/64"
   ipFamily: dual
+  dnsSearch: []
 nodes:
 - role: control-plane
 - role: worker


### PR DESCRIPTION
## Description
- By default kind appends all search domains from the host machine when running `make e2e-tests`. This can cause failures in `nc` commands when performing short-name service lookups due to exceeding 256 total character for resolv.conf `search` param in [musl](https://git.musl-libc.org/cgit/musl/tree/src/network/lookup_name.c?h=v1.1.24#n171) used within the alpine baseimage for `registry.k8s.io/e2e-test-images/agnhost`.
- error example:
  ```  Aug  7 12:09:02.482: INFO: Running 'kubectl --server=https://127.0.0.1:43649 --kubeconfig=/git/calico/hack/test/kind/kind-kubeconfig.yaml --namespace=services-5824 exec execpod4f824 -- /bin/sh -x -c echo hostName | nc -v -t -w 2 multi-endpoint-test 80'
  Aug  7 12:09:07.638: INFO: rc: 1
  Aug  7 12:09:07.638: INFO: Service reachability failing with error: error running kubectl --server=https://127.0.0.1:43649 --kubeconfig=/git/calico/hack/test/kind/kind-kubeconfig.yaml --namespace=services-5824 exec execpod4f824 -- /bin/sh -x -c echo hostName | nc -v -t -w 2 multi-endpoint-test 80:
  Command stdout:

  stderr:
  + echo hostName
  + nc -v -t -w 2 multi-endpoint-test 80
  nc: getaddrinfo: Try again
  command terminated with exit code 1

  error:
  exit status 1
  Retrying...
  ```
- Adding `dnsSearch: []` to kind configs prevent this behavior and allows tests to succeed.

## Related issues/PRs

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
