### PR TITLE
Fail FV tests on core dumps and races.

### DIFF
--- a/felix/dataplane/linux/int_dataplane.go
+++ b/felix/dataplane/linux/int_dataplane.go
@@ -2303,13 +2303,14 @@ func (d *InternalDataplane) apply() {
 	// Update the routing table in parallel with the other updates.  We'll wait for it to finish
 	// before we return.
 	var routesWG sync.WaitGroup
+	var numBackgroundProblems atomic.Uint64
 	for _, r := range d.routeTableSyncers() {
 		routesWG.Add(1)
 		go func(r routetable.SyncerInterface) {
 			err := r.Apply()
 			if err != nil {
 				log.Warn("Failed to synchronize routing table, will retry...")
-				d.dataplaneNeedsSync = true
+				numBackgroundProblems.Add(1)
 			}
 			d.reportHealth()
 			routesWG.Done()
@@ -2325,7 +2326,7 @@ func (d *InternalDataplane) apply() {
 			err := r.Apply()
 			if err != nil {
 				log.Warn("Failed to synchronize routing rules, will retry...")
-				d.dataplaneNeedsSync = true
+				numBackgroundProblems.Add(1)
 			}
 			d.reportHealth()
 			rulesWG.Done()
@@ -2380,6 +2381,10 @@ func (d *InternalDataplane) apply() {
 
 	// Wait for the rule updates to finish.
 	rulesWG.Wait()
+
+	if numBackgroundProblems.Load() > 0 {
+		d.dataplaneNeedsSync = true
+	}
 
 	// And publish and status updates.
 	d.endpointStatusCombiner.Apply()

--- a/felix/docker-image/calico-felix-wrapper
+++ b/felix/docker-image/calico-felix-wrapper
@@ -45,7 +45,8 @@ while true; do
   source /extra-env.sh
 
   echo "calico-felix-wrapper: Starting calico-felix"
-  calico-felix &
+  # Only enable tracebacks for Felix, not other binaries.
+  GOTRACEBACK=${FELIX_GOTRACEBACK} calico-felix &
   pid=$!
   echo "calico-felix-wrapper: Started calico-felix, PID=$pid"
   wait $pid

--- a/felix/fv/bpf_test.go
+++ b/felix/fv/bpf_test.go
@@ -602,7 +602,7 @@ func describeBPFTests(opts ...bpfTestOpt) bool {
 				Describe("with custom IptablesMarkMask", func() {
 					BeforeEach(func() {
 						// Disable core dumps, we know we're about to cause a panic.
-						options.ExtraEnvVars["GOTRACEBACK"] = ""
+						options.FelixCoreDumpsEnabled = false
 						felixPanicExpected = true
 					})
 

--- a/felix/fv/containers/containers.go
+++ b/felix/fv/containers/containers.go
@@ -51,11 +51,12 @@ type Container struct {
 	runCmd         *exec.Cmd
 	Stdin          io.WriteCloser
 
-	mutex         sync.Mutex
-	binaries      set.Set[string]
-	stdoutWatches []*watch
-	stderrWatches []*watch
-	dataRaces     []string
+	mutex                 sync.Mutex
+	binaries              set.Set[string]
+	stdoutWatches         []*watch
+	stderrWatches         []*watch
+	dataRaces             []string
+	raceDetectionDisabled bool
 
 	logFinished      sync.WaitGroup
 	dropAllLogs      bool
@@ -438,7 +439,19 @@ func (c *Container) DataRaces() []string {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	if c.raceDetectionDisabled {
+		return nil
+	}
 	return c.dataRaces
+}
+
+// DisableRaceDetector disables race detection for this test.  This is useful
+// for testing the race detection logic.
+func (c *Container) DisableRaceDetector() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.raceDetectionDisabled = true
 }
 
 func (c *Container) DockerInspect(format string) string {

--- a/felix/fv/infrastructure/datastore_describe.go
+++ b/felix/fv/infrastructure/datastore_describe.go
@@ -15,10 +15,14 @@ package infrastructure
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/calico/libcalico-go/lib/apiconfig"
+	"github.com/projectcalico/calico/libcalico-go/lib/set"
 )
 
 type InfraFactory func(...CreateOption) DatastoreInfra
@@ -32,21 +36,52 @@ type InfraFactory func(...CreateOption) DatastoreInfra
 // The *datastores* parameter is a slice of the DatastoreTypes to test.
 func DatastoreDescribe(description string, datastores []apiconfig.DatastoreType, body func(InfraFactory)) bool {
 	for _, ds := range datastores {
-		switch ds {
-		case apiconfig.EtcdV3:
-			Describe(fmt.Sprintf("%s (etcdv3 backend)", description),
-				func() {
-					body(createEtcdDatastoreInfra)
+
+		Describe(fmt.Sprintf("%s (%s backend)", description, ds), func() {
+			var coreFilesAtStart set.Set[string]
+			BeforeEach(func() {
+				coreFilesAtStart = readCoreFiles()
+			})
+
+			switch ds {
+			case apiconfig.EtcdV3:
+				body(createEtcdDatastoreInfra)
+			case apiconfig.Kubernetes:
+				body(createK8sDatastoreInfra)
+			default:
+				panic(fmt.Errorf("Unknown DatastoreType, %s", ds))
+			}
+
+			AfterEach(func() {
+				afterCoreFiles := readCoreFiles()
+				coreFilesAtStart.Iter(func(item string) error {
+					afterCoreFiles.Discard(item)
+					return nil
 				})
-		case apiconfig.Kubernetes:
-			Describe(fmt.Sprintf("%s (kubernetes backend)", description),
-				func() {
-					body(createK8sDatastoreInfra)
-				})
-		default:
-			panic(fmt.Errorf("Unknown DatastoreType, %s", ds))
-		}
+				if afterCoreFiles.Len() != 0 {
+					if CurrentGinkgoTestDescription().Failed {
+						Fail(fmt.Sprintf("Test FAILED and new core files were detected during tear-down: %v.  "+
+							"Felix must have panicked during the test.", afterCoreFiles.Slice()))
+						return
+					}
+					Fail(fmt.Sprintf("Test PASSED but new core files were detected during tear-down: %v.  "+
+						"Felix must have panicked during the test.", afterCoreFiles.Slice()))
+				}
+			})
+		})
 	}
 
 	return true
+}
+
+func readCoreFiles() set.Set[string] {
+	tmpFiles, err := os.ReadDir("/tmp")
+	Expect(err).NotTo(HaveOccurred())
+	var coreFiles []string
+	for _, f := range tmpFiles {
+		if strings.HasPrefix(f.Name(), "core_felix-") {
+			coreFiles = append(coreFiles, f.Name())
+		}
+	}
+	return set.From(coreFiles...)
 }

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -125,9 +125,7 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 	// are called concurrently with other instances of RunFelix so it's important to only
 	// read from options.*.
 	envVars := map[string]string{
-		// Enable core dumps.
-		"GOTRACEBACK": "crash",
-		"GORACE":      "history_size=2",
+		"GORACE": "history_size=2",
 		// Tell the wrapper to set the core file name pattern so we can find the dump.
 		"SET_CORE_PATTERN": "true",
 
@@ -140,6 +138,9 @@ func RunFelix(infra DatastoreInfra, id int, options TopologyOptions) *Felix {
 		"FELIX_BPFIPV6SUPPORT":           bpfEnableIPv6,
 		// Disable log dropping, because it can cause flakes in tests that look for particular logs.
 		"FELIX_DEBUGDISABLELOGDROPPING": "true",
+	}
+	if options.FelixCoreDumpsEnabled {
+		envVars["FELIX_GOTRACEBACK"] = "crash"
 	}
 	// Collect the volumes for this container.
 	wd, err := os.Getwd()

--- a/felix/fv/infrastructure/felix.go
+++ b/felix/fv/infrastructure/felix.go
@@ -268,6 +268,12 @@ func (f *Felix) Stop() {
 		_ = f.ExecMayFail("rmdir", path.Join("/run/calico/cgroup/", f.Name))
 	}
 	f.Container.Stop()
+
+	if CurrentGinkgoTestDescription().Failed {
+		Expect(f.DataRaces()).To(BeEmpty(), "Test FAILED and data races were detected in the logs at teardown.")
+	} else {
+		Expect(f.DataRaces()).To(BeEmpty(), "Test PASSED but data races were detected in the logs at teardown.")
+	}
 }
 
 func (f *Felix) Restart() {

--- a/felix/logutils/logutils.go
+++ b/felix/logutils/logutils.go
@@ -140,10 +140,6 @@ func ConfigureLogging(configParams *config.Config) {
 	// hook above to fan out logs to multiple destinations.
 	log.SetOutput(&logutils.NullWriter{})
 
-	// Since we push our logs onto a second thread via a channel, we can disable the
-	// Logger's built-in mutex completely.
-	log.StandardLogger().SetNoLock()
-
 	// Do any deferred error logging.
 	if fileDirErr != nil {
 		log.WithError(fileDirErr).WithField("file", configParams.LogFilePath).


### PR DESCRIPTION

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
We've had detection for races and core dumps for a long time but we weren't failing tests as a result.  This made the detection not very useful: when we did get a race/core dump there was no associated log because logs are hidden unless the test fails.  

* Make tests fail in `AfterEach()` if a race/corefile is detected.  This causes Ginkgo to dump logs, making it much easier to debug the race/panic.
* Make it clear what the result of the test was to avoid confusion between "test failed" and "a race was hit during the test".
* Stop dumping core for test-workload and other test binaries.  Some panic on failure so we were getting lots of core files for no reason!
* Fix race caused by configuring logrus to disable its lock.  Struggled to find a better fix.  The problem is that Felix starts some threads before it does that configuration, and then can log before the lock gets disabled.  It's only safe to disable the lock once our logging configuration is in place.

## Related issues/PRs

<!-- If appropriate, include a link to the issue this fixes.
fixes <ISSUE LINK>

If appropriate, add links to any number of PRs documented by this PR
documents <PR LINK>
-->

CORE-10585

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
TBD
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.
