### PR TITLE
Fix resizing of BPF maps.

### DIFF
--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
+	"github.com/projectcalico/calico/felix/bpf/maps"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 )
 
@@ -97,6 +98,12 @@ func (ap *AttachPoint) loadObject(file string) (*libbpf.Obj, error) {
 				return nil, fmt.Errorf("failed to configure %s: %w", file, err)
 			}
 			continue
+		}
+
+		if size := maps.Size(mapName); size != 0 {
+			if err := m.SetSize(size); err != nil {
+				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
+			}
 		}
 
 		log.Debugf("Pinning map %s k %d v %d", mapName, m.KeySize(), m.ValueSize())

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
+	"github.com/projectcalico/calico/felix/bpf/maps"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 )
 
@@ -166,7 +167,13 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 			}
 			continue
 		}
-		// TODO: We need to set map size here like tc.
+
+		if size := maps.Size(mapName); size != 0 {
+			if err := m.SetSize(size); err != nil {
+				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
+			}
+		}
+
 		pinDir := bpf.MapPinDir(m.Type(), mapName, ap.Iface, hook.XDP)
 		if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
 			return nil, fmt.Errorf("error pinning map %s: %w", mapName, err)

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -201,7 +201,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			cancel()
 		})
 
-		It("should implement untracked policy correctly", func() {
+		checkUntrackedPol := func() {
 			// This test covers both normal connectivity and failsafe connectivity.  We combine the
 			// tests because we rely on the changes of normal connectivity at each step to make sure
 			// that the policy has actually flowed through to the dataplane.
@@ -329,6 +329,31 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			if BPFMode() {
 				expectFailSafeOnlyConnectivityWithHost0(ExpectWithIPVersion(6))
 			}
-		})
+		}
+
+		It("should implement untracked policy correctly", checkUntrackedPol)
+
+		if BPFMode() {
+			Describe("with a custom map size", func() {
+				BeforeEach(func() {
+					newRtSize := 1000
+					newNATFeSize := 2000
+					newNATBeSize := 3000
+					newNATAffSize := 4000
+					newIpSetMapSize := 5000
+					newCtMapSize := 6000
+					infrastructure.UpdateFelixConfiguration(client, func(cfg *api.FelixConfiguration) {
+						cfg.Spec.BPFMapSizeRoute = &newRtSize
+						cfg.Spec.BPFMapSizeNATFrontend = &newNATFeSize
+						cfg.Spec.BPFMapSizeNATBackend = &newNATBeSize
+						cfg.Spec.BPFMapSizeNATAffinity = &newNATAffSize
+						cfg.Spec.BPFMapSizeIPSets = &newIpSetMapSize
+						cfg.Spec.BPFMapSizeConntrack = &newCtMapSize
+					})
+				})
+
+				It("should implement untracked policy correctly", checkUntrackedPol)
+			})
+		}
 	})
 })

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -16,6 +16,7 @@ package infrastructure
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -26,6 +27,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf/jump"
@@ -566,4 +571,22 @@ func (p PrometheusMetric) Float() (float64, error) {
 		return 0, err
 	}
 	return strconv.ParseFloat(raw, 64)
+}
+
+func UpdateFelixConfiguration(client client.Interface, deltaFn func(*api.FelixConfiguration)) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cfg, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
+	if _, doesNotExist := err.(errors.ErrorResourceDoesNotExist); doesNotExist {
+		cfg = api.NewFelixConfiguration()
+		cfg.Name = "default"
+		deltaFn(cfg)
+		_, err = client.FelixConfigurations().Create(ctx, cfg, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		Expect(err).NotTo(HaveOccurred())
+		deltaFn(cfg)
+		_, err = client.FelixConfigurations().Update(ctx, cfg, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}
 }

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -28,10 +28,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
+
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf/jump"
 	"github.com/projectcalico/calico/felix/bpf/polprog"


### PR DESCRIPTION
## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Maps were being correctly resized but the program attachment metadata wasn't updated so the programs failed to attach.

- Fix the test to actually verify basic workload connectivity.
- Add metadta updates to each of the attach points.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-10581

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
ebpf: Fix Felix panic when using non-default BPF map sizes.  Size was not updated in all places resulting in failure to attach programs.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
