### PR TITLE
[release-v3.28] Auto pick #9117: Fix resizing of BPF maps.

### DIFF
--- a/felix/bpf/tc/attach.go
+++ b/felix/bpf/tc/attach.go
@@ -30,6 +30,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
+	"github.com/projectcalico/calico/felix/bpf/maps"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 )
 
@@ -97,6 +98,12 @@ func (ap *AttachPoint) loadObject(file string) (*libbpf.Obj, error) {
 				return nil, fmt.Errorf("failed to configure %s: %w", file, err)
 			}
 			continue
+		}
+
+		if size := maps.Size(mapName); size != 0 {
+			if err := m.SetSize(size); err != nil {
+				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
+			}
 		}
 
 		log.Debugf("Pinning map %s k %d v %d", mapName, m.KeySize(), m.ValueSize())

--- a/felix/bpf/xdp/attach.go
+++ b/felix/bpf/xdp/attach.go
@@ -26,6 +26,7 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/bpfdefs"
 	"github.com/projectcalico/calico/felix/bpf/hook"
 	"github.com/projectcalico/calico/felix/bpf/libbpf"
+	"github.com/projectcalico/calico/felix/bpf/maps"
 	tcdefs "github.com/projectcalico/calico/felix/bpf/tc/defs"
 )
 
@@ -167,7 +168,13 @@ func (ap *AttachPoint) AttachProgram() (bpf.AttachResult, error) {
 			}
 			continue
 		}
-		// TODO: We need to set map size here like tc.
+
+		if size := maps.Size(mapName); size != 0 {
+			if err := m.SetSize(size); err != nil {
+				return nil, fmt.Errorf("error resizing map %s: %w", mapName, err)
+			}
+		}
+
 		pinDir := bpf.MapPinDir(m.Type(), mapName, ap.Iface, hook.XDP)
 		if err := m.SetPinPath(path.Join(pinDir, mapName)); err != nil {
 			return nil, fmt.Errorf("error pinning map %s: %w", mapName, err)

--- a/felix/fv/bpf_map_resize_test.go
+++ b/felix/fv/bpf_map_resize_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf/conntrack"
 	"github.com/projectcalico/calico/felix/bpf/ipsets"
@@ -99,7 +98,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 		})
 
 		ctMap := conntrack.Map()
-		Eventually(func() int { return getMapSize(tc.Felixes[0], ctMap) }, "10s", "200ms").Should(Equal(newCtMapSize))
+		Eventually(getMapSizeFn(tc.Felixes[0], ctMap), "10s", "200ms").Should(Equal(newCtMapSize))
 		out, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "dump")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.Count(out, srcIP.String())).To(Equal(1), "entry not found in conntrack map")
@@ -114,12 +113,12 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 		ctMap := conntrack.Map()
 
 		felix := tc.Felixes[0]
-		Eventually(func() int { return getMapSize(felix, rtMap) }, "10s", "200ms").Should(Equal((rtMap.(*maps.PinnedMap)).MaxEntries))
-		Eventually(func() int { return getMapSize(felix, feMap) }, "10s", "200ms").Should(Equal((feMap.(*maps.PinnedMap)).MaxEntries))
-		Eventually(func() int { return getMapSize(felix, beMap) }, "10s", "200ms").Should(Equal((beMap.(*maps.PinnedMap)).MaxEntries))
-		Eventually(func() int { return getMapSize(felix, affMap) }, "10s", "200ms").Should(Equal((affMap.(*maps.PinnedMap)).MaxEntries))
-		Eventually(func() int { return getMapSize(felix, ipsMap) }, "10s", "200ms").Should(Equal((ipsMap.(*maps.PinnedMap)).MaxEntries))
-		Eventually(func() int { return getMapSize(felix, ctMap) }, "10s", "200ms").Should(Equal((ctMap.(*maps.PinnedMap)).MaxEntries))
+		Eventually(getMapSizeFn(felix, rtMap), "10s", "200ms").Should(Equal((rtMap.(*maps.PinnedMap)).MaxEntries))
+		Eventually(getMapSizeFn(felix, feMap), "10s", "200ms").Should(Equal((feMap.(*maps.PinnedMap)).MaxEntries))
+		Eventually(getMapSizeFn(felix, beMap), "10s", "200ms").Should(Equal((beMap.(*maps.PinnedMap)).MaxEntries))
+		Eventually(getMapSizeFn(felix, affMap), "10s", "200ms").Should(Equal((affMap.(*maps.PinnedMap)).MaxEntries))
+		Eventually(getMapSizeFn(felix, ipsMap), "10s", "200ms").Should(Equal((ipsMap.(*maps.PinnedMap)).MaxEntries))
+		Eventually(getMapSizeFn(felix, ctMap), "10s", "200ms").Should(Equal((ctMap.(*maps.PinnedMap)).MaxEntries))
 
 		By("configuring route map size = 1000, nat fe size = 2000, nat be size = 3000, nat affinity size = 4000")
 		newRtSize := 1000
@@ -163,21 +162,33 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 	})
 })
 
-func getMapSize(felix *infrastructure.Felix, m maps.Map) int {
-	output := showBpfMap(felix, m)
-	return int(output["max_entries"].(float64))
+func getMapSizeFn(felix *infrastructure.Felix, m maps.Map) func() (int, error) {
+	return func() (int, error) {
+		return getMapSize(felix, m)
+	}
 }
 
-func showBpfMap(felix *infrastructure.Felix, m maps.Map) map[string]interface{} {
-	fileExists := felix.FileExists(m.Path())
-	Expect(fileExists).Should(BeTrue(), fmt.Sprintf("showBpfMap: map %s didn't show up inside container", m.Path()))
+func getMapSize(felix *infrastructure.Felix, m maps.Map) (int, error) {
+	output, err := showBpfMap(felix, m)
+	if err != nil {
+		return 0, err
+	}
+	return int(output["max_entries"].(float64)), nil
+}
+
+func showBpfMap(felix *infrastructure.Felix, m maps.Map) (map[string]interface{}, error) {
+	var data map[string]interface{}
 	cmd, err := maps.ShowMapCmd(m)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get BPF map show command: "+m.Path())
-	log.WithField("cmd", cmd).Debug("showBPFMap")
+	if err != nil {
+		return nil, err
+	}
 	out, err := felix.ExecOutput(cmd...)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get show BPF map: "+m.Path())
-	var mapData map[string]interface{}
-	err = json.Unmarshal([]byte(out), &mapData)
-	Expect(err).NotTo(HaveOccurred(), "Failed to parse show map data: "+m.Path())
-	return mapData
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(out), &data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }

--- a/felix/fv/bpf_map_resize_test.go
+++ b/felix/fv/bpf_map_resize_test.go
@@ -17,12 +17,10 @@
 package fv_test
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 	"time"
 
@@ -36,17 +34,17 @@ import (
 	"github.com/projectcalico/calico/felix/bpf/maps"
 	"github.com/projectcalico/calico/felix/bpf/nat"
 	"github.com/projectcalico/calico/felix/bpf/routes"
+	"github.com/projectcalico/calico/felix/fv/connectivity"
 	"github.com/projectcalico/calico/felix/fv/infrastructure"
+	"github.com/projectcalico/calico/felix/fv/workload"
 	"github.com/projectcalico/calico/felix/timeshim"
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
-	"github.com/projectcalico/calico/libcalico-go/lib/errors"
-	"github.com/projectcalico/calico/libcalico-go/lib/options"
 )
 
 var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable map size", []apiconfig.DatastoreType{apiconfig.EtcdV3}, func(getInfra infrastructure.InfraFactory) {
 
-	if os.Getenv("FELIX_FV_ENABLE_BPF") != "true" {
+	if !BPFMode() {
 		// Non-BPF run.
 		return
 	}
@@ -55,40 +53,29 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 		infra  infrastructure.DatastoreInfra
 		tc     infrastructure.TopologyContainers
 		client client.Interface
+
+		w  [2]*workload.Workload
+		cc *connectivity.Checker
 	)
 
 	BeforeEach(func() {
 		infra = getInfra()
 		opts := infrastructure.DefaultTopologyOptions()
 		tc, client = infrastructure.StartNNodeTopology(1, opts, infra)
+
+		infra.AddDefaultAllow()
 	})
 
 	AfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
 			infra.DumpErrorData()
 		}
-
+		for _, wl := range w {
+			wl.Stop()
+		}
 		tc.Stop()
 		infra.Stop()
 	})
-
-	updateFelixConfig := func(deltaFn func(*api.FelixConfiguration)) {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		cfg, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
-		if _, doesNotExist := err.(errors.ErrorResourceDoesNotExist); doesNotExist {
-			cfg = api.NewFelixConfiguration()
-			cfg.Name = "default"
-			deltaFn(cfg)
-			_, err = client.FelixConfigurations().Create(ctx, cfg, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		} else {
-			Expect(err).NotTo(HaveOccurred())
-			deltaFn(cfg)
-			_, err = client.FelixConfigurations().Update(ctx, cfg, options.SetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		}
-	}
 
 	It("should copy data from old map to new map", func() {
 		srcIP := net.IPv4(123, 123, 123, 123)
@@ -107,7 +94,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.Count(out, srcIP.String())).To(Equal(1), "entry not found in conntrack map")
 		newCtMapSize := 6000
-		updateFelixConfig(func(cfg *api.FelixConfiguration) {
+		infrastructure.UpdateFelixConfiguration(client, func(cfg *api.FelixConfiguration) {
 			cfg.Spec.BPFMapSizeConntrack = &newCtMapSize
 		})
 
@@ -116,7 +103,6 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 		out, err = tc.Felixes[0].ExecOutput("calico-bpf", "conntrack", "dump")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.Count(out, srcIP.String())).To(Equal(1), "entry not found in conntrack map")
-
 	})
 
 	It("should program new map sizes", func() {
@@ -142,7 +128,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 		newNATAffSize := 4000
 		newIpSetMapSize := 5000
 		newCtMapSize := 6000
-		updateFelixConfig(func(cfg *api.FelixConfiguration) {
+		infrastructure.UpdateFelixConfiguration(client, func(cfg *api.FelixConfiguration) {
 			cfg.Spec.BPFMapSizeRoute = &newRtSize
 			cfg.Spec.BPFMapSizeNATFrontend = &newNATFeSize
 			cfg.Spec.BPFMapSizeNATBackend = &newNATBeSize
@@ -150,12 +136,30 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ Felix bpf test configurable
 			cfg.Spec.BPFMapSizeIPSets = &newIpSetMapSize
 			cfg.Spec.BPFMapSizeConntrack = &newCtMapSize
 		})
-		Eventually(func() int { return getMapSize(felix, rtMap) }, "10s", "200ms").Should(Equal(newRtSize))
-		Eventually(func() int { return getMapSize(felix, feMap) }, "10s", "200ms").Should(Equal(newNATFeSize))
-		Eventually(func() int { return getMapSize(felix, beMap) }, "10s", "200ms").Should(Equal(newNATBeSize))
-		Eventually(func() int { return getMapSize(felix, affMap) }, "10s", "200ms").Should(Equal(newNATAffSize))
-		Eventually(func() int { return getMapSize(felix, ipsMap) }, "10s", "200ms").Should(Equal(newIpSetMapSize))
-		Eventually(func() int { return getMapSize(felix, ctMap) }, "10s", "200ms").Should(Equal(newCtMapSize))
+		Eventually(getMapSizeFn(felix, rtMap), "10s", "200ms").Should(Equal(newRtSize))
+		Eventually(getMapSizeFn(felix, feMap), "10s", "200ms").Should(Equal(newNATFeSize))
+		Eventually(getMapSizeFn(felix, beMap), "10s", "200ms").Should(Equal(newNATBeSize))
+		Eventually(getMapSizeFn(felix, affMap), "10s", "200ms").Should(Equal(newNATAffSize))
+		Eventually(getMapSizeFn(felix, ipsMap), "10s", "200ms").Should(Equal(newIpSetMapSize))
+		Eventually(getMapSizeFn(felix, ctMap), "10s", "200ms").Should(Equal(newCtMapSize))
+
+		// Add some workloads after resize to verify that provisioning is working with the new map sizes.
+		for i := range w {
+			w[i] = workload.Run(
+				tc.Felixes[0],
+				fmt.Sprintf("w%d", i),
+				"default",
+				fmt.Sprintf("10.65.0.%d", i+2),
+				"8080",
+				"tcp",
+			)
+			w[i].ConfigureInInfra(infra)
+		}
+		cc = &connectivity.Checker{}
+
+		cc.Expect(connectivity.Some, w[0], w[1])
+		cc.Expect(connectivity.Some, w[1], w[0])
+		cc.CheckConnectivity()
 	})
 })
 

--- a/felix/fv/donottrack_test.go
+++ b/felix/fv/donottrack_test.go
@@ -198,7 +198,7 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			cancel()
 		})
 
-		It("should implement untracked policy correctly", func() {
+		checkUntrackedPol := func() {
 			// This test covers both normal connectivity and failsafe connectivity.  We combine the
 			// tests because we rely on the changes of normal connectivity at each step to make sure
 			// that the policy has actually flowed through to the dataplane.
@@ -326,6 +326,31 @@ var _ = infrastructure.DatastoreDescribe("_BPF-SAFE_ do-not-track policy tests; 
 			if BPFMode() {
 				expectFailSafeOnlyConnectivityWithHost0(ExpectWithIPVersion(6))
 			}
-		})
+		}
+
+		It("should implement untracked policy correctly", checkUntrackedPol)
+
+		if BPFMode() {
+			Describe("with a custom map size", func() {
+				BeforeEach(func() {
+					newRtSize := 1000
+					newNATFeSize := 2000
+					newNATBeSize := 3000
+					newNATAffSize := 4000
+					newIpSetMapSize := 5000
+					newCtMapSize := 6000
+					infrastructure.UpdateFelixConfiguration(client, func(cfg *api.FelixConfiguration) {
+						cfg.Spec.BPFMapSizeRoute = &newRtSize
+						cfg.Spec.BPFMapSizeNATFrontend = &newNATFeSize
+						cfg.Spec.BPFMapSizeNATBackend = &newNATBeSize
+						cfg.Spec.BPFMapSizeNATAffinity = &newNATAffSize
+						cfg.Spec.BPFMapSizeIPSets = &newIpSetMapSize
+						cfg.Spec.BPFMapSizeConntrack = &newCtMapSize
+					})
+				})
+
+				It("should implement untracked policy correctly", checkUntrackedPol)
+			})
+		}
 	})
 })

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -16,6 +16,7 @@ package infrastructure
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -26,6 +27,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/calico/libcalico-go/lib/errors"
+	"github.com/projectcalico/calico/libcalico-go/lib/options"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf/jump"
@@ -514,4 +519,22 @@ func (p PrometheusMetric) Float() (float64, error) {
 		return 0, err
 	}
 	return strconv.ParseFloat(raw, 64)
+}
+
+func UpdateFelixConfiguration(client client.Interface, deltaFn func(*api.FelixConfiguration)) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cfg, err := client.FelixConfigurations().Get(ctx, "default", options.GetOptions{})
+	if _, doesNotExist := err.(errors.ErrorResourceDoesNotExist); doesNotExist {
+		cfg = api.NewFelixConfiguration()
+		cfg.Name = "default"
+		deltaFn(cfg)
+		_, err = client.FelixConfigurations().Create(ctx, cfg, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		Expect(err).NotTo(HaveOccurred())
+		deltaFn(cfg)
+		_, err = client.FelixConfigurations().Update(ctx, cfg, options.SetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}
 }

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -28,10 +28,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	api "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	log "github.com/sirupsen/logrus"
+
 	client "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/calico/libcalico-go/lib/errors"
 	"github.com/projectcalico/calico/libcalico-go/lib/options"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calico/felix/bpf/jump"
 	"github.com/projectcalico/calico/felix/bpf/polprog"


### PR DESCRIPTION
Cherry pick of #9117 on release-v3.28.

#9117: Fix resizing of BPF maps.

# Original PR Body below

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Maps were being correctly resized but the program attachment metadata wasn't updated so the programs failed to attach.

- Fix the test to actually verify basic workload connectivity.
- Add metadta updates to each of the attach points.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-10581

## Todos

- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix Felix panic when using non-default BPF map sizes.  Size was not updated in all places resulting in failure to attach programs.
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.